### PR TITLE
Add UI tests for Vm and VmHost views

### DIFF
--- a/routes/object_storage.rb
+++ b/routes/object_storage.rb
@@ -3,6 +3,7 @@
 class Clover
   hash_branch("object-storage") do |r|
     r.get true do
+      @page_title = "Object Storage"
       view content: render("components/page_header", locals: {title: "This service is under development"})
     end
   end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -5,6 +5,9 @@ if (suite = ENV.delete("COVERAGE"))
 
   SimpleCov.start do
     enable_coverage :branch
+    minimum_coverage line: 80, branch: 50
+    minimum_coverage_by_file line: 32, branch: 0
+
     command_name suite
 
     add_filter "/spec/"

--- a/spec/web/object_storage_spec.rb
+++ b/spec/web/object_storage_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "object_storage" do
+  it "can not access without login" do
+    visit "/object-storage"
+
+    expect(page.title).to eq("Ubicloud - Login")
+  end
+
+  describe "authenticated" do
+    before do
+      login
+    end
+
+    it "show service is under development" do
+      visit "/object-storage"
+
+      expect(page.title).to eq("Ubicloud - Object Storage")
+      expect(page).to have_content "This service is under development"
+    end
+  end
+end

--- a/spec/web/settings_spec.rb
+++ b/spec/web/settings_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "settings" do
+  it "can not access without login" do
+    visit "/settings"
+
+    expect(page.title).to eq("Ubicloud - Login")
+  end
+
+  describe "authenticated" do
+    before do
+      login
+    end
+
+    it "show password change page" do
+      visit "/settings"
+
+      expect(page.title).to eq("Ubicloud - Settings")
+      expect(page).to have_content "Change Password"
+    end
+  end
+end

