### PR TITLE
guest_mac is removed, we use mac from controlplane

### DIFF
--- a/rhizome/lib/vm_path.rb
+++ b/rhizome/lib/vm_path.rb
@@ -50,7 +50,6 @@ class VmPath
   # Define path, q_path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
-    guest_mac
     guest_ephemeral
     clover_ephemeral
     dnsmasq.conf

--- a/rhizome/spec/vm_path_spec.rb
+++ b/rhizome/spec/vm_path_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe VmPath do
   subject(:vp) { described_class.new("test'vm") }
 
   it "can compute a path" do
-    expect(vp.guest_mac).to eq("/vm/test'vm/guest_mac")
+    expect(vp.guest_ephemeral).to eq("/vm/test'vm/guest_ephemeral")
   end
 
   it "can escape a path" do
-    expect(vp.q_guest_mac).to eq("/vm/test\\'vm/guest_mac")
+    expect(vp.q_guest_ephemeral).to eq("/vm/test\\'vm/guest_ephemeral")
   end
 
   it "will snakeify difficult characters" do


### PR DESCRIPTION
Previous commit 1ad6f54 has already moved mac address assignment to the controlplane. This commit removes the unnecessary function and cleans up the dataplane code properly.