### PR TITLE
Use ${vendor}${year}-${pad}${core}c-${pad}${ram}r product notation

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -29,8 +29,8 @@ module Option
 
   VmSize = Struct.new(:name, :display_name, :vcpu, :memory)
   VmSizes = [
-    ["c5a.2x", "c5a.2x", 2, 2],
-    ["c5a.4x", "c5a.4x", 4, 4],
-    ["c5a.6x", "c5a.6x", 6, 6]
+    ["amd19-1c-8r"] * 2 + [2, 8],
+    ["amd19-2c-t16r"] * 2 + [4, 16],
+    ["amd19-4c-t64r"] * 2 + [8, 64]
   ].map { |args| VmSize.new(*args) }.freeze
 end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -37,45 +37,52 @@ class Vm < Sequel::Model
     assigned_vm_address&.ip
   end
 
-  Product = Struct.new(:line, :cores)
+  class Product < Struct.new(:manufacturer, :year, :cores, :ram, keyword_init: true)
+    def initialize(**args)
+      %i[year cores ram].each {
+        args[_1] = args[_1].to_s
+      }
+      super(**args)
 
-  def product
-    return @product if @product
-    fail "BUG: cannot parse vm size" unless size =~ /\A(.*)\.(\d+)x\z/
-    line = $1
+      # Used for the side effect of eagerly raising errors if the
+      # input cannot be rendered.
+      to_s
+    end
 
-    # YYY: Hack to deal with the presentation currently being in
-    # "vcpu" which has a pretty specific meaning being ambigious to
-    # threads or actual cores.
-    #
-    # The presentation is currently helpful because our bare metal
-    # sizes are quite small, supporting only 1, 2, 3 cores (reserving
-    # one for ourselves) and 2, 4, 6 vcpu.  So the product line is
-    # ambiguous as to whether it's ordinal or descriptive (it's
-    # descriptive).  To convey the right thing in demonstration, use
-    # vcpu counts.  It would have been nice to have gotten bigger
-    # hardware in time to avoid that and standardize on cores.
-    #
-    # As an aside, although we probably want to reserve a core an I/O
-    # process of some kind (e.g. SPDK, reserving the entire memory
-    # quota for it may be overkill.
-    cores = Integer($2) / 2
-    @product = Product.new(line, cores)
-  end
+    def to_s
+      "#{manufacturer}#{year}-#{self.class.sort_padded(cores)}c-#{self.class.sort_padded(ram)}r"
+    end
 
-  def mem_gib_ratio
-    @mem_gib_ratio ||= case product.line
-    when "m5a"
-      4
-    when "c5a"
-      2
-    else
-      fail "BUG: unrecognized product line"
+    MATCHER = /(?<manufacturer>[a-z]+)(?<year>\d+)-[t-w]?(?<cores>\d+(?:\.\d+)?)c-[t-w]?(?<ram>\d+(?:\.\d+)?)r/
+
+    def self.parse(s)
+      fail "BUG: cannot parse vm size" unless (match = MATCHER.match(s))
+      new(**match.named_captures.transform_keys(&:intern))
+    end
+
+    def self.sort_padded(number)
+      rendered = number.to_s
+      return rendered if rendered.include?(".")
+
+      case rendered.length
+      when 1
+        ""
+      when 2
+        "t"
+      when 3
+        "u"
+      when 4
+        "v"
+      when 5
+        "w"
+      else
+        fail "BUG: unsupported number of digits"
+      end + rendered
     end
   end
 
-  def mem_gib
-    product.cores * mem_gib_ratio
+  def product
+    @product ||= Product.parse(size)
   end
 
   # cloud-hypervisor takes topology information in this format:
@@ -132,7 +139,15 @@ class Vm < Sequel::Model
   end
 
   def cores
-    product.cores
+    Integer(product.cores)
+  end
+
+  def mem_gib
+    Integer(product.ram)
+  end
+
+  def mem_gib_ratio
+    mem_gib.to_f / cores
   end
 
   def self.ubid_to_name(id)

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -9,7 +9,7 @@ require "base64"
 class Prog::Vm::Nexus < Prog::Base
   semaphore :destroy, :refresh_mesh
 
