### PR TITLE
Fix Prog::BootstrapRhizome.setup

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -32,7 +32,7 @@ class Prog::BootstrapRhizome < Prog::Base
   end
 
   def setup
-    pop "rhizome user bootstrapped and source installed" if retval&.dig("msg") == "installed rhizome"
+    pop "rhizome user bootstrapped and source installed" if retval&.dig(:msg) == "installed rhizome"
 
     rootish_ssh(<<SH)
 set -ueo pipefail

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -49,7 +49,7 @@ FIXTURE
     end
 
     it "exits once InstallRhizome has returned" do
-      br.strand.retval = {"msg" => "installed rhizome"}
+      br.strand.retval = {msg: "installed rhizome"}
       expect { br.setup }.to raise_error Prog::Base::Exit do |h|
         expect(h.to_s).to eq('Strand exits from BootstrapRhizome#setup with {"msg"=>"rhizome user bootstrapped and source installed"}')
       end


### PR DESCRIPTION
The key in retval should be :msg not "msg". Otherwise the pop won't happen and the ssh commands in setup will be executed multiple times, which causes a failure.