### PR TITLE
ipv4 support

### DIFF
--- a/migrate/013_add_ipv4.rb
+++ b/migrate/013_add_ipv4.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm) do
+      add_column :local_vetho_ip, :text, collate: '"C"'
+    end
+    create_table :address do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :cidr, :cidr, null: false, unique: true
+      column :is_failover_ip, :boolean, null: false, default: false
+      foreign_key :routed_to_host_id, :vm_host, type: :uuid, null: false
+    end
+    create_table :assigned_vm_address do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :ip, :cidr, null: false, unique: true
+      foreign_key :address_id, :address, type: :uuid, null: false
+      foreign_key :dst_vm_id, :vm, type: :uuid, null: false
+    end
+    create_table :assigned_host_address do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :ip, :cidr, null: false, unique: true
+      foreign_key :address_id, :address, type: :uuid, null: false
+      foreign_key :host_id, :vm_host, type: :uuid, null: false
+    end
+  end
+end

--- a/model/address.rb
+++ b/model/address.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class Address < Sequel::Model
+  one_to_many :assigned_vm_address, key: :address_id, class: :AssignedVmAddress
+  one_to_many :assigned_host_address, key: :address_id, class: :AssignedHostAddress
+end

--- a/model/assigned_host_address.rb
+++ b/model/assigned_host_address.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class AssignedHostAddress < Sequel::Model
+  many_to_one :vm_host, key: :host_id
+  many_to_one :address, key: :address_id
+end

--- a/model/assigned_vm_address.rb
+++ b/model/assigned_vm_address.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class AssignedVmAddress < Sequel::Model
+  one_to_one :vm, key: :dst_vm_id
+  many_to_one :address, key: :address_id
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -7,6 +7,8 @@ class Vm < Sequel::Model
   many_to_one :vm_host
   one_to_many :vm_private_subnet, key: :vm_id
   one_to_many :ipsec_tunnels, key: :src_vm_id
+  one_to_one :sshable, key: :id
+  one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
 
   dataset_module Authorization::Dataset
 
@@ -23,6 +25,14 @@ class Vm < Sequel::Model
 
   def path
     "/vm/#{ulid}"
+  end
+
+  def ephemeral_net4
+    assigned_vm_address&.ip&.nth(1)
+  end
+
+  def ip4
+    assigned_vm_address&.ip
   end
 
   Product = Struct.new(:line, :cores)

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -7,7 +7,8 @@ class Prog::Vm::HostNexus < Prog::Base
     DB.transaction do
       sa = Sshable.create(host: sshable_hostname)
       VmHost.create(location: location, net6: net6, ndp_needed: ndp_needed) { _1.id = sa.id }
-
+      Address.create(cidr: sshable_hostname, routed_to_host_id: sa.id) { _1.id = sa.id }
+      AssignedHostAddress.create(ip: sshable_hostname, address_id: sa.id, host_id: sa.id)
       Strand.create(prog: "Vm::HostNexus", label: "start") { _1.id = sa.id }
     end
   end

--- a/rhizome/bin/prep_host.rb
+++ b/rhizome/bin/prep_host.rb
@@ -29,6 +29,8 @@ end
 File.write("/etc/sysctl.d/72-clover-forward-packets.conf", <<CONF)
 net.ipv6.conf.all.forwarding=1
 net.ipv6.conf.all.proxy_ndp=1
+net.ipv4.conf.all.forwarding=1
+net.ipv4.ip_forward=1
 CONF
 r "sysctl --system"
 

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -23,6 +23,16 @@ unless (gua = params["public_ipv6"])
   exit 1
 end
 
+unless (ip4 = params["public_ipv4"])
+  puts "need public_ipv4 in parameters json"
+  exit 1
+end
+
+unless (local_ip4 = params["local_ipv4"])
+  puts "need local_ipv4 in parameters json"
+  exit 1
+end
+
 unless (unix_user = params["unix_user"])
   puts "need unix_user in parameters json"
   exit 1
@@ -64,5 +74,5 @@ require "fileutils"
 require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
-VmSetup.new(vm_name).prep(unix_user, ssh_public_key, private_subnets, gua, boot_image,
-  max_vcpus, cpu_topology, mem_gib, ndp_needed)
+VmSetup.new(vm_name).prep(unix_user, ssh_public_key, private_subnets, gua, ip4,
+  local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed)

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "spec_helper"
+require_relative "../../model/address"
 
 RSpec.describe VmHost do
   subject(:vh) {
@@ -8,6 +9,29 @@ RSpec.describe VmHost do
       net6: NetAddr.parse_net("2a01:4f9:2b:35a::/64"),
       ip6: NetAddr.parse_ip("2a01:4f9:2b:35a::2")
     )
