### PR TITLE
Assign a private subnet to each VM

### DIFF
--- a/migrate/005_networking.rb
+++ b/migrate/005_networking.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:vm_private_subnet) do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      foreign_key :vm_id, :vm, type: :uuid, null: false
+      column :private_subnet, :cidr, null: false
+    end
+  end
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -5,4 +5,5 @@ require_relative "../model"
 class Vm < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :vm_host
+  one_to_many :vm_private_subnet, key: :vm_id
 end

--- a/model/vm_private_subnet.rb
+++ b/model/vm_private_subnet.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class VmPrivateSubnet < Sequel::Model
+  many_to_one :vm
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
+require "netaddr"
+require "json"
 require "ulid"
 
 class Prog::Vm::Nexus < Prog::Base
   def self.assemble(public_key, name: nil, size: "standard-4",
-    unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy")
+    unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
+    private_subnets: [])
+
+    # if the caller hasn't provided any subnets, generate a random one
+    if private_subnets.empty?
+      private_subnets.append(random_ula)
+    end
+
     DB.transaction do
       id = SecureRandom.uuid
       name ||= uuid_to_name(id)
       vm = Vm.create(public_key: public_key, unix_user: unix_user,
         name: name, size: size, location: location, boot_image: boot_image) { _1.id = id }
+      private_subnets.each do
+        VmPrivateSubnet.create(vm_id: vm.id, private_subnet: _1.to_s)
+      end
       Strand.create(prog: "Vm::Nexus", label: "start") { _1.id = vm.id }
     end
   end
@@ -18,13 +30,23 @@ class Prog::Vm::Nexus < Prog::Base
     "vm" + ULID.from_uuidish(id).to_s[0..5].downcase
   end
 
-  def q_vm
+  def vm_name
     # YYY: various names in linux, like interface names, are obliged
     # to be short, so alas, probably can't reproduce entropy from
     # vm.id to be collision free and there will need to be a second
     # addressing scheme scoped to each VmHost.  But for now, assume
     # entropy.
-    self.class.uuid_to_name(vm.id).shellescape
+    self.class.uuid_to_name(vm.id)
+  end
+
+  def q_vm
+    vm_name.shellescape
+  end
+
+  def self.random_ula
+    network_address = NetAddr::IPv6.new((SecureRandom.bytes(7) + 0xfd.chr).unpack1("Q<") << 64)
+    network_mask = NetAddr::Mask128.new(64)
+    NetAddr::IPv6Net.new(network_address, network_mask)
   end
 
   def vm
@@ -41,6 +63,10 @@ class Prog::Vm::Nexus < Prog::Base
 
   def public_key
     @public_key ||= vm.public_key
+  end
+
+  def private_subnets
+    @private_subnets ||= vm.vm_private_subnet.map { _1.private_subnet }
   end
 
   def start
@@ -72,7 +98,25 @@ SQL
 
   def prep
     q_net = vm.ephemeral_net6.to_s.shellescape
-    host.sshable.cmd("sudo bin/prepvm.rb #{q_vm} #{q_net} #{unix_user.shellescape} #{public_key.shellescape} #{vm.boot_image.shellescape}")
+    params_json = JSON.pretty_generate({
+      "vm_name" => vm_name,
+      "public_ipv6" => q_net,
+      "unix_user" => unix_user,
+      "ssh_public_key" => public_key,
+      "private_subnets" => private_subnets.map { _1.to_s },
+      "boot_image" => vm.boot_image
+    })
+
+    # create vm's home directory
+    vm_home = File.join("", "vm", vm_name)
+    host.sshable.cmd("sudo adduser --disabled-password --gecos '' --home #{vm_home.shellescape} #{q_vm}")
+    host.sshable.cmd("sudo usermod -a -G kvm #{q_vm}")
+
+    # put prep.json
+    params_path = File.join(vm_home, "prep.json")
+    host.sshable.cmd("echo #{params_json.shellescape} | sudo -u #{q_vm} tee #{params_path.shellescape}")
+
+    host.sshable.cmd("sudo bin/prepvm.rb #{params_path.shellescape}")
     hop :run
   end
 

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -1,30 +1,45 @@
 #!/bin/env ruby
 # frozen_string_literal: true
 
-unless (vm_name = ARGV.shift)
-  puts "need vm name as argument"
+require "json"
+
+unless (params_path = ARGV.shift)
+  puts "expected path to prep.json as argument"
+  exit 1
+end
+
+params_json = File.read(params_path)
+params = JSON.parse(params_json)
+
+unless (vm_name = params["vm_name"])
+  puts "need vm_name in parameters json"
   exit 1
 end
 
 # "Global Unicast" subnet, i.e. a subnet for exchanging packets with
 # the internet.
-unless (gua = ARGV.shift)
-  puts "need global unicast subnet as argument"
+unless (gua = params["public_ipv6"])
+  puts "need public_ipv6 in parameters json"
   exit 1
 end
 
-unless (unix_user = ARGV.shift)
-  puts "need unix user as argument"
+unless (unix_user = params["unix_user"])
+  puts "need unix_user in parameters json"
   exit 1
 end
 
-unless (ssh_public_key = ARGV.shift)
-  puts "need ssh public key as argument"
+unless (ssh_public_key = params["ssh_public_key"])
+  puts "need ssh_public_key in parameters json"
   exit 1
 end
 
