### PR TITLE
Move VmHost SSH public keys from create view to show view

### DIFF
--- a/views/vm_host/create.erb
+++ b/views/vm_host/create.erb
@@ -22,29 +22,12 @@
                       locals: {
                         name: "hostname",
                         label: "Hostname or IP Address",
-                        description:
-                          "Control plane connects to VM host as <span class='font-bold text-rose-500'>root</span> user via SSH. One of following keys should be added to the host before adding VM host.",
                         attributes: {
                           required: true,
                           placeholder: "i.e: 10.10.10.10, example.com"
                         }
                       }
                     ) %>
-                    <div class="mt-2 space-y-2">
-                      <% if @ssh_keys && !@ssh_keys.empty? %>
-                        <% @ssh_keys.each do |key| %>
-                          <div
-                            class="overflow-scroll whitespace-nowrap font-mono rounded-lg overlay text-sm leading-6 bg-slate-800 text-slate-50 px-4 py-2"
-                          >
-                            <%= key %>
-                          </div>
-                        <% end %>
-                      <% else %>
-                        <div class="rounded-md bg-red-50 p-4 text-sm text-red-800 font-medium">
-                          Could not detect any SSH keys loaded. Use "<span class="font-mono font-bold text-slate-800">ssh-add [PATH_TO_KEY]</span>" to add SSH keys to agent.
-                        </div>
-                      <% end %>
-                    </div>
                   </div>
                   <div class="col-span-full">
                     <%== render(

--- a/views/vm_host/show.erb
+++ b/views/vm_host/show.erb
@@ -53,8 +53,35 @@
                 <dt class="text-sm font-medium text-gray-500">IPv6</dt>
                 <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
                   <span class="copy-content cursor-pointer" data-content="<%= @vm_host.ip6 %>" data-message="Copied IPv6">
-                    <%= @vm_host.ip6 %>
+                    <%= @vm_host.ip6 || "-" %>
                   </span>
+                </dd>
+              </div>
+              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
+                <dt class="text-sm font-medium text-gray-500">SSH Public Keys</dt>
+                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  <% unless @vm_host.public_keys.empty? %>
+                    <div
+                      class="overflow-hidden whitespace-nowrap font-mono rounded-lg overlay text-sm leading-6 bg-slate-800 text-slate-50 px-4 py-2"
+                    >
+                      <span
+                        class="copy-content cursor-pointer"
+                        data-content="<%= @vm_host.public_keys.join("\n") %>"
+                        data-message="Copied SSH public keys"
+                      >
+                        <%== @vm_host.public_keys.join("</br>") %>
+                      </span>
+                    </div>
+                    <div class="mt-2">
+                      The control plane connects to VM host as
+                      <span class="font-bold text-rose-500">root</span>
+                      user via SSH.
+                      <br>
+                      SSH public keys should be added to the host.
+                    </div>
+                  <% else %>
+                    Waiting for SSH keys to be created. Please refresh the page.
+                  <% end %>
                 </dd>
               </div>
             </dl>


### PR DESCRIPTION
Agent is used for SSH keys to connect VmHost at development. For production, keys are stored in Sshable model at database. So they are created after VmHost added. User redirected to detail page after VmHost added. Then user have to set showed public keys to the host, otherwise it's stuck at "unprepared".

The one thing I don't like, if public keys aren't created yet, user have to refresh page. Keys are generated after respirate run its strand at least one time.