### PR TITLE
Purify access policy JSON before highlighting

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -116,10 +116,10 @@ function setupPolicyEditor() {
   $(".policy-editor").each(function() {
     let pre = $(this).find("pre");
     let textarea = $(this).find("textarea");
-    pre.html(jsonHighlight(pre.text()));
+    pre.html(jsonHighlight(DOMPurify.sanitize(pre.text())));
 
     pre.on("focusout", function () {
-      pre.html(jsonHighlight(pre.text()));
+      pre.html(jsonHighlight(DOMPurify.sanitize(pre.text())));
     })
 
     pre.on("keyup", function () {

--- a/clover_web.rb
+++ b/clover_web.rb
@@ -24,7 +24,7 @@ class CloverWeb < Roda
     csp.style_src :self
     csp.img_src :self
     csp.form_action :self
-    csp.script_src :self, "https://cdn.jsdelivr.net"
+    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.6.4/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
     csp.connect_src :self
     csp.base_uri :none
     csp.frame_ancestors :none

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -13,6 +13,11 @@
       integrity="sha256-oP6HI9z1XaZNBrJURtCoUT5SUnxFr8s3BzRl+cbzUq8="
       crossorigin="anonymous"
     ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
+      integrity="sha256-QigBQMy2be3IqJD2ezKJUJ5gycSmyYlRHj2VGBuITpU="
+      crossorigin="anonymous"
+    ></script>
   </head>
 
   <body class="h-full">


### PR DESCRIPTION
Dependabot created two security alerts titled as "DOM text reinterpreted as HTML" for `pre.html(jsonHighlight(pre.text())` lines.

It says "Extracting text from a DOM node and interpreting it as HTML can lead to a cross-site scripting vulnerability."

People and ChatGPT recommend to use [DOMPurify](https://github.com/cure53/DOMPurify) library to sanitize HTML input.

Actually we have very strict Content-Security-Policy and don't allow inline scripts.

But to be future-proof, I added DOMPurify. I hope it will resolve these security alerts. I couldn't find a way to be sure is it resolving or not before merging it.