### PR TITLE
Add full name field to user

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -122,6 +122,9 @@ class CloverWeb < Roda
     create_account_view { view "auth/create_account", "Create Account" }
     create_account_redirect { login_route }
     create_account_set_password? true
+    before_create_account do
+      account[:name] = param("name")
+    end
     after_create_account do
       current_user = Account[account_id]
       current_user.create_project_with_default_policy("#{current_user.username}-default-project")

--- a/migrate/20230713_add_user_name.rb
+++ b/migrate/20230713_add_user_name.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:accounts) do
+      add_column :name, :text, collate: '"C"'
+    end
+  end
+end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Clover, "auth" do
 
   it "can not login new account without verification" do
     visit "/create-account"
-    fill_in "Email address", with: TEST_USER_EMAIL
+    fill_in "Email Address", with: TEST_USER_EMAIL
     fill_in "Password", with: TEST_USER_PASSWORD
     fill_in "Password Confirmation", with: TEST_USER_PASSWORD
     click_button "Create Account"
@@ -21,7 +21,7 @@ RSpec.describe Clover, "auth" do
     expect(page.title).to eq("Ubicloud - Login")
 
     visit "/login"
-    fill_in "Email address", with: TEST_USER_EMAIL
+    fill_in "Email Address", with: TEST_USER_EMAIL
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -30,7 +30,8 @@ RSpec.describe Clover, "auth" do
 
   it "can create new account and verify it" do
     visit "/create-account"
-    fill_in "Email address", with: TEST_USER_EMAIL
+    fill_in "Full Name", with: "John Doe"
+    fill_in "Email Address", with: TEST_USER_EMAIL
     fill_in "Password", with: TEST_USER_PASSWORD
     fill_in "Password Confirmation", with: TEST_USER_PASSWORD
     click_button "Create Account"
@@ -50,7 +51,7 @@ RSpec.describe Clover, "auth" do
     account = create_account
 
     visit "/login"
-    fill_in "Email address", with: TEST_USER_EMAIL
+    fill_in "Email Address", with: TEST_USER_EMAIL
     fill_in "Password", with: TEST_USER_PASSWORD
     check "Remember me"
     click_button "Sign in"

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Clover do
     expect(Account).to receive(:[]).and_raise(RuntimeError)
 
     visit "/create-account"
-    fill_in "Email address", with: TEST_USER_EMAIL
+    fill_in "Email Address", with: TEST_USER_EMAIL
     fill_in "Password", with: TEST_USER_PASSWORD
     fill_in "Password Confirmation", with: TEST_USER_PASSWORD
 

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -31,7 +31,7 @@ end
 
 def login(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
   visit "/login"
-  fill_in "Email address", with: email
+  fill_in "Email Address", with: email
   fill_in "Password", with: password
   click_button "Sign in"
 

--- a/views/auth/create_account.erb
+++ b/views/auth/create_account.erb
@@ -8,9 +8,21 @@
   <%== render(
     "components/form/text",
     locals: {
+      name: "name",
+      label: "Full Name",
+      attributes: {
+        required: true,
+        autocomplete: "name"
+      }
+    }
+  ) %>
+
+  <%== render(
+    "components/form/text",
+    locals: {
       name: "login",
       type: "email",
-      label: "Email address",
+      label: "Email Address",
       attributes: {
         required: true,
         autocomplete: "email"

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -10,7 +10,7 @@
     locals: {
       name: "login",
       type: "email",
-      label: "Email address",
+      label: "Email Address",
       attributes: {
         required: true,
         autocomplete: "email"

--- a/views/auth/reset_password_request.erb
+++ b/views/auth/reset_password_request.erb
@@ -12,7 +12,7 @@
     locals: {
       name: "login",
       type: "email",
-      label: "Email address",
+      label: "Email Address",
       attributes: {
         required: true,
         autocomplete: "email"

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -105,7 +105,7 @@
             />
           </svg>
           <span class="sr-only">Your profile</span>
-          <span aria-hidden="true"><%= DB[:accounts].where(id: rodauth.session_value).get(:email) %></span>
+          <span aria-hidden="true"><%= DB[:accounts].where(id: rodauth.session_value).get(:name) %></span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
We only get email and password from user while registering. Full name is another good data to help to get more insight about customer. Also it can be used at console UI and emails.

I checked other nonhyperscalers and they get full name too.