### PR TITLE
Introduce authorization basics

### DIFF
--- a/doc/authorization.md
+++ b/doc/authorization.md
@@ -1,0 +1,136 @@
+# Authorization
+
+Authorization beyond the most basic is a feature that is missing almost entirely
+from non-hyperscaler products in the cloud-adjacent space.
+
+All three hyperscalers seem to be gradually moving towards attribute-based
+access control (ABAC), which is explained best in general by
+[Tailscale blog post](https://tailscale.com/blog/rbac-like-it-was-meant-to-be/).
+
+You can see implementations of this, though they can be circuitous (by relying
+on conditional expressions) relative to a clean-sheet ABAC design.
+- [Amazon](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_attribute-based-access-control.html)
+- [Azure](https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview)
+- [GCP](https://cloud.google.com/iam/docs/conditions-overview)
+
+Ubicloud's authorization is going to deliver something about as powerful as IAM
+seen on any of the hyperscalers. It's in active development. Expect to have
+major adjustments.
+
+Default tag space with all powers is created when new user account is created.
+So new user may start to use our console right away without any knowledge about
+authorization. After getting familiar with our services, they can create new
+tag spaces, manage users, update policies etc.
+
+## Design
+A tag space is first and foremost a namespace for tags. Also, a tag space
+provides a convenient hook to associate with billing. In this respect, it has a
+lot in common with the Azure Subscription.
+
+Access tag is the name of a tag and its tag space, so that two distinct tag
+spaces could have a tag by the same name yet mean something distinct. When we
+apply a access tag to a resources, applied tags are created. Applied tags
+defines relations between resources and access tags. An access policy defines
+who (subject) can do what (power) on what (object). It like a formula to connect
+subjects and objects via powers. Any tag can be a subject or object. Powers are
+like permissions.
+
+```
+                                               +---------------+
+                        +---------------+      |  AppliedTags  |
+    +----------+        |   AccessTag   |      |      id       |
+    | TagSpace |        |      id       |<-+-->| access_tag_id |
++-->|    id    |<------>|  tag_space_id |  +-->|   tagged_id   |
+|   +----------+        |     name      |  |   +---------------+
+|                       |  hyper_tag_id |<-+
+|  +--------------+     +---------------+  |
+|  | AccessPolicy |                        |   +--------------+
++->| tag_space_id |                        |   |  Object ID   |
+   |     name     |                        +-->|   User, Vm   |
+   |     body     +----+                       | TagSpace etc.|
+   +--------------+    |                       +--------------+
+                       |
+                       v
+                   array({subjects, powers, objects})
+```
+
+### Hyper Tags
+One way to associate a principal with some power over tags in a tag space is
+hyper tagging. A way to implement hyper-tagging is to allow other kinds of
+objects to also be a tag. In this case, the TagSpace, User, Vm record could
+also be a tag.
+
+Tags have some alternate life as another object (User, TagSpace, Vm, maybe
+a Role record). To use a resource in access policy, it should be somehow
+represented in this tag space. Resource are tagged with its access tag, so they
+can be used in policy evaluation.
+
+### Access Policy Language
+Access policies have 3 main parts: subjects, powers, and objects. All of them
+can be a single string or a list of strings. Access tags are used for subjects,
+and objects. To use a tag in policy, it should have hyper-tag in that tag space.
+Powers are predefined.
+
+| Power           | Description                                            |
+|-----------------|--------------------------------------------------------|
+| Vm:view         | Grants permission to view Vm resources                 |
+| Vm:create       | Grants permission to create Vm in TagSpace             |
+| Vm:delete       | Grants permission to delete Vm                         |
+| TagSpace:view   | Grants permission to view TagSpace details             |
+| TagSpace:delete | Grants permission to delete TagSpace                   |
+| TagSpace:user   | Grants permission to add/remove users to/from TagSpace |
+| TagSpace:policy | Grants permission to update TagSpace's access policies |
+
+#### Examples
+
+User "test@test.com" can create a Vm in "default-tag-space" tag space.
+```json
+{
+  "acls": [
+    {
+      "subjects": "User/test@test.com",
+      "powers": "Vm:create",
+      "objects": "TagSpace/default-tag-space"
+    }
+  ]
+}
+```
+
+User "test@test.com" can view and delete Vms in "default-tag-space" tag space.
+```json
+{
+  "acls": [
+    {
+      "subjects": "User/test@test.com",
+      "powers": ["Vm:view", "Vm:delete"],
+      "objects": "TagSpace/default-tag-space"
+    }
+  ]
+}
+```
+
+User "test@test.com" can only view "vm1" and "vm2".
+```json
+{
+  "acls": [
+    {
+      "subjects": "User/test@test.com",
+      "powers": "Vm:view",
+      "objects": ["Vm/vm1", "Vm/vm2"]
+    }
+  ]
+}
+```
+
+User "test@test.com" can manage tag space users.
+```json
+{
+  "acls": [
+    {
+      "subjects": "User/test@test.com",
+      "powers": "TagSpace:user",
+      "objects": "TagSpace/default-tag-space"
+    }
+  ]
+}
+```

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Authorization
+  class Unauthorized < StandardError; end
+
+  def self.has_power?(subject_id, powers, object_id)
+    !matched_policies(subject_id, powers, object_id).empty?
+  end
+
+  def self.authorize(subject_id, powers, object_id)
+    unless has_power?(subject_id, powers, object_id)
+      fail Unauthorized
+    end
+  end
+
+  def self.authorized_resources(subject_id, powers)
+    matched_policies(subject_id, powers).map { _1[:tagged_id] }
+  end
+
+  def self.matched_policies(subject_id, powers, object_id = nil)
+    object_filter = if object_id
+      Sequel.lit("AND object_applied_tags.tagged_id = ?", object_id)
+    else
+      Sequel.lit("")
+    end
+
+    DB[<<~SQL, {subject_id: subject_id, powers: Sequel.pg_array(Array(powers)), object_filter: object_filter}].all
+      SELECT object_applied_tags.tagged_id, object_applied_tags.tagged_table, subjects, powers, objects
+      FROM accounts AS subject
+        JOIN applied_tag AS subject_applied_tags ON subject.id = subject_applied_tags.tagged_id
+          JOIN access_tag AS subject_access_tags ON subject_applied_tags.access_tag_id = subject_access_tags.id
+          JOIN access_policy AS acl ON subject_access_tags.tag_space_id = acl.tag_space_id
+          JOIN jsonb_to_recordset(acl.body->'acls') as items(subjects JSONB, powers JSONB, objects JSONB) ON TRUE
+          JOIN access_tag AS object_access_tags ON subject_access_tags.tag_space_id = object_access_tags.tag_space_id
+          JOIN applied_tag AS object_applied_tags ON object_access_tags.id = object_applied_tags.access_tag_id AND objects ? object_access_tags."name"
+      WHERE subject.id = :subject_id
+        AND powers ?| array[:powers]
+        AND subjects ? subject_access_tags."name"
+        :object_filter
+    SQL
+  end
+
+  def self.generate_default_acls(subject, object)
+    {
+      acls: [
+        {subjects: subject, powers: ["TagSpace:view", "TagSpace:delete", "TagSpace:user", "TagSpace:policy"], objects: object},
+        {subjects: subject, powers: ["Vm:view", "Vm:create", "Vm:delete"], objects: object}
+      ]
+    }
+  end
+
+  module Dataset
+    def authorized(subject_id, powers)
+      where(id: Authorization.authorized_resources(subject_id, powers))
+    end
+  end
+
+  module HyperTagMethods
+    def self.included(base)
+      base.class_eval do
+        many_to_many :tag_spaces, join_table: AccessTag.table_name, left_key: :hyper_tag_id, right_key: :tag_space_id
+      end
+    end
+
+    def hyper_tag_identifier
+      :name
+    end
+
+    def hyper_tag_prefix
+      self.class.name
+    end
+
+    def hyper_tag_name
+      "#{hyper_tag_prefix}/#{send(hyper_tag_identifier)}"
+    end
+
+    def hyper_tag(tag_space)
+      AccessTag.where(tag_space_id: tag_space.id, hyper_tag_id: id).first
+    end
+
+    def create_hyper_tag(tag_space)
+      AccessTag.create(tag_space_id: tag_space.id, name: hyper_tag_name, hyper_tag_id: id, hyper_tag_table: self.class.table_name)
+    end
+
+    def delete_hyper_tag(tag_space)
+      DB.transaction do
+        tag = hyper_tag(tag_space)
+        AppliedTag.where(access_tag_id: tag.id).delete
+        tag.delete
+      end
+    end
+
+    def associate_with_tag_space(tag_space)
+      return if tag_space.nil?
+
+      DB.transaction do
+        self_tag = create_hyper_tag(tag_space)
+        tag_space_tag = tag_space.hyper_tag(tag_space)
+        tag(self_tag)
+        tag(tag_space_tag) if self_tag.id != tag_space_tag.id
+      end
+    end
+
+    def dissociate_with_tag_space(tag_space)
+      return if tag_space.nil?
+
+      DB.transaction do
+        tag_space_tag = tag_space.hyper_tag(tag_space)
+        untag(tag_space_tag)
+        delete_hyper_tag(tag_space)
+      end
+    end
+  end
+
+  module TaggableMethods
+    def self.included(base)
+      base.class_eval do
+        many_to_many :applied_access_tags, class: AccessTag, join_table: AppliedTag.table_name, left_key: :tagged_id, right_key: :access_tag_id
+      end
+    end
+
+    def tag(access_tag)
+      AppliedTag.create(access_tag_id: access_tag.id, tagged_id: id, tagged_table: self.class.table_name)
+    end
+
+    def untag(access_tag)
+      AppliedTag.where(access_tag_id: access_tag.id, tagged_id: id).delete
+    end
+  end
+end

--- a/migrate/010_authorization.rb
+++ b/migrate/010_authorization.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table :tag_space do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :name, :text, collate: '"C"', null: false, unique: true
+    end
+
+    create_table :access_tag do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      foreign_key :tag_space_id, :tag_space, type: :uuid, null: false
+      column :hyper_tag_id, :uuid, null: true
+      column :hyper_tag_table, :text, collate: '"C"', null: false
+      column :name, :text, collate: '"C"', null: false
+
+      index [:tag_space_id, :hyper_tag_id], unique: true
+      index [:tag_space_id, :name], unique: true
+    end
+
+    create_table :applied_tag do
+      foreign_key :access_tag_id, :access_tag, type: :uuid, null: false
+      column :tagged_id, :uuid, null: false
+      column :tagged_table, :text, collate: '"C"', null: false
+
+      index [:access_tag_id, :tagged_id], unique: true
+      index :tagged_id
+    end
+
+    create_table :access_policy do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      foreign_key :tag_space_id, :tag_space, type: :uuid, null: false
+      column :name, :text, collate: '"C"', null: false
+      column :body, :jsonb, null: false
+
+      index [:tag_space_id, :name], unique: true
+    end
+  end
+end

--- a/model/access_policy.rb
+++ b/model/access_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class AccessPolicy < Sequel::Model
+  many_to_one :tag_space
+end

--- a/model/access_tag.rb
+++ b/model/access_tag.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class AccessTag < Sequel::Model
+  many_to_one :tag_space
+  one_to_many :applied_tags
+end

--- a/model/account.rb
+++ b/model/account.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "ulid"
+require "mail"
+require_relative "../model"
+
+class Account < Sequel::Model(:accounts)
+  include Authorization::HyperTagMethods
+
+  def hyper_tag_identifier
+    :email
+  end
+
+  def hyper_tag_prefix
+    "User"
+  end
+
+  include Authorization::TaggableMethods
+
+  def create_tag_space_with_default_policy(name, policy_body = nil)
+    tag_space = TagSpace.create(name: name)
+    tag_space.associate_with_tag_space(tag_space)
+    associate_with_tag_space(tag_space)
+    tag_space.add_access_policy(name: "default", body: policy_body || Authorization.generate_default_acls(hyper_tag_name, tag_space.hyper_tag_name))
+    tag_space
+  end
+
+  # TODO: probably we need to get name from users
+  def username
+    "#{Mail::Address.new(email).local}_#{ULID.from_uuidish(id).to_s[0..5].downcase}"
+  end
+end

--- a/model/applied_tag.rb
+++ b/model/applied_tag.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class AppliedTag < Sequel::Model
+  many_to_one :access_tag
+end

--- a/model/tag_space.rb
+++ b/model/tag_space.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class TagSpace < Sequel::Model
+  one_to_many :access_tags
+  one_to_many :access_policies
+
+  dataset_module Authorization::Dataset
+
+  include Authorization::HyperTagMethods
+  include Authorization::TaggableMethods
+
+  def user_ids
+    access_tags_dataset.where(hyper_tag_table: Account.table_name.to_s).select_map(:hyper_tag_id)
+  end
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -8,8 +8,13 @@ class Vm < Sequel::Model
   one_to_many :vm_private_subnet, key: :vm_id
   one_to_many :ipsec_tunnels, key: :src_vm_id
 
+  dataset_module Authorization::Dataset
+
   include SemaphoreMethods
   semaphore :destroy, :refresh_mesh
+
+  include Authorization::HyperTagMethods
+  include Authorization::TaggableMethods
 
   def private_subnets
     vm_private_subnet.map { _1.private_subnet }

--- a/routes/tag_space.rb
+++ b/routes/tag_space.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "ulid"
+
+class Clover
+  class TagSpaceShadow
+    attr_accessor :id, :name, :raw_id
+
+    def initialize(tag_space)
+      @id = ULID.from_uuidish(tag_space.id).to_s.downcase
+      @raw_id = tag_space.id
+      @name = tag_space.name
+    end
+  end
+
+  class UserShadow
+    attr_accessor :id, :email
+
+    def initialize(user)
+      @id = ULID.from_uuidish(user.id).to_s.downcase
+      @email = user.email
+    end
+  end
+
+  class AccessPolicyShadow
+    attr_accessor :id, :name, :body
+
+    def initialize(policy)
+      @id = ULID.from_uuidish(policy.id).to_s.downcase
+      @name = policy.name
+      @body = policy.body.to_json
+    end
+  end
+
+  hash_branch("tag-space") do |r|
+    current_user = Account[rodauth.session_value]
+
+    r.get true do
+      @tag_spaces = current_user.tag_spaces.map { TagSpaceShadow.new(_1) }
+
+      view "tag_space/index"
+    end
+
+    r.post true do
+      tag_space = current_user.create_tag_space_with_default_policy(r.params["name"])
+
+      r.redirect "/tag-space/#{TagSpaceShadow.new(tag_space).id}"
+    end
+
+    r.is "create" do
+      r.get true do
+        view "tag_space/create"
+      end
+    end
+
+    r.on String do |tag_space_ulid|
+      tag_space = TagSpace[id: ULID.parse(tag_space_ulid).to_uuidish]
+
+      unless tag_space
+        response.status = 404
+        r.halt
+      end
+
+      @tag_space = TagSpaceShadow.new(tag_space)
+
+      r.get true do
+        Authorization.authorize(rodauth.session_value, "TagSpace:view", tag_space.id)
+
+        view "tag_space/show_details"
+      end
+
+      r.delete true do
+        Authorization.authorize(rodauth.session_value, "TagSpace:delete", tag_space.id)
+
+        # If it has some resources, do not allow to delete it.
+        if tag_space.access_tags_dataset.exclude(hyper_tag_table: [Account.table_name.to_s, TagSpace.table_name.to_s, AccessTag.table_name.to_s]).count > 0
+          flash["error"] = "'#{tag_space.name}' tag space has some resources. Delete all related resources first."
+          return {message: "'#{tag_space.name}' tag space has some resources. Delete all related resources first."}.to_json
+        end
+
+        DB.transaction do
+          tag_space.access_tags.each { |access_tag| access_tag.applied_tags_dataset.delete }
+          tag_space.access_tags_dataset.delete
+          tag_space.access_policies_dataset.delete
+          tag_space.delete
+        end
+
+        flash["notice"] = "'#{tag_space.name}' tag space is deleted."
+        return {message: "'#{tag_space.name}' tag space is deleted."}.to_json
+      end
+
+      r.on "user" do
+        Authorization.authorize(rodauth.session_value, "TagSpace:user", tag_space.id)
+
+        r.get true do
+          users_with_hyper_tag = tag_space.user_ids
+          @users = Account.where(id: users_with_hyper_tag).map { UserShadow.new(_1) }
+
+          view "tag_space/show_users"
+        end
+
+        r.post true do
+          email = r.params["email"]
+          user = Account[email: email]
+
+          if user
+            user.associate_with_tag_space(tag_space)
+            # TODO: Send new tag space notification email
+          else
+            # TODO: Send invitation email to new user
+          end
+
+          flash["notice"] = "Invitation sent successfully to '#{email}'. You need to add some policies to allow new user to operate in the tag space."
+
+          r.redirect "/tag-space/#{TagSpaceShadow.new(tag_space).id}/user"
+        end
+
+        r.is String do |user_ulid|
+          user = Account[id: ULID.parse(user_ulid).to_uuidish]
+
+          unless user
+            response.status = 404
+            r.halt
+          end
+
+          r.delete true do
+            unless tag_space.user_ids.count > 1
+              response.status = 400
+              return {message: "You can't remove the last user from '#{tag_space.name}' tag space. Delete tag space instead."}.to_json
+            end
+
+            user.dissociate_with_tag_space(tag_space)
+
+            return {message: "Removing #{user.email} from #{tag_space.name}"}.to_json
+          end
+        end
+      end
+
+      r.on "policy" do
+        Authorization.authorize(rodauth.session_value, "TagSpace:policy", tag_space.id)
+
+        r.get true do
+          @policy = AccessPolicyShadow.new(tag_space.access_policies.first)
+
+          view "tag_space/show_policies"
+        end
+
+        r.is String do |policy_ulid|
+          policy = AccessPolicy[id: ULID.parse(policy_ulid).to_uuidish]
+
+          unless policy
+            response.status = 404
+            r.halt
+          end
+
+          r.post true do
+            policy.update(body: r.params["body"])
+
+            flash["notice"] = "'#{policy.name}' policy updated for '#{tag_space.name}'"
+
+            r.redirect "/tag-space/#{TagSpaceShadow.new(tag_space).id}/policy"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+RSpec.describe Authorization do
+  let(:users) { [Account.create(email: "auth1@example.com"), Account.create(email: "auth2@example.com")] }
+  let(:tag_spaces) { (0..1).map { users[_1].create_tag_space_with_default_policy("tag-space-#{_1}") } }
+  let(:vms) { (0..3).map { Prog::Vm::Nexus.assemble("key", tag_spaces[_1 / 2].id, name: "vm#{_1}") }.map(&:vm) }
+  let(:access_policy) { tag_spaces[0].access_policies.first }
+
+  after do
+    users.each(&:destroy)
+  end
+
+  describe "#matched_policies" do
+    it "without specific object" do
+      [
+        [[], SecureRandom.uuid, "Vm:view", 0],
+        [[], SecureRandom.uuid, ["Vm:view"], 0],
+        [[], SecureRandom.uuid, ["Vm:view"], 0],
+        [[], users[0].id, "Vm:view", 0],
+        [[], users[0].id, ["Vm:view"], 0],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:view", objects: tag_spaces[0].hyper_tag_name}], users[0].id, "Vm:view", 4],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:view", objects: tag_spaces[0].hyper_tag_name}], users[0].id, ["Vm:view", "Vm:create"], 4],
+        [[{subjects: [users[0].hyper_tag_name], powers: ["Vm:view"], objects: [tag_spaces[0].hyper_tag_name]}], users[0].id, "Vm:view", 4],
+        [[{subjects: [users[0].hyper_tag_name, users[1].hyper_tag_name], powers: ["Vm:view", "Vm:delete"], objects: [tag_spaces[0].hyper_tag_name]}], users[0].id, ["Vm:view", "Vm:create"], 4],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:view", objects: vms[0].hyper_tag_name}], users[0].id, "Vm:view", 1],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:view", objects: vms.map(&:hyper_tag_name)}], users[0].id, "Vm:view", 2],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:delete", objects: vms[0].hyper_tag_name}], users[0].id, "Vm:view", 0]
+      ].each do |policies, subject_id, powers, matched_count|
+        access_policy.update(body: {acls: policies})
+        expect(described_class.matched_policies(subject_id, powers).count).to eq(matched_count)
+      end
+    end
+
+    it "with specific object" do
+      [
+        [[], SecureRandom.uuid, "Vm:view", SecureRandom.uuid, 0],
+        [[], SecureRandom.uuid, ["Vm:view"], SecureRandom.uuid, 0],
+        [[], SecureRandom.uuid, ["Vm:view"], vms[0].id, 0],
+        [[], users[0].id, ["Vm:view"], vms[0].id, 0],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:view", objects: tag_spaces[0].hyper_tag_name}], users[0].id, "Vm:view", vms[0].id, 1],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:view", objects: tag_spaces[0].hyper_tag_name}], users[0].id, ["Vm:view", "Vm:create"], vms[0].id, 1],
+        [[{subjects: [users[0].hyper_tag_name], powers: ["Vm:view"], objects: [tag_spaces[0].hyper_tag_name]}], users[0].id, "Vm:view", vms[0].id, 1],
+        [[{subjects: [users[0].hyper_tag_name, users[1].hyper_tag_name], powers: ["Vm:view", "Vm:delete"], objects: [tag_spaces[0].hyper_tag_name]}], users[0].id, ["Vm:view", "Vm:create"], vms[0].id, 1],
+        [[{subjects: users[0].hyper_tag_name, powers: "Vm:delete", objects: tag_spaces[0].hyper_tag_name}], users[0].id, "Vm:view", vms[0].id, 0],
+        [[{subjects: [users[0].hyper_tag_name], powers: ["Vm:view"], objects: [tag_spaces[0].hyper_tag_name, tag_spaces[0].hyper_tag_name]}], users[0].id, "Vm:view", vms[0].id, 1]
+      ].each do |policies, subject_id, powers, object_id, matched_count|
+        access_policy.update(body: {acls: policies})
+        expect(described_class.matched_policies(subject_id, powers, object_id).count).to eq(matched_count)
+      end
+    end
+  end
+
+  describe "#has_power?" do
+    it "returns true when has matched policies" do
+      expect(described_class.has_power?(users[0].id, "Vm:view", vms[0].id)).to be(true)
+    end
+
+    it "returns false when has no matched policies" do
+      access_policy.update(body: [])
+      expect(described_class.has_power?(users[0].id, "Vm:view", vms[0].id)).to be(false)
+    end
+  end
+
+  describe "#authorize" do
+    it "not raises error when has matched policies" do
+      expect { described_class.authorize(users[0].id, "Vm:view", vms[0].id) }.not_to raise_error
+    end
+
+    it "raises error when has no matched policies" do
+      access_policy.update(body: [])
+      expect { described_class.authorize(users[0].id, "Vm:view", vms[0].id) }.to raise_error Authorization::Unauthorized
+    end
+  end
+
+  describe "#authorized_resources" do
+    it "returns resource ids when has matched policies" do
+      ids = [vms[0].id, vms[1].id, tag_spaces[0].id, users[0].id]
+      expect(described_class.authorized_resources(users[0].id, "Vm:view").sort).to eq(ids.sort)
+    end
+
+    it "returns no resource ids when has no matched policies" do
+      access_policy.update(body: [])
+      expect(described_class.authorized_resources(users[0].id, "Vm:view")).to eq([])
+    end
+  end
+
+  describe "#Dataset" do
+    it "returns authorized resources" do
+      ids = [vms[0].id, vms[1].id]
+      expect(Vm.authorized(users[0].id, "Vm:view").select_map(:id).sort).to eq(ids.sort)
+    end
+
+    it "returns no authorized resources" do
+      expect(Vm.authorized(users[0].id, "Vm:view").select_map(:id).sort).to eq([])
+    end
+  end
+
+  describe "#HyperTagMethods" do
+    it "hyper_tag_name" do
+      expect(users[0].hyper_tag_name).to eq("User/auth1@example.com")
+      expect(vms[0].hyper_tag_name).to eq("Vm/vm0")
+      expect(tag_spaces[0].hyper_tag_name).to eq("TagSpace/tag-space-0")
+    end
+
+    it "hyper_tag methods" do
+      tag_space = TagSpace.create(name: "test")
+      expect(tag_space.hyper_tag(tag_space)).to be_nil
+
+      tag = tag_space.create_hyper_tag(tag_space)
+      expect(tag_space.hyper_tag(tag_space)).to exist
+
+      vms.each { _1.tag(tag) }
+      expect(AppliedTag.where(access_tag_id: tag.id).count).to eq(4)
+
+      tag_space.delete_hyper_tag(tag_space)
+      expect(tag_space.hyper_tag(tag_space)).to be_nil
+      expect(AppliedTag.where(access_tag_id: tag.id).count).to eq(0)
+    end
+
+    it "associate/dissociate with tag space" do
+      tag_space = TagSpace.create(name: "test")
+      tag_space.associate_with_tag_space(tag_space)
+      users[0].associate_with_tag_space(tag_space)
+
+      expect(tag_space.applied_access_tags.count).to eq(1)
+      expect(users[0].applied_access_tags.count).to eq(2)
+
+      users[0].dissociate_with_tag_space(tag_space)
+      tag_space.dissociate_with_tag_space(tag_space)
+
+      expect(tag_space.reload.applied_access_tags.count).to eq(0)
+      expect(users[0].reload.applied_access_tags.count).to eq(0)
+    end
+
+    it "does not associate/dissociate with nil tag space" do
+      tag_space = TagSpace.create(name: "test")
+      expect(tag_space.associate_with_tag_space(nil)).to be_nil
+      expect(tag_space.applied_access_tags.count).to eq(0)
+
+      expect(tag_space.dissociate_with_tag_space(nil)).to be_nil
+      expect(tag_space.applied_access_tags.count).to eq(0)
+    end
+  end
+
+  describe "#TaggableMethods" do
+    it "can tag" do
+      tag = tag_spaces[1].hyper_tag(tag_spaces[1])
+      expect(vms[0].applied_access_tags.include?(tag)).to be(false)
+      vms[0].tag(tag)
+      expect(vms[0].reload.applied_access_tags.include?(tag)).to be(true)
+    end
+
+    it "can untag" do
+      tag = tag_spaces[0].hyper_tag(tag_spaces[0])
+      expect(vms[0].applied_access_tags.include?(tag)).to be(true)
+      vms[0].untag(tag)
+      expect(vms[0].reload.applied_access_tags.include?(tag)).to be(false)
+    end
+  end
+end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -10,13 +10,14 @@ RSpec.describe Prog::Vm::Nexus do
 
   let(:st) { Strand.new }
   let(:vm) { Vm.new(size: "m5a.2x") }
