### PR TITLE
Add config to determine managed_service or not

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -75,4 +75,5 @@ module Config
   optional :hetzner_password, string, clear: true
   override :providers, "hetzner", array(string)
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
+  override :managed_service, false, bool
 end


### PR DESCRIPTION
Some features such as billing, ToS etc are only used for managed service. Open source users don't need them. This flag helps to determine is it managed service or not. I prefer to use bool instead of an enum, because we should have more mode. I makes maintenance harder.

> I'm open the name suggestions. `managed_service`, `hosted_version` 
