### PR TITLE
Program to reboot host

### DIFF
--- a/migrate/20230804_host_reboot.rb
+++ b/migrate/20230804_host_reboot.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_enum_value(:vm_display_state, "rebooting host")
+    add_enum_value(:vm_display_state, "starting")
+  end
+end

--- a/prog/reboot_host.rb
+++ b/prog/reboot_host.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Prog::RebootHost < Prog::Base
+  subject_is :sshable, :vm_host
+
+  def start
+    vm_host.vms.each { |vm|
+      vm.update(display_state: "rebooting host")
+    }
+
+    begin
+      sshable.cmd("sudo reboot")
+    rescue
+    end
+
+    hop :wait_reboot
+  end
+
+  def wait_reboot
+    begin
+      sshable.cmd("echo 1")
+    rescue
+      nap 15
+    end
+
+    hop :start_vms
+  end
+
+  def start_vms
+    vm_host.vms.each { |vm|
+      vm.incr_start_after_host_reboot
+    }
+
+    pop "host rebooted"
+  end
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -334,12 +334,16 @@ SQL
   def start_after_host_reboot
     register_deadline(:wait, 5 * 60)
 
+    vm.update(display_state: "starting")
+
     secrets_json = JSON.generate({
       storage: storage_secrets
     })
 
     host.sshable.cmd("sudo bin/recreate-unpersisted #{params_path.shellescape}", stdin: secrets_json)
     host.sshable.cmd("sudo systemctl start #{q_vm}")
+
+    vm.update(display_state: "running")
 
     decr_start_after_host_reboot
 

--- a/spec/prog/reboot_host_spec.rb
+++ b/spec/prog/reboot_host_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::RebootHost do
+  subject(:rh) {
+    described_class.new(Strand.new(prog: "RebootHost",
+      stack: [{sshable_id: "bogus"}]))
+  }
+
+  let(:vms) { [instance_double(Vm), instance_double(Vm)] }
+  let(:vm_host) {
+    host = instance_double(VmHost)
+    allow(host).to receive(:vms).and_return(vms)
+    host
+  }
+  let(:sshable) { instance_double(Sshable) }
+
+  before do
+    allow(rh).to receive_messages(vm_host: vm_host, sshable: sshable)
+  end
+
+  describe "#start" do
+    it "transitions to wait_reboot" do
+      expect(vms).to all receive(:update).with(display_state: "rebooting host")
+      expect(sshable).to receive(:cmd).with("sudo reboot")
+      expect(rh).to receive(:hop).with(:wait_reboot)
+      rh.start
+    end
+  end
+
+  describe "#wait_reboot" do
+    it "naps if ssh fails" do
+      expect(sshable).to receive(:cmd).with("echo 1").and_raise("not connected")
+      expect { rh.wait_reboot }.to nap(15)
+    end
+
+    it "transitions to start_vms if ssh succeeds" do
+      expect(sshable).to receive(:cmd).with("echo 1").and_return("1")
+      expect { rh.wait_reboot }.to hop("start_vms")
+    end
+  end
+
+  describe "#start_vms" do
+    it "starts vms & pops" do
+      expect(vms).to all receive(:incr_start_after_host_reboot)
+      expect(rh).to receive(:pop).with("host rebooted")
+      rh.start_vms
+    end
+  end
+end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -380,6 +380,8 @@ RSpec.describe Prog::Vm::Nexus do
       )
       expect(sshable).to receive(:cmd).with(/sudo systemctl start vm[0-9a-z]+/)
       expect(nx).to receive(:incr_refresh_mesh)
+      expect(vm).to receive(:update).with(display_state: "starting")
+      expect(vm).to receive(:update).with(display_state: "running")
 
       expect { nx.start_after_host_reboot }.to hop("wait")
     end

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -1,7 +1,7 @@
 <% case state %>
   <% when "running" %>
     <% color = "bg-green-100 text-green-800" %>
-    <% when "creating" %>
+    <% when "creating", "rebooting host", "starting" %>
       <% color = "bg-yellow-100 text-yellow-800" %>
     <% else %>
       <% color = "bg-slate-100 text-slate-800" %>


### PR DESCRIPTION
This will make sure that state of VMs on the host is updated when rebooting host, and that they start after the host is up.

An example of creating a strand for this program is:

```
> st = Strand.create_with_id(prog: 'RebootHost', label: 'start', stack: [{subject_id: VmHost.first.id}])
```