### PR TITLE
Setup VM networking & storage after host reboot

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -15,7 +15,7 @@ class Vm < Sequel::Model
 
   include ResourceMethods
   include SemaphoreMethods
-  semaphore :destroy, :refresh_mesh
+  semaphore :destroy, :refresh_mesh, :start_after_host_reboot
 
   include Authorization::HyperTagMethods
 

--- a/rhizome/bin/recreate-unpersisted
+++ b/rhizome/bin/recreate-unpersisted
@@ -1,0 +1,63 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+
+secrets = JSON.parse($stdin.read)
+
+unless (storage_secrets = secrets["storage"])
+  puts "need storage secrets in secrets json"
+  exit 1
+end
+
+unless (params_path = ARGV.shift)
+  puts "expected path to prep.json as argument"
+  exit 1
+end
+
+params_json = File.read(params_path)
+params = JSON.parse(params_json)
+
+unless (vm_name = params["vm_name"])
+  puts "need vm_name in parameters json"
+  exit 1
+end
+
+unless (gua = params["public_ipv6"])
+  puts "need public_ipv6 in parameters json"
+  exit 1
+end
+
+unless (ip4 = params["public_ipv4"])
+  puts "need public_ipv4 in parameters json"
+  exit 1
+end
+
+unless (local_ip4 = params["local_ipv4"])
+  puts "need local_ipv4 in parameters json"
+  exit 1
+end
+
+unless (nics = params["nics"])
+  puts "need nics in parameters json"
+  exit 1
+end
+
+unless (mem_gib = params["mem_gib"])
+  puts "need mem_gib in parameters json"
+  exit 1
+end
+
+ndp_needed = params.fetch("ndp_needed", false)
+
+unless (storage_volumes = params["storage_volumes"])
+  puts "need storage_volumes in parameters json"
+  exit 1
+end
+
+require_relative "../lib/vm_setup"
+
+VmSetup.new(vm_name).recreate_unpersisted(
+  gua, ip4, local_ip4, nics, mem_gib,
+  ndp_needed, storage_volumes, storage_secrets
+)

--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -43,16 +43,51 @@ class VmSetup
   end
 
   def prep(unix_user, public_key, nics, gua, ip4, local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_volumes, storage_secrets)
-    ip4 = nil if ip4.empty?
-    interfaces(nics)
-    setup_veths_6(gua, ndp_needed)
-    setup_taps_6(gua, nics)
-    routes4(ip4, local_ip4, nics)
-    nat4(ip4, nics)
+    setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed)
     cloudinit(unix_user, public_key, nics)
     vhost_sockets = storage(storage_volumes, storage_secrets, boot_image)
     hugepages(mem_gib)
     install_systemd_unit(max_vcpus, cpu_topology, mem_gib, vhost_sockets, nics)
+  end
+
+  def recreate_unpersisted(gua, ip4, local_ip4, nics, mem_gib, ndp_needed, storage_volumes, storage_secrets)
+    setup_networking(true, gua, ip4, local_ip4, nics, ndp_needed)
+    hugepages(mem_gib)
+
+    storage_volumes.each { |volume|
+      disk_index = volume["disk_index"]
+      device_id = volume["device_id"]
+      disk_file = vp.disk(disk_index)
+      key_wrapping_secrets = storage_secrets[device_id]
+      encryption_key = read_data_encryption_key(disk_index, key_wrapping_secrets) if key_wrapping_secrets
+      setup_spdk_bdev(device_id, disk_file, encryption_key)
+      setup_spdk_vhost(disk_index, device_id)
+    }
+  end
+
+  def setup_networking(skip_persisted, gua, ip4, local_ip4, nics, ndp_needed)
+    ip4 = nil if ip4.empty?
+    guest_ephemeral, clover_ephemeral = subdivide_network(NetAddr.parse_net(gua))
+
+    if !skip_persisted
+      # Write out guest-delegated and clover infrastructure address
+      # ranges, designed around non-floating IPv6 networks bound to the
+      # host.
+      vp.write_guest_ephemeral(guest_ephemeral.to_s)
+      vp.write_clover_ephemeral(clover_ephemeral.to_s)
+
+      if ip4
+        vm_sub = NetAddr::IPv4Net.parse(ip4)
+        vp.write_public_ipv4(vm_sub.to_s)
+        write_nat4_config(ip4, nics)
+      end
+    end
+
+    interfaces(nics)
+    setup_veths_6(guest_ephemeral, clover_ephemeral, gua, ndp_needed)
+    setup_taps_6(gua, nics)
+    routes4(ip4, local_ip4, nics)
+    apply_nat4_rules if ip4
     forwarding
   end
 
