### PR TITLE
Make unencrypted storage default.

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -12,7 +12,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   def self.assemble(public_key, project_id, name: nil, size: "m5a.2x",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
-    private_subnets: [], storage_size_gib: 20, storage_encrypted: true)
+    private_subnets: [], storage_size_gib: 20, storage_encrypted: false)
 
     project = Project[project_id]
     unless project || Config.development?


### PR DESCRIPTION
We currently hit I/O issues in VMs with encrypted disks. For example following when doing `sudo apt upgrade`:

```
update-initramfs: Generating /boot/initrd.img-5.15.0-75-generic
sync: error syncing '/boot/initrd.img-5.15.0-75-generic': Input/output error
```

or

```
$ touch test.txt
touch: cannot touch 'test.txt': Read-only file system
```

See https://github.com/ubicloud/ubicloud/issues/276 for details.

This PR makes unencrypted default until we resolve those issues.