### PR TITLE
Make subjects and objects values array for default access policy

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -43,8 +43,8 @@ module Authorization
   def self.generate_default_acls(subject, object)
     {
       acls: [
-        {subjects: subject, powers: ["TagSpace:view", "TagSpace:delete", "TagSpace:user", "TagSpace:policy"], objects: object},
-        {subjects: subject, powers: ["Vm:view", "Vm:create", "Vm:delete"], objects: object}
+        {subjects: [subject], powers: ["TagSpace:view", "TagSpace:delete", "TagSpace:user", "TagSpace:policy"], objects: [object]},
+        {subjects: [subject], powers: ["Vm:view", "Vm:create", "Vm:delete"], objects: [object]}
       ]
     }
   end


### PR DESCRIPTION
It doesn't change functionality. When newbies wants to add new users to existing policies, it guides them to add as JSON array naturally instead of comma separated string.