### PR TITLE
Configure dependabot to update all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    allow:
+      - dependency-type: "all"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'
+    allow:
+      - dependency-type: "all"
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
       interval: 'daily'
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Previously, it was only handling direct dependencies, the default. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file