### PR TITLE
Omit eager loading when running migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,12 @@
 
 migrate = lambda do |env, version|
   ENV["RACK_ENV"] = env
+
+  # Eager loading normally will force the loading of models, but this
+  # is liable to break when model files and accompanying migrations
+  # have both been added.  A solution is to not eagerly load, even in
+  # production, when running migrations.
+  ENV["NO_EAGER_LOAD"] = "true"
   require_relative "loader"
   require "logger"
   require "sequel"

--- a/config.rb
+++ b/config.rb
@@ -50,6 +50,7 @@ module Config
 
   # Override -- value is returned or the set default.
   override :database_timeout, 10, int
+  override :no_eager_load, false, bool
   override :db_pool, 5, int
   override :deployment, "production", string
   override :force_ssl, true, bool

--- a/loader.rb
+++ b/loader.rb
@@ -77,6 +77,6 @@ end
 
 AUTOLOAD_CONSTANTS.freeze
 
-if Config.production?
+if Config.production? && !Config.no_eager_load
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
 end


### PR DESCRIPTION
Eager loading will try to load models before running migrations, and the loading is liable to crash because the migration that creates a related table hasn't been run yet, creating a catch-22.

Resolve the catch-22 by not eager loading when running migration, even in production mode.