### PR TITLE
Semaphore to reboot host

### DIFF
--- a/migrate/20230804_host_reboot.rb
+++ b/migrate/20230804_host_reboot.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_enum_value(:vm_display_state, "rebooting")
+    add_enum_value(:vm_display_state, "starting")
+
+    alter_table(:vm_host) do
+      add_column :last_boot_id, :text, null: true
+    end
+  end
+end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -12,6 +12,8 @@ class VmHost < Sequel::Model
   one_to_many :assigned_host_addresses, key: :host_id, class: :AssignedHostAddress
 
   include ResourceMethods
+  include SemaphoreMethods
+  semaphore :reboot
 
   def host_prefix
     net6.netmask.prefix_len

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -334,12 +334,16 @@ SQL
   def start_after_host_reboot
     register_deadline(:wait, 5 * 60)
 
+    vm.update(display_state: "starting")
+
     secrets_json = JSON.generate({
       storage: storage_secrets
     })
 
     host.sshable.cmd("sudo bin/recreate-unpersisted #{params_path.shellescape}", stdin: secrets_json)
     host.sshable.cmd("sudo systemctl start #{q_vm}")
+
+    vm.update(display_state: "running")
 
     decr_start_after_host_reboot
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -380,6 +380,8 @@ RSpec.describe Prog::Vm::Nexus do
       )
       expect(sshable).to receive(:cmd).with(/sudo systemctl start vm[0-9a-z]+/)
       expect(nx).to receive(:incr_refresh_mesh)
+      expect(vm).to receive(:update).with(display_state: "starting")
+      expect(vm).to receive(:update).with(display_state: "running")
 
       expect { nx.start_after_host_reboot }.to hop("wait")
     end

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -1,7 +1,7 @@
 <% case state %>
 <% when "running" %>
   <% color = "bg-green-100 text-green-800" %>
-<% when "creating" %>
+<% when "creating", "rebooting", "starting" %>
   <% color = "bg-yellow-100 text-yellow-800" %>
 <% else %>
   <% color = "bg-slate-100 text-slate-800" %>


### PR DESCRIPTION
This will make sure that state of VMs on the host is updated when rebooting host, and that they start after the host is up.

An example of invoking this is:

```
> VmHost.first.incr_reboot
```