### PR TITLE
Add navigation convenience infrastructure

### DIFF
--- a/doc/composition.md
+++ b/doc/composition.md
@@ -99,7 +99,7 @@ machines:
 
     class Prog::Vm::PrepHost < Prog::Base
       def sshable
-        @sshable ||= Sshable[frame["vmhost_id"]]
+        @sshable ||= Sshable[frame["vm_host_id"]]
       end
 
       def start

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -7,6 +7,12 @@ class Strand < Sequel::Model
   many_to_one :parent, key: :parent_id, class: self
   one_to_many :children, key: :parent_id, class: self
 
+  NAVIGATE = %w[vm vm_host sshable].freeze
+
+  NAVIGATE.each do
+    one_to_one _1.intern, key: :id
+  end
+
   def lease
     self.class.lease(id) do
       yield

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -6,6 +6,23 @@ class Prog::Base
   def initialize(strand, snap = nil)
     @snap = snap || SemSnap.new(strand.id)
     @strand = strand
+
+    frame&.each do |k, v|
+      next unless k =~ /([a-z0-9_]+)_id/
+      table_name = $1
+      next unless Strand::NAVIGATE.include?(table_name)
+
+      q_v = v.inspect
+      instance_eval <<ACCESSOR, __FILE__, __LINE__ + 1
+def #{table_name}
+  @#{table_name} ||= #{camelize(table_name)}[#{q_v}]
+end
+
+def #{k}
+  #{q_v}
+end
+ACCESSOR
+    end
   end
 
   def self.semaphore(*names)
@@ -41,7 +58,7 @@ end
       Sequel.pg_jsonb_wrap(o)
     end
 
-    if strand.stack.length > 0 && (link = frame[:link])
+    if strand.stack.length > 0 && (link = frame["link"])
       # This is a multi-level stack with a back-link, i.e. one prog
       # calling another in the same Strand of execution.  The thing to
       # do here is pop the stack entry.
@@ -101,7 +118,7 @@ end
   end
 
   def frame
-    strand.stack[0]
+    strand.stack&.first
   end
 
   def retval
@@ -111,7 +128,7 @@ end
   def push(prog, frame, label = "start")
     old_prog = strand.prog
     old_label = strand.label
