### PR TITLE
Simplify cache invalidation in Prog::Base#reap

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -150,7 +150,7 @@ end
   def reap
     strand.children_dataset.where(Sequel.~(exitval: nil)).returning.delete.tap {
       # Clear cache if anything was deleted.
-      strand.associations.delete(:children) unless _1.empty?
+      strand.children(reload: true) unless _1.empty?
     }
   end
 


### PR DESCRIPTION
There was a suspicious defect that looks like, after `reap`, `leaf?`
was returning true even though it should not have, as seen in
https://github.com/ubicloud/ubicloud/pull/172.

Although the original intent of this code was to invalidate the
association cache without necessarily forcing a reload, the symptom
reported is very suspicious, and this code is better than a bogus
association cache after `reap`, and also perhaps better than forcing
`leaf?` to always do a database query, as proposed in that pull
request.

Part of the reason this is so suspicious is because, prior to
1f71e162, the cache invalidation expression was dead code, and I
(thought I) "fixed" it to meet the intent in that patch.  And the
whole thing was predicated on a somewhat murky manipulation of
Sequel's cache tracking.

This might be a good question for the Sequel mailing list, but, until
then...