### PR TITLE
Allow destroying VMs that never got allocated

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -203,20 +203,21 @@ SQL
   end
 
   def destroy
-    # YYY make idempotent. And less repetitive.
-    begin
-      host.sshable.cmd("sudo systemctl stop #{q_vm}")
-    rescue Sshable::SshError => ex
-      raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.message)
-    end
+    unless host.nil?
+      begin
+        host.sshable.cmd("sudo systemctl stop #{q_vm}")
+      rescue Sshable::SshError => ex
+        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.message)
+      end
 
-    begin
-      host.sshable.cmd("sudo systemctl stop #{q_vm}-dnsmasq")
-    rescue Sshable::SshError => ex
-      raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.message)
-    end
+      begin
+        host.sshable.cmd("sudo systemctl stop #{q_vm}-dnsmasq")
+      rescue Sshable::SshError => ex
+        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.message)
+      end
 
-    host.sshable.cmd("sudo bin/deletevm.rb #{q_vm}")
+      host.sshable.cmd("sudo bin/deletevm.rb #{q_vm}")
+    end
 
     vm.vm_private_subnet_dataset.delete
     VmHost.dataset.where(id: vm.vm_host_id).update(


### PR DESCRIPTION
VMs that never got allocated do not have a host, so, skip the host-scrubbing steps in destroy if it's not present.  Otherwise it crashes because `host` is nil.