### PR TITLE
Bring base and bootstrap rhizome to 100%

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "net/ssh"
+
 class Prog::BootstrapRhizome < Prog::Base
   subject_is :sshable
 
@@ -30,7 +32,7 @@ class Prog::BootstrapRhizome < Prog::Base
   end
 
   def setup
-    pop "rhizome user bootstrapped and source installed" if retval == "installed rhizome"
+    pop "rhizome user bootstrapped and source installed" if retval&.dig("msg") == "installed rhizome"
 
     rootish_ssh(<<SH)
 set -ueo pipefail

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -2,17 +2,20 @@
 
 # A no-operation prog for testing.
 class Prog::Test < Prog::Base
+  subject_is :sshable
+  semaphore :test_semaphore
+
   def start
   end
 
   def pusher1
-    pop 1 if retval
-    push Prog::Test, {test_level: 2}, :pusher2
+    pop "1" if retval
+    push Prog::Test, {test_level: "2"}, :pusher2
   end
 
   def pusher2
     pop frame[:test_level] if retval
-    push Prog::Test, {test_level: 3}, :pusher3
+    push Prog::Test, {test_level: "3"}, :pusher3
   end
 
   def pusher3
@@ -44,7 +47,7 @@ class Prog::Test < Prog::Base
 
   def reaper
     reap
-    nap 0
+    donate
   end
 
   def napper
@@ -53,5 +56,28 @@ class Prog::Test < Prog::Base
 
   def popper
     pop({msg: "popped"})
+  end
+
+  def invalid_hop
+    hop "hop_exit"
+  end
+
+  def budder
+    bud self.class, frame, :popper
+    hop :reaper
+  end
+
+  def increment_semaphore
+    incr_test_semaphore
+    donate
+  end
+
+  def decrement_semaphore
+    decr_test_semaphore
+    donate
+  end
+
+  def bad_pop
+    pop nil
   end
 end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -5,8 +5,8 @@ if (suite = ENV.delete("COVERAGE"))
 
   SimpleCov.start do
     enable_coverage :branch
-    minimum_coverage line: 88, branch: 68.5
-    minimum_coverage_by_file line: 30, branch: 0
+    minimum_coverage line: 87, branch: 68.5
+    minimum_coverage_by_file line: 11, branch: 0
 
     command_name suite
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -3,23 +3,34 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::Base do
-  it "deletes a child with a exitval set" do
-    parent = Strand.create(prog: "Test", label: "reaper")
-    child = parent.add_child(parent_id: parent.id,
-      prog: "Test", label: "popper")
-    expect(child.run.class).to eq(Prog::Base::Exit)
+  it "can bud and reap" do
+    parent = Strand.create(prog: "Test", label: "budder")
     expect {
+      parent.unsynchronized_run
+      parent.reload
+    }.to change { parent.load.leaf? }.from(true).to(false)
+
+    expect {
+      # Execution donated to child sets the exitval.
+      parent.run
+
+      # Parent notices exitval is set and reaps the child.
       parent.run
     }.to change { parent.load.leaf? }.from(false).to(true)
   end
 
-  it "does not delete a child that has no retval yet" do
-    parent = Strand.create(prog: "Test", label: "reaper")
-    parent.add_child(parent_id: parent.id, prog: "Test", label: "popper")
+  describe "#pop" do
+    it "can reject unanticipated values" do
+      expect {
+        Strand.new(prog: "Test", label: "bad_pop").unsynchronized_run
+      }.to raise_error RuntimeError, "BUG: must pop with string or hash"
+    end
 
-    expect {
-      parent.run
-    }.not_to change { parent.load.leaf? }.from(false)
+    it "crashes is the stack is malformed" do
+      expect {
+        Strand.new(prog: "Test", label: "popper", stack: [{}] * 2).unsynchronized_run
+      }.to raise_error RuntimeError, "BUG: expect no stacks exceeding depth 1 with no back-link"
+    end
   end
 
   it "can push prog and frames on the stack" do
@@ -37,15 +48,15 @@ RSpec.describe Prog::Base do
     expect {
       st.run
     }.to change { st.label }.from("pusher3").to "pusher2"
-    expect(st.retval).to eq Sequel.pg_jsonb_wrap(3)
+    expect(st.retval).to eq({msg: "3"})
 
     expect {
       st.run
     }.to change { st.label }.from("pusher2").to "pusher1"
-    expect(st.retval).to eq Sequel.pg_jsonb_wrap(2)
+    expect(st.retval).to eq({msg: "2"})
 
     st.run
-    expect(st.exitval).to eq Sequel.pg_jsonb_wrap(1)
+    expect(st.exitval).to eq({msg: "1"})
 
     expect { st.run }.to raise_error "already deleted"
     expect { st.reload }.to raise_error Sequel::NoExistingObject
@@ -59,8 +70,40 @@ RSpec.describe Prog::Base do
     expect(post - ante).to be > 121
   end
 
