### PR TITLE
Support a-priori net6

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -3,10 +3,10 @@
 class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
 
-  def self.assemble(sshable_hostname, location: "hetzner-hel1")
+  def self.assemble(sshable_hostname, location: "hetzner-hel1", net6: nil)
     DB.transaction do
       sa = Sshable.create(host: sshable_hostname)
-      VmHost.create(location: location) { _1.id = sa.id }
+      VmHost.create(location: location, net6: net6) { _1.id = sa.id }
 
       Strand.create(prog: "Vm::HostNexus", label: "start") { _1.id = sa.id }
     end
@@ -25,7 +25,7 @@ class Prog::Vm::HostNexus < Prog::Base
 
   def prep
     bud Prog::Vm::PrepHost
-    bud Prog::LearnNetwork
+    bud Prog::LearnNetwork unless vm_host.net6
     bud Prog::LearnMemory
     bud Prog::LearnCores
     bud Prog::InstallDnsmasq


### PR DESCRIPTION
DataPacket has a different way of configuring IPv6 static routes that we may see more of in the future.  The general way it works is the interface has to respond to IPv6 NDP on a particular address, and the result is the non-overlapping subnet is routed to that machine.

Because that non-overlapping subnet is not sound to compute from anything automatically "learned" from the instance itself, it must be programmed a priori.

And to do that, there need to be a few key relaxations in constraints and a few branches to get around code assuming the style where the network range is "learned" from the interface already configured.