### PR TITLE
Fix reap to continue returning deleted objects

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -166,10 +166,12 @@ end
 
   def reap
     exited_children = strand.children_dataset.where(Sequel.~(exitval: nil))
-    exited_children_count = exited_children.count
+    exited_children_materialized = DB.fetch(exited_children).all
+    exited_children_count = exited_children_materialized.count
     exited_children.destroy
     # Clear cache if anything was deleted.
     strand.associations.delete(:children) if exited_children_count > 0
+    exited_children_materialized
   end
 
   def leaf?

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -46,7 +46,10 @@ class Prog::Test < Prog::Base
   end
 
   def reaper
-    reap
+    # below loop is only for ensuring we are able to process reaped strands
+    reap.each do |st|
+      st.fetch(:exitval)
+    end
     donate
   end
 


### PR DESCRIPTION
With soft delete commit we started to use destroy in delete in all places. One difference between delete and destroy is destroy does not support returning. However we use returned child strands deleted by reap method.

With this commit, we are fixing reap behaviour to return deleted objects by first materializing the query result and then deleting the records. We also modified one of the tests to check the returned values.