### PR TITLE
Refresh mesh after host reboot

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -339,6 +339,9 @@ SQL
 
     decr_start_after_host_reboot
 
+    # trigger setting up private subnet connections
+    incr_refresh_mesh
+
     hop :wait
   end
 end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -364,6 +364,7 @@ RSpec.describe Prog::Vm::Nexus do
         {stdin: "{\"storage\":{}}"}
       )
       expect(sshable).to receive(:cmd).with(/sudo systemctl start vm[0-9a-z]+/)
+      expect(nx).to receive(:incr_refresh_mesh)
 
       expect { nx.start_after_host_reboot }.to hop("wait")
     end


### PR DESCRIPTION
In #338 we recreated a VM's networking state after host reboot, but it didn't refresh the ipsec tunnels between VMs in a private subnet.

This PR does that by triggering refresh_mesh after host reboot.

Assuming `vm1` and `vm2` have a nic in the same private subnet, then the following will bring them up after host reboot & create the ipsec tunnels between them:

```
vm1.incr_start_after_host_reboot
vm2.incr_start_after_host_reboot

# run the following few times to run all strands
Strand.all.each{|s| s.run 100 }
Strand.all.each{|s| s.run 100 }
Strand.all.each{|s| s.run 100 }
```