### PR TITLE
Remove pricing from UI and make some UI improvements

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -77,16 +77,6 @@ $(".back-btn").on("click", function (event) {
     history.back();
 })
 
-// Show price change for demo
-$("#location-radios input[type=radio]").on("change", function (event) {
-    let location = $(this).val();
-    $('#size-radios .size-price').each(function (i, obj) {
-        let prices = $(this).data("prices");
-        let price = prices[location] || prices["default"]
-        $(this).text(`$${price.toFixed(2)}`)
-    });
-});
-
 function notification(message) {
     let container = $("#notification-template").parent();
     let newNotification = $("#notification-template").clone();

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -3,7 +3,7 @@
 module Option
   Location = Struct.new(:name, :display_name)
   BootImage = Struct.new(:name, :display_name)
-  VmSize = Struct.new(:name, :display_name, :vcpu, :memory, :disk, :prices)
+  VmSize = Struct.new(:name, :display_name, :vcpu, :memory, :disk)
 
   Locations = [
     ["hetzner-hel1", "Hetzner Helsinki"],
@@ -21,9 +21,9 @@ module Option
   ].map { |args| BootImage.new(*args) }.freeze
 
   VmSizes = [
-    ["standard-1", "Standard 1", 1, 2, 160, {default: 8}],
-    ["standard-2", "Standard 2", 2, 4, 256, {default: 16, "hetzner-nbg1": 20}],
-    ["standard-3", "Standard 3", 4, 8, 512, {default: 32}],
-    ["standard-4", "Standard 4", 8, 16, 512, {default: 64}]
+    ["standard-1", "Standard 1", 1, 2, 160],
+    ["standard-2", "Standard 2", 2, 4, 256],
+    ["standard-3", "Standard 3", 4, 8, 512],
+    ["standard-4", "Standard 4", 8, 16, 512]
   ].map { |args| VmSize.new(*args) }.freeze
 end

--- a/routes/object_storage.rb
+++ b/routes/object_storage.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Clover
+  hash_branch("object-storage") do |r|
+    r.get true do
+      view content: render("components/page_header", locals: {title: "This service is under development"})
+    end
+  end
+end

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -10,7 +10,7 @@
   <label for="<%= name %>" class="text-sm font-medium leading-6 text-gray-900"><%= label %></label>
   <fieldset class="radio-small-cards" id="<%= name %>-radios">
     <legend class="sr-only"><%= label %></legend>
-    <div class="grid gap-3 grid-cols-1 sm:grid-cols-3 lg:grid-cols-4">
+    <div class="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
       <% options.each do |opt_val, opt_text| %>
         <label>
           <input

--- a/views/index.erb
+++ b/views/index.erb
@@ -6,11 +6,9 @@
   </div>
   <!-- Create Card -->
   <div class="mt-8 flow-root">
-    <div
-      class="divide-y divide-gray-200 overflow-hidden rounded-lg bg-gray-200 shadow sm:grid sm:grid-cols-2 sm:gap-px sm:divide-y-0"
-    >
+    <div class="gap-10 overflow-hidden grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 pb-5">
       <div
-        class="rounded-tl-lg rounded-tr-lg sm:rounded-tr-none group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+        class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
       >
         <div>
           <span class="inline-flex rounded-lg p-3 bg-teal-50 text-teal-700 ring-4 ring-white">
@@ -44,7 +42,7 @@
       </div>
 
       <div
-        class="sm:rounded-tr-lg group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+        class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
       >
         <div>
           <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white">
@@ -76,7 +74,9 @@
         </span>
       </div>
 
-      <div class="group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500">
+      <div
+        class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+      >
         <div>
           <span class="inline-flex rounded-lg p-3 bg-sky-50 text-sky-700 ring-4 ring-white">
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -108,7 +108,9 @@
         </span>
       </div>
 
-      <div class="group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500">
+      <div
+        class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+      >
         <div>
           <span class="inline-flex rounded-lg p-3 bg-yellow-50 text-yellow-700 ring-4 ring-white">
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -45,38 +45,36 @@
                     ) %>
                   </div>
                   <div class="col-span-full">
