### PR TITLE
Introduce Hetzner API support for IPv4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "rack-unreloader", ">= 1.8"
 gem "rake"
 gem "warning"
 gem "pry"
+gem "excon"
 
 group :development do
   gem "brakeman"
@@ -47,4 +48,5 @@ group :test do
   gem "database_cleaner-sequel"
   gem "capybara"
   gem "rspec"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
     chunky_png (1.4.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     database_cleaner-core (2.0.1)
     database_cleaner-sequel (2.0.2)
@@ -59,11 +61,13 @@ GEM
     docile (1.4.0)
     ed25519 (1.3.0)
     erubi (1.12.0)
+    excon (0.99.0)
     ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
     foreman (0.87.2)
+    hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
@@ -220,6 +224,10 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     warning (1.3.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -238,6 +246,7 @@ DEPENDENCIES
   ed25519
   erb-formatter!
   erubi (>= 1.5)
+  excon
   foreman
   mail
   net-ssh
@@ -269,6 +278,7 @@ DEPENDENCIES
   standard (>= 1.24.3)
   tilt (>= 2.0.9)
   warning
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/config.rb
+++ b/config.rb
@@ -64,4 +64,8 @@ module Config
   override :timeout, 10, int
   override :versioning, false, bool
   override :allowed_vm_host_users, "", array(string)
+  optional :hetzner_user, string, clear: true
+  optional :hetzner_password, string, clear: true
+  override :providers, "hetzner", array(string)
+  override :hetzner_connection_string, "https://robot-ws.your-server.de", string
 end

--- a/lib/hosting/apis.rb
+++ b/lib/hosting/apis.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "excon"
+class Hosting::Apis
+  def self.pull_ips(vm_host)
+    if vm_host.provider == HetznerHost::PROVIDER_NAME
+      vm_host.hetzner_host.api.pull_ips
+    else
+      raise "unknown provider #{vm_host.provider}"
+    end
+  end
+end

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "excon"
+class Hosting::HetznerApis
+  FailoverSubnet = Struct.new(:ips, :subnets, :failovers)
+
+  def initialize(hetzner_host)
+    @host = hetzner_host
+  end
+
+  # Fetches and processes the IPs, subnets, and failovers from the Hetzner API.
+  # It then calls `find_matching_ips` to retrieve IP addresses that match with the host's IP address.
+  # This whole thing is needed because Hetzner API is simply not good enough to do this in one call.
+  # Also the failover IP implementation depends on the host server and the IP continues to live under the original server.
+  # host even if the failover is performed. So we need to check the failover IP separately.
+  def pull_ips
+    connection = Excon.new(@host.connection_string, user: @host.user, password: @host.password)
+    response = connection.get(path: "/subnet")
+    if response.status != 200
+      raise "unexpected status #{response.status}"
+    end
+    json_arr_subnets = JSON.parse(response.body)
+
+    response = connection.get(path: "/ip")
+    if response.status != 200
+      raise "unexpected status #{response.status}"
+    end
+    json_arr_ips = JSON.parse(response.body)
+
+    response = connection.get(path: "/failover")
+    if response.status != 200
+      raise "unexpected status #{response.status}"
+    end
+    json_arr_failover = JSON.parse(response.body)
+
+    addresses_with_assignment = process_ips_subnets_failovers(json_arr_ips, json_arr_subnets, json_arr_failover)
+    find_matching_ips(addresses_with_assignment)
+  end
+
+  def process_ips_subnets_failovers(ips, subnets, failovers)
+    failovers_map = failovers.each_with_object({}) do |failover, map|
+      map[failover["failover"]["ip"]] = failover
+    end
+
+    {ips: process_items(ips, failovers_map), subnets: process_items(subnets, failovers_map)}
+  end
+
+  def process_items(items, failovers_map)
+    items.map do |item|
+      item_info = item[item.keys.first]
+      failover_info = failovers_map[item_info["ip"]]
+
+      item_info["failover_ip"] = !!failover_info
+      item_info["active_server_ip"] = failover_info ? failover_info["failover"]["active_server_ip"] : item_info["server_ip"]
+
+      item_info
+    end
+  end
+
+  def find_matching_ips(result)
+    host_address = @host.vm_host.sshable.host
+    matching_ips = []
+
+    # Check ips
+    result[:ips].each do |ip|
+      if ip["active_server_ip"] == host_address
+        matching_ips << {
+          ip_address: "#{ip["ip"]}/32",
+          source_host_ip: ip["server_ip"],
+          is_failover: ip["failover_ip"]
+        }
+      end
+    end
+
+    # Check subnets
+    result[:subnets].each do |subnet|
+      if subnet["active_server_ip"] == host_address
+        # Check if it is IPv6 or not by the existence of colon in the IP address
+        mask = subnet["ip"].include?(":") ? 64 : subnet["mask"]
+        matching_ips << {
+          ip_address: "#{subnet["ip"]}/#{mask}",
+          source_host_ip: subnet["server_ip"],
+          is_failover: subnet["failover_ip"]
+        }
+      end
+    end
+
+    matching_ips
+  end
+end

--- a/migrate/014_add_ipv4_hetzner_api.rb
+++ b/migrate/014_add_ipv4_hetzner_api.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table :hetzner_host do
+      foreign_key :id, :vm_host, primary_key: true, type: :uuid
+      column :server_identifier, :text, null: false, unique: true
+    end
+  end
+end

--- a/model/hetzner_host.rb
+++ b/model/hetzner_host.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class HetznerHost < Sequel::Model
+  one_to_one :vm_host, key: :id
+
+  PROVIDER_NAME = "hetzner"
+
+  def api
+    @api ||= Hosting::HetznerApis.new(self)
+  end
+
+  def connection_string
+    Config.hetzner_connection_string
+  end
+
+  def user
+    Config.hetzner_user
+  end
+
+  def password
+    Config.hetzner_password
+  end
+end

--- a/spec/lib/hosting/apis_spec.rb
+++ b/spec/lib/hosting/apis_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Hosting::Apis do
+  let(:vm_host) {
+    instance_double(
+      VmHost,
+      provider: HetznerHost::PROVIDER_NAME,
+      hetzner_host: hetzner_host
+    )
+  }
+  let(:connection) { instance_double(Excon::Connection) }
+  let(:hetzner_apis) { instance_double(Hosting::HetznerApis, pull_ips: []) }
+  let(:hetzner_host) { instance_double(HetznerHost, connection_string: "str", user: "user1", password: "pass", api: hetzner_apis) }
+
+  describe "pull_ips" do
+    it "can pull data from the API" do
+      expect(hetzner_apis).to receive(:pull_ips).and_return([])
+      described_class.pull_ips(vm_host)
+    end
+
+    it "raises an error if the provider is unknown" do
+      expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
+      expect { described_class.pull_ips(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
+    end
+  end
+end

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Hosting::HetznerApis do
+  let(:vm_host) {
+    instance_double(
+      VmHost,
+      provider: HetznerHost::PROVIDER_NAME,
+      sshable: instance_double(Sshable, host: "1.1.1.1")
+    )
+  }
+  let(:hetzner_host) { instance_double(HetznerHost, connection_string: "https://robot-ws.your-server.de", user: "user1", password: "pass", vm_host: vm_host) }
+  let(:hetzner_apis) { described_class.new(hetzner_host) }
+
+  describe "hetzner_pull_ips" do
+    it "can pull empty data from the API" do
+      stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([]))
+      stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([]))
+      stub_request(:get, "https://robot-ws.your-server.de/failover").to_return(status: 200, body: JSON.dump([]))
+
+      expect { hetzner_apis.pull_ips }.not_to raise_error
+    end
+
+    it "raises an error if the ip API returns an unexpected status" do
+      stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 400, body: JSON.dump([]))
+      stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([]))
+
+      expect { hetzner_apis.pull_ips }.to raise_error RuntimeError, "unexpected status 400"
+    end
+
+    it "raises an error if the subnet API returns an unexpected status" do
+      stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 400, body: JSON.dump([]))
+
+      expect { hetzner_apis.pull_ips }.to raise_error RuntimeError, "unexpected status 400"
+    end
+
+    it "raises an error if the failover API returns an unexpected status" do
+      stub_request(:get, "https://robot-ws.your-server.de/failover").to_return(status: 400, body: JSON.dump([]))
+      stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([]))
+      stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([]))
+
+      expect { hetzner_apis.pull_ips }.to raise_error RuntimeError, "unexpected status 400"
+    end
+
+    it "can pull data from the API" do
+      stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([{
+        "ip" => {
+          "ip" => "1.1.1.1",
+          "server_ip" => "1.1.1.1"
+        }
+      },
+        "ip" => {
+          "ip" => "1.1.2.0",
+          "server_ip" => "1.1.1.1"
+        }]))
+      stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([{
+        "subnet" => {
+          "ip" => "2.2.2.0",
+          "mask" => 29,
+          "server_ip" => "1.1.1.1"
+        }
+      },
+        {
+          "subnet" => {
+            "ip" => "3.3.3.0",
+            "mask" => 20,
+            "server_ip" => "1.1.1.0" # assigned to a different server
+          }
+        },
+        {
+          "subnet" => {
+            "ip" => "15.15.15.15",
+            "mask" => 29,
+            "server_ip" => "1.1.1.1"
+          }
+        },
+        {
+          "subnet" => {
+            "ip" => "30.30.30.30",
+            "mask" => 29,
+            "server_ip" => "1.1.1.1"
+          }
+        }]))
+
+      stub_request(:get, "https://robot-ws.your-server.de/failover").to_return(status: 200, body: JSON.dump([{
+        "failover" => {
+          "ip" => "15.15.15.15",
+          "mask" => 29,
+          "server_ip" => "1.1.1.1",
+          "active_server_ip" => "0.0.0.0" # routed to a different server
+        }
+      },
+        "failover" => {
+          "ip" => "30.30.30.30",
+          "mask" => 29,
+          "server_ip" => "1.1.1.1",
+          "active_server_ip" => "1.1.1.1"
+        }]))
+
+      expect(hetzner_apis.pull_ips).to eq(
+        [{ip_address: "1.1.1.1/32", source_host_ip: "1.1.1.1", is_failover: false},
+          {ip_address: "1.1.2.0/32", source_host_ip: "1.1.1.1", is_failover: false},
+          {ip_address: "2.2.2.0/29", source_host_ip: "1.1.1.1", is_failover: false},
+          {ip_address: "30.30.30.30/29", source_host_ip: "1.1.1.1", is_failover: true}]
+      )
+    end
+  end
+end

