### PR TITLE
Enable encrypted-at-rest storage

### DIFF
--- a/migrate/20230705_storage_encryption.rb
+++ b/migrate/20230705_storage_encryption.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:storage_key_encryption_key) do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :algorithm, :text, null: false, collate: '"C"'
+      column :key, :text, null: false
+      column :init_vector, :text, null: false
+      column :auth_data, :text, null: false
+      column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+
+    alter_table(:vm_storage_volume) do
+      add_foreign_key :key_encryption_key_1_id, :storage_key_encryption_key, type: :uuid, null: true
+      add_foreign_key :key_encryption_key_2_id, :storage_key_encryption_key, type: :uuid, null: true
+    end
+  end
+end

--- a/model/storage_key_encryption_key.rb
+++ b/model/storage_key_encryption_key.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class StorageKeyEncryptionKey < Sequel::Model
+  plugin :column_encryption do |enc|
+    enc.column :key
+    enc.column :init_vector
+  end
+
+  def secret_key_material_hash
+    # default to_hash doesn't decrypt encrypted columns, so implement
+    # this to decrypt keys when they need to be sent to a running copy
+    # of spdk.
+    {
+      "key" => key,
+      "init_vector" => init_vector,
+      "algorithm" => algorithm,
+      "auth_data" => auth_data
+    }
+  end
+end

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -4,6 +4,8 @@ require_relative "../model"
 
 class VmStorageVolume < Sequel::Model
   many_to_one :vm
+  many_to_one :key_encryption_key_1, class: :StorageKeyEncryptionKey
+  many_to_one :key_encryption_key_2, class: :StorageKeyEncryptionKey
 
   def device_id
     "#{vm.inhost_name}_#{disk_index}"

--- a/prog/rotate_storage_kek.rb
+++ b/prog/rotate_storage_kek.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "json"
+
+class Prog::RotateStorageKek < Prog::Base
+  subject_is :vm_storage_volume
+
+  def start
+    if vm_storage_volume.key_encryption_key_1_id.nil?
+      pop "storage volume is not encrypted"
+    end
+
+    key_wrapping_algorithm = "aes-256-gcm"
+    cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
+    key_wrapping_key = cipher.random_key
+    key_wrapping_iv = cipher.random_iv
+    auth_data = vm_storage_volume.device_id
+
+    DB.transaction do
+      key_encryption_key = StorageKeyEncryptionKey.create(
+        algorithm: key_wrapping_algorithm,
+        key: Base64.encode64(key_wrapping_key),
+        init_vector: Base64.encode64(key_wrapping_iv),
+        auth_data: auth_data
+      )
+
+      vm_storage_volume.update({key_encryption_key_2_id: key_encryption_key.id})
+    end
+
+    hop :install
+  end
+
+  def install
+    data_json = JSON.generate({
+      old_key: vm_storage_volume.key_encryption_key_1.secret_key_material_hash,
+      new_key: vm_storage_volume.key_encryption_key_2.secret_key_material_hash
+    })
+
+    q_vm = vm.inhost_name.shellescape
+    disk_index = vm_storage_volume.disk_index
+    sshable.cmd("sudo bin/storage-key-tool #{q_vm} #{disk_index} reencrypt", stdin: data_json)
+
+    hop :test_keys_on_server
+  end
+
+  def test_keys_on_server
+    data_json = JSON.generate({
+      old_key: vm_storage_volume.key_encryption_key_1.secret_key_material_hash,
+      new_key: vm_storage_volume.key_encryption_key_2.secret_key_material_hash
+    })
+
+    q_vm = vm.inhost_name.shellescape
+    disk_index = vm_storage_volume.disk_index
+    sshable.cmd("sudo bin/storage-key-tool #{q_vm} #{disk_index} test-keys", stdin: data_json)
+
+    hop :retire_old_key_on_server
+  end
+
+  def retire_old_key_on_server
+    q_vm = vm.inhost_name.shellescape
+    disk_index = vm_storage_volume.disk_index
+    sshable.cmd("sudo bin/storage-key-tool #{q_vm} #{disk_index} retire-old-key", stdin: "{}")
+
+    hop :retire_old_key_in_database
+  end
+
+  def retire_old_key_in_database
+    vm_storage_volume.update({
+      key_encryption_key_1_id: vm_storage_volume.key_encryption_key_2_id,
+      key_encryption_key_2_id: nil
+    })
+
+    pop "key rotated successfully"
+  end
+
+  def vm
+    @vm ||= vm_storage_volume.vm
+  end
+
+  def sshable
+    @sshable ||= vm.vm_host.sshable
+  end
+end

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -3,6 +3,13 @@
 
 require "json"
 
