### PR TITLE
Intoduce label-based deadline infrastructure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "warning"
 gem "pry"
 gem "excon"
 gem "jwt"
+gem "pagerduty", ">= 4.0"
 
 group :development do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
+    pagerduty (4.0.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -256,6 +257,7 @@ DEPENDENCIES
   mail
   net-ssh
   netaddr
+  pagerduty (>= 4.0)
   pry
   pry-byebug
   puma (>= 6.2.2)

--- a/config.rb
+++ b/config.rb
@@ -44,6 +44,7 @@ module Config
   optional :versioning_app_name, string
   optional :clover_session_secret, base64, clear: true
   optional :clover_column_encryption_key, base64, clear: true
+  optional :pagerduty_key, string, clear: true
 
   override :mail_driver, (production? ? :smtp : :logger), symbol
   override :mail_from, (production? ? nil : "dev@example.com"), string

--- a/lib/ubid.rb
+++ b/lib/ubid.rb
@@ -48,6 +48,7 @@ class UBID
   TYPE_STRAND = "st"
   TYPE_SEMAPHORE = "sm"
   TYPE_SSHABLE = "sh"
+  TYPE_PAGE = "pg"
 
   def self.generate(type)
     case type
@@ -103,6 +104,8 @@ class UBID
       Semaphore[uuid]
     when TYPE_SSHABLE
       Sshable[uuid]
+    when TYPE_PAGE
+      Page[uuid]
     else
       fail "Couldn't decode ubid: #{ubid_str}"
     end

--- a/migrate/20230721_pages.rb
+++ b/migrate/20230721_pages.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:page) do
+      column :id, :uuid, primary_key: true, default: nil
+      column :created_at, :timestamptz, null: false, default: Sequel::CURRENT_TIMESTAMP
+      column :resolved_at, :timestamptz
+      column :summary, :text, collate: '"C"'
+    end
+  end
+end

--- a/model/page.rb
+++ b/model/page.rb
@@ -2,6 +2,8 @@
 
 require_relative "../model"
 
+require "pagerduty"
+
 class Page < Sequel::Model
   dataset_module do
     def active
@@ -17,7 +19,23 @@ class Page < Sequel::Model
     UBID::TYPE_PAGE
   end
 
+  def pagerduty_client
+    @@pagerduty_client ||= Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2)
+  end
+
+  def trigger
+    return unless Config.pagerduty_key
+
+    incident = pagerduty_client.incident(Digest::MD5.hexdigest(id))
+    incident.trigger(summary: summary, severity: "error", source: "clover")
+  end
+
   def resolve
     update(resolved_at: Time.now)
+
+    return unless Config.pagerduty_key
+
+    incident = pagerduty_client.incident(Digest::MD5.hexdigest(id))
+    incident.resolve
   end
 end

--- a/model/page.rb
+++ b/model/page.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class Page < Sequel::Model
+  dataset_module do
+    def active
+      where(resolved_at: nil)
+    end
+  end
+
+  include SemaphoreMethods
+  include ResourceMethods
+  semaphore :resolve
+
+  def self.ubid_type
+    UBID::TYPE_PAGE
+  end
+
+  def resolve
+    update(resolved_at: Time.now)
+  end
+end

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -60,6 +60,8 @@ end
       # This is a multi-level stack with a back-link, i.e. one prog
       # calling another in the same Strand of execution.  The thing to
       # do here is pop the stack entry.
+      Page[frame["page_id"]].incr_resolve if frame["page_id"]
+
       old_prog = strand.prog
       old_label = strand.label
       prog, label = link
@@ -178,6 +180,15 @@ end
     fail "BUG: #hop only accepts a symbol" unless label.is_a? Symbol
     label = label.to_s
     fail Hop.new(@strand.prog, @strand.label, {label: label, retval: nil})
