### PR TITLE
Make dmidecode memory size learn regexp more strict

### DIFF
--- a/prog/learn_memory.rb
+++ b/prog/learn_memory.rb
@@ -5,7 +5,7 @@ class Prog::LearnMemory < Prog::Base
 
   def parse_sum(s)
     s.each_line.filter_map do |line|
-      next unless line =~ /Size: (\d+) (\w+)/
+      next unless line =~ /\A\s*Size: (\d+) (\w+)/
       # Fail noisily if unit is not in gigabytes
       fail "BUG: unexpected dmidecode unit" unless $2 == "GB"
       Integer($1)


### PR DESCRIPTION
You can otherwise get lines like this double-counting a RAM stick:

    Volatile Size: 16 GB

In general, we probably need a more structured `dmidecode` or a better parser if interesting input is going to come out of there, e.g. checking for lines like these to weed out other devices that may report a "Size:" field.

    Type: DDR4
    Memory Technology: DRAM
    Form Factor: DIMM