### PR TITLE
Standardize retval with string keys

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -48,7 +48,7 @@ end
     outval = Sequel.pg_jsonb_wrap(
       case args
       in [String => s]
-        {msg: s}
+        {"msg" => s}
       in [Hash => h]
         h
       else

--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -32,7 +32,7 @@ class Prog::BootstrapRhizome < Prog::Base
   end
 
   def setup
-    pop "rhizome user bootstrapped and source installed" if retval&.dig(:msg) == "installed rhizome"
+    pop "rhizome user bootstrapped and source installed" if retval&.dig("msg") == "installed rhizome"
 
     rootish_ssh(<<SH)
 set -ueo pipefail

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -48,15 +48,15 @@ RSpec.describe Prog::Base do
     expect {
       st.run
     }.to change { st.label }.from("pusher3").to "pusher2"
-    expect(st.retval).to eq({msg: "3"})
+    expect(st.retval).to eq({"msg" => "3"})
 
     expect {
       st.run
     }.to change { st.label }.from("pusher2").to "pusher1"
-    expect(st.retval).to eq({msg: "2"})
+    expect(st.retval).to eq({"msg" => "2"})
 
     st.run
-    expect(st.exitval).to eq({msg: "1"})
+    expect(st.exitval).to eq({"msg" => "1"})
 
     expect { st.run }.to raise_error "already deleted"
     expect { st.reload }.to raise_error Sequel::NoExistingObject

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -49,7 +49,7 @@ FIXTURE
     end
 
     it "exits once InstallRhizome has returned" do
-      br.strand.retval = {msg: "installed rhizome"}
+      br.strand.retval = {"msg" => "installed rhizome"}
       expect { br.setup }.to raise_error Prog::Base::Exit do |h|
         expect(h.to_s).to eq('Strand exits from BootstrapRhizome#setup with {"msg"=>"rhizome user bootstrapped and source installed"}')
       end


### PR DESCRIPTION
When reading back from Postgres, JSONB values like retval and exitval provide the JSON keys as strings.  But, some code we had would represent keys in symbols, and `Strand` values that were re-used within one session would evaluate branches differently.

8ebacaaf3b2d5ee3adff182f5e33bb2175f01a1d is an example of an expedient "fix" for this, that made development work better, but any background worker that loaded a fresh Strand value would not work.
