### PR TITLE
Clean rodauth tables between tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ require_relative "./coverage_helper"
 require "rspec"
 require "database_cleaner/sequel"
 require "logger"
+require "sequel/core"
 
 # DatabaseCleaner assumes the usual DATABASE_URL, but the
 # "roda-sequel-stack" way names each environment *and* application
@@ -42,16 +43,13 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
     DB.loggers << Logger.new($stdout) if DB.loggers.empty?
+
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation,
-      # Skip tables that are part of RodAuth and can't be truncated on
-      # account of `ph` user separation.
+      # Skip tables that are filled with migrations.
       except: %w[
-        account_previous_password_hashes
         schema_info_password
-        account_password_hashes
-        accounts
         account_statuses
       ])
   end

--- a/spec/web/object_storage_spec.rb
+++ b/spec/web/object_storage_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Clover, "object_storage" do
 
   describe "authenticated" do
     before do
+      create_account
       login
     end
 

--- a/spec/web/settings_spec.rb
+++ b/spec/web/settings_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Clover, "settings" do
 
   describe "authenticated" do
     before do
+      create_account
       login
     end
 

--- a/spec/web/tag_space_spec.rb
+++ b/spec/web/tag_space_spec.rb
@@ -3,8 +3,8 @@
 require_relative "spec_helper"
 
 RSpec.describe Clover, "tag_space" do
-  let(:user) { Account[email: "user@example.com"] }
-  let(:user2) { Account[email: "user2@example.com"] }
+  let(:user) { create_account }
+  let(:user2) { create_account("user2@example.com") }
 
   let(:tag_space) { user.create_tag_space_with_default_policy("tag-space-1") }
 
@@ -26,7 +26,7 @@ RSpec.describe Clover, "tag_space" do
 
   describe "authenticated" do
     before do
-      login
+      login(user.email)
     end
 
     describe "list" do

--- a/spec/web/vm_host_spec.rb
+++ b/spec/web/vm_host_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Clover, "vm_host" do
 
   describe "authenticated" do
     before do
+      create_account
       login
     end
 

--- a/spec/web/vm_spec.rb
+++ b/spec/web/vm_spec.rb
@@ -3,7 +3,7 @@
 require_relative "spec_helper"
 
 RSpec.describe Clover, "vm" do
-  let(:user) { Account[email: "user@example.com"] }
+  let(:user) { create_account }
 
   let(:tag_space) { user.create_tag_space_with_default_policy("tag-space-1") }
 
@@ -33,7 +33,7 @@ RSpec.describe Clover, "vm" do
 
   describe "authenticated" do
     before do
-      login
+      login(user.email)
     end
 
     describe "list" do


### PR DESCRIPTION
Rodauth uses separate database user for password hash tables to maximize
security by default. Default database user can't truncate password tables
so DatabaseCleaner can't clean them between tests.

Previously, test suite creates a global account if not exists. But this
account isn't removed, so it exists forever even after test run.

I'm planning to run tests for user actions such as creating account,
login, verifying account. Persistent user accounts prevent it.

In addition, isolating test case runs is good practice instead of
depending a global entity.

This PR grants default database user to truncate password tables while
running migrations for test database. So DatabaseCleaner is able to clean
database.