### PR TITLE
Use test delivery method for mails while testing

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -79,6 +79,10 @@ class Clover < Roda
     ::Mail.defaults do
       delivery_method :logger
     end
+  when :test
+    ::Mail.defaults do
+      delivery_method :test
+    end
   end
 
   if Config.development?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 ENV["RACK_ENV"] = "test"
+ENV["MAIL_DRIVER"] = "test"
 require_relative "../loader"
 require_relative "./coverage_helper"
 require "rspec"

--- a/spec/web/tag_space_spec.rb
+++ b/spec/web/tag_space_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Clover, "tag_space" do
         expect(page).to have_content "Forbidden"
       end
 
-      it "can invite new user to tag space" do
+      it "can invite registered user to tag space" do
         shadow = Clover::TagSpaceShadow.new(tag_space)
         visit "/tag-space/#{shadow.id}/user"
 
@@ -145,9 +145,11 @@ RSpec.describe Clover, "tag_space" do
 
         expect(page).to have_content user.email
         expect(page).to have_content user2.email
+        expect(Mail::TestMailer.deliveries.length).to eq 1
+        Mail::TestMailer.deliveries.clear
       end
 
-      it "can invite new existing email to tag space and nothing happens" do
+      it "can invite unregistered user to tag space" do
         shadow = Clover::TagSpaceShadow.new(tag_space)
         visit "/tag-space/#{shadow.id}/user"
 
@@ -158,6 +160,8 @@ RSpec.describe Clover, "tag_space" do
 
         expect(page).to have_content user.email
         expect(page).to have_content "Invitation sent successfully to 'new@example.com'."
+        expect(Mail::TestMailer.deliveries.length).to eq 1
+        Mail::TestMailer.deliveries.clear
       end
 
       it "can remove user from tag space" do


### PR DESCRIPTION
:logger delivery method is hard to test and prints all mails to stdout. It makes reading rspec results harder. :test delivery method is more suitable for specs. Also it makes testing mails easier with helper methods.