### PR TITLE
Alter README.md and overwrite_envrb to produce a better tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,19 +288,20 @@ If you ran `overwrite_envrb`, it generates a file that's prone to
 correction by RuboCop:
 
     $ bundle exec rubocop -a
-    Inspecting 46 files
-    C.............................................
+    Inspecting 68 files
+    C...................................................................
 
     Offenses:
 
-    .env.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-    case ENV["RACK_ENV"] ||= "development"
-    ^
-    .env.rb:2:1: C: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
-    case ENV["RACK_ENV"] ||= "development"
-    ^
+    .env.rb:6:34: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
+      ENV["CLOVER_DATABASE_URL"] ||= 'postgres:///clover_test?user=clover'
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    46 files inspected, 2 offenses detected, 2 offenses corrected
+    68 files inspected, 1 offense detected, 1 offense corrected
+
+Some useful corrections are only made with `bundle exec rubocop -A`
+(upper case `A`) which applies "unsafe" corrections that may alter the
+semantics of the program.
 
 ### Running the migrations
 

--- a/Rakefile
+++ b/Rakefile
@@ -82,10 +82,12 @@ task :overwrite_envrb do
   require "securerandom"
 
   File.write(".env.rb", <<ENVRB)
+# frozen_string_literal: true
+
 case ENV["RACK_ENV"] ||= "development"
 when "test"
   ENV["CLOVER_SESSION_SECRET"] ||= "#{SecureRandom.base64(64)}"
-  ENV["CLOVER_DATABASE_URL"] ||= "postgres:///clover_test?user=clover"
+  ENV["CLOVER_DATABASE_URL"] ||= 'postgres:///clover_test?user=clover'
   ENV["CLOVER_COLUMN_ENCRYPTION_KEY"] ||= "#{SecureRandom.base64(32)}"
 else
   ENV["CLOVER_SESSION_SECRET"] ||= "#{SecureRandom.base64(64)}"


### PR DESCRIPTION
This bug was introduced by 73350398634936c4fb2d4fead5c31ab3357cf5da: `frozen_string_literal` corrections are "unsafe" and so do not get automatically corrected by RuboCop.

Alas, it's a very useful correction, so README has to teach the reader about `-A` and `-a`.