### PR TITLE
Add default type and class level helper to serializers

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -66,7 +66,7 @@ autoload_normal = ->(subdirectory, include_first: false) do
 end
 
 %w[model lib clover.rb clover_web.rb clover_api.rb].each { autoload_normal.call(_1) }
-%w[scheduling prog serializers/web serializers/api].each { autoload_normal.call(_1, include_first: true) }
+%w[scheduling prog serializers serializers/web serializers/api].each { autoload_normal.call(_1, include_first: true) }
 
 AUTOLOAD_CONSTANTS.freeze
 

--- a/serializers/api/vm.rb
+++ b/serializers/api/vm.rb
@@ -12,7 +12,7 @@ class Serializers::Api::Vm < Serializers::Base
       size: vm.size,
       unix_user: vm.unix_user,
       ip6: vm.ephemeral_net6&.nth(2),
-      projects: Serializers::Api::Project.new(:default).serialize(vm.projects)
+      projects: Serializers::Api::Project.serialize(vm.projects)
     }
   end
 

--- a/serializers/base.rb
+++ b/serializers/base.rb
@@ -30,7 +30,11 @@ module Serializers
       @@structures["#{name}::#{type}"] = blk
     end
 
-    def initialize(type)
+    def self.serialize(object)
+      new.serialize(object)
+    end
+
+    def initialize(type = :default)
       @type = type
     end
 

--- a/serializers/web/access_policy.rb
+++ b/serializers/web/access_policy.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../base"
-
 class Serializers::Web::AccessPolicy < Serializers::Base
   def self.base(ap)
     {

--- a/serializers/web/account.rb
+++ b/serializers/web/account.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../base"
-
 class Serializers::Web::Account < Serializers::Base
   def self.base(a)
     {

--- a/serializers/web/project.rb
+++ b/serializers/web/project.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../base"
-
 class Serializers::Web::Project < Serializers::Base
   def self.base(p)
     {

--- a/serializers/web/vm.rb
+++ b/serializers/web/vm.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../base"
-
 class Serializers::Web::Vm < Serializers::Base
   def self.base(vm)
     {

--- a/spec/serializers/base_spec.rb
+++ b/spec/serializers/base_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Serializers::Base do
+  it "use default structure when not provided" do
+    ser = described_class.new
+    expect(ser.instance_variable_get(:@type)).to eq(:default)
+  end
+
+  it "initilize new seriliazer when class method called" do
+    ser = instance_double(described_class)
+    expect(described_class).to receive(:new).and_return(ser)
+    expect(ser).to receive(:serialize).and_return({})
+
+    expect(described_class.serialize(nil)).to eq({})
+  end
+end

--- a/spec/serializers/web/vm_spec.rb
+++ b/spec/serializers/web/vm_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../spec_helper"
 
 RSpec.describe Serializers::Web::Vm do
   let(:vm) { Vm.new(name: "test-vm", size: "m5a.2x").tap { _1.id = "a410a91a-dc31-4119-9094-3c6a1fb49601" } }
-  let(:ser) { described_class.new(:default) }
+  let(:ser) { described_class.new }
 
   it "can serialize with the default structure" do
     data = ser.serialize(vm)


### PR DESCRIPTION
While working with Furkan for networking UI, I realized these helpers might be helpful.

Old way:

    Serializers::Web::PrivateSubnet.new(:default).serialize(data)

New ways:

    Serializers::Web::PrivateSubnet.new.serialize(data)
    Serializers::Web::PrivateSubnet.serialize(data)