### PR TITLE
Make installing rhizome easier

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -85,4 +85,9 @@ class VmHost < Sequel::Model
 
     [threads_per_core, cores_per_die, dies_per_package, total_sockets].map(&:to_s).join(":")
   end
+
+  # Introduced for refreshing rhizome programs via REPL.
+  def install_rhizome
+    Strand.create(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id}])
+  end
 end


### PR DESCRIPTION
I found myself doing this a lot while preparing a demonstration, and on Heroku, where I (in a decent model of a safer way to operate in production) didn't have the benefit of my pry history file.  This makes it easier to re-type in such a setting.