### PR TITLE
Compile and install dnsmasq on host prep

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -112,7 +112,7 @@ end
   end
 
   def frame
-    strand.stack&.first
+    strand.stack&.first&.freeze
   end
 
   def retval

--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Prog::InstallDnsmasq < Prog::Base
+  subject_is :sshable
+
+  def start
+    # Handle some short, non-dependent steps concurrently, keeping
+    # overall code compact by self-budding and starting at a different
+    # label.
+    bud self.class, frame, :install_build_dependencies
+    bud self.class, frame, :git_clone_dnsmasq
+
+    hop :wait_downloads
+  end
+
+  def wait_downloads
+    reap
+    hop :compile_and_install if leaf?
+    donate
+  end
+
+  def compile_and_install
+    sshable.cmd("(cd dnsmasq && make -sj$(nproc) && sudo make install)")
+    pop "compiled and installed dnsmasq"
+  end
+
+  def install_build_dependencies
+    sshable.cmd("sudo apt-get -y install make gcc")
+    pop "installed build dependencies"
+  end
+
+  def git_clone_dnsmasq
+    sshable.cmd("git clone https://github.com/fdr/dnsmasq.git --depth=1 && " \
+                "(cd dnsmasq && git checkout aaba66efbd3b4e7283993ca3718df47706a8549b && git fsck --full)")
+    pop "downloaded and verified dnsmasq successfully"
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -30,6 +30,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnNetwork
     bud Prog::LearnMemory
     bud Prog::LearnCores
+    bud Prog::InstallDnsmasq
     hop :wait_prep
   end
 


### PR DESCRIPTION
As dnsmasq may offer a passable alternative to setting up separate DHCP, DNS (for some cases...), and IPv6 Router Advertisement infrastructure, I decided to integrate it into the stack.

As it turns out, I think we may want very new and possibly modified versions, so I wrote this prog to clone it from a copy of mine on GitHub, compile, and install it.

This prog does something new not seen in the code base: it buds *itself* to perform parallel steps, and multiple labels exit via `pop`.

This is an interesting pattern: the `Vm::HostNexus` is makes extensive use of small, supervised progs to maintain focus in the nexus file, but introduces some bloat in the process.  The `Vm::Nexus` takes the opposite extreme, doing no concurrency and being linear, using `hop` more extensively to chain things together, more akin to Clover's predecessors.

This does something new, with most of the compactness of `hop` but the concurrency of `bud.` And atop of that, it slots in neatly and concurrently with `Vm::HostNexus`, whose focus on smaller files and concurrency is looking better and better as it grows.  In doing so, it's our first Strand supervision chain that is thrice deep: `Vm::HostNexus`, supervising `InstallDnsmasq`, which in turn supervises copies of itself that start from a different label (in principle initial stacks could also be used to vary the entry point).

Todo:

- [ ] Test
- [ ] Has a point (dnsmasq/dhcp delivers an improvement to first-boot issue)