### PR TITLE
VM private networking setup

### DIFF
--- a/migrate/20230706_add_private_subnet_ipv4.rb
+++ b/migrate/20230706_add_private_subnet_ipv4.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_private_subnet) do
+      add_column :net4, :cidr, null: false
+      rename_column :private_subnet, :net6
+    end
+  end
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -5,7 +5,7 @@ require_relative "../model"
 class Vm < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :vm_host
-  one_to_many :vm_private_subnet, key: :vm_id
+  one_to_many :private_subnets, key: :vm_id, class: :VmPrivateSubnet
   one_to_many :ipsec_tunnels, key: :src_vm_id
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
@@ -20,16 +20,12 @@ class Vm < Sequel::Model
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
 
-  def private_subnets
-    vm_private_subnet.map { _1.private_subnet }
-  end
-
   def path
     "/vm/#{ulid}"
   end
 
   def ephemeral_net4
-    assigned_vm_address&.ip&.nth(1)
+    assigned_vm_address&.ip&.network
   end
 
   def ip4

--- a/rhizome/bin/prepvm.rb
+++ b/rhizome/bin/prepvm.rb
@@ -40,6 +40,11 @@ unless (local_ip4 = params["local_ipv4"])
   exit 1
 end
 
+unless (private_ipv4 = params["private_ipv4"])
+  puts "need private_ipv4 in parameters json"
+  exit 1
+end
+
 unless (unix_user = params["unix_user"])
   puts "need unix_user in parameters json"
   exit 1
@@ -87,5 +92,5 @@ require_relative "../lib/common"
 require_relative "../lib/vm_setup"
 
 VmSetup.new(vm_name).prep(unix_user, ssh_public_key, private_subnets, gua, ip4,
-  local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_volumes,
-  storage_secrets)
+  local_ip4, private_ipv4, boot_image, max_vcpus, cpu_topology, mem_gib,
+  ndp_needed, storage_volumes, storage_secrets)

--- a/rhizome/bin/setup-ipsec
+++ b/rhizome/bin/setup-ipsec
@@ -1,43 +1,53 @@
 #!/bin/env ruby
 # frozen_string_literal: true
 
-unless (command = ARGV.shift)
-  puts "expected ipsec command as argument"
+unless (namespace = ARGV.shift)
+  puts "expected namespace as argument"
   exit 1
 end
 
-unless (src_vm_name = ARGV.shift)
-  puts "expected src_vm_name as argument"
+unless (src_clover_ephemeral = ARGV.shift)
+  puts "expected src_clover_ephemeral as argument"
   exit 1
 end
 
-unless (src_ephemeral_net6 = ARGV.shift)
-  puts "expected src_ephemeral_net6 as argument"
+unless (dst_clover_ephemeral = ARGV.shift)
+  puts "expected dst_clover_ephemeral as argument"
   exit 1
 end
 
-unless (src_private_subnet = ARGV.shift)
-  puts "expected src_private_subnet as argument"
+unless (src_private_addr_6 = ARGV.shift)
+  puts "expected src_private_addr_6 as argument"
   exit 1
 end
 
-unless (dest_vm_name = ARGV.shift)
-  puts "expected dest_vm_name as argument"
+unless (dst_private_addr_6 = ARGV.shift)
+  puts "expected dst_private_addr_6 as argument"
   exit 1
 end
 
-unless (dest_ephemeral_net6 = ARGV.shift)
-  puts "expected dest_ephemeral_net6 as argument"
+unless (src_private_addr_4 = ARGV.shift)
+  puts "expected src_private_addr_4 as argument"
   exit 1
 end
 
-unless (dest_private_subnet = ARGV.shift)
-  puts "expected dest_private_subnet as argument"
+unless (dst_private_addr_4 = ARGV.shift)
+  puts "expected dst_private_addr_4 as argument"
+  exit 1
+end
+
+unless (direction = ARGV.shift)
+  puts "expected direction as argument"
   exit 1
 end
 
 unless (spi = ARGV.shift)
   puts "expected spi as argument"
+  exit 1
+end
+
+unless (spi4 = ARGV.shift)
+  puts "expected spi4 as argument"
   exit 1
 end
 
@@ -52,15 +62,10 @@ require_relative "../lib/ipsec_tunnel"
 require "fileutils"
 require "netaddr"
 
-src_endpoint = IPSecTunnelEndpoint.new(src_vm_name, NetAddr.parse_net(src_ephemeral_net6), src_private_subnet)
-dest_endpoint = IPSecTunnelEndpoint.new(dest_vm_name, NetAddr.parse_net(dest_ephemeral_net6), dest_private_subnet)
-ipsec_tunnel = IPSecTunnel.new(src_endpoint, dest_endpoint, spi, security_key)
+ipsec_tunnel = IPSecTunnel.new(namespace,
+  src_clover_ephemeral, dst_clover_ephemeral,
+  src_private_addr_6, dst_private_addr_6,
+  src_private_addr_4, dst_private_addr_4,
+  spi, spi4, security_key, direction)
 