+secrets = JSON.parse($stdin.read)
+
+unless (storage_secrets = secrets["storage"])
+  puts "need storage secrets in secrets json"
+  exit 1
+end
+
 unless (params_path = ARGV.shift)
   puts "expected path to prep.json as argument"
   exit 1
@@ -80,4 +87,5 @@ require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
 VmSetup.new(vm_name).prep(unix_user, ssh_public_key, private_subnets, gua, ip4,
-  local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_volumes)
+  local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_volumes,
+  storage_secrets)

--- a/rhizome/bin/storage-key-tool
+++ b/rhizome/bin/storage-key-tool
@@ -1,0 +1,57 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../lib/storage_key_tool"
+
+params = JSON.parse($stdin.read)
+
+unless (vm_name = ARGV.shift)
+  puts "expected vm_name as argument"
+  exit 1
+end
+
+unless (disk_index = ARGV.shift)
+  puts "expected disk_index as argument"
+  exit 1
+end
+
+unless (action = ARGV.shift)
+  puts "expected action as argument"
+  exit 1
+end
+
+storage_key_tool = StorageKeyTool.new(vm_name, disk_index)
+
+case action
+when "reencrypt"
+  unless (old_key = params["old_key"])
+    puts "need old_key"
+    exit 1
+  end
+
+  unless (new_key = params["new_key"])
+    puts "need new_key"
+    exit 1
+  end
+  storage_key_tool.reencrypt_key_file(old_key, new_key)
+
+when "test-keys"
+  unless (old_key = params["old_key"])
+    puts "need old_key"
+    exit 1
+  end
+
+  unless (new_key = params["new_key"])
+    puts "need new_key"
+    exit 1
+  end
+  storage_key_tool.test_keys(old_key, new_key)
+
+when "retire-old-key"
+  storage_key_tool.retire_old_key
+
+else
+  puts "invalid action : #{action}"
+  exit 1
+end

--- a/rhizome/lib/storage_key_encryption.rb
+++ b/rhizome/lib/storage_key_encryption.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "common"
+require "openssl"
+require "base64"
+
+class StorageKeyEncryption
+  def initialize(key_encryption_cipher)
+    @key_encryption_cipher = key_encryption_cipher
+  end
+
+  def write_encrypted_dek(key_file, data_encryption_key)
+    File.open(key_file, "w") {
+      _1.write(JSON.pretty_generate({
+        cipher: data_encryption_key[:cipher],
+        key: wrap_key(data_encryption_key[:key]),
+        key2: wrap_key(data_encryption_key[:key2])
+      }))
+      fsync_or_fail(_1)
+    }
+  end
+
+  def read_encrypted_dek(key_file)
+    data_encryption_key = JSON.parse(File.read(key_file))
+    {
+      cipher: data_encryption_key["cipher"],
+      key: unwrap_key(data_encryption_key["key"]),
+      key2: unwrap_key(data_encryption_key["key2"])
+    }
+  end
+
+  def wrap_key(key)
+    algorithm = @key_encryption_cipher["algorithm"]
+    fail "currently only aes-256-gcm is supported" unless algorithm == "aes-256-gcm"
+
+    cipher = OpenSSL::Cipher.new(algorithm)
+    cipher.encrypt
+    cipher.key = Base64.decode64(@key_encryption_cipher["key"])
+    cipher.iv = Base64.decode64(@key_encryption_cipher["init_vector"])
+    cipher.auth_data = @key_encryption_cipher["auth_data"]
+    [
+      Base64.encode64(cipher.update(key) + cipher.final),
+      Base64.encode64(cipher.auth_tag)
+    ]
+  end
+
+  def unwrap_key(encrypted_key)
+    algorithm = @key_encryption_cipher["algorithm"]
+    fail "currently only aes-256-gcm is supported" unless algorithm == "aes-256-gcm"
+
+    decipher = OpenSSL::Cipher.new(algorithm)
+    decipher.decrypt
+    decipher.key = Base64.decode64(@key_encryption_cipher["key"])
+    decipher.iv = Base64.decode64(@key_encryption_cipher["init_vector"])
+    decipher.auth_data = @key_encryption_cipher["auth_data"]
+
+    auth_tag = Base64.decode64(encrypted_key[1])
+
+    # We reject if auth_tag length is not the spec maximum (16), see
+    # https://github.com/ruby/openssl/issues/63 for more details.
+    fail "Invalid auth_tag size: #{auth_tag.bytesize}" unless auth_tag.bytesize == 16
+
+    decipher.auth_tag = auth_tag
+    decipher.update(Base64.decode64(encrypted_key[0])) + decipher.final
+  end
+end

