### PR TITLE
Change ownership of the vhost socket symlink

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -278,6 +278,11 @@ EOS
     # create a symlink to the socket in the per vm storage dir
     FileUtils.ln_s Spdk.vhost_sock(vhost), vp.vhost_sock(index)
 
+    # Change ownership of the symlink. FileUtils.chown uses File.lchown for
+    # symlinks and doesn't follow links. We don't use File.lchown directly
+    # because it expects numeric uid & gid, which is less convenient.
+    FileUtils.chown @vm_name, @vm_name, vp.vhost_sock(index)
+
     vp.vhost_sock(index)
   end
 

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe VmSetup do
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", disk_file)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", spdk_vhost_sock)
       expect(FileUtils).to receive(:ln_s).with(spdk_vhost_sock, vm_vhost_sock)
+      expect(FileUtils).to receive(:chown).with("test", "test", vm_vhost_sock)
       expect(vs).to receive(:r).with(/setfacl.*#{spdk_vhost_sock}/)
 
       expect(


### PR DESCRIPTION
We have a symlink to the spdk socket in the disk storage directory. Previously this symlink was owned by root:

```
$ ls -lh /var/storage/vm3ge3mk/0/
total 3.1G
-rw-------  1 vm3ge3mk vm3ge3mk 324 Jul  7 06:37 data_encryption_key.json
-rw-rw----+ 1 vm3ge3mk vm3ge3mk 30G Jul  7 06:38 disk.raw
lrwxrwxrwx  1 root     root      29 Jul  7 06:37 vhost.sock -> /var/storage/vhost/vm3ge3mk_0
```

This PR changes the ownership to VM user to be consistent with other files in that dir:

```
$ ls /var/storage/vm7a9tfk/0/ -lh
total 2.2G
-rw-------  1 vm7a9tfk vm7a9tfk 324 Jul  7 06:49 data_encryption_key.json
-rw-rw----+ 1 vm7a9tfk vm7a9tfk 30G Jul  7 06:49 disk.raw
lrwxrwxrwx  1 vm7a9tfk vm7a9tfk  29 Jul  7 06:49 vhost.sock -> /var/storage/vhost/vm7a9tfk_0
```