### PR TITLE
Add custom rspec matcher to expect prog nap

### DIFF
--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Prog::InstallDnsmasq do
     it "donates if any sub-progs are still running" do
       expect(idm).to receive(:donate).and_call_original
       expect(idm).to receive(:leaf?).and_return false
-      expect { idm.wait_downloads }.to raise_error(Prog::Base::Nap)
+      expect { idm.wait_downloads }.to nap(0)
     end
 
     it "hops to compile_and_install when the downloads are done" do

--- a/spec/prog/setup_hugepages_spec.rb
+++ b/spec/prog/setup_hugepages_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Prog::SetupHugepages do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with("echo 1").and_raise("not connected")
       expect(sh).to receive(:sshable).and_return(sshable)
-      expect { sh.wait_reboot }.to raise_error Prog::Base::Nap
+      expect { sh.wait_reboot }.to nap(15)
     end
 
     it "transitions to check_hugepages if ssh succeeds" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return false
       expect(nx).to receive(:donate).and_call_original
 
-      expect { nx.wait_bootstrap_rhizome }.to raise_error Prog::Base::Nap
+      expect { nx.wait_bootstrap_rhizome }.to nap(0)
     end
   end
 
@@ -128,7 +128,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:reap).and_return([])
       expect(nx).to receive(:leaf?).and_return(false)
       expect(nx).to receive(:donate).and_call_original
-      expect { nx.wait_prep }.to raise_error Prog::Base::Nap
+      expect { nx.wait_prep }.to nap(0)
     end
   end
 
@@ -154,7 +154,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return false
       expect(nx).to receive(:donate).and_call_original
 
-      expect { nx.wait_setup_hugepages }.to raise_error Prog::Base::Nap
+      expect { nx.wait_setup_hugepages }.to nap(0)
     end
   end
 
@@ -182,13 +182,13 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return false
       expect(nx).to receive(:donate).and_call_original
 
-      expect { nx.wait_setup_spdk }.to raise_error Prog::Base::Nap
+      expect { nx.wait_setup_spdk }.to nap(0)
     end
   end
 
   describe "#wait" do
     it "naps" do
-      expect { nx.wait }.to raise_error Prog::Base::Nap
+      expect { nx.wait }.to nap(30)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -204,4 +204,28 @@ RSpec.configure do |config|
         "got: ".rjust(16) + (@ext.nil? ? "not exited" : @ext.exitval.to_s) + "\n "
     end
   end
+
+  # Custom matcher to expect Progs to nap
+  # If expected_seconds is not provided, it expects to nap with any seconds.
+  RSpec::Matchers.define :nap do |expected_seconds|
+    supports_block_expectations
+
+    match do |block|
+      block.call
+      false
+    rescue Prog::Base::Nap => nap
+      @nap = nap
+      expected_seconds.nil? || nap.seconds == expected_seconds
+    end
+
+    failure_message do
+      "expected: ".rjust(16) + "nap" + (expected_seconds.nil? ? "" : " #{expected_seconds} seconds") + "\n" +
+        "got: ".rjust(16) + (@nap.nil? ? "not nap" : "nap #{@nap.seconds} seconds") + "\n "
+    end
+
+    failure_message_when_negated do
+      "not expected: ".rjust(16) + "nap" + (expected_seconds.nil? ? "" : " #{expected_seconds} seconds") + "\n" +
+        "got: ".rjust(16) + (@nap.nil? ? "not nap" : "nap #{@nap.seconds} seconds") + "\n "
+    end
+  end
 end


### PR DESCRIPTION
Prog naps via raised errors. Expecting with `to raise_error` matcher for each nap makes hard to read. New custom matcher helps to expect nap with expected seconds.

`expect { ... }.to nap(expected_seconds)`

Failure message:

    Failure/Error: expect { sh.wait_reboot }.to nap(30)

                 expected: nap 30 seconds
                      got: nap 15 seconds