### PR TITLE
Update schedule so that bin/respirate roughly round-robins

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -25,7 +25,7 @@ class Strand < Sequel::Model
   def self.lease(id)
     affected = DB[<<SQL, id].first
 UPDATE strand
-SET lease = now() + '120 seconds'
+SET lease = now() + '120 seconds', schedule = now()
 WHERE id = ? AND (lease IS NULL OR lease < now())
 RETURNING lease
 SQL


### PR DESCRIPTION
Previously, schedule was entirely a placeholder.  Now it's only mosty a placeholder: this is enough code to get ./bin/respirate to execute one strand after another rather than selecting the same one every time, and thus you can use the web site without toggling to pry anymore.