### PR TITLE
Extract UI form elements as component

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -12,17 +12,6 @@ $(".toggle-mobile-menu").on("click", function (event) {
     }
 });
 
-$(".radio-small-cards input[type=radio]").on("change", function (event) {
-    let name = $(this).attr("name");
-    $(`#${name}-radios label`)
-        .addClass("ring-1 ring-inset ring-gray-300 bg-white text-gray-900 hover:bg-gray-50")
-        .removeClass("ring-2 ring-indigo-600 ring-offset-2 bg-indigo-600 text-white hover:bg-indigo-500");
-    $(this)
-        .parent()
-        .removeClass("ring-1 ring-inset ring-gray-300 bg-white text-gray-900 hover:bg-gray-50")
-        .addClass("ring-2 ring-indigo-600 ring-offset-2 bg-indigo-600 text-white hover:bg-indigo-500");
-});
-
 $(".radio-stacked-cards input[type=radio]").on("change", function (event) {
     let name = $(this).attr("name");
     $(`#${name}-radios label`).removeClass("border-indigo-600 ring-2 ring-indigo-600");
@@ -45,12 +34,13 @@ $(".delete-btn").on("click", function (event) {
     let url = $(this).data("url");
     let csrf = $(this).data("csrf");
     let confirmation = $(this).data("confirmation");
+    let redirect = $(this).data("redirect");
 
     if (!confirm("Are you sure to delete?")) {
         return;
     }
 
-    if (confirmation && prompt("Please enter resource name to confirm deletion", "") != confirmation) {
+    if (confirmation && prompt(`Please type "${confirmation}" to confirm deletion`, "") != confirmation) {
         alert("Could not confirm resource name");
         return;
     }
@@ -60,7 +50,7 @@ $(".delete-btn").on("click", function (event) {
         type: 'DELETE',
         data: { '_csrf': csrf },
         success: function (result) {
-            window.location.href = "/vm";
+            window.location.href = redirect;
         },
         error: function (xhr, ajaxOptions, thrownError) {
             alert(`Error: ${thrownError}`);
@@ -72,7 +62,10 @@ $(".copy-content").on("click", function (event) {
     let content = $(this).data("content");
     let message = $(this).data("message");
     navigator.clipboard.writeText(content);
-    notification(message);
+
+    if (message) {
+        notification(message);
+    }
 })
 
 $(".back-btn").on("click", function (event) {

--- a/views/auth/create_account.erb
+++ b/views/auth/create_account.erb
@@ -5,48 +5,45 @@
 <form class="rodauth space-y-6" role="form" method="POST">
   <%== rodauth.csrf_tag %>
   <%== render("components/flash_message") %>
-  <div>
-    <label for="email" class="block text-sm font-medium leading-6 text-gray-900">Email address</label>
-    <div class="mt-2">
-      <input
-        id="email"
-        name="login"
-        type="email"
-        autocomplete="email"
-        required
-        class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-      >
-    </div>
-  </div>
+  <%== render(
+    "components/form/text",
+    locals: {
+      name: "login",
+      type: "email",
+      label: "Email address",
+      attributes: {
+        required: true,
+        autocomplete: "email"
+      }
+    }
+  ) %>
 
   <% if rodauth.create_account_set_password? %>
-    <div>
-      <label for="password" class="block text-sm font-medium leading-6 text-gray-900">Password</label>
-      <div class="mt-2">
-        <input
-          id="password"
-          name="password"
-          type="password"
-          autocomplete="current-password"
-          required
-          class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-        >
-      </div>
-    </div>
+    <%== render(
+      "components/form/text",
+      locals: {
+        name: "password",
+        type: "password",
+        label: "Password",
+        attributes: {
+          required: true,
+          autocomplete: "current-password"
+        }
+      }
+    ) %>
     <% if rodauth.require_password_confirmation? %>
-      <div>
-        <label for="password-confirm" class="block text-sm font-medium leading-6 text-gray-900">Password Confirmation</label>
-        <div class="mt-2">
-          <input
-            id="password-confirm"
-            name="password-confirm"
-            type="password"
-            autocomplete="current-password"
-            required
-            class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-          >
-        </div>
-      </div>
+      <%== render(
+        "components/form/text",
+        locals: {
+          name: "password-confirm",
+          type: "password",
+          label: "Password Confirmation",
+          attributes: {
+            required: true,
+            autocomplete: "current-password"
+          }
+        }
+      ) %>
     <% end %>
   <% end %>
 

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -5,33 +5,32 @@
 <form class="rodauth space-y-6" role="form" method="POST">
   <%== rodauth.csrf_tag %>
   <%== render("components/flash_message") %>
-  <div>
-    <label for="email" class="block text-sm font-medium leading-6 text-gray-900">Email address</label>
-    <div class="mt-2">
-      <input
-        id="email"
-        name="login"
-        type="email"
-        autocomplete="email"
-        required
-        class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-      >
-    </div>
-  </div>
 
-  <div>
-    <label for="password" class="block text-sm font-medium leading-6 text-gray-900">Password</label>
-    <div class="mt-2">
-      <input
-        id="password"
-        name="password"
-        type="password"
-        autocomplete="current-password"
-        required
-        class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-      >
-    </div>
-  </div>
+  <%== render(
+    "components/form/text",
+    locals: {
+      name: "login",
+      type: "email",
+      label: "Email address",
+      attributes: {
+        required: true,
+        autocomplete: "email"
+      }
+    }
+  ) %>
+
+  <%== render(
+    "components/form/text",
+    locals: {
+      name: "password",
+      type: "password",
+      label: "Password",
+      attributes: {
+        required: true,
+        autocomplete: "current-password"
+      }
+    }
+  ) %>
 
   <div class="flex items-center justify-between">
     <div class="flex items-center">

--- a/views/auth/verify_account.erb
+++ b/views/auth/verify_account.erb
@@ -7,33 +7,31 @@
   <%== render("components/flash_message") %>
 
   <% if rodauth.verify_account_set_password? %>
-    <div>
-      <label for="password" class="block text-sm font-medium leading-6 text-gray-900">Password</label>
-      <div class="mt-2">
-        <input
-          id="password"
-          name="password"
-          type="password"
-          autocomplete="current-password"
-          required
-          class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-        >
-      </div>
-    </div>
+    <%== render(
+      "components/form/text",
+      locals: {
+        name: "password",
+        type: "password",
+        label: "Password",
+        attributes: {
+          required: true,
+          autocomplete: "current-password"
+        }
+      }
+    ) %>
     <% if rodauth.require_password_confirmation? %>
-      <div>
-        <label for="password-confirm" class="block text-sm font-medium leading-6 text-gray-900">Password Confirmation</label>
-        <div class="mt-2">
-          <input
-            id="password-confirm"
-            name="password-confirm"
-            type="password"
-            autocomplete="current-password"
-            required
-            class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-          >
-        </div>
-      </div>
+      <%== render(
+        "components/form/text",
+        locals: {
+          name: "password-confirm",
+          type: "password",
+          label: "Password Confirmation",
+          attributes: {
+            required: true,
+            autocomplete: "current-password"
+          }
+        }
+      ) %>
     <% end %>
   <% end %>
 

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -1,0 +1,41 @@
+<% name = defined?(name) ? name : nil %>
+<% label = defined?(label) ? label : nil %>
+<% options = (defined?(options) && options) ? options : {} %>
+<% selected = defined?(selected) ? selected : nil %>
+<% error = defined?(error) ? error : flash.dig("errors", name) %>
+<% description = defined?(description) ? description : nil %>
+<% attributes = defined?(attributes) ? attributes : {} %>
+
+<div class="space-y-2">
+  <label for="<%= name %>" class="text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+  <fieldset class="radio-small-cards" id="<%= name %>-radios">
+    <legend class="sr-only"><%= label %></legend>
+    <div class="grid gap-3 grid-cols-1 sm:grid-cols-3 lg:grid-cols-4">
+      <% options.each do |opt_val, opt_text| %>
+        <label>
+          <input
+            type="radio"
+            name="<%= name %>"
+            value="<%= opt_val %>"
+            class="peer sr-only"
+            <%= (opt_val == selected) ? "checked" : "" %>
+            <% attributes.each do |key, value| %>
+            <%= key %>="<%= value %>"
+            <% end%>
+          >
+          <span
+            class="flex items-center justify-center rounded-md py-3 px-3 text-sm font-semibold sm:flex-1 cursor-pointer focus:outline-none
+              ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
+              peer-focus-visible:ring-2 peer-focus-visible:ring-indigo-600 peer-focus-visible:ring-offset-2 peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:hover:bg-indigo-500"
+          ><%= opt_text %></span>
+        </label>
+      <% end %>
+    </div>
+  </fieldset>
+  <% if error %>
+    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
+  <% end %>
+  <% if description %>
+    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%= description %></p>
+  <% end %>
+</div>

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -1,0 +1,25 @@
+<% name = defined?(name) ? name : nil %>
+<% label = defined?(label) ? label : nil %>
+<% type = (defined?(type) && type) ? type : "text" %>
+<% error = defined?(error) ? error : flash.dig("errors", name) %>
+<% description = defined?(description) ? description : nil %>
+<% attributes = defined?(attributes) ? attributes : {} %>
+
+<div class="space-y-2">
+  <label for="<%= name %>" class="block text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+  <input
+    id="<%= name %>"
+    type="<%= type %>"
+    name="<%= name %>"
+    class="block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-indigo-600"%>"
+    <% attributes.each do |key, value| %>
+    <%= key %>="<%= value %>"
+    <% end%>
+  >
+  <% if error %>
+    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
+  <% end %>
+  <% if description %>
+    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%= description %></p>
+  <% end %>
+</div>

--- a/views/components/form/textarea.erb
+++ b/views/components/form/textarea.erb
@@ -1,0 +1,23 @@
+<% name = defined?(name) ? name : nil %>
+<% label = defined?(label) ? label : nil %>
+<% error = defined?(error) ? error : flash.dig("errors", name) %>
+<% description = defined?(description) ? description : nil %>
+<% attributes = defined?(attributes) ? attributes : {} %>
+
+<div class="space-y-2">
+  <label for="<%= name %>" class="block text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+  <textarea
+    id="<%= name %>"
+    name="<%= name %>"
+    class="block w-full rounded-md border-0 sm:py-1.5 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-indigo-600"%>"
+    <% attributes.each do |key, value| %>
+    <%= key %>="<%= value %>"
+    <% end%>
+  ></textarea>
+  <% if error %>
+    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
+  <% end %>
+  <% if description %>
+    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%= description %></p>
+  <% end %>
+</div>

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -1,0 +1,18 @@
+<% case state %>
+  <% when "running" %>
+    <% color = "bg-green-100 text-green-800" %>
+    <% when "creating" %>
+      <% color = "bg-yellow-100 text-yellow-800" %>
+    <% else %>
+      <% color = "bg-slate-100 text-slate-800" %>
+    <% end %>
+    <% extra_class = defined?(extra_class) ? extra_class : nil %>
+
+    <span
+      class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>"
+    >
+      <svg class="mr-1.5 h-2 w-2" fill="currentColor" viewBox="0 0 8 8">
+        <circle cx="4" cy="4" r="3"/>
+      </svg>
+      <%= state %>
+    </span>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -18,34 +18,31 @@
                 <h2 class="text-base font-semibold leading-7 text-gray-900">Details</h2>
                 <p class="mt-1 text-sm leading-6 text-gray-600">Enter details for your virtual machine.</p>
                 <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-                  <div class="sm:col-span-4">
-                    <label for="name" class="block text-sm font-medium leading-6 text-gray-900">Name</label>
-                    <input
-                      type="text"
-                      name="name"
-                      id="name"
-                      class="mt-2 block sm:max-w-md rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                      placeholder="Enter Name"
-                      required
-                    >
+                  <div class="sm:col-span-2">
+                    <%== render(
+                      "components/form/text",
+                      locals: {
+                        name: "name",
+                        label: "Name",
+                        attributes: {
+                          required: true,
+                          placeholder: "Enter name"
+                        }
+                      }
+                    ) %>
                   </div>
                   <div class="col-span-full">
-                    <div class="flex items-center justify-between">
-                      <h2 class="text-sm font-medium leading-6 text-gray-900">Location</h2>
-                    </div>
-                    <fieldset class="mt-2 radio-small-cards" id="location-radios">
-                      <legend class="sr-only">Choose a location option</legend>
-                      <div class="grid gap-3 grid-cols-1 sm:grid-cols-3 lg:grid-cols-4">
-                        <% Option::Locations.each do |location| %>
-                          <label
-                            class="flex items-center justify-center rounded-md py-3 px-3 text-sm font-semibold sm:flex-1 cursor-pointer focus:outline-none ring-1 ring-inset ring-gray-300 bg-white text-gray-900 hover:bg-gray-50"
-                          >
-                            <input type="radio" name="location" value="<%= location.name %>" class="sr-only" required>
-                            <span><%= location.display_name %></span>
-                          </label>
-                        <% end %>
-                      </div>
-                    </fieldset>
+                    <%== render(
+                      "components/form/radio_small_cards",
+                      locals: {
+                        name: "location",
+                        label: "Location",
+                        options: Option::Locations.to_h { |l| [l.name, l.display_name] },
+                        attributes: {
+                          required: true
+                        }
+                      }
+                    ) %>
                   </div>
                   <div class="col-span-full">
                     <div class="flex items-center justify-between">
@@ -82,57 +79,54 @@
 
                   </div>
                   <div class="col-span-full">
-                    <div class="flex items-center justify-between">
-                      <h2 class="text-sm font-medium leading-6 text-gray-900">Boot Image</h2>
-                    </div>
-                    <fieldset class="mt-2 radio-small-cards" id="boot-image-radios">
-                      <legend class="sr-only">Choose a image option</legend>
-                      <div class="grid gap-3 grid-cols-1 sm:grid-cols-3 lg:grid-cols-4">
-                        <% Option::BootImages.each do |image| %>
-                          <label
-                            class="flex items-center justify-center rounded-md py-3 px-3 text-sm font-semibold sm:flex-1 cursor-pointer focus:outline-none ring-1 ring-inset ring-gray-300 bg-white text-gray-900 hover:bg-gray-50"
-                          >
-                            <input type="radio" name="boot-image" value="<%= image.name %>" class="sr-only" required>
-                            <span><%= image.display_name %></span>
-                          </label>
-                        <% end %>
-                      </div>
-                    </fieldset>
+                    <%== render(
+                      "components/form/radio_small_cards",
+                      locals: {
+                        name: "boot-image",
+                        label: "Boot Image",
+                        options: Option::BootImages.to_h { |bi| [bi.name, bi.display_name] },
+                        attributes: {
+                          required: true
+                        }
+                      }
+                    ) %>
                   </div>
                 </div>
               </div>
-
               <div class="border-b border-gray-900/10 pb-12">
                 <h2 class="text-base font-semibold leading-7 text-gray-900">Login Information</h2>
                 <p class="mt-1 text-sm leading-6 text-gray-600">This information will be used to login virtual machine.</p>
 
                 <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-                  <div class="sm:col-span-4">
-                    <label for="user" class="block text-sm font-medium leading-6 text-gray-900">User</label>
-                    <input
-                      type="text"
-                      name="user"
-                      id="user"
-                      class="mt-2 block sm:max-w-md rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                      placeholder="Unix username"
-                      value="ubi"
-                      required
-                    >
+                  <div class="sm:col-span-2">
+                    <%== render(
+                      "components/form/text",
+                      locals: {
+                        name: "user",
+                        label: "User",
+                        attributes: {
+                          required: true,
+                          placeholder: "Unix username",
+                          value: "ubi"
+                        }
+                      }
+                    ) %>
                   </div>
 
                   <div class="col-span-full">
-                    <label for="about" class="block text-sm font-medium leading-6 text-gray-900">SSH Public Key</label>
-                    <div class="mt-2">
-                      <textarea
-                        id="public-key"
-                        name="public-key"
-                        rows="3"
-                        class="block w-full rounded-md border-0 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:py-1.5 sm:text-sm sm:leading-6"
-                        placeholder="ssh-ed25519 AAAA.."
-                        required
-                      ></textarea>
-                    </div>
-                    <p class="mt-3 text-sm leading-6 text-gray-600">SSH keys are a more secure method of logging into a server.</p>
+                    <%== render(
+                      "components/form/textarea",
+                      locals: {
+                        name: "public-key",
+                        label: "SSH Public Key",
+                        description: "SSH keys are a more secure method of logging into a server.",
+                        attributes: {
+                          required: true,
+                          placeholder: "ssh-ed25519 AAAA...",
+                          rows: 3
+                        }
+                      }
+                    ) %>
                   </div>
                 </div>
               </div>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -35,11 +35,7 @@
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm.location %></td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm.size %></td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      <span
-                        class="inline-flex rounded-full <%= (vm.state == "running") ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800" %> px-2 text-xs font-semibold leading-5"
-                      >
-                        <%= vm.state %>
-                      </span>
+                      <%== render("components/vm_state_label", locals: { state: vm.state }) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <span class="copy-content cursor-pointer" data-content="<%= vm.ip6 %>" data-message="Copied IPv6">

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -7,9 +7,7 @@
       "components/page_header",
       locals: {
         title: @vm.name,
-        right_items: [
-          "<span class='inline-flex items-center rounded-full px-3 py-0.5 text-md font-medium #{(@vm.state == "running") ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800"}'>#{@vm.state}</span>"
-        ]
+        right_items: [render("components/vm_state_label", locals: { state: @vm.state, extra_class: "text-md" })]
       }
     ) %>
   </div>
@@ -63,6 +61,7 @@
                   data-url="<%= request.path %>"
                   data-csrf="<%= csrf_token(request.path, "DELETE") %>"
                   data-confirmation="<%= @vm.name %>"
+                  data-redirect="/vm"
                   class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
                 >
                   <svg class="-ml-0.5 mr-1.5 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">


### PR DESCRIPTION
Form elements such as text input, textarea, radio are used in different places at UI. Copying all HTML structure and CSS classes again and again makes it harder to maintain. New partials can be used with a few arguments. Also we can add more functionality to them. For example when you put a error message to `flash["errors"]["name"]`, it shows error below name input. Another example, `radio_small_cards` accepts options as hash, it makes this component very useful.

Tailwind docs recommends extract components too.
https://tailwindcss.com/docs/reusing-styles#extracting-components-and-partials