### PR TITLE
Enable soft delete for almost all models

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -87,8 +87,8 @@ module Authorization
     def delete_hyper_tag(project)
       DB.transaction do
         tag = hyper_tag(project)
-        AppliedTag.where(access_tag_id: tag.id).delete
-        tag.delete
+        AppliedTag.where(access_tag_id: tag.id).destroy
+        tag.destroy
       end
     end
 
@@ -126,7 +126,7 @@ module Authorization
     end
 
     def untag(access_tag)
-      AppliedTag.where(access_tag_id: access_tag.id, tagged_id: id).delete
+      AppliedTag.where(access_tag_id: access_tag.id, tagged_id: id).destroy
     end
   end
 end

--- a/lib/sem_snap.rb
+++ b/lib/sem_snap.rb
@@ -45,7 +45,7 @@ class SemSnap
 
   def apply
     return if @defer_delete.empty?
-    Semaphore.where(strand_id: @strand_id, id: @defer_delete).delete
+    Semaphore.where(strand_id: @strand_id, id: @defer_delete).destroy
     @defer_delete.clear
   end
 

--- a/migrate/20230727_add_primary_keys_to_applied_tags.rb
+++ b/migrate/20230727_add_primary_keys_to_applied_tags.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  up do
+    alter_table(:applied_tag) do
+      drop_index [:access_tag_id, :tagged_id], concurrently: true
+      add_primary_key [:access_tag_id, :tagged_id]
+    end
+  end
+
+  down do
+    alter_table(:applied_tag) do
+      drop_index [:access_tag_id, :tagged_id], concurrently: true
+      add_unique_constraint [:access_tag_id, :tagged_id]
+    end
+  end
+end

--- a/migrate/20230727_soft_delete_models.rb
+++ b/migrate/20230727_soft_delete_models.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:deleted_record) do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :deleted_at, :timestamptz, null: false, default: Sequel::CURRENT_TIMESTAMP
+      column :model_name, :text, null: false
+      column :model_values, :jsonb, null: false, default: "{}"
+    end
+  end
+end

--- a/model.rb
+++ b/model.rb
@@ -41,6 +41,18 @@ module ResourceMethods
     @ubid ||= UBID.from_uuidish(id).to_s.downcase
   end
 
+  NON_ARCHIVED_MODELS = ["DeletedRecord", "Semaphore"]
+  def before_destroy
+    model_name = self.class.name
+    unless NON_ARCHIVED_MODELS.include?(model_name)
+      model_values = values.merge(model_name: model_name)
+
+      DeletedRecord.create(deleted_at: Time.now, model_name: model_name, model_values: model_values)
+    end
+
+    super
+  end
+
   module ClassMethods
     # Adapted from sequel/model/inflections.rb's underscore, to convert
     # class names into symbols

--- a/model.rb
+++ b/model.rb
@@ -47,6 +47,13 @@ module ResourceMethods
     unless NON_ARCHIVED_MODELS.include?(model_name)
       model_values = values.merge(model_name: model_name)
 
+      encryption_metadata = self.class.instance_variable_get(:@column_encryption_metadata)
+      unless encryption_metadata.empty?
+        encryption_metadata.keys.each do |key|
+          model_values.delete(key)
+        end
+      end
+
       DeletedRecord.create(deleted_at: Time.now, model_name: model_name, model_values: model_values)
     end
 

--- a/model/applied_tag.rb
+++ b/model/applied_tag.rb
@@ -5,3 +5,5 @@ require_relative "../model"
 class AppliedTag < Sequel::Model
   many_to_one :access_tag
 end
+
+AppliedTag.unrestrict_primary_key

--- a/model/deleted_record.rb
+++ b/model/deleted_record.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class DeletedRecord < Sequel::Model
+end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -51,7 +51,7 @@ SQL
         # since incr is entitled to be run at *any time* (including
         # after exitval is set) and any such incements will prevent
         # deletion of a Strand via foreign_key
-        Semaphore.where(strand_id: id).delete
+        Semaphore.where(strand_id: id).destroy
         return
       end
 
@@ -126,8 +126,8 @@ SQL
       update(exitval: ext.exitval, retval: nil)
       if parent_id.nil?
         # No parent Strand to reap here, so self-reap.
-        Semaphore.where(strand_id: id).delete
-        delete
+        Semaphore.where(strand_id: id).destroy
+        destroy
         @deleted = true
       end
 

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -165,10 +165,11 @@ end
   end
 
   def reap
-    strand.children_dataset.where(Sequel.~(exitval: nil)).returning.delete.tap {
-      # Clear cache if anything was deleted.
-      strand.associations.delete(:children) unless _1.empty?
-    }
+    exited_children = strand.children_dataset.where(Sequel.~(exitval: nil))
+    exited_children_count = exited_children.count
+    exited_children.destroy
+    # Clear cache if anything was deleted.
+    strand.associations.delete(:children) if exited_children_count > 0
   end
 
   def leaf?

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -317,15 +317,15 @@ SQL
         nic.incr_destroy
       end
 
