### PR TITLE
Fix asdf-vm config file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ I find use of `asdf` with
 obligatory, for the reasons discussed in its README.  Let's set it up
 as a user-global tool, and not a project-local one:
 
-    echo "direnv 2.32.2" >> ~/.tool_versions
+    echo "direnv 2.32.2" >> ~/.tool-versions
     asdf direnv setup --version latest
 
 After `direnv setup` you need to source your shell's startup files or


### PR DESCRIPTION
It looks like a typo. Correct one is ".tool-versions", not ".tool_versions"