### PR TITLE
Enforce minimum test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,5 @@ jobs:
         CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
         CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
       run: |
-        bundle exec rspec
+        COVERAGE=1 bundle exec rspec
         bundle exec rspec -O /dev/null rhizome

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -5,8 +5,8 @@ if (suite = ENV.delete("COVERAGE"))
 
   SimpleCov.start do
     enable_coverage :branch
-    minimum_coverage line: 84, branch: 54
-    minimum_coverage_by_file line: 32, branch: 0
+    minimum_coverage line: 88, branch: 68.5
+    minimum_coverage_by_file line: 30, branch: 0
 
     command_name suite
 


### PR DESCRIPTION
Previously, I introduced minimum_coverage values to SimpleCov, but they are not effective because CI runs tests without coverage calculations.

Let's run tests with coverage at CI and try not to decrease coverage values.