### PR TITLE
Add brakeman for security vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
     - name: Run rubocop
       run: bundle exec rubocop
 
+    - name: Run brakeman
+      run: bundle exec brakeman --force -Aq
+
     - name: Apply migrations
       env:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "zeitwerk"
 gem "warning"
 
 group :development do
+  gem "brakeman"
   gem "erb-formatter", github: "fdr/erb-formatter", ref: "5ecacb2cd5544a41de969bc86b57a98523f0ce06"
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
+    brakeman (5.4.1)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.39.0)
@@ -217,6 +218,7 @@ PLATFORMS
 DEPENDENCIES
   argon2
   bcrypt_pbkdf
+  brakeman
   capybara
   database_cleaner-sequel
   ed25519


### PR DESCRIPTION
Brakeman is a static analysis tool which checks for security vulnerabilities. It works better with Rail applications. It helps to catch some fundamental issues such as SQL injection. It was mandatory for Ruby projects at Microsoft.