### PR TITLE
Seperate Prog::SetupSpdk into 2 steps.

### DIFF
--- a/prog/setup_spdk.rb
+++ b/prog/setup_spdk.rb
@@ -6,6 +6,10 @@ class Prog::SetupSpdk < Prog::Base
   def start
     fail "Not enough hugepages" unless vm_host.total_hugepages_1g > vm_host.used_hugepages_1g
     sshable.cmd("sudo bin/setup-spdk")
+    hop :start_service
+  end
+
+  def start_service
     sshable.cmd("sudo systemctl start spdk")
     vm_host.update(used_hugepages_1g: vm_host.used_hugepages_1g + 1)
     pop "SPDK was setup"


### PR DESCRIPTION
As @enescakir pointed in #209, previously if setup-sdk succeeded but "systemctl start" failed, running the strand again would cause setup-sdk to run again. This PR seperates 2 steps, so a repeated run just tries to start the service.