### PR TITLE
Add provider to project

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -1,21 +1,33 @@
 # frozen_string_literal: true
 
 module Option
-  Location = Struct.new(:name, :display_name)
-  BootImage = Struct.new(:name, :display_name)
-  VmSize = Struct.new(:name, :display_name, :vcpu, :memory)
+  Provider = Struct.new(:name, :display_name) do
+    self::HETZNER = "hetzner"
+    self::DATAPACKET = "dp"
+  end
+  Providers = [
+    [Provider::HETZNER, "Hetzner"],
+    [Provider::DATAPACKET, "DataPacket"]
+  ].map { |args| [args[0], Provider.new(*args)] }.to_h.freeze
 
+  Location = Struct.new(:provider, :name, :display_name)
   Locations = [
-    ["hetzner-hel1", "Hetzner Finland"],
-    ["hetzner-fsn1", "Hetzner Germany"],
-    ["dp-istanbul-mars", "DataPacket Istanbul"]
+    [Providers[Provider::HETZNER], "hetzner-hel1", "Finland"],
+    [Providers[Provider::HETZNER], "hetzner-fsn1", "Germany"],
+    [Providers[Provider::DATAPACKET], "dp-istanbul-mars", "Istanbul"]
   ].map { |args| Location.new(*args) }.freeze
 
+  def self.locations_for_provider(provider)
+    Option::Locations.select { provider.nil? || _1.provider.name == provider }
+  end
+
+  BootImage = Struct.new(:name, :display_name)
   BootImages = [
     ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"],
     ["almalinux-9.1", "AlmaLinux 9.1"]
   ].map { |args| BootImage.new(*args) }.freeze
 
+  VmSize = Struct.new(:name, :display_name, :vcpu, :memory)
   VmSizes = [
     ["c5a.2x", "c5a.2x", 2, 2],
     ["c5a.4x", "c5a.4x", 4, 4],

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -5,7 +5,7 @@ module Validation
     attr_reader :errors
     def initialize(errors)
       @errors = errors
-      super("Validation failed for some fields")
+      super("Validation failed for following fields: #{errors.keys.join(", ")}")
     end
   end
 
@@ -20,5 +20,16 @@ module Validation
   def self.validate_name(name)
     msg = "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."
     fail ValidationFailed.new({name: msg}) unless name.match(ALLOWED_NAME_PATTERN)
+  end
+
+  def self.validate_provider(provider)
+    msg = "\"#{provider}\" is not a valid provider. Available providers: #{Option::Providers.keys}"
+    fail ValidationFailed.new({provider: msg}) unless Option::Providers.key?(provider)
+  end
+
+  def self.validate_location(location, provider = nil)
+    available_locs = Option.locations_for_provider(provider).map(&:name)
+    msg = "\"#{location}\" is not a valid location for provider \"#{provider}\". Available locations: #{available_locs}"
+    fail ValidationFailed.new({provider: msg}) unless available_locs.include?(location)
   end
 end

--- a/migrate/20230721_add_project_provider.rb
+++ b/migrate/20230721_add_project_provider.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:project) do
+      add_column :provider, String, collate: '"C"'
+    end
+  end
+end

--- a/model/account.rb
+++ b/model/account.rb
@@ -16,8 +16,9 @@ class Account < Sequel::Model(:accounts)
 
   include Authorization::TaggableMethods
 
-  def create_project_with_default_policy(name, policy_body = nil)
-    project = Project.create(name: name) { _1.id = UBID.generate(UBID::TYPE_PROJECT).to_uuid }
+  def create_project_with_default_policy(name, provider: Option::Provider::HETZNER, policy_body: nil)
+    Validation.validate_provider(provider)
+    project = Project.create(name: name, provider: provider) { _1.id = UBID.generate(UBID::TYPE_PROJECT).to_uuid }
     project.associate_with_project(project)
     associate_with_project(project)
     project.add_access_policy(

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -17,6 +17,7 @@ class Prog::Vm::Nexus < Prog::Base
     unless project || Config.development?
       fail "No existing project"
     end
+    Validation.validate_location(location, project&.provider)
 
     ubid = UBID.generate(UBID::TYPE_VM)
     name ||= Vm.ubid_to_name(ubid)

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -11,7 +11,7 @@ class CloverApi
     end
 
     r.post true do
-      project = @current_user.create_project_with_default_policy(r.params["name"])
+      project = @current_user.create_project_with_default_policy(r.params["name"], provider: r.params["provider"])
 
       serialize(project)
     end

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -11,7 +11,7 @@ class CloverWeb
     end
 
     r.post true do
-      project = @current_user.create_project_with_default_policy(r.params["name"])
+      project = @current_user.create_project_with_default_policy(r.params["name"], provider: r.params["provider"])
 
       r.redirect project.path
     end

--- a/serializers/web/project.rb
+++ b/serializers/web/project.rb
@@ -8,7 +8,8 @@ class Serializers::Web::Project < Serializers::Base
       id: p.id,
       ubid: p.ubid,
       path: p.path,
-      name: p.name
+      name: p.name,
+      provider: Option::Providers[p.provider]
     }
   end
 

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -29,5 +29,36 @@ RSpec.describe Validation do
         expect { described_class.validate_name(name) }.to raise_error described_class::ValidationFailed
       end
     end
