### PR TITLE
Make VM size configurable in Web UI

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -3,7 +3,7 @@
 module Option
   Location = Struct.new(:name, :display_name)
   BootImage = Struct.new(:name, :display_name)
-  VmSize = Struct.new(:name, :display_name, :vcpu, :memory, :disk)
+  VmSize = Struct.new(:name, :display_name, :vcpu, :memory)
 
   Locations = [
     ["hetzner-hel1", "Hetzner Finland"],
@@ -18,8 +18,8 @@ module Option
   ].map { |args| BootImage.new(*args) }.freeze
 
   VmSizes = [
-    ["c5a.2x", "c5a.2x", 2, 2, 30],
-    ["c5a.4x", "c5a.4x", 4, 4, 60],
-    ["c5a.6x", "c5a.6x", 6, 6, 90]
+    ["c5a.2x", "c5a.2x", 2, 2],
+    ["c5a.4x", "c5a.4x", 4, 4],
+    ["c5a.6x", "c5a.6x", 6, 6]
   ].map { |args| VmSize.new(*args) }.freeze
 end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -146,4 +146,8 @@ class Vm < Sequel::Model
     # entropy.
     self.class.uuid_to_name(id)
   end
+
+  def storage_size_gib
+    vm_storage_volumes.map { _1.size_gib }.sum
+  end
 end

--- a/routes/vm.rb
+++ b/routes/vm.rb
@@ -23,7 +23,8 @@ class Clover
         unix_user: r.params["user"],
         size: r.params["size"],
         location: r.params["location"],
-        boot_image: r.params["boot-image"]
+        boot_image: r.params["boot-image"],
+        storage_size_gib: r.params["storage-size-gib"].to_i
       )
 
       flash["notice"] = "'#{r.params["name"]}' will be ready in a few minutes"

--- a/serializers/web/vm.rb
+++ b/serializers/web/vm.rb
@@ -12,6 +12,7 @@ class Serializers::Web::Vm < Serializers::Base
       state: vm.display_state,
       location: vm.location,
       size: vm.size,
+      storage_size_gib: vm.storage_size_gib,
       ip6: vm.ephemeral_net6&.nth(2),
       projects: Serializers::Web::Project.new(:default).serialize(vm.projects)
     }

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -58,6 +58,23 @@
                     ) %>
                   </div>
                   <div class="col-span-full">
+                    <%== render(
+                      "components/form/range_slider",
+                      locals: {
+                        name: "storage-size-gib",
+                        label: "Storage Size",
+                        range_labels: (1..10).map { "#{_1 * 10}GB" },
+                        value: 40,
+                        attributes: {
+                          min: 10,
+                          max: 100,
+                          step: 10,
+                          required: true
+                        }
+                      }
+                    ) %>
+                  </div>
+                  <div class="col-span-full">
                     <div class="space-y-2">
                       <label for="size" class="text-sm font-medium leading-6 text-gray-900">Server size</label>
                       <fieldset class="radio-small-cards" id="size-radios">
@@ -84,9 +101,7 @@
                                     <span class="block sm:inline"><%= size.vcpu %>
                                       vCPUs /
                                       <%= size.memory %>
-                                      GB /
-                                      <%= size.disk %>
-                                      GB SSD</span>
+                                      GB</span>
                                   </span>
                                 </span>
                               </span>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -22,6 +22,7 @@
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Project</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Provider & Location</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Size</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Storage Size</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">IPv6</th>
                   <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
@@ -36,6 +37,8 @@
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:projects].map { _1[:name] }.join(", ") %></td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:location] %></td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:size] %></td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:storage_size_gib] %>
+                      GB</td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <%== render("components/vm_state_label", locals: { state: vm[:state] }) %>
                     </td>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -39,6 +39,11 @@
                 <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:size] %></dd>
               </div>
               <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
+                <dt class="text-sm font-medium text-gray-500">Storage Size</dt>
+                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:storage_size_gib] %>
+                  GB</dd>
+              </div>
+              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
                 <dt class="text-sm font-medium text-gray-500">IPv6</dt>
                 <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
                   <span class="copy-content cursor-pointer" data-content="<%= @vm[:ip6] %>" data-message="Copied IPv6">


### PR DESCRIPTION
This adds a "Storage Size" slider to the Web UI to configure storage_size_gib parameter of `Prog::Vm::Nexus.assemble`.

Also adds storage information to Vm index and Vm show views.