### PR TITLE
Tweak web-related autoloads

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -71,7 +71,7 @@ def autoload_normal(subdirectory, include_first: false)
 end
 
 %w[model lib].each { autoload_normal(_1) }
-%w[scheduling prog].each { autoload_normal(_1, include_first: true) }
+%w[scheduling prog serializers/web].each { autoload_normal(_1, include_first: true) }
 
 AUTOLOAD_CONSTANTS.freeze
 


### PR DESCRIPTION
This has to do with some remaining differences between Zeitwerk's general way of doing things and Unreloader, which only recently gained the autoload feature.

One set of autoloads, the Serializers, have to be promoted to be handled in `loader.rb` so their symbols can be eager-loaded in production, as that code in loader.rb executes exactly once. Probably, loader.rb should not bind the `autoload_normal` symbol globally to avoid these mistakes.

Unreloader, which evolved with Roda and `hash_branch`, is adapted to situations where some files do not create any new constants (becaus they reopen a Roda app).  As there are no new bound constants, no other file can depend on a route file, so a simpler approach can work well.

But, we use a global Unreloader object that also addresses code written in the Zeitwerk way.  Because of that, we can't do the customary thing and disable autoloading in production, converting it to require, because then we'll have to track a minimal set of dependencies between files, and I don't want to do that.  See 998ef052242cee9f9cef6fec25ef61023ba43801.