+  }
+
+  let(:cidr) { NetAddr::IPv4Net.parse("0.0.0.0/30") }
+  let(:address) {
+    Address.new(
+      cidr: cidr,
+      routed_to_host_id: "46683a25-acb1-4371-afe9-d39f303e44b4"
+    )
+  }
+  let(:assigned_host_address) {
+    AssignedHostAddress.new(
+      ip: cidr,
+      address_id: address.id,
+      host_id: "46683a25-acb1-4371-afe9-d39f303e44b4"
+    )
+  }
+  let(:hetzner_ips) {
+    [
+      {ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true},
+      {ip_address: "1.1.1.2/32", source_host_ip: "1.1.0.0", is_failover: true},
+      {ip_address: "1.1.1.3/32", source_host_ip: "1.1.1.1", is_failover: false},
+      {ip_address: "2a01:4f8:10a:128b::/64", source_host_ip: "1.1.1.1", is_failover: true}
+    ]
   }
 
   it "requires an Sshable too" do
@@ -40,5 +64,91 @@ RSpec.describe VmHost do
       expect(args[:stack]).to eq([subject_id: vh.id])
     end
     vh.install_rhizome
+  end
+
+  it "assigned_subnets returns the assigned subnets" do
+    expect(vh).to receive(:assigned_subnets).and_return([address])
+    expect(vh).to receive(:vm_addresses).and_return([])
+    expect(SecureRandom).to receive(:random_number).with(2).and_return(0)
+    ip4, r_address = vh.ip4_random_vm_network
+    expect(ip4.to_s).to eq("0.0.0.0/31")
+    expect(r_address).to eq(address)
+  end
+
+  it "returns nil if there is no available subnet" do
+    expect(vh).to receive(:assigned_subnets).and_return([address])
+    expect(address.assigned_vm_address).to receive(:count).and_return(2)
+    ip4, address = vh.ip4_random_vm_network
+    expect(ip4).to be_nil
+    expect(address).to be_nil
+  end
+
+  it "finds another address if it's already assigned" do
+    expect(vh).to receive(:assigned_subnets).and_return([address]).at_least(:once)
+    expect(vh).to receive(:vm_addresses).and_return([instance_double(AssignedVmAddress, ip: NetAddr::IPv4Net.parse("0.0.0.0/31"))]).at_least(:once)
+    expect(SecureRandom).to receive(:random_number).with(2).and_return(0, 1)
+    ip4, r_address = vh.ip4_random_vm_network
+    expect(ip4.to_s).to eq("0.0.0.2/31")
+    expect(r_address).to eq(address)
+  end
+
+  it "returns vm_addresses" do
+    vm = instance_double(Vm, assigned_vm_address: address)
+    expect(vh).to receive(:vms).and_return([vm])
+    expect(vh.vm_addresses).to eq([address])
+  end
+
+  it "sshable_address returns the sshable address" do
+    expect(vh).to receive(:assigned_host_addresses).and_return([assigned_host_address])
+    expect(vh.sshable_address).to eq(assigned_host_address)
+  end
+
+  it "create_addresses fails if a failover ip of non existent server is being added" do
+    expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)
+    Sshable.create(host: "test.localhost") { _1.id = vh.id }
+    described_class.create(location: "test-location") { _1.id = vh.id }
+
+    expect(vh).to receive(:assigned_subnets).and_return([]).at_least(:once)
+    expect { vh.create_addresses(hetzner_ips) }.to raise_error(RuntimeError, "BUG: source host 1.1.1.1 isn't added to the database")
+  end
+
+  it "create_addresses creates addresses properly" do
+    expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)
+    Sshable.create(host: "1.1.0.0") { _1.id = vh.id }
+    Sshable.create(host: "1.1.1.1")
+
+    described_class.create(location: "test-location") { _1.id = vh.id }
+
+    expect(vh).to receive(:assigned_subnets).and_return([]).at_least(:once)
+    vh.create_addresses(hetzner_ips)
+
+    expect(Address.where(routed_to_host_id: vh.id).count).to eq(4)
+  end
+
+  it "create_addresses returns immediately if there are no addresses to create" do
+    vh.create_addresses([])
+    expect(Address.where(routed_to_host_id: vh.id).count).to eq(0)
+  end
+
+  it "skips already assigned subnets" do
+    expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)
+    Sshable.create(host: "1.1.0.0") { _1.id = vh.id }
+    Sshable.create(host: "1.1.1.1")
+    described_class.create(location: "test-location") { _1.id = vh.id }
+
+    expect(vh).to receive(:assigned_subnets).and_return([Address.new(cidr: NetAddr::IPv4Net.parse("1.1.1.0/30".shellescape))]).at_least(:once)
+    vh.create_addresses(hetzner_ips)
+    expect(Address.where(routed_to_host_id: vh.id).count).to eq(3)
+  end
+
+  it "finds local ip to assign to veth* devices" do
+    expect(SecureRandom).to receive(:random_number).with(32767).and_return(5)
+    expect(vh.veth_pair_random_ip4_addr.network.to_s).to eq("169.254.0.10")
+  end
+
+  it "finds local ip to assign to veth* devices and eliminates already assigned" do
+    expect(vh).to receive(:vms).and_return([instance_double(Vm, local_vetho_ip: "169.254.0.10")]).at_least(:once)
+    expect(SecureRandom).to receive(:random_number).with(32767).and_return(5, 10)
+    expect(vh.veth_pair_random_ip4_addr.network.to_s).to eq("169.254.0.20")
   end
 end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -121,4 +121,17 @@ RSpec.describe Vm do
       end
     end
   end
