### PR TITLE
Change MAC column type for Nic model to macaddr

### DIFF
--- a/migrate/20230802_change_mac_type.rb
+++ b/migrate/20230802_change_mac_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:nic) do
+      set_column_type(:mac, "macaddr USING mac::macaddr")
+    end
+  end
+end


### PR DESCRIPTION
With this commit, we are changing the MAC column type in nic model from text to macaddr.