+
+    describe "#validate_provider" do
+      it "valid provider" do
+        expect(described_class.validate_provider("hetzner")).to be_nil
+      end
+
+      it "invalid provider" do
+        expect { described_class.validate_provider("hetzner-cloud") }.to raise_error described_class::ValidationFailed
+      end
+    end
+
+    describe "#validate_location" do
+      it "valid locations" do
+        [
+          ["hetzner-hel1", nil],
+          ["hetzner-hel1", "hetzner"]
+        ].each do |location, provider|
+          expect(described_class.validate_location(location, provider)).to be_nil
+        end
+      end
+
+      it "invalid locations" do
+        [
+          ["hetzner-hel2", nil],
+          ["hetzner-hel2", "hetzner"],
+          ["dp-mars-istanbul", "hetzner"]
+        ].each do |location, provider|
+          expect { described_class.validate_location(location, provider) }.to raise_error described_class::ValidationFailed
+        end
+      end
+    end
   end
 end

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Clover, "vm" do
     describe "create" do
       it "success" do
         post "/api/project", {
-          name: "test-project"
+          name: "test-project",
+          provider: "hetzner"
         }
 
         expect(last_response.status).to eq(200)

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe Clover, "project" do
         expect(page.title).to eq("Ubicloud - Create Project")
 
         fill_in "Name", with: name
+        choose option: "hetzner"
+
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")

--- a/views/layouts/topbar.erb
+++ b/views/layouts/topbar.erb
@@ -12,6 +12,12 @@
   <img class="h-8 w-auto lg:hidden" src="/logo-orange.png" alt="Ubicloud">
   <div class="flex flex-1 gap-x-4 self-stretch justify-end lg:gap-x-6">
     <div class="flex items-center gap-x-4 lg:gap-x-6">
+      <% if @project_data %>
+        <div class="text-gray-900">
+          <span class="font-semibold">Provider:</span>
+          <%= @project_data.dig(:provider, :display_name) %>
+        </div>
+      <% end %>
       <!-- Separator -->
       <div class="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10" aria-hidden="true"></div>
       <!-- Profile dropdown -->

--- a/views/project/create.erb
+++ b/views/project/create.erb
@@ -26,6 +26,19 @@
               }
             ) %>
           </div>
+          <div class="sm:col-span-full">
+            <%== render(
+              "components/form/radio_small_cards",
+              locals: {
+                name: "provider",
+                label: "Provider",
+                options: Option::Providers.map { [_1, _2.display_name] }.to_h,
+                attributes: {
+                  required: true
+                }
+              }
+            ) %>
+          </div>
         </div>
 
       </div>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -13,7 +13,16 @@
 
 <div class="grid gap-6">
   <!-- Detail Card -->
-  <%== render("components/kv_data_card", locals: { data: [["ID", @project_data[:ubid]], ["Name", @project_data[:name]]] }) %>
+  <%== render(
+    "components/kv_data_card",
+    locals: {
+      data: [
+        ["ID", @project_data[:ubid]],
+        ["Name", @project_data[:name]],
+        ["Provider", @project_data.dig(:provider, :display_name)]
+      ]
+    }
+  ) %>
   <!-- Delete Card -->
   <% if Authorization.has_permission?(@current_user.id, "Vm:delete", @project_data[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -46,8 +46,8 @@
                   "components/form/radio_small_cards",
                   locals: {
                     name: "location",
-                    label: "Provider & Location",
-                    options: Option::Locations.to_h { |l| [l.name, l.display_name] },
+                    label: "Location",
+                    options: Option.locations_for_provider(@project_data.dig(:provider, :name)).to_h { |l| [l.name, l.display_name] },
                     attributes: {
                       required: true
                     }

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -27,7 +27,7 @@
         <thead class="bg-gray-50">
           <tr>
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Provider & Location</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Location</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Size</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Storage Size</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -29,7 +29,7 @@
       data: [
         ["ID", @vm[:ubid]],
         ["Name", @vm[:name]],
-        ["Provider & Location", @vm[:location]],
+        ["Location", @vm[:location]],
         ["Size", @vm[:size]],
         ["Storage", "#{@vm[:storage_size_gib]}GB (#{@vm[:storage_encryption]})"],
         ["IPv4", @vm[:ip4], { copieble: true }],


### PR DESCRIPTION
Technically, project can have resources from multiple providers. But we don't know the characteristics of our providers. When customer mixed and matched same type of resources from different providers, these resources might behave differently across those providers. It's easy to create resources in locations from different providers by mistake.

We decided to limit customer for project with single provider. We don't yet know what customers want from different providers. If people come back to us and ask for more flexibility with mixing and matching providers, then that's always something we could add on later. It's always going to be easier to move from less flexible to more flexible than the other way around.

> **Note:** I'm not sure about structure of variables in `Option` module. We can refactor them when location based pricing introduced.