### PR TITLE
Upgrade SPDK to include the crypto fix

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -11,7 +11,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   def self.assemble(public_key, project_id, name: nil, size: "m5a.2x",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
-    private_subnet_id: nil, nic_id: nil, storage_size_gib: 20, storage_encrypted: false,
+    private_subnet_id: nil, nic_id: nil, storage_size_gib: 20, storage_encrypted: true,
     enable_ip4: false)
 
     project = Project[project_id]

--- a/rhizome/bin/setup-spdk
+++ b/rhizome/bin/setup-spdk
@@ -10,7 +10,7 @@ r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev l
 
 # spdk binaries
 FileUtils.cd Spdk.install_prefix do
-  r "curl -L3 -o /tmp/spdk.tar.gz https://ubicloud-spdk2.s3.us-east-2.amazonaws.com/spdk.tar.gz"
+  r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/7adbcfb/spdk-7adbcfb.tar.gz"
   r "tar -xzf /tmp/spdk.tar.gz"
 end
 


### PR DESCRIPTION
There used to be a bug in SPDK [1] which prevented us from using encrypted volumes reliably. This was fixed by [2]. This PR changes the SPDK package to a version which includes that fix.

For testing I tried the following in an encrypted VM without any issues:

* The `dd` command in [1] which replicated the issue in the previous buggy version.
* apt update & upgrade & install postgres requirements.
* clone postgresql & build it & run it.
* create a table with 10m rows & run couple of aggregates.

I also tried the above steps in a different unencrypted VM.

[1] https://github.com/spdk/spdk/issues/3076
[2] https://review.spdk.io/gerrit/c/spdk/spdk/+/19232