### PR TITLE
Parse storage sizes with decimal points

### DIFF
--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -5,11 +5,11 @@ class Prog::LearnStorage < Prog::Base
 
   def parse_size_gib(storage_root, s)
     sizes = s.each_line.filter_map do |line|
-      next unless line =~ /^\s*(\d+)(\w+)$/
+      next unless line =~ /^\s*([\d.]+)(\w+)$/
       if $2 == "G"
-        Integer($1)
+        Float($1).floor
       elsif $2 == "T"
-        Integer($1) * 1024
+        (Float($1) * 1024).floor
       else
         # Fail noisily if unit is not in gigabytes or terabytes
         fail "BUG: unexpected storage size unit: #{$2}"

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -41,6 +41,24 @@ EOS
       ).to eq(5 * 1024)
     end
 
+    it "can parse size with decimal point" do
+      expect(
+        ls.parse_size_gib("/var", <<EOS)
+            Size
+            1.8T
+EOS
+      ).to eq(1843)
+    end
+
+    it "fails to parse size with invalid chars" do
+      expect {
+        ls.parse_size_gib("/var", <<EOS)
+            Size
+            1x8T
+EOS
+      }.to raise_error RuntimeError, "BUG: unexpected storage size unit: x8T"
+    end
+
     it "crashes if an unfamiliar unit is provided" do
       expect {
         ls.parse_size_gib("/var", <<EOS)


### PR DESCRIPTION
If a disk size is more than 1T then `df -h` will report it with decimal points. Previously we only allowed digits in size and threw an exception for decimal points. This PR fixes that.