### PR TITLE
Convert implied hash interface to Struct

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -140,9 +140,9 @@ class VmHost < Sequel::Model
 
     DB.transaction do
       ip_records.each do |ip_record|
-        ip_addr = ip_record[:ip_address]
-        source_host_ip = ip_record[:source_host_ip]
-        is_failover_ip = ip_record[:is_failover]
+        ip_addr = ip_record.ip_address
+        source_host_ip = ip_record.source_host_ip
+        is_failover_ip = ip_record.is_failover
 
         next if assigned_subnets.any? { |a| a.cidr.to_s == ip_addr }
 

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -106,12 +106,16 @@ RSpec.describe Hosting::HetznerApis do
         }
       ]))
 
-      expect(hetzner_apis.pull_ips).to eq(
-        [{ip_address: "1.1.1.1/32", source_host_ip: "1.1.1.1", is_failover: false},
-          {ip_address: "1.1.2.0/32", source_host_ip: "1.1.1.1", is_failover: false},
-          {ip_address: "2.2.2.0/29", source_host_ip: "1.1.1.1", is_failover: false},
-          {ip_address: "30.30.30.30/29", source_host_ip: "1.1.1.1", is_failover: true}]
-      )
+      expected = [
+        ["1.1.1.1/32", "1.1.1.1", false],
+        ["1.1.2.0/32", "1.1.1.1", false],
+        ["2.2.2.0/29", "1.1.1.1", false],
+        ["30.30.30.30/29", "1.1.1.1", true]
+      ].map {
+        Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2, is_failover: _3)
+      }
+
+      expect(hetzner_apis.pull_ips).to eq expected
     end
   end
 end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe VmHost do
   }
   let(:hetzner_ips) {
     [
-      {ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true},
-      {ip_address: "1.1.1.2/32", source_host_ip: "1.1.0.0", is_failover: true},
-      {ip_address: "1.1.1.3/32", source_host_ip: "1.1.1.1", is_failover: false},
-      {ip_address: "2a01:4f8:10a:128b::/64", source_host_ip: "1.1.1.1", is_failover: true}
-    ]
+      ["1.1.1.0/30", "1.1.1.1", true],
+      ["1.1.1.2/32", "1.1.0.0", true],
+      ["1.1.1.3/32", "1.1.1.1", false],
+      ["2a01:4f8:10a:128b::/64", "1.1.1.1", true]
+    ].map {
+      Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2, is_failover: _3)
+    }
   }
 
   it "requires an Sshable too" do
@@ -174,7 +176,9 @@ RSpec.describe VmHost do
   end
 
   it "updates the routed_to_host_id if the address is reassigned to another host and there is no vm using the ip range" do
-    hetzner_ips = [{ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true}]
+    hetzner_ips = [
+      Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)
+    ]
     old_id = "4c5dc171-a116-4a05-9e6d-381a4b382b71"
     new_id = "46683a25-acb1-4371-afe9-d39f303e44b4"
 
@@ -193,7 +197,9 @@ RSpec.describe VmHost do
   end
 
   it "fails if the ip range is already assigned to a vm" do
-    hetzner_ips = [{ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true}]
+    hetzner_ips = [
+      Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)
+    ]
     old_id = "4c5dc171-a116-4a05-9e6d-381a4b382b71"
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Prog::Vm::HostNexus do
   let(:st) { Strand.new }
   let(:hetzner_ips) {
     [
-      {ip_address: "127.0.0.1", source_host_ip: "127.0.0.1", is_failover: false},
-      {ip_address: "30.30.30.32/29", source_host_ip: "127.0.0.1", is_failover: true},
-      {ip_address: "2a01:4f8:10a:128b::/64", source_host_ip: "127.0.0.1", is_failover: true}
-    ]
+      ["127.0.0.1", "127.0.0.1", false],
+      ["30.30.30.32/29", "127.0.0.1", true],
+      ["2a01:4f8:10a:128b::/64", "127.0.0.1", true]
+    ].map {
+      Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2, is_failover: _3)
+    }
   }
 
   describe ".assemble" do


### PR DESCRIPTION
This implied interface is seen in a few places in application code, and in many cases in the tests, but since it's a literal with no interface checking, any one of these sites can fall out of synchronization.  Because a lot of it is in tests, the result is bogus tests.

Using a struct fixes this, although it winds up more wordy to construct the literal in tests.

A positional argument style Struct would have been more terse, but I find the potential for error in production code paths unsatisfying in that case.