### PR TITLE
Avoid default routing in VM namespace

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -113,7 +113,7 @@ class VmSetup
     # Routing: from subordinate to host.
     vetho_ll = mac_to_ipv6_link_local(File.read("/sys/class/net/vetho#{q_vm}/address").chomp)
     r "ip -n #{q_vm} link set dev vethi#{q_vm} up"
-    r "ip -n #{q_vm} route add default via #{vetho_ll.shellescape} dev vethi#{q_vm}"
+    r "ip -n #{q_vm} route add 2000::/3 via #{vetho_ll.shellescape} dev vethi#{q_vm}"
 
     vp.write_guest_ephemeral(guest_ephemeral.to_s)
     vp.write_clover_ephemeral(clover_ephemeral.to_s)


### PR DESCRIPTION
The default route here has bothered me for quite a while: while developing I've introduced routing loops, and it makes it all too easy to spill unencrypted intended-to-be network overlay traffic into the host network namespace and then the ethernet card, if IPsec policies are not set just right to skim off those packets and encrypt & encapsulate them first.

As-is, as we never need to contact anything from a guest VM namespace that's not an IPv6 GUA (Global Unicast Address), so go ahead and itemize those explicitly.  Now, any otherwise leaked ULA address traffic will find itself without a route, which is much better.

I gave this patch a try and it seems to have no ill effect on Internet connectivity from the VM.