### PR TITLE
Archive coverage report if CI failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,10 @@ jobs:
       run: |
         COVERAGE=1 bundle exec rspec
         bundle exec rspec -O /dev/null rhizome
+
+    - name: Archive code coverage results
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: code-coverage-report
+        path: coverage/


### PR DESCRIPTION
It's a good resource to debug when CI failed.