### PR TITLE
Enable autoload for hash_branch routes

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -142,17 +142,11 @@ class Clover < Roda
     secret: Config.clover_session_secret
 
   autoload_normal("serializers/web", include_first: true)
-
-  # YYY: It'd be nice to use autoload, but it can't work while
-  # constants used across files are defined inside routes files and
-  # the autoload dependency cannot be tracked cheaply.
-  #
-  # if Unreloader.autoload?
-  #   plugin :autoload_hash_branches
-  #   autoload_hash_branch_dir("./routes")
-  # end
-
-  Unreloader.require("routes", delete_hook: proc { |f| hash_branch(File.basename(f).delete_suffix(".rb")) }) {}
+  plugin :autoload_hash_branches
+  Dir["routes/*"].each do |f|
+    autoload_hash_branch(File.basename(f, ".rb").tr("_", "-"), f)
+  end
+  Unreloader.autoload("routes", delete_hook: proc { |f| hash_branch(File.basename(f, ".rb").tr("_", "-")) }) {}
 
   plugin :rodauth do
     enable :argon2, :change_login, :change_password, :close_account, :create_account,


### PR DESCRIPTION
We couldn't autoload hash branches before because some constants that defined in route files used across files.

I moved them to separate files at https://github.com/ubicloud/ubicloud/pull/198. So we can autoload our hash branches now.

Autoloading hash branches is little bit tricky. Of course Jeremy has `autoload_hash_branches` plugin and it accepts directories too. `autoload_hash_branch_dir` expects filename and hash branches to be same. But filenames use `_` and hash branches use `-` as separator. Because of that we autoload files one by one instead of using `autoload_hash_branch_dir`.