### PR TITLE
Reap should continue deleting, not destroy

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -165,11 +165,10 @@ end
   end
 
   def reap
-    exited_children = strand.children_dataset.where(Sequel.~(exitval: nil))
-    exited_children_count = exited_children.count
-    exited_children.destroy
-    # Clear cache if anything was deleted.
-    strand.associations.delete(:children) if exited_children_count > 0
+    strand.children_dataset.where(Sequel.~(exitval: nil)).returning.delete(force: true).tap {
+      # Clear cache if anything was deleted.
+      strand.associations.delete(:children) unless _1.empty?
+    }
   end
 
   def leaf?


### PR DESCRIPTION
The commit 06b9eb8 changed the reap behavior to destroy but .destroy only returns the row count when used with returning. On the other hand, .delete returns the objects deleted in hash form which we use later in the host_nexus. So, the VmHost setup was broken. This commit fixes that.