### PR TITLE
Remove dnsmasq service on Vm destroy

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -62,6 +62,7 @@ class VmSetup
     end
 
     FileUtils.rm_f(vp.systemd_service)
+    FileUtils.rm_f(vp.dnsmasq_service)
     r "systemctl daemon-reload"
 
     begin


### PR DESCRIPTION
Otherwise these service files accumulate forever.  At least `Prog::Vm::Nexus#destroy` took care of stopping the service.