### PR TITLE
Add 10G of space to the root disk

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -205,6 +205,7 @@ EOS
     # Images are presumed to be atomically renamed into the path,
     # i.e. no partial images will be passed to qemu-image.
     r "qemu-img convert -p -f qcow2 -O raw #{image_path.shellescape} #{vp.q_boot_raw}"
+    r "truncate -s +10G #{vp.q_boot_raw}"
     FileUtils.chown @vm_name, @vm_name, vp.boot_raw
   end
 

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe VmSetup do
       end.and_yield
 
       expect(vs).to receive(:r).with("curl -L10 -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("truncate -s +10G /vm/test/boot.raw")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/ubuntu-jammy.qcow2 /vm/test/boot.raw")
 
       expect(FileUtils).to receive(:mv).with("/opt/ubuntu-jammy.qcow2.tmp", "/opt/ubuntu-jammy.qcow2")
@@ -37,6 +38,7 @@ RSpec.describe VmSetup do
 
     it "can use an image that's already downloaded" do
       expect(File).to receive(:exist?).with("/opt/almalinux-9.1.qcow2").and_return(true)
+      expect(vs).to receive(:r).with("truncate -s +10G /vm/test/boot.raw")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/almalinux-9.1.qcow2 /vm/test/boot.raw")
       expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/boot.raw")
       vs.boot_disk("almalinux-9.1")


### PR DESCRIPTION
The openSUSE image has very little extra space, I was easily running out trying to use `zypper` (the package manager) for some small programs. Increase the root block device size by 10G to make it more usable.  `cloud-init` grows the file system via `resize_rootfs`, typically set to `true` by default, including in openSUSE's case.