### PR TITLE
Change shebang for respirate script

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative "../loader"


### PR DESCRIPTION
pry (`#!/usr/bin/env ruby`) and respirate (`#!/bin/env ruby`) have different shebangs. `/bin/env` does not exist for macOS. Using pry's shebang for consistency.