### PR TITLE
Disable IPsec mesh networking in non-development

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -174,6 +174,12 @@ SQL
   end
 
   def refresh_mesh
+    # YYY: Implement a robust mesh networking concurrency algorithm.
+    unless Config.development?
+      decr_refresh_mesh
+      hop :wait
+    end
+
     # don't create tunnels to self or VMs already connected to
     reject_list = vm.ipsec_tunnels.map(&:src_vm_id)
     reject_list.append(vm.id)


### PR DESCRIPTION
It was committed with known concurrency issues (see 3fd86a5bc7f34d83e0ebfe3424ebe70251d3202f), to focus on having some tangible `ip xfrm` manipulation integrated, as the latter is somewhat obscure.

Given we:

1) haven't had time to address those issues yet
2) haven't integrated this feature into demonstrations

I think the thing to do is only have this code run in development, so it won't injure demonstrations.