### PR TITLE
Fix race condition in dispatcher spec

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -5,14 +5,6 @@ require_relative "../loader"
 
 d = Scheduling::Dispatcher.new
 
-Thread.new do
-  Ractor.receive_if { _1 == :thread_dump }
-  Thread.list.each do |thread|
-    puts "Thread: #{thread.inspect}"
-    puts thread.backtrace&.join("\n")
-  end
-end
-
 loop do
   d.wait_cohort
   d.start_cohort

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Scheduling::Dispatcher do
         di.instance_variable_set(:@apoptosis_timeout, 0)
         di.instance_variable_set(:@dump_timeout, 0)
         Strand.create(prog: "Test", label: "wait_exit")
-        di.start_cohort
         expect(described_class).to receive(:print_thread_dump)
+        di.start_cohort
         w.close
         di.threads.each(&:join)
       ensure

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Scheduling::Dispatcher do
         di.instance_variable_set(:@dump_timeout, 0)
         Strand.create(prog: "Test", label: "wait_exit")
         di.start_cohort
-        expect(Ractor.receive).to eq :thread_dump
+        expect(described_class).to receive(:print_thread_dump)
         w.close
         di.threads.each(&:join)
       ensure


### PR DESCRIPTION
print_thread_dump is called in start_cohort. It should expect before function call.

Failed run:

https://github.com/ubicloud/ubicloud/actions/runs/5014017247/jobs/8987785907

    bundle exec rspec --seed 14305