--- a/rhizome/lib/storage_key_tool.rb
+++ b/rhizome/lib/storage_key_tool.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "common"
+require_relative "vm_path"
+require_relative "../lib/storage_key_encryption"
+
+class StorageKeyTool
+  def initialize(vm_name, disk_index)
+    vp = VmPath.new(vm_name)
+    @key_file = vp.data_encryption_key(disk_index)
+    @new_key_file = "#{@key_file}.new"
+  end
+
+  def reencrypt_key_file(old_key, new_key)
+    sek_old = StorageKeyEncryption.new(old_key)
+    sek_new = StorageKeyEncryption.new(new_key)
+
+    data_encryption_key = sek_old.read_encrypted_dek(@key_file)
+
+    sek_new.write_encrypted_dek(@new_key_file, data_encryption_key)
+  end
+
+  def test_keys(old_key, new_key)
+    sek_old = StorageKeyEncryption.new(old_key)
+    sek_new = StorageKeyEncryption.new(new_key)
+
+    old_dek = sek_old.read_encrypted_dek(@key_file)
+    new_dek = sek_new.read_encrypted_dek(@new_key_file)
+
+    if old_dek[:cipher] != new_dek[:cipher]
+      raise "ciphers don't match"
+    end
+
+    if old_dek[:key] != new_dek[:key]
+      raise "keys don't match"
+    end
+
+    if old_dek[:key2] != new_dek[:key2]
+      raise "second keys don't match"
+    end
+  end
+
+  def retire_old_key
+    File.rename @new_key_file, @key_file
+    sync_parent_dir(@key_file)
+  end
+end

--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -39,8 +39,8 @@ class VmPath
     File.join("", "vm", @vm_name, n)
   end
 
-  def storage(n)
-    File.join("", "var", "storage", @vm_name, n)
+  def storage(disk_index, n)
+    File.join("", "var", "storage", @vm_name, disk_index.to_s, n)
   end
 
   # Define path, q_path, read, write methods for files in
@@ -90,11 +90,15 @@ class VmPath
     end
   end
 
-  def vhost_sock(index)
-    storage("vhost_#{index}.sock")
+  def vhost_sock(disk_index)
+    storage(disk_index, "vhost.sock")
   end
 
-  def disk(index)
-    storage("disk_#{index}.raw")
+  def disk(disk_index)
+    storage(disk_index, "disk.raw")
+  end
+
+  def data_encryption_key(disk_index)
+    storage(disk_index, "data_encryption_key.json")
   end
 end

