### PR TITLE
Introduce UBID identifiers

### DIFF
--- a/lib/ubid.rb
+++ b/lib/ubid.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require("securerandom")
+
+class UBID
+  # Binary format, which is UUDIv8 compatible, is:
+  # 0                   1                   2                   3
+  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+  #  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  #  |                      32_bit_uint_time_high                    |
+  #  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  #  |     16_bit_uint_time_low      |  ver  |r_1|  type_1 |  type_2 |
+  #  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  #  |var|                         r_2                               |
+  #  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  #  |                             r_2                               |
+  #  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  #
+  # String format is:
+  #  base32(type_1) + base32(type_2) + \
+  #    base32_n(msb[0..53] * 2 + parity(msb[0..53])) + \
+  #    base32_n(msb[64..127] * 2 + parity(msb[64..127))
+
+  # we have 64 random bits in the format, so 2^64 - 1
+  MAX_ENTROPY = 18446744073709551615
+
+  def self.generate(type, moment: current_milliseconds, entropy: reasonable_entropy)
+    from_parts(moment, type, entropy & 0b11, entropy >> 2)
+  end
+
+  def self.from_uuidish(uuidish)
+    value = uuidish.to_s.tr("-", "").to_i(16)
+    new(value)
+  end
+
+  def to_uuid
+    # 8-4-4-4-12 format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    a = UBID.extract_bits_as_hex(@value, 24, 8)
+    b = UBID.extract_bits_as_hex(@value, 20, 4)
+    c = UBID.extract_bits_as_hex(@value, 16, 4)
+    d = UBID.extract_bits_as_hex(@value, 12, 4)
+    e = UBID.extract_bits_as_hex(@value, 0, 12)
+    "#{a}-#{b}-#{c}-#{d}-#{e}"
+  end
+
+  def self.parse(s)
+    fail "Invalid encoding length: #{s.length}" unless s.length == 26
+
+    type = s[0..1]
+
+    top_bits_with_parity = to_base32_n(s[2..12])
+    fail "Invalid top bits parity" unless parity(top_bits_with_parity) == 0
+    top_bits = (top_bits_with_parity >> 1)
+    unix_ts_ms = get_bits(top_bits, 6, 53)
+    version = get_bits(top_bits, 2, 5)
+    rand_a = get_bits(top_bits, 0, 1)
+
+    bottom_bits_with_parity = to_base32_n(s[13..])
+    fail "Invalid bottom bits parity" unless parity(bottom_bits_with_parity) == 0
+    bottom_bits = (bottom_bits_with_parity >> 1)
+    variant = get_bits(bottom_bits, 62, 63)
+    rand_b = get_bits(bottom_bits, 0, 61)
+
+    from_parts(unix_ts_ms, type, rand_a, rand_b, version: version, variant: variant)
+  end
+
+  def self.from_parts(unix_ts_ms, type, rand_a, rand_b, version: 0b1000, variant: 0b10)
+    value = 0
+    # timestamp (48 bits)
+    value |= (unix_ts_ms & 0xffffffffffff) << 80
+    # version (4 bits)
+    value = set_bits(value, 76, 79, version)
+    # rand_a (2 bits)
+    value = set_bits(value, 74, 75, rand_a & 0b11)
+    # type char 1 (5 bits)
+    value = set_bits(value, 69, 73, to_base32(type[0]))
+    # type char 2 (5 bits)
+    value = set_bits(value, 64, 68, to_base32(type[1]))
+    # variant (2 bits)
+    value = set_bits(value, 62, 63, variant)
+    # rand_b (62 bits)
+    value |= (rand_b & 0x3fffffffffffffff)
+
+    new(value)
+  end
+
+  def initialize(value)
+    @value = value
+  end
+
+  def to_s
+    result = ""
+    # type
+    result += UBID.from_base32(UBID.get_bits(@value, 69, 73))
+    result += UBID.from_base32(UBID.get_bits(@value, 64, 68))
+    # top-bits: 127..74 (54 bits)
+    top_bits = UBID.get_bits(@value, 74, 127)
+    result += UBID.from_base32_n((top_bits << 1) | UBID.parity(top_bits), 11)
+    # bottom-bits: 63..0 (64 bits)
+    bottom_bits = UBID.get_bits(@value, 0, 63)
+    result += UBID.from_base32_n((bottom_bits << 1) | UBID.parity(bottom_bits), 13)
+    result
+  end
+
+  def to_i
+    @value
+  end
+
+  #
+  # Utility functions
+  #
+
+  def self.current_milliseconds
+    (Time.now.to_r * 1000).to_i
+  end
+
+  def self.reasonable_entropy
+    SecureRandom.random_number(MAX_ENTROPY)
+  end
+
+  def self.set_bits(n, from, to, bits)
+    (from..to).each { |i|
+      if (bits & (1 << (i - from))) != 0
+        n |= (1 << i)
+      end
+    }
+    n
+  end
+
+  def self.get_bits(n, from, to)
+    result = 0
+    (from..to).each { |i|
+      if (n & (1 << i)) != 0
+        result |= (1 << (i - from))
+      end
+    }
+    result
+  end
+
+  BASE32_DATA = [
+    "0Oo",
+    "1IL",
+    "2", "3", "4", "5", "6", "7", "8", "9",
+    "A", "B", "C", "D", "E", "F", "G", "H",
+    "J", "K", "M", "N", "P", "Q", "R", "S",
+    "T", "V", "W", "X", "Y", "Z"
+  ]
+
+  def self.to_base32(c)
+    c = c.upcase
+    BASE32_DATA.each_with_index do |e, idx|
+      if e.include? c
+        return idx
+      end
+    end
+
+    raise "Invalid base32 encoding: #{c}"
+  end
+
+  def self.to_base32_n(s)
+    result = 0
+    s.chars.each {
+      result = result * 32 + to_base32(_1)
+    }
+    result
+  end
+
+  def self.from_base32(num)
+    fail "Invalid base32 number: #{num}" if num < 0 || num >= 32
+    BASE32_DATA[num][0].downcase
+  end
+
+  def self.from_base32_n(num, cnt)
+    (cnt - 1).downto(0).map { |i|
+      from_base32(get_bits(num, 5 * i, 5 * i + 4))
+    }.join
+  end
+
+  def self.parity(num)
+    if num == 0
+      0
+    elsif (num & 1) == 0
+      parity(num >> 1)
+    else
+      1 - parity(num >> 1)
+    end
+  end
+
+  def self.extract_bits_as_hex(value, from_digit, digit_count)
+    bit_count = digit_count * 4
+    from_bit = from_digit * 4
+    bitmask = (1 << bit_count) - 1
+    bits_i = (value & (bitmask << from_bit)) >> from_bit
+    bits_i.to_s(16).rjust(digit_count, "0")
+  end
+end

