### PR TITLE
SPDK service survives reboot

### DIFF
--- a/prog/setup_spdk.rb
+++ b/prog/setup_spdk.rb
@@ -10,7 +10,11 @@ class Prog::SetupSpdk < Prog::Base
   end
 
   def start_service
+    sshable.cmd("sudo systemctl enable home-spdk-hugepages.mount")
+    sshable.cmd("sudo systemctl enable spdk")
+
     sshable.cmd("sudo systemctl start spdk")
+
     vm_host.update(used_hugepages_1g: vm_host.used_hugepages_1g + 1)
     pop "SPDK was setup"
   end

--- a/rhizome/bin/setup-spdk
+++ b/rhizome/bin/setup-spdk
@@ -24,15 +24,30 @@ rescue CommandFail => ex
 end
 
 r "sudo --user=#{q_user} mkdir -p #{q_hugepages_dir}"
-r "mount -t hugetlbfs -o uid=#{q_user},size=1G nodev #{q_hugepages_dir}"
 
 # Directory to put vhost sockets.
 FileUtils.mkdir_p(Spdk.vhost_dir)
 FileUtils.chown Spdk.user, Spdk.user, Spdk.vhost_dir
 
-spdk_service = <<SPDK_SERVICE
+File.write("/lib/systemd/system/home-spdk-hugepages.mount", <<SPDK_HUGEPAGES_MOUNT
+[Unit]
+Description=SPDK hugepages mount
+
+[Mount]
+What=hugetlbfs
+Where=/home/spdk/hugepages
+Type=hugetlbfs
+Options=uid=spdk,size=1G
+
+[Install]
+WantedBy=spdk.service
+SPDK_HUGEPAGES_MOUNT
+)
+
+File.write("/lib/systemd/system/spdk.service", <<SPDK_SERVICE
 [Unit]
 Description=Block Storage Service
+Requires=home-spdk-hugepages.mount
 [Service]
 Type=simple
 Environment="XDG_RUNTIME_DIR=#{Spdk.home.shellescape}"
@@ -52,6 +67,8 @@ ProtectHome=no
 NoNewPrivileges=yes
 User=spdk
 Group=spdk
+[Install]
+WantedBy=multi-user.target
+Alias=spdk.service
 SPDK_SERVICE
-
-File.write("/etc/systemd/system/spdk.service", spdk_service)
+)

--- a/spec/prog/setup_spdk_spec.rb
+++ b/spec/prog/setup_spdk_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe Prog::SetupSpdk do
   describe "#start_service" do
     it "exits, reducing number of hugepages" do
       sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("sudo systemctl enable home-spdk-hugepages.mount")
+      expect(sshable).to receive(:cmd).with("sudo systemctl enable spdk")
       expect(sshable).to receive(:cmd).with("sudo systemctl start spdk")
       vm_host = instance_double(VmHost)
       expect(vm_host).to receive(:used_hugepages_1g).and_return(0)


### PR DESCRIPTION
Previously SPDK didn't automatically start on reboot. This PR fixes that by adding hugepages mount points and changes to the systemd config.

Note that this PR doesn't recreate the bdevs for VMs. That'll be part of future PRs.