--- a/rhizome/spec/storage_key_encryption_spec.rb
+++ b/rhizome/spec/storage_key_encryption_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../lib/storage_key_encryption"
+require "openssl"
+require "base64"
+
+RSpec.describe StorageKeyEncryption do
+  subject(:sek) {
+    algorithm = "aes-256-gcm"
+    cipher = OpenSSL::Cipher.new(algorithm)
+    described_class.new({
+      "algorithm" => algorithm,
+      "key" => Base64.encode64(cipher.random_key),
+      "init_vector" => Base64.encode64(cipher.random_iv),
+      "auth_data" => "Ubicloud-Test-Auth"
+    })
+  }
+
+  it "can unwrap a wrapped key" do
+    key = "abcdefgh01234567abcdefgh01234567"
+    expect(sek.unwrap_key(sek.wrap_key(key))).to eq(key)
+  end
+
+  it "can wrap a key" do
+    dek = OpenSSL::Cipher.new("aes-256-xts").random_key.unpack1("H*")
+    r1 = sek.wrap_key(dek[..63])
+    expect(Base64.decode64(r1[0]).length).to eq(64)
+    expect(Base64.decode64(r1[1]).length).to eq(16)
+    r2 = sek.wrap_key(dek[64..])
+    expect(Base64.decode64(r2[0]).length).to eq(64)
+    expect(Base64.decode64(r2[1]).length).to eq(16)
+  end
+
+  it "fails if algorithm is not aes-256-gcm" do
+    sek2 = described_class.new({
+      "algorithm" => "aes256-wrap",
+      :key => "123",
+      :init_vector => "456"
+    })
+
+    expect {
+      sek2.unwrap_key("some key")
+    }.to raise_error RuntimeError, "currently only aes-256-gcm is supported"
+
+    expect {
+      sek2.wrap_key("some key")
+    }.to raise_error RuntimeError, "currently only aes-256-gcm is supported"
+  end
+
+  it "fails if auth_tag is not 16" do
+    key = "abcdefgh01234567abcdefgh01234567"
+    wrapped = sek.wrap_key(key)
+    wrapped[1] = Base64.encode64(Base64.decode64(wrapped[1])[0])
+
+    expect {
+      sek.unwrap_key(wrapped)
+    }.to raise_error RuntimeError, "Invalid auth_tag size: 1"
+  end
+end

--- a/rhizome/spec/storage_key_tool_spec.rb
+++ b/rhizome/spec/storage_key_tool_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require_relative "../lib/storage_key_tool"
+require "openssl"
+require "base64"
+
+RSpec.describe StorageKeyTool do
+  subject(:skt) { described_class.new("vm12345", 3) }
+
+  def generate_kek
+    key_wrapping_algorithm = "aes-256-gcm"
+    cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
+    {
+      algorithm: key_wrapping_algorithm,
+      key: cipher.random_key,
+      init_vector: cipher.random_iv,
+      auth_data: "Ubicloud-Storage-Auth"
+    }
+  end
+
+  def key_file
+    "/var/storage/vm12345/3/data_encryption_key.json"
+  end
+
+  def new_key_file
+    "#{key_file}.new"
+  end
+
+  def register_ro_storage_key_encryption(kek, key_file, cipher, key, key2)
+    ske = instance_double(StorageKeyEncryption)
+    expect(ske).to receive(:read_encrypted_dek).with(key_file).and_return({
+      cipher: cipher,
+      key: key,
+      key2: key2
+    })
+    expect(StorageKeyEncryption).to receive(:new).with(kek).and_return(ske)
+  end
+
+  def register_wo_storage_key_encryption(kek, key_file, cipher, key, key2)
+    ske = instance_double(StorageKeyEncryption)
+    expect(ske).to receive(:write_encrypted_dek).with(key_file, {
+      cipher: cipher,
+      key: key,
+      key2: key2
+    })
+    expect(StorageKeyEncryption).to receive(:new).with(kek).and_return(ske)
+  end
+
+  it "can reencrypt key file" do
+    old_key = generate_kek
+    new_key = generate_kek
+
+    register_ro_storage_key_encryption(old_key, key_file, "cipher", "key", "key2")
+    register_wo_storage_key_encryption(new_key, new_key_file, "cipher", "key", "key2")
+
+    expect(skt.reencrypt_key_file(old_key, new_key)).to be_nil
+  end
+
+  describe "#test_keys" do
+    it "raises error if ciphers don't match" do
+      old_key = generate_kek
+      new_key = generate_kek
+
+      register_ro_storage_key_encryption(old_key, key_file, "cipher_1", "key", "key2")
+      register_ro_storage_key_encryption(new_key, new_key_file, "cipher_2", "key", "key2")
+
+      expect {
+        skt.test_keys(old_key, new_key)
+      }.to raise_error RuntimeError, "ciphers don't match"
+    end
+
+    it "raises error if keys don't match" do
+      old_key = generate_kek
+      new_key = generate_kek
+
+      register_ro_storage_key_encryption(old_key, key_file, "cipher", "key_1", "key2")
+      register_ro_storage_key_encryption(new_key, new_key_file, "cipher", "key_2", "key2")
+
+      expect {
+        skt.test_keys(old_key, new_key)
+      }.to raise_error RuntimeError, "keys don't match"
+    end
+
+    it "raises error if second keys don't match" do
+      old_key = generate_kek
+      new_key = generate_kek
+
+      register_ro_storage_key_encryption(old_key, key_file, "cipher", "key", "key2_1")
+      register_ro_storage_key_encryption(new_key, new_key_file, "cipher", "key", "key2_2")
+
+      expect {
+        skt.test_keys(old_key, new_key)
+      }.to raise_error RuntimeError, "second keys don't match"
+    end
+
+    it "can test keys" do
+      old_key = generate_kek
+      new_key = generate_kek
+
+      register_ro_storage_key_encryption(old_key, key_file, "cipher", "key", "key2")
+      register_ro_storage_key_encryption(new_key, new_key_file, "cipher", "key", "key2")
+
+      expect(skt.test_keys(old_key, new_key)).to be_nil
+    end
+  end
+
+  it "can retire old key" do
+    expect(File).to receive(:rename).with(new_key_file, key_file)
+
+    f = instance_double(File)
+    expect(File).to receive(:open).with("/var/storage/vm12345/3").and_return(f)
+
+    skt.retire_old_key
+  end
+end

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 require_relative "../lib/vm_setup"
+require "openssl"
+require "base64"
 
 RSpec.describe VmSetup do
   subject(:vs) { described_class.new("test") }