+  let(:tg) { TagSpace.create(name: "default").tap { _1.associate_with_tag_space(_1) } }
 
   it "creates the user and key record" do
     private_subnets = [
       NetAddr::IPv6Net.parse("fd55:666:cd1a:ffff::/64"),
       NetAddr::IPv6Net.parse("fd12:345:6789:0abc::/64")
     ]
-    st = described_class.assemble("some_ssh_key", private_subnets: private_subnets)
+    st = described_class.assemble("some_ssh_key", tg.id, private_subnets: private_subnets)
     prog = described_class.new(st)
     vm = prog.vm
     vm.ephemeral_net6 = "fe80::/64"

--- a/spec/web/spec_helper.rb
+++ b/spec/web/spec_helper.rb
@@ -10,10 +10,6 @@ require "argon2"
 
 Gem.suffix_pattern
 
-Clover.plugin :error_handler do |e|
-  raise e
-end
-
 Capybara.app = Clover.freeze.app
 Capybara.exact = true
 
@@ -34,20 +30,30 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    # Create a default user to use in all test if not exits
-    # Database cleaner can't trunca accounts tables because of
-    # account of `ph` user separation.
-    unless DB[:accounts].where(email: "user@example.com").first
-      hash = Argon2::Password.new({
-        t_cost: 1,
-        m_cost: 3,
-        secret: Config.clover_session_secret
-      }).create("0123456789")
-
-      account_id = DB[:accounts].insert(email: "user@example.com", status_id: 2)
-      DB[:account_password_hashes].insert(id: account_id, password_hash: hash)
-    end
+    create_user_if_not_exist("user@example.com", "0123456789")
+    create_user_if_not_exist("user2@example.com", "0123456789")
   end