--- a/spec/model/hetzner_host_spec.rb
+++ b/spec/model/hetzner_host_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe HetznerHost do
+  subject(:hetzner_host) { described_class.new }
+
+  let(:vm_host) {
+    instance_double(
+      VmHost,
+      provider: HetznerHost::PROVIDER_NAME,
+      hetzner_host: hetzner_host
+    )
+  }
+
+  describe "connection_string" do
+    it "returns the connection string" do
+      expect(hetzner_host.connection_string).to eq "https://robot-ws.your-server.de"
+    end
+  end
+
+  describe "user" do
+    it "returns the user" do
+      expect(hetzner_host.user).to eq "user1"
+    end
+  end
+
+  describe "password" do
+    it "returns the password" do
+      expect(hetzner_host.password).to eq "pass"
+    end
+  end
+
+  describe "api" do
+    it "returns the api" do
+      expect(hetzner_host.api).to be_a Hosting::HetznerApis
+    end
+  end
+end

--- a/spec/model/spec_helper.rb
+++ b/spec/model/spec_helper.rb
@@ -5,3 +5,7 @@ require_relative "../../model"
 raise "test database doesn't end with test" if DB.opts[:database] && !DB.opts[:database].end_with?("test")
 
 require_relative "../spec_helper"
+
+ENV["HETZNER_CONNECTION_STRING"] = "https://robot-ws.your-server.de"
+ENV["HETZNER_USER"] = "user1"
+ENV["HETZNER_PASSWORD"] = "pass"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,9 @@
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 ENV["RACK_ENV"] = "test"
 ENV["MAIL_DRIVER"] = "test"
