### PR TITLE
Improve erb-formatter integration into the development process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         ruby-version: .tool-versions
         bundler-cache: true
 
+    - name: Run erb-formatter
+      run: |
+        bundle exec erb-format views/**/*.erb --write --print-width 120
+        git diff --exit-code
+
     - name: Run rubocop
       run: bundle exec rubocop
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,10 @@ Style/FrozenStringLiteralComment:
 Layout/HeredocIndentation:
   Enabled: false
 
+Layout/SpaceInsideHashLiteralBraces:
+  Exclude:
+    - 'views/**/*.erb'
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "zeitwerk"
 gem "warning"
 
 group :development do
-  gem "erb-formatter"
+  gem "erb-formatter", github: "fdr/erb-formatter", ref: "5ecacb2cd5544a41de969bc86b57a98523f0ce06"
   gem "pry"
   gem "pry-byebug"
   gem "rackup"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/fdr/erb-formatter.git
+  revision: 5ecacb2cd5544a41de969bc86b57a98523f0ce06
+  ref: 5ecacb2cd5544a41de969bc86b57a98523f0ce06
+  specs:
+    erb-formatter (0.4.2)
+      syntax_tree (~> 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -49,8 +57,6 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     ed25519 (1.3.0)
-    erb-formatter (0.4.3)
-      syntax_tree (~> 6.0)
     erubi (1.12.0)
     ffi (1.15.5)
     ffi-compiler (1.0.1)
@@ -83,6 +89,10 @@ GEM
       net-protocol
     net-ssh (7.1.0)
     netaddr (2.0.6)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -186,7 +196,7 @@ GEM
       language_server-protocol (~> 3.17.0.2)
       rubocop (~> 1.48.1)
       rubocop-performance (~> 1.16.0)
-    syntax_tree (6.1.1)
+    syntax_tree (5.3.0)
       prettier_print (>= 1.2.0)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -200,6 +210,8 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-22
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -208,7 +220,7 @@ DEPENDENCIES
   capybara
   database_cleaner-sequel
   ed25519
-  erb-formatter
+  erb-formatter!
   erubi (>= 1.5)
   mail
   net-ssh

--- a/views/index.erb
+++ b/views/index.erb
@@ -28,8 +28,8 @@
   <h1>Overview</h1>
 
   <p>This is the demo site for
-    <a href="https://github.com/jeremyevans/rodauth">Rodauth</a>. Rodauth is an authentication and account management framework for rack
-    applications, with the following design goals:</p>
+    <a href="https://github.com/jeremyevans/rodauth">Rodauth</a>. Rodauth is an authentication and account management framework for rack applications, with the following design
+    goals:</p>
 
   <ol>
     <li>Security: Ship in a maximum security by default configuration</li>
@@ -40,7 +40,6 @@
   <p>It's easiest to get started by going to the
     <a href="/login">login page</a>.</p>
 
-  <p>This demo site is part of the Rodauth repository, so if you want to know
-    how it works, you can
+  <p>This demo site is part of the Rodauth repository, so if you want to know how it works, you can
     <a href="https://github.com/jeremyevans/rodauth/tree/master/demo-site">review the source</a>.</p>
 <% end %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -79,11 +79,7 @@
         <% if rodauth.logged_in? %>
           <form action="/logout" class="navbar-form pull-right" method="post">
             <%== csrf_tag("/logout") %>
-            <input
-              class="btn btn-primary form-control auth-button"
-              type="submit"
-              value="Logout"
-            />
+            <input class="btn btn-primary form-control auth-button" type="submit" value="Logout"/>
           </form>
         <% end %>
       </div>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -3,13 +3,7 @@
   <%== csrf_tag("/vm/create") %>
   <div class="form-group">
     <label for="name">Name</label>
-    <input
-      type="text"
-      class="form-control"
-      id="name"
-      name="name"
-      placeholder="Enter name"
-    >
+    <input type="text" class="form-control" id="name" name="name" placeholder="Enter name">
   </div>
   <div class="form-group">
     <label for="size">Size</label>
@@ -29,24 +23,11 @@
   </div>
   <div class="form-group">
     <label for="user">User</label>
-    <input
-      type="text"
-      class="form-control"
-      id="user"
-      name="user"
-      placeholder="unix user"
-      value="ubi"
-    >
+    <input type="text" class="form-control" id="user" name="user" placeholder="unix user" value="ubi">
   </div>
   <div class="form-group">
     <label for="public-key">SSH Public Key</label>
-    <input
-      type="text"
-      class="form-control"
-      id="public-key"
-      name="public-key"
-      placeholder="ssh-ed25519 AAAA..."
-    >
+    <input type="text" class="form-control" id="public-key" name="public-key" placeholder="ssh-ed25519 AAAA...">
   </div>
   <div class="form-group">
     <label for="size">Boot Image</label>


### PR DESCRIPTION
Add it to CI and switch to a branch that does not use multi-line class attributes, to be less verbose when working with "utility" CSS frameworks.

A slight change is made to rubocop rules not out of style preference, but because erb-formatter and rubocop disagree on code formatting on at least this one minor point.  This patch opts to let erb-formatter have it for simplicity reasons.