### PR TITLE
Switch product names to standard-(cores*2) notation

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -27,10 +27,10 @@ module Option
     ["almalinux-9.1", "AlmaLinux 9.1"]
   ].map { |args| BootImage.new(*args) }.freeze
 
-  VmSize = Struct.new(:name, :display_name, :vcpu, :memory)
-  VmSizes = [
-    ["c5a.2x", "c5a.2x", 2, 2],
-    ["c5a.4x", "c5a.4x", 4, 4],
-    ["c5a.6x", "c5a.6x", 6, 6]
-  ].map { |args| VmSize.new(*args) }.freeze
+  VmSize = Struct.new(:name, :vcpu, :memory) do
+    alias_method :display_name, :name
+  end
+  VmSizes = [2, 4, 8, 16].map {
+    VmSize.new("standard-#{_1}", _1, _1 * 4)
+  }.freeze
 end

--- a/migrate/20230807_update_billing.rb
+++ b/migrate/20230807_update_billing.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    DB[:billing_rate].truncate(cascade: true)
+    copy_into :billing_rate, data: <<COPY
+139d9a67-8182-8578-a303-235cabd5161c	VmCores	standard	hetzner-fsn1	0.000171296
+08c502f7-df5d-8978-9896-feafa0ec5c40	VmCores	standard	hetzner-hel1	0.000154167
+COPY
+  end
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -9,7 +9,7 @@ require "base64"
 class Prog::Vm::Nexus < Prog::Base
   semaphore :destroy, :refresh_mesh, :start_after_host_reboot
 
-  def self.assemble(public_key, project_id, name: nil, size: "m5a.2x",
+  def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
     private_subnet_id: nil, nic_id: nil, storage_size_gib: 20, storage_encrypted: true,
     enable_ip4: false)
@@ -93,7 +93,7 @@ class Prog::Vm::Nexus < Prog::Base
         project_id: project_id,
         resource_id: vm.id,
         resource_name: vm.name,
-        billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.product.line, location).id,
+        billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.product.prefix, location).id,
         amount: vm.product.cores
       )
 

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe InvoiceGenerator do
       resource_id: vm.id,
       resource_name: vm.name,
       span: span,
-      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.product.line, vm.location).id,
+      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.product.prefix, vm.location).id,
       amount: vm.product.cores
     )
   end
@@ -16,7 +16,7 @@ RSpec.describe InvoiceGenerator do
   def check_invoice_for_single_vm(invoices, project, vm, duration)
     expect(invoices.count).to eq(1)
 
