### PR TITLE
Enable autoload for clover app at dev

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -2,11 +2,6 @@
 
 require_relative "model"
 
-unless defined?(Unreloader)
-  require "rack/unreloader"
-  Unreloader = Rack::Unreloader.new(reload: false, autoload: !ENV["NO_AUTOLOAD"])
-end
-
 require "mail"
 require "roda"
 require "tilt/sass"
@@ -144,11 +139,13 @@ class Clover < Roda
 
   if Unreloader.autoload?
     plugin :autoload_hash_branches
-    autoload_hash_branch_dir("./routes")
+    Dir["routes/*"].each do |f|
+      autoload_hash_branch(File.basename(f, ".rb").tr("_", "-"), f)
+    end
   end
 
   # rubocop:disable Performance/StringIdentifierArgument
-  Unreloader.autoload("routes", delete_hook: proc { |f| hash_branch(File.basename(f).delete_suffix(".rb")) }) {}
+  Unreloader.autoload("routes", delete_hook: proc { |f| hash_branch(File.basename(f, ".rb").tr("_", "-")) }) {}
   # rubocop:enable Performance/StringIdentifierArgument
 
   plugin :rodauth do

--- a/config.ru
+++ b/config.ru
@@ -10,7 +10,7 @@ end
 require_relative "loader"
 
 require "rack/unreloader"
-Unreloader = Rack::Unreloader.new(subclasses: %w[Roda Sequel::Model], logger: logger, reload: dev) { Clover }
+Unreloader = Rack::Unreloader.new(subclasses: %w[Roda Sequel::Model], logger: logger, reload: dev, autoload: dev) { Clover }
 require_relative "model"
 Unreloader.require("clover.rb") { "Clover" }
 run(dev ? Unreloader : Clover.freeze.app)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -141,3 +141,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+unless defined?(Unreloader)
+  require "rack/unreloader"
+  Unreloader = Rack::Unreloader.new(reload: false, autoload: !ENV["NO_AUTOLOAD"])
+end

--- a/spec/web.rb
+++ b/spec/web.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-Dir["./spec/web/*_spec.rb"].sort.each { |f| require f }


### PR DESCRIPTION
We have some `Unreloader.autoload` directives, but autoload isn't enabled. It works similar to `require` when not enabled. Autoload speeds things up at dev, or when only running a subset of tests. If the constants are not accessed, you don’t need to pay the cost of loading the related files.

Autoloading hash branches is little bit tricky. Of course Jeremy has `autoload_hash_branches` plugin and it accepts directories too. `autoload_hash_branch_dir` expects filename and hash branches to be same. But filenames use `_` and hash branches use `-` as separator. Because of that we autoload files one by one instead of using `autoload_hash_branch_dir`.