### PR TITLE
Hoist strand updating from Prog::Base to Strand

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -88,9 +88,11 @@ SQL
       self.schedule = scheduled
       changed_columns.delete(:schedule)
       e
-    rescue Prog::Base::Hop => e
+    rescue Prog::Base::Hop => hp
+      update(**hp.strand_update_args)
       e
-    rescue Prog::Base::Exit => e
+    rescue Prog::Base::Exit => ext
+      update(exitval: ext.exitval, retval: nil)
       if parent_id.nil?
         # No parent Strand to reap here, so self-reap.
         Semaphore.where(strand_id: id).delete
@@ -98,7 +100,7 @@ SQL
         @deleted = true
       end
 
-      e
+      ext
     else
       fail "BUG: Prog #{prog}##{label} did not provide flow control"
     end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe Prog::Base do
 
     it "can render exit" do
       expect(described_class::Exit.new(
-        Strand.new(prog: "TestProg", label: "exitingLabel", exitval: '{msg: "done"}')
-      ).to_s).to eq('Strand exits from TestProg#exitingLabel with {msg: "done"}')
+        Strand.new(prog: "TestProg", label: "exiting_label"), {"msg" => "done"}
+      ).to_s).to eq('Strand exits from TestProg#exiting_label with {"msg"=>"done"}')
     end
   end
 end


### PR DESCRIPTION
As I was writing prog tests, I found that many tests could be written without database interactions for some speedup, but some were made unnecessarily brutal because base.rb made calls to `Sequel::Model#update` directly.

So I hoist these up to the site where `FlowControl` exceptions are rescued, and do the database modification at the last moment instead. The resulting code is a bit less simple, so it's offered on the principle of making the natural testing procedure a bit more efficient.