### PR TITLE
Fix VmHost create page

### DIFF
--- a/routes/vm_host.rb
+++ b/routes/vm_host.rb
@@ -39,10 +39,7 @@ class Clover
         @ssh_keys = if Config.development?
           begin
             agent = Net::SSH::Authentication::Agent.connect
-
-            (sshable.keys.map(&:public_key) + agent.identities.map { |pub|
-                                                SshKey.public_key(pub)
-                                              }).join("\n")
+            agent.identities.map { |pub| SshKey.public_key(pub) }
           ensure
             agent.close
           end


### PR DESCRIPTION
Reverting changes that introduced in e231faa79e0f7f5d71cdf06e3aa1f6406414f744 at routes/vm_host.rb. It raises exception because sshable is not exist.

Clover connects to VmHost via root user with local SSH keys initially. It installs sshable.private_keys to host after initial bootstrapping. We don't have valid sshable object for VmHost create page because we don't have VmHost yet