### PR TITLE
Rename authorization tags for vm and projects

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -66,16 +66,8 @@ module Authorization
       end
     end
 
-    def hyper_tag_identifier
-      :name
-    end
-
-    def hyper_tag_prefix
-      self.class.name
-    end
-
-    def hyper_tag_name
-      "#{hyper_tag_prefix}/#{send(hyper_tag_identifier)}"
+    def hyper_tag_name(project = nil)
+      raise NoMethodError
     end
 
     def hyper_tag(project)
@@ -83,7 +75,7 @@ module Authorization
     end
 
     def create_hyper_tag(project)
-      AccessTag.create(project_id: project.id, name: hyper_tag_name, hyper_tag_id: id, hyper_tag_table: self.class.table_name)
+      AccessTag.create(project_id: project.id, name: hyper_tag_name(project), hyper_tag_id: id, hyper_tag_table: self.class.table_name)
     end
 
     def delete_hyper_tag(project)

--- a/model/account.rb
+++ b/model/account.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "ulid"
 require "mail"
 require_relative "../model"
 
@@ -8,12 +7,8 @@ class Account < Sequel::Model(:accounts)
   include ResourceMethods
   include Authorization::HyperTagMethods
 
-  def hyper_tag_identifier
-    :email
-  end
-
-  def hyper_tag_prefix
-    "User"
+  def hyper_tag_name(project = nil)
+    "user/#{email}"
   end
 
   include Authorization::TaggableMethods
@@ -28,6 +23,6 @@ class Account < Sequel::Model(:accounts)
 
   # TODO: probably we need to get name from users
   def username
-    "#{Mail::Address.new(email).local}_#{ULID.from_uuidish(id).to_s[0..5].downcase}"
+    "#{Mail::Address.new(email).local}-#{ulid.to_s[0..5].downcase}"
   end
 end

--- a/model/project.rb
+++ b/model/project.rb
@@ -12,6 +12,11 @@ class Project < Sequel::Model
 
   include ResourceMethods
   include Authorization::HyperTagMethods
+
+  def hyper_tag_name(project = nil)
+    "project/#{ulid}"
+  end
+
   include Authorization::TaggableMethods
 
   def user_ids

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -18,6 +18,11 @@ class Vm < Sequel::Model
   semaphore :destroy, :refresh_mesh
 
   include Authorization::HyperTagMethods
+
+  def hyper_tag_name(project)
+    "project/#{project.ulid}/location/#{location}/vm/#{name}"
+  end
+
   include Authorization::TaggableMethods
 
   def path

--- a/views/project/show_policies.erb
+++ b/views/project/show_policies.erb
@@ -43,9 +43,9 @@
                   <p class="mt-2">
                     Access policies have 3 main parts: subjects, actions, and objects. All of them can be a single
                     string or a list of strings.
-                    <span class="text-gray-700 font-medium">"Project/&lt;NAME&gt;"</span>,
-                    <span class="text-gray-700 font-medium">"User/&lt;EMAIL&gt;"</span>,
-                    <span class="text-gray-700 font-medium">"Vm/&lt;NAME&gt;"</span>
+                    <span class="text-gray-700 font-medium">"project/&lt;PROJECT_ID&gt;"</span>,
+                    <span class="text-gray-700 font-medium">"user/&lt;EMAIL&gt;"</span>,
+                    <span class="text-gray-700 font-medium">"project/&lt;PROJECT_ID&gt;/location/&lt;LOCATION_NAME&gt;/vm/&lt;VM_NAME&gt;"</span>
                     or custom tags can be used for subjects, and objects. To use a tag in policy, it should have to
                     assoaciated with the project. Actions are predefined.
                   </p>


### PR DESCRIPTION
While designing API, we made some decisions about name uniqueness of
resources based on multi-region instance deployments. Global uniqueness
is a hard problem to solve when you have multiple instances running.
We try to minimize universe of uniqueness as possible as.

- Project: Project name is not unique anymore. Different users may have
  projects like "Prod", "Dev" etc. We don't want to limit them. To
  achieve hypertag uniqueness we use project id in tags instead of name.

    `Project/#{project.name}` to `project/#{project.ulid}`

- Vm: Vm names are unique in project and location. Different projects or
  locations may have vms with same name. To achieve hypertag uniqueness
  we use project id and location name in tags. It also helps us to
  determine project and location of the vm, when any clover instance get
  request for the vm. We don't need to keep a global store for
  name-location pairs.

    `Vm/#{vm.name}` to `project/#{project.ulid}/location/#{location}/vm/#{name}`

- User: Transform resource type prefix to lowercase.

    `User/#{user.email}` to `user/#{user.email}`

Hypertag prefixes are lowercase, and they are matched with path of
resources at web console and API. It makes finding hypertag of a resource
easier. User can just copy resource path from address bar and use as
hypertag.

I will change web console paths in the following patches.