-    br = BillingRate.from_resource_properties("VmCores", vm.product.line, vm.location)
+    br = BillingRate.from_resource_properties("VmCores", vm.product.prefix, vm.location)
     cost = (vm.product.cores * (duration / 60) * br.unit_price)
     expect(invoices.first).to eq({
       project_id: project.id,
@@ -27,7 +27,7 @@ RSpec.describe InvoiceGenerator do
         line_items: [{
           location: br.location,
           resource_type: "VmCores",
-          resource_family: vm.product.line,
+          resource_family: vm.product.prefix,
           amount: vm.product.cores,
           cost: cost
         }],
@@ -41,7 +41,7 @@ RSpec.describe InvoiceGenerator do
     Account.create_with_id(email: "auth1@example.com")
     Project.create_with_id(name: "cool-project", provider: "hetzner")
   }
-  let(:vm1) { Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", size: "c5a.2x", location: "hetzner-hel1", boot_image: "x") }
+  let(:vm1) { Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", size: "standard-2", location: "hetzner-hel1", boot_image: "x") }
 
   let(:day) { 60 * 60 * 24 }
   let(:begin_time) { Time.parse("2023-06-01") }

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -8,30 +8,37 @@ RSpec.describe Vm do
   describe "#product" do
     it "crashes if a bogus product is passed" do
       vm.size = "bogustext"
-      expect { vm.product }.to raise_error RuntimeError, "BUG: cannot parse vm size"
+      expect { vm.product }.to raise_error RuntimeError, "BUG: cannot parse product"
     end
   end
 
   describe "#mem_gib" do
-    it "handles the 'm5a' instance line" do
-      vm.size = "m5a.2x"
-      expect(vm.mem_gib).to eq 4
+    it "handles standard-2" do
+      vm.size = "standard-2"
+      expect(vm.mem_gib).to eq 8
     end
 
-    it "handles the 'c5a' instance line" do
-      vm.size = "c5a.2x"
-      expect(vm.mem_gib).to eq 2
+    it "handles standard-16" do
+      vm.size = "standard-16"
+      expect(vm.mem_gib).to eq 64
     end
 
-    it "crashes if a bogus size is passed" do
-      vm.size = "nope.10x"
-      expect { vm.mem_gib }.to raise_error RuntimeError, "BUG: unrecognized product line"
+    context "with invalid input" do
+      it "crashes with a bogus size is passed" do
+        vm.size = "standard-3"
+        expect { vm.mem_gib }.to raise_error RuntimeError, "BUG: unrecognized product scale"
+      end
+
+      it "crashes with a bogus line is passed" do
+        vm.size = "generalpurpose-1"
+        expect { vm.mem_gib }.to raise_error RuntimeError, "BUG: unrecognized product prefix"
+      end
     end
   end
 
   describe "#cloud_hypervisor_cpu_topology" do
     it "scales a single-socket hyperthreaded system" do
-      vm.size = "m5a.4x"
+      vm.size = "standard-4"
       expect(vm).to receive(:vm_host).and_return(instance_double(
         VmHost,
         total_cpus: 12,
@@ -43,7 +50,7 @@ RSpec.describe Vm do
     end
 
     it "scales a dual-socket hyperthreaded system" do
-      vm.size = "m5a.4x"
+      vm.size = "standard-4"
       expect(vm).to receive(:vm_host).and_return(instance_double(
         VmHost,
         total_cpus: 24,
@@ -77,7 +84,7 @@ RSpec.describe Vm do
     end
 
     it "crashes if cores allocated per die is not uniform number" do
-      vm.size = "m5a.4x"
+      vm.size = "standard-4"
 
       expect(vm).to receive(:vm_host).and_return(instance_double(
         VmHost,
@@ -91,9 +98,6 @@ RSpec.describe Vm do
     end
 
     context "with a dual socket Ampere Altra" do
-      # YYY: Hacked up to pretend Ampere Altras have hyperthreading
-      # for demonstration on small metal instances.
-
       before do
         expect(vm).to receive(:vm_host).and_return(instance_double(
           # Based on a dual-socket Ampere Altra running in quad-node
@@ -111,12 +115,12 @@ RSpec.describe Vm do
         # grained configuration, such an allocation we prefer to grant
         # locality so the VM guest doesn't have to think about NUMA
         # until this size.
-        vm.size = "m5a.40x"
+        expect(vm).to receive(:product).and_return(described_class::Product.new("bogus", 20)).at_least(:once)
         expect(vm.cloud_hypervisor_cpu_topology.to_s).to eq("1:20:1:1")
       end
 
-      it "can compute bizarre, multi-node topologies for bizarre allocations" do
-        vm.size = "m5a.180x"
+      it "can compute multi-node topologies for stranger allocations" do
+        expect(vm).to receive(:product).and_return(described_class::Product.new("bogus", 90)).at_least(:once)
         expect(vm.cloud_hypervisor_cpu_topology.to_s).to eq("1:15:3:2")
       end
     end

--- a/spec/routes/api/vm_spec.rb
+++ b/spec/routes/api/vm_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Clover, "vm" do
           public_key: "ssh key",
           name: "test-vm",
           unix_user: "ubi",
-          size: "c5a.2x",
+          size: "standard-2",
           boot_image: "ubuntu-jammy"
         }
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Clover, "vm" do
         choose option: "hetzner-hel1"
         uncheck "Enable Public IPv4"
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "standard-2"
 
         expect(BillingRecord).to receive(:create_with_id)
         click_button "Create"
@@ -94,7 +94,7 @@ RSpec.describe Clover, "vm" do
         choose option: "hetzner-hel1"
         check "Enable Public IPv4"
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "standard-2"
 
         click_button "Create"
 
@@ -119,7 +119,7 @@ RSpec.describe Clover, "vm" do
         choose option: "hetzner-hel1"
         select match: :prefer_exact, text: ps.name
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "standard-2"
 
         expect(BillingRecord).to receive(:create_with_id)
         click_button "Create"
@@ -140,7 +140,7 @@ RSpec.describe Clover, "vm" do
         fill_in "Name", with: "invalid name"
         choose option: "hetzner-hel1"
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "standard-2"
 
         click_button "Create"
 
@@ -158,7 +158,7 @@ RSpec.describe Clover, "vm" do
         fill_in "Name", with: vm.name
         choose option: "hetzner-hel1"
         choose option: "ubuntu-jammy"
-        choose option: "c5a.2x"
+        choose option: "standard-2"
 
         click_button "Create"
 


### PR DESCRIPTION
Why cores * 2? Because SMT features, as seen on Intel and AMD products
for some year now make this equal to the number of "CPUs" or "vCPUs"
when exposed to the guest operating system.

The theory is that an integer in the product code will be compared to
vCPU references similar products on various data tables and so forth
on The Internet, or more to the point, shouldn't be a smaller integer
than those references for the same hardware.  Note, I do not subscribe
to theory's assigned magnitude of this, and have my objections to what
it does to the cogency of product comparison as written below, but
nonetheless, I've written this operating under this theory.

The ugliness arrives when we consider SMT-off configurations or
relatively recent addition of ARM processors that do not implement
SMT.  If the product scale factor was taken to describe vCPUs, we'd
end up the situation that GCP and Azure are in: t2d.standard-1 is a
one vCPU in SMT-off configuration, and thus a single core, and so is
n2d.standard-2, and these are otherwise the most comparable products.

Azure did something rather strange to deal with this, where a
"Standard_E2" is 2 vCPUs on one core via SMT and 16 gigabytes of
memory, but "Standard_E2p" on ARM is 2 cores and 16 gigabytes of
memory, a more compute-rich ratio by quite a bit.

One solution, absent indexing the product by cores directly, which
produces an integer that could be misconstrued and deemed too small,
is to double the core number in all circumstances.  The idea of a
popular architecture with three or more threads per core seems
unlikely at this point, and in any case it'd be an emergent
architecture where we could be forgiven for an awkward numbering
system.  And it solves the problem for allowing someone to scan
laterally from "standard-2" and a hypothetical "standard-2-arm".  Even
if standard-2-arm has a single core.

Of course, there's nothing stopping us from deciding to really make
the product scale factor relate to vCPUs, that is, to have integers of
larger magnitudes for architectures with SMT, and maybe if people do
prove to be uniformly alert about SMT and find `standard-2-arm`
misleading, we can elect to do things that way.
