### PR TITLE
Clear retval when hopping

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -146,7 +146,7 @@ end
     label = label.to_s if label.is_a?(Symbol)
     old_prog = @strand.prog
     old_label = @strand.label
-    @strand.update(label: label)
+    @strand.update(label: label, retval: nil)
     fail Hop.new(old_prog, old_label, @strand)
   end
 end


### PR DESCRIPTION
The proximate reason was this interesting bug:

https://github.com/jeremyevans/sequel/issues/2028

But also, failing to clear retval can cause confusion about what push resulted in what return.  Given the lightweight composition of push (vs. bud), scoping the use of retval to the current label seems adequate.