### PR TITLE
Remove `inactive` key for cloud-init user data

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -217,7 +217,6 @@ EOS
 users:
   - name: #{yq(unix_user)}
     sudo: ALL=(ALL) NOPASSWD:ALL
-    inactive: False
     shell: /bin/bash
     ssh_authorized_keys:
       - #{yq(public_key)}


### PR DESCRIPTION
According to the manual, this is to be an integer: https://cloudinit.readthedocs.io/en/latest/reference/examples.html

We get annoying and misleading warning messages in boot-up about invalid schemas for cloud-init, even if things continue to work.  But, when they don't, this inevitably is misleading.  So, squelch those warnings by getting things exactly right:

    ubi@vm1sedt3:~$ sudo cloud-init schema --system
    Valid cloud-config: user-data