@@ -82,9 +117,9 @@ class VmSetup
     params = JSON.parse(File.read(vp.prep_json))
     params["storage_volumes"].each { |disk|
       device_id = disk["device_id"]
-      index = disk["disk_index"]
+      disk_index = disk["disk_index"]
 
-      vhost_controller = Spdk.vhost_controller(@vm_name, index)
+      vhost_controller = Spdk.vhost_controller(@vm_name, disk_index)
 
       r "#{Spdk.rpc_py} vhost_delete_controller #{vhost_controller.shellescape}"
 
@@ -105,9 +140,9 @@ class VmSetup
   end
 
   def hugepages(mem_gib)
-    r "mkdir #{vp.q_hugepages}"
+    FileUtils.mkdir_p vp.hugepages
+    FileUtils.chown @vm_name, @vm_name, vp.hugepages
     r "mount -t hugetlbfs -o uid=#{q_vm},size=#{mem_gib}G nodev #{vp.q_hugepages}"
-    r "chown -R #{q_vm} #{vp.q_hugepages}"
   end
 
   def interfaces(nics)
@@ -137,16 +172,11 @@ class VmSetup
     [halved, halved.next_sib]
   end
 
-  def setup_veths_6(gua, ndp_needed)
+  def setup_veths_6(guest_ephemeral, clover_ephemeral, gua, ndp_needed)
     # Routing: from host to subordinate.
     vethi_ll = mac_to_ipv6_link_local(r("ip netns exec #{q_vm} cat /sys/class/net/vethi#{q_vm}/address").chomp)
     r "ip link set dev vetho#{q_vm} up"
     r "ip route replace #{gua.shellescape} via #{vethi_ll.shellescape} dev vetho#{q_vm}"
-
-    # Write out guest-delegated and clover infrastructure address
-    # ranges, designed around non-floating IPv6 networks bound to the
-    # host.
-    guest_ephemeral, clover_ephemeral = subdivide_network(NetAddr.parse_net(gua))
 
     if ndp_needed
       routes = r "ip -j route"
@@ -162,9 +192,6 @@ class VmSetup
     vetho_ll = mac_to_ipv6_link_local(File.read("/sys/class/net/vetho#{q_vm}/address").chomp)
     r "ip -n #{q_vm} link set dev vethi#{q_vm} up"
     r "ip -n #{q_vm} route replace 2000::/3 via #{vetho_ll.shellescape} dev vethi#{q_vm}"
-
-    vp.write_guest_ephemeral(guest_ephemeral.to_s)
-    vp.write_clover_ephemeral(clover_ephemeral.to_s)
   end
 
   def setup_taps_6(gua, nics)
@@ -206,8 +233,6 @@ class VmSetup
     vetho, vethi = [local_ip.network.to_s,
       local_ip.next_sib.network.to_s]
 
-    vp.write_public_ipv4(vm) if ip4
-
     r "ip addr replace #{vetho}/32 dev vetho#{q_vm}"
     r "ip route replace #{vm} dev vetho#{q_vm}" if ip4
     r "echo 1 > /proc/sys/net/ipv4/conf/vetho#{q_vm}/proxy_arp"
@@ -229,7 +254,7 @@ class VmSetup
     end
   end
 
-  def nat4(ip4, nics)
+  def write_nat4_config(ip4, nics)
     return unless ip4
     public_sub = NetAddr::IPv4Net.parse(ip4)
     public_ipv4 = public_sub.network.to_s
@@ -247,6 +272,9 @@ table ip raw {
   }
 }
 NFTABLES_CONF
+  end
+
+  def apply_nat4_rules
     # We first flush the ruleset to make this function idempotent
     r "ip netns exec #{q_vm} bash -c 'nft flush ruleset'"
     r "ip netns exec #{q_vm} bash -c 'nft -f #{vp.q_nftables_conf}'"