+
+  def key_wrapping_secrets
+    key_wrapping_algorithm = "aes-256-gcm"
+    cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
+    {
+      "key" => Base64.encode64(cipher.random_key),
+      "init_vector" => Base64.encode64(cipher.random_iv),
+      "algorithm" => key_wrapping_algorithm,
+      "auth_data" => "Ubicloud-Test-Auth"
+    }
+  end
 
   it "can halve an IPv6 network" do
     lower, upper = vs.subdivide_network(NetAddr.parse_net("2a01:4f9:2b:35b:7e40::/79"))
@@ -23,77 +36,124 @@ RSpec.describe VmSetup do
 
   describe "#setup_volume" do
     it "can setup a storage volume" do
-      disk_file = "/var/storage/test/disk_0.raw"
+      disk_file = "/var/storage/test/0/disk.raw"
       device_id = "some_device_id"
       spdk_vhost_sock = "/var/storage/vhost/test_0"
+      vm_vhost_sock = "/var/storage/test/0/vhost.sock"
+      boot_image = "ubuntu-jammy"
+      size_gib = 5
+      key_wrapping_secrets = {}
+      data_encryption_key = {cipher: "AES-XTS", k: "123", e: "456"}
 
       expect(vs).to receive(:setup_disk_file).and_return(disk_file)
       expect(vs).to receive(:r).with(/setfacl.*#{disk_file}/)
-      expect(vs).to receive(:r).with(/.*rpc.py.*bdev_aio_create/)
+      expect(vs).to receive(:setup_data_encryption_key).with(0, key_wrapping_secrets).and_return(data_encryption_key)
+      expect(vs).to receive(:copy_image).with(disk_file, boot_image, size_gib, true, data_encryption_key)
+      expect(vs).to receive(:setup_spdk_bdev).with(device_id, disk_file, true, data_encryption_key)
       expect(vs).to receive(:r).with(/.*rpc.py.*vhost_create_blk_controller test_0 #{device_id}/)
       expect(FileUtils).to receive(:chown).with("test", "test", disk_file)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", disk_file)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", spdk_vhost_sock)
-      expect(FileUtils).to receive(:ln_s).with(spdk_vhost_sock, "/var/storage/test/vhost_0.sock")
+      expect(FileUtils).to receive(:ln_s).with(spdk_vhost_sock, vm_vhost_sock)
       expect(vs).to receive(:r).with(/setfacl.*#{spdk_vhost_sock}/)
 
       expect(
-        vs.setup_volume({"boot" => true, "size_gib" => 5, "device_id" => device_id}, 0, "ubuntu-jammy")
-      ).to eq("/var/storage/test/vhost_0.sock")
+        vs.setup_volume({"boot" => true, "size_gib" => size_gib, "device_id" => device_id},
+          0, boot_image, key_wrapping_secrets)
+      ).to eq(vm_vhost_sock)
     end
   end
 
   describe "#setup_disk_file" do
-    it "can setup a boot disk" do
-      boot_image = "ubuntu-jammy"
-      image_path = "/opt/#{boot_image}.qcow2"
-      disk_file = "/var/storage/test/disk_0.raw"
-      expect(vs).to receive(:download_boot_image).and_return image_path
-      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw #{image_path} #{disk_file}")
-      expect(File).to receive(:size).with(disk_file).and_return(2 * 2**30)
-      expect(vs).to receive(:r).with("truncate -s 5G #{disk_file}")
-      expect(
-        vs.setup_disk_file({"boot" => true, "size_gib" => 5, "device_id" => "disk0"}, 0, boot_image)
-      ).to eq(disk_file)
-    end
-
-    it "fails if requested size is too small" do
-      boot_image = "ubuntu-jammy"
-      image_path = "/opt/#{boot_image}.qcow2"
-      disk_file = "/var/storage/test/disk_0.raw"
-      expect(vs).to receive(:download_boot_image).and_return image_path
-      expect(vs).to receive(:r)
-      expect(File).to receive(:size).with(disk_file).and_return(5 * 2**30)
-      expect {
-        vs.setup_disk_file({"boot" => true, "size_gib" => 4, "device_id" => "disk0"}, 0, boot_image)
-      }.to raise_error RuntimeError, "Image size greater than requested disk size"
-    end
-
-    it "can setup a non-boot disk" do
-      disk_file = "/var/storage/test/disk_0.raw"
+    it "can setup a disk" do
+      disk_file = "/var/storage/test/0/disk.raw"
       expect(FileUtils).to receive(:touch).with(disk_file)
       expect(vs).to receive(:r).with("truncate -s 5G #{disk_file}")
       expect(
-        vs.setup_disk_file({"boot" => false, "size_gib" => 5, "device_id" => "disk0"}, 0, "boot_image")
+        vs.setup_disk_file({"boot" => true, "size_gib" => 5, "device_id" => "disk0"}, 0)
       ).to eq(disk_file)
+    end
+  end
+
+  describe "#copy_image" do
+    it "fails if requested size is too small" do
+      boot_image = "ubuntu-jammy"
+      image_path = "/opt/#{boot_image}.raw"
+      disk_file = "/var/storage/test/disk_0.raw"
+      expect(vs).to receive(:download_boot_image).and_return image_path
+      expect(File).to receive(:size).with(image_path).and_return(5 * 2**30)
+      expect {
+        vs.copy_image(disk_file, boot_image, 2, false, nil)
+      }.to raise_error RuntimeError, "Image size greater than requested disk size"
+    end
+
+    it "copies non-encrypted image" do
+      boot_image = "ubuntu-jammy"
+      image_path = "/opt/#{boot_image}.raw"
+      disk_file = "/var/storage/test/disk_0.raw"
+      expect(vs).to receive(:download_boot_image).and_return image_path
+      expect(File).to receive(:size).with(image_path).and_return(2 * 2**30)
+      expect(vs).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob aio0$/, stdin: /{.*}/)
+      vs.copy_image(disk_file, boot_image, 10, false, nil)
+    end
+
+    it "copies encrypted image" do
+      boot_image = "ubuntu-jammy"
+      image_path = "/opt/#{boot_image}.raw"
+      disk_file = "/var/storage/test/disk_0.raw"
+      encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
+      expect(vs).to receive(:download_boot_image).and_return image_path
+      expect(File).to receive(:size).with(image_path).and_return(2 * 2**30)
+      expect(vs).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0$/, stdin: /{.*}/)
+      vs.copy_image(disk_file, boot_image, 10, true, encryption_key)
     end
   end
 
   describe "#download_boot_image" do
     it "can download an image" do