+
+  describe "#utility functions" do
+    it "can compute the ipv4 addresses" do
+      as_ad = instance_double(AssignedVmAddress, ip: NetAddr::IPv4Net.new(NetAddr.parse_ip("1.1.1.0"), NetAddr::Mask32.new(31)))
+      expect(vm).to receive(:assigned_vm_address).and_return(as_ad).at_least(:once)
+      expect(vm.ephemeral_net4.to_s).to eq("1.1.1.1")
+      expect(vm.ip4.to_s).to eq("1.1.1.0/31")
+    end
+
+    it "can compute nil if ipv4 is not assigned" do
+      expect(vm.ephemeral_net4).to be_nil
+    end
+  end
 end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Prog::Vm::Nexus do
       vm.ephemeral_net6 = "fe80::/64"
       vm.unix_user = "test_user"
       vm.public_key = "test_ssh_key"
+      vm.local_vetho_ip = "169.254.0.0"
       expect(vm).to receive(:private_subnets).and_return [NetAddr.parse_net("fd10:9b0b:6b4b:8fbb::/64")]
       expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(1, 1, 1, 1))
 
@@ -87,7 +88,8 @@ RSpec.describe Prog::Vm::Nexus do
           "ssh_public_key" => "test_ssh_key",
           "max_vcpus" => 1,
           "cpu_topology" => "1:1:1:1",
-          "mem_gib" => 4
+          "mem_gib" => 4,
+          "local_ipv4" => "169.254.0.0"
         })
       end
       expect(sshable).to receive(:cmd).with(/sudo bin\/prepvm/)
@@ -95,6 +97,16 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.prep }.to raise_error Prog::Base::Hop do |hop|
         expect(hop.new_label).to eq("trigger_refresh_mesh")
       end
+    end
+
+    it "generates local_ipv4 if not set" do
+      expect(nx.local_ipv4).to eq("")
+    end
+
+    it "generates local_ipv4 if set" do
+      vm = nx.vm
+      vm.local_vetho_ip = "169.254.0.0"
+      expect(nx.local_ipv4).to eq("169.254.0.0")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 ENV["RACK_ENV"] = "test"
 ENV["MAIL_DRIVER"] = "test"
+
 require_relative "../loader"
 require_relative "./coverage_helper"
 require "rspec"


### PR DESCRIPTION
IPv4 Support
This PR enhances the network functionality by introducing IPv4 support.
In order to utilize IPv4, it is required to obtain an IPv4 subnet. Once
the IPv4 address is acquired, the host pulls this information from
Hetzner, and IP addresses are randomly assigned to the devices. In the
future, we can further improve this process by allowing customers to
specify the desired IP address.  If it is not feasible to assign an IP
address due to all addresses being in use, the system will gracefully
proceed without assigning one.

To enable local redirection, the PR leverages the local address space
169.254.*.*. This ensures efficient communication within the local
network while utilizing private IP addresses.

To try the patch,
1. You need to have a VmHost and order an ipv4 block from Hetzner for
that server. If you already have a host, you can just add an ipv4 block
and continue to step 3
2. Once you have both, add the vm_host to clover.
3. Once it's waiting, you can add the ipv4 address space you want to use
by using vm_host.create_addresses.
4. Create a VM for that host.
5. Fetch the ipv4 address and ssh in!

```
st = Prog::Vm::HostNexus.assemble("host_ip")
st.run 60

# make sure it's in wait state
st.vm_host.reload.create_addresses([{:ip_address=>"such as 1.1.1.0/24",
:source_host_ip=>"host_ip", :is_failover=>true/false}])

# check Addresses
st.vm_host.reload.assigned_subnets

# create a VM
mykey = File.read("path/to/your/key")
st = Prog::Vm::Nexus.assemble(mykey, nil)
st.run 70

# once it's in wait state, fetch the ipv4 address
st.vm.reload.ephemeral_net4.to_s
```
Now you can use it to ssh in.
Notes:
1. You have to have a subnet of at least /31. It doesn't work with
single ip ranges because we are assigning 1 ip to tap device and 1 ip
to the VM.
2. Reboot is an issue for the whole networking stack, same here. We'll
have to fix it.
3. We collect information of `is_failover_ip` but never use it now.
That will be useful when we get into ip block reassignments (e.g.
failover).