+end
+
+def create_user_if_not_exist(email, password)
+  # Create a default user to use in all test if not exits
+  # Database cleaner can't trunca accounts tables because of
+  # account of `ph` user separation.
+
+  user = Account[email: email] || begin
+    hash = Argon2::Password.new({
+      t_cost: 1,
+      m_cost: 3,
+      secret: Config.clover_session_secret
+    }).create(password)
+
+    account = Account.create(email: email, status_id: 2)
+    DB[:account_password_hashes].insert(id: account.id, password_hash: hash)
+
+    account
+  end
+  user.create_tag_space_with_default_policy("#{user.username}_tag_space")
+  user
 end
 
 def login(email = "user@example.com", password = "0123456789")

--- a/spec/web/tag_space_spec.rb
+++ b/spec/web/tag_space_spec.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "tag_space" do
+  let(:user) { Account[email: "user@example.com"] }
+  let(:user2) { Account[email: "user2@example.com"] }
+
+  let(:tag_space) { user.create_tag_space_with_default_policy("tag-space-1") }
+
+  let(:tag_space_wo_permissions) { user.create_tag_space_with_default_policy("tag-space-2", policy_body: []) }
+
+  describe "unauthenticated" do
+    it "can not list without login" do
+      visit "/tag-space"
+
+      expect(page.title).to eq("Ubicloud - Login")
+    end
+
+    it "can not create without login" do
+      visit "/tag-space/create"
+
+      expect(page.title).to eq("Ubicloud - Login")
+    end
+  end
+
+  describe "authenticated" do
+    before do
+      login
+    end
+
+    describe "list" do
+      it "can list no tag spaces" do
+        expect(Account).to receive(:[]).and_return(user).twice
+        expect(user).to receive(:tag_spaces).and_return([])
+
+        visit "/tag-space"
+
+        expect(page.title).to eq("Ubicloud - Tag Spaces")
+        expect(page).to have_content "No tag spaces"
+
+        click_link "New Tag Space"
+        expect(page.title).to eq("Ubicloud - Create Tag Space")
+      end
+
+      it "can not list tag spaces when does not invited" do
+        tag_space
+        new_tag_space = user2.create_tag_space_with_default_policy("tag-space-3")
+
+        visit "/tag-space"
+
+        expect(page.title).to eq("Ubicloud - Tag Spaces")
+        expect(page).to have_content tag_space.name
+        expect(page).not_to have_content new_tag_space.name
+      end
+    end
+
+    describe "create" do
+      it "can create new tag space" do
+        name = "new-tag-space"
+        visit "/tag-space/create"
+
+        expect(page.title).to eq("Ubicloud - Create Tag Space")
+
+        fill_in "Name", with: name
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - #{name}")
+        expect(page).to have_content name
+
+        tag_space = TagSpace[name: name]
+        expect(tag_space.access_tags.count).to be 2
+        expect(tag_space.access_policies.count).to be 1
+        expect(tag_space.applied_access_tags.count).to be 1
+        expect(user.hyper_tag(tag_space)).to exist
+      end
+    end
+
+    describe "show - details" do
+      it "can show tag space details" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        visit "/tag-space"
+
+        expect(page.title).to eq("Ubicloud - Tag Spaces")
+        expect(page).to have_content shadow.name
+
+        click_link "Show", href: "/tag-space/#{shadow.id}"
+
+        expect(page.title).to eq("Ubicloud - #{shadow.name}")
+        expect(page).to have_content shadow.name
+      end
+
+      it "raises forbidden when does not have permissions" do
+        shadow = Clover::TagSpaceShadow.new(tag_space_wo_permissions)
+        visit "/tag-space"
+
+        expect(page.title).to eq("Ubicloud - Tag Spaces")
+        expect(page).to have_content shadow.name
+
+        click_link "Show", href: "/tag-space/#{shadow.id}"
+
+        expect(page.title).to eq("Ubicloud - Forbidden")
+        expect(page.status_code).to eq(403)
+        expect(page).to have_content "Forbidden"
+      end
+
+      it "raises not found when virtual machine not exists" do
+        visit "/tag-space/08s56d4kaj94xsmrnf5v5m3mav"
+
+        expect(page.title).to eq("Ubicloud - Page not found")
+        expect(page.status_code).to eq(404)
+        expect(page).to have_content "Page not found"
+      end
+    end
+
+    describe "show - users" do
+      it "can show tag space users" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        visit "/tag-space/#{shadow.id}"
+
+        click_link "Users"
+
+        expect(page.title).to eq("Ubicloud - #{shadow.name} - Users")
+        expect(page).to have_content user.email
+      end
+
+      it "raises forbidden when does not have permissions" do
+        shadow = Clover::TagSpaceShadow.new(tag_space_wo_permissions)
+        visit "/tag-space/#{shadow.id}/user"
+
+        expect(page.title).to eq("Ubicloud - Forbidden")
+        expect(page.status_code).to eq(403)
+        expect(page).to have_content "Forbidden"
+      end
+
+      it "can invite new user to tag space" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        visit "/tag-space/#{shadow.id}/user"
+
+        expect(page).to have_content user.email
+        expect(page).not_to have_content user2.email
+
+        fill_in "Email", with: user2.email
+        click_button "Invite"
+
+        expect(page).to have_content user.email
+        expect(page).to have_content user2.email
+      end
+
+      it "can invite new existing email to tag space and nothing happens" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        visit "/tag-space/#{shadow.id}/user"
+
+        expect(page).to have_content user.email
+
+        fill_in "Email", with: "new@example.com"
+        click_button "Invite"
+
+        expect(page).to have_content user.email
+        expect(page).to have_content "Invitation sent successfully to 'new@example.com'."
+      end
+
+      it "can remove user from tag space" do
+        tag_space_shadow = Clover::TagSpaceShadow.new(tag_space)
+        user2_shadow = Clover::UserShadow.new(user2)
+        user2.associate_with_tag_space(tag_space)
+
+        visit "/tag-space/#{tag_space_shadow.id}/user"
+
+        expect(page).to have_content user.email
+        expect(page).to have_content user2.email
+
+        # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
+        # UI tests run without a JavaScript enginer.
+        btn = find "#user-#{user2_shadow.id} .delete-btn"
+        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+        expect(page.body).to eq({message: "Removing #{user2.email} from #{tag_space.name}"}.to_json)
+
+        visit "/tag-space/#{tag_space_shadow.id}/user"
+        expect(page).to have_content user.email
+        expect(page).not_to have_content user2.email
+      end
+
+      it "raises bad request when it's the last user" do
+        tag_space_shadow = Clover::TagSpaceShadow.new(tag_space)
+        user_shadow = Clover::UserShadow.new(user)
+
+        visit "/tag-space/#{tag_space_shadow.id}/user"
+
+        # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
+        # UI tests run without a JavaScript enginer.
+        btn = find "#user-#{user_shadow.id} .delete-btn"
+        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+        expect(page.body).to eq({message: "You can't remove the last user from '#{tag_space.name}' tag space. Delete tag space instead."}.to_json)
+
+        visit "/tag-space/#{tag_space_shadow.id}/user"
+        expect(page).to have_content user.email
+      end
+
+      it "raises not found when user not exists" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+
+        expect(Account).to receive(:[]).and_return(nil).twice
+
+        visit "/tag-space/#{shadow.id}/user/08s56d4kaj94xsmrnf5v5m3mav"
+
+        expect(page.title).to eq("Ubicloud - Page not found")
+        expect(page.status_code).to eq(404)
+        expect(page).to have_content "Page not found"
+      end
+    end
+
+    describe "show - policies" do
+      it "can show tag space policy" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        visit "/tag-space/#{shadow.id}"
+
+        click_link "Policy"
+
+        expect(page.title).to eq("Ubicloud - #{shadow.name} - Policy")
+        expect(page).to have_content tag_space.access_policies.first.body.to_json
+      end
+
+      it "raises forbidden when does not have permissions" do
+        shadow = Clover::TagSpaceShadow.new(tag_space_wo_permissions)
+        visit "/tag-space/#{shadow.id}/policy"
+
+        expect(page.title).to eq("Ubicloud - Forbidden")
+        expect(page.status_code).to eq(403)
+        expect(page).to have_content "Forbidden"
+      end
+
+      it "can update policy" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        current_policy = tag_space.access_policies.first.body
+        new_policy = {
+          acls: [
+            {powers: ["TagSpace:policy"], objects: tag_space.hyper_tag_name, subjects: user.hyper_tag_name}
+          ]
+        }
+
+        visit "/tag-space/#{shadow.id}/policy"
+
+        expect(page).to have_content current_policy.to_json
+
+        fill_in "body", with: new_policy.to_json
+        click_button "Update"
+
+        expect(page).to have_content new_policy.to_json
+      end
+
+      it "raises not found when access policy not exists" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+
+        expect(AccessPolicy).to receive(:[]).and_return(nil)
+
+        visit "/tag-space/#{shadow.id}/policy/08s56d4kaj94xsmrnf5v5m3mav"
+
+        expect(page.title).to eq("Ubicloud - Page not found")
+        expect(page.status_code).to eq(404)
+        expect(page).to have_content "Page not found"
+      end
+    end
+
+    describe "delete" do
+      it "can delete tag space" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        visit "/tag-space/#{shadow.id}"
+
+        # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
+        # UI tests run without a JavaScript enginer.
+        btn = find ".delete-btn"
+        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+        expect(page.body).to eq({message: "'#{tag_space.name}' tag space is deleted."}.to_json)
+
+        expect(TagSpace[tag_space.id]).to be_nil
+        expect(AccessTag.where(tag_space_id: tag_space.id).count).to eq(0)
+        expect(AccessPolicy.where(tag_space_id: tag_space.id).count).to eq(0)
+      end
+
+      it "can not delete tag space when it has resources" do
+        shadow = Clover::TagSpaceShadow.new(tag_space)
+        Prog::Vm::Nexus.assemble("key", tag_space.id, name: "vm1")
+
+        visit "/tag-space/#{shadow.id}"
+
+        # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
+        # UI tests run without a JavaScript enginer.
+        btn = find ".delete-btn"
+        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+        expect(page.body).to eq({message: "'#{tag_space.name}' tag space has some resources. Delete all related resources first."}.to_json)
+
+        visit "/tag-space"
+
+        expect(page).to have_content tag_space.name
+      end
+
+      it "can not delete tag space when does not have permissions" do
+        shadow = Clover::TagSpaceShadow.new(tag_space_wo_permissions)
+
+        # Give permission to view, so we can see the detail page
+        tag_space_wo_permissions.access_policies.first.update(body: {acls: [
+          {subjects: user.hyper_tag_name, powers: ["TagSpace:view"], objects: tag_space_wo_permissions.hyper_tag_name}
+        ]})
+
+        visit "/tag-space/#{shadow.id}"
+
+        expect { find ".delete-btn" }.to raise_error Capybara::ElementNotFound
+      end
+    end
+  end
+end

