### PR TITLE
Increase spdk_dd block size to improve performance

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -434,7 +434,8 @@ EOS
     "--disable-cpumask-locks " \
     "--rpc-socket #{rpc_socket.shellescape} " \
     "--if #{image_path.shellescape} " \
-    "--ob #{target_bdev.shellescape}", stdin: spdk_config_json)
+    "--ob #{target_bdev.shellescape} " \
+    "--bs=2097152", stdin: spdk_config_json)
   end
 
   def setup_disk_file(storage_volume, index)

--- a/rhizome/spec/vm_setup_spec.rb
+++ b/rhizome/spec/vm_setup_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe VmSetup do
       disk_file = "/var/storage/test/disk_0.raw"
       expect(vs).to receive(:download_boot_image).and_return image_path
       expect(File).to receive(:size).with(image_path).and_return(2 * 2**30)
-      expect(vs).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob aio0$/, stdin: /{.*}/)
+      expect(vs).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob aio0 --bs=[0-9]+$/, stdin: /{.*}/)
       vs.copy_image(disk_file, boot_image, 10, false, nil)
     end
 
@@ -105,7 +105,7 @@ RSpec.describe VmSetup do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
       expect(vs).to receive(:download_boot_image).and_return image_path
       expect(File).to receive(:size).with(image_path).and_return(2 * 2**30)
-      expect(vs).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0$/, stdin: /{.*}/)
+      expect(vs).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0 --bs=[0-9]+$/, stdin: /{.*}/)
       vs.copy_image(disk_file, boot_image, 10, true, encryption_key)
     end
   end


### PR DESCRIPTION
We use spdk_dd to copy boot image to the storage file. This was slow. This PR increases its block size parameter to 2MB to improve performance. Default was 4KB.

This block size was decided by the following benchmark for the time in seconds it took to copy ubuntu jammy raw image using spdk_dd:

```
| blksz | encrypted | unencrypted |
|---------------------------------|
| 4KB   | 20.1      | 15.169      |
| 8KB   | 13.843    | 8.692       |
| 16KB  | 8.659     | 6.516       |
| 32KB  | 5.941     | 4.550       |
| 64KB  | 4.650     | 3.705       |
| 128KB | 4.321     | 3.003       |
| 256KB | 4.152     | 2.895       |
| 512KB | 4.221s    | 2.744       |
| 1MB   | 4.196s    | 2.535       |
| 2MB   | 4.119     | 2.464       |
| 4MB   | 4.385     | 2.461       |
| 8MB   | 4.485     | 2.558       |
| 16MB  | 4.661s    | 2.634       |
```

Note that for the unencrypted case we could use a simple "cp" command, but I prefer to use the spdk_dd because it can be used for more scenarios (encrypted, not file based, ...) and if we want to catch issues in the spdk_dd path as soon as possible by using it in all cases.