### PR TITLE
Add enable/disable public ipv4

### DIFF
--- a/migrate/20230731_add_enable_ip4.rb
+++ b/migrate/20230731_add_enable_ip4.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm) do
+      add_column :ip4_enabled, TrueClass, default: false, null: false
+    end
+  end
+end

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -23,7 +23,8 @@ class CloverWeb
         location: r.params["location"],
         boot_image: r.params["boot-image"],
         storage_size_gib: r.params["storage-size-gib"].to_i,
-        private_subnet_id: ps_id
+        private_subnet_id: ps_id,
+        enable_ip4: r.params.key?("enable-ip4")
       )
 
       flash["notice"] = "'#{r.params["name"]}' will be ready in a few minutes"

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Clover, "vm" do
         name = "dummy-vm"
         fill_in "Name", with: name
         choose option: "hetzner-hel1"
+        uncheck "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "c5a.2x"
 
@@ -78,6 +79,30 @@ RSpec.describe Clover, "vm" do
         expect(Vm.count).to eq(1)
         expect(Vm.first.projects.first.id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).not_to be_nil
+        expect(Vm.first.ip4_enabled).to be_falsey
+      end
+
+      it "can create new virtual machine with public ipv4" do
+        project
+
+        visit "#{project.path}/vm/create"
+
+        expect(page.title).to eq("Ubicloud - Create Virtual Machine")
+        name = "dummy-vm"
+        fill_in "Name", with: name
+        choose option: "hetzner-hel1"
+        check "Enable Public IPv4"
+        choose option: "ubuntu-jammy"
+        choose option: "c5a.2x"
+
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - #{name}")
+        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(Vm.count).to eq(1)
+        expect(Vm.first.projects.first.id).to eq(project.id)
+        expect(Vm.first.private_subnets.first.id).not_to be_nil
+        expect(Vm.first.ip4_enabled).to be_truthy
       end
 
       it "can create new virtual machine with chosen private subnet" do

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -68,6 +68,17 @@
               </div>
               <div class="col-span-full">
                 <%== render(
+                  "components/form/checkbox",
+                  locals: {
+                    name: "enable-ip4",
+                    label: "Enable Public IPv4",
+                    value: "1",
+                    selected: "1"
+                  }
+                ) %>
+              </div>
+              <div class="col-span-full">
+                <%== render(
                   "components/form/range_slider",
                   locals: {
                     name: "storage-size-gib",


### PR DESCRIPTION
This commit adds the enable/disable public ipv4 functionality both to the UI and the Nexus.
Here is how the UI changed in vm creation;
<img width="459" alt="Screenshot 2023-07-31 at 15 44 30" src="https://github.com/ubicloud/ubicloud/assets/6233557/ea8c3f5a-533c-4853-879d-eed2b418381e">
<img width="342" alt="Screenshot 2023-07-31 at 15 44 39" src="https://github.com/ubicloud/ubicloud/assets/6233557/819bd717-abb3-4a6a-941c-54ebfe0824ce">
