### PR TITLE
Install a public ssh key

### DIFF
--- a/migrate/003_add_ssh_users.rb
+++ b/migrate/003_add_ssh_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm) do
+      add_column :unix_user, :text, collate: '"C"', null: false
+      add_column :public_key, :text, collate: '"C"', null: false
+    end
+  end
+end

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -13,8 +13,18 @@ unless (gua = ARGV.shift)
   exit 1
 end
 
+unless (unix_user = ARGV.shift)
+  puts "need unix user as argument"
+  exit 1
+end
+
+unless (ssh_public_key = ARGV.shift)
+  puts "need ssh public key as argument"
+  exit 1
+end
+
 require "fileutils"
 require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
-VmSetup.new(vm_name).prep(gua)
+VmSetup.new(vm_name).prep(unix_user, ssh_public_key, gua)

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -10,4 +10,14 @@ RSpec.describe VmSetup do
     expect(lower.to_s).to eq("2a01:4f9:2b:35b:7e40:e918::/96")
     expect(upper.to_s).to eq("2a01:4f9:2b:35b:7e40:e919::/96")
   end
+
+  it "templates user YAML" do
+    vps = instance_spy(VmPath)
+    expect(vs).to receive(:vp).and_return(vps).at_least(:once)
+    vs.write_user_data("some_user", "some_ssh_key")
+    expect(vps).to have_received(:write_user_data) {
+      expect(_1).to match(/some_user/)
+      expect(_1).to match(/some_ssh_key/)
+    }
+  end
 end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Vm::Nexus do
+  it "creates the user and key record" do
+    st = described_class.assemble("some_ssh_key")
+    vm = Vm[st.id]
+    vm.update(ephemeral_net6: "fe80::/64")
+
+    expect(vm.unix_user).to eq("ubi")
+    expect(vm.public_key).to eq("some_ssh_key")
+
+    prog = described_class.new(st)
+    sshable = instance_double(Sshable)
+    vmh = instance_double(VmHost, sshable: sshable)
+
+    expect(sshable).to receive(:cmd).with("sudo bin/prepvm.rb #{prog.q_vm} fe80::/64 ubi some_ssh_key")
+    expect(st).to receive(:load).and_return(prog)
+    expect(prog).to receive(:host).and_return(vmh)
+
+    st.update(label: "prep")
+    st.run
+  end
+end


### PR DESCRIPTION
Enables logging into the VMs using a SSH key. To do this, the
signature of Prog::Vm::Nexus.assemble now accepts two additional
parameters:

   > def self.assemble(public_key, unix_user: "ubi")

An example usage of this is:

  > mykey = File.read("/path/to/home/.ssh/id_rsa.pub")
  > st = Prog::Vm::Nexus.assemble(mykey)

After the VM is created, you should be able to connect to the VM
using your SSH key.