-  it "doesn't interpret navigations for undefined *_id strings" do
-    pr = Strand.new(prog: "Test", label: "start", stack: [{"bogus_id" => "nope"}]).load
-    expect(pr.respond_to?(:bogus_id)).to be false
+  it "requires a symbol for hop" do
+    expect {
+      Strand.new(prog: "Test", label: "invalid_hop").unsynchronized_run
+    }.to raise_error RuntimeError, "BUG: #hop only accepts a symbol"
+  end
+
+  it "can manipulate semaphores" do
+    st = Strand.create(prog: "Test", label: "increment_semaphore")
+    expect {
+      st.run
+    }.to change { Semaphore.where(strand_id: st.id).any? }.from(false).to(true)
+
+    st.label = "decrement_semaphore"
+    expect {
+      st.unsynchronized_run
+    }.to change { Semaphore.where(strand_id: st.id).any? }.from(true).to(false)
+  end
+
+  context "when rendering FlowControl strings" do
+    it "can render hop" do
+      expect(
+        described_class::Hop.new("OldProg", "old_label",
+          Strand.new(prog: "NewProg", label: "new_label")).to_s
+      ).to eq("hop OldProg#old_label -> NewProg#new_label")
+    end
+
+    it "can render nap" do
+      expect(described_class::Nap.new("10").to_s).to eq("nap for 10 seconds")
+    end
+
+    it "can render exit" do
+      expect(described_class::Exit.new(
+        Strand.new(prog: "TestProg", label: "exitingLabel", exitval: '{msg: "done"}')
+      ).to_s).to eq('Strand exits from TestProg#exitingLabel with {msg: "done"}')
+    end
   end
 end

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::BootstrapRhizome do
+  subject(:br) {
+    described_class.new(Strand.new(prog: "BootstrapRhizome",
+      stack: [{sshable_id: "bogus"}]))
+  }
+
+  describe "#start" do
+    before { br.strand.label = "start" }
+
+    it "generates a keypair" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:update) do |**args|
+        key = args[:raw_private_key_1]
+        expect(key).to be_instance_of String
+        expect(key.length).to eq 64
+      end
+
+      expect(br).to receive(:sshable).and_return(sshable)
+
+      expect { br.start }.to raise_error Prog::Base::Hop do |h|
+        expect(h.to_s).to eq("hop BootstrapRhizome#start -> BootstrapRhizome#setup")
+      end
+    end
+  end
+
+  describe "#setup" do
+    before { br.strand.label = "setup" }
+
+    it "runs initializing shell wih public keys" do
+      sshable = instance_double(Sshable, keys: [instance_double(SshKey, public_key: "test key")])
+      expect(br).to receive(:sshable).and_return(sshable)
+      expect(br).to receive(:rootish_ssh).with <<FIXTURE
+set -ueo pipefail
+sudo apt update && sudo apt-get -y install ruby-bundler
+sudo adduser --disabled-password --gecos '' rhizome
+echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
+sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh
+sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authorized_keys
+echo test key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+FIXTURE
+
+      expect { br.setup }.to raise_error Prog::Base::Hop do |h|
+        expect(h.to_s).to eq("hop BootstrapRhizome#setup -> InstallRhizome#start")
+      end
+    end
+
+    it "exits once InstallRhizome has returned" do
+      br.strand.retval = {"msg" => "installed rhizome"}
+      expect { br.setup }.to raise_error Prog::Base::Exit do |h|
+        expect(h.to_s).to eq('Strand exits from BootstrapRhizome#setup with {"msg"=>"rhizome user bootstrapped and source installed"}')
+      end
+    end
+  end
+
+  describe "#rootish_ssh" do
+    let(:sshable) {
+      instance_double(Sshable, host: "127.0.0.1",
+        keys: [instance_double(SshKey, private_key: "test private key")])
+    }
+
+    before do
+      expect(br).to receive(:sshable).and_return(sshable).at_least(:once)
+    end
+
+    it "executes a command using root by default" do
+      expect(Net::SSH).to receive(:start) do |&blk|
+        sess = instance_double(Net::SSH::Connection::Session)
+        expect(sess).to receive(:exec!).with("test command").and_return(
+          Net::SSH::Connection::Session::StringWithExitstatus.new("it worked", 0)
+        )
+        blk.call sess
+      end
+
+      br.rootish_ssh("test command")
+    end
+
+    it "fails if a command fails" do
+      expect(Net::SSH).to receive(:start) do |&blk|
+        sess = instance_double(Net::SSH::Connection::Session)
+        expect(sess).to receive(:exec!).with("failing command").and_return(
+          Net::SSH::Connection::Session::StringWithExitstatus.new("it didn't work", 1)
+        )
+        blk.call sess
+      end
+
+      expect { br.rootish_ssh("failing command") }.to raise_error RuntimeError, "Could not bootstrap rhizome"
+    end
+  end
+end


### PR DESCRIPTION
In addition to the usual testing enhancements, I also changed how "pop" behaves with various value types, in particular, popping with a bare string now yields a stored JSON object (`{}`) implicitly.

The reason for this is awkwardness in ambiguity with bare JSON objects and Sequel: https://github.com/jeremyevans/sequel/issues/2028.  My solution is to stop doing that.

The only code I can identify matching the retval/exitval message is in `BootstrapRhizome` and its interaction with `InstallRhizome`, so I change it and test it, too.