-      expect(File).to receive(:exist?).with("/opt/ubuntu-jammy.qcow2").and_return(false)
+      expect(File).to receive(:exist?).with("/opt/ubuntu-jammy.raw").and_return(false)
       expect(File).to receive(:open) do |path, *_args|
         expect(path).to eq("/opt/ubuntu-jammy.qcow2.tmp")
       end.and_yield
-      expect(FileUtils).to receive(:mv).with("/opt/ubuntu-jammy.qcow2.tmp", "/opt/ubuntu-jammy.qcow2")
       expect(vs).to receive(:r).with("curl -L10 -o /opt/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /opt/ubuntu-jammy.qcow2.tmp /opt/ubuntu-jammy.raw")
 
       vs.download_boot_image("ubuntu-jammy")
     end
 
     it "can use an image that's already downloaded" do
-      expect(File).to receive(:exist?).with("/opt/almalinux-9.1.qcow2").and_return(true)
+      expect(File).to receive(:exist?).with("/opt/almalinux-9.1.raw").and_return(true)
       vs.download_boot_image("almalinux-9.1")
+    end
+  end
+
+  describe "#setup_spdk_bdev" do
+    it "can setup a non-encrypted volume" do
+      bdev = "bdev_name"
+      disk_file = "/path/to/disk/file"
+      expect(vs).to receive(:r).with(/.*rpc.py.*bdev_aio_create #{disk_file} #{bdev} 512$/)
+      vs.setup_spdk_bdev(bdev, disk_file, false, nil)
+    end
+
+    it "can setup an encrypted volume" do
+      bdev = "bdev_name"
+      disk_file = "/path/to/disk/file"
+      encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
+      expect(vs).to receive(:r).with(/.*rpc.py.*accel_crypto_key_create -c aes_xts -k key1value -e key2value/)
+      expect(vs).to receive(:r).with(/.*rpc.py.*bdev_aio_create #{disk_file} #{bdev}_aio 512$/)
+      expect(vs).to receive(:r).with(/.*rpc.py.*bdev_crypto_create.*#{bdev}_aio #{bdev}$/)
+      vs.setup_spdk_bdev(bdev, disk_file, true, encryption_key)
+    end
+  end
+
+  describe "#setup_data_encryption_key" do
+    it "can setup data encryption key" do
+      key_file = "/var/storage/test/3/data_encryption_key.json"
+      expect(FileUtils).to receive(:chown).with("test", "test", key_file)
+      expect(FileUtils).to receive(:chmod).with("u=rw,g=,o=", key_file)
+      expect(File).to receive(:open).with(key_file, "w")
+      expect(vs).to receive(:sync_parent_dir).with(key_file)
+      vs.setup_data_encryption_key(3, key_wrapping_secrets)
     end
   end
 end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Prog::Vm::Nexus do
           "local_ipv4" => "169.254.0.0"
         })
       end
-      expect(sshable).to receive(:cmd).with(/sudo bin\/prepvm/)
+      expect(sshable).to receive(:cmd).with(/sudo bin\/prepvm/, {stdin: "{\"storage\":{}}"})
 
       expect { nx.prep }.to raise_error Prog::Base::Hop do |hop|
         expect(hop.new_label).to eq("trigger_refresh_mesh")


### PR DESCRIPTION
Adds the option to keep storage devices encrypted at rest. This can be enabled or disabled by a parameter to `Vm.assemble`. It is enabled by default:

```
> st = Prog::Vm::Nexus.assemble(mykey, nil, storage_encrypted: true)
```

We also add a program to rotate key encryption keys:

```
> st = Strand.create(prog: 'RotateStorageKek', label: 'start', stack: [{subject_id: vm_storage_volume.id}])
```

We use envelope encryption [1]. On the Clover side, a "key encryption key" (KEK) is generated & stored in database. On the rhizome side, a "data encryption key" (DEK) is generated & used to encrypt data. The DEK is encrypted using KEK & saved near the storage data in the host. Now attackers cannot decrypt data if they only get access to either of DB or the file system. They need to get access to both of them to be able to decrypt.

We use "AES-256-GCM" for key encryption, and "AES_XTS" for data encryption. The KEK is saved in the "StorageKeyEncryptionKey" table. The DEK is saved in `/var/storage/$vm_name/$disk_index/data_encryption_key.json`. Key fields of the json file are encrypted using KEK. I have named the key fields "key" and "key2" to match the terminology SPDK uses.

[1] https://cloud.google.com/kms/docs/envelope-encryption