-case command
-when "setup_src"
-  ipsec_tunnel.setup_src
-when "setup_dst"
-  ipsec_tunnel.setup_dst
-else
-  puts "Unknown command: #{command}"
-end
+ipsec_tunnel.setup

--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -57,6 +57,8 @@ class VmPath
     ch-api.sock
     serial.log
     hugepages
+    public_ipv4
+    nftables_conf
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
     fail "BUG" if method_defined?(method_name)

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -74,15 +74,17 @@ RSpec.describe VmHost do
   it "assigned_subnets returns the assigned subnets" do
     expect(vh).to receive(:assigned_subnets).and_return([address])
     expect(vh).to receive(:vm_addresses).and_return([])
-    expect(SecureRandom).to receive(:random_number).with(2).and_return(0)
+    expect(SecureRandom).to receive(:random_number).with(4).and_return(0)
+    expect(vh).to receive(:sshable).and_return(instance_double(Sshable, host: "0.0.0.2")).at_least(:once)
     ip4, r_address = vh.ip4_random_vm_network
-    expect(ip4.to_s).to eq("0.0.0.0/31")
+    expect(ip4.to_s).to eq("0.0.0.0")
     expect(r_address).to eq(address)
   end
 
   it "returns nil if there is no available subnet" do
     expect(vh).to receive(:assigned_subnets).and_return([address])
-    expect(address.assigned_vm_address).to receive(:count).and_return(2)
+    expect(address.assigned_vm_address).to receive(:count).and_return(4)
+    expect(vh).to receive(:sshable).and_return(instance_double(Sshable, host: "0.0.0.2")).at_least(:once)
     ip4, address = vh.ip4_random_vm_network
     expect(ip4).to be_nil
     expect(address).to be_nil
@@ -90,10 +92,11 @@ RSpec.describe VmHost do
 
   it "finds another address if it's already assigned" do
     expect(vh).to receive(:assigned_subnets).and_return([address]).at_least(:once)
-    expect(vh).to receive(:vm_addresses).and_return([instance_double(AssignedVmAddress, ip: NetAddr::IPv4Net.parse("0.0.0.0/31"))]).at_least(:once)
-    expect(SecureRandom).to receive(:random_number).with(2).and_return(0, 1)
+    expect(vh).to receive(:vm_addresses).and_return([instance_double(AssignedVmAddress, ip: NetAddr::IPv4Net.parse("0.0.0.0"))]).at_least(:once)
+    expect(vh).to receive(:sshable).and_return(instance_double(Sshable, host: "0.0.0.2")).at_least(:once)
+    expect(SecureRandom).to receive(:random_number).with(4).and_return(0, 1)
     ip4, r_address = vh.ip4_random_vm_network
-    expect(ip4.to_s).to eq("0.0.0.2/31")
+    expect(ip4.to_s).to eq("0.0.0.1")
     expect(r_address).to eq(address)
   end
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -124,10 +124,10 @@ RSpec.describe Vm do
 
   describe "#utility functions" do
     it "can compute the ipv4 addresses" do
-      as_ad = instance_double(AssignedVmAddress, ip: NetAddr::IPv4Net.new(NetAddr.parse_ip("1.1.1.0"), NetAddr::Mask32.new(31)))
+      as_ad = instance_double(AssignedVmAddress, ip: NetAddr::IPv4Net.new(NetAddr.parse_ip("1.1.1.0"), NetAddr::Mask32.new(32)))
       expect(vm).to receive(:assigned_vm_address).and_return(as_ad).at_least(:once)
-      expect(vm.ephemeral_net4.to_s).to eq("1.1.1.1")
-      expect(vm.ip4.to_s).to eq("1.1.1.0/31")
+      expect(vm.ephemeral_net4.to_s).to eq("1.1.1.0")
+      expect(vm.ip4.to_s).to eq("1.1.1.0/32")
     end
 
     it "can compute nil if ipv4 is not assigned" do


### PR DESCRIPTION
This PR introduces a couple of new changes to support;
1.  Public ipv4: Nat implementation from public to private ipv4.
```
table ip raw {
  chain prerouting {
    type filter hook prerouting priority raw; policy accept;
    ip daddr #{public_ipv4} ip daddr set #{private_ipv4} notrack
    ip saddr #{private_ipv4} ip daddr != 192.168.0.0/16 ip saddr set #{public_ipv4} notrack
  }
}
```
The above rule means;
- If there is a packet coming into public ipv4 address of the VM, we change it to private ip. We use stateless nat here since the number of state objects increasing with the connection count can bring down the whole system to kneel.
- If there is a packet coming out of the VM that is targeted to a public system, change the source address of the packet to public ip, if it's destined to private ipv4, leave it as is, which will be handled by ipsec tunnelling work. Explained below.

