### PR TITLE
Expand VM namespace to /79 from /95

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -13,21 +13,27 @@ class VmHost < Sequel::Model
   # Compute the IPv6 Subnet that can be used to address the host
   # itself, and should not be delegated to any VMs.
   #
-  # The default prefix length is 95, so that customers can be given a
-  # /96 for their own exclusive use, and paired is the adjacent /96
-  # for Clover's use on behalf of that VM.  This leaves 31 bits of
+  # The default prefix length is 79, so that customers can be given a
+  # /80 for their own exclusive use, and paired is the adjacent /80
+  # for Clover's use on behalf of that VM.  This leaves 15 bits of
   # entropy relative to the customary /64 allocated to a real device.
   #
-  # Offering a /96 to the VM renders nicely in the IPv6 format, as
-  # it's 6 * 16, and each delimited part of IPv6 is 16 bits.
-  def ip6_reserved_network(prefix = 95)
+  # Offering a /80 to the VM renders nicely in the IPv6 format, as
+  # it's 5 * 16, and each delimited part of IPv6 is 16 bits.
+  #
+  # A /80 is the longest prefix that is divisible by 16 and contains
+  # multiple /96 subnets within it.  /96 is of special significance
+  # because it contains enough space within it to hold the IPv4
+  # address space, i.e. leaving the door open for schemes relying on
+  # SIIT translation: https://datatracker.ietf.org/doc/html/rfc7915
+  def ip6_reserved_network(prefix = 79)
     fail "BUG" unless host_prefix < prefix
     NetAddr::IPv6Net.new(ip6, NetAddr::Mask128.new(prefix))
   end
 
   # Generate a random network that is a slice of the host's network
   # for delegation to a VM.
-  def ip6_random_vm_network(prefix = 95)
+  def ip6_random_vm_network(prefix = 79)
     subnet_bits = prefix - host_prefix
 
     # If there was only one subnet bit, it would be allocated already
@@ -41,7 +47,7 @@ class VmHost < Sequel::Model
     # Generate bits to sit between the host_prefix and the vm network.
     #
     # Shift them into the right place for a 128 bit IPv6 address
-    lower_bits = SecureRandom.bytes(bytes_needed).unpack1("N") << (128 - prefix - 1)
+    lower_bits = SecureRandom.bytes(bytes_needed).unpack1("n") << (128 - prefix - 1)
 
     # Combine it with the higher bits for the host.
     proposal = NetAddr::IPv6Net.new(

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe VmSetup do
   subject(:vs) { described_class.new("test") }
 
   it "can halve an IPv6 network" do
-    lower, upper = vs.subdivide_network(NetAddr.parse_net("2a01:4f9:2b:35b:7e40:e918::/95"))
-    expect(lower.to_s).to eq("2a01:4f9:2b:35b:7e40:e918::/96")
-    expect(upper.to_s).to eq("2a01:4f9:2b:35b:7e40:e919::/96")
+    lower, upper = vs.subdivide_network(NetAddr.parse_net("2a01:4f9:2b:35b:7e40::/79"))
+    expect(lower.to_s).to eq("2a01:4f9:2b:35b:7e40::/80")
+    expect(upper.to_s).to eq("2a01:4f9:2b:35b:7e41::/80")
   end
 
   it "templates user YAML" do


### PR DESCRIPTION
Thus, instead of a pair of /96s for each namespace, the lower allocated to the VM and the upper allocated to Clover, we instead have two /80s, which are five hextets in IPv6 notation rather than six.

I previously chose /96 to on the principle of being conservative and it being easier to expand than to contract, but it still would be a pretty big pain to do it.

But, after considering some of IPv4 transition technologies this implementation may see in its life, one is SIIT, whereby a /96 is delegated for the purpose of holding IPv4 addresses in its remaining bits.

If you only have one /96 range to work with for all purposes, then you can't reasonably delegate it wholesale, i.e. one /96 for the VM or Clover is not big enough.  Hence, the upgrade to /80.

Several large mobile phone operators have transitioned to IPv6-only infrastructure in this way, some almost ten years ago (T-Mobile). Their approach is called "464XLAT." Mobile providers have a lot of address pressure, so they are the most interested, but operating systems and data centers may follow in the coming years.

All in all, I think SIIT techniques might be useful to both us and customers some day, and I didn't have a great reason to be so tight-fisted with customer address space, so, let's expand it in off chance it can help us.