### PR TITLE
Ensure stacks to have one empty frame by default

### DIFF
--- a/migrate/20230717_set_stack_default.rb
+++ b/migrate/20230717_set_stack_default.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:strand) do
+      set_column_default(:stack, "[{}]")
+    end
+  end
+
+  down do
+    alter_table(:strand) do
+      set_column_default(:stack, "[]")
+    end
+  end
+end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -3,6 +3,9 @@
 require_relative "../model"
 
 class Strand < Sequel::Model
+  Strand.plugin :defaults_setter, cache: true
+  Strand.default_values[:stack] = [{}]
+
   LEASE_EXPIRATION = 120
   many_to_one :parent, key: :parent_id, class: self
   one_to_many :children, key: :parent_id, class: self

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -128,7 +128,7 @@ end
   end
 
   def frame
-    strand.stack&.first.freeze
+    strand.stack.first.freeze
   end
 
   def retval


### PR DESCRIPTION
This simplifies the deadline infrastructure. We keep the deadline information in stack frames, however before this commit it used to be possible to have stacks with no frames in them. That means deadlines would need to create the frame themselves if it is not exist.

Instead we decided to create the stacks with one frame in them by default. This simplifies the workflows by removing special case. As a side benefit, we don't need to modify Strand.new calls in our unit tests to ensure each of them passes stack as [{}] to accomodate deadlines we are registering.