### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{md}]
+indent_size = 4
+
+[*.{rb,erb,js}]
+indent_size = 2


### PR DESCRIPTION
This can avoid some hassles with e.g. newline termination with some editors, though substantially we rely on non-interactive code-formatters like rubocop.