+  end
+
+  def register_deadline(deadline_target, deadline_in)
+    return if strand.stack.first["deadline_target"] == deadline_target && Time.parse(strand.stack.first["deadline_at"].to_s) < Time.now + deadline_in
+
+    strand.stack.first["deadline_target"] = deadline_target
+    strand.stack.first["deadline_at"] = Time.now + deadline_in
+
+    strand.modified!(:stack)
   end
 
   # Copied from sequel/model/inflections.rb's camelize, to convert

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Prog::PageNexus < Prog::Base
+  subject_is :page
+  semaphore :resolve
+
+  def self.assemble(summary)
+    DB.transaction do
+      p = Page.create_with_id(summary: summary)
+
+      Strand.create(prog: "PageNexus", label: "start") { _1.id = p.id }
+    end
+  end
+
+  def start
+    #no op until we have a pagerduty integration
+    hop :wait
+  end
+
+  def wait
+    when_resolve_set? do
+      page.resolve
+      pop "page is resolved"
+    end
+
+    nap 30
+  end
+end

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -13,7 +13,7 @@ class Prog::PageNexus < Prog::Base
   end
 
   def start
-    #no op until we have a pagerduty integration
+    page.trigger
     hop :wait
   end
 

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -77,6 +77,20 @@ class Prog::Test < Prog::Base
     donate
   end
 
+  def set_expired_deadline
+    register_deadline(:pusher2, -1)
+    hop :pusher1
+  end
+
+  def set_popping_deadline1
+    push Prog::Test, {}, :set_popping_deadline2
+  end
+
+  def set_popping_deadline2
+    register_deadline(:pusher2, -1)
+    hop :popper
+  end
+
   def bad_pop
     pop nil
   end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -21,6 +21,8 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   def start
+    register_deadline(:wait, 15 * 60)
+
     bud Prog::BootstrapRhizome
     hop :wait_bootstrap_rhizome
   end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -175,6 +175,8 @@ SQL
   end
 
   def start
+    register_deadline(:wait, 10 * 60)
+
     vm_host_id = allocate
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network
@@ -305,6 +307,8 @@ SQL
   end
 
   def refresh_mesh
+    register_deadline(:wait, 5 * 60)
+
     # YYY: Implement a robust mesh networking concurrency algorithm.
     unless Config.development?
       decr_refresh_mesh
@@ -336,6 +340,8 @@ SQL
   end
 
   def destroy
+    register_deadline(nil, 5 * 60)
+
     unless host.nil?
       begin
         host.sshable.cmd("sudo systemctl stop #{q_vm}")

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+require "json"
+
+RSpec.describe Page do
+  subject(:p) { described_class.create_with_id }
+
+  describe "#trigger" do
+    it "triggers a page in Pagerduty if key is present" do
+      expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)
+      stub_request(:post, "https://events.pagerduty.com/v2/enqueue")
+        .to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
+
+      p.trigger
+    end
+  end
+
+  describe "#resolve" do
+    it "resolves the page in Pagerduty if key is present" do
+      expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)
+      stub_request(:post, "https://events.pagerduty.com/v2/enqueue")
+        .to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
+
+      p.resolve
+    end
+  end
+end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -106,4 +106,60 @@ RSpec.describe Prog::Base do
       ).to_s).to eq('Strand exits from TestProg#exiting_label with {"msg"=>"done"}')
     end
   end
