### PR TITLE
Do not generate demo environment if it exists

### DIFF
--- a/demo/generate_env
+++ b/demo/generate_env
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
 
+FILE="$(dirname "$0")/.env"
+
+if [ -f "$FILE" ]; then
+    echo "$FILE environment file exists."
+    echo "Please remove it before generating a new one or use existing one."
+    exit 1
+fi
+
 POSTGRES_PASSWORD="$(head -c 12 /dev/random  | base64 | tr -d =+/)"
 CLOVER_SESSION_SECRET="$(head -c 64 /dev/random | base64)"
 CLOVER_COLUMN_ENCRYPTION_KEY="$(head -c 32 /dev/random | base64)"


### PR DESCRIPTION
If user has docker PostgreSQL container with existing demo environment, overwriting environment causes mismatch between database password and application's database password. If user has existing demo environment file, we should not overwrite it.