### PR TITLE
Fix home route redirect issue

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -152,6 +152,7 @@ class Clover < Roda
     hmac_secret Config.clover_session_secret
 
     login_view { view "auth/login", "Login" }
+    login_redirect "/dashboard"
     login_return_to_requested_location? true
     two_factor_auth_return_to_requested_location? true
     already_logged_in { redirect login_redirect }
@@ -196,6 +197,10 @@ class Clover < Roda
     nil
   end
 
+  hash_branch("dashboard") do |r|
+    view "/dashboard"
+  end
+
   route do |r|
     check_csrf! unless r.env["CONTENT_TYPE"]&.include?("application/json")
 
@@ -205,12 +210,12 @@ class Clover < Roda
     rodauth.load_memory
     rodauth.check_active_session
     r.rodauth
+    r.root do
+      r.redirect rodauth.login_route
+    end
     rodauth.require_authentication
     check_csrf!
 
-    r.hash_branches("")
-    r.root do
-      view "dashboard"
-    end
+    r.hash_branches
   end
 end

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -11,8 +11,8 @@
             "layouts/sidebar/item",
             locals: {
               name: "Dashboard",
-              url: "/",
-              is_active: (request.path == "/"),
+              url: "/dashboard",
+              is_active: (request.path == "/dashboard"),
               icon:
                 "<path stroke-linecap='round' stroke-linejoin='round' d='M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25' />"
             }


### PR DESCRIPTION
Dashboard is at "/" path and it requires authentication. So when we visit "/" path, it redirects to login page with "Please login to continue" error. It's not a good UX for first timers. I moved dashboard to "/dashboard" path and "/" path redirects to login page directly without any error message.