+
+  context "with deadlines" do
+    it "triggers a page exactly once when deadline is expired" do
+      st = Strand.create_with_id(prog: "Test", label: :set_expired_deadline)
+      st.unsynchronized_run
+      expect {
+        st.unsynchronized_run
+      }.to change { Page.active.count }.from(0).to(1)
+
+      expect {
+        st.unsynchronized_run
+      }.not_to change { Page.active.count }.from(1)
+    end
+
+    it "resolves the page if the frame is popped" do
+      st = Strand.create_with_id(prog: "Test", label: :set_popping_deadline1)
+      st.unsynchronized_run
+      st.unsynchronized_run
+      expect {
+        st.unsynchronized_run
+      }.to change { Page.active.count }.from(0).to(1)
+
+      expect {
+        st.unsynchronized_run
+
+        page_id = Page.first.id
+        Strand[page_id].unsynchronized_run
+        Strand[page_id].unsynchronized_run
+      }.to change { Page.active.count }.from(1).to(0)
+    end
+
+    it "resolves the page once the target is reached" do
+      st = Strand.create_with_id(prog: "Test", label: :napper)
+      page_id = Prog::PageNexus.assemble("dummy-summary").id
+
+      st.stack.first["deadline_target"] = :napper
+      st.stack.first["deadline_at"] = Time.now - 1
+      st.stack.first["page_id"] = page_id
+
+      expect {
+        st.unsynchronized_run
+        Strand[page_id].unsynchronized_run
+        Strand[page_id].unsynchronized_run
+      }.to change { Page.active.count }.from(1).to(0)
+    end
+
+    it "doesn't try to resolve a page if it isn't exist" do
+      st = Strand.create_with_id(prog: "Test", label: :napper)
+      st.stack.first["deadline_target"] = :napper
+      st.stack.first["deadline_at"] = Time.now - 1
+
+      expect(st.stack.first).not_to receive(:delete).with("page_id")
+
+      st.unsynchronized_run
+    end
+  end
 end


### PR DESCRIPTION
This PR consist of 3 commits. My intention to merge this without squashing as each commit makes sense on their own. We considered pop-based deadlines [here](https://github.com/ubicloud/ubicloud/pull/300) as well, but they seemed a bit restrictive after playing with them a bit. We also realized we can implement label-based deadlines with relatively low effort. Actual deadline logic code ended up being quite short 14 lines in model/strand.rb and 4 lines in prog/base.rb. The rest are either for paging or tests.

[Introduce Page model](https://github.com/ubicloud/ubicloud/pull/308/commits/5cfd29fa48d761d3d343d2ed6362010ce24487f6) 
This commit introduces simple page model. At the moment, we are not concerning
about page's content. It only has a summary column as content. Our motivation
right now is providing enough baseline for deadline infrastructure. After that
it is possible to enrich the content of the pages to provide more information
to on-call engineers.

[Pagerduty integration](https://github.com/ubicloud/ubicloud/pull/308/commits/e434d42eab8ce8f6406e9bf2a054cc66e0d10da7) 
This commit introduces Pagerduty integration. Added functionality only runs if
Config.pagerduty_key is set. Otherwise it would continue to create pages in the
database but does not/cannot trigger pages.

Added code for the Pagerduty integration is quite small and unintruisive, so
that it can be replaces with another provider if necessary. For the moment, our
expectation from on-call provider is quite minimal:
- Ability to trigger alerts (notification, e-mail, SMS, phone call)
- Ability to set on-call schedule and escalation policy

Both are part of core features of such providers, so it isn't big effort to
replace it.

[Introduce label based deadline infrastructure](https://github.com/ubicloud/ubicloud/pull/308/commits/656ca1fc5ad38dc8c2479966d8b4c19662eb59cd) 
Deadlines are pretty key in our mode of operation to detect anomalies in the
system. Any operation that doesn't progress in a timely manner would create
a deadline and trigger an incident for on-call person to look at.

Initially we planned to put these deadlines only for the exit time of Progs.
That means if a Prog doesn't exit in a given time duration, it would create a
deadline. However that is bit restrictive, so instead we are introducing label
based deadlines. Label based deadlines would allow setting a deadline for Prog
to not just exit but also for reaching to an intermediate label.

Currently deadline related properties live in stack frames. It is possible
that number of deadline related fields increase over time. For example, it is
likely that we would want to trigger incident only for certain deadlines, which
would require adding deadline_severity field to the stack frames. I think it
would be better to create a deadline model at that time to not pollute frames
to much and then only keeping deadline_id in the frame.