--- a/views/components/form/select.erb
+++ b/views/components/form/select.erb
@@ -1,27 +1,33 @@
 <% name = defined?(name) ? name : nil %>
 <% label = defined?(label) ? label : nil %>
-<% type = (defined?(type) && type) ? type : "text" %>
-<% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
-<% description = (defined?(description) && description) ? description : nil %>
-<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
+<% options = (defined?(options) && options) ? options : {} %>
+<% selected = defined?(selected) ? selected : nil %>
+<% error = defined?(error) ? error : flash.dig("errors", name) %>
+<% description = defined?(description) ? description : nil %>
+<% attributes = defined?(attributes) ? attributes : {} %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>
-    <label for="<%= name %>" class="block text-sm font-medium leading-6"><%= label %></label>
+    <label for="<%= name %>" class="text-sm font-medium leading-6"><%= label %></label>
   <% end %>
-  <input
+  <select
     id="<%= name %>"
-    type="<%= type %>"
     name="<%= name %>"
     class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-indigo-600"%>"
     <% attributes.each do |atr_key, atr_value| %>
     <%= atr_key %>="<%= atr_value %>"
     <% end%>
   >
+    <% options.each do |opt_val, opt_text| %>
+      <option value="<%= opt_val %>" <%= (opt_val == selected) ? "selected" : "" %>>
+        <%= opt_text %>
+      </option>
+    <% end %>
+  </select>
   <% if error %>
     <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
   <% end %>
   <% if description %>
