### PR TITLE
Use a more minimal loading environment for migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,15 +4,11 @@
 
 migrate = lambda do |env, version|
   ENV["RACK_ENV"] = env
-
-  # Eager loading normally will force the loading of models, but this
-  # is liable to break when model files and accompanying migrations
-  # have both been added.  A solution is to not eagerly load, even in
-  # production, when running migrations.
-  ENV["NO_EAGER_LOAD"] = "true"
-  require_relative "loader"
+  require "bundler/setup"
+  Bundler.setup
   require "logger"
   require "sequel"
+  require_relative "db"
   Sequel.extension :migration
   DB.extension :pg_enum
 

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
-require_relative "loader"
+require_relative "lib/casting_config_helpers"
+
+begin
+  require_relative ".env"
+rescue LoadError
+  # .env.rb is optional
+end
+
 # Adapted from
 # https://github.com/interagent/pliny/blob/fcc8f3b103ec5296bd754898fdefeb2fda2ab292/lib/template/config/config.rb.
 #
@@ -50,7 +57,6 @@ module Config
 
   # Override -- value is returned or the set default.
   override :database_timeout, 10, int
-  override :no_eager_load, false, bool
   override :db_pool, 5, int
   override :deployment, "production", string
   override :force_ssl, true, bool

--- a/db.rb
+++ b/db.rb
@@ -1,13 +1,8 @@
 # frozen_string_literal: true
 
 require "netaddr"
-
-begin
-  require_relative ".env"
-rescue LoadError
-end
-
 require "sequel/core"
+require_relative "config"
 
 DB = Sequel.connect(Config.clover_database_url).tap do |db|
   # Replace dangerous (for cidrs) Ruby IPAddr type that is otherwise

--- a/loader.rb
+++ b/loader.rb
@@ -1,18 +1,9 @@
 # frozen_string_literal: true
 
-begin
-  require_relative ".env"
-rescue LoadError
-  # .env.rb is optional, if the environment variables have been set
-  # some other way.
-end
-
 require "bundler/setup"
 Bundler.setup
 
-require_relative "./lib/casting_config_helpers"
-require_relative "./config"
-
+require_relative "config"
 require "rack/unreloader"
 
 Unreloader = Rack::Unreloader.new(
@@ -77,6 +68,6 @@ end
 
 AUTOLOAD_CONSTANTS.freeze
 
-if Config.production? && !Config.no_eager_load
+if Config.production?
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
 end


### PR DESCRIPTION
In practice, migrations don't, and shouldn't, use too many advanced program symbols, because those are liable to change in functionality even if the migration is applied far after the date of it being authored.

In this light, using `loader.rb` is overkill, only to have the production eager-load behavior necessarily suppressed with yet another flag, giving it an unsatisfying wheels-within-wheels type of logic. So, replicate the necessary start-up activities to achieve Sequel migrator database access only: environment variables, Config, and database connection.

To shorten the implementation, `config.rb` has been made responsible for loading `.env` overrides and this responsibility has been centralized.