### PR TITLE
Fix install_rhizome helper for vm hosts

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -127,7 +127,7 @@ class VmHost < Sequel::Model
 
   # Introduced for refreshing rhizome programs via REPL.
   def install_rhizome
-    Strand.create(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id}])
+    Strand.create_with_id(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id}])
   end
 
   def sshable_address


### PR DESCRIPTION
Strand's ID column doesn't have default value anymore. We need to create new strand with `create_with_id` helper to set ID to an UBID.