### PR TITLE
Allow zero-length naps to execute again immediately

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -92,7 +92,9 @@ SQL
       loop do
         ret = unsynchronized_run
         now = Time.now
-        if now > deadline || ret.is_a?(Prog::Base::Nap) || ret.is_a?(Prog::Base::Exit)
+        if now > deadline ||
+            (ret.is_a?(Prog::Base::Nap) && ret.seconds != 0) ||
+            ret.is_a?(Prog::Base::Exit)
           return ret
         end
       end


### PR DESCRIPTION
Although "sleep 0" has traditionally been a way for unix programs to advise a good time to yield execution, breaking the "run" loop does make `st.run 45` annoying with zero-length naps which are emitted from "donate" in multi-strand progs.

So go ahead and keep running instead.

I considered making this dependent on whether the session was a REPL or not, but I don't see the obvious harm of having this behavior in `bin/respirate` as well.