### PR TITLE
Add custom rspec matcher to expect prog hop

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -94,7 +94,7 @@ end
   end
 
   class Hop < FlowControl
-    attr_reader :strand_update_args
+    attr_reader :strand_update_args, :old_prog
 
     def initialize(old_prog, old_label, strand_update_args)
       @old_prog = old_prog

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe Prog::BootstrapRhizome do
 
       expect(br).to receive(:sshable).and_return(sshable)
 
-      expect { br.start }.to raise_error Prog::Base::Hop do |h|
-        expect(h.to_s).to eq("hop BootstrapRhizome#start -> BootstrapRhizome#setup")
-      end
+      expect { br.start }.to hop("setup", "BootstrapRhizome")
     end
   end
 
@@ -43,9 +41,7 @@ sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authoriz
 echo test key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 FIXTURE
 
-      expect { br.setup }.to raise_error Prog::Base::Hop do |h|
-        expect(h.to_s).to eq("hop BootstrapRhizome#setup -> InstallRhizome#start")
-      end
+      expect { br.setup }.to hop("start", "InstallRhizome")
     end
 
     it "exits once InstallRhizome has returned" do

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe Prog::InstallDnsmasq do
       expect(idm).to receive(:bud).with(described_class, {sshable_id: "bogus"}, :install_build_dependencies)
       expect(idm).to receive(:bud).with(described_class, {sshable_id: "bogus"}, :git_clone_dnsmasq)
 
-      expect { idm.start }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq "wait_downloads"
-      end
+      expect { idm.start }.to hop("wait_downloads")
     end
   end
 
@@ -30,9 +28,7 @@ RSpec.describe Prog::InstallDnsmasq do
 
     it "hops to compile_and_install when the downloads are done" do
       expect(idm).to receive(:leaf?).and_return true
-      expect { idm.wait_downloads }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq "compile_and_install"
-      end
+      expect { idm.wait_downloads }.to hop("compile_and_install")
     end
   end
 

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe Prog::InstallRhizome do
         # https://www.gnu.org/software/tar/manual/html_node/Standard.html
         expect(kwargs[:stdin][257..261]).to eq "ustar"
       end
-      expect { ir.start }.to raise_error Prog::Base::Hop do |h|
-        expect(h.new_label).to eq "install_gems"
-      end
+      expect { ir.start }.to hop("install_gems")
     end
   end
 

--- a/spec/prog/setup_hugepages_spec.rb
+++ b/spec/prog/setup_hugepages_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe Prog::SetupHugepages do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with("echo 1").and_return("1")
       expect(sh).to receive(:sshable).and_return(sshable)
-      expect { sh.wait_reboot }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("check_hugepages")
-      end
+      expect { sh.wait_reboot }.to hop("check_hugepages")
     end
   end
 

--- a/spec/prog/setup_spdk_spec.rb
+++ b/spec/prog/setup_spdk_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe Prog::SetupSpdk do
       expect(vm_host).to receive(:used_hugepages_1g).and_return(0)
       expect(ss).to receive(:sshable).and_return(sshable)
       expect(ss).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect { ss.start }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("start_service")
-      end
+      expect { ss.start }.to hop("start_service")
     end
 
     it "fails if not enough hugepages" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -44,9 +44,7 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#start" do
     it "buds a bootstrap rhizome process" do
       expect(nx).to receive(:bud).with(Prog::BootstrapRhizome)
-      expect { nx.start }.to raise_error Prog::Base::Hop do
-        expect(_1.new_label).to eq("wait_bootstrap_rhizome")
-      end
+      expect { nx.start }.to hop("wait_bootstrap_rhizome")
     end
   end
 
@@ -56,9 +54,7 @@ RSpec.describe Prog::Vm::HostNexus do
     it "hops to prep if there are no sub-programs running" do
       expect(nx).to receive(:leaf?).and_return true
 
-      expect { nx.wait_bootstrap_rhizome }.to raise_error Prog::Base::Hop do
-        expect(_1.new_label).to eq("prep")
-      end
+      expect { nx.wait_bootstrap_rhizome }.to hop("prep")
     end
 
     it "donates if there are sub-programs running" do
@@ -78,9 +74,7 @@ RSpec.describe Prog::Vm::HostNexus do
         budded << _1
       end.at_least(:once)
 
