### PR TITLE
Add default developer project to bin/pry

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -7,6 +7,12 @@ require_relative "../loader"
 
 require "pry"
 
+def dev_project
+  return unless Config.development?
+  ac = Account[email: "dev@ubicloud.com"] || Account.create_with_id(email: "dev@ubicloud.com")
+  ac.projects.first || ac.create_project_with_default_policy("default")
+end
+
 $0 = "clover-#{ENV["RACK_ENV"]}"
 opts = Pry::CLI.parse_options
 Pry.config.prompt_name = $0


### PR DESCRIPTION
This commit adds a default account and a project to bin/pry. This way, in development, we can use this project to associate entities.