### PR TITLE
Rename plans for demonstration

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -6,24 +6,19 @@ module Option
   VmSize = Struct.new(:name, :display_name, :vcpu, :memory, :disk)
 
   Locations = [
-    ["hetzner-hel1", "Hetzner Helsinki"],
-    ["hetzner-nbg1", "Hetzner Nuremberg"],
-    ["equinix-da11", "Equinix Dallas 11"],
-    ["equinix-ist", "Equinix Istanbul"],
-    ["aws-centraleu1", "AWS Frankfurt"],
-    ["aws-apsoutheast2", "AWS Sydney"]
+    ["hetzner-hel1", "Hetzner Finland"],
+    ["hetzner-fsn1", "Hetzner Germany"],
+    ["equinix-da11", "Equinix Dallas"]
   ].map { |args| Location.new(*args) }.freeze
 
   BootImages = [
     ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"],
-    ["almalinux-9.1", "AlmaLinux 9.1"],
-    ["opensuse-leap-15.4", "openSUSE Leap 15.4"]
+    ["almalinux-9.1", "AlmaLinux 9.1"]
   ].map { |args| BootImage.new(*args) }.freeze
 
   VmSizes = [
-    ["standard-1", "Standard 1", 1, 2, 160],
-    ["standard-2", "Standard 2", 2, 4, 256],
-    ["standard-3", "Standard 3", 4, 8, 512],
-    ["standard-4", "Standard 4", 8, 16, 512]
+    ["m5a.2x", "m5a.2x", 2, 4, 30],
+    ["m5a.4x", "m5a.4x", 4, 8, 60],
+    ["m5a.6x", "m5a.6x", 6, 12, 90]
   ].map { |args| VmSize.new(*args) }.freeze
 end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -7,7 +7,7 @@ require "ulid"
 class Prog::Vm::Nexus < Prog::Base
   semaphore :destroy, :refresh_mesh
 
-  def self.assemble(public_key, name: nil, size: "standard-1",
+  def self.assemble(public_key, name: nil, size: "m5a.2x",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
     private_subnets: [])
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Vm::Nexus do
   }
 
   let(:st) { Strand.new }
-  let(:vm) { Vm.new(size: "standard-1") }
+  let(:vm) { Vm.new(size: "m5a.2x") }
 
   it "creates the user and key record" do
     private_subnets = [

--- a/spec/web/vm_spec.rb
+++ b/spec/web/vm_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Clover, "vm" do
       fill_in "Name", with: "dummy-vm"
       choose option: "hetzner-hel1"
       choose option: "ubuntu-jammy"
-      choose option: "standard-1"
+      choose option: "m5a.2x"
 
       click_button "Create"
 


### PR DESCRIPTION
openSUSE is also removed from the UI since it still is busted even
with DHCP6 as I have it right now.

For some very uninteresting time-related reasons for demonstrations,
and given the pre-existing terminology choice of "vcpu," I presume all
cores we sell are 2:1 hyperthreaded here, and update the tests
accordingly.

But longer term, I'd prefer to sell by the core, since core-splitting
via hyperthreading doesn't make much sense.

The prefix "m5a" happens to be somewhat similar to the product code in
AWS we'd be targeting on Hetzner: an AMD Zen2 system with a 4GB * 1
core ratio.  But for demonstration, these are backed by whatever I
could buy off the auction today, which is Intel, though with the
correct (and relatively high) RAM ratio.  Alas, we're probably a few
days away from our AMD Zen2 EPYC servers being available.  And we'll
probably change our product coding as well; this is to help audiences
get the right general idea.
