### PR TITLE
Add more tests for uncovered lines of UBID, PageNexus, and HostNexus

### DIFF
--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -5,7 +5,7 @@ if (suite = ENV.delete("COVERAGE"))
 
   SimpleCov.start do
     enable_coverage :branch
-    minimum_coverage line: 90, branch: 90
+    minimum_coverage line: 90.5, branch: 91
     minimum_coverage_by_file line: 0, branch: 50
 
     command_name suite

--- a/spec/prog/page_nexus_spec.rb
+++ b/spec/prog/page_nexus_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::PageNexus do
+  subject(:pn) {
+    described_class.new(Strand.new).tap {
+      _1.instance_variable_set(:@page, pg)
+    }
+  }
+
+  let(:pg) { Page.new }
+
+  describe "#start" do
+    it "triggers page and hops" do
+      expect(pg).to receive(:trigger)
+      expect { pn.start }.to hop("wait")
+    end
+  end
+
+  describe "#wait" do
+    it "exits when resolved" do
+      expect(pn).to receive(:when_resolve_set?).and_yield
+      expect(pg).to receive(:resolve)
+      expect { pn.wait }.to exit({"msg" => "page is resolved"})
+    end
+
+    it "naps" do
+      expect { pn.wait }.to nap(30)
+    end
+  end
+end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -108,9 +108,11 @@ RSpec.describe Prog::Vm::HostNexus do
       nx.instance_variable_set(:@vm_host, vmh)
       expect(vmh).to receive(:update).with(total_mem_gib: 1)
       expect(vmh).to receive(:update).with(total_cores: 4, total_cpus: 5, total_nodes: 3, total_sockets: 2)
+      expect(vmh).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
       expect(nx).to receive(:reap).and_return([
         {prog: "LearnMemory", exitval: {"mem_gib" => 1}},
         {prog: "LearnCores", exitval: {"total_sockets" => 2, "total_nodes" => 3, "total_cores" => 4, "total_cpus" => 5}},
+        {prog: "LearnStorage", exitval: {"total_storage_gib" => 300, "available_storage_gib" => 500}},
         {prog: "ArbitraryOtherProg"}
       ])
 
@@ -125,6 +127,11 @@ RSpec.describe Prog::Vm::HostNexus do
     it "crashes if an expected field is not set for LearnCores" do
       expect(nx).to receive(:reap).and_return([{prog: "LearnCores", exitval: {}}])
       expect { nx.wait_prep }.to raise_error RuntimeError, "BUG: one of the LearnCores fields is not set"
+    end
+
+    it "crashes if an expected field is not set for LearnStorage" do
+      expect(nx).to receive(:reap).and_return([{prog: "LearnStorage", exitval: {}}])
+      expect { nx.wait_prep }.to raise_error RuntimeError, "BUG: one of the LearnStorage fields is not set"
     end
 
     it "donates to children if they are not exited yet" do

--- a/ubid.rb
+++ b/ubid.rb
@@ -50,9 +50,11 @@ class UBID
   TYPE_SSHABLE = "sh"
   TYPE_PAGE = "pg"
 
+  CURRENT_TIMESTAMP_TYPES = [TYPE_STRAND, TYPE_SEMAPHORE]
+
   def self.generate(type)
     case type
-    when TYPE_STRAND, TYPE_SEMAPHORE
+    when *CURRENT_TIMESTAMP_TYPES
       generate_from_current_ts(type)
     else
       generate_random(type)


### PR DESCRIPTION
Some UBID test cases checks uniqueness and ability to generates randomly
for all types. They had hardcoded type list, but it's easy to forget add
new types to that list. I made type list dynamic. It gets all constants
which starts with "TYPE_" from `UBID` class.