### PR TITLE
Remove Nic wait from Vm:Nexus

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -187,10 +187,6 @@ SQL
   def start
     register_deadline(:wait, 10 * 60)
 
-    unless vm.nics.all? { |n| n.strand.label == "wait" }
-      nap 10
-    end
-
     vm_host_id = allocate
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -19,7 +19,7 @@ class Prog::Vnet::NicNexus < Prog::Base
         encryption_key: gen_encryption_key, name: name,
         private_subnet_id: private_subnet_id) { _1.id = ubid.to_uuid }
       subnet.add_nic(nic)
-      Strand.create(prog: "Vnet::NicNexus", label: "wait_vnet") { _1.id = ubid.to_uuid }
+      Strand.create(prog: "Vnet::NicNexus", label: "wait") { _1.id = ubid.to_uuid }
     end
   end
 
@@ -29,14 +29,6 @@ class Prog::Vnet::NicNexus < Prog::Base
 
   def nic
     @nic ||= Nic[strand.id]
-  end
-
-  def wait_vnet
-    unless nic.private_subnet.strand.label == "wait"
-      nap 1
-    end
-
-    hop :wait
   end
 
   def wait

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -215,12 +215,6 @@ RSpec.describe Prog::Vm::Nexus do
 
       expect { nx.start }.to hop("create_unix_user")
     end
-
-    it "waits nics to be waiting" do
-      st = instance_double(Strand, label: "creating")
-      expect(vm).to receive(:nics).and_return([instance_double(Nic, strand: st)]).at_least(:once)
-      expect { nx.start }.to nap(10)
-    end
   end
 
   describe "#allocate" do

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Prog::Vnet::NicNexus do
         private_subnet_id: "57afa8a7-2357-4012-9632-07fbe13a3133",
         name: "demonic"
       ).and_return(true)
-      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait_vnet").and_yield(Strand.new).and_return(Strand.new)
+      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
       described_class.assemble(ps.id, ipv6_addr: "fd10:9b0b:6b4b:8fbb::/128", name: "demonic")
     end
 
@@ -53,35 +53,8 @@ RSpec.describe Prog::Vnet::NicNexus do
         name: "demonic"
       ).and_return(true)
       expect(ps).to receive(:add_nic).and_return(true)
-      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait_vnet").and_yield(Strand.new).and_return(Strand.new)
+      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
       described_class.assemble(ps.id, ipv4_addr: "10.0.0.12/32", name: "demonic")
-    end
-  end
-
-  describe "#wait_vnet" do
-    let(:subnet_strand) {
-      instance_double(Strand, label: "creating")
-    }
-    let(:nic) {
-      ps = instance_double(PrivateSubnet, strand: subnet_strand)
-      instance_double(Nic, private_subnet: ps)
-    }
-
-    before do
-      allow(nx).to receive(:nic).and_return(nic)
-    end
-
-    it "naps if vnet is not waiting" do
-      expect {
-        nx.wait_vnet
-      }.to nap(1)
-    end
-
-    it "hops to wait if vnet is waiting" do
-      expect(subnet_strand).to receive(:label).and_return("wait")
-      expect {
-        nx.wait_vnet
-      }.to hop("wait")
     end
   end
 


### PR DESCRIPTION
This commit remvoes the Nic waiting from Vm:Nexus. That's not necessary as we don't essentially need nic to be in any specific state to create the VM. It's enough that the Nic is created and private ip addresses are assigned. Waiting for Nic which makes Nic to wait for PrivateSubnet can end-up in a race condition for Subnets with >1 VM and another VM being provisioned. Because, the moment Nic is created, it's a destination address for all the Nics in the subnet, new Vm not being fully operable causes the tunnel creation failure for all the other Nics. Since the Subnet is not in wait state, we also start waiting for it to be functional before continuing with VM provisioning. Therefore, we create a circular/never ending dependency. This commit breakes that chain by simply continuing with VM provisioning. We are already triggering a refresh_mesh after the VM provisioning, so we do not lose any functionality doing so.