### PR TITLE
Use SPDK to provide storage to VMs

### DIFF
--- a/prog/setup_spdk.rb
+++ b/prog/setup_spdk.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Prog::SetupSpdk < Prog::Base
+  subject_is :sshable, :vm_host
+
+  def start
+    fail "Not enough hugepages" unless vm_host.total_hugepages_1g > vm_host.used_hugepages_1g
+    sshable.cmd("sudo bin/setup-spdk")
+    sshable.cmd("sudo systemctl start spdk")
+    vm_host.update(used_hugepages_1g: vm_host.used_hugepages_1g + 1)
+    pop "SPDK was setup"
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -65,7 +65,17 @@ class Prog::Vm::HostNexus < Prog::Base
 
   def wait_setup_hugepages
     reap
+    hop :setup_spdk if leaf?
+    donate
+  end
 
+  def setup_spdk
+    bud Prog::SetupSpdk
+    hop :wait_setup_spdk
+  end
+
+  def wait_setup_spdk
+    reap
     if leaf?
       vm_host.update(allocation_state: "accepting")
       hop :wait

--- a/rhizome/bin/setup-spdk
+++ b/rhizome/bin/setup-spdk
@@ -1,0 +1,57 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/common"
+require_relative "../lib/spdk"
+require "fileutils"
+
+# spdk dependencies
+r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev"
+
+# spdk binaries
+FileUtils.cd Spdk.install_prefix do
+  r "curl -L3 -o /tmp/spdk.tar.gz https://ubicloud-spdk2.s3.us-east-2.amazonaws.com/spdk.tar.gz"
+  r "tar -xzf /tmp/spdk.tar.gz"
+end
+
+q_user = Spdk.user.shellescape
+q_hugepages_dir = Spdk.hugepages_dir.shellescape
+
+begin
+  r "adduser #{q_user} --disabled-password --gecos '' --home #{Spdk.home.shellescape}"
+rescue CommandFail => ex
+  raise unless /adduser: The user `.*' already exists\./.match?(ex.message)
+end
+
+r "sudo --user=#{q_user} mkdir -p #{q_hugepages_dir}"
+r "mount -t hugetlbfs -o uid=#{q_user},size=1G nodev #{q_hugepages_dir}"
+
+# Directory to put vhost sockets.
+FileUtils.mkdir_p(Spdk.vhost_dir)
+FileUtils.chown Spdk.user, Spdk.user, Spdk.vhost_dir
+
+spdk_service = <<SPDK_SERVICE
+[Unit]
+Description=Block Storage Service
+[Service]
+Type=simple
+Environment="XDG_RUNTIME_DIR=#{Spdk.home.shellescape}"
+ExecStart=/opt/spdk/bin/vhost -S #{Spdk.vhost_dir.shellescape} \
+--huge-dir #{q_hugepages_dir} \
+--iova-mode va \
+--rpc-socket #{Spdk.rpc_sock.shellescape} \
+--cpumask [0] \
+--disable-cpumask-locks
+ExecReload=/bin/kill -HUP $MAINPID
+LimitMEMLOCK=8400113664
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectHome=no
+NoNewPrivileges=yes
+User=spdk
+Group=spdk
+SPDK_SERVICE
+
+File.write("/etc/systemd/system/spdk.service", spdk_service)

--- a/rhizome/lib/spdk.rb
+++ b/rhizome/lib/spdk.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Spdk
+  def self.user
+    "spdk"
+  end
+
+  def self.home
+    File.join("", "home", user)
+  end
+
+  def self.vhost_dir
+    File.join("", "var", "storage", "vhost")
+  end
+
+  def self.vhost_sock(vm_name)
+    File.join(vhost_dir, vm_name)
+  end
+
+  def self.hugepages_dir
+    File.join(home, "hugepages")
+  end
+
+  def self.rpc_sock
+    File.join(home, "spdk.sock")
+  end
+
+  def self.install_prefix
+    File.join("", "opt")
+  end
+
+  def self.rpc_py
+    bin = File.join(install_prefix, "spdk", "scripts", "rpc.py")
+    "#{bin} -s #{rpc_sock}"
+  end
+end

--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -39,6 +39,10 @@ class VmPath
     File.join("", "vm", @vm_name, n)
   end
 
+  def storage(n)
+    File.join("", "var", "storage", @vm_name, n)
+  end
+
   # Define path, q_path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
@@ -46,7 +50,6 @@ class VmPath
     guest_ephemeral
     clover_ephemeral
     dnsmasq.conf
-    boot.raw
     meta-data
     network-config
     user-data
@@ -84,6 +87,27 @@ class VmPath
     fail "BUG" if method_defined?(write_method_name)
     define_method write_method_name do |s|
       write(home(file_name), s)
+    end
+  end
+
+  # Define path, q_path methods for files in `/var/storage/#{vm_name}`
+  %w[
+    vhost.sock
+    boot.raw
+  ].each do |file_name|
+    method_name = file_name.tr(".-", "_")
+    fail "BUG" if method_defined?(method_name)
+
+    # Method producing a path, e.g. #user_data
+    define_method method_name do
+      storage(file_name)
+    end
+
+    # Method producing a shell-quoted path, e.g. #q_user_data.
+    quoted_method_name = "q_" + method_name
+    fail "BUG" if method_defined?(quoted_method_name)
+    define_method quoted_method_name do
+      storage(file_name).shellescape
     end
   end
 end

