### PR TITLE
Use SPDK to provide storage to VMs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "clover",
+  "name": "ubicloud",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/rhizome/bin/prep_host.rb
+++ b/rhizome/bin/prep_host.rb
@@ -48,10 +48,10 @@ r "sysctl --system"
 # driver.
 r "apt-get -y install qemu-utils mtools"
 
-# We currently use 1GB of hugepages per VM, so by requesting 16K 2MB pages as
+# We currently use 512MB of hugepages per VM, so by requesting 8K 2MB pages as
 # below, we will have enough hugepages for 32 VMs in a host.
 #
 # TODO: It is possible that OS allocates less hugepages than requested, so
 # check how much hugepages were actually allocated, and use it in capacity
 # calculations.
-r "echo 16384 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
+r "echo 8192 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"

--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -22,8 +22,16 @@ class VmPath
     "/etc/systemd/system/#{@vm_name}-dnsmasq.service"
   end
 
+  def spdk_service
+    "/etc/systemd/system/#{@vm_name}-spdk.service"
+  end
+
   def write_dnsmasq_service(s)
     write(dnsmasq_service, s)
+  end
+
+  def write_spdk_service(s)
+    write(spdk_service, s)
   end
 
   def systemd_service
@@ -53,6 +61,10 @@ class VmPath
     cloudinit.img
     ch-api.sock
     serial.log
+    spdk-config
+    spdk.sock
+    hugepages
+    vhost.sock
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
     fail "BUG" if method_defined?(method_name)


### PR DESCRIPTION
We want to use SPDK for storage in the longer run. This allows to have more control over storage, and provide features like snapshots, encryption, and replication.

Before this PR, we just passed the $VmHome/boot.raw file as the VM disk:

boot.raw <-> VMM

This PR changes that and adds SPDK as an intermediate:

boot.raw <-> SPDK <-(vhost protocol)-> VMM

Although this doesn't add a new functionality, but it paves the way to modify the SPDK layer above to add other features in future.

Follow up items in next PRs:
* Record information about VMs storage topology in database
* Add encryption layer
* Add the possibility to provide raw NVMe disks directly to VMs
* Take into account the cpu that is locked for SPDK in VM allocation.