### PR TITLE
Add rake tasks for linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,14 @@ jobs:
 
     - name: Run erb-formatter
       run: |
-        bundle exec erb-format views/**/*.erb --write --print-width 120
+        rake linter:erb_formatter
         git diff --exit-code
 
     - name: Run rubocop
-      run: bundle exec rubocop
+      run: rake linter:rubocop
 
     - name: Run brakeman
-      run: bundle exec brakeman --force -Aq
+      run: rake linter:brakeman
 
     - name: Apply migrations
       env:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -417,7 +417,7 @@ in. You'll see the "Getting Started" page.
 
 When you change any template file, format them with `erb-formatter`:
 
-    bundle exec erb-format views/**/*.erb --write --print-width 120
+    rake linter:erb_formatter
 
 ### Conclusion
 


### PR DESCRIPTION
Running linters via rake tasks helps to run same command everywhere. Devs don't have to remember all the arguments used in CI.

    rake linter                     # Run all linters
    rake linter:brakeman            # Run Brakeman
    rake linter:erb_formatter       # Run ERB::Formatter
    rake linter:rubocop             # Run Rubocop