### PR TITLE
Add expedient low-ram (a.k.a. high-compute) product line

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -19,6 +19,8 @@ module Option
   VmSizes = [
     ["m5a.2x", "m5a.2x", 2, 4, 30],
     ["m5a.4x", "m5a.4x", 4, 8, 60],
-    ["m5a.6x", "m5a.6x", 6, 12, 90]
+    ["m5a.6x", "m5a.6x", 6, 12, 90],
+    ["c5a.2x", "c5a.2x", 2, 2, 30],
+    ["c5a.6x", "c5a.6x", 6, 6, 90]
   ].map { |args| VmSize.new(*args) }.freeze
 end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -45,6 +45,8 @@ class Vm < Sequel::Model
     @mem_gib_ratio ||= case product.line
     when "m5a"
       4
+    when "c5a"
+      2
     else
       fail "BUG: unrecognized product line"
     end


### PR DESCRIPTION
To be able to use one server we have in a different location that happens to have less memory in a demonstration.