-    frame = frame.merge(link: [strand.prog, old_label])
+    frame = frame.merge("link" => [strand.prog, old_label])
     # YYY: Use in-database jsonb prepend rather than re-rendering a
     # new value doing the prepend.
     @strand.update(prog: Strand.prog_verify(prog), label: label,
@@ -148,5 +165,13 @@ end
     old_label = @strand.label
     @strand.update(label: label)
     fail Hop.new(old_prog, old_label, @strand)
+  end
+
+  private
+
+  # Copied from sequel/model/inflections.rb's camelize, to convert
+  # table names into idiomatic model class names.
+  def camelize(s)
+    s.gsub(/\/(.?)/) { |x| "::#{x[-1..].upcase unless x == "/"}" }.gsub(/(^|_)(.)/) { |x| x[-1..].upcase }
   end
 end

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class Prog::InstallRhizome < Prog::Base
-  def sshable
-    @sshable ||= Sshable[frame["sshable_id"]]
-  end
-
   def start
     require "rubygems/package"
     require "stringio"

--- a/prog/learn_cores.rb
+++ b/prog/learn_cores.rb
@@ -3,10 +3,6 @@
 require "json"
 
 class Prog::LearnCores < Prog::Base
-  def sshable
-    @sshable ||= Sshable[frame["sshable_id"]]
-  end
-
   CpuTopology = Struct.new(:total_cpus, :total_cores, :total_nodes, :total_sockets, keyword_init: true)
 
   def parse_count(s)

--- a/prog/learn_memory.rb
+++ b/prog/learn_memory.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class Prog::LearnMemory < Prog::Base
-  def sshable
-    @sshable ||= Sshable[frame["sshable_id"]]
-  end
-
   def parse_sum(s)
     s.each_line.filter_map do |line|
       next unless line =~ /Size: (\d+) (\w+)/

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -4,11 +4,7 @@ require "json"
 
 class Prog::LearnNetwork < Prog::Base
   def sshable
-    @sshable ||= Sshable[vm_host.id]
-  end
-
-  def vm_host
-    @vm_host ||= VmHost[frame["vmhost_id"]]
+    @sshable ||= Sshable[vm_host_id]
   end
 
   def start

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -37,8 +37,8 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   def prep
-    bud Prog::Vm::PrepHost, vmhost_id: strand.id
-    bud Prog::LearnNetwork, vmhost_id: strand.id
+    bud Prog::Vm::PrepHost, sshable_id: strand.id
+    bud Prog::LearnNetwork, vm_host_id: strand.id
     bud Prog::LearnMemory, sshable_id: strand.id
     bud Prog::LearnCores, sshable_id: strand.id
     hop :wait_prep

--- a/prog/vm/prep_host.rb
+++ b/prog/vm/prep_host.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class Prog::Vm::PrepHost < Prog::Base
-  def sshable
-    @sshable ||= Sshable[frame["vmhost_id"]]
-  end
-
   def start
     sshable.cmd("sudo bin/prep_host.rb")
     pop "host prepared"

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -57,4 +57,9 @@ RSpec.describe Prog::Base do
     post = st.schedule
     expect(post - ante).to be > 121
   end
+
+  it "doesn't interpret navigations for undefined *_id strings" do
+    pr = Strand.new(prog: "Test", label: "start", stack: [{"bogus_id" => "nope"}]).load
+    expect(pr.respond_to?(:bogus_id)).to be false
+  end
 end

--- a/spec/prog/learn_cores_spec.rb
+++ b/spec/prog/learn_cores_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnCores do
-  subject(:lc) { described_class.new(Strand.new(stack: [])) }
+  subject(:lc) { described_class.new(Strand.new(stack: [{sshable_id: "bogus"}])) }
 
   # Gin up a topologically complex processor to test summations.
   let(:eight_thread_four_core_four_numa_two_socket) do
@@ -105,16 +105,6 @@ JSON
       expect(lc).to receive(:sshable).and_return(sshable)
       expect(lc).to receive(:pop).with(total_sockets: 2, total_cores: 4, total_nodes: 4, total_cpus: 8)
       lc.start
-    end
-  end
-
-  # YYY: clean up having to test these simple accessors for every
-  # prog, or worse yet, having to do with database access.
-  describe "#sshable" do
-    it "can load" do
-      lc.strand.stack = [{"sshable_id" => "abc"}]
-      expect(Sshable).to receive(:[]).with("abc")
-      lc.sshable
     end
   end
 end

--- a/spec/prog/learn_memory_spec.rb
+++ b/spec/prog/learn_memory_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnMemory do
-  subject(:lm) { described_class.new(Strand.new(stack: [])) }
+  subject(:lm) { described_class.new(Strand.new(stack: [{sshable_id: "bogus"}])) }
 
   let(:four_units) do
     <<EOS
@@ -32,16 +32,6 @@ EOS
 	Size: 16384 MB
 EOS
       }.to raise_error RuntimeError, "BUG: unexpected dmidecode unit"
-    end
-  end
-
-  # YYY: clean up having to test these simple accessors for every
-  # prog, or worse yet, having to do with database access.
-  describe "#sshable" do
-    it "can load" do
-      lm.strand.stack = [{"sshable_id" => "abc"}]
-      expect(Sshable).to receive(:[]).with("abc")
-      lm.sshable
     end
   end
 end


### PR DESCRIPTION
I'd like to point out this patch removes net lines of code even at this early date.

There were a few boring things I was doing all the time.  In the REPL:

    st = Strand['id']
    ... later ...
    Vm[st.id]

Now, I can run:

    st = Strand['id']
    st.vm # or st.vm_host, or st.sshable

The other boring thing I was writing in sourcetext was stuff like this in progs:

    def sshable
      @sshable ||= Sshable[frame["sshable_id"]]
    end

Worse yet, this code requires coverage and would have to get even more gross (with #:nocov:) to automate coverage inspection.  Or you have to write some boring tests (which I did).

By automatically scanning the current stack frame for certain `foo_id` identifiers, the code can automatically define memoized attribute accessors like the one above.

It's so consistent it discovered a terminological bug: `vmhost_id` is the uncanny valley of `vm_host_id` (as would be seen in attribute names in Postgres, and thus Sequel models) and `VmHost` (but without capitalization).  I standardize and fix this to `vm_host_id`.