### PR TITLE
Add "udec" shortcut when in REPL

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -11,3 +11,7 @@ $0 = "clover-#{ENV["RACK_ENV"]}"
 opts = Pry::CLI.parse_options
 Pry.config.prompt_name = $0
 Pry::CLI.start(opts)
+
+def udec(*args)
+  UBID.decode(*args)
+end


### PR DESCRIPTION
Instead of `UBID.decode`, when working interactively, `udec` suffices:

    > udec 'vmabcd...'