### PR TITLE
Add navigation bar

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -20,7 +20,7 @@ class Clover < Roda
     csp.default_src :none
     csp.style_src :self, "https://stackpath.bootstrapcdn.com"
     csp.form_action :self
-    csp.script_src :self
+    csp.script_src :self, "https://cdn.jsdelivr.net"
     csp.connect_src :self
     csp.base_uri :none
     csp.frame_ancestors :none

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -9,6 +9,17 @@
       integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
       crossorigin="anonymous"
     >
+    <script
+      src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"
+      integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
+      crossorigin="anonymous"
+    ></script>
+
     <title><%= ["UbiCloud", @page_title].compact.join("/") %></title>
     <style nonce="<%= @request_nonce %>">
 	 .error {border: 1px #a00 solid;}
@@ -30,9 +41,40 @@
 
   <body>
 
-    <nav class="navbar navbar-default" role="navigation">
-      <div class="container">
-        <a class="navbar-brand" href="/">Rodauth Demo</a>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <a class="navbar-brand" href="/">UbiCloud</a>
+      <button
+        class="navbar-toggler"
+        type="button"
+        data-toggle="collapse"
+        data-target="#navbarSupportedContent"
+        aria-controls="navbarSupportedContent"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item dropdown">
+            <a
+              class="nav-link dropdown-toggle"
+              href="#"
+              id="navbarDropdown"
+              role="button"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false"
+            >
+              Virtual Machines
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <a class="dropdown-item" href="/vm/create">Create</a>
+              <a class="dropdown-item" href="/vm">List</a>
+            </div>
+          </li>
+        </ul>
 
         <% if rodauth.logged_in? %>
           <form action="/logout" class="navbar-form pull-right" method="post">


### PR DESCRIPTION
Instead of having to remember our key paths (`/vm`, `/vm/create`), this adds a drop-down that lets you navigate to those links.

Clicking "UbiCloud" brings you back to the root, which is still the rodauth demo page, which has account manipulation options (change password, close account, MFA, etc).