-unless (boot_image = ARGV.shift)
-  puts "need boot image as an argument"
+unless (private_subnets = params["private_subnets"])
+  puts "need private_subnets in parameters json"
+  exit 1
+end
+
+unless (boot_image = params["boot_image"])
+  puts "need boot_image in parameters json"
   exit 1
 end
 
@@ -32,4 +47,4 @@ require "fileutils"
 require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
-VmSetup.new(vm_name).prep(unix_user, ssh_public_key, gua, boot_image)
+VmSetup.new(vm_name).prep(unix_user, ssh_public_key, private_subnets, gua, boot_image)

--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -28,7 +28,7 @@ class VmPath
   end
 
   def home(n)
-    File.join("", "home", @vm_name, n)
+    File.join("", "vm", @vm_name, n)
   end
 
   # Define path, q_path, read, write methods for files in

--- a/rhizome/spec/vm_path_spec.rb
+++ b/rhizome/spec/vm_path_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe VmPath do
   subject(:vp) { described_class.new("test'vm") }
 
   it "can compute a path" do
-    expect(vp.guest_mac).to eq("/home/test'vm/guest_mac")
+    expect(vp.guest_mac).to eq("/vm/test'vm/guest_mac")
   end
 
   it "can escape a path" do
-    expect(vp.q_guest_mac).to eq("/home/test\\'vm/guest_mac")
+    expect(vp.q_guest_mac).to eq("/vm/test\\'vm/guest_mac")
   end
 
   it "will snakeify difficult characters" do
-    expect(vp.boot_raw).to eq("/home/test'vm/boot.raw")
+    expect(vp.boot_raw).to eq("/vm/test'vm/boot.raw")
   end
 
   it "can read file contents" do

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -28,17 +28,17 @@ RSpec.describe VmSetup do
       end.and_yield
 
       expect(vs).to receive(:r).with("curl -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
-      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/ubuntu-jammy.qcow2 /home/test/boot.raw")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/ubuntu-jammy.qcow2 /vm/test/boot.raw")
 
       expect(FileUtils).to receive(:mv).with("/opt/ubuntu-jammy.qcow2.tmp", "/opt/ubuntu-jammy.qcow2")
-      expect(FileUtils).to receive(:chown).with("test", "test", "/home/test/boot.raw")
+      expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/boot.raw")
       vs.boot_disk("ubuntu-jammy")
     end
 
     it "can use an image that's already downloaded" do
       expect(File).to receive(:exist?).with("/opt/almalinux-9.1.qcow2").and_return(true)
-      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/almalinux-9.1.qcow2 /home/test/boot.raw")
-      expect(FileUtils).to receive(:chown).with("test", "test", "/home/test/boot.raw")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/almalinux-9.1.qcow2 /vm/test/boot.raw")
+      expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/boot.raw")
       vs.boot_disk("almalinux-9.1")
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require_relative "../../model/spec_helper"
+require "netaddr"
 
 RSpec.describe Prog::Vm::Nexus do
   it "creates the user and key record" do
-    st = described_class.assemble("some_ssh_key")
+    private_subnets = [
+      NetAddr::IPv6Net.parse("fd55:666:cd1a:ffff::/64"),
+      NetAddr::IPv6Net.parse("fd12:345:6789:0abc::/64")
+    ]
+    st = described_class.assemble("some_ssh_key", private_subnets: private_subnets)
     vm = Vm[st.id]
     vm.update(ephemeral_net6: "fe80::/64")
 
@@ -12,12 +17,21 @@ RSpec.describe Prog::Vm::Nexus do
     expect(vm.public_key).to eq("some_ssh_key")
 
     prog = described_class.new(st)
-    sshable = instance_double(Sshable)
+    sshable = instance_spy(Sshable)
     vmh = instance_double(VmHost, sshable: sshable)
 
-    expect(sshable).to receive(:cmd).with("sudo bin/prepvm.rb #{prog.q_vm} fe80::/64 ubi some_ssh_key ubuntu-jammy")
     expect(st).to receive(:load).and_return(prog)
-    expect(prog).to receive(:host).and_return(vmh)
+    expect(prog).to receive(:host).and_return(vmh).at_least(:once)
+
+    expect(sshable).to receive(:cmd).with(/echo (.|\n)* \| sudo -u vm[0-9a-z]+ tee/) do
+      require "json"
+      params = JSON(_1.shellsplit[1])
+      expect(params["unix_user"]).to eq("ubi")
+      expect(params["ssh_public_key"]).to eq("some_ssh_key")
+      expect(params["public_ipv6"]).to eq("fe80::/64")
+      expect(params["private_subnets"]).to include(*private_subnets.map { |s| s.to_s })
+      expect(params["boot_image"]).to eq("ubuntu-jammy")
+    end
 
     st.update(label: "prep")
     st.run


### PR DESCRIPTION
Assigns a 0xfd.../64 subnet to each VM. We will setup IPSec tunnels between VMs so they communicate using the private subnets.

To do this, adds anew parameter `private_subnet` of Prog::Vm::Nexus.assemble. If `private_subnet` is not nil, then this string will be used. Otherwise, a random subnet will be generated.

This PR also moves the home directory of VMs to `/vm/$vmname`, and passes the prepvm parameters in `/vm/$vmname/params.json`.