--- a/rhizome/spec/vm_path_spec.rb
+++ b/rhizome/spec/vm_path_spec.rb
@@ -14,23 +14,23 @@ RSpec.describe VmPath do
   end
 
   it "will snakeify difficult characters" do
-    expect(vp.boot_raw).to eq("/vm/test'vm/boot.raw")
+    expect(vp.serial_log).to eq("/vm/test'vm/serial.log")
   end
 
   it "can read file contents" do
-    expect(File).to receive(:read).with(vp.boot_raw).and_return("\n")
-    expect(vp.read_boot_raw).to eq("")
+    expect(File).to receive(:read).with(vp.serial_log).and_return("\n")
+    expect(vp.read_serial_log).to eq("")
   end
 
   context "when writing" do
     it "affixes a newline if it is missing" do
-      expect(File).to receive(:write).with(vp.boot_raw, "test content\n")
-      vp.write_boot_raw("test content")
+      expect(File).to receive(:write).with(vp.serial_log, "test content\n")
+      vp.write_serial_log("test content")
     end
 
     it "doesn't add more newlines than necessary" do
-      expect(File).to receive(:write).with(vp.boot_raw, "test content\n")
-      vp.write_boot_raw("test content\n")
+      expect(File).to receive(:write).with(vp.serial_log, "test content\n")
+      vp.write_serial_log("test content\n")
     end
   end
 end

--- a/spec/prog/setup_spdk_spec.rb
+++ b/spec/prog/setup_spdk_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::SetupSpdk do
+  subject(:ss) {
+    described_class.new(Strand.new(prog: "SetupSpdk",
+      stack: [{sshable_id: "bogus"}]))
+  }
+
+  describe "#start" do
+    it "exits, reducing number of hugepages" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("sudo bin/setup-spdk")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start spdk")
+      vm_host = instance_double(VmHost)
+      expect(vm_host).to receive(:total_hugepages_1g).and_return(10)
+      expect(vm_host).to receive(:used_hugepages_1g).and_return(0).at_least(:once)
+      expect(vm_host).to receive(:update).with(used_hugepages_1g: 1)
+      expect(ss).to receive(:sshable).and_return(sshable).at_least(:once)
+      expect(ss).to receive(:vm_host).and_return(vm_host).at_least(:once)
+      expect(ss).to receive(:pop).with("SPDK was setup")
+      ss.start
+    end
+
+    it "fails if not enough hugepages" do
+      vm_host = instance_double(VmHost)
+      expect(vm_host).to receive(:total_hugepages_1g).and_return(10)
+      expect(vm_host).to receive(:used_hugepages_1g).and_return(10)
+      expect(ss).to receive(:vm_host).and_return(vm_host).at_least(:once)
+      expect { ss.start }.to raise_error RuntimeError, "Not enough hugepages"
+    end
+  end
+end


### PR DESCRIPTION
We want to use SPDK for storage in the longer run. This allows to have more control over storage, and provide features like snapshots, encryption, and replication.

Replaces https://github.com/ubicloud/ubicloud/pull/170.

Before this PR, we just passed the $VmHome/boot.raw file as the VM disk:

boot.raw <-> VMM

This PR changes that and adds SPDK as an intermediate:

boot.raw <-> SPDK <-(vhost protocol)-> VMM

Although this doesn't add a new functionality, but it paves the way to modify the SPDK layer above to add other features in future.

Follow up items in next PRs:

* Record information about VMs storage topology in database
* Add encryption layer
* Add the possibility to provide raw NVMe disks directly to VMs
