### PR TITLE
Revive explicit DNS server setting for dnsmasq

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -143,6 +143,7 @@ enable-ra
 dhcp-authoritative
 ra-param=tap#{@vm_name}
 dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
+dhcp-option=option6:dns-server,2620:fe::fe,2620:fe::9
 DNSMASQ_CONF
 
     vp.write_network_config(<<EOS)


### PR DESCRIPTION
By default, this will ask `systemd-resolved` where to do the query, which fails given that systemd configures `systemd-resolved` as yet another level of recursive resolver, bound to localhost, e.g. 127.0.0.53.  dnsmasq is in a separate namespace that does not have the same localhost, so it cannot contact `systemd-resolved`, and we probably don't want two levels of recursive resolution anyway.

So instead, install some datacenter-neutral-ish DNS servers.  These are from Quad9.