-      vm.assigned_vm_address_dataset.delete
-      vm.vm_storage_volumes_dataset.delete
+      vm.assigned_vm_address_dataset.destroy
+      vm.vm_storage_volumes_dataset.destroy
 
       VmHost.dataset.where(id: vm.vm_host_id).update(
         used_cores: Sequel[:used_cores] - vm.cores
       )
       vm.projects.map { vm.dissociate_with_project(_1) }
 
-      vm.delete
+      vm.destroy
     end
 
     pop "vm deleted"

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -75,10 +75,10 @@ class Prog::Vnet::NicNexus < Prog::Base
     end
 
     DB.transaction do
-      nic.src_ipsec_tunnels_dataset.delete
-      nic.dst_ipsec_tunnels_dataset.delete
+      nic.src_ipsec_tunnels_dataset.destroy
+      nic.dst_ipsec_tunnels_dataset.destroy
       nic.private_subnet.incr_refresh_mesh
-      nic.delete
+      nic.destroy
     end
 
     pop "nic deleted"
@@ -87,8 +87,8 @@ class Prog::Vnet::NicNexus < Prog::Base
   def detach_vm
     DB.transaction do
       nic.update(vm_id: nil)
-      nic.src_ipsec_tunnels_dataset.delete
-      nic.dst_ipsec_tunnels_dataset.delete
+      nic.src_ipsec_tunnels_dataset.destroy
+      nic.dst_ipsec_tunnels_dataset.destroy
       nic.private_subnet.incr_refresh_mesh
       decr_detach_vm
     end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -64,7 +64,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     if ps.nics.empty?
       DB.transaction do
         ps.projects.map { ps.disassociate_with_project(_1) }
-        ps.delete
+        ps.destroy
       end
       pop "subnet destroyed"
     else

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -48,10 +48,10 @@ class CloverWeb
         end
 
         DB.transaction do
-          @project.access_tags.each { |access_tag| access_tag.applied_tags_dataset.delete }
-          @project.access_tags_dataset.delete
-          @project.access_policies_dataset.delete
-          @project.delete
+          @project.access_tags.each { |access_tag| access_tag.applied_tags_dataset.destroy }
+          @project.access_tags_dataset.destroy
+          @project.access_policies_dataset.destroy
+          @project.destroy
         end
 
         flash["notice"] = "'#{@project.name}' project is deleted."

--- a/spec/lib/sem_snap_spec.rb
+++ b/spec/lib/sem_snap_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe SemSnap do
   it "operates immediately by default in non-block form" do
     snap = described_class.new(st.id)
     snap.incr(:test)
-    delete_set = instance_double(Sequel::Dataset)
-    expect(delete_set).to receive(:delete)
+    delete_set = instance_double(Sequel::Model::DatasetMethods)
+    expect(delete_set).to receive(:destroy)
     expect(Semaphore).to receive(:where).and_return(delete_set)
     snap.decr(:test)
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe Prog::Vm::Nexus do
       nic = instance_double(Nic, incr_destroy: true)
       expect(nic).to receive(:update).with(vm_id: nil).and_return(true)
       expect(vm).to receive(:nics).and_return([nic])
-      expect(vm).to receive(:delete).and_return(true)
+      expect(vm).to receive(:destroy).and_return(true)
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(nx).to receive(:pop).with("vm deleted").and_return(true)
       nx.destroy

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -180,14 +180,14 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "destroys nic" do
-      expect(ipsec_tunnels[0]).to receive(:delete).and_return(true)
-      expect(ipsec_tunnels[1]).to receive(:delete).and_return(true)
+      expect(ipsec_tunnels[0]).to receive(:destroy).and_return(true)
+      expect(ipsec_tunnels[1]).to receive(:destroy).and_return(true)
       expect(nic).to receive(:src_ipsec_tunnels_dataset).and_return(ipsec_tunnels[0])
       expect(nic).to receive(:dst_ipsec_tunnels_dataset).and_return(ipsec_tunnels[1])
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(ps).to receive(:incr_refresh_mesh).and_return(true)
       expect(nx).to receive(:pop).with("nic deleted").and_return(true)
-      expect(nic).to receive(:delete).and_return(true)
+      expect(nic).to receive(:destroy).and_return(true)
       nx.destroy
     end
 
@@ -226,9 +226,9 @@ RSpec.describe Prog::Vnet::NicNexus do
     it "detaches vm and refreshes mesh" do
       expect(nic).to receive(:update).with(vm_id: nil).and_return(true)
       expect(nic).to receive(:src_ipsec_tunnels_dataset).and_return(ipsec_tunnels[0])
-      expect(ipsec_tunnels[0]).to receive(:delete).and_return(true)
+      expect(ipsec_tunnels[0]).to receive(:destroy).and_return(true)
       expect(nic).to receive(:dst_ipsec_tunnels_dataset).and_return(ipsec_tunnels[1])
