### PR TITLE
Split VM size into family and cores in DB

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -24,10 +24,10 @@ module Option
     ["almalinux-9.1", "AlmaLinux 9.1"]
   ].map { |args| BootImage.new(*args) }.freeze
 
-  VmSize = Struct.new(:name, :vcpu, :memory, :storage_size_gib) do
+  VmSize = Struct.new(:name, :family, :vcpu, :memory, :storage_size_gib) do
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16].map {
-    VmSize.new("standard-#{_1}", _1, _1 * 4, (_1 / 2) * 25)
+    VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 25)
   }.freeze
 end

--- a/migrate/20230823_split_vm_size.rb
+++ b/migrate/20230823_split_vm_size.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:vm) do
+      add_column :family, String, collate: '"C"'
+      add_column :cores, Integer
+    end
+
+    run "UPDATE vm SET family = split_part(size, '-', 1), cores = (split_part(size, '-', 2)::integer) / 2"
+
+    alter_table(:vm) do
+      drop_column :size
+      set_column_not_null :family
+      set_column_not_null :cores
+    end
+  end
+
+  down do
+    alter_table(:vm) do
+      add_column :size, String, collate: '"C"'
+    end
+
+    run "UPDATE vm SET size = family || '-' || (2 * cores)::text"
+
+    alter_table(:vm) do
+      drop_column :family
+      drop_column :cores
+      set_column_not_null :size
+    end
+  end
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -72,7 +72,7 @@ class Prog::Vm::Nexus < Prog::Base
       end
 
       vm = Vm.create(public_key: public_key, unix_user: unix_user,
-        name: name, size: size, location: location, boot_image: boot_image, ip4_enabled: enable_ip4) { _1.id = ubid.to_uuid }
+        name: name, family: vm_size.family, cores: vm_size.vcpu / 2, location: location, boot_image: boot_image, ip4_enabled: enable_ip4) { _1.id = ubid.to_uuid }
       nic.update(vm_id: vm.id)
 
       vm.associate_with_project(project)
@@ -279,8 +279,8 @@ SQL
       project_id: vm.projects.first.id,
       resource_id: vm.id,
       resource_name: vm.name,
-      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.product.prefix, vm.location)["id"],
-      amount: vm.product.cores
+      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.family, vm.location)["id"],
+      amount: vm.cores
     )
 
     if vm.ip4_enabled

--- a/serializers/api/vm.rb
+++ b/serializers/api/vm.rb
@@ -9,7 +9,7 @@ class Serializers::Api::Vm < Serializers::Base
       name: vm.name,
       state: vm.display_state,
       location: vm.location,
-      size: vm.size,
+      display_size: vm.display_size,
       unix_user: vm.unix_user,
       ip6: vm.ephemeral_net6&.nth(2),
       projects: Serializers::Api::Project.serialize(vm.projects)

--- a/serializers/web/vm.rb
+++ b/serializers/web/vm.rb
@@ -9,7 +9,7 @@ class Serializers::Web::Vm < Serializers::Base
       name: vm.name,
       state: vm.display_state,
       location: vm.location,
-      size: vm.size,
+      display_size: vm.display_size,
       storage_size_gib: vm.storage_size_gib,
       storage_encryption: vm.storage_encrypted? ? "encrypted" : "not encrypted",
       ip6: vm.ephemeral_net6&.nth(2),

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe InvoiceGenerator do
       resource_id: vm.id,
       resource_name: vm.name,
       span: span,
-      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.product.prefix, vm.location)["id"],
-      amount: vm.product.cores
+      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.family, vm.location)["id"],
+      amount: vm.cores
     )
   end
 
   def check_invoice_for_single_vm(invoices, project, vm, duration)
     expect(invoices.count).to eq(1)
 
