### PR TITLE
Add initial VM index and create view

### DIFF
--- a/migrate/004_add_vm_display.rb
+++ b/migrate/004_add_vm_display.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    extension :pg_enum
+    create_enum(:vm_display_state, %w[creating running])
+
+    alter_table(:vm_host) do
+      add_column :location, :text, collate: '"C"', null: false
+    end
+
+    alter_table(:vm) do
+      add_column :display_state, :vm_display_state, default: "creating", null: false
+      add_column :name, :text, collate: '"C"', null: false
+      add_column :size, String, collate: '"C"', null: false
+      add_column :location, String, collate: '"C"', null: false
+      add_column :boot_image, String, collate: '"C"', null: false
+    end
+  end
+end

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -40,15 +40,15 @@ class Prog::LearnNetwork < Prog::Base
     case JSON.parse(s)
     in [iface]
       case iface.fetch("addr_info").filter_map { |info|
-             if (local = info["local"]) && (prefixlen = info["prefixlen"])
-               p Ip6.new(local, prefixlen)
+             if (local = info["local"]) && (prefixlen = info["prefixlen"]) && prefixlen <= 64
+               Ip6.new(local, prefixlen)
              end
            }
-      in [net6]
-        net6
-      else
-        fail "only one global unique address prefix supported on interface"
-      end
+        in [net6]
+          net6
+        else
+          fail "only one global unique address prefix supported on interface"
+        end
     else
       fail "only one one interface supported"
     end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Prog::Vm::HostNexus < Prog::Base
-  def self.assemble(sshable_hostname)
+  def self.assemble(sshable_hostname, location: "hetzner-hel1")
     DB.transaction do
       sa = Sshable.create(host: sshable_hostname)
-      VmHost.create { _1.id = sa.id }
+      VmHost.create(location: location) { _1.id = sa.id }
 
       Strand.create(prog: "Vm::HostNexus", label: "start") { _1.id = sa.id }
     end

--- a/rhizome/bin/prep_host.rb
+++ b/rhizome/bin/prep_host.rb
@@ -39,7 +39,3 @@ r "sysctl --system"
 # For qemu-image convert and mcopy for cloud-init with the nocloud
 # driver.
 r "apt-get -y install qemu-utils mtools"
-
-FileUtils.cd "/opt" do
-  r "curl -O https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-end

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -23,8 +23,13 @@ unless (ssh_public_key = ARGV.shift)
   exit 1
 end
 
+unless (boot_image = ARGV.shift)
+  puts "need boot image as an argument"
+  exit 1
+end
+
 require "fileutils"
 require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
-VmSetup.new(vm_name).prep(unix_user, ssh_public_key, gua)
+VmSetup.new(vm_name).prep(unix_user, ssh_public_key, gua, boot_image)

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -20,4 +20,26 @@ RSpec.describe VmSetup do
       expect(_1).to match(/some_ssh_key/)
     }
   end
+
+  describe "#boot_disk" do
+    it "can download an image before converting it" do
+      expect(File).to receive(:open) do |path, *_args|
+        expect(path).to eq("/opt/ubuntu-jammy.qcow2.tmp")
+      end.and_yield
+
+      expect(vs).to receive(:r).with("curl -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/ubuntu-jammy.qcow2 /home/test/boot.raw")
+
+      expect(FileUtils).to receive(:mv).with("/opt/ubuntu-jammy.qcow2.tmp", "/opt/ubuntu-jammy.qcow2")
+      expect(FileUtils).to receive(:chown).with("test", "test", "/home/test/boot.raw")
+      vs.boot_disk("ubuntu-jammy")
+    end
+
+    it "can use an image that's already downloaded" do
+      expect(File).to receive(:exist?).with("/opt/almalinux-9.1.qcow2").and_return(true)
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/almalinux-9.1.qcow2 /home/test/boot.raw")
+      expect(FileUtils).to receive(:chown).with("test", "test", "/home/test/boot.raw")
+      vs.boot_disk("almalinux-9.1")
+    end
+  end
 end

--- a/routes/prefix1.rb
+++ b/routes/prefix1.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class Clover
-  hash_branch("prefix1") do |r|
-    # /prefix1 branch handling
-  end
-end

--- a/routes/vm.rb
+++ b/routes/vm.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "ulid"
+
+class Clover
+  PageVm = Struct.new(:id, :name, :state, :ip6, keyword_init: true)
+
+  hash_branch("vm") do |r|
+    r.get true do
+      @page_title = "Virtual Machine"
+
+      @data = Vm.map { |vm|
+        PageVm.new(id: ULID.from_uuidish(vm.id).to_s.downcase,
+          name: vm.name,
+          state: vm.display_state,
+          ip6: vm.ephemeral_net6&.network)
+      }
+
+      view "vm/index"
+    end
+
+    r.on "create" do
+      r.get true do
+        @page_title = "Create Virtual Machine"
+        view "vm/create"
+      end
+
+      r.post true do
+        Prog::Vm::Nexus.assemble(
+          r.params["public-key"],
+          name: r.params["name"],
+          unix_user: r.params["user"],
+          size: r.params["size"],
+          location: r.params["location"],
+          boot_image: r.params["boot-image"]
+        )
+
+        r.redirect "/vm"
+      end
+    end
+  end
+end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe VmHost do
   it "requires an Sshable too" do
     expect {
       sa = Sshable.create(host: "test.localhost", private_key: "test not a real private key")
-      described_class.create { _1.id = sa.id }
+      described_class.create(location: "test-location") { _1.id = sa.id }
     }.not_to raise_error
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Prog::Vm::Nexus do
     sshable = instance_double(Sshable)
     vmh = instance_double(VmHost, sshable: sshable)
 
