### PR TITLE
Fill in SSH features

### DIFF
--- a/lib/ssh_key.rb
+++ b/lib/ssh_key.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+class SshKey
+  def self.generate
+    new Ed25519::SigningKey.generate
+  end
+
+  def self.from_binary(keypair)
+    new Ed25519::SigningKey.from_keypair keypair
+  end
+
+  def initialize(signer)
+    @signer = signer
+  end
+
+  def keypair
+    @signer.keypair
+  end
+
+  def private_key
+    return @private_key if @private_key
+
+    # N.B. net-ssh only supports one private key in a key_data at one
+    # time, in ed25519.rb in 7.1.0:
+    #
+    #    raise ArgumentError.new("Only 1 key is supported in ssh keys #{num_keys} was in private key") unless num_keys == 1
+    #
+    # Kudos
+    # https://dnaeon.github.io/openssh-private-key-binary-format/ with
+    # excerpts and replication of primary references below.
+    #
+    # https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.key?annotate=HEAD
+    #
+    # byte[]  AUTH_MAGIC
+    # string  ciphername
+    # string  kdfname
+    # string  kdfoptions
+    # uint32  number of keys N
+    # string  publickey1
+    # string  publickey2
+    # ...
+    # string  publickeyN
+    # string  encrypted, padded list of private keys
+    #
+    # We don't use OpenSSH encryption, preferring column encryption or
+    # some other application method, so he encipherment will be none:
+    #
+    # > For unencrypted keys the cipher "none" and the KDF "none" are
+    # > used with empty passphrases. The options if the KDF "none" are
+    # > the empty string.
+    #
+    # uint32  checkint
+    # uint32  checkint
+    # byte[]  privatekey1
+    # string  comment1
+    # byte[]  privatekey2
+    # string  comment2
+    # ...
+    # string  privatekeyN
+    # string  commentN
+    # byte    1
+    # byte    2
+    # byte    3
+    # ...
+    # byte    padlen % 255
+    #
+    # > The list of privatekey/comment pairs is padded with the bytes
+    # > 1, 2, 3, ... until the total length is a multiple of the
+    # > cipher block size.
+    #
+    # If here is no cipher, the padding is eight:
+    # https://github.com/openssh/openssh-portable/blob/eba523f0a130f1cce829e6aecdcefa841f526a1a/cipher.c#L86
+    #
+    # The byte array containing he private key has a per-key defined
+    # level of protocol.
+    checkint = rand(0..(2**32 - 1))
+    verify_key_bytes = @signer.verify_key.to_bytes
+    nested_private_key = Net::SSH::Buffer.from(
+      :long, checkint,
+      :long, checkint,
+      # 'encrypted' private keys
+      :string, "ssh-ed25519",
+      :string, verify_key_bytes,
+      :string, @signer.keypair
+    )
+
+    # Negative modulus is a handy trick to fill out pads like this.
+    padding = (nested_private_key.length % -8).abs
+    nested_private_key.write("12345678".slice(0, padding))
+    # :nocov:
+    fail "BUG: padding broken" unless nested_private_key.length % 8 == 0
+    # :nocov:
+
+    @private_key = StringIO.open { |s|
+      s.puts "-----BEGIN OPENSSH PRIVATE KEY-----"
+      s.write Base64.encode64(Net::SSH::Buffer.from(
+        :raw, "openssh-key-v1\0", # AUTH_MAGIC
+        :string, "none", # cipher
+        :string, "none", # kdf
+        :string, "", # kdfoptions
+        :long, 1, # number of keys N
+        :string, verify_key_bytes, # publickey1,
+        :string, nested_private_key.content
+      ).content)
+      s.puts "-----END OPENSSH PRIVATE KEY-----"
+      s.string
+    }
+  end
+
+  def self.public_key(public_key)
+    type, binary = case public_key
+    when OpenSSL::PKey::RSA
+      ["ssh-rsa", public_key.to_blob]
+    else
+      verify_key = case public_key
+      when Ed25519::VerifyKey
+        public_key
+      when Net::SSH::Authentication::ED25519::PubKey
+        public_key.verify_key
+      else
+        fail "BUG: unrecognized key type"
+      end
+
+      ["ssh-ed25519", Net::SSH::Buffer.from(
+        :string, "ssh-ed25519",
+        :string, verify_key.to_bytes
+      ).content]
+    end
+
+    type + " " + Base64.strict_encode64(binary)
+  end
+
+  def public_key
+    @public_key ||= self.class.public_key(@signer.verify_key)
+  end
+end

