### PR TITLE
Add range slider component to UI

### DIFF
--- a/views/components/form/range_slider.erb
+++ b/views/components/form/range_slider.erb
@@ -1,0 +1,38 @@
+<% name = defined?(name) ? name : nil %>
+<% label = defined?(label) ? label : nil %>
+<% range_labels = (defined?(range_labels) && range_labels) ? range_labels : {} %>
+<% value = flash.dig("old", name) || ((defined?(value) && value) ? value : 0) %>
+<% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
+<% description = (defined?(description) && description) ? description : nil %>
+<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
+
+<div class="space-y-2 text-gray-900">
+  <% if label %>
+    <label for="<%= name %>" class="block text-sm font-medium leading-6"><%= label %></label>
+  <% end %>
+  <div class="flex justify-between">
+    <% range_labels.each do |lbl| %>
+      <div><%= lbl %></div>
+    <% end %>
+  </div>
+  <div class="flex items-center space-x-4">
+    <input
+      id="<%= name %>"
+      type="range"
+      name="<%= name %>"
+      <% if value %>
+      value="<%= value %>"
+      <% end %>
+      class="w-full range-lg h-2 bg-gray-200 accent-orange-600 rounded-lg appearance-none cursor-pointer border-transparent <%= error ? "text-red-900 ring-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 focus:ring-orange-600"%>"
+      <% attributes.each do |atr_key, atr_value| %>
+      <%= atr_key %>="<%= atr_value %>"
+      <% end%>
+    >
+  </div>
+  <% if error %>
+    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
+  <% end %>
+  <% if description %>
+    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%== description %></p>
+  <% end %>
+</div>


### PR DESCRIPTION
It's a basic HTML range slider with small UI modifications. Range labels are not related with actual values, you can put anything you want on UI.

Example usage:
```
    <div class="col-span-full">
        <%== render(
          "components/form/range_slider",
          locals: {
            name: "storage-size",
            label: "Storage Size",
            range_labels: (1..10).map { "#{_1 * 10}GB" },
            value: 40,
            attributes: {
              min: 10,
              max: 100,
              step: 10,
              required: true
            }
          }
        ) %>
    </div>
```

<img width="1157" alt="Screenshot 2023-06-26 at 15 24 01" src="https://github.com/ubicloud/ubicloud/assets/993199/8ee1deb8-86dc-4fa8-a33a-633ea05f72be">