@@ -325,65 +353,36 @@ EOS
 
   def storage(storage_volumes, storage_secrets, boot_image)
     storage_volumes.map { |volume|
-      idx = volume["disk_index"]
-      FileUtils.mkdir_p vp.storage(idx, "")
+      disk_index = volume["disk_index"]
+      FileUtils.mkdir_p vp.storage(disk_index, "")
       device_id = volume["device_id"]
       key_wrapping_secrets = storage_secrets[device_id]
-      setup_volume(volume, idx, boot_image, key_wrapping_secrets)
+      setup_volume(volume, disk_index, boot_image, key_wrapping_secrets)
+      setup_spdk_vhost(disk_index, device_id)
     }
   end
 
-  def setup_volume(storage_volume, index, boot_image, key_wrapping_secrets)
+  def setup_volume(storage_volume, disk_index, boot_image, key_wrapping_secrets)
     encrypted = !key_wrapping_secrets.nil?
-    encryption_key = setup_data_encryption_key(index, key_wrapping_secrets) if encrypted
+    encryption_key = setup_data_encryption_key(disk_index, key_wrapping_secrets) if encrypted
 
-    disk_file = setup_disk_file(storage_volume, index)
-
-    FileUtils.chown @vm_name, @vm_name, disk_file
-
-    # don't allow others to read user's disk
-    FileUtils.chmod "u=rw,g=r,o=", disk_file
-
-    # allow spdk to access the image
-    r "setfacl -m u:spdk:rw #{disk_file.shellescape}"
-
-    bdev = storage_volume["device_id"]
+    disk_file = setup_disk_file(storage_volume, disk_index)
 
     if storage_volume["boot"]
       copy_image(disk_file, boot_image,
         storage_volume["size_gib"],
-        encrypted, encryption_key)
+        encryption_key)
     end
 
-    setup_spdk_bdev(bdev, disk_file, encrypted, encryption_key)
-
-    vhost_controller = Spdk.vhost_controller(@vm_name, index)
-    spdk_vhost_sock = Spdk.vhost_sock(vhost_controller)
-
-    r "#{Spdk.rpc_py} vhost_create_blk_controller #{vhost_controller.shellescape} #{bdev.shellescape}"
-
-    # don't allow others to access the vhost socket
-    FileUtils.chmod "u=rw,g=r,o=", spdk_vhost_sock
-
-    # allow vm user to access the vhost socket
-    r "setfacl -m u:#{@vm_name}:rw #{spdk_vhost_sock.shellescape}"
-
-    # create a symlink to the socket in the per vm storage dir
-    FileUtils.ln_s spdk_vhost_sock, vp.vhost_sock(index)
-
-    # Change ownership of the symlink. FileUtils.chown uses File.lchown for
-    # symlinks and doesn't follow links. We don't use File.lchown directly
-    # because it expects numeric uid & gid, which is less convenient.
-    FileUtils.chown @vm_name, @vm_name, vp.vhost_sock(index)
-
-    vp.vhost_sock(index)
+    bdev = storage_volume["device_id"]
+    setup_spdk_bdev(bdev, disk_file, encryption_key)
   end
 
-  def setup_spdk_bdev(bdev, disk_file, encrypted, encryption_key)
+  def setup_spdk_bdev(bdev, disk_file, encryption_key)
     q_bdev = bdev.shellescape
     q_disk_file = disk_file.shellescape
 
-    if encrypted
+    if encryption_key
       q_keyname = "#{bdev}_key".shellescape
       q_aio_bdev = "#{bdev}_aio".shellescape
       r "#{Spdk.rpc_py} accel_crypto_key_create " \
@@ -398,7 +397,32 @@ EOS
     end
   end
 