--- a/migrate/009_ssh_generation.rb
+++ b/migrate/009_ssh_generation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :sshable do
+      # Rename to be more verbose, a short name that uses higher level
+      # abstractions is provided.  A long name deters using the wrong
+      # method.
+      rename_column :private_key, :raw_private_key_1
+
+      # Make room for a second key for rotation.
+      add_column :raw_private_key_2, :text, collate: '"C"'
+
+      # After consideration for Sshable Vms, relaxing the non-nullable
+      # host name constraint is the smallest evil to deal with a
+      # common situation: we need to store a private key, and send a
+      # public key somewhere, e.g. to a new Vm that will run
+      # cloud-init, but do not yet know the network address or host it
+      # will be assigned.
+      #
+      # Using the Strand stack is not advisable for secret data, as
+      # it's not encrypted.  And decomposing Sshable to avoid nulls by
+      # separating out the keys from the host name is overwrought.  A
+      # nullable host squares the circle even if it's a little weird.
+      set_column_allow_null :host
+    end
+  end
+end

--- a/prog/rotate_ssh_key.rb
+++ b/prog/rotate_ssh_key.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+class Prog::RotateSshKey < Prog::Base
+  subject_is :sshable
+
+  def start
+    sshable.update(raw_private_key_2: SshKey.generate.keypair)
+    hop :install
+  end
+
+  def install
+    public_keys = sshable.keys.map(&:public_key).join("\n")
+
+    sshable.cmd(<<SH)
+set -ueo pipefail
+echo #{public_keys.shellescape} > ~/.ssh/authorized_keys2
+SH
+    hop :retire_old_key_on_server
+  end
+
+  def retire_old_key_on_server
+    # Test authentication with new key new key at the same time.
+    Net::SSH.start(sshable.host, "rhizome",
+      Sshable::COMMON_SSH_ARGS.merge(key_data: [SshKey.from_binary(sshable.raw_private_key_2).private_key])) do |sess|
+      sess.exec!(<<SH)
+set -ueo pipefail
+sync ~/.ssh/authorized_keys2
+mv ~/.ssh/authorized_keys2 ~/.ssh/authorized_keys
+sync ~/.ssh
+SH
+    end
+
+    hop :retire_old_key_in_database
+  end
+
+  def retire_old_key_in_database
+    changed_records = sshable.this.where(
+      Sequel.~(raw_private_key_2: nil)
+    ).update(raw_private_key_1: Sequel[:raw_private_key_2], raw_private_key_2: nil)
+
+    fail unless changed_records == 1
+
+    hop :test_rotation
+  end
+
+  def test_rotation
+    # Bypass Sshable caching for the test, as it can have an existing
+    # authorized session.
+    Net::SSH.start(sshable.host, "rhizome",
+      Sshable::COMMON_SSH_ARGS.merge(key_data: sshable.keys.map(&:private_key))) do |sess|
+      ret = sess.exec!("echo key rotated successfully")
+      fail unless ret.exitstatus.zero?
+      fail unless ret == "key rotated successfully\n"
+    end
+
+    pop "key rotated successfully"
+  end
+end

--- a/spec/lib/ssh_key_spec.rb
+++ b/spec/lib/ssh_key_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "net/ssh"
+
+RSpec.describe SshKey do
+  it "can generate an ed25519 key that loads successfully" do
+    # Catenate a few simple tests together for speedup.
+    sk = described_class.generate
+
+    # Test round trip.
+    sk2 = described_class.from_binary(sk.keypair)
+    expect(sk.keypair).to eq sk2.keypair
+
+    expect {
+      # Test parsing.
+      Net::SSH::KeyFactory.load_data_private_key(sk.private_key)
+
+      # Test caching.
+      sk.private_key
+      sk.public_key
+      sk.public_key
+    }.not_to raise_error
+  end
+end

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -3,15 +3,19 @@
 require_relative "spec_helper"
 
 RSpec.describe Sshable do
+  # Avoid using excessive entropy by using one generated key for all
+  # tests.
+  key = SshKey.generate.keypair.freeze
+
   subject(:sa) {
-    described_class.new(host: "test.localhost", private_key: "test not a real private key")
+    described_class.new(host: "test.localhost", raw_private_key_1: key)
   }
 
   it "can encrypt and decrypt a field" do
     sa.save_changes
 
-    expect(sa.values[:private_key] =~ /\AA[AgQ]..A/).not_to be_nil
-    expect(sa.private_key).to eq("test not a real private key")
+    expect(sa.values[:raw_private_key_1] =~ /\AA[AgQ]..A/).not_to be_nil
+    expect(sa.raw_private_key_1).to eq(key)
   end
 
   describe "caching" do

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -5,7 +5,7 @@ require_relative "spec_helper"
 RSpec.describe VmHost do
   it "requires an Sshable too" do
     expect {
-      sa = Sshable.create(host: "test.localhost", private_key: "test not a real private key")
+      sa = Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
       described_class.create(location: "test-location") { _1.id = sa.id }
     }.not_to raise_error
   end


### PR DESCRIPTION
Add SSH key generation and rotation, though the latter is not automatically scheduled yet.

Key generation simplifies creating Sshable VMs in an environment that does not have an ssh-agent with the keys loaded, i.e. non-development.

The approach here is to store tiny, bare ed25519 private key material in encrypted columns, and bloat it up to the format expected by OpenSSH and net-ssh on-demand.

Also, consult the ssh agent via net-ssh in the `vm_host` route, and guard it so it only runs this convenience development mode.