### PR TITLE
Use more stable approach for openSUSE Leap downloads

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -181,7 +181,7 @@ EOS
     urls = {
       "ubuntu-jammy" => "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img",
       "almalinux-9.1" => "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.1-20221118.x86_64.qcow2",
-      "opensuse-leap-15.4" => "https://mirror.dogado.de/opensuse/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-Minimal-VM.x86_64-15.4.0-OpenStack-Cloud-Build31.185.qcow2"
+      "opensuse-leap-15.4" => "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-Minimal-VM.x86_64-OpenStack-Cloud.qcow2"
     }
 
     download = urls.fetch(boot_image)
@@ -197,7 +197,7 @@ EOS
       # code longer term, but, that's not the plan.
       temp_path = image_path + ".tmp"
       File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
-        r "curl -o #{temp_path.shellescape} #{download.shellescape}"
+        r "curl -L10 -o #{temp_path.shellescape} #{download.shellescape}"
       end
       FileUtils.mv(temp_path, image_path)
     end

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe VmSetup do
         expect(path).to eq("/opt/ubuntu-jammy.qcow2.tmp")
       end.and_yield
 
-      expect(vs).to receive(:r).with("curl -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("curl -L10 -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/ubuntu-jammy.qcow2 /vm/test/boot.raw")
 
       expect(FileUtils).to receive(:mv).with("/opt/ubuntu-jammy.qcow2.tmp", "/opt/ubuntu-jammy.qcow2")


### PR DESCRIPTION
The openSUSE Leap download URL already broke because old builds are pulled down when new ones become available.  By following redirects, a more stable URL can be used instead.