### PR TITLE
Add a feature flag for VM Host management

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -217,6 +217,12 @@ class Clover < Roda
     nil
   end
 
+  def vm_host_allowed?
+    vm_host_users = Config.allowed_vm_host_users
+    return true if vm_host_users.empty?
+    vm_host_users.include?(Account[rodauth.session_value].email)
+  end
+
   hash_branch("dashboard") do |r|
     view "/dashboard"
   end

--- a/config.rb
+++ b/config.rb
@@ -49,6 +49,7 @@ module Config
   override :root, File.expand_path(__dir__), string
   override :timeout, 10, int
   override :versioning, false, bool
+  override :allowed_vm_host_users, "", array(string)
 
   def self.development?
     Config.rack_env == "development"

--- a/routes/vm_host.rb
+++ b/routes/vm_host.rb
@@ -20,6 +20,10 @@ class Clover
   end
 
   hash_branch("vm-host") do |r|
+    unless vm_host_allowed?
+      fail Authorization::Unauthorized
+    end
+
     r.get true do
       @vm_hosts = VmHost.eager(:sshable, :vms).all.map { |vm_host| VmHostShadow.new(vm_host) }
 

--- a/spec/web/vm_host_spec.rb
+++ b/spec/web/vm_host_spec.rb
@@ -16,6 +16,42 @@ RSpec.describe Clover, "vm_host" do
       login
     end
 
+    describe "#vm_host_allowed?" do
+      it "can not list if email not allowed" do
+        expect(Config).to receive(:allowed_vm_host_users).and_return("user2@example.com,user3@example.com")
+
+        visit "/vm-host"
+
+        expect(page.title).to eq("Ubicloud - Forbidden")
+        expect(page.status_code).to eq(403)
+        expect(page).to have_content "Forbidden"
+      end
+
+      it "can not click on sidebar if email not allowed" do
+        expect(Config).to receive(:allowed_vm_host_users).and_return("user2@example.com,user3@example.com").twice
+
+        visit "/dashboard"
+
+        expect(page.title).to eq("Ubicloud - Dashboard")
+        expect(page.status_code).to eq(200)
+
+        expect(page).not_to have_content "VM Hosts"
+        expect { find "a[href='/vm-host']" }.to raise_error Capybara::ElementNotFound
+      end
+
+      it "can list if email allowed" do
+        expect(Config).to receive(:allowed_vm_host_users).and_return("user@example.com,user2@example.com").at_least(:once)
+
+        visit "/vm-host"
+
+        expect(page.title).to eq("Ubicloud - VM Hosts")
+        expect(page).to have_content "No virtual machine host"
+
+        click_link "New Virtual Machine Host"
+        expect(page.title).to eq("Ubicloud - Add VM Host")
+      end
+    end
+
     it "can list no virtual machine hosts" do
       visit "/vm-host"
 

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -25,7 +25,7 @@
                 "<path stroke-linecap='round' stroke-linejoin='round' d='M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z' />",
               items: [
                 ["Virtual Machines", "/vm", (request.path == "/vm" || request.path.start_with?("/vm/"))],
-                ["VM Hosts", "/vm-host", request.path.start_with?("/vm-host")]
+                vm_host_allowed? ? ["VM Hosts", "/vm-host", request.path.start_with?("/vm-host")] : nil
               ]
             }
           ) %>

--- a/views/layouts/sidebar/group.erb
+++ b/views/layouts/sidebar/group.erb
@@ -1,5 +1,5 @@
 <li>
-  <div class="group <%= items.map { _1[2] }.any? ? "active" : "" %>">
+  <div class="group <%= items.compact.map { _1[2] }.any? ? "active" : "" %>">
     <button
       type="button"
       class="sidebar-group-btn w-full text-indigo-200 hover:text-white hover:bg-indigo-700 flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"
@@ -21,7 +21,7 @@
       </svg>
     </button>
     <ul class="mt-1 px-2 hidden group-[.active]:block">
-      <% items.each do |item_name, item_url, item_is_active| %>
+      <% items.compact.each do |item_name, item_url, item_is_active| %>
         <li>
           <a
             href="<%= item_url %>"


### PR DESCRIPTION
We do not want to show VmHost pages to users on some demo deployments. If 'ALLOWED_VM_HOST_USERS' environment variable set, it only allows this user emails to see VmHost pages. It's comma separated list of emails. If it's not provided, it allows all users.