-  def setup_data_encryption_key(index, key_wrapping_secrets)
+  def setup_spdk_vhost(disk_index, device_id)
+    q_bdev = device_id.shellescape
+    vhost_controller = Spdk.vhost_controller(@vm_name, disk_index)
+    spdk_vhost_sock = Spdk.vhost_sock(vhost_controller)
+
+    r "#{Spdk.rpc_py} vhost_create_blk_controller #{vhost_controller.shellescape} #{q_bdev}"
+
+    # don't allow others to access the vhost socket
+    FileUtils.chmod "u=rw,g=r,o=", spdk_vhost_sock
+
+    # allow vm user to access the vhost socket
+    r "setfacl -m u:#{@vm_name}:rw #{spdk_vhost_sock.shellescape}"
+
+    # create a symlink to the socket in the per vm storage dir
+    rm_if_exists(vp.vhost_sock(disk_index))
+    FileUtils.ln_s spdk_vhost_sock, vp.vhost_sock(disk_index)
+
+    # Change ownership of the symlink. FileUtils.chown uses File.lchown for
+    # symlinks and doesn't follow links. We don't use File.lchown directly
+    # because it expects numeric uid & gid, which is less convenient.
+    FileUtils.chown @vm_name, @vm_name, vp.vhost_sock(disk_index)
+
+    vp.vhost_sock(disk_index)
+  end
+
+  def setup_data_encryption_key(disk_index, key_wrapping_secrets)
     data_encryption_key = OpenSSL::Cipher.new("aes-256-xts").random_key.unpack1("H*")
 
     result = {
@@ -407,7 +431,7 @@ EOS
       key2: data_encryption_key[64..]
     }
 
-    key_file = vp.data_encryption_key(index)
+    key_file = vp.data_encryption_key(disk_index)
 
     # save encrypted key
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
@@ -421,8 +445,15 @@ EOS
     result
   end
 
-  def copy_image(disk_file, boot_image, disk_size_gib, encrypted, encryption_key)
+  def read_data_encryption_key(disk_index, key_wrapping_secrets)
+    key_file = vp.data_encryption_key(disk_index)
+    sek = StorageKeyEncryption.new(key_wrapping_secrets)
+    sek.read_encrypted_dek(key_file)
+  end
+
+  def copy_image(disk_file, boot_image, disk_size_gib, encryption_key)
     image_path = download_boot_image(boot_image)
+    encrypted = !encryption_key.nil?
 
     size = File.size(image_path)
 
@@ -503,13 +534,20 @@ EOS
     "--bs=2097152", stdin: spdk_config_json)
   end
 
-  def setup_disk_file(storage_volume, index)
-    disk_file = vp.disk(index)
+  def setup_disk_file(storage_volume, disk_index)
+    disk_file = vp.disk(disk_index)
     q_disk_file = disk_file.shellescape
 
     FileUtils.touch(disk_file)
     r "truncate -s #{storage_volume["size_gib"]}G #{q_disk_file}"
 
+    FileUtils.chown @vm_name, @vm_name, disk_file
+
+    # don't allow others to read user's disk
+    FileUtils.chmod "u=rw,g=r,o=", disk_file
+
+    # allow spdk to access the image
+    r "setfacl -m u:spdk:rw #{disk_file.shellescape}"
     disk_file
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -355,4 +355,23 @@ RSpec.describe Prog::Vm::Nexus do
       nx.destroy
     end
   end
+
+  describe "#start_after_host_reboot" do
+    let(:sshable) { instance_double(Sshable) }
+    let(:vm_host) { instance_double(VmHost, sshable: sshable) }
+
+    before do
+      expect(vm).to receive(:vm_host).and_return(vm_host)
+    end
+
+    it "can start a vm after reboot" do
+      expect(sshable).to receive(:cmd).with(
+        /sudo bin\/recreate-unpersisted \/vm\/vm[0-9a-z]+\/prep.json/,
+        {stdin: "{\"storage\":{}}"}
+      )
+      expect(sshable).to receive(:cmd).with(/sudo systemctl start vm[0-9a-z]+/)
+
+      expect { nx.start_after_host_reboot }.to hop("wait")
+    end
+  end
 end


### PR DESCRIPTION
Recreates VM's storage & networking state after host reboot & starts it.

This can be invoked by incrementing VM's start after host reboot semaphore:

```
> strand_id = vm.incr_start_after_host_reboot[:strand_id]
> Strand[strand_id].run 100
```

Internally
* It sends VM's config & secrets to `rhizome/bin/recreate-unpersisted`, which will call the appropriate methods to recreate storage & network state
* then starts the VM

**Note :** If you want to try this, make sure the VM is properly shutdown by running `sudo shutdown now` inside the VM before rebooting the host. Otherwise some of data might not have been flushed to disks & VM might fail to start properly.

I am leaving recreating vnet & tunnel configs to a separate PR.