### PR TITLE
Fix SshError message for vm destroy

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -338,13 +338,13 @@ SQL
       begin
         host.sshable.cmd("sudo systemctl stop #{q_vm}")
       rescue Sshable::SshError => ex
-        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.message)
+        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
       end
 
       begin
         host.sshable.cmd("sudo systemctl stop #{q_vm}-dnsmasq")
       rescue Sshable::SshError => ex
-        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.message)
+        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
       end
 
       host.sshable.cmd("sudo bin/deletevm.rb #{q_vm}")


### PR DESCRIPTION
We moved command's error output from `message` to `stderr` at 3bc75ce81ad77abed0ced998cc06453d918610af.

Vm destroy checks wrong property and stuck here.