### PR TITLE
Upgrade dnsmasq to version v2.89

### DIFF
--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -31,7 +31,7 @@ class Prog::InstallDnsmasq < Prog::Base
 
   def git_clone_dnsmasq
     sshable.cmd("git clone https://github.com/fdr/dnsmasq.git --depth=1 && " \
-                "(cd dnsmasq && git checkout aaba66efbd3b4e7283993ca3718df47706a8549b && git fsck --full)")
+                "(cd dnsmasq && git checkout 5dc14b6e05f39a5ab0dc02e376b1d7da2fda5bc1 && git fsck --full)")
     pop "downloaded and verified dnsmasq successfully"
   end
 end


### PR DESCRIPTION
Per usual, I prefer to use a commit SHA1 with a fsck to establish something of a "trust on first use" relationship with the artifact.

I figured it'd be better to use a release rather than a commit I selected in a mostly, but not entirely, arbitrary manner: I thought there would be value for having new versions of dnsmasq for such an important dependency, and a chance we'd want to make alterations or pick up specific new changes.