### PR TITLE
Change default project name

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -136,8 +136,7 @@ class CloverWeb < Roda
       account[:name] = param("name")
     end
     after_create_account do
-      current_user = Account[account_id]
-      current_user.create_project_with_default_policy("#{current_user.username}-default-project")
+      Account[account_id].create_project_with_default_policy("Default")
     end
 
     reset_password_view { view "auth/reset_password", "Request Password" }

--- a/model/account.rb
+++ b/model/account.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "mail"
 require_relative "../model"
 
 class Account < Sequel::Model(:accounts)
@@ -19,10 +18,5 @@ class Account < Sequel::Model(:accounts)
     associate_with_project(project)
     project.add_access_policy(name: "default", body: policy_body || Authorization.generate_default_acls(hyper_tag_name, project.hyper_tag_name))
     project
-  end
-
-  # TODO: probably we need to get name from users
-  def username
-    "#{Mail::Address.new(email).local}-#{ulid.to_s[0..5].downcase}"
   end
 end

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -16,6 +16,6 @@ def create_account(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
 
   account = Account.create(email: email, status_id: 2)
   DB[:account_password_hashes].insert(id: account.id, password_hash: hash)
-  account.create_project_with_default_policy("#{account.username}-project")
+  account.create_project_with_default_policy("Default")
   account
 end


### PR DESCRIPTION
Since project names are not unique, we don't have to add random string to make it unique. "Default" looks more humane than old one.