### PR TITLE
Bring VmHost to 100% and fix collision resolution bugs

### DIFF
--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -3,6 +3,13 @@
 require_relative "spec_helper"
 
 RSpec.describe VmHost do
+  subject(:vh) {
+    described_class.new(
+      net6: NetAddr.parse_net("2a01:4f9:2b:35a::/64"),
+      ip6: NetAddr.parse_ip("2a01:4f9:2b:35a::2")
+    )
+  }
+
   it "requires an Sshable too" do
     expect {
       sa = Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
@@ -11,10 +18,27 @@ RSpec.describe VmHost do
   end
 
   it "can generate random ipv6 subnets" do
-    vh = described_class.new(
-      net6: NetAddr.parse_net("2a01:4f9:2b:35a::/64"),
-      ip6: NetAddr.parse_ip("2a01:4f9:2b:35a::2")
-    )
     expect(vh.ip6_random_vm_network.contains(vh.ip6)).to be false
+  end
+
+  it "crashes if the prefix length for a VM is shorter than the host's prefix" do
+    expect {
+      vh.ip6_reserved_network(1)
+    }.to raise_error RuntimeError, "BUG: host prefix must be is shorter than reserved prefix"
+  end
+
+  it "tries to get another random network if the proposal matches the reserved nework" do
+    expect(SecureRandom).to receive(:bytes).and_return("\0\0")
+    expect(SecureRandom).to receive(:bytes).and_call_original
+    expect(vh.ip6_random_vm_network.to_s).not_to eq(vh.ip6_reserved_network)
+  end
+
+  it "has a shortcut to install Rhizome" do
+    vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
+    expect(Strand).to receive(:create) do |args|
+      expect(args[:prog]).to eq("InstallRhizome")
+      expect(args[:stack]).to eq([subject_id: vh.id])
+    end
+    vh.install_rhizome
   end
 end


### PR DESCRIPTION
"==" does not do what a reasonable person would think they ought to do with NetAddr IPv6 objects (it appears to be more like reference equality).  So use `#cmp(o) == 0`.

Also, the re-run of obtaining a random subnet was never being returned, so instead, the conflicting "proposal" would be returned instead.  One way to fix this would be to use `return` (that was my intention earlier) but given the reliance on `cmp` I rely on `case` instead.

Finally, one invariant is removed, as there are cases where there's no reserved subnet, for example, DataPacket statically routes an entire /64 linked to a computer responding via NDP to a formally unrelated /64 network.  As such, the host takes no bite out of the subnets available to guests here.