### PR TITLE
Delete vm associations while destroying it

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -352,6 +352,9 @@ SQL
 
     DB.transaction do
       vm.private_subnets_dataset.delete
+      vm.assigned_vm_address_dataset.delete
+      vm.vm_storage_volumes_dataset.delete
+
       VmHost.dataset.where(id: vm.vm_host_id).update(
         used_cores: Sequel[:used_cores] - vm.cores
       )


### PR DESCRIPTION
AssignedVmAddress and VmStorageVolume were introduced at previous commits.

They're not removed while destroying vm. It blocks operation with 'DETAIL:  Key (id)=(UUID) is still referenced from table "assigned_vm_address"' exception.

We might need extra operations at dataplane to cleanup residues.