### PR TITLE
Make storage size & id customizeable

### DIFF
--- a/migrate/015_storage.rb
+++ b/migrate/015_storage.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:vm_storage_volume) do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      foreign_key :vm_id, :vm, type: :uuid, null: false
+      column :boot, :bool, null: false
+      column :size_gib, :bigint, null: false
+      column :disk_index, :int, null: false
+
+      unique [:vm_id, :disk_index]
+    end
+
+    alter_table(:vm_host) do
+      add_constraint(:hugepages_allocation_limit) { used_hugepages_1g <= total_hugepages_1g }
+    end
+  end
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -9,6 +9,7 @@ class Vm < Sequel::Model
   one_to_many :ipsec_tunnels, key: :src_vm_id
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
+  one_to_many :vm_storage_volumes, key: :vm_id
 
   dataset_module Authorization::Dataset
 
@@ -131,5 +132,18 @@ class Vm < Sequel::Model
 
   def cores
     product.cores
+  end
+
+  def self.uuid_to_name(id)
+    "vm" + ULID.from_uuidish(id).to_s[0..5].downcase
+  end
+
+  def inhost_name
+    # YYY: various names in linux, like interface names, are obliged
+    # to be short, so alas, probably can't reproduce entropy from
+    # vm.id to be collision free and there will need to be a second
+    # addressing scheme scoped to each VmHost.  But for now, assume
+    # entropy.
+    self.class.uuid_to_name(id)
   end
 end

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class VmStorageVolume < Sequel::Model
+  many_to_one :vm
+
+  def device_id
+    "#{vm.inhost_name}_#{disk_index}"
+  end
+
+  def device_path
+    "/dev/disk/by-id/virtio-#{device_id}"
+  end
+end

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -70,9 +70,14 @@ end
 
 ndp_needed = params.fetch("ndp_needed", false)
 
+unless (storage_volumes = params["storage_volumes"])
+  puts "need storage_volumes in parameters json"
+  exit 1
+end
+
 require "fileutils"
 require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
 VmSetup.new(vm_name).prep(unix_user, ssh_public_key, private_subnets, gua, ip4,
-  local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed)
+  local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_volumes)

--- a/rhizome/bin/setup-spdk
+++ b/rhizome/bin/setup-spdk
@@ -36,7 +36,7 @@ Description=Block Storage Service
 [Service]
 Type=simple
 Environment="XDG_RUNTIME_DIR=#{Spdk.home.shellescape}"
-ExecStart=/opt/spdk/bin/vhost -S #{Spdk.vhost_dir.shellescape} \
+ExecStart=#{Spdk.bin("vhost")} -S #{Spdk.vhost_dir.shellescape} \
 --huge-dir #{q_hugepages_dir} \
 --iova-mode va \
 --rpc-socket #{Spdk.rpc_sock.shellescape} \

--- a/rhizome/lib/spdk.rb
+++ b/rhizome/lib/spdk.rb
@@ -29,6 +29,10 @@ module Spdk
     File.join("", "opt")
   end
 
+  def self.bin(n)
+    File.join(install_prefix, "spdk", "bin", n)
+  end
+
   def self.rpc_py
     bin = File.join(install_prefix, "spdk", "scripts", "rpc.py")
     "#{bin} -s #{rpc_sock}"

--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -90,24 +90,11 @@ class VmPath
     end
   end
 
-  # Define path, q_path methods for files in `/var/storage/#{vm_name}`
-  %w[
-    vhost.sock
-    boot.raw
-  ].each do |file_name|
-    method_name = file_name.tr(".-", "_")
-    fail "BUG" if method_defined?(method_name)
+  def vhost_sock(index)
+    storage("vhost_#{index}.sock")
+  end
 
-    # Method producing a path, e.g. #user_data
-    define_method method_name do
-      storage(file_name)
-    end
-
-    # Method producing a shell-quoted path, e.g. #q_user_data.
-    quoted_method_name = "q_" + method_name
-    fail "BUG" if method_defined?(quoted_method_name)
-    define_method quoted_method_name do
-      storage(file_name).shellescape
-    end
+  def disk(index)
+    storage("disk_#{index}.raw")
   end
 end

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -21,29 +21,72 @@ RSpec.describe VmSetup do
     }
   end
 
-  describe "#boot_disk" do
-    it "can download an image before converting it" do
-      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/")
+  describe "#setup_volume" do
+    it "can setup a storage volume" do
+      disk_file = "/var/storage/test/disk_0.raw"
+      device_id = "some_device_id"
 
