### PR TITLE
Introduce pop based deadlines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "warning"
 gem "pry"
 gem "excon"
 gem "jwt"
+gem 'pagerduty', '~> 2.1'
 
 group :development do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
+    pagerduty (2.1.3)
+      json (>= 1.7.7)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -257,6 +259,7 @@ DEPENDENCIES
   mail
   net-ssh
   netaddr
+  pagerduty (~> 2.1)
   pry
   pry-byebug
   puma (>= 6.2.2)

--- a/config.rb
+++ b/config.rb
@@ -44,6 +44,7 @@ module Config
   optional :versioning_app_name, string
   optional :clover_session_secret, base64, clear: true
   optional :clover_column_encryption_key, base64, clear: true
+  optional :pagerduty_key, string, clear: true
 
   override :mail_driver, (production? ? :smtp : :logger), symbol
   override :mail_from, (production? ? nil : "dev@example.com"), string

--- a/migrate/20230713_pages.rb
+++ b/migrate/20230713_pages.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:page) do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :incident_key, :text, collate: '"C"', default: Sequel.lit("md5(random()::text)")
+      column :summary, :text, collate: '"C"'
+      column :resolved_at, :timestamptz
+    end
+  end
+end

--- a/model/page.rb
+++ b/model/page.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class Page < Sequel::Model
+  dataset_module do
+    def active
+      where(resolved_at: nil)
+    end
+  end
+
+  def initialize
+    #@@pagerduty ||= Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2) if Config.pagerduty_key
+  end
+
+  def after_create
+    #@@pagerduty&.trigger(incident_key: incident_key, summary: summary, severity: "error")
+  end
+
+  def resolve
+    @resolved_at = Time.now
+
+    #@@pagerduty&.incident(incident_key)&.resolve
+  end
+end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -70,6 +70,16 @@ SQL
   end
 
   def unsynchronized_run
+    stack.each do |frame|
+      next unless (deadline_at = frame["deadline_at"])
+
+      if Time.now > deadline_at
+        # TODO: Enrich the summary
+        # TODO: Use better conflict target
+        Page.dataset.insert_conflict(target: :id).insert(summary: "Strand #{id} hit a deadline")
+      end
+    end
+
     DB.transaction do
       SemSnap.use(id) do |snap|
         load(snap).public_send(label)

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -77,6 +77,11 @@ class Prog::Test < Prog::Base
     donate
   end
 
+  def set_expired_deadline
+    push Prog::Test, {test_level: "1"}, :pusher1, deadline_in: -1
+    nap 0
+  end
+
   def bad_pop
     pop nil
   end

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -3,7 +3,7 @@
 require_relative "spec_helper"
 
 RSpec.describe Strand do
-  let(:st) { described_class.new(prog: "Test", label: "start") }
+  let(:st) { described_class.create(prog: "Test", label: "start", stack: [{}]) }
 
   context "when leasing" do
     it "can take a lease only if one is not already taken" do

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Prog::Base do
   describe "#pop" do
     it "can reject unanticipated values" do
       expect {
-        Strand.new(prog: "Test", label: "bad_pop").unsynchronized_run
+        Strand.new(prog: "Test", label: "bad_pop", stack: [{}]).unsynchronized_run
       }.to raise_error RuntimeError, "BUG: must pop with string or hash"
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Prog::Base do
 
   it "requires a symbol for hop" do
     expect {
-      Strand.new(prog: "Test", label: "invalid_hop").unsynchronized_run
+      Strand.new(prog: "Test", label: "invalid_hop", stack: [{}]).unsynchronized_run
     }.to raise_error RuntimeError, "BUG: #hop only accepts a symbol"
   end
 
@@ -105,5 +105,13 @@ RSpec.describe Prog::Base do
         Strand.new(prog: "TestProg", label: "exiting_label"), {"msg" => "done"}
       ).to_s).to eq('Strand exits from TestProg#exiting_label with {"msg"=>"done"}')
     end
+  end
+
+  it "triggers a page when deadline is expired" do
+    st = Strand.create(prog: "Test", label: :set_expired_deadline, stack: [{}])
+    st.unsynchronized_run
+    expect {
+      st.unsynchronized_run
+    }.to change { Page.active.count }.from(0).to(1)
   end
 end


### PR DESCRIPTION
This commit introduces pop based deadlines. That means it is now possible to set a deadline for the exit time during push and bud calls. If Prog does not exit before the deadline, a page is triggered.

Triggering page happens via sending request to Pagerduty. The prerequise for that is generating an API key and putting that to .env.rb file. If the key does not exist, pages database entity would still get created but would not fire an incident.

We also considered more powerful, label based deadlines. Label based deadlines would allow setting a deadline for Prog to not just exit but also for reaching to an intermediate label. However, for initial stage,  pop based deadlines seems sufficient. If we see the need, we can add label based deadlines with relatively low effort on top of this work. 