### PR TITLE
Prototype: Add dynamic display state based on strand's label

### DIFF
--- a/migrate/20230816_drop_states.rb
+++ b/migrate/20230816_drop_states.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:private_subnet) do
+      drop_column :state
+    end
+
+    alter_table(:vm) do
+      drop_column :display_state
+    end
+
+    drop_enum(:vm_display_state)
+  end
+
+  down do
+    create_enum(:vm_display_state, %w[creating running rebooting starting deleting])
+
+    alter_table(:vm) do
+      add_column :display_state, :vm_display_state, default: "creating", null: false
+    end
+
+    alter_table(:private_subnet) do
+      add_column :state, :text, null: false, default: "creating"
+    end
+  end
+end

--- a/model.rb
+++ b/model.rb
@@ -67,6 +67,10 @@ module ResourceMethods
     super
   end
 
+  def display_state
+    self.class.display_states[strand.label.intern]
+  end
+
   module ClassMethods
     # Adapted from sequel/model/inflections.rb's underscore, to convert
     # class names into symbols
@@ -94,6 +98,16 @@ module ResourceMethods
 
     def create_with_id(*, **)
       create(*, **) { _1.id = generate_uuid }
+    end
+
+    def display_states
+      @display_states || {}
+    end
+
+    def display_state(display, labels)
+      @display_states ||= {}
+
+      labels.each { @display_states[_1] = display }
     end
   end
 end

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -14,6 +14,7 @@ class PrivateSubnet < Sequel::Model
   ].freeze
 
   dataset_module Authorization::Dataset
+
   include Authorization::HyperTagMethods
   def hyper_tag_name(project)
     "project/#{project.ubid}/location/#{location}/private-subnet/#{name}"
@@ -26,13 +27,12 @@ class PrivateSubnet < Sequel::Model
   end
 
   include ResourceMethods
+  display_state :available, [:wait]
+  display_state :refreshing_mesh, [:refresh_mesh, :wait_refresh_mesh]
+  display_state :deleting, [:destroy]
 
   def self.ubid_to_name(ubid)
     ubid.to_s[0..7]
-  end
-
-  def display_state
-    (state == "waiting") ? "available" : state
   end
 
   include SemaphoreMethods

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -15,6 +15,16 @@ class Vm < Sequel::Model
   dataset_module Authorization::Dataset
 
   include ResourceMethods
+  display_state :creating, [:start, :create_unix_user, :prep, :run, :wait_sshable]
+  display_state :running, [:wait]
+  display_state :deleting, [:destroy]
+  display_state :starting, [:start_after_host_reboot]
+
+  def display_state
+    return "deleting" if destroy_set?
+    super
+  end
+
   include SemaphoreMethods
   semaphore :destroy, :start_after_host_reboot
 
@@ -36,11 +46,6 @@ class Vm < Sequel::Model
 
   def ip4
     assigned_vm_address&.ip
-  end
-
-  def display_state
-    return "deleting" if destroy_set?
-    super
   end
 
   def mem_gib_ratio

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -105,6 +105,7 @@ class Prog::Vm::HostNexus < Prog::Base
     boot_id = get_boot_id
     vm_host.update(last_boot_id: boot_id)
 
+    # FIXME(enes)
     vm_host.vms.each { |vm|
       vm.update(display_state: "rebooting")
     }

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -298,7 +298,6 @@ SQL
     addr = vm.ephemeral_net4 || vm.ephemeral_net6.nth(2)
     out = `ssh -o BatchMode=yes -o ConnectTimeout=1 -o PreferredAuthentications=none user@#{addr} 2>&1`
     if out.include? "Host key verification failed."
-      vm.update(display_state: "running")
       hop_wait
     end
     nap 1
@@ -316,8 +315,6 @@ SQL
     register_deadline(nil, 5 * 60)
 
     decr_destroy
-
-    vm.update(display_state: "deleting")
 
     unless host.nil?
       begin
