### PR TITLE
Ignore rspec example status persistence file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.env.rb
 /coverage
+spec/examples.txt


### PR DESCRIPTION
This is a generated file used for --only-failures and --next-failure rspec features.