-    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%== description %></p>
+    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%= description %></p>
   <% end %>
 </div>

--- a/views/components/form/textarea.erb
+++ b/views/components/form/textarea.erb
@@ -1,19 +1,22 @@
 <% name = defined?(name) ? name : nil %>
+<% value = defined?(value) ? value : nil %>
 <% label = defined?(label) ? label : nil %>
 <% error = defined?(error) ? error : flash.dig("errors", name) %>
 <% description = defined?(description) ? description : nil %>
 <% attributes = defined?(attributes) ? attributes : {} %>
 
 <div class="space-y-2">
-  <label for="<%= name %>" class="block text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+  <% if label %>
+    <label for="<%= name %>" class="block text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+  <% end %>
   <textarea
     id="<%= name %>"
     name="<%= name %>"
     class="block w-full rounded-md border-0 sm:py-1.5 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-indigo-600"%>"
-    <% attributes.each do |key, value| %>
-    <%= key %>="<%= value %>"
+    <% attributes.each do |atr_key, atr_value| %>
+    <%= atr_key %>="<%= atr_value %>"
     <% end%>
-  ></textarea>
+  ><%= value %></textarea>
   <% if error %>
     <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
   <% end %>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -91,7 +91,7 @@
         </div>
         <div class="mt-8">
           <h3 class="text-base font-semibold leading-6 text-gray-900">