-    br = BillingRate.from_resource_properties("VmCores", vm.product.prefix, vm.location)
-    cost = (vm.product.cores * (duration / 60) * br["unit_price"])
+    br = BillingRate.from_resource_properties("VmCores", vm.family, vm.location)
+    cost = (vm.cores * (duration / 60) * br["unit_price"])
     expect(invoices.first).to eq({
       project_id: project.id,
       project_name: project.name,
@@ -27,8 +27,8 @@ RSpec.describe InvoiceGenerator do
         line_items: [{
           location: br["location"],
           resource_type: "VmCores",
-          resource_family: vm.product.prefix,
-          amount: vm.product.cores,
+          resource_family: vm.family,
+          amount: vm.cores,
           cost: cost
         }],
         cost: cost
@@ -41,7 +41,7 @@ RSpec.describe InvoiceGenerator do
     Account.create_with_id(email: "auth1@example.com")
     Project.create_with_id(name: "cool-project", provider: "hetzner")
   }
-  let(:vm1) { Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", size: "standard-2", location: "hetzner-hel1", boot_image: "x") }
+  let(:vm1) { Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", family: "standard", cores: 2, location: "hetzner-hel1", boot_image: "x") }
 
   let(:day) { 60 * 60 * 24 }
   let(:begin_time) { Time.parse("2023-06-01") }

--- a/spec/prog/rotate_storage_kek_spec.rb
+++ b/spec/prog/rotate_storage_kek_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Prog::RotateStorageKek do
 
   let(:vm) {
     vm_host = instance_double(VmHost)
-    vm = Vm.new(size: "m5a.2x").tap {
+    vm = Vm.new.tap {
       _1.id = Vm.generate_uuid
     }
     allow(vm_host).to receive(:sshable).and_return(sshable)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Prog::Vm::Nexus do
     ) { _1.id = StorageKeyEncryptionKey.generate_uuid }
     disk = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0)
     disk.key_encryption_key_1 = kek
-    vm = Vm.new(size: "standard-2", name: "dummy-vm", location: "hetzner-hel1").tap {
+    vm = Vm.new(family: "standard", cores: 1, name: "dummy-vm", location: "hetzner-hel1").tap {
       _1.id = Vm.generate_uuid
       _1.vm_storage_volumes.append(disk)
       disk.vm = _1
@@ -27,8 +27,8 @@ RSpec.describe Prog::Vm::Nexus do
       project_id: SecureRandom.uuid,
       resource_id: vm.id,
       resource_name: vm.name,
-      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.product.prefix, vm.location)["id"],
-      amount: vm.product.cores
+      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.family, vm.location)["id"],
+      amount: vm.cores
     )
     vm
   }

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
   let(:tunnel) {
     sa = Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
     vmh = VmHost.create(location: "test-location") { _1.id = sa.id }
-    vm_src = Vm.create_with_id(name: "hellovm", vm_host_id: vmh.id, unix_user: "root", public_key: "public-key", size: "1", location: "location", boot_image: "image")
-    vm_dst = Vm.create_with_id(name: "hellovm2", vm_host_id: vmh.id, unix_user: "root", public_key: "public-key", size: "1", location: "location", boot_image: "image")
+    vm_src = Vm.create_with_id(name: "hellovm", vm_host_id: vmh.id, unix_user: "root", public_key: "public-key", family: "standard", cores: 1, location: "location", boot_image: "image")
+    vm_dst = Vm.create_with_id(name: "hellovm2", vm_host_id: vmh.id, unix_user: "root", public_key: "public-key", family: "standard", cores: 1, location: "location", boot_image: "image")
     n_src = Nic.create_with_id(private_subnet_id: ps.id,
       private_ipv6: "fd10:9b0b:6b4b:8fbb:abc::",
       private_ipv4: "10.0.0.1",

--- a/spec/serializers/web/vm_spec.rb
+++ b/spec/serializers/web/vm_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../../spec_helper"
 
 RSpec.describe Serializers::Web::Vm do
-  let(:vm) { Vm.new(name: "test-vm", size: "m5a.2x").tap { _1.id = "a410a91a-dc31-4119-9094-3c6a1fb49601" } }
+  let(:vm) { Vm.new(name: "test-vm", family: "standard", cores: 1).tap { _1.id = "a410a91a-dc31-4119-9094-3c6a1fb49601" } }
   let(:ser) { described_class.new }
 
   it "can serialize with the default structure" do

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe UBID do
   end
 
   it "generates ids with proper prefix" do
-    vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", size: "x", location: "x", boot_image: "x")
+    vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
     expect(vm.ubid).to start_with UBID::TYPE_VM
 
     sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false)
@@ -216,7 +216,7 @@ RSpec.describe UBID do
   end
 
   it "can decode ids" do
-    vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", size: "x", location: "x", boot_image: "x")
+    vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
     sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false)
     kek = StorageKeyEncryptionKey.create_with_id(algorithm: "x", key: "x", init_vector: "x", auth_data: "x")
     account = Account.create_with_id(email: "x@y.net")

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -113,7 +113,7 @@
                             value="<%= size.name %>"
                             class="peer sr-only location-based-price"
                             data-resource-type="VmCores"
-                            data-resource-family="<%= size.name.split("-").first %>"
+                            data-resource-family="<%= size.family %>"
                             data-amount="<%= size.vcpu / 2 %>"
                             required
                             <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -43,7 +43,7 @@
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= vm[:name] %></td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:location] %></td>
-              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:size] %></td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:display_size] %></td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:storage_size_gib] %>
                 GB</td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -31,7 +31,7 @@
         ["ID", @vm[:ubid]],
         ["Name", @vm[:name]],
         ["Location", @vm[:location]],
-        ["Size", @vm[:size]],
+        ["Size", @vm[:display_size]],
         ["Storage", "#{@vm[:storage_size_gib]}GB (#{@vm[:storage_encryption]})"],
         ["IPv4", @vm[:ip4], { copieble: true }],
         ["IPv6", @vm[:ip6], { copieble: true }],


### PR DESCRIPTION
It is easier to make calculations or use foreign keys if we keep the parsed
version of the size in the DB. This work will enable using foreign constraints
in billing records to ensure correctness of the records.