### PR TITLE
Add storage size accounting

### DIFF
--- a/migrate/20230720_add_storage_cap.rb
+++ b/migrate/20230720_add_storage_cap.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      add_column :total_storage_gib, Integer
+      add_column :available_storage_gib, Integer
+    end
+  end
+end

--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -23,8 +23,8 @@ class Prog::LearnStorage < Prog::Base
 
   def start
     storage_root = "/var"
-    total_storage_gib = parse_size_gib(storage_root, sshable.cmd("sudo df -h --output=size #{storage_root}"))
-    reported_available_storage_gib = parse_size_gib(storage_root, sshable.cmd("sudo df -h --output=avail #{storage_root}"))
+    total_storage_gib = parse_size_gib(storage_root, sshable.cmd("df -h --output=size #{storage_root}"))
+    reported_available_storage_gib = parse_size_gib(storage_root, sshable.cmd("df -h --output=avail #{storage_root}"))
 
     # reserve 5G for future host related stuff
     available_storage_gib = [0, reported_available_storage_gib - 5].max

--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -6,12 +6,13 @@ class Prog::LearnStorage < Prog::Base
   def parse_size_gib(storage_root, s)
     sizes = s.each_line.filter_map do |line|
       next unless line =~ /^\s*(\d+)(\w+)$/
-      # Fail noisily if unit is not in gigabytes or terabytes
-      fail "BUG: unexpected storage size unit: #{$2}" unless ($2 == "G") || ($2 == "T")
       if $2 == "G"
         Integer($1)
-      else
+      elsif $2 == "T"
         Integer($1) * 1024
+      else
+        # Fail noisily if unit is not in gigabytes or terabytes
+        fail "BUG: unexpected storage size unit: #{$2}"
       end
     end
 

--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Prog::LearnStorage < Prog::Base
+  subject_is :sshable
+
+  def parse_size_gib(storage_root, s)
+    sizes = s.each_line.filter_map do |line|
+      next unless line =~ /^\s*(\d+)(\w+)$/
+      # Fail noisily if unit is not in gigabytes or terabytes
+      fail "BUG: unexpected storage size unit: #{$2}" unless ($2 == "G") || ($2 == "T")
+      if $2 == "G"
+        Integer($1)
+      else
+        Integer($1) * 1024
+      end
+    end
+
+    fail "BUG: expected one size for #{storage_root}, but received: [#{sizes.join(", ")}]" unless sizes.length == 1
+
+    sizes.first
+  end
+
+  def start
+    storage_root = "/var"
+    total_storage_gib = parse_size_gib(storage_root, sshable.cmd("sudo df -h --output=size #{storage_root}"))
+    reported_available_storage_gib = parse_size_gib(storage_root, sshable.cmd("sudo df -h --output=avail #{storage_root}"))
+
+    # reserve 5G for future host related stuff
+    available_storage_gib = [0, reported_available_storage_gib - 5].max
+    pop total_storage_gib: total_storage_gib, available_storage_gib: available_storage_gib
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -36,6 +36,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnNetwork unless vm_host.net6
     bud Prog::LearnMemory
     bud Prog::LearnCores
+    bud Prog::LearnStorage
     bud Prog::InstallDnsmasq
     hop :wait_prep
   end
@@ -55,6 +56,15 @@ class Prog::Vm::HostNexus < Prog::Base
         }
 
         fail "BUG: one of the LearnCores fields is not set" if kwargs.value?(nil)
+
+        vm_host.update(**kwargs)
+      when "LearnStorage"
+        kwargs = {
+          total_storage_gib: st.dig(:exitval, "total_storage_gib"),
+          available_storage_gib: st.dig(:exitval, "available_storage_gib")
+        }
+
+        fail "BUG: one of the LearnStorage fields is not set" if kwargs.value?(nil)
 
         vm_host.update(**kwargs)
       end

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Prog::LearnStorage do
   describe "#start" do
     it "exits, popping total storage and available storage" do
       sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("sudo df -h --output=size /var").and_return(<<EOS)
+      expect(sshable).to receive(:cmd).with("df -h --output=size /var").and_return(<<EOS)
       Size
       500G
 EOS
-      expect(sshable).to receive(:cmd).with("sudo df -h --output=avail /var").and_return(<<EOS)
+      expect(sshable).to receive(:cmd).with("df -h --output=avail /var").and_return(<<EOS)
       Avail
        200G
 EOS

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::LearnStorage do
+  subject(:ls) { described_class.new(Strand.new(stack: [{sshable_id: "bogus"}])) }
+
+  describe "#start" do
+    it "exits, popping total storage and available storage" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("sudo df -h --output=size /var").and_return(<<EOS)
+      Size
+      500G
+EOS
+      expect(sshable).to receive(:cmd).with("sudo df -h --output=avail /var").and_return(<<EOS)
+      Avail
+       200G
+EOS
+      expect(ls).to receive(:sshable).and_return(sshable).at_least(:once)
+      expect(ls).to receive(:pop).with(total_storage_gib: 500, available_storage_gib: 195)
+      ls.start
+    end
+  end
+
+  describe "#parse_size_gib" do
+    it "can parse gigabytes" do
+      expect(
+        ls.parse_size_gib("/var", <<EOS)
+            Size
+            460G
+EOS
+      ).to eq(460)
+    end
+
+    it "can parse terabytes" do
+      expect(
+        ls.parse_size_gib("/var", <<EOS)
+            Size
+            5T
+EOS
+      ).to eq(5 * 1024)
+    end
+
+    it "crashes if an unfamiliar unit is provided" do
+      expect {
+        ls.parse_size_gib("/var", <<EOS)
+        Size
+        460M
+EOS
+      }.to raise_error RuntimeError, "BUG: unexpected storage size unit: M"
+    end
+
+    it "crashes if more than one size is provided" do
+      expect {
+        ls.parse_size_gib("/var", <<EOS)
+          Size
+          460G
+          420G
+EOS
+      }.to raise_error RuntimeError, "BUG: expected one size for /var, but received: [460, 420]"
+    end
+  end
+end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe Prog::Vm::HostNexus do
         Prog::Vm::PrepHost,
         Prog::LearnMemory,
         Prog::LearnCores,
+        Prog::LearnStorage,
         Prog::InstallDnsmasq
       ])
     end


### PR DESCRIPTION
Learns available storage size at the vm host, and uses that to allocate disk space to each VM. Also fails if not enough disk space is remaining at the host.

Adds the following information to the vm_host table:
 * total_storage_gib
 * available_storage_gib