### PR TITLE
Update Content-Security-Policy

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -22,9 +22,9 @@ class CloverWeb < Roda
   plugin :content_security_policy do |csp|
     csp.default_src :none
     csp.style_src :self
-    csp.img_src :self
+    csp.img_src :self, "data: image/svg+xml"
     csp.form_action :self
-    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.6.4/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
+    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
     csp.connect_src :self
     csp.base_uri :none
     csp.frame_ancestors :none

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -9,8 +9,8 @@
     <title><%= ["Ubicloud", @page_title].compact.join(" - ") %></title>
     <%== assets(:css) %>
     <script
-      src="https://cdn.jsdelivr.net/npm/jquery@3.6.4/dist/jquery.min.js"
-      integrity="sha256-oP6HI9z1XaZNBrJURtCoUT5SUnxFr8s3BzRl+cbzUq8="
+      src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"
+      integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g="
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
jsdelivr.net is a CDN provider. It can host any kind of script. Using package's full link instead of domain is recommended way.

Tailwind has inline SVG icons as CSS background for some for form inputs. Checkbox should have tick in it and Select has small down arrow. Current CSP blocks them. I allow inline SVG icons for them.