### PR TITLE
Remove unique constraint for project name

### DIFF
--- a/migrate/20230714_not_unique_project_name.rb
+++ b/migrate/20230714_not_unique_project_name.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:project) do
+      drop_constraint :project_name_key, type: :unique
+    end
+  end
+
+  down do
+    alter_table(:project) do
+      add_unique_constraint :name
+    end
+  end
+end


### PR DESCRIPTION
Project names are not unique anymore. Different users may have projects like "Prod", "Dev" etc.