### PR TITLE
Improve Sshable#cmd usability

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+REPL = true
+
 require_relative "../loader"
 
 require "pry"

--- a/loader.rb
+++ b/loader.rb
@@ -6,6 +6,8 @@ Bundler.setup
 require_relative "config"
 require "rack/unreloader"
 
+REPL = false unless defined? REPL
+
 Unreloader = Rack::Unreloader.new(
   reload: Config.development?,
   autoload: true,

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -149,7 +149,7 @@ SQL
     begin
       host.sshable.cmd("sudo adduser --disabled-password --gecos '' --home #{vm_home.shellescape} #{q_vm}")
     rescue Sshable::SshError => ex
-      raise unless /adduser: The user `.*' already exists\./.match?(ex.message)
+      raise unless /adduser: The user `.*' already exists\./.match?(ex.stderr)
     end
 
     hop :prep

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "absorbs an already-exists error as a success" do
       expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/).and_raise(
-        Sshable::SshError.new("adduser: The user `vmabc123' already exists.", 1, nil)
+        Sshable::SshError.new("adduser", "", "adduser: The user `vmabc123' already exists.", 1, nil)
       )
 
       expect { nx.create_unix_user }.to raise_error Prog::Base::Hop do |hop|
@@ -57,7 +57,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "raises other errors" do
-      ex = Sshable::SshError.new("out of memory", 1, nil)
+      ex = Sshable::SshError.new("allocate a lot", "", "out of memory", 1, nil)
       expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/).and_raise(ex)
 
       expect { nx.create_unix_user }.to raise_error ex


### PR DESCRIPTION
d3cfd6f62db40e41eb73909a0db1a708bc2541be created usability regressions.  Net::SSH's `#exec!` method mixes stderr and stdout, which is not sound under some interleavings but more useful than stdout alone when the latter has no information.

So instead, make SshError even richer, but avoid reflecting stdout/stderr into `Exception#message`, instead, write the stdout *and* stderr output to REPL stderr.

Also, some problems with cache invalidation upon error were reported, try to solve this by moving the channel.wait inside the rescue block.

Now stderr output looks like this:
    
        > sshable.cmd("ls /nope")
        ls: cannot access '/nope': No such file or directory
        Sshable::SshError: command exited with an error: ls /nope
        from /home/fdr/code/clover/model/sshable.rb:67:in `cmd'
