### PR TITLE
Move key-value data to component

### DIFF
--- a/views/components/kv_data_card.erb
+++ b/views/components/kv_data_card.erb
@@ -1,0 +1,20 @@
+<div class="overflow-hidden bg-white shadow sm:rounded-lg">
+  <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
+    <dl class="sm:divide-y sm:divide-gray-200">
+      <% data.each do |name, value, opts| %>
+        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
+          <dt class="text-sm font-medium text-gray-500"><%= name %></dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+            <% if opts && opts[:copieble] %>
+              <span class="copy-content cursor-pointer" data-content="<%= value %>" data-message="Copied <%= name %>">
+                <%= value %>
+              </span>
+            <% else %>
+              <%= value %>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+</div>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -15,45 +15,20 @@
   <div class="mt-8 flow-root">
     <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
       <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-        <div class="overflow-hidden bg-white shadow sm:rounded-lg">
-          <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
-            <dl class="sm:divide-y sm:divide-gray-200">
-              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
-                <dt class="text-sm font-medium text-gray-500">ID</dt>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:ulid] %></dd>
-              </div>
-              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
-                <dt class="text-sm font-medium text-gray-500">Name</dt>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:name] %></dd>
-              </div>
-              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
-                <dt class="text-sm font-medium text-gray-500">Project</dt>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:projects].map { _1[:name] }.join(", ") %></dd>
-              </div>
-              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
-                <dt class="text-sm font-medium text-gray-500">Provider & Location</dt>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:location] %></dd>
-              </div>
-              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
-                <dt class="text-sm font-medium text-gray-500">Size</dt>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:size] %></dd>
-              </div>
-              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
-                <dt class="text-sm font-medium text-gray-500">Storage</dt>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @vm[:storage_size_gib] %>
-                  GB (<%= @vm[:storage_encryption] %>)</dd>
-              </div>
-              <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
-                <dt class="text-sm font-medium text-gray-500">IPv6</dt>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
-                  <span class="copy-content cursor-pointer" data-content="<%= @vm[:ip6] %>" data-message="Copied IPv6">
-                    <%= @vm[:ip6] %>
-                  </span>
-                </dd>
-              </div>
-            </dl>
-          </div>
-        </div>
+        <%== render(
+          "components/kv_data_card",
+          locals: {
+            data: [
+              ["ID", @vm[:ulid]],
+              ["Name", @vm[:name]],
+              ["Project", @vm[:projects].map { _1[:name] }.join(", ")],
+              ["Provider & Location", @vm[:location]],
+              ["Size", @vm[:size]],
+              ["Storage", "#{@vm[:storage_size_gib]}GB (#{@vm[:storage_encryption]})"],
+              ["IPv6", @vm[:ip6], { copieble: true }]
+            ]
+          }
+        ) %>
         <% if Authorization.has_permission?(rodauth.session_value, "Vm:delete", @vm[:id]) %>
           <div class="mt-6 bg-white shadow sm:rounded-lg">
             <div class="px-4 py-5 sm:p-6">


### PR DESCRIPTION
It makes easier to update data shown on vm detail page. Devs don't have to mess with HTML details. It can be used for other resources in future.