### PR TITLE
Set hugetlb_free_vmemmap=on

### DIFF
--- a/prog/setup_hugepages.rb
+++ b/prog/setup_hugepages.rb
@@ -7,7 +7,7 @@ class Prog::SetupHugepages < Prog::Base
     hugepage_size = "1G"
     # put away 1 core of overhead for host, and reserve 1G for SPDK
     hugepage_cnt = 1 + (vm_host.total_mem_gib * (vm_host.total_cores - 1)) / vm_host.total_cores
-    sshable.cmd("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ default_hugepagesz=#{hugepage_size} hugepagesz=#{hugepage_size} hugepages=#{hugepage_cnt}&/' /etc/default/grub")
+    sshable.cmd("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ hugetlb_free_vmemmap=on default_hugepagesz=#{hugepage_size} hugepagesz=#{hugepage_size} hugepages=#{hugepage_cnt}&/' /etc/default/grub")
     sshable.cmd("sudo update-grub")
     begin
       sshable.cmd("sudo reboot")


### PR DESCRIPTION
This promises to free considerable memory given our most-memory-is-hugepages situation for VMs since
725fb3f15b1705f748971697930ac542432a671a.

As to how it works, see https://lwn.net/Articles/855910/.  In brief, even with hugepages, there is a lot of per-page (e.g. 4K) struct accounting that does make hugepage allocation/deallocation a bit faster, but also costs considerable memory.

As we allocate hugepages *once* at boot by necessity, given the issues of physical memory fragmentation at run-time, and never de-allocated, these modest extra costs are not material, but can free up considerable space, and that was the motivation for the patch as seen at lwn.net.

Fixes https://github.com/ubicloud/ubicloud/issues/284