### PR TITLE
Subnet disassociates from the project on destroy

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -62,7 +62,10 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     end
 
     if ps.nics.empty?
-      ps.delete
+      DB.transaction do
+        ps.projects.map { ps.disassociate_with_project(_1) }
+        ps.delete
+      end
       pop "subnet destroyed"
     else
       ps.nics.map { |n| n.incr_destroy }


### PR DESCRIPTION
We need to disassociate the subnet from the project so that the tags are destroyed, too.