### PR TITLE
Add ssh TCP KeepAlive settings

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -32,6 +32,7 @@ class Sshable < Sequel::Model
     # Cache miss.
     sess = Net::SSH.start(host, "rhizome", non_interactive: true, timeout: 30,
       user_known_hosts_file: [], key_data: [private_key].compact,
+      keepalive: true, keepalive_interval: 3, keepalive_maxcount: 5,
       use_agent: Config.development?)
     Thread.current[:clover_ssh_cache][host] = sess
     sess


### PR DESCRIPTION
TCP KeepAlive could also be termed "MakeDead" as it causes missed packets to inject a exception as the operating system will close the socket.

Prompted by some sessions hanging longer than they should.  These settings will inject the fault after about fifteen seconds of the connection having gone dead.