### PR TITLE
Switch from static network configuration to dnsmasq and dhcp6

### DIFF
--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Prog::InstallDnsmasq < Prog::Base
+  subject_is :sshable
+
+  def start
+    # Handle some short, non-dependent steps concurrently, keeping
+    # overall code compact by self-budding and starting at a different
+    # label.
+    bud self.class, frame, :install_build_dependencies
+    bud self.class, frame, :git_clone_dnsmasq
+
+    hop :wait_downloads
+  end
+
+  def wait_downloads
+    reap
+    hop :compile_and_install if leaf?
+    donate
+  end
+
+  def compile_and_install
+    sshable.cmd("(cd dnsmasq && make -sj$(nproc) && sudo make install)")
+    pop "compiled and installed dnsmasq"
+  end
+
+  def install_build_dependencies
+    sshable.cmd("sudo apt-get -y install make gcc")
+    pop "installed build dependencies"
+  end
+
+  def git_clone_dnsmasq
+    sshable.cmd("git clone https://github.com/fdr/dnsmasq.git --depth=1 && " \
+                "(cd dnsmasq && git checkout aaba66efbd3b4e7283993ca3718df47706a8549b && git fsck --full)")
+    pop "downloaded and verified dnsmasq successfully"
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -30,6 +30,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnNetwork
     bud Prog::LearnMemory
     bud Prog::LearnCores
+    bud Prog::InstallDnsmasq
     hop :wait_prep
   end
 

--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -18,6 +18,14 @@ class VmPath
     File.write(path, s)
   end
 
+  def dnsmasq_service
+    "/etc/systemd/system/#{@vm_name}-dnsmasq.service"
+  end
+
+  def write_dnsmasq_service(s)
+    write(dnsmasq_service, s)
+  end
+
   def systemd_service
     File.join("/etc/systemd/system",
       IO.popen(["systemd-escape", @vm_name + ".service"]) { _1.read.chomp })
@@ -37,6 +45,7 @@ class VmPath
     guest_mac
     guest_ephemeral
     clover_ephemeral
+    dnsmasq.conf
     boot.raw
     meta-data
     network-config

--- a/routes/vm.rb
+++ b/routes/vm.rb
@@ -12,7 +12,7 @@ class Clover
       @state = vm.display_state
       @location = vm.location
       @size = vm.size
-      @ip6 = vm.ephemeral_net6&.network
+      @ip6 = vm.ephemeral_net6&.nth(2)
     end
   end
 


### PR DESCRIPTION
Of the three distributions supported, only Ubuntu has been successful
in obtaining intended network access on the first boot.  Now AlmaLinux
is also successful, but openSUSE still doesn't work.

The main errata here is this breaks support for multiple IPv6 prefixes
on an interface for now.  This is required for the mesh networking
support.  Someone, probably me, will add those back in later.

A side effect is also now, much like Hetzner, the third IPv6 address
in the subnet, ::2, is allocated to the VM.  dnsmasq appears to
require an in-subnet address on the host side to listen on for DHCP
messages, so I chose the customary "gateway" address at ::1. Later on,
it can also be the local DNS server, since we want to offer in-mesh
DNS names not available in the wider world as well.  My attempt to ask
a question about avoiding this intrusion into the customer's subnet
was met with silence so far:

https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2023q2/017013.html

The zero-suffix address, `::`, is left empty: this is also apparently
an IPv6 norm to avoid confusion between referencing a network and
referencing an address & prefix length combo.  In principle, however,
the guest VM can bind it and use it if they want, though.

Background information:

There were some reports on the web about static networking cloud-init
not quite working, perhaps only Ubuntu (whose sponsoring company also
controls cloud-init) took care to make it work at this time.

In any case, static network configuration was never going to remain
good enough for very long: for one, we can't boot a VM on another
machine, since cloud-init nominally runs just once...to init.
