### PR TITLE
Do not run CI pipeline on PR twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,44 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      DB_USER: clover
+      DB_PASSWORD: nonempty
+      DB_NAME: clover_test
+
     services:
       postgres:
         image: postgres
         env:
-          POSTGRES_USER: clover
-          POSTGRES_PASSWORD: 'nonempty'
-          POSTGRES_DB: clover_test
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
         ports:
-        - 5432:5432
+          - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
     - name: Perform superuser-only actions, then remove superuser
-      run: psql "postgres://clover:nonempty@localhost:5432/clover_test" -c "CREATE EXTENSION citext; CREATE ROLE clover_password PASSWORD 'nonempty' LOGIN; ALTER ROLE clover NOSUPERUSER"
+      run: |
+        psql "postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}" \
+          -c "CREATE EXTENSION citext; CREATE ROLE clover_password PASSWORD '${{ env.DB_PASSWORD }}' LOGIN; ALTER ROLE ${{ env.DB_USER }} NOSUPERUSER"
 
-    - uses: actions/checkout@v3
+    - name: Check out code
+      uses: actions/checkout@v3
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.1
+        ruby-version: .tool-versions
         bundler-cache: true
 
     - name: Run rubocop
@@ -33,12 +46,14 @@ jobs:
 
     - name: Apply migrations
       env:
-        CLOVER_DATABASE_URL: postgres://clover:nonempty@localhost:5432/clover_test
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: rake test_up
 
     - name: Run tests
       env:
-        CLOVER_DATABASE_URL: postgres://clover:nonempty@localhost:5432/clover_test
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
         CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
         CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
-      run: bundle exec rspec && bundle exec rspec -O /dev/null rhizome
+      run: |
+        bundle exec rspec
+        bundle exec rspec -O /dev/null rhizome


### PR DESCRIPTION
`push` and `pull_request` triggers are activated when new commit's pushed to a branch that has a pull request. Running on pull requests and only pushes to main branch is enough.

<img width="939" alt="ci-twice" src="https://user-images.githubusercontent.com/993199/229595212-1c48308a-1b35-49f6-ab5e-8cf94dd1c971.png">

`ruby/setup-ruby@v1` action is able to read ruby version from `.tool-versions` file. No need to hard coded version here.

Also, I moved database configurations to env. So no need to repeat them again and again.