### PR TITLE
Setup IPSec tunnel between two VMs

### DIFF
--- a/migrate/006_ipsec.rb
+++ b/migrate/006_ipsec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:ipsec_tunnel) do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      foreign_key :src_vm_id, :vm, type: :uuid, null: false
+      foreign_key :dst_vm_id, :vm, type: :uuid, null: false
+    end
+  end
+end

--- a/model/ipsec_tunnel.rb
+++ b/model/ipsec_tunnel.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class IpsecTunnel < Sequel::Model
+  many_to_one :vm
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -6,7 +6,12 @@ class Vm < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :vm_host
   one_to_many :vm_private_subnet, key: :vm_id
+  one_to_many :ipsec_tunnels, key: :src_vm_id
 
   include SemaphoreMethods
-  semaphore :destroy
+  semaphore :destroy, :refresh_mesh
+
+  def private_subnets
+    vm_private_subnet.map { _1.private_subnet }
+  end
 end

--- a/rhizome/bin/setup-ipsec
+++ b/rhizome/bin/setup-ipsec
@@ -1,0 +1,66 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+unless (command = ARGV.shift)
+  puts "expected ipsec command as argument"
+  exit 1
+end
+
+unless (src_vm_name = ARGV.shift)
+  puts "expected src_vm_name as argument"
+  exit 1
+end
+
+unless (src_ephemeral_net6 = ARGV.shift)
+  puts "expected src_ephemeral_net6 as argument"
+  exit 1
+end
+
+unless (src_private_subnet = ARGV.shift)
+  puts "expected src_private_subnet as argument"
+  exit 1
+end
+
+unless (dest_vm_name = ARGV.shift)
+  puts "expected dest_vm_name as argument"
+  exit 1
+end
+
+unless (dest_ephemeral_net6 = ARGV.shift)
+  puts "expected dest_ephemeral_net6 as argument"
+  exit 1
+end
+
+unless (dest_private_subnet = ARGV.shift)
+  puts "expected dest_private_subnet as argument"
+  exit 1
+end
+
+unless (spi = ARGV.shift)
+  puts "expected spi as argument"
+  exit 1
+end
+
+unless (security_key = ARGV.shift)
+  puts "expected security_key as argument"
+  exit 1
+end
+
+require_relative "../lib/common"
+require_relative "../lib/ipsec_tunnel"
+
+require "fileutils"
+require "netaddr"
+
+src_endpoint = IPSecTunnelEndpoint.new(src_vm_name, NetAddr.parse_net(src_ephemeral_net6), src_private_subnet)
+dest_endpoint = IPSecTunnelEndpoint.new(dest_vm_name, NetAddr.parse_net(dest_ephemeral_net6), dest_private_subnet)
+ipsec_tunnel = IPSecTunnel.new(src_endpoint, dest_endpoint, spi, security_key)
+
+case command
+when "setup_src"
+  ipsec_tunnel.setup_src
+when "setup_dst"
+  ipsec_tunnel.setup_dst
+else
+  puts "Unknown command: #{command}"
+end

--- a/rhizome/lib/ipsec_tunnel.rb
+++ b/rhizome/lib/ipsec_tunnel.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative "common"
+require_relative "vm_path"
+require "netaddr"
+
+IPSecTunnelEndpoint = Struct.new(:vm_name, :ephemeral_net6, :private_subnet) do
+  def clover_ephemeral
+    vp = VmPath.new(vm_name)
+    subnet = NetAddr::IPv6Net.parse(vp.read_clover_ephemeral)
+    subnet.network.to_s
+  end
+
+  def q_clover_ephemeral
+    @q_clover_ephemeral ||= clover_ephemeral.shellescape
+  end
+
+  def q_private_subnet
+    private_subnet.shellescape
+  end
+end
+
+class IPSecTunnel
+  def initialize(from_endpoint, to_endpoint, spi, security_key)
+    @from_endpoint = from_endpoint
+    @to_endpoint = to_endpoint
+    @security_key = security_key
+    @spi = spi
+  end
+
+  def setup_src
+    namespace = @from_endpoint.vm_name
+    # first delete any existing state & policy for idempotency
+    r(delete_state_command(namespace))
+    r(delete_policy_command(namespace, "out"))
+    r(add_state_command(namespace))
+    r(add_policy_command(namespace, "out"))
+  end
+
+  def setup_dst
+    namespace = @to_endpoint.vm_name
+    # first delete any existing state & policy for idempotency
+    r(delete_state_command(namespace))
+    r(delete_policy_command(namespace, "fwd"))
+    r(add_state_command(namespace))
+    r(add_policy_command(namespace, "fwd"))
+  end
+
+  def delete_state_command(namespace)
+    p "ip -n #{namespace.shellescape} xfrm state deleteall " \
+        "src #{@from_endpoint.q_clover_ephemeral} " \
+        "dst #{@to_endpoint.q_clover_ephemeral}"
+  end
+
+  def delete_policy_command(namespace, direction)
+    p "ip -n #{namespace.shellescape} xfrm policy deleteall " \
+        "src #{@from_endpoint.q_private_subnet} " \
+        "dst #{@to_endpoint.q_private_subnet} " \
+        "dir #{direction}"
+  end
+
+  def add_state_command(namespace)
+    p "ip -n #{namespace.shellescape} xfrm state add " \
+      "src #{@from_endpoint.q_clover_ephemeral} " \
+      "dst #{@to_endpoint.q_clover_ephemeral} " \
+      "proto esp " \
+      "spi #{@spi} reqid 1 mode tunnel " \
+      "aead 'rfc4106(gcm(aes))' #{@security_key.shellescape} 128"
+  end
+
+  def add_policy_command(namespace, direction)
+    p "ip -n #{namespace.shellescape} xfrm policy add " \
+      "src #{@from_endpoint.q_private_subnet} " \
+      "dst #{@to_endpoint.q_private_subnet} dir #{direction} " \
+      "tmpl src #{@from_endpoint.q_clover_ephemeral} " \
+      "dst #{@to_endpoint.q_clover_ephemeral} " \
+      "spi #{@spi} proto esp reqid 1 " \
+      "mode tunnel"
+  end
+end


### PR DESCRIPTION
Creates IPSec tunnels between the new vm and all other VMs on create.

To do this,
1. On rhizome side, introduces `rhizome/bin/setup-ipsec` which does the necessary setup to have a tunnel between two VMs.
2. Clover calls `rhizome/bin/setup-ipsec` to create missing tunnels when a VMs mesh is refreshed
3. After a VM is created, we signal the refresh_mesh semaphore for all VMs.

TODO: We will revisit this future, to create a mechanism to achieve:

* Ability to gracefully rotate keys, in two phases (using spi and/or reqid and policy changes)
* Use as few SSH sessions as possible (consecutive cmds are cheapin a thread thanks to caching).
* Being able to batch processing reasonably.
* Allowing re-resynchronization of vmhost ip xfrm state without micromanagement of ultra-fine records in the database to address
  abnormalities or development needs.
* Solve the concurrency issues with Vm.each {} with overlapping transaction snapshots to make sure we don't miss VMs that get
  created.