### PR TITLE
Add VsCode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,17 @@ demo/.env
 # Frontend
 node_modules
 assets/css/app.css
+
+# vscode: https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Global/VisualStudioCode.gitignore
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix


### PR DESCRIPTION
This crept into another patch, so I picked up a more extensive version in https://github.com/github/gitignore and broke it out into this change.