-                    <div class="flex items-center justify-between">
-                      <h2 class="text-sm font-medium leading-6 text-gray-900">Server size</h2>
-                    </div>
-                    <fieldset class="mt-2 radio-stacked-cards" id="size-radios">
-                      <div class="space-y-4">
-                        <% Option::VmSizes.each do |size| %>
-                          <label
-                            class="relative block cursor-pointer rounded-lg border bg-white px-6 py-4 shadow-sm focus:outline-none sm:flex sm:justify-between"
-                          >
-                            <input type="radio" name="size" value="<%= size.name %>" class="sr-only" required>
-                            <span class="flex items-center">
-                              <span class="flex flex-col text-sm">
-                                <span class="font-medium text-gray-900"><%= size.display_name %></span>
-                                <span class="text-gray-500">
-                                  <span class="block sm:inline"><%= size.memory %>GB /
-                                    <%= size.vcpu %>
-                                    CPUs</span>
-                                  <span class="hidden sm:mx-1 sm:inline" aria-hidden="true">&middot;</span>
-                                  <span class="block sm:inline"><%= size.disk %>GB SSD disk</span>
+                    <div class="space-y-2">
+                      <label for="size" class="text-sm font-medium leading-6 text-gray-900">Server size</label>
+                      <fieldset class="radio-small-cards" id="size-radios">
+                        <legend class="sr-only">Server size</legend>
+                        <div class="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 xl:grid-cols-4">
+                          <% Option::VmSizes.each do |size| %>
+                            <label>
+                              <input type="radio" name="size" value="<%= size.name %>" class="peer sr-only" required>
+                              <span
+                                class="flex items-center rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
+                                ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
+                                peer-focus-visible:ring-2 peer-focus-visible:ring-indigo-600 peer-focus-visible:ring-offset-2 peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:hover:bg-indigo-500"
+                              >
+                                <span class="flex flex-col">
+                                  <span class="text-md font-semibold"><%= size.display_name %></span>
+                                  <span class="text-sm opacity-80">
+                                    <span class="block sm:inline"><%= size.vcpu %>
+                                      vCPUs /
+                                      <%= size.memory %>
+                                      GB /
+                                      <%= size.disk %>
+                                      GB SSD</span>
+                                  </span>
                                 </span>
                               </span>
-                            </span>
-                            <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
-                              <span class="size-price font-medium text-gray-900" data-prices="<%= size.prices.to_json %>">-</span>
-                              <span class="ml-1 text-gray-500 sm:ml-0">/mo</span>
-                            </span>
-                            <span class="pointer-events-none absolute -inset-px rounded-lg border-2" aria-hidden="true"></span>
-                          </label>
-                        <% end %>
-                      </div>
-                    </fieldset>
-
+                            </label>
+                          <% end %>
+                        </div>
+                      </fieldset>
+                    </div>
                   </div>
                   <div class="col-span-full">
                     <%== render(


### PR DESCRIPTION
We don't need pricing on UI until we really charge users. We added it just for demo video.

Small UI improvements
* Rename "CPUs" to "vCPUs"
* Make dashboard buttons look like more button
* Add under development text to object storage

Fixes some items https://github.com/ubicloud/clover/issues/60

<img width="1676" alt="Screen Shot 2023-04-13 at 16 39 08" src="https://user-images.githubusercontent.com/993199/231776658-0cdbe008-8c85-4301-b8b3-9f43d1c62541.png">
<img width="1690" alt="Screen Shot 2023-04-13 at 16 39 43" src="https://user-images.githubusercontent.com/993199/231776811-9346dfd3-4a4d-49e2-a276-a21c50c527ee.png">
<img width="1297" alt="Screen Shot 2023-04-13 at 16 40 00" src="https://user-images.githubusercontent.com/993199/231776900-d5ca4a45-5283-42f8-a76a-4f7567b07eca.png">
