### PR TITLE
Remove Zeitwerk and rely on Unreloader only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem "sequel", ">= 5.62"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "rack-unreloader", ">= 1.8"
 gem "rake"
-gem "zeitwerk"
 gem "warning"
 gem "pry"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,6 @@ GEM
     webrick (1.8.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.8)
 
 PLATFORMS
   arm64-darwin-22
@@ -270,7 +269,6 @@ DEPENDENCIES
   standard (>= 1.24.3)
   tilt (>= 2.0.9)
   warning
-  zeitwerk
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/config.ru
+++ b/config.ru
@@ -1,19 +1,8 @@
 # frozen_string_literal: true
 
-dev = ENV["RACK_ENV"] == "development"
-
-if dev
-  require "logger"
-  logger = Logger.new($stdout)
-end
-
 require_relative "loader"
 
-require "rack/unreloader"
-Unreloader = Rack::Unreloader.new(subclasses: %w[Roda Sequel::Model], logger: logger, reload: dev) { Clover }
-require_relative "model"
-Unreloader.require("clover.rb") { "Clover" }
-run(dev ? Unreloader : Clover.freeze.app)
+run(Config.development? ? Unreloader : Clover.freeze.app)
 
 freeze_core = false
 # freeze_core = !dev # Uncomment to enable refrigerator

--- a/model.rb
+++ b/model.rb
@@ -32,15 +32,6 @@ module SemaphoreMethods
   end
 end
 
-if ENV["RACK_ENV"] == "development"
-  unless defined?(Unreloader)
-    require "rack/unreloader"
-    Unreloader = Rack::Unreloader.new(reload: false)
-  end
-
-  Unreloader.require("model") { |f| Sequel::Model.send(:camelize, File.basename(f).delete_suffix(".rb")) }
-end
-
 if ENV["RACK_ENV"] == "development" || ENV["RACK_ENV"] == "test"
   require "logger"
   LOGGER = Logger.new($stdout)


### PR DESCRIPTION

As it turns out, Clover was started almost on the same day Unreloader
got a release that implemented autoload functionality.  Had it been
around a bit longer, maybe I would have done things like this to begin
with.

As it turns out, we had some issues with Zeitwerk being a bit too
clever -- or prescriptive -- about how it handled constants, and as a
result, code reloading didn't quite work right.  Now, this does:

    Unreloader.reload!

Also somewhat less idiomatic to Unreloader vs. Zeitwerk is setting up
autoload, and subsequently forcing them to load in production cases.
Doing things this way frees Clover code from having to require
dependencies within the project manually: otherwise, when
Unreloader.autoload is switched to a "require" when `autoload: false`
is passed, missing constant dependencies between files can crash.  I
considered whether we should abide the old Ruby ways and get a correct
require order embedded into each file, but decided the Zeitwerk style
seemed more practical.

Alternatively, I considered removing Unreloader in favor of Zeitwerk,
but that seemed unappealing: the in-place reloading funcionality it
was designed for with hash_branch and Roda is too good to give up.
See https://github.com/jeremyevans/roda-sequel-stack/issues/21.

And Unreloader has some more advanced features that improve the
quality of reloading if one is willing to write bespoke code to help
Unreloader, which we are.

One piece of errata: Zeitwerk is good about figuring out if a
namespace should be a class or a module given files like this:

    a/dir/foo.rb
    a/dir.rb

In this case, Zeitwerk will notice that A::Dir should be a class, not
a module.  The code I wrote here is not so smart: if the list of files
is presented with a nested constant first, it'll create modules to
contain it, even if later a class is found that should define the
namespace.

But right now, we don't have this ambiguity, so I figure we can solve
it later as necessary.