--- a/spec/lib/ubid_spec.rb
+++ b/spec/lib/ubid_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/ubid"
+require "ulid"
+
+RSpec.describe UBID do
+  it "can set_bits" do
+    expect(described_class.set_bits(0, 0, 7, 0xab)).to eq(0xab)
+    expect(described_class.set_bits(0xab, 8, 12, 0xc)).to eq(0xcab)
+    expect(described_class.set_bits(0xcab, 40, 48, 0x12)).to eq(0x120000000cab)
+  end
+
+  it "can get bits" do
+    expect(described_class.get_bits(0x120000000cab, 8, 11)).to eq(0xc)
+  end
+
+  it "can convert to base32" do
+    tests = [
+      ["0", 0], ["o", 0], ["A", 10], ["e", 14], ["m", 20], ["S", 25], ["z", 31]
+    ]
+    tests.each {
+      expect(described_class.to_base32(_1[0])).to eq(_1[1])
+    }
+  end
+
+  it "can extract bits as hex" do
+    expect(described_class.extract_bits_as_hex(0x12345, 1, 3)).to eq("234")
+    expect(described_class.extract_bits_as_hex(0xabcdef00012, 4, 5)).to eq("cdef0")
+    expect(described_class.extract_bits_as_hex(0xabcdef00012, 1, 4)).to eq("0001")
+    expect(described_class.extract_bits_as_hex(0xabcdef00012, 9, 5)).to eq("000ab")
+  end
+
+  it "can encode multiple numbers" do
+    expect(described_class.from_base32_n(10 + 20 * 32 + 1 * 32 * 32, 3)).to eq("1ma")
+  end
+
+  it "fails to convert U to base32" do
+    expect { described_class.to_base32("u") }.to raise_error RuntimeError, "Invalid base32 encoding: U"
+  end
+
+  it "can convert from base32" do
+    tests = [
+      [0, "0"], [12, "c"], [16, "g"], [20, "m"], [26, "t"], [28, "w"], [31, "z"]
+    ]
+    tests.each {
+      expect(described_class.from_base32(_1[0])).to eq(_1[1])
+    }
+  end
+
+  it "can convert multiple from base32" do
+    expect(described_class.to_base32_n("1MA")).to eq(10 + 20 * 32 + 1 * 32 * 32)
+  end
+
+  it "fails to convert from out of range numbers" do
+    expect {
+      described_class.from_base32(-1)
+    }.to raise_error RuntimeError, "Invalid base32 number: -1"
+
+    expect {
+      described_class.from_base32(32)
+    }.to raise_error RuntimeError, "Invalid base32 number: 32"
+  end
+
+  it "can calculate parity" do
+    expect(described_class.parity(0b10101)).to eq(1)
+    expect(described_class.parity(0b101011)).to eq(0)
+  end
+
+  it "can create from parts & encode it & parse it" do
+    id = described_class.from_parts(1000, "ab", 3, 12292929)
+    expect(described_class.parse(id.to_s).to_i).to eq(id.to_i)
+  end
+
+  it "generates the same ULID as the ULID it was generated from" do
+    ulid1 = ULID.generate
+    ubid1 = described_class.new(ulid1.to_i)
+    ubid2 = described_class.parse(ubid1.to_s)
+    ulid2 = ULID.from_integer(ubid2.to_i)
+    expect(ulid1.to_s).to eq(ulid2.to_s)
+  end
+
+  it "can generate random ids" do
+    ubid1 = described_class.generate("vm")
+    ubid2 = described_class.parse(ubid1.to_s)
+    expect(ubid2.to_i).to eq(ubid1.to_i)
+  end
+
+  it "can convert to and from uuid" do
+    ubid1 = described_class.generate("sr")
+    ubid2 = described_class.from_uuidish(ubid1.to_uuid)
+    expect(ubid2.to_s).to eq(ubid1.to_s)
+  end
+
+  it "can convert from and to uuid" do
+    uuid1 = "550e8400-e29b-41d4-a716-446655440000"
+    uuid2 = described_class.from_uuidish(uuid1).to_uuid
+    expect(uuid2).to eq(uuid1)
+  end
+
+  it "fails to parse if length is not 26" do
+    expect {
+      described_class.parse("123456")
+    }.to raise_error RuntimeError, "Invalid encoding length: 6"
+  end
+
+  it "fails to parse if top bits parity is incorrect" do
+    invalid_ubid = "vm164pbm96ba3grq6vbsvjb3ax"
+    expect {
+      described_class.parse(invalid_ubid)
+    }.to raise_error RuntimeError, "Invalid top bits parity"
+  end
+
+  it "fails to parse if bottom bits parity is incorrect" do
+    invalid_ubid = "vm064pbm96ba3grq6vbsvjb3az"
+    expect {
+      described_class.parse(invalid_ubid)
+    }.to raise_error RuntimeError, "Invalid bottom bits parity"
+  end
+end