-      expect(ipsec_tunnels[1]).to receive(:delete).and_return(true)
+      expect(ipsec_tunnels[1]).to receive(:destroy).and_return(true)
 
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(ps).to receive(:incr_refresh_mesh).and_return(true)

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "deletes and pops if nics are destroyed" do
-      expect(ps).to receive(:delete).and_return(true)
+      expect(ps).to receive(:destroy).and_return(true)
       expect(ps).to receive(:nics).and_return([]).at_least(:once)
       expect(nx).to receive(:pop).with("subnet destroyed").and_return(true)
       nx.destroy

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -3,6 +3,18 @@
 RSpec.describe ResourceMethods do
   let(:sa) { Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair) }
 
+  it "discourages deleting models with delete method" do
+    expect { sa.delete }.to raise_error(RuntimeError, /Calling delete is discouraged/)
+  end
+
+  it "allows deleting models with delete method if forced" do
+    expect { sa.delete(force: true) }.not_to raise_error
+  end
+
+  it "allows deleting models with destroy" do
+    expect { sa.destroy }.not_to raise_error
+  end
+
   it "archives scrubbed version of the model when deleted" do
     scrubbed_values_hash = sa.values.merge(model_name: "Sshable")
     scrubbed_values_hash.delete(:raw_private_key_1)

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe ResourceMethods do
+  let(:sa) { Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair) }
+
+  it "archives the model when deleted" do
+    values_hash = sa.values.merge(model_name: "Sshable")
+    expect(DeletedRecord).to receive(:create).with(hash_including(model_values: values_hash))
+    sa.destroy
+  end
+end

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -3,9 +3,11 @@
 RSpec.describe ResourceMethods do
   let(:sa) { Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair) }
 
-  it "archives the model when deleted" do
-    values_hash = sa.values.merge(model_name: "Sshable")
-    expect(DeletedRecord).to receive(:create).with(hash_including(model_values: values_hash))
+  it "archives scrubbed version of the model when deleted" do
+    scrubbed_values_hash = sa.values.merge(model_name: "Sshable")
+    scrubbed_values_hash.delete(:raw_private_key_1)
+    scrubbed_values_hash.delete(:raw_private_key_2)
+    expect(DeletedRecord).to receive(:create).with(hash_including(model_values: scrubbed_values_hash))
     sa.destroy
   end
 end


### PR DESCRIPTION
[Use destroy instead of delete](https://github.com/ubicloud/ubicloud/pull/350/commits/7f889033f499fd978086cb1ed532906ea593dc27) 

In a subsequent commit, We will start to archive deleted records to a separate
table. Archiving will be done in before_destroy hook. Sequel does not trigger
any hooks for delete calls, so we are converting all delete calls to destroy.
Both calls are quite similar with few notable differences;
- delete does not trigger any hooks but destroy does.
- delete is more efficient while working with datasets, it directly runs DELETE
query with the given conditions of the dataset, but destroy instantiates each
object and calls destroy on the resulting object. For models, their performance
is comparable; only additional overhead comes from triggering hooks.
- Since destroy instantiates each object, it needs primary key. Thus we added
primary key to AppliedTag model.
- destroy does not work properly with returning as it processes each row one by
one.

[Archive deleted records to a separate table](https://github.com/ubicloud/ubicloud/pull/350/commits/e0edeac18259937041bf05d0ab4c9f7c29c80491) 

This is prerequisite for audit records. We should be able to identify which VMs
and IP addresses used by which Projects/Accounts at a given time, so that we
can take necessary precautions against network abuse and spamming.

Since keeping historical records are useful for debugging as well, with this
commit we enable soft delete for not only VMs/IP addresses but for almost all
other models too. There are two exceptions at the moment;
- DeletedRecord: Not archived to prevent infinite loops, also archiving them
is not very meaningful.
- Semaphore: Not archived because we produce a lot of them.

Of course keeping historical records makes GDPR compliance a bit more difficult,
but that can be resolved by deleting very old records via batch processing after
certain duration.

[Scrub encrypted columns before archiving](https://github.com/ubicloud/ubicloud/pull/350/commits/ff6ac0bc40e0160a6d70def5edaf1447aad48337) 

This is an improvement over existing soft delete mechanism. We continue to
archive models that has encrpted columns, but we scrub those columns before
archiving.

[Discourage using delete method](https://github.com/ubicloud/ubicloud/pull/350/commits/f15ca651d35b48433bfb49f5426b4c4bb9ff4a84) 

Using delete method while deleting Sequel models does not trigger destroy hooks,
which we use for archival. With an earlier commit, we already removed all delete
calls from our codebase. However, it is still possible that a delete call might
be introduced in the future or an operator might call delete manually by mistake.

To prevent such unintentinal delete calls, with this commit, we are prepending
Sequel::Dataset and Sequel::Model classes to overwrite the delete behaviour. Now
using delete method raises an error and suggests using destroy instead. If delete
is really necessary in the given context, it can be still called via force flag.

One ugly part of this commit is that in our version of delete, we check the call
stack to see if;
- delete is called from rodauth
- delete is called from destroy itself
to allow those uses of delete.