### PR TITLE
Add SPDK dependency to VM.

### DIFF
--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -638,8 +638,10 @@ DNSMASQ_SERVICE
 [Unit]
 Description=#{@vm_name}
 After=network.target
+After=spdk.service
 After=#{@vm_name}-dnsmasq.service
 Requires=#{@vm_name}-dnsmasq.service
+Requires=spdk.service
 
 [Service]
 NetworkNamespacePath=/var/run/netns/#{@vm_name}


### PR DESCRIPTION
This is required to stop services in correct order on host reboot, so we don't lose data. For example if SPDK stops before the VM is shutdown, then disk flush in VM will fail and we will lose data.