### PR TITLE
Improve and simplify navigation convenience infrastructure

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Prog::BootstrapRhizome < Prog::Base
+  subject_is :sshable
+
   def user
     @user ||= frame.fetch("user", "root")
   end
@@ -39,6 +41,6 @@ echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
 sudo install -D -o rhizome -g rhizome -m 0600 #{authorized_keys_file.shellescape} /home/rhizome/.ssh/authorized_keys
 SH
 
-    push Prog::InstallRhizome, {sshable_id: sshable_id}
+    push Prog::InstallRhizome
   end
 end

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Prog::InstallRhizome < Prog::Base
+  subject_is :sshable
+
   def start
     require "rubygems/package"
     require "stringio"

--- a/prog/learn_cores.rb
+++ b/prog/learn_cores.rb
@@ -3,6 +3,8 @@
 require "json"
 
 class Prog::LearnCores < Prog::Base
+  subject_is :sshable
+
   CpuTopology = Struct.new(:total_cpus, :total_cores, :total_nodes, :total_sockets, keyword_init: true)
 
   def parse_count(s)

--- a/prog/learn_memory.rb
+++ b/prog/learn_memory.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Prog::LearnMemory < Prog::Base
+  subject_is :sshable
+
   def parse_sum(s)
     s.each_line.filter_map do |line|
       next unless line =~ /Size: (\d+) (\w+)/

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -3,9 +3,7 @@
 require "json"
 
 class Prog::LearnNetwork < Prog::Base
-  def sshable
-    @sshable ||= Sshable[vm_host_id]
-  end
+  subject_is :sshable, :vm_host
 
   def start
     ip6 = parse_ip_addr_j(sshable.cmd("/usr/sbin/ip -j -6 addr show scope global"))

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -15,7 +15,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   def start
-    bud Prog::BootstrapRhizome, sshable_id: strand.id
+    bud Prog::BootstrapRhizome
     hop :wait_bootstrap_rhizome
   end
 
@@ -26,10 +26,10 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   def prep
-    bud Prog::Vm::PrepHost, sshable_id: strand.id
-    bud Prog::LearnNetwork, vm_host_id: strand.id
-    bud Prog::LearnMemory, sshable_id: strand.id
-    bud Prog::LearnCores, sshable_id: strand.id
+    bud Prog::Vm::PrepHost
+    bud Prog::LearnNetwork
+    bud Prog::LearnMemory
+    bud Prog::LearnCores
     hop :wait_prep
   end
 

--- a/prog/vm/prep_host.rb
+++ b/prog/vm/prep_host.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Prog::Vm::PrepHost < Prog::Base
+  subject_is :sshable
+
   def start
     sshable.cmd("sudo bin/prep_host.rb")
     pop "host prepared"


### PR DESCRIPTION
    This patch manages to simplify the mechanism in
    3ed62e21f43367a88982f47db0ba60e0570ed009: it is less dynamic, with
    class definition rather than `instance_eval`.
    
    The main thing lost here is accessors for any record, including ones
    not directly correlated by `strand.id` or the stack frame's
    `subject_id`.  But, in spite of that loss, I think this patch is an
    improvement, for these reasons:
    
    1) Navigation of indirectly correlated records is nonexistent in the
       code base so far. I think there are solutions, but let's wait for
       concrete ugly examples to rectify.
    
    2) The stack-scanning mechanism encourages duplication of references
       in both entity records, and the stack.  The latter does not have
       the benefit of constraints, either.  This is asking for trouble
       when entities and a stack do not agree, and makes operational fixes
       more complex, because two references must be updated.
    
    3) Source code has fewer subexpressions, as `bud` and `push` calls are
       simplified in all extant situations.