### PR TITLE
Improve dnsmasq cloning for commits not at the tip

### DIFF
--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -30,8 +30,12 @@ class Prog::InstallDnsmasq < Prog::Base
   end
 
   def git_clone_dnsmasq
-    sshable.cmd("git clone https://github.com/fdr/dnsmasq.git --depth=1 && " \
-                "(cd dnsmasq && git checkout aaba66efbd3b4e7283993ca3718df47706a8549b && git fsck --full)")
+    q_commit = "aaba66efbd3b4e7283993ca3718df47706a8549b".shellescape
+    sshable.cmd("git init dnsmasq && " \
+                "(cd dnsmasq && " \
+                "  git fetch https://github.com/fdr/dnsmasq.git #{q_commit} --depth=1 &&" \
+                "  git checkout #{q_commit} &&" \
+                "  git fsck --full)")
     pop "downloaded and verified dnsmasq successfully"
   end
 end


### PR DESCRIPTION
`git clone` with `depth 1` will only be able to handle commits that co-incide with the default branch of the repository, which breaks the moment the mirror is updated.

And unfortunately it doesn't look like `git clone` can accept a ref directly for `--depth 1`, so instead use `git fetch` on a blank repository, which can accept a ref and ask the remote computer for only that reference and the objects it needs to check it out.