### PR TITLE
Teach Sshable#cmd to support stdin

### DIFF
--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -7,47 +7,28 @@ class Prog::InstallRhizome < Prog::Base
     require "rubygems/package"
     require "stringio"
 
-    sshable.connect.open_channel do |channel|
-      channel.exec("tar xf -") do |ch, success|
-        raise "could not execute command" unless success
-
-        # Print stdout.
-        channel.on_data do |ch, data|
-          $stdout.write(data)
-        end
-
-        # Print stderr.
-        channel.on_extended_data do |ch, data|
-          $stderr.write(data)
-        end
-
-        tar = StringIO.new
-        Gem::Package::TarWriter.new(tar) do |writer|
-          base = Config.root + "/rhizome"
-          Dir.glob("**/*", base: base).map do |file|
-            full_path = base + "/" + file
-            stat = File.stat(full_path)
-            if stat.directory?
-              writer.mkdir(file, stat.mode)
-            elsif stat.file?
-              writer.add_file(file, stat.mode) do |tf|
-                File.open(full_path, "rb") do
-                  IO.copy_stream(_1, tf)
-                end
-              end
-            else
-              fail "BUG"
+    tar = StringIO.new
+    Gem::Package::TarWriter.new(tar) do |writer|
+      base = Config.root + "/rhizome"
+      Dir.glob("**/*", base: base).map do |file|
+        full_path = base + "/" + file
+        stat = File.stat(full_path)
+        if stat.directory?
+          writer.mkdir(file, stat.mode)
+        elsif stat.file?
+          writer.add_file(file, stat.mode) do |tf|
+            File.open(full_path, "rb") do
+              IO.copy_stream(_1, tf)
             end
           end
+        else
+          fail "BUG"
         end
-
-        ch.send_data tar.string
-        ch.eof!
-        ch.wait
       end
+    end
 
-      channel.wait
-    end.wait
+    payload = tar.string.freeze
+    sshable.cmd("tar xf -", stdin: payload)
 
     hop :install_gems
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "absorbs an already-exists error as a success" do
       expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/).and_raise(
-        Sshable::SshError.new("adduser: The user `vmabc123' already exists.")
+        Sshable::SshError.new("adduser: The user `vmabc123' already exists.", 1, nil)
       )
 
       expect { nx.create_unix_user }.to raise_error Prog::Base::Hop do |hop|
@@ -57,7 +57,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "raises other errors" do
-      ex = Sshable::SshError.new("out of memory")
+      ex = Sshable::SshError.new("out of memory", 1, nil)
       expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/).and_raise(ex)
 
       expect { nx.create_unix_user }.to raise_error ex


### PR DESCRIPTION
This allows passing of data awkward to pass via arguments (like tar's binary data), and also allows more secure transmission of secrets that otherwise would be exposed to the process table and `sudo` command line auditing, and thus make their way into the systemd journal.

Here are some demonstrations of how thing work, or continue to work:

    > sshable.cmd("echo hello")
    => "hello\n"

    > sshable.cmd("exit 0")
    => ""

    > sshable.cmd("echo 'it is an error'; exit 3")
    Sshable::SshError: it is an error
    from /home/fdr/code/clover/model/sshable.rb:64:in `cmd'

    > _ex_.exit_code
    => 3

    > sshable.cmd("cat", stdin: "hello")
    => "hello"