### PR TITLE
Keep old form inputs when redirected back

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -101,10 +101,10 @@ class Clover < Roda
     case e
     when Sequel::ValidationFailed
       flash["error"] = e.to_s
-      return request.redirect env["HTTP_REFERER"]
+      return redirect_back_with_inputs
     when Validation::ValidationFailed
       flash["errors"] = (flash["errors"] || {}).merge(e.errors)
-      return request.redirect env["HTTP_REFERER"]
+      return redirect_back_with_inputs
     when Roda::RodaPlugins::RouteCsrf::InvalidToken
       response.status = 419
       @error_code = 419
@@ -215,12 +215,9 @@ class Clover < Roda
     require_bcrypt? false
   end
 
-  def last_sms_sent
-    nil
-  end
-
-  def last_mail_sent
-    nil
+  def redirect_back_with_inputs
+    flash["old"] = request.params
+    request.redirect env["HTTP_REFERER"]
   end
 
   def vm_host_allowed?

--- a/routes/tag_space.rb
+++ b/routes/tag_space.rb
@@ -173,7 +173,7 @@ class Clover
               fail JSON::ParserError unless JSON.parse(body).is_a?(Hash)
             rescue JSON::ParserError
               flash["error"] = "The policy isn't a valid JSON object."
-              return request.redirect env["HTTP_REFERER"]
+              return redirect_back_with_inputs
             end
 
             policy.update(body: body)

--- a/spec/web/tag_space_spec.rb
+++ b/spec/web/tag_space_spec.rb
@@ -261,7 +261,8 @@ RSpec.describe Clover, "tag_space" do
         click_button "Update"
 
         expect(page).to have_content "The policy isn't a valid JSON object."
-        expect(page).to have_content current_policy.to_json
+        expect(page).to have_content "{'invalid': 'json',}"
+        expect(current_policy).to eq(tag_space.access_policies.first.body)
       end
 
       it "raises not found when access policy not exists" do

--- a/spec/web/vm_spec.rb
+++ b/spec/web/vm_spec.rb
@@ -78,6 +78,25 @@ RSpec.describe Clover, "vm" do
         expect(Vm.count).to eq(1)
       end
 
+      it "can not create virtual machine with invalid name" do
+        tag_space
+        visit "/vm/create"
+
+        expect(page.title).to eq("Ubicloud - Create Virtual Machine")
+
+        fill_in "Name", with: "invalid name"
+        select tag_space.name, from: "tag-space-id"
+        choose option: "hetzner-hel1"
+        choose option: "ubuntu-jammy"
+        choose option: "c5a.2x"
+
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - Create Virtual Machine")
+        expect(page).to have_content "Name must only contain"
+        expect((find "input[name=name]")["value"]).to eq("invalid name")
+      end
+
       it "can not select tag space when does not have permissions" do
         tag_space
         tag_space_wo_permissions

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -1,7 +1,7 @@
 <% name = defined?(name) ? name : nil %>
 <% label = defined?(label) ? label : nil %>
 <% options = (defined?(options) && options) ? options : {} %>
-<% selected = defined?(selected) ? selected : nil %>
+<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
 <% error = defined?(error) ? error : flash.dig("errors", name) %>
 <% description = defined?(description) ? description : nil %>
 <% attributes = defined?(attributes) ? attributes : {} %>
@@ -19,8 +19,8 @@
             value="<%= opt_val %>"
             class="peer sr-only"
             <%= (opt_val == selected) ? "checked" : "" %>
-            <% attributes.each do |key, value| %>
-            <%= key %>="<%= value %>"
+            <% attributes.each do |atr_key, atr_value| %>
+            <%= atr_key %>="<%= atr_value %>"
             <% end%>
           >
           <span

--- a/views/components/form/select.erb
+++ b/views/components/form/select.erb
@@ -1,7 +1,7 @@
 <% name = defined?(name) ? name : nil %>
 <% label = defined?(label) ? label : nil %>
 <% options = (defined?(options) && options) ? options : {} %>
-<% selected = defined?(selected) ? selected : nil %>
+<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
 <% error = defined?(error) ? error : flash.dig("errors", name) %>
 <% description = defined?(description) ? description : nil %>
 <% attributes = defined?(attributes) ? attributes : {} %>

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -1,6 +1,7 @@
 <% name = defined?(name) ? name : nil %>
 <% label = defined?(label) ? label : nil %>
 <% type = (defined?(type) && type) ? type : "text" %>
+<% value = flash.dig("old", name) || ((defined?(value) && value) ? value : nil) %>
 <% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
 <% description = (defined?(description) && description) ? description : nil %>
 <% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
@@ -13,6 +14,9 @@
     id="<%= name %>"
     type="<%= type %>"
     name="<%= name %>"
+    <% if value %>
+    value="<%= value %>"
+    <% end %>
     class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%>"
     <% attributes.each do |atr_key, atr_value| %>
     <%= atr_key %>="<%= atr_value %>"

--- a/views/components/form/textarea.erb
+++ b/views/components/form/textarea.erb
@@ -1,5 +1,5 @@
 <% name = defined?(name) ? name : nil %>
-<% value = defined?(value) ? value : nil %>
+<% value = flash.dig("old", name) || (defined?(value) ? value : nil) %>
 <% label = defined?(label) ? label : nil %>
 <% error = defined?(error) ? error : flash.dig("errors", name) %>
 <% description = defined?(description) ? description : nil %>

--- a/views/tag_space/show_policies.erb
+++ b/views/tag_space/show_policies.erb
@@ -29,7 +29,7 @@
                   <div class="col-span-full">
                     <div class="policy-editor">
                       <pre class="bg-gray-50 rounded-lg p-3 h-[60vh] overflow-scroll" contenteditable="true">
-                        <%= @policy.body %>
+                        <%= flash.dig("old", "body") || @policy.body %>
                       </pre>
                       <textarea name="body" class="hidden" required></textarea>
                     </div>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -65,7 +65,14 @@
                         <div class="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 xl:grid-cols-4">
                           <% Option::VmSizes.each do |size| %>
                             <label>
-                              <input type="radio" name="size" value="<%= size.name %>" class="peer sr-only" required>
+                              <input
+                                type="radio"
+                                name="size"
+                                value="<%= size.name %>"
+                                class="peer sr-only"
+                                required
+                                <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>
+                              >
                               <span
                                 class="flex items-center rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
                                 ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
@@ -115,10 +122,10 @@
                       locals: {
                         name: "user",
                         label: "User",
+                        value: "ubi",
                         attributes: {
                           required: true,
-                          placeholder: "Unix username",
-                          value: "ubi"
+                          placeholder: "Unix username"
                         }
                       }
                     ) %>


### PR DESCRIPTION
When validation is failed, backend redirects to previous page. It resets all user inputs. It's not very good user experience, they need to enter all inputs again.

In this PR, request parameters are placed into flash (one time session) while redirecting back. Input components show these value if `flash["old"][INPUT_NAME]` exists.