### PR TITLE
Make all migrations reversible including "ph" ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
         COVERAGE=1 bundle exec rspec
         bundle exec rspec -O /dev/null rhizome
 
+    - name: Revert migrations
+      env:
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+      run: rake test_down
+
     - name: Archive code coverage results
       if: failure()
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
We have two different migration paths. Default one has reverting logic but "ph" migrations don't have that. Default migrations can't down to version zero without reverting "ph" migrations because some tables depend each other.

If we are reverting default migrations to version zero, it reverts "ph" migrations to zero first.

"009_ssh_generation" migration has "set_column_allow_null" and it's not auto reversible in change block. I divided it to up/down blocks.

Also, I added "rake test_down" to the end of CI pipeline, so we can be sure new migrations are reversible too.