### PR TITLE
Switch from Ractors to Threads for stall termination

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -5,14 +5,6 @@ require_relative "../loader"
 
 d = Scheduling::Dispatcher.new
 
-Thread.new do
-  Ractor.receive_if { _1 == :thread_dump }
-  Thread.list.each do |thread|
-    puts "Thread: #{thread.inspect}"
-    puts thread.backtrace&.join("\n")
-  end
-end
-
 loop do
   d.wait_cohort
   d.start_cohort

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Scheduling::Dispatcher do
         di.instance_variable_set(:@dump_timeout, 0)
         Strand.create(prog: "Test", label: "wait_exit")
         di.start_cohort
-        expect(Ractor.receive).to eq :thread_dump
+        expect(described_class).to receive(:print_thread_dump)
         w.close
         di.threads.each(&:join)
       ensure


### PR DESCRIPTION
Alas, Ractors cause some problems with non-deterministic coverage results, that do not occur with Threads.  It looks suspiciously like the Ractors are flushing coverage state to me.

I wrote a somewhat superficial bug report at
https://github.com/simplecov-ruby/simplecov/issues/1058 about this.

In the past, I have managed this problem with Threads, and they've been fine, even if they widen the potential for a theoretical problem of a thread not getting scheduled because of a bug in other code in releasing the GVL.