### PR TITLE
Skips VMs at refresh_mesh if the ephemeral_net6 is nil

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -200,6 +200,7 @@ SQL
     vms = Vm.reject { reject_list.include? _1.id }
 
     vms.each do |dst_vm|
+      next if dst_vm.ephemeral_net6.nil?
       private_subnets.each do |my_subnet|
         dst_vm.private_subnets.each do |dst_subnet|
           create_ipsec_tunnel(my_subnet, dst_vm, dst_subnet)


### PR DESCRIPTION
We just skip the vms if they don't have ephemeral_net6 assigned yet. Because they don't get it at the starting step and if we provision multiple of them, the refresh_mesh step gives this error:

```
Sshable::SshError: /home/rhizome/vendor/bundle/ruby/3.0.0/gems/netaddr-2.0.6/lib/util.rb:224:in `parse_IPv4': IPv4 requires (4) octets. (NetAddr::ValidationError)
        from /home/rhizome/vendor/bundle/ruby/3.0.0/gems/netaddr-2.0.6/lib/ipv4.rb:23:in `parse'
        from /home/rhizome/vendor/bundle/ruby/3.0.0/gems/netaddr-2.0.6/lib/ipv4net.rb:37:in `parse'
        from /home/rhizome/vendor/bundle/ruby/3.0.0/gems/netaddr-2.0.6/lib/netaddr.rb:54:in `parse_net'
        from bin/setup-ipsec:56:in `<main>'
```

This is happening because the `dst_ip` is nil