### PR TITLE
Ignore some warnings in mail gem while testing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ require "rspec"
 require "database_cleaner/sequel"
 require "logger"
 require "sequel/core"
+require "warning"
 
 # DatabaseCleaner assumes the usual DATABASE_URL, but the
 # "roda-sequel-stack" way names each environment *and* application
@@ -32,6 +33,8 @@ require "sequel/core"
 DatabaseCleaner.url_allowlist = [
   nil
 ]
+
+Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser.*/)
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|


### PR DESCRIPTION
These warnings make reading rspec results harder. mikel/mail gem has 3 years old issues at GitHub for them. But they aren't resolved.

https://github.com/mikel/mail/issues/1384
https://github.com/mikel/mail/issues/1424
https://github.com/mikel/mail/issues/1572