-  def self.assemble(public_key, project_id, name: nil, size: "m5a.2x",
+  def self.assemble(public_key, project_id, name: nil, size: "amd19-1c-4r",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
     private_subnets: [], storage_size_gib: 20, storage_encrypted: false)
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Prog::Vm::Nexus do
   let(:st) { Strand.new }
   let(:vm) {
     disk = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0)
-    Vm.new(size: "m5a.2x").tap {
+    Vm.new(size: "amd19-1c-4r").tap {
       _1.id = UBID.generate(UBID::TYPE_VM).to_uuid
       _1.vm_storage_volumes.append(disk)
       disk.vm = _1

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Clover, "vm" do
         fill_in "Name", with: name
         choose option: "hetzner-hel1"
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "amd19-1c-8r"
 
         click_button "Create"
 
@@ -87,7 +87,7 @@ RSpec.describe Clover, "vm" do
         fill_in "Name", with: "invalid name"
         choose option: "hetzner-hel1"
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "amd19-1c-8r"
 
         click_button "Create"
 
@@ -105,7 +105,7 @@ RSpec.describe Clover, "vm" do
         fill_in "Name", with: vm.name
         choose option: "hetzner-hel1"
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "amd19-1c-8r"
 
         click_button "Create"
 

--- a/spec/serializers/web/vm_spec.rb
+++ b/spec/serializers/web/vm_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../../spec_helper"
 
 RSpec.describe Serializers::Web::Vm do
-  let(:vm) { Vm.new(name: "test-vm", size: "m5a.2x").tap { _1.id = "a410a91a-dc31-4119-9094-3c6a1fb49601" } }
+  let(:vm) { Vm.new(name: "test-vm", size: "amd19-1c-4r").tap { _1.id = "a410a91a-dc31-4119-9094-3c6a1fb49601" } }
   let(:ser) { described_class.new(:default) }
 
   it "can serialize with the default structure" do


### PR DESCRIPTION
Use ${vendor}${year}-${pad}${core}c-${pad}${ram}r product notation

Previously, we used AWS-style names to convey a general idea to those
receiving a demonstration, but there are many problems with AWS-style
names that we don't need to repeat. In particular, they convey nothing
useful about the instance and sort badly, sending me off to the manual
with regularity for simple matters.

The results are like this:

    amd19-0.3c-1.3r
    amd19-0.3c-2.6r
    amd19-1c-4r
    amd19-1c-8r
    amd19-2c-8r
    amd19-2c-t16r
    amd19-4c-t16r
    amd19-4c-t32r
    amd19-8c-t32r
    amd19-8c-t64r
    amd19-t16c-t64r
    amd19-t16c-u128r
    amd19-t32c-u128r
    amd19-t32c-u256r
    amd19-t64c-u256r
    amd19-t64c-u512r
    amd19-u128c-u512r
    amd19-u128c-v1024r

A string like `amd19-2c-8r` means: an AMD chip, released in 2019, two
cores, eight gigabytes of ram.

A string like `amd19-u128c-u512r` means: an AMD chip, released in
2019, 128 cores, 512 gigabytes of ram.  Note the `u` character has no
meaning: it's only for sort assistance, explained in more detail
below.

A string like `amd19-0.3c-1.3r` is intended to be for a third of a
core, a product we don't support yet, but I wanted to include how it
might look.

The meaning of each part:

`c` is cores, `r` is gigabytes of ram.  We could omit these to be
positional like `amd19-2-4`, but I thought it'd invite errors as
people would swap the meaning of the two positions.

the `t` and `u`, `v` bytes seen with two, three, and four digit
numbers respectively are used to help the product strings sort.  They
have no other meaning.  No such sort assist byte is necessary for
decimalized numbers or single-digit numbers.

This is the strangest part of the design, introducing a meaningless
character to assist sorts.  I'm not convinced of it, but bad sorts on
product names have been a pebble in my shoe for a long time.  Normally
this is accomplished by zero-padding, but this would result in long
and hard to type product strings for small products, which tend to be
the most commonly used, e.g. a hypothetical `amd19-002c-0008r`.  I
thought this was intolerable.

== Comparisons to other vendors

In the form of shell expansion with a default: `${symbol:example}`

GCP is of the form:

    ${obscure-microarchitecture-string:t2d}-${ram-ratio-string:standard}-${cores}

Example: `t2d.standard-4`

Azure is of the form:

    Standard_${ram-ratio+manufacturer-char:D}#{vcpu:64}${other-char-modifiers:s}_${microarch_version:v5}

Example: `Standard_D64ds_v4`

I don't know why the `Standard_` shows up so often without variation
in Azure.  Another annoying quirk is how instance lines are referred
to like "Dds" but in a product name, the vcpu count interrupts, so you
can't copy and paste.

AWS is of the form:

    ${memory-ratio:m}${microarchish:5}${manufacturer:a}.${t-shirt-size}

Example: `m5a.xlarge`

== The Sort Assist Byte Range

The general idea here is to choose bytes that are:

* Contiguous (easy to write a regexp range against)
* Meaningless

So I wrote a table of the alphabet and assigned meaning to characters.
The range `[t-w]` stood out as a good range in the lack of meaning
present:

    a - arm, amd
    b
    c - core
    d - disk
    e
    f
    g - gigabyte
    h
    i - intel, instance
    j
    k
    l - thin when in non-monospace fonts
    m - memory, megabyte
    n - network
    o
    p
    q
    r - ram
    s - storage
    t
    u
    v
    w
    x - multiply?
    y
    z