@@ -360,16 +357,12 @@ SQL
   label def start_after_host_reboot
     register_deadline(:wait, 5 * 60)
 
-    vm.update(display_state: "starting")
-
     secrets_json = JSON.generate({
       storage: storage_secrets
     })
 
     host.sshable.cmd("sudo bin/recreate-unpersisted #{params_path.shellescape}", stdin: secrets_json)
     host.sshable.cmd("sudo systemctl start #{q_vm}")
-
-    vm.update(display_state: "running")
 
     decr_start_after_host_reboot
 

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe PrivateSubnet do
       net6: NetAddr.parse_net("fd1b:9793:dcef:cd0a::/64"),
       net4: NetAddr.parse_net("10.9.39.0/26"),
       location: "hetzner-hel1",
-      state: "waiting",
       name: "ps"
     )
   }

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prog::Vnet::NicNexus do
   let(:st) { Strand.new }
   let(:ps) {
     PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
-      net4: "10.0.0.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+      net4: "10.0.0.0/26").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
   }
 
   describe ".assemble" do
@@ -279,7 +279,7 @@ RSpec.describe Prog::Vnet::NicNexus do
   describe "#destroy" do
     let(:ps) {
       PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
-        net4: "1.1.1.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+        net4: "1.1.1.0/26").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
     }
     let(:nic) {
       Nic.new(private_subnet_id: ps.id,
@@ -323,7 +323,7 @@ RSpec.describe Prog::Vnet::NicNexus do
   describe "#detach_vm" do
     let(:ps) {
       PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
-        net4: "1.1.1.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+        net4: "1.1.1.0/26").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
     }
     let(:nic) {
       Nic.new(private_subnet_id: ps.id,

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
   let(:prj) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
   let(:ps) {
     PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
-      net4: "1.1.1.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+      net4: "1.1.1.0/26").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
   }
 
   before do
@@ -50,8 +50,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
         name: "default-ps",
         location: "hetzner-hel1",
         net6: "fd10:9b0b:6b4b:8fbb::/64",
-        net4: "10.0.0.0/26",
-        state: "waiting"
+        net4: "10.0.0.0/26"
       ).and_return(ps)
       expect(described_class).to receive(:random_private_ipv4).and_return("10.0.0.0/26")
       expect(Strand).to receive(:create).with(prog: "Vnet::SubnetNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
@@ -70,8 +69,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
         name: "default-ps",
         location: "hetzner-hel1",
         net6: "fd10:9b0b:6b4b:8fbb::/64",
-        net4: "10.0.0.0/26",
-        state: "waiting"
+        net4: "10.0.0.0/26"
       ).and_return(ps)
       expect(described_class).to receive(:random_private_ipv6).and_return("fd10:9b0b:6b4b:8fbb::/64")
       expect(Strand).to receive(:create).with(prog: "Vnet::SubnetNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
@@ -379,6 +377,13 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(ps).to receive(:dissociate_with_project).with(prj).and_return(true)
       expect(nx).to receive(:pop).with("subnet destroyed").and_return(true)
       nx.destroy
+    end
+  end
+
+  it "each label has display state" do
+    expect(described_class.labels.length).to eq(PrivateSubnet::DISPLAY_STATES.length)
+    described_class.labels.each do |label|
+      expect(PrivateSubnet::DISPLAY_STATES[label]).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
> Prototype: This PR is just a prototype for initial feedbacks. I didn't refactor all states yet

We need display state for resources to show users on UI. Vm has display_state, VmHost has allocation_state, PrivateSubnet has state etc.

Also resource nexuses have label to keep current state. Model's state and nexus' label have some kind of relation. We need to update model's state in code to keep them synchronized. It's easy to forget update model's state when label changed. Of course model's state isn't change with every change of label.

We can determine display state of resources dynamically based on a nexus label-state map. Also we can test to be sure every label has a display state to show.