### PR TITLE
Fix error page layout

### DIFF
--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -16,7 +16,7 @@
   </head>
 
   <body class="h-full">
-    <% if @error_code %>
+    <% if @error %>
       <%== yield %>
     <% elsif rodauth.authenticated? %>
       <div>


### PR DESCRIPTION
I changed structure of error at 0b17aa2b93a18b3e8be4534d1231956cf354475c.
Error fields are combined into \@error hash instead of separate variables.

I forgot to update this condition check, it causes errors to render with a sidebar instead of full screen.