--- a/spec/web/spec_helper.rb
+++ b/spec/web/spec_helper.rb
@@ -6,12 +6,10 @@ raise "test database doesn't end with test" if DB.opts[:database] && !DB.opts[:d
 require "capybara"
 require "capybara/rspec"
 require "rack/test"
+require "argon2"
 
 Gem.suffix_pattern
 
-Clover.plugin :not_found do
-  raise "404 - File Not Found"
-end
 Clover.plugin :error_handler do |e|
   raise e
 end
@@ -34,4 +32,29 @@ RSpec.configure do |config|
     Capybara.reset_sessions!
     Capybara.use_default_driver
   end
+
+  config.before(:suite) do
+    # Create a default user to use in all test if not exits
+    # Database cleaner can't trunca accounts tables because of
+    # account of `ph` user separation.
+    unless DB[:accounts].where(email: "user@example.com").first
+      hash = Argon2::Password.new({
+        t_cost: 1,
+        m_cost: 3,
+        secret: Config.clover_session_secret
+      }).create("0123456789")
+
+      account_id = DB[:accounts].insert(email: "user@example.com", status_id: 2)
+      DB[:account_password_hashes].insert(id: account_id, password_hash: hash)
+    end
+  end
+end
+
+def login(email = "user@example.com", password = "0123456789")
+  visit "/login"
+  fill_in "Email address", with: email
+  fill_in "Password", with: password
+  click_button "Sign in"
+
+  expect(page.title).to eq("Ubicloud - Dashboard")
 end

--- a/spec/web/vm_host_spec.rb
+++ b/spec/web/vm_host_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "vm_host" do
+  let(:vm_host) { Prog::Vm::HostNexus.assemble("127.0.0.1").vm_host }
+
+  it "can not access without login" do
+    visit "/vm-host"
+
+    expect(page.title).to eq("Ubicloud - Login")
+  end
+
+  describe "authenticated" do
+    before do
+      login
+    end
+
+    it "can list no virtual machine hosts" do
+      visit "/vm-host"
+
+      expect(page.title).to eq("Ubicloud - VM Hosts")
+      expect(page).to have_content "No virtual machine host"
+
+      click_link "New Virtual Machine Host"
+      expect(page.title).to eq("Ubicloud - Add VM Host")
+    end
+
+    it "can add new virtual machine host" do
+      visit "/vm-host/create"
+
+      expect(page.title).to eq("Ubicloud - Add VM Host")
+
+      fill_in "hostname", with: "127.0.0.1"
+      choose option: "hetzner-hel1"
+
+      click_button "Add"
+
+      expect(page.title).to eq("Ubicloud - VM Hosts")
+      expect(page).to have_content "'127.0.0.1' host will be ready in a few minutes"
+      expect(VmHost.count).to eq(1)
+    end
+
+    it "can list ssh agent public keys at development" do
+      expect(Config).to receive(:development?).and_return(true)
+      expect(Net::SSH::Authentication::Agent).to receive(:connect) do
+        agent = instance_double(Net::SSH::Authentication::Agent, close: nil)
+        expect(agent).to receive(:identities).and_return(["dummy-key"])
+        expect(SshKey).to receive(:public_key).and_return(["dummy-key"])
+        agent
+      end
+
+      visit "/vm-host/create"
+
+      expect(page.title).to eq("Ubicloud - Add VM Host")
+      expect(page).to have_content "dummy-key"
+    end
+
+    it "can show virtual machine host details" do
+      shadow = Clover::VmHostShadow.new(vm_host)
+      visit "/vm-host"
+
+      expect(page.title).to eq("Ubicloud - VM Hosts")
+      expect(page).to have_content shadow.host
+
+      click_link "Show", href: "/vm-host/#{shadow.id}"
+
+      expect(page.title).to eq("Ubicloud - #{shadow.host}")
+      expect(page).to have_content shadow.host
+    end
+
+    it "raises not found when virtual machine host not exists" do
+      visit "/vm-host/08s56d4kaj94xsmrnf5v5m3mav"
+
+      expect(page.title).to eq("Ubicloud - Page not found")
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content "Page not found"
+    end
+  end
+end

--- a/spec/web/vm_spec.rb
+++ b/spec/web/vm_spec.rb
@@ -2,9 +2,83 @@
 
 require_relative "spec_helper"
 
-RSpec.describe Clover, "/vm" do
-  it "has a page title" do
+RSpec.describe Clover, "vm" do
+  let(:vm) do
+    vm = Prog::Vm::Nexus.assemble("dummy-public-key", name: "dummy-vm").vm
+    vm.update(ephemeral_net6: "2a01:4f8:173:1ed3:aa7c::/79")
+    vm.reload # without reload ephemeral_net6 is string and can't call .network
+  end
+
+  it "can not access without login" do
     visit "/vm"
+
     expect(page.title).to eq("Ubicloud - Login")
+  end
+
+  describe "authenticated" do
+    before do
+      login
+    end
+
+    it "can list no virtual machines" do
+      visit "/vm"
+
+      expect(page.title).to eq("Ubicloud - Virtual Machines")
+      expect(page).to have_content "No virtual machines"
+
+      click_link "New Virtual Machine"
+      expect(page.title).to eq("Ubicloud - Create Virtual Machine")
+    end
+
+    it "can create new virtual machine" do
+      visit "/vm/create"
+
+      expect(page.title).to eq("Ubicloud - Create Virtual Machine")
+
+      fill_in "Name", with: "dummy-vm"
+      choose option: "hetzner-hel1"
+      choose option: "ubuntu-jammy"
+      choose option: "standard-1"
+
+      click_button "Create"
+
+      expect(page.title).to eq("Ubicloud - Virtual Machines")
+      expect(page).to have_content "'dummy-vm' will be ready in a few minutes"
+      expect(Vm.count).to eq(1)
+    end
+
+    it "can show virtual machine details" do
+      shadow = Clover::VmShadow.new(vm)
+      visit "/vm"
+
+      expect(page.title).to eq("Ubicloud - Virtual Machines")
+      expect(page).to have_content shadow.name
+
+      click_link "Show", href: "/vm/#{shadow.id}"
+
+      expect(page.title).to eq("Ubicloud - #{shadow.name}")
+      expect(page).to have_content shadow.name
+    end
+
+    it "raises not found when virtual machine not exists" do
+      visit "/vm/08s56d4kaj94xsmrnf5v5m3mav"
+
+      expect(page.title).to eq("Ubicloud - Page not found")
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content "Page not found"
+    end
+
+    it "delete" do
+      shadow = Clover::VmShadow.new(vm)
+      visit "/vm/#{shadow.id}"
+
+      # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
+      # UI tests run without a JavaScript enginer.
+      btn = find ".delete-btn"
+      page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+      expect(page.body).to eq("Deleting #{vm.id}")
+      expect(SemSnap.new(vm.id).set?("destroy")).to be true
+    end
   end
 end


### PR DESCRIPTION
Frontend is difficult to test. JavaScript engine is required to test some interactive functionalities. We are planning to use more sophisticated frontend test frameworks in future.

But for now, we need to be sure our UI is not broken by commits. Testing all pages manually is not very feasible.

Capybara helps to test UI easily. We don't need JavaScript for basic functionalities. Actually, Capybara has Selenium driver to run JavaScript codes too, but it slow downs tests.