2. Private ipv4: Using dnsmasq dhcp4
This is handled as simple as adding below line to the dnsmasq.conf 
```
dhcp-range=tapvm7m86kv,192.168.0.85,192.168.0.85,32
```
We also add the proper routing rules to handle the private ipv4 routing in between VM <-> tap* <-> namespace NAT/IPsec Tunnelling

3. Private ipv6: Using dnsmasq slaac
 This is handled by adding the below rule to the dnsmasq.conf 
 ```
 dhcp-range=tapvm7m86kv,fdfe:62d4:efc4:ef3b::2,fdfe:62d4:efc4:ef3b::2,slaac,64,12h
 ```
Slaac means there will be a router advertisement for the given range and the mask length. After that, the client figures out its own ip address and adds it to its networking stack. For this router advertisement to reach to VM, we had to add the first slice of ipv6 address to the tap* device. Though, the below is also needed;
```
r "ip -n #{q_vm} addr add #{NetAddr.parse_net(net6).nth(1)}/64 dev tap#{q_vm}"
```
4. Ipsec tunnelling for private ipv6 communication
This was already in place but the rule creation and the addresses needed some clean-up. 
5. Ipsec tunnelling for private ipv4 communication
We added new policy and states to support ipv4 in ipv6 tunnelling. Example end result for 2 VMs to communicate with each other is the following;
```
root@Ubuntu-2204-jammy-amd64-base /vm/vm7m86kv # ip x p
src 192.168.0.127/32 dst 192.168.0.85/32
	dir fwd priority 0
	tmpl src 2a01:4f8:10a:128b:fc0f:: dst 2a01:4f8:242:4f68:3f93::
		proto esp spi 0x49f55272 reqid 1 mode tunnel
src fdc9:3955:7bf:873c::/64 dst fdfe:62d4:efc4:ef3b::/64
	dir fwd priority 0
	tmpl src 2a01:4f8:10a:128b:fc0f:: dst 2a01:4f8:242:4f68:3f93::
		proto esp spi 0xf567061f reqid 1 mode tunnel
src 192.168.0.85/32 dst 192.168.0.127/32
	dir out priority 0
	tmpl src 2a01:4f8:242:4f68:3f93:: dst 2a01:4f8:10a:128b:fc0f::
		proto esp spi 0x562a887b reqid 1 mode tunnel
src fdfe:62d4:efc4:ef3b::/64 dst fdc9:3955:7bf:873c::/64
	dir out priority 0
	tmpl src 2a01:4f8:242:4f68:3f93:: dst 2a01:4f8:10a:128b:fc0f::
		proto esp spi 0x2ec0170c reqid 1 mode tunnel
root@Ubuntu-2204-jammy-amd64-base /vm/vm7m86kv # ip x s
src 2a01:4f8:10a:128b:fc0f:: dst 2a01:4f8:242:4f68:3f93::
	proto esp spi 0x49f55272 reqid 1 mode tunnel
	replay-window 0
	aead rfc4106(gcm(aes)) 0xf330d5810712412b64fd3f2c7800c15e689010abceea3b85270aa65a9132f9d736f69d32 128
	anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0
src 2a01:4f8:10a:128b:fc0f:: dst 2a01:4f8:242:4f68:3f93::
	proto esp spi 0xf567061f reqid 1 mode tunnel
	replay-window 0
	aead rfc4106(gcm(aes)) 0xf330d5810712412b64fd3f2c7800c15e689010abceea3b85270aa65a9132f9d736f69d32 128
	anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
	sel src ::/0 dst ::/0
src 2a01:4f8:242:4f68:3f93:: dst 2a01:4f8:10a:128b:fc0f::
	proto esp spi 0x562a887b reqid 1 mode tunnel
	replay-window 0
	aead rfc4106(gcm(aes)) 0xc15cd35dbb66ecc5460c9d668c42226ab34ddc1400f4593a539079947f1da9f5b81ed171 128
	anti-replay context: seq 0x0, oseq 0xc, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0
src 2a01:4f8:242:4f68:3f93:: dst 2a01:4f8:10a:128b:fc0f::
	proto esp spi 0x2ec0170c reqid 1 mode tunnel
	replay-window 0
	aead rfc4106(gcm(aes)) 0xc15cd35dbb66ecc5460c9d668c42226ab34ddc1400f4593a539079947f1da9f5b81ed171 128
	anti-replay context: seq 0x0, oseq 0x10f, bitmap 0x00000000
	sel src ::/0 dst ::/0
```
The above outputs mean that for both ip4 and ip6 stack, we check the source and destination addresses. If they are from a specific private ip4 to specific private ip6, we use them respectively with public ip6 addresses and setup a tunnel and send an encrypted packet. Both ends know the keys to encrypt/decrypt packets.