### PR TITLE
Support NDP Proxying

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -8,7 +8,8 @@ module Option
   Locations = [
     ["hetzner-hel1", "Hetzner Finland"],
     ["hetzner-fsn1", "Hetzner Germany"],
-    ["dp-istanbul-mars", "DataPacket Istanbul"]
+    ["dp-istanbul-mars", "DataPacket Istanbul"],
+    ["mars-istanbul", "Mars Istanbul"]
   ].map { |args| Location.new(*args) }.freeze
 
   BootImages = [

--- a/migrate/011_ipv6_ndp_support.rb
+++ b/migrate/011_ipv6_ndp_support.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      add_column :ndp_needed, :boolean, null: false, default: false
+    end
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -3,10 +3,10 @@
 class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
 
-  def self.assemble(sshable_hostname, location: "hetzner-hel1", net6: nil)
+  def self.assemble(sshable_hostname, location: "hetzner-hel1", net6: nil, ndp_needed: false)
     DB.transaction do
       sa = Sshable.create(host: sshable_hostname)
-      VmHost.create(location: location, net6: net6) { _1.id = sa.id }
+      VmHost.create(location: location, net6: net6, ndp_needed: ndp_needed) { _1.id = sa.id }
 
       Strand.create(prog: "Vm::HostNexus", label: "start") { _1.id = sa.id }
     end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -141,7 +141,8 @@ SQL
       "boot_image" => vm.boot_image,
       "max_vcpus" => topo.max_vcpus,
       "cpu_topology" => topo.to_s,
-      "mem_gib" => vm.mem_gib
+      "mem_gib" => vm.mem_gib,
+      "ndp_needed" => host.ndp_needed
     })
 
     # Enable KVM access for VM user.

--- a/rhizome/bin/prep_host.rb
+++ b/rhizome/bin/prep_host.rb
@@ -28,6 +28,7 @@ end
 # the physical interface.
 File.write("/etc/sysctl.d/72-clover-forward-packets.conf", <<CONF)
 net.ipv6.conf.all.forwarding=1
+net.ipv6.conf.all.proxy_ndp=1
 CONF
 r "sysctl --system"
 

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -58,9 +58,14 @@ unless (mem_gib = params["mem_gib"])
   exit 1
 end
 
+unless (ndp_needed = params["ndp_needed"])
+  puts "need ndp_needed in parameters json"
+  exit 1
+end
+
 require "fileutils"
 require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
 VmSetup.new(vm_name).prep(unix_user, ssh_public_key, private_subnets, gua, boot_image,
-  max_vcpus, cpu_topology, mem_gib)
+  max_vcpus, cpu_topology, mem_gib, ndp_needed)

--- a/routes/vm_host.rb
+++ b/routes/vm_host.rb
@@ -4,7 +4,7 @@ require "ulid"
 
 class Clover
   class VmHostShadow
-    attr_accessor :id, :host, :state, :location, :ip6, :vms_count, :total_cores, :used_cores, :public_keys
+    attr_accessor :id, :host, :state, :location, :ip6, :vms_count, :total_cores, :used_cores, :public_keys, :ndp_needed
 
     def initialize(vm_host)
       @id = ULID.from_uuidish(vm_host.id).to_s.downcase
@@ -16,6 +16,7 @@ class Clover
       @total_cores = vm_host.total_cores
       @used_cores = vm_host.used_cores
       @public_keys = vm_host.sshable.keys.map(&:public_key)
+      @ndp_needed = vm_host.ndp_needed
     end
   end
 
@@ -33,7 +34,8 @@ class Clover
     r.post true do
       st = Prog::Vm::HostNexus.assemble(
         r.params["hostname"],
-        location: r.params["location"]
+        location: r.params["location"],
+        ndp_needed: r.params.key?("ndp-needed")
       )
 
       flash["notice"] = "You need to add SSH public keys to your host, so the control plane can connect to the host as root via SSH."

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     sshable = instance_spy(Sshable)
     vmh = instance_double(VmHost, sshable: sshable,
-      total_cpus: 80, total_cores: 80, total_nodes: 1, total_sockets: 1)
+      total_cpus: 80, total_cores: 80, total_nodes: 1, total_sockets: 1, ndp_needed: false)
 
     expect(st).to receive(:load).and_return(prog)
     expect(vm).to receive(:vm_host).and_return(vmh).at_least(:once)

--- a/views/components/form/checkbox.erb
+++ b/views/components/form/checkbox.erb
@@ -1,0 +1,38 @@
+<% name = defined?(name) ? name : nil %>
+<% label = defined?(label) ? label : nil %>
+<% value = (defined?(value) && value) ? value : nil %>
+<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
+<% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
+<% description = (defined?(description) && description) ? description : nil %>
+<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
+
+<div class="space-y-2 text-gray-900">
+  <fieldset>
+    <div class="space-y-5">
+      <div class="relative flex items-start">
+        <div class="flex h-6 items-center">
+          <input
+            id="<%= name %>"
+            name="<%= name %>"
+            type="checkbox"
+            value="<%= value %>"
+            class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
+            <%= (value == selected) ? "checked" : "" %>
+            <% attributes.each do |atr_key, atr_value| %>
+            <%= atr_key %>="<%= atr_value %>"
+            <% end%>
+          >
+        </div>
+        <div class="ml-3 text-sm leading-6">
+          <label for="<%= name %>" class="font-medium text-gray-900"><%= label %></label>
+          <% if error %>
+            <p class="text-red-600" id="<%= name %>-error"><%= error %></p>
+          <% end %>
+          <% if description %>
+            <p class="text-gray-500" id="<%= name %>-description"><%== description %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/views/vm_host/create.erb
+++ b/views/vm_host/create.erb
@@ -42,6 +42,18 @@
                       }
                     ) %>
                   </div>
+                  <div class="col-span-full">
+                    <%== render(
+                      "components/form/checkbox",
+                      locals: {
+                        name: "ndp-needed",
+                        label: "NDP Proxying",
+                        value: "1",
+                        description:
+                          "NDP proxy is needed for some hosting providers. Check with your provider to see if they need ndp proxy for IPv6 subnets."
+                      }
+                    ) %>
+                  </div>
                 </div>
               </div>
             </div>

--- a/views/vm_host/show.erb
+++ b/views/vm_host/show.erb
@@ -31,6 +31,12 @@
                 </dd>
               </div>
               <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
+                <dt class="text-sm font-medium text-gray-500">NDP Proxying</dt>
+                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  <%= @vm_host.ndp_needed %>
+                </dd>
+              </div>
+              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
                 <dt class="text-sm font-medium text-gray-500">Provider & Location</dt>
                 <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm_host.location %></dd>
               </div>


### PR DESCRIPTION
We are running on a landscape that different hosting providers have different implementations on how they redirect traffic for IPv6 ranges.
    There are 2 main themes;
    1. For a given subnet, redirect the whole traffic according to prefix by skipping ndp. In this implementation, if we are assigned /64 subnet, all the packets in that range will be sent to the host.
    2. We are assigned /64 subnet, we split it to /79 chunks but when we need to send a packet to that /79 chunk, switch sends ns messages to resolve the MAC address. If it doesn't get any response, the package is dropped. That's why our host needs to respond to these messages via proxy ndp and we should teach it to respond a specific ip address even if it is under our range. This comes with a cost of not being able to use all the ip addresses in the range since we have to add them 1 by 1 but it is a hosting provider limitation and we cannot do much atm.