### PR TITLE
Load pg_enum correctly in migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ migrate = lambda do |env, version|
   require "logger"
   require "sequel"
   Sequel.extension :migration
+  DB.extension :pg_enum
 
   DB.loggers << Logger.new($stdout) if DB.loggers.empty?
   Sequel::Migrator.apply(DB, "migrate", version)

--- a/migrate/001_tables.rb
+++ b/migrate/001_tables.rb
@@ -2,8 +2,6 @@
 
 Sequel.migration do
   change do
-    extension :pg_enum
-
     create_enum(:allocation_state, %w[unprepared accepting draining])
 
     create_table(:strand) do

--- a/migrate/004_add_vm_display.rb
+++ b/migrate/004_add_vm_display.rb
@@ -2,7 +2,6 @@
 
 Sequel.migration do
   change do
-    extension :pg_enum
     create_enum(:vm_display_state, %w[creating running])
 
     alter_table(:vm_host) do


### PR DESCRIPTION
`rake dev_down` fails with below

    Sequel::Error: irreversible migration method used in
    migrate/004_add_vm_display.rb, you may need to write your own down
    method

To use `create_enum` in a reversible migration, migration extension should loaded before `change`. Migration `change` blocks can't handle `extension` calls.

Issue: https://github.com/jeremyevans/sequel/issues/1579