### PR TITLE
Learn VmHost core and memory quantities during prep

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -71,7 +71,7 @@ class Clover < Roda
     end
   else
     def self.freeze
-      Sequel::Model.freeze_descendents
+      Sequel::Model.freeze_descendents unless Config.test?
       DB.freeze
       super
     end

--- a/migrate/007_add_vmhost_sizes.rb
+++ b/migrate/007_add_vmhost_sizes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      add_column :total_mem_gib, Integer
+
+      # Standardize on lscpu nomenclature. "cpus" may also be
+      # "threads," "nodes" seems to closest to "dies."  "Socket" could
+      # also be rendered "package." "core" has no terminological
+      # variants.
+      add_column :total_sockets, Integer
+      add_column :total_nodes, Integer
+      add_column :total_cores, Integer
+      add_column :total_cpus, Integer
+    end
+  end
+end

--- a/prog/learn_cores.rb
+++ b/prog/learn_cores.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "json"
+
+class Prog::LearnCores < Prog::Base
+  def sshable
+    @sshable ||= Sshable[frame["sshable_id"]]
+  end
+
+  CpuTopology = Struct.new(:total_cpus, :total_cores, :total_nodes, :total_sockets, keyword_init: true)
+
+  def parse_count(s)
+    parsed = JSON.parse(s).fetch("cpus").map { |cpu|
+      [cpu.fetch("socket"), cpu.fetch("node"), cpu.fetch("core")]
+    }
+    cpus = parsed.count
+    sockets = parsed.map { |socket, _, _| socket }.uniq.count
+    nodes = parsed.map { |socket, node, _| [socket, node] }.uniq.count
+    cores = parsed.uniq.count
+
+    CpuTopology.new(total_cpus: cpus, total_cores: cores,
+      total_nodes: nodes, total_sockets: sockets)
+  end
+
+  def start
+    topo = parse_count(sshable.cmd("/usr/bin/lscpu -Jye"))
+    pop(**topo.to_h)
+  end
+end

--- a/prog/learn_memory.rb
+++ b/prog/learn_memory.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Prog::LearnMemory < Prog::Base
+  def sshable
+    @sshable ||= Sshable[frame["sshable_id"]]
+  end
+
+  def parse_sum(s)
+    s.each_line.filter_map do |line|
+      next unless line =~ /Size: (\d+) (\w+)/
+      # Fail noisily if unit is not in gigabytes
+      fail "BUG: unexpected dmidecode unit" unless $2 == "GB"
+      Integer($1)
+    end.sum
+  end
+
+  def start
+    # Use dmidecode to get an integral amount of system memory.
+    # Generally, there is a gigabyte or so less available to
+    # applications than installed as reported by /proc/meminfo.
+    #
+    # Thus, in practice we can't run VMs at 100% system size anyway,
+    # we'll have to leave padding, but to keep the ratios neat for the
+    # customer, we compute CPU memory allocation ratio against
+    # physical memory.
+    mem_gib = parse_sum(sshable.cmd("sudo /usr/sbin/dmidecode -t memory | fgrep Size:"))
+    pop mem_gib: mem_gib
+  end
+end

--- a/spec/model/spec_helper.rb
+++ b/spec/model/spec_helper.rb
@@ -4,6 +4,4 @@ ENV["RACK_ENV"] = "test"
 require_relative "../../model"
 raise "test database doesn't end with test" if DB.opts[:database] && !DB.opts[:database].end_with?("test")
 
-Sequel::Model.freeze_descendents
-
 require_relative "../spec_helper"

