### PR TITLE
Fix subnet destroy

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -63,7 +63,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
     if ps.nics.empty?
       DB.transaction do
-        ps.projects.map { ps.disassociate_with_project(_1) }
+        ps.projects.each { |p| p.dissociate_with_project(p) }
         ps.destroy
       end
       pop "subnet destroyed"

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -174,6 +174,8 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "deletes and pops if nics are destroyed" do
       expect(ps).to receive(:destroy).and_return(true)
       expect(ps).to receive(:nics).and_return([]).at_least(:once)
+      expect(ps).to receive(:projects).and_return([p]).at_least(:once)
+      expect(p).to receive(:dissociate_with_project).and_return(true)
       expect(nx).to receive(:pop).with("subnet destroyed").and_return(true)
       nx.destroy
     end


### PR DESCRIPTION
the right function call is dissociate_with_project. It was called as disassociate_with_project. That was my bad english