### PR TITLE
Require "shellwords" in nexus.rb

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -3,6 +3,7 @@
 require "netaddr"
 require "json"
 require "ulid"
+require "shellwords"
 
 class Prog::Vm::Nexus < Prog::Base
   semaphore :destroy, :refresh_mesh


### PR DESCRIPTION
Previously when I started ./bin/respirate I sometimes saw errors like:

```
nexus.rb:196:in `create_ipsec_tunnel': undefined method `shellescape' for "vm4a0dt9":String (NoMethodError)

    q_dst_name = dst_vm.inhost_name.shellescape
```