### PR TITLE
Show vm size price on UI depending on location

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,6 @@
 $(function() {
   setupPolicyEditor();
+  setupVmSizes();
 });
 
 $(".toggle-mobile-menu").on("click", function (event) {
@@ -152,5 +153,32 @@ function jsonHighlight(str) {
           cls = 'text-pink-700'; // null
       }
       return '<span class="' + cls + '">' + match + '</span>';
+  });
+}
+
+$("input[type=radio]").on("change", function (event) {
+  setupVmSizes();
+});
+
+function setupVmSizes() {
+  let selectedLocation = $("input[name=location]:checked")
+  let prices = selectedLocation.length ? selectedLocation.data("details") : {};
+  $("input[name=size]").each(function(i, obj) {
+    let details = $(this).data("details");
+    let sizeCount = 0
+    if (pricePerCore = prices?.VmCores?.[details?.family]) {
+      let monthly = pricePerCore * details.vcpu * 60 * 24 * 30;
+      $(this).parent().show();
+      $(this).parent().find(".price").text(`$${monthly.toFixed(2)}`);
+      sizeCount++;
+    } else {
+      $(this).parent().hide();
+      $(this).prop('checked', false);
+    }
+    if (sizeCount) {
+      $("#size-description").hide();
+    } else {
+      $("#size-description").show();
+    }
   });
 }

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -36,6 +36,10 @@ class CloverWeb
       r.get true do
         Authorization.authorize(@current_user.id, "Vm:create", @project.id)
         @subnets = Serializers::Web::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
+        @prices = BillingRate.all.each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
+          hash[br.location][br.resource_type][br.resource_family] = br.unit_price.to_f
+        end
+
         view "vm/create"
       end
     end

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -11,12 +11,13 @@
   <fieldset class="radio-small-cards" id="<%= name %>-radios">
     <legend class="sr-only"><%= label %></legend>
     <div class="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-      <% options.each do |opt_val, opt_text| %>
+      <% options.each do |opt_val, opt_text, opt_details| %>
         <label>
           <input
             type="radio"
             name="<%= name %>"
             value="<%= opt_val %>"
+            data-details="<%= opt_details %>"
             class="peer sr-only"
             <%= (opt_val == selected) ? "checked" : "" %>
             <% attributes.each do |atr_key, atr_value| %>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -47,7 +47,10 @@
                   locals: {
                     name: "location",
                     label: "Location",
-                    options: Option.locations_for_provider(@project_data.dig(:provider, :name)).to_h { |l| [l.name, l.display_name] },
+                    options:
+                      Option
+                        .locations_for_provider(@project_data.dig(:provider, :name))
+                        .map { |l| [l.name, l.display_name, @prices[l.name].to_json] },
                     attributes: {
                       required: true
                     }
@@ -107,11 +110,12 @@
                             name="size"
                             value="<%= size.name %>"
                             class="peer sr-only"
+                            data-details="<%= {family: size.name.split(".").first, vcpu: size.vcpu}.to_json %>"
                             required
                             <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>
                           >
                           <span
-                            class="flex items-center rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
+                            class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
                                 ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
                                 peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700"
                           >
@@ -124,11 +128,17 @@
                                   GB</span>
                               </span>
                             </span>
+                            <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
+                              <span class="font-medium price">-</span>
+                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                            </span>
                           </span>
                         </label>
                       <% end %>
                     </div>
                   </fieldset>
+                  <p id="size-description" class="text-sm text-gray-500 leading-6">
+                    Select location to see available server sizes</p>
                 </div>
               </div>
               <div class="col-span-full">


### PR DESCRIPTION
We have billing_rate table to determine how much cost each core on that location based on family. If location doesn't have billing_rate record for resource_family, we don't show it on that location.

> Note: This PR requires small refactor after new vm size format merged