### PR TITLE
Don't allow other users to access vhost socket of a VM

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -253,11 +253,14 @@ EOS
     r "#{Spdk.rpc_py} bdev_aio_create #{q_disk_file} #{q_bdev} 512"
     r "#{Spdk.rpc_py} vhost_create_blk_controller #{vhost.shellescape} #{q_bdev}"
 
-    # create a symlink to the socket in the per vm storage dir
-    FileUtils.ln_s Spdk.vhost_sock(vhost), vp.vhost_sock(index)
+    # don't allow others to access the vhost socket
+    FileUtils.chmod "u=rw,g=r,o=", Spdk.vhost_sock(vhost)
 
     # allow vm user to access the vhost socket
-    r "setfacl -m u:#{@vm_name}:rw #{vp.vhost_sock(index).shellescape}"
+    r "setfacl -m u:#{@vm_name}:rw #{Spdk.vhost_sock(vhost).shellescape}"
+
+    # create a symlink to the socket in the per vm storage dir
+    FileUtils.ln_s Spdk.vhost_sock(vhost), vp.vhost_sock(index)
 
     vp.vhost_sock(index)
   end

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe VmSetup do
     it "can setup a storage volume" do
       disk_file = "/var/storage/test/disk_0.raw"
       device_id = "some_device_id"
+      spdk_vhost_sock = "/var/storage/vhost/test_0"
 
       expect(vs).to receive(:setup_disk_file).and_return(disk_file)
       expect(vs).to receive(:r).with(/setfacl.*#{disk_file}/)
@@ -32,8 +33,9 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:r).with(/.*rpc.py.*vhost_create_blk_controller test_0 #{device_id}/)
       expect(FileUtils).to receive(:chown).with("test", "test", disk_file)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", disk_file)
-      expect(FileUtils).to receive(:ln_s).with("/var/storage/vhost/test_0", "/var/storage/test/vhost_0.sock")
-      expect(vs).to receive(:r).with(/setfacl.*vhost_0.sock/)
+      expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", spdk_vhost_sock)
+      expect(FileUtils).to receive(:ln_s).with(spdk_vhost_sock, "/var/storage/test/vhost_0.sock")
+      expect(vs).to receive(:r).with(/setfacl.*#{spdk_vhost_sock}/)
 
       expect(
         vs.setup_volume({"boot" => true, "size_gib" => 5, "device_id" => device_id}, 0, "ubuntu-jammy")


### PR DESCRIPTION
Previously other users had read & execute permission to a vhost socket created for a VM, which could have security risks:

```
/var/storage/vhost # ls -l vm3z0fs9_0
srwxrwxr-x+ 1 spdk spdk 0 Jun 20 00:24 vm3z0fs9_0
```

This PR revokes those permissions by calling a proper chmod:

```
/var/storage/vhost # ls -l vm6w7ee6_0
srw-rw----+ 1 spdk spdk 0 Jun 21 19:50 vm6w7ee6_0
```