### PR TITLE
Use Sequel::Model#add_* method to keep cached association in sync

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -137,9 +137,11 @@ end
 
   def bud(prog, new_frame = nil, label = "start")
     new_frame = (new_frame || {}).merge("subject_id" => @subject_id)
-    Strand.create(parent_id: strand.id,
-      prog: Strand.prog_verify(prog), label: label,
-      stack: Sequel.pg_jsonb_wrap([new_frame]))
+    strand.add_child(
+      prog: Strand.prog_verify(prog),
+      label: label,
+      stack: Sequel.pg_jsonb_wrap([new_frame])
+    )
   end
 
   def donate


### PR DESCRIPTION
https://github.com/ubicloud/ubicloud/pull/172 noted that, after 1f71e162, host preparation broke, because `leaf?` was returning `true` even though there were records in the database.  And the way this can happen is.

This patch operates under the theory that the problem is how `Strand` objects are re-used, including their `children` association cache, and `children` gets out of sync when records are created without either invalidating the associaiton cache or keeping it in synchronization somehow.

By using the `add_$MODELNAME` method in Sequel, `children` is kept up to date.  It's not entirely clear to me if avoiding a `strand#reload` between `unsynchronized_run` calls is really an economy to preserve, but I'm going to defer thinking about that and fix `#bud` so that the association cache is updated accordingly.