### PR TITLE
FsyncFail should inherit directly from Exception

### DIFF
--- a/rhizome/lib/common.rb
+++ b/rhizome/lib/common.rb
@@ -18,8 +18,10 @@ class CommandFail < RuntimeError
   end
 end
 
-class FsyncFail < RuntimeError
+# rubocop:disable Lint/InheritException
+class FsyncFail < Exception
 end
+# rubocop:enable Lint/InheritException
 
 def r(commandline, stdin: "")
   stdout, stderr, status = Open3.capture3(commandline, stdin_data: stdin)


### PR DESCRIPTION
It seems that rubocop undid this change. So, disabling rubocop for that line & redoing it.
