### PR TITLE
Add name validation to virtual machines

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -99,6 +99,9 @@ class Clover < Roda
     when Sequel::ValidationFailed
       flash["error"] = e.to_s
       return request.redirect env["HTTP_REFERER"]
+    when Validation::ValidationFailed
+      flash["errors"] = (flash["errors"] || {}).merge(e.errors)
+      return request.redirect env["HTTP_REFERER"]
     when Roda::RodaPlugins::RouteCsrf::InvalidToken
       response.status = 419
       @error_code = 419

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Validation
+  class ValidationFailed < StandardError
+    attr_reader :errors
+    def initialize(errors)
+      @errors = errors
+      super("Validation failed for some fields")
+    end
+  end
+
+  # Allow DNS compatible names
+  # - Max length 63
+  # - Only lowercase letters, numbers, and hyphens
+  # - Not start or end with a hyphen
+  # Adapted from https://stackoverflow.com/a/7933253
+  # Do not allow uppercase letters to not deal with case sensitivity
+  ALLOWED_NAME_PATTERN = '\A[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\z'
+
+  def self.validate_name(name)
+    msg = "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."
+    fail ValidationFailed.new({name: msg}) unless name.match(ALLOWED_NAME_PATTERN)
+  end
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -16,14 +16,17 @@ class Prog::Vm::Nexus < Prog::Base
       fail "Not existing tag space"
     end
 
+    id = SecureRandom.uuid
+    name ||= uuid_to_name(id)
+
+    Validation.validate_name(name)
+
     # if the caller hasn't provided any subnets, generate a random one
     if private_subnets.empty?
       private_subnets.append(random_ula)
     end
 
     DB.transaction do
-      id = SecureRandom.uuid
-      name ||= uuid_to_name(id)
       vm = Vm.create(public_key: public_key, unix_user: unix_user,
         name: name, size: size, location: location, boot_image: boot_image) { _1.id = id }
       vm.associate_with_tag_space(tag_space)

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe Validation do
+  describe "#validate_name" do
+    it "valid names" do
+      [
+        "abc",
+        "abc123",
+        "abc-123",
+        "123abc",
+        "abc--123",
+        "a-b-c-1-2",
+        "a" * 63
+      ].each do |name|
+        expect(described_class.validate_name(name)).to be_nil
+      end
+    end
+
+    it "invalid names" do
+      [
+        "-abc",
+        "abc-",
+        "-abc-",
+        "ABC",
+        "ABC_123",
+        "ABC$123",
+        "a" * 64
+      ].each do |name|
+        expect { described_class.validate_name(name) }.to raise_error described_class::ValidationFailed
+      end
+    end
+  end
+end


### PR DESCRIPTION
We force names to be slug-like and DNS compatible. It allows us to use resource names in URL. In addition, we might give some auto-generated DNS records to customers in future.

Current rules:
- Max length 63
- Only lowercase letters, numbers, and hyphens
- Not start or end with a hyphen

I put validation method to separate module because it can be reused for other models too