-    expect(sshable).to receive(:cmd).with("sudo bin/prepvm.rb #{prog.q_vm} fe80::/64 ubi some_ssh_key")
+    expect(sshable).to receive(:cmd).with("sudo bin/prepvm.rb #{prog.q_vm} fe80::/64 ubi some_ssh_key ubuntu-jammy")
     expect(st).to receive(:load).and_return(prog)
     expect(prog).to receive(:host).and_return(vmh)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,14 @@ DatabaseCleaner.url_allowlist = [
 ]
 
 RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|
+    # Extract the name of the subdirectory that the test file is in
+    subdirectory = metadata[:file_path].split("/")[-2]
+
+    # Set the :subdirectory metadata tag to the extracted value
+    metadata[:subdirectory] = subdirectory
+  end
+
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     DB.loggers << Logger.new($stdout) if DB.loggers.empty?

--- a/spec/web/vm_spec.rb
+++ b/spec/web/vm_spec.rb
@@ -2,10 +2,9 @@
 
 require_relative "spec_helper"
 
-RSpec.describe Clover, "/prefix1" do
+RSpec.describe Clover, "/vm" do
   it "has a page title" do
-    visit "/prefix1"
+    visit "/vm"
     expect(page.title).to eq("UbiCloud/Login")
-    # ...
   end
 end

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -1,0 +1,59 @@
+<form action="create" method="POST">
+  <!-- YYY: need a better way to manage coupling of routes and erbs -->
+  <%== csrf_tag("/vm/create") %>
+  <div class="form-group">
+    <label for="name">Name</label>
+    <input
+      type="text"
+      class="form-control"
+      id="name"
+      name="name"
+      placeholder="Enter name"
+    >
+  </div>
+  <div class="form-group">
+    <label for="size">Size</label>
+    <select class="form-control" id="size" name="size">
+      <option value="standard-1">standard-1</option>
+      <option value="standard-2">standard-2</option>
+      <option value="standard-4">standard-4</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="location">Location</label>
+    <select class="form-control" id="location" name="location">
+      <option value="hetzner-hel1">Hetzner Helsinki</option>
+      <option value="hetzner-nbg1">Hetzner Nuremberg</option>
+      <option value="equinix-da11">Equinix Dallas 11</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="user">User</label>
+    <input
+      type="text"
+      class="form-control"
+      id="user"
+      name="user"
+      placeholder="unix user"
+      value="ubi"
+    >
+  </div>
+  <div class="form-group">
+    <label for="public-key">SSH Public Key</label>
+    <input
+      type="text"
+      class="form-control"
+      id="public-key"
+      name="public-key"
+      placeholder="ssh-ed25519 AAAA..."
+    >
+  </div>
+  <div class="form-group">
+    <label for="size">Boot Image</label>
+    <select class="form-control" id="boot-image" name="boot-image">
+      <option value="ubuntu-jammy">Ubuntu Jammy 22.04 LTS</option>
+      <option value="almalinux-9.1">AlmaLinux 9.1</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Create Virtual Machine</button>
+</form>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -1,0 +1,18 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">id</th>
+      <th scope="col">name</th>
+      <th scope="col">state</th>
+      <th scope="col">IPv6</th>
+    </tr>
+  </thead>
+  <tbody><% @data.each do |item| %>
+      <tr>
+        <th scope="row"><%= item.id %></th>
+        <td><%= item.name %></td>
+        <td><%= item.state %></td>
+        <td><%= item.ip6 %></td>
+      </tr>
+    <% end %></tbody>
+</table>


### PR DESCRIPTION
By running:

    bundle exec rackup

And then visiting http://localhost:9292, you can create an account. Check the rackup log for the verification link to navigate to, in production, we would send that output as email.  Having verified, log in.  You'll see the RodAuth demo pages.

To visit the VM index, visit http://localhost:9292/vm.  At first it will be empty.

To create a vm, navigate to http://localhost:9292/vm/create

In order for a vm to allocate a slot on a host, you need a host where `vm.location` matches `vm_host.location`.  Here are the strings I am using in the web form:

    hetzner-hel1
    hetzner-nbg1
    equinix-da11

Because vm allocation is lazy, you can create the VmHost for a Vm *after* the Vm record already exists.  You can create VmHost records in a particular location like so:

    Prog::Vm::HostNexus.assemble('145.40.99.21', location: 'equinix-da11')
    Prog::Vm::HostNexus.assemble('95.216.67.38', location: 'hetzner-hel1')

It so happens that these addresses were actually in Equinix Dallas 11 and Hetzner Helsinki 1, respectively, but you are free to enter arbitrary location data for testing.

Besides web pages and location constraints, another change in this patch is lazy Linux image downloading.  The reason for this is I wanted to test a second image (I chose AlmaLinux) but I did not want to penalize every development path with downloading both images when preparing a host, considering it is convenient to drop the Postgres database and erase the host while developing.  In this way, the common case where people never download AlmaLinux remains as quick as it did before, although the time spent downloading the Linux boot image is shifted to the first VM using that image on a host.

For demonstration purposes, it would make sense to "prewarm" the host and download both images.