### PR TITLE
dnsmasq commit is updated

### DIFF
--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -31,7 +31,7 @@ class Prog::InstallDnsmasq < Prog::Base
 
   def git_clone_dnsmasq
     sshable.cmd("git clone https://github.com/fdr/dnsmasq.git --depth=1 && " \
-                "(cd dnsmasq && git checkout aaba66efbd3b4e7283993ca3718df47706a8549b && git fsck --full)")
+                "(cd dnsmasq && git checkout 9bbf098a970c9e5fa251939208e25fb21064d1be && git fsck --full)")
     pop "downloaded and verified dnsmasq successfully"
   end
 end


### PR DESCRIPTION
Looks like there are new commits and we make a shallow clone of the repo history with `--depth 1`. Ideally, we can just not checkout since this is a mirror repo and @fdr controls which commits are used. Another way to do it is to specifically fetch the `aaba66efbd3b4e7283993ca3718df47706a8549b`. For now, I have simply updated the commit. If you have a preference, please tell me. My preference would be to simply not checkout and continue from the tip.