### PR TITLE
Expand NAT to include all private IPv4 ranges

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -195,7 +195,7 @@ table ip raw {
   chain prerouting {
     type filter hook prerouting priority raw; policy accept;
     ip daddr #{public_ipv4} ip daddr set #{private_ipv4} notrack
-    ip saddr #{private_ipv4} ip daddr != 192.168.0.0/16 ip saddr set #{public_ipv4} notrack
+    ip saddr #{private_ipv4} ip daddr != { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } ip saddr set #{public_ipv4} notrack
   }
 }
 NFTABLES_CONF


### PR DESCRIPTION
The previous commit https://github.com/ubicloud/ubicloud/commit/6524645b650262d7efd1bdc5a3b411e7361ed356 ommits to itemize
private ipv4 Class A (10.0.0.0/8) and Class B (172.16.0.0/12) address ranges for
NAT. We are adding them to the list of NATted ranges because we want to support
them as part of the virtual networking setup. This means, via nftables, for an
outgoing packet, if the destination ip is not part of these subnets, we replace
the source ip addr with the public ip, becuase simply client wants to
communicate with public ip addresses. If not, we keep it as is and the
communication is handled by ipsec tunnels in later stages.