-            <a href="/profile" class="focus:outline-none">
+            <a href="/settings" class="focus:outline-none">
               <!-- Extend touch target to entire panel -->
               <span class="absolute inset-0" aria-hidden="true"></span>
               Account Settings

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -32,6 +32,16 @@
           <%== render(
             "layouts/sidebar/item",
             locals: {
+              name: "Tag Space",
+              url: "/tag-space",
+              is_active: request.path.start_with?("/tag-space"),
+              icon:
+                "<path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' /><path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' />"
+            }
+          ) %>
+          <%== render(
+            "layouts/sidebar/item",
+            locals: {
               name: "Object Storage",
               url: "/object-storage",
               is_active: request.path.start_with?("/object-storage"),

--- a/views/tag_space/create.erb
+++ b/views/tag_space/create.erb
@@ -1,0 +1,45 @@
+<% @page_title = "Create Tag Space" %>
+
+<div class="px-2 sm:px-3 lg:px-4">
+  <div class="space-y-1">
+    <%== render("components/breadcrumb", locals: { back: "/tag-space", parts: [["Tag Spaces", "/tag-space"], %w[Create #]] }) %>
+    <%== render("components/page_header", locals: { title: "Create Tag Space" }) %>
+  </div>
+  <!-- Create Card -->
+  <div class="mt-8 flow-root">
+    <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+        <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg bg-white">
+          <form action="/tag-space" method="POST">
+            <!-- YYY: need a better way to manage coupling of routes and erbs -->
+            <%== csrf_tag("/tag-space") %>
+            <div class="space-y-12 px-4 py-6 sm:p-8">
+              <div class="border-b border-gray-900/10 pb-12">
+                <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                  <div class="sm:col-span-3">
+                    <%== render(
+                      "components/form/text",
+                      locals: {
+                        name: "name",
+                        label: "Name",
+                        attributes: {
+                          required: true,
+                          placeholder: "Enter name"
+                        }
+                      }
+                    ) %>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="mb-8 flex items-center justify-end gap-x-6 px-8">
+              <a href="/vm" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>
+              <%== render("components/form/submit_button", locals: { text: "Create" }) %>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/tag_space/index.erb
+++ b/views/tag_space/index.erb
@@ -1,13 +1,13 @@
-<% @page_title = "Virtual Machines" %>
+<% @page_title = "Tag Spaces" %>
 
-<% if @vms.count > 0 %>
+<% if @tag_spaces.count > 0 %>
   <div class="px-2 sm:px-3 lg:px-4">
     <%== render(
       "components/page_header",
       locals: {
-        title: "Virtual Machines",
+        title: "Tag Spaces",
         right_items: [
-          "<a href='vm/create' class='inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'>Create Virtual Machine</a>"
+          "<a href='tag-space/create' class='inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'>Create Tag Space</a>"
         ]
       }
     ) %>
@@ -19,33 +19,17 @@
               <thead class="bg-gray-50">
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Tag Space</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Provider & Location</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Size</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">IPv6</th>
                   <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
                     <span class="sr-only">Show</span>
                   </th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-200 bg-white">
-                <% @vms.each do |vm| %>
+                <% @tag_spaces.each do |tag_space| %>
                   <tr>
-                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= vm.name %></td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm.tag_spaces.map(&:name).join(", ") %></td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm.location %></td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm.size %></td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      <%== render("components/vm_state_label", locals: { state: vm.state }) %>
-                    </td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      <span class="copy-content cursor-pointer" data-content="<%= vm.ip6 %>" data-message="Copied IPv6">
-                        <%= vm.ip6 %>
-                      </span>
-                    </td>
+                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= tag_space.name %></td>
                     <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                      <a href="/vm/<%= vm.id %>" class="text-indigo-600 hover:text-indigo-900">Show</a>
+                      <a href="/tag-space/<%= tag_space.id %>" class="text-indigo-600 hover:text-indigo-900">Show</a>
                     </td>
                   </tr>
                 <% end %>
@@ -65,11 +49,11 @@
         d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z"
       />
     </svg>
-    <h3 class="mt-2 text-sm font-semibold text-gray-900">No virtual machines</h3>
-    <p class="mt-1 text-sm text-gray-500">Get started by creating a new virtual machine.</p>
+    <h3 class="mt-2 text-sm font-semibold text-gray-900">No tag spaces</h3>
+    <p class="mt-1 text-sm text-gray-500">Get started by creating a tag space.</p>
     <div class="mt-6">
       <a
-        href="/vm/create"
+        href="/tag-space/create"
         class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
       >
         <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -77,7 +61,7 @@
             d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z"
           />
         </svg>
-        New Virtual Machine
+        New Tag Space
       </a>
     </div>
   </div>

--- a/views/tag_space/show_details.erb
+++ b/views/tag_space/show_details.erb
@@ -1,0 +1,73 @@
+<% @page_title = @tag_space.name %>
+
+<div class="px-2 sm:px-3 lg:px-4">
+  <div class="space-y-1">
+    <%== render(
+      "components/breadcrumb",
+      locals: {
+        back: "/tag-space",
+        parts: [["Tag Spaces", "/tag-space"], [@tag_space.name, "/tag-space/#{@tag_space.id}"], %w[Details #]]
+      }
+    ) %>
+    <%== render("components/page_header", locals: { title: @tag_space.name }) %>
+  </div>
+
+  <main class="mt-4 md:mt-8">
+    <div class="max-w-screen-xl pb-6 lg:pb-16">
+      <div class="overflow-hidden rounded-lg bg-white shadow">
+        <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+          <%== render("tag_space/show_sidebar") %>
+          <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+            <!-- Details -->
+            <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
+              <div>
+                <h2 class="text-lg font-medium leading-6 text-gray-900">Details</h2>
+              </div>
+              <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
+                <dl class="sm:divide-y sm:divide-gray-200">
+                  <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
+                    <dt class="text-sm font-medium text-gray-500">ID</dt>
+                    <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @tag_space.id %></dd>
+                  </div>
+                  <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
+                    <dt class="text-sm font-medium text-gray-500">Name</dt>
+                    <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @tag_space.name %></dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+            <!-- Delete -->
+            <% if Authorization.has_power?(rodauth.session_value, "TagSpace:delete", @tag_space.raw_id) %>
+              <div>
+                <div class="px-4 py-6 sm:px-6">
+                  <h2 class="text-lg font-medium leading-6 text-gray-900">Delete tag space</h2>
+                  <p class="mt-1 text-sm text-gray-500">
+                    This action will permanently delete this tag space. Deleted data cannot be recovered. Use it
+                    carefully.
+                  </p>
+                  <button
+                    type="button"
+                    data-url="<%= request.path %>"
+                    data-csrf="<%= csrf_token(request.path, "DELETE") %>"
+                    data-confirmation="<%= @tag_space.name %>"
+                    data-redirect="/tag-space"
+                    class="delete-btn inline-flex items-center mt-2 rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
+                  >
+                    <svg class="-ml-0.5 mr-1.5 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                      />
+                    </svg>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>

--- a/views/tag_space/show_policies.erb
+++ b/views/tag_space/show_policies.erb
@@ -1,0 +1,102 @@
+<% @page_title = "#{@tag_space.name} - Policy" %>
+
+<div class="px-2 sm:px-3 lg:px-4">
+  <div class="space-y-1">
+    <%== render(
+      "components/breadcrumb",
+      locals: {
+        back: "/tag-space",
+        parts: [["Tag Spaces", "/tag-space"], [@tag_space.name, "/tag-space/#{@tag_space.id}"], %w[Policy #]]
+      }
+    ) %>
+    <%== render("components/page_header", locals: { title: @tag_space.name }) %>
+  </div>
+
+  <main class="mt-4 md:mt-8">
+    <div class="max-w-screen-xl pb-6 lg:pb-16">
+      <div class="overflow-hidden rounded-lg bg-white shadow">
+        <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+          <%== render("tag_space/show_sidebar") %>
+          <div class="divide-y divide-gray-200 lg:col-span-10 pb-10">
+            <!-- Invite user -->
+            <form action="<%= "/tag-space/#{@tag_space.id}/policy/#{@policy.id}" %>" role="form" method="POST">
+              <%== csrf_tag("/tag-space/#{@tag_space.id}/policy/#{@policy.id}") %>
+              <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
+                <div>
+                  <h2 class="text-lg font-medium leading-6 text-gray-900">Update policy</h2>
+                </div>
+                <div class="grid grid-cols-12 gap-6">
+                  <div class="col-span-full">
+                    <div class="policy-editor">
+                      <pre class="bg-gray-50 rounded-lg p-3 h-[60vh] overflow-scroll" contenteditable="true">
+                        <%= @policy.body %>
+                      </pre>
+                      <textarea name="body" class="hidden" required></textarea>
+                    </div>
+                  </div>
+                  <div class="col-span-3 sm:col-span-6">
+                    <%== render("components/form/submit_button", locals: { text: "Update" }) %>
+                  </div>
+                </div>
+                <div class="mt-12 text-sm text-gray-500">
+                  <h4 class="font-medium text-gray-900 text-lg">Access Policy Language</h4>
+                  <p class="mt-2">
+                    Access policies have 3 main parts: subjects, powers, and objects. All of them can be a single
+                    string or a list of strings.
+                    <span class="text-gray-700 font-medium">"TagSpace/&lt;NAME&gt;"</span>,
+                    <span class="text-gray-700 font-medium">"User/&lt;EMAIL&gt;"</span>,
+                    <span class="text-gray-700 font-medium">"Vm/&lt;NAME&gt;"</span>
+                    or custom tags can be used for subjects, and objects. To use a tag in policy, it should have to
+                    assoaciated with the tag space. Powers are predefined.
+                  </p>
+                  <table class="mt-4 min-w-full divide-y divide-gray-300 text-left text-sm">
+                    <thead class="font-semibold">
+                      <tr>
+                        <th scope="col" class="px-2 py-3.5 text-gray-900 border">Power</th>
+                        <th scope="col" class="px-2 py-3.5 text-gray-900 border">Description</th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 ">
+                      <tr>
+                        <td class="px-2 py-2 text-gray-500 border">Vm:view</td>
+                        <td class="px-2 py-2 text-gray-500 border">Grants permission to view Vm resources</td>
+                      </tr>
+                      <tr>
+                        <td class="px-2 py-2 text-gray-500 border">Vm:create</td>
+                        <td class="px-2 py-2 text-gray-500 border">Grants permission to create Vm in TagSpace</td>
+                      </tr>
+                      <tr>
+                        <td class="px-2 py-2 text-gray-500 border">Vm:delete</td>
+                        <td class="px-2 py-2 text-gray-500 border">Grants permission to delete Vm</td>
+                      </tr>
+                      <tr>
+                        <td class="px-2 py-2 text-gray-500 border">TagSpace:view</td>
+                        <td class="px-2 py-2 text-gray-500 border">Grants permission to view TagSpace details</td>
+                      </tr>
+                      <tr>
+                        <td class="px-2 py-2 text-gray-500 border">TagSpace:delete</td>
+                        <td class="px-2 py-2 text-gray-500 border">Grants permission to delete TagSpace</td>
+                      </tr>
+                      <tr>
+                        <td class="px-2 py-2 text-gray-500 border">TagSpace:user</td>
+                        <td class="px-2 py-2 text-gray-500 border">Grants permission to add/remove users to/from TagSpace</td>
+                      </tr>
+                      <tr>
+                        <td class="px-2 py-2 text-gray-500 border">TagSpace:policy</td>
+                        <td class="px-2 py-2 text-gray-500 border">Grants permission to update TagSpace's access policies</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <p class="mt-2">
+                    Be careful while updating policy, if you remove your tag space permissions, you may lose your
+                    access to this tag space.
+                  </p>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>

--- a/views/tag_space/show_sidebar.erb
+++ b/views/tag_space/show_sidebar.erb
@@ -1,0 +1,46 @@
+<aside class="py-6 lg:col-span-2">
+  <nav class="space-y-1">
+    <% [
+        ["Details", "/tag-space/#{@tag_space.id}", "<path stroke-linecap='round' stroke-linejoin='round' d='M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75' />"],
+        ["Users", "/tag-space/#{@tag_space.id}/user", "<path strokeLinecap='round' strokeLinejoin='round' d='M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z' />"],
+        ["Policy", "/tag-space/#{@tag_space.id}/policy", "<path stroke-linecap='round' stroke-linejoin='round' d='M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z' />"]
+      ].each do |label, url, icon| %>
+      <% if request.path == url %>
+        <a
+          href="<%= url %>"
+          class="border-indigo-500 bg-indigo-50 text-indigo-700 hover:bg-indigo-50 hover:text-indigo-700 group flex items-center border-l-4 px-3 py-2 text-sm font-medium"
+          aria-current="page"
+        >
+          <svg
+            class="text-indigo-500 group-hover:text-indigo-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+          >
+            <%== icon %>
+          </svg>
+          <span class="truncate"><%= label %></span>
+        </a>
+      <% else %>
+        <a
+          href="<%= url %>"
+          class="border-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900 group flex items-center border-l-4 px-3 py-2 text-sm font-medium"
+        >
+          <svg
+            class="text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+          >
+            <%== icon %>
+          </svg>
+          <span class="truncate"><%= label %></span>
+        </a>
+
+      <% end %>
+    <% end %>
+
+  </nav>
+</aside>

--- a/views/tag_space/show_users.erb
+++ b/views/tag_space/show_users.erb
@@ -1,0 +1,97 @@
+<% @page_title = "#{@tag_space.name} - Users" %>
+
+<div class="px-2 sm:px-3 lg:px-4">
+  <div class="space-y-1">
+    <%== render(
+      "components/breadcrumb",
+      locals: {
+        back: "/tag-space",
+        parts: [["Tag Spaces", "/tag-space"], [@tag_space.name, "/tag-space/#{@tag_space.id}"], %w[Users #]]
+      }
+    ) %>
+    <%== render("components/page_header", locals: { title: @tag_space.name }) %>
+  </div>
+
+  <main class="mt-4 md:mt-8">
+    <div class="max-w-screen-xl pb-6 lg:pb-16">
+      <div class="overflow-hidden rounded-lg bg-white shadow">
+        <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+          <%== render("tag_space/show_sidebar") %>
+          <div class="divide-y divide-gray-200 lg:col-span-10 pb-10">
+            <!-- Invite user -->
+            <form action="<%= "/tag-space/#{@tag_space.id}/user" %>" role="form" method="POST">
+              <%== csrf_tag("/tag-space/#{@tag_space.id}/user") %>
+              <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
+                <div>
+                  <h2 class="text-lg font-medium leading-6 text-gray-900">Invite a new user</h2>
+                  <p class="mt-1 text-sm text-gray-500">
+                    You can invite new users to your tag space, though initially they will not have any permissions.
+                    You may modify the tag space access policy to grant permissions to these new users.
+                  </p>
+                </div>
+                <div class="grid grid-cols-12 gap-6">
+                  <div class="col-span-9 sm:col-span-6">
+                    <%== render(
+                      "components/form/text",
+                      locals: {
+                        name: "email",
+                        type: "email",
+                        attributes: {
+                          required: true,
+                          placeholder: "Email"
+                        }
+                      }
+                    ) %>
+                  </div>
+                  <div class="col-span-3 sm:col-span-6">
+                    <%== render("components/form/submit_button", locals: { text: "Invite" }) %>
+                  </div>
+                </div>
+              </div>
+            </form>
+            <!-- List users -->
+            <div>
+              <div class="px-4 py-6 sm:px-6">
+                <h2 class="text-lg font-medium leading-6 text-gray-900">Users</h2>
+                <p class="mt-1 text-sm text-gray-500">
+                  Access policies can be utilized to grant permissions to these users. While they will be able to see
+                  that they are a part of the tag space, they will not have access to its details without the proper
+                  permissions.
+                </p>
+              </div>
+              <table class="min-w-full divide-y divide-gray-300">
+                <thead class="">
+                  <tr>
+                    <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Email</th>
+                    <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6">
+                      <span class="sr-only">Remove</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 bg-white">
+                  <% @users.each do |user| %>
+                    <tr id="user-<%= user.id%>" class="whitespace-nowrap text-sm font-medium">
+                      <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row"><%= user.email %></td>
+                      <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
+                        <button
+                          type="button"
+                          data-url="<%= "/tag-space/#{@tag_space.id}/user/#{user.id}" %>"
+                          data-csrf="<%= csrf_token("/tag-space/#{@tag_space.id}/user/#{user.id}", "DELETE") %>"
+                          data-confirmation="<%= user.email %>"
+                          data-redirect="<%= "/tag-space/#{@tag_space.id}/user" %>"
+                          class="delete-btn text-rose-600 hover:text-rose-900"
+                        >
+                          Remove
+                        </button>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -18,7 +18,7 @@
                 <h2 class="text-base font-semibold leading-7 text-gray-900">Details</h2>
                 <p class="mt-1 text-sm leading-6 text-gray-600">Enter details for your virtual machine.</p>
                 <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-                  <div class="sm:col-span-2">
+                  <div class="sm:col-span-3">
                     <%== render(
                       "components/form/text",
                       locals: {
@@ -27,6 +27,19 @@
                         attributes: {
                           required: true,
                           placeholder: "Enter name"
+                        }
+                      }
+                    ) %>
+                  </div>
+                  <div class="sm:col-span-3">
+                    <%== render(
+                      "components/form/select",
+                      locals: {
+                        name: "tag-space-id",
+                        label: "Tag Space",
+                        options: @tag_spaces.to_h { |tg| [tg.id, tg.name] },
+                        attributes: {
+                          required: true
                         }
                       }
                     ) %>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -27,6 +27,10 @@
                 <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm.name %></dd>
               </div>
               <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
+                <dt class="text-sm font-medium text-gray-500">Tag Space</dt>
+                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm.tag_spaces.map(&:name).join(", ") %></dd>
+              </div>
+              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
                 <dt class="text-sm font-medium text-gray-500">Provider & Location</dt>
                 <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm.location %></dd>
               </div>
@@ -45,38 +49,40 @@
             </dl>
           </div>
         </div>
-        <div class="mt-6 bg-white shadow sm:rounded-lg">
-          <div class="px-4 py-5 sm:p-6">
-            <div class="sm:flex sm:items-center sm:justify-between">
-              <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Delete virtual machine</h3>
-                <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will permanently delete this virtual machine. Deleted data cannot be recovered. Use it
-                    carefully.</p>
+        <% if Authorization.has_power?(rodauth.session_value, "Vm:delete", @vm.raw_id) %>
+          <div class="mt-6 bg-white shadow sm:rounded-lg">
+            <div class="px-4 py-5 sm:p-6">
+              <div class="sm:flex sm:items-center sm:justify-between">
+                <div>
+                  <h3 class="text-base font-semibold leading-6 text-gray-900">Delete virtual machine</h3>
+                  <div class="mt-2 text-sm text-gray-500">
+                    <p>This action will permanently delete this virtual machine. Deleted data cannot be recovered. Use
+                      it carefully.</p>
+                  </div>
                 </div>
-              </div>
-              <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-                <button
-                  type="button"
-                  data-url="<%= request.path %>"
-                  data-csrf="<%= csrf_token(request.path, "DELETE") %>"
-                  data-confirmation="<%= @vm.name %>"
-                  data-redirect="/vm"
-                  class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
-                >
-                  <svg class="-ml-0.5 mr-1.5 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                    />
-                  </svg>
-                  Delete
-                </button>
+                <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                  <button
+                    type="button"
+                    data-url="<%= request.path %>"
+                    data-csrf="<%= csrf_token(request.path, "DELETE") %>"
+                    data-confirmation="<%= @vm.name %>"
+                    data-redirect="/vm"
+                    class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
+                  >
+                    <svg class="-ml-0.5 mr-1.5 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                      />
+                    </svg>
+                    Delete
+                  </button>
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Authorization beyond the most basic is a feature that is missing almost entirely from non-hyperscaler products in the cloud-adjacent space.

All three hyperscalers seem to be gradually moving towards attribute-based access control (ABAC), which is explained best in general by [Tailscale blog post](https://tailscale.com/blog/rbac-like-it-was-meant-to-be/).

You can see implementations of this, though they can be circuitous (by relying on conditional expressions) relative to a clean-sheet ABAC design.
- [Amazon](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_attribute-based-access-control.html)
- [Azure](https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview)
- [GCP](https://cloud.google.com/iam/docs/conditions-overview)

Ubicloud's authorization is going to deliver something about as powerful as IAM seen on any of the hyperscalers. It's in active development. Expect to have major adjustments.

Default tag space with all powers is created when new user account is created. So new user may start to use our console right away without any knowledge about authorization. After getting familiar with our services, they can create new tag spaces, manage users, update policies etc.

A tag space is first and foremost a namespace for tags. Also, a tag space provides a convenient hook to associate with billing. In this respect, it has a lot in common with the Azure Subscription.

Access tag is the name of a tag and its tag space, so that two distinct tag spaces could have a tag by the same name yet mean something distinct. When we apply a access tag to a resources, applied tags are created. Applied tags defines relations between resources and access tags. An access policy defines who (subject) can do what (power) on what (object). It like a formula to connect subjects and objects via powers. Any tag can be a subject or object. Powers are like permissions.

```
                                               +---------------+
                        +---------------+      |  AppliedTags  |
    +----------+        |   AccessTag   |      |      id       |
    | TagSpace |        |      id       |<-+-->| access_tag_id |
+-->|    id    |<------>|  tag_space_id |  +-->|   tagged_id   |
|   +----------+        |     name      |  |   +---------------+
|                       |  hyper_tag_id |<-+
|  +--------------+     +---------------+  |
|  | AccessPolicy |                        |   +--------------+
+->| tag_space_id |                        |   |  Object ID   |
   |     name     |                        +-->|   User, Vm   |
   |     body     +----+                       | TagSpace etc.|
   +--------------+    |                       +--------------+
                       |
                       v
                   array({subjects, powers, objects})
```

One way to associate a principal with some power over tags in a tag space is hyper tagging. A way to implement hyper-tagging is to allow other kinds of objects to also be a tag. In this case, the TagSpace, User, Vm record could also be a tag.

Tags have some alternate life as another object (User, TagSpace, Vm, maybe a Role record). To use a resource in access policy, it should be somehow represented in this tag space. Resource are tagged with its access tag, so they can be used in policy evaluation.

Access policies have 3 main parts: subjects, powers, and objects. All of them can be a single string or a list of strings. Access tags are used for subjects, and objects. To use a tag in policy, it should have hyper-tag in that tag space. Powers are predefined.

| Power           | Description                                            |
|-----------------|--------------------------------------------------------|
| Vm:view         | Grants permission to view Vm resources                 |
| Vm:create       | Grants permission to create Vm in TagSpace             |
| Vm:delete       | Grants permission to delete Vm                         |
| TagSpace:view   | Grants permission to view TagSpace details             |
| TagSpace:delete | Grants permission to delete TagSpace                   |
| TagSpace:user   | Grants permission to add/remove users to/from TagSpace |
| TagSpace:policy | Grants permission to update TagSpace's access policies |

User "test@test.com" can create a Vm in "default-tag-space" tag space.
```json
{
  "acls": [
    {
      "subjects": "User/test@test.com",
      "powers": "Vm:create",
      "objects": "TagSpace/default-tag-space"
    }
  ]
}
```

User "test@test.com" can view and delete Vms in "default-tag-space" tag space.
```json
{
  "acls": [
    {
      "subjects": "User/test@test.com",
      "powers": ["Vm:view", "Vm:delete"],
      "objects": "TagSpace/default-tag-space"
    }
  ]
}
```

User "test@test.com" can only view "vm1" and "vm2".
```json
{
  "acls": [
    {
      "subjects": "User/test@test.com",
      "powers": "Vm:view",
      "objects": ["Vm/vm1", "Vm/vm2"]
    }
  ]
}
```

User "test@test.com" can manage tag space users.
```json
{
  "acls": [
    {
      "subjects": "User/test@test.com",
      "powers": "TagSpace:user",
      "objects": "TagSpace/default-tag-space"
    }
  ]
}
```