### PR TITLE
Remove unintended side effect from Prog::Base.frame

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -128,7 +128,7 @@ end
   end
 
   def frame
-    strand.stack.first.freeze
+    @frame ||= strand.stack.first.dup.freeze
   end
 
   def retval


### PR DESCRIPTION
Prog::Base.frame used to call freeze to prevent unwanted modifications that can be done by the caller of the frame. However, the object stay frozen even if try to access it in other contexts, not via Prog::Base.frame but using
stack.first.

To keep the frame unfrozen in necessary context while continuing to prevent modifications we provide shallow copy to the callers of the frame. We also freeze the copy so that if caller modifies the frame they get an error message instead of silent ignore.