### PR DESCRIPTION
This PR adds the UBID class which represents identifiers, similar to ulids, but with following advantages:

* UUIDv8 compatible
* Has reasonable sorting behaviour
  * Binary format sorts by time, then by type
  * String format sorts by type, then by time
* Has type digits as prefix of string representation, which is useful for logs, unix names, ....
* Uses the extra 2-bits in string representation to store parity information

An example usage & its string representation is:

```
> ubid = UBID.generate("vm")
=> #<UBID:0x00007f4fa389e780 @value=2042640560516295518174432377362386156>

> ubid.to_s
=> "vm064pbx41f62j8ajywqmqc6es"
```

As you see, the string representation starts with the type characters we provided, and it consists of 26 base-32 characters.

## API
### Construction
* From type, timestamp, and random number: `UBID.generate(type, moment: current_milliseconds, entropy: reasonable_entropy)`
* From string representation: `UBID.parse(s)`
* From UUID: `UBID.from_uuidish(uuidish)`
* From low-level parts: `UBID.from_parts(unix_ts_ms, type, rand_a, rand_b, version: 0b1000, variant: 0b10)`
* From a 128-bit integer: `UBID.new(n)`

### Conversion
* To string representation: `ubid.to_s`
* To integer representation: `ubid.to_i`
* To UUID: `ubid.to_uuid`

## Binary Format

Binary format is as follows which is UUIDv8 compatible.

```
0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                      32_bit_uint_time_high                    |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|     16_bit_uint_time_low      |  ver  |r_1|  type_1 |  type_2 |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|var|                         r_2                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                             r_2                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

## String Format

```
base32(type_1) + base32(type_2) + \
   base32_n(msb[0..53] * 2 + parity(msb[0..53])) + \
   base32_n(msb[64..127] * 2 + parity(msb[64..127))
```