--- a/spec/prog/learn_cores_spec.rb
+++ b/spec/prog/learn_cores_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::LearnCores do
+  subject(:lc) { described_class.new(Strand.new(stack: [])) }
+
+  # Gin up a topologically complex processor to test summations.
+  let(:eight_thread_four_core_four_numa_two_socket) do
+    <<JSON
+{
+   "cpus": [
+      {
+         "cpu": 0,
+         "node": 0,
+         "socket": 0,
+         "core": 0,
+         "l1d:l1i:l2:l3": "0:0:0:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.0060
+      },{
+         "cpu": 1,
+         "node": 0,
+         "socket": 0,
+         "core": 0,
+         "l1d:l1i:l2:l3": "1:1:1:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.1600
+      },{
+         "cpu": 2,
+         "node": 1,
+         "socket": 0,
+         "core": 1,
+         "l1d:l1i:l2:l3": "2:2:2:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.0340
+      },{
+         "cpu": 3,
+         "node": 1,
+         "socket": 0,
+         "core": 1,
+         "l1d:l1i:l2:l3": "3:3:3:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.1680
+      },{
+         "cpu": 4,
+         "node": 2,
+         "socket": 1,
+         "core": 0,
+         "l1d:l1i:l2:l3": "0:0:0:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.0060
+      },{
+         "cpu": 5,
+         "node": 2,
+         "socket": 1,
+         "core": 0,
+         "l1d:l1i:l2:l3": "1:1:1:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.1600
+      },{
+         "cpu": 6,
+         "node": 3,
+         "socket": 1,
+         "core": 1,
+         "l1d:l1i:l2:l3": "2:2:2:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.0340
+      },{
+         "cpu": 7,
+         "node": 3,
+         "socket": 1,
+         "core": 1,
+         "l1d:l1i:l2:l3": "3:3:3:0",
+         "online": true,
+         "maxmhz": 4500.0000,
+         "minmhz": 800.0000,
+         "mhz": 800.1680
+      }
+   ]
+}
+JSON
+  end
+
+  describe "#start" do
+    it "exits, saving the number of cores" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("/usr/bin/lscpu -Jye").and_return(
+        eight_thread_four_core_four_numa_two_socket
+      )
+      expect(lc).to receive(:sshable).and_return(sshable)
+      expect(lc).to receive(:pop).with(total_sockets: 2, total_cores: 4, total_nodes: 4, total_cpus: 8)
+      lc.start
+    end
+  end
+
+  # YYY: clean up having to test these simple accessors for every
+  # prog, or worse yet, having to do with database access.
+  describe "#sshable" do
+    it "can load" do
+      lc.strand.stack = [{"sshable_id" => "abc"}]
+      expect(Sshable).to receive(:[]).with("abc")
+      lc.sshable
+    end
+  end
+end

--- a/spec/prog/learn_memory_spec.rb
+++ b/spec/prog/learn_memory_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::LearnMemory do
+  subject(:lm) { described_class.new(Strand.new(stack: [])) }
+
+  let(:four_units) do
+    <<EOS
+
+	Size: 16 GB
+	Size: 16 GB
+	Size: 16 GB
+	Size: 16 GB
+EOS
+  end
+
+  describe "#start" do
+    it "exits, saving the number of memory" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("sudo /usr/sbin/dmidecode -t memory | fgrep Size:").and_return(four_units)
+      expect(lm).to receive(:sshable).and_return(sshable)
+      expect(lm).to receive(:pop).with(mem_gib: 64)
+      lm.start
+    end
+  end
+
+  describe "#parse_sum" do
+    it "crashes if an unfamiliar unit is provided" do
+      expect {
+        lm.parse_sum(<<EOS)
+	Size: 16384 MB
+EOS
+      }.to raise_error RuntimeError, "BUG: unexpected dmidecode unit"
+    end
+  end
+
+  # YYY: clean up having to test these simple accessors for every
+  # prog, or worse yet, having to do with database access.
+  describe "#sshable" do
+    it "can load" do
+      lm.strand.stack = [{"sshable_id" => "abc"}]
+      expect(Sshable).to receive(:[]).with("abc")
+      lm.sshable
+    end
+  end
+end


### PR DESCRIPTION
This allows us to compute a memory to core ratio and then divvy up resources in proportion to that.  It also adds a field to record how many cores have already been allocated.

Here I experiment with using `exitval` for the first time.  Note how this decouples LearnMemory and LearnCores from VmHost: the data is passed out of the prog via the exitval, and could be used for any purpose or by any model.

We have no need for reuse of those at present, so normally I'd frown on what could be considered an aesthetic choice, but I'm still in the exploration phase on some of the core features of the Strand execution system and do not quite yet know what I'm doing with some of the constructs.  This is part of getting there.

The two new progs have 100% branch coverage, and achieving this was instructive.  It was mostly fine, though.

Alas, I have to relax Model freezing in test, to allow `expect` to function for something like `expect(Sshable).to receive(:[])`.