### PR TITLE
Do not wrap long YAML strings

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -29,7 +29,7 @@ class VmSetup
     #
     # > YAML.dump('NO')[4..-2]
     # => "'NO'"
-    YAML.dump(s)[4..-2]
+    YAML.dump(s, line_width: -1)[4..-2]
   end
 
   def vp


### PR DESCRIPTION
Default line width is 80. YAML emitter wraps string and it causes problem with SSH public keys. "line_width: -1" means no wrapping.