### PR TITLE
Fix HostNexus setup.

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -48,7 +48,7 @@ end
     outval = Sequel.pg_jsonb_wrap(
       case args
       in [String => s]
-        {msg: s}
+        {"msg" => s}
       in [Hash => h]
         h
       else
@@ -155,7 +155,7 @@ end
   end
 
   def leaf?
-    strand.children.empty?
+    strand.children(reload: true).empty?
   end
 
   # A hop is a kind of jump, as in, like a jump instruction.

--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -32,7 +32,7 @@ class Prog::BootstrapRhizome < Prog::Base
   end
 
   def setup
-    pop "rhizome user bootstrapped and source installed" if retval&.dig(:msg) == "installed rhizome"
+    pop "rhizome user bootstrapped and source installed" if retval&.dig("msg") == "installed rhizome"
 
     rootish_ssh(<<SH)
 set -ueo pipefail

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -48,15 +48,15 @@ RSpec.describe Prog::Base do
     expect {
       st.run
     }.to change { st.label }.from("pusher3").to "pusher2"
-    expect(st.retval).to eq({msg: "3"})
+    expect(st.retval).to eq({"msg" => "3"})
 
     expect {
       st.run
     }.to change { st.label }.from("pusher2").to "pusher1"
-    expect(st.retval).to eq({msg: "2"})
+    expect(st.retval).to eq({"msg" => "2"})
 
     st.run
-    expect(st.exitval).to eq({msg: "1"})
+    expect(st.exitval).to eq({"msg" => "1"})
 
     expect { st.run }.to raise_error "already deleted"
     expect { st.reload }.to raise_error Sequel::NoExistingObject

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -49,7 +49,7 @@ FIXTURE
     end
 
     it "exits once InstallRhizome has returned" do
-      br.strand.retval = {msg: "installed rhizome"}
+      br.strand.retval = {"msg" => "installed rhizome"}
       expect { br.setup }.to raise_error Prog::Base::Exit do |h|
         expect(h.to_s).to eq('Strand exits from BootstrapRhizome#setup with {"msg"=>"rhizome user bootstrapped and source installed"}')
       end


### PR DESCRIPTION
Before this, HostNexus setup succeeded, but it skipped many steps because of checking stale strand.children.

* don't use cache for strand.children in leaf?
* Use {"msg" => ...} in return value, so we get the same thing if we re-read it from database. {msg: ...} is saved as {"msg" => ...} in db, so re-reading it doesn't return same thing.