### PR TITLE
Add custom rspec matcher to expect prog exit

### DIFF
--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -46,9 +46,7 @@ FIXTURE
 
     it "exits once InstallRhizome has returned" do
       br.strand.retval = {"msg" => "installed rhizome"}
-      expect { br.setup }.to raise_error Prog::Base::Exit do |h|
-        expect(h.to_s).to eq('Strand exits from BootstrapRhizome#setup with {"msg"=>"rhizome user bootstrapped and source installed"}')
-      end
+      expect { br.setup }.to exit({"msg" => "rhizome user bootstrapped and source installed"})
     end
   end
 

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -38,9 +38,7 @@ RSpec.describe Prog::InstallDnsmasq do
       expect(sshable).to receive(:cmd).with "(cd dnsmasq && make -sj$(nproc) && sudo make install)"
       expect(idm).to receive(:sshable).and_return(sshable)
 
-      expect { idm.compile_and_install }.to raise_error(Prog::Base::Exit) do
-        expect(_1.exitval).to eq({"msg" => "compiled and installed dnsmasq"})
-      end
+      expect { idm.compile_and_install }.to exit({"msg" => "compiled and installed dnsmasq"})
     end
   end
 
@@ -50,9 +48,7 @@ RSpec.describe Prog::InstallDnsmasq do
       expect(sshable).to receive(:cmd).with "sudo apt-get -y install make gcc"
       expect(idm).to receive(:sshable).and_return(sshable)
 
-      expect { idm.install_build_dependencies }.to raise_error(Prog::Base::Exit) do
-        expect(_1.exitval).to eq({"msg" => "installed build dependencies"})
-      end
+      expect { idm.install_build_dependencies }.to exit({"msg" => "installed build dependencies"})
     end
   end
 
@@ -64,9 +60,7 @@ git init dnsmasq && (cd dnsmasq &&   git fetch https://github.com/fdr/dnsmasq.gi
 CMD
       expect(idm).to receive(:sshable).and_return(sshable)
 
-      expect { idm.git_clone_dnsmasq }.to raise_error(Prog::Base::Exit) do
-        expect(_1.exitval).to eq({"msg" => "downloaded and verified dnsmasq successfully"})
-      end
+      expect { idm.git_clone_dnsmasq }.to exit({"msg" => "downloaded and verified dnsmasq successfully"})
     end
   end
 end

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe Prog::InstallRhizome do
     it "runs some commands and exits" do
       expect(sshable).to receive(:cmd).with("bundle config set --local path vendor/bundle")
       expect(sshable).to receive(:cmd).with("bundle install")
-      expect { ir.install_gems }.to raise_error Prog::Base::Exit do |ex|
-        expect(ex.exitval).to eq({"msg" => "installed rhizome"})
-      end
+      expect { ir.install_gems }.to exit({"msg" => "installed rhizome"})
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,4 +180,28 @@ RSpec.configure do |config|
       prog.nil? ? "" : "#{prog}#"
     end
   end
+
+  # Custom matcher to expect Progs to exit
+  # If expected_exitval is not provided, it expects to exit with any value.
+  RSpec::Matchers.define :exit do |expected_exitval|
+    supports_block_expectations
+
+    match do |block|
+      block.call
+      false
+    rescue Prog::Base::Exit => ext
+      @ext = ext
+      expected_exitval.nil? || ext.exitval == expected_exitval
+    end
+
+    failure_message do
+      "expected: ".rjust(16) + (expected_exitval.nil? ? "exit with any value" : expected_exitval.to_s) + "\n" +
+        "got: ".rjust(16) + (@ext.nil? ? "not exited" : @ext.exitval.to_s) + "\n "
+    end
+
+    failure_message_when_negated do
+      "not expected: ".rjust(16) + (expected_exitval.nil? ? "exit with any value" : expected_exitval.to_s) + "\n" +
+        "got: ".rjust(16) + (@ext.nil? ? "not exited" : @ext.exitval.to_s) + "\n "
+    end
+  end
 end


### PR DESCRIPTION
Prog exits via raised errors. Expecting with `to raise_error` matcher for each exit makes hard to read. New custom matcher helps to expect exit with expected exitval.

`expect { ... }.to exit(expected_exitval)`

Failure message:

    Failure/Error: expect { ir.install_gems }.to exit({"msg" => "installed rhizome2"})

                 expected: {"msg"=>"installed rhizome2"}
                      got: {"msg"=>"installed rhizome"}