### PR TITLE
Fix fragile tests for zero-length naps

### DIFF
--- a/prog/test.rb
+++ b/prog/test.rb
@@ -24,14 +24,14 @@ class Prog::Test < Prog::Base
     w = th[:clover_test_in]
     th.thread_variable_set(:clover_test_out, Thread.current)
     w.close
-    nap 0
+    pop "done"
   end
 
   def wait_exit
     th = Thread.list.find { _1.name == "clover_test" }
     r = th[:clover_test_in]
     r.read
-    nap 0
+    pop "done"
   end
 
   def hop_entry


### PR DESCRIPTION
This should have been a part of
f5b67140e44af5305248b8f49dbbb3c7127e0194, otherwise, the tests fail in non-deterministic fashion (as CI did succeed).

The tests were not designed for dispatcher to spin running the label in question multiple times because "nap 0" has become a loop, effectively, rather than interrupting execution as it was before, which was the point, to make running strands with "donate" which emits a zero-length nap more convenient.