-      expect { nx.prep }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("wait_prep")
-      end
+      expect { nx.prep }.to hop("wait_prep")
 
       expect(budded).to eq([
         Prog::Vm::PrepHost,
@@ -98,9 +92,7 @@ RSpec.describe Prog::Vm::HostNexus do
         budded_learn_network ||= (_1 == Prog::LearnNetwork)
       end.at_least(:once)
 
-      expect { nx.prep }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("wait_prep")
-      end
+      expect { nx.prep }.to hop("wait_prep")
 
       expect(budded_learn_network).to be true
     end
@@ -119,9 +111,7 @@ RSpec.describe Prog::Vm::HostNexus do
         {prog: "ArbitraryOtherProg"}
       ])
 
-      expect { nx.wait_prep }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("setup_hugepages")
-      end
+      expect { nx.wait_prep }.to hop("setup_hugepages")
     end
 
     it "crashes if an expected field is not set for LearnMemory" do
@@ -145,9 +135,7 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#setup_hugepages" do
     it "buds the hugepage program" do
       expect(nx).to receive(:bud).with(Prog::SetupHugepages)
-      expect { nx.setup_hugepages }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("wait_setup_hugepages")
-      end
+      expect { nx.setup_hugepages }.to hop("wait_setup_hugepages")
     end
   end
 
@@ -158,9 +146,7 @@ RSpec.describe Prog::Vm::HostNexus do
       vmh = instance_double(VmHost)
       nx.instance_variable_set(:@vm_host, vmh)
 
-      expect { nx.wait_setup_hugepages }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("setup_spdk")
-      end
+      expect { nx.wait_setup_hugepages }.to hop("setup_spdk")
     end
 
     it "donates its time if child strands are still running" do
@@ -175,9 +161,7 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#setup_spdk" do
     it "buds the spdk program" do
       expect(nx).to receive(:bud).with(Prog::SetupSpdk)
-      expect { nx.setup_spdk }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("wait_setup_spdk")
-      end
+      expect { nx.setup_spdk }.to hop("wait_setup_spdk")
     end
   end
 
@@ -190,9 +174,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
       expect(vmh).to receive(:update).with(allocation_state: "accepting")
 
-      expect { nx.wait_setup_spdk }.to raise_error(Prog::Base::Hop) do
-        expect(_1.new_label).to eq("wait")
-      end
+      expect { nx.wait_setup_spdk }.to hop("wait")
     end
 
     it "donates its time if child strands are still running" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -43,9 +43,7 @@ RSpec.describe Prog::Vm::Nexus do
     it "runs adduser" do
       expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/)
 
-      expect { nx.create_unix_user }.to raise_error Prog::Base::Hop do |hop|
-        expect(hop.new_label).to eq("prep")
-      end
+      expect { nx.create_unix_user }.to hop("prep")
     end
 
     it "absorbs an already-exists error as a success" do
@@ -53,9 +51,7 @@ RSpec.describe Prog::Vm::Nexus do
         Sshable::SshError.new("adduser", "", "adduser: The user `vmabc123' already exists.", 1, nil)
       )
 
-      expect { nx.create_unix_user }.to raise_error Prog::Base::Hop do |hop|
-        expect(hop.new_label).to eq("prep")
-      end
+      expect { nx.create_unix_user }.to hop("prep")
     end
 
     it "raises other errors" do
@@ -96,9 +92,7 @@ RSpec.describe Prog::Vm::Nexus do
       end
       expect(sshable).to receive(:cmd).with(/sudo bin\/prepvm/, {stdin: "{\"storage\":{}}"})
 
-      expect { nx.prep }.to raise_error Prog::Base::Hop do |hop|
-        expect(hop.new_label).to eq("trigger_refresh_mesh")
-      end
+      expect { nx.prep }.to hop("trigger_refresh_mesh")
     end
 
     it "generates local_ipv4 if not set" do
@@ -127,9 +121,7 @@ RSpec.describe Prog::Vm::Nexus do
         expect(args[:vm_host_id]).to match vmh_id
       end
 
-      expect { nx.start }.to raise_error Prog::Base::Hop do |hop|
-        expect(hop.new_label).to eq("create_unix_user")
-      end
+      expect { nx.start }.to hop("create_unix_user")
     end
   end
 


### PR DESCRIPTION
Prog hops from old label to new label via raised errors. Expecting with `to raise_error` matcher for each hop makes hard to read. New custom matcher helps to expect hop to new prog and new label.

`expect { ... }.to hop(expected_label, expected_prog)`

Failure message:

    Failure/Error: expect { idm.wait_downloads }.to hop("compile_and_install2")

             expected: InstallDnsmasq#compile_and_install2
                  got: InstallDnsmasq#compile_and_install