-
+ENV["HETZNER_CONNECTION_STRING"] = "https://robot-ws.your-server.de"
+ENV["HETZNER_USER"] = "user1"
+ENV["HETZNER_PASSWORD"] = "pass"
 require_relative "../loader"
 require_relative "./coverage_helper"
 require "rspec"
@@ -25,6 +27,7 @@ require "database_cleaner/sequel"
 require "logger"
 require "sequel/core"
 require "warning"
+require "webmock/rspec"
 
 # DatabaseCleaner assumes the usual DATABASE_URL, but the
 # "roda-sequel-stack" way names each environment *and* application

--- a/spec/web/vm_host_spec.rb
+++ b/spec/web/vm_host_spec.rb
@@ -3,7 +3,7 @@
 require_relative "spec_helper"
 
 RSpec.describe Clover, "vm_host" do
-  let(:vm_host) { Prog::Vm::HostNexus.assemble("127.0.0.1").vm_host }
+  let(:vm_host) { Prog::Vm::HostNexus.assemble("127.0.0.1", provider: "test").vm_host }
 
   it "can not access without login" do
     visit "/vm-host"


### PR DESCRIPTION
This PR integrates the IPv4 address creation for Hetzner with their provided
APIs. This way, we don't need to manually add the ip ranges, controlplane
figures out itself at the host creation time.

The API for ip addresses on Hetzner has a some bits need more explanation.
First of all bought IP addresses are billed/assigned to the servers. Doesn't
matter if it's a failover IP address or not, they are connected even if you
perform a reassignment. If we need to perform a proper failover and disconnect
all the relationship of the ip from the originating server, we have to open a
support ticket. So, we need to treat carefully and use the failover ip ranges
properly.

Failure scenarios;
1. In this PR, when we are looking for failover ip ranges for the vm_host, we pull
all the ips and look for the ones assigned to the created vm_host from the field
active_server_ip. There is also server_ip which means the ip address of the
server that the ip range is first bought for. We fail if that server is not in
our control with an error message.

2. In relation to above scenario, in case we discover an ip range that is created
before for another vm_host and we now discover that it's actually routed to the
new vm_host, we update the routed_to_host_id property of the address object. If
there is already a VM that's using an ip address from that range, that means
there is a bug because the range is now routed to a new vm_host and the vm ip4
setup is broken. In that case, we fail with an error message.