+      expect(vs).to receive(:setup_disk_file).and_return(disk_file)
+      expect(vs).to receive(:r).with(/setfacl.*#{disk_file}/)
+      expect(vs).to receive(:r).with(/.*rpc.py.*bdev_aio_create/)
+      expect(vs).to receive(:r).with(/.*rpc.py.*vhost_create_blk_controller test_0 #{device_id}/)
+      expect(FileUtils).to receive(:chown).with("test", "test", disk_file)
+      expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", disk_file)
+      expect(FileUtils).to receive(:ln_s).with("/var/storage/vhost/test_0", "/var/storage/test/vhost_0.sock")
+      expect(vs).to receive(:r).with(/setfacl.*vhost_0.sock/)
+
+      expect(
+        vs.setup_volume({"boot" => true, "size_gib" => 5, "device_id" => device_id}, 0, "ubuntu-jammy")
+      ).to eq("/var/storage/test/vhost_0.sock")
+    end
+  end
+
+  describe "#setup_disk_file" do
+    it "can setup a boot disk" do
+      boot_image = "ubuntu-jammy"
+      image_path = "/opt/#{boot_image}.qcow2"
+      disk_file = "/var/storage/test/disk_0.raw"
+      expect(vs).to receive(:download_boot_image).and_return image_path
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw #{image_path} #{disk_file}")
+      expect(File).to receive(:size).with(disk_file).and_return(2 * 2**30)
+      expect(vs).to receive(:r).with("truncate -s 5G #{disk_file}")
+      expect(
+        vs.setup_disk_file({"boot" => true, "size_gib" => 5, "device_id" => "disk0"}, 0, boot_image)
+      ).to eq(disk_file)
+    end
+
+    it "fails if requested size is too small" do
+      boot_image = "ubuntu-jammy"
+      image_path = "/opt/#{boot_image}.qcow2"
+      disk_file = "/var/storage/test/disk_0.raw"
+      expect(vs).to receive(:download_boot_image).and_return image_path
+      expect(vs).to receive(:r)
+      expect(File).to receive(:size).with(disk_file).and_return(5 * 2**30)
+      expect {
+        vs.setup_disk_file({"boot" => true, "size_gib" => 4, "device_id" => "disk0"}, 0, boot_image)
+      }.to raise_error RuntimeError, "Image size greater than requested disk size"
+    end
+
+    it "can setup a non-boot disk" do
+      disk_file = "/var/storage/test/disk_0.raw"
+      expect(FileUtils).to receive(:touch).with(disk_file)
+      expect(vs).to receive(:r).with("truncate -s 5G #{disk_file}")
+      expect(
+        vs.setup_disk_file({"boot" => false, "size_gib" => 5, "device_id" => "disk0"}, 0, "boot_image")
+      ).to eq(disk_file)
+    end
+  end
+
+  describe "#download_boot_image" do
+    it "can download an image" do
+      expect(File).to receive(:exist?).with("/opt/ubuntu-jammy.qcow2").and_return(false)
       expect(File).to receive(:open) do |path, *_args|
         expect(path).to eq("/opt/ubuntu-jammy.qcow2.tmp")
       end.and_yield
-
-      boot_raw = "/var/storage/test/boot.raw"
-
-      expect(vs).to receive(:r).with("curl -L10 -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
-      expect(vs).to receive(:r).with("truncate -s +10G #{boot_raw}")
-      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/ubuntu-jammy.qcow2 #{boot_raw}")
-      expect(vs).to receive(:r).with(/setfacl.*boot.raw/)
-      expect(vs).to receive(:r).with(/.*rpc.py.*bdev_aio_create/)
-      expect(vs).to receive(:r).with(/.*rpc.py.*vhost_create_blk_controller/)
-
       expect(FileUtils).to receive(:mv).with("/opt/ubuntu-jammy.qcow2.tmp", "/opt/ubuntu-jammy.qcow2")
-      expect(FileUtils).to receive(:chown).with("test", "test", boot_raw)
-      expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", boot_raw)
-      expect(FileUtils).to receive(:ln_s).with("/var/storage/vhost/test", "/var/storage/test/vhost.sock")
-      expect(vs).to receive(:r).with(/setfacl.*vhost.sock/)
-      vs.storage("ubuntu-jammy")
+      expect(vs).to receive(:r).with("curl -L10 -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
+
+      vs.download_boot_image("ubuntu-jammy")
     end
 
     it "can use an image that's already downloaded" do


### PR DESCRIPTION
Previously disk size was fixed at image_size+10G. This PR makes users able to choose the disk size. Users can do this by providing a `storage_size_gib` parameter to `Vm.assemble`:

```
> st = Prog::Vm::Nexus.assemble(mykey, nil, storage_size_gib: 30)
```

Also, we explicitly set disk id when creating the VM, so users can access disks using `/dev/disk/by-id/virtio-#{vm_name}_#{disk_index}`. For example, if a vm has a single disk, we will see the following from inside the vm. One id for the main disk, and 3 ids for each of its partitions.

```
$ ls /dev/disk/by-id/virtio-vm* -1
/dev/disk/by-id/virtio-vm3z0fs9_0
/dev/disk/by-id/virtio-vm3z0fs9_0-part1
/dev/disk/by-id/virtio-vm3z0fs9_0-part14
/dev/disk/by-id/virtio-vm3z0fs9_0-part15
```

Some notes on how the device_id is communicated between different components are as follows.

The device id in above is provided by the virtio device. Linux kernel extracts & uses it in virtblk_get_id function in virtio_blk driver [1].

For file backed disks which we used to use (not anymore), cloud-hypervisor sets this id as "$dev$rdev$inode" in [2].

For SPDK backed disks, SPDK sets device id to the actual bdev name in SPDK [3].

So in this patch we pass the device_id directly as SPDK device name. Because we use the same SPDK instance for all VMs on the same host, we require the device_id to be unique across all VMs in a host.

[1] https://github.com/torvalds/linux/blob/5f63595ebd82f56a2dd36ca013dd7f5ff2e2416a/drivers/block/virtio_blk.c#LL900C55-L900C61
[2] https://github.com/cloud-hypervisor/cloud-hypervisor/blob/95626ae56459f65aebd0029bb8e99dfd285575e5/block_util/src/lib.rs#L77
[3] https://github.com/spdk/spdk/blob/1334e3e40700b9f9f9c9d357bc748a33fb08797a/lib/vhost/vhost_blk.c#L625