### PR TITLE
Don't reboot right after installing huepages

### DIFF
--- a/prog/setup_hugepages.rb
+++ b/prog/setup_hugepages.rb
@@ -9,40 +9,6 @@ class Prog::SetupHugepages < Prog::Base
     hugepage_cnt = 1 + (vm_host.total_mem_gib * (vm_host.total_cores - 1)) / vm_host.total_cores
     sshable.cmd("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ hugetlb_free_vmemmap=on default_hugepagesz=#{hugepage_size} hugepagesz=#{hugepage_size} hugepages=#{hugepage_cnt}&/' /etc/default/grub")
     sshable.cmd("sudo update-grub")
-    begin
-      sshable.cmd("sudo reboot")
-    rescue
-    end
-    hop :wait_reboot
-  end
-
-  def wait_reboot
-    begin
-      sshable.cmd("echo 1")
-    rescue
-      nap 15
-    end
-
-    hop :check_hugepages
-  end
-
-  def check_hugepages
-    host_meminfo = sshable.cmd("cat /proc/meminfo")
-    fail "Couldn't set hugepage size to 1G" unless host_meminfo.match?(/^Hugepagesize:\s+1048576 kB$/)
-
-    total_hugepages_match = host_meminfo.match(/^HugePages_Total:\s+(\d+)$/)
-    fail "Couldn't extract total hugepage count" unless total_hugepages_match
-
-    free_hugepages_match = host_meminfo.match(/^HugePages_Free:\s+(\d+)$/)
-    fail "Couldn't extract free hugepage count" unless free_hugepages_match
-
-    total_hugepages = Integer(total_hugepages_match.captures.first)
-    free_hugepages = Integer(free_hugepages_match.captures.first)
-
-    vm_host.update(
-      total_hugepages_1g: total_hugepages,
-      used_hugepages_1g: total_hugepages - free_hugepages
-    )
 
     pop "hugepages installed"
   end

--- a/prog/setup_spdk.rb
+++ b/prog/setup_spdk.rb
@@ -4,18 +4,14 @@ class Prog::SetupSpdk < Prog::Base
   subject_is :sshable, :vm_host
 
   def start
-    fail "Not enough hugepages" unless vm_host.total_hugepages_1g > vm_host.used_hugepages_1g
     sshable.cmd("sudo bin/setup-spdk")
-    hop :start_service
+    hop :enable_service
   end
 
-  def start_service
+  def enable_service
     sshable.cmd("sudo systemctl enable home-spdk-hugepages.mount")
     sshable.cmd("sudo systemctl enable spdk")
 
-    sshable.cmd("sudo systemctl start spdk")
-
-    vm_host.update(used_hugepages_1g: vm_host.used_hugepages_1g + 1)
     pop "SPDK was setup"
   end
 end

--- a/spec/prog/setup_hugepages_spec.rb
+++ b/spec/prog/setup_hugepages_spec.rb
@@ -9,71 +9,17 @@ RSpec.describe Prog::SetupHugepages do
   }
 
   describe "#start" do
-    it "transitions to wait_reboot" do
+    it "pops after installing hugepages" do
       vm_host = instance_double(VmHost)
       expect(vm_host).to receive(:total_mem_gib).and_return(64)
       expect(vm_host).to receive(:total_cores).and_return(4).at_least(:once)
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with(/sudo sed.*default_hugepagesz=1G.*hugepagesz=1G.*hugepages=49.*grub/)
       expect(sshable).to receive(:cmd).with("sudo update-grub")
-      expect(sshable).to receive(:cmd).with("sudo reboot")
       expect(sh).to receive(:sshable).and_return(sshable).at_least(:once)
       expect(sh).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect(sh).to receive(:hop).with(:wait_reboot)
-      sh.start
-    end
-  end
-
-  describe "#wait_reboot" do
-    it "naps if ssh fails" do
-      sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("echo 1").and_raise("not connected")
-      expect(sh).to receive(:sshable).and_return(sshable)
-      expect { sh.wait_reboot }.to nap(15)
-    end
-
-    it "transitions to check_hugepages if ssh succeeds" do
-      sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("echo 1").and_return("1")
-      expect(sh).to receive(:sshable).and_return(sshable)
-      expect { sh.wait_reboot }.to hop("check_hugepages")
-    end
-  end
-
-  describe "#check_hugepages" do
-    it "fails if hugepagesize!=1G" do
-      sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo").and_return("Hugepagesize: 2048 kB\n")
-      expect(sh).to receive(:sshable).and_return(sshable)
-      expect { sh.check_hugepages }.to raise_error RuntimeError, "Couldn't set hugepage size to 1G"
-    end
-
-    it "fails if total hugepages couldn't be extracted" do
-      sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo").and_return("Hugepagesize: 1048576 kB\n")
-      expect(sh).to receive(:sshable).and_return(sshable)
-      expect { sh.check_hugepages }.to raise_error RuntimeError, "Couldn't extract total hugepage count"
-    end
-
-    it "fails if free hugepages couldn't be extracted" do
-      sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo")
-        .and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 5")
-      expect(sh).to receive(:sshable).and_return(sshable)
-      expect { sh.check_hugepages }.to raise_error RuntimeError, "Couldn't extract free hugepage count"
-    end
-
-    it "updates vm_host with hugepage stats and pops" do
-      sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo")
-        .and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 5\nHugePages_Free: 4")
-      vm_host = instance_double(VmHost)
-      expect(vm_host).to receive(:update)
-        .with(total_hugepages_1g: 5, used_hugepages_1g: 1)
-      expect(sh).to receive(:sshable).and_return(sshable)
-      expect(sh).to receive(:vm_host).and_return(vm_host)
       expect(sh).to receive(:pop).with("hugepages installed")
-      sh.check_hugepages
+      sh.start
     end
   end
 end

--- a/spec/prog/setup_spdk_spec.rb
+++ b/spec/prog/setup_spdk_spec.rb
@@ -12,36 +12,19 @@ RSpec.describe Prog::SetupSpdk do
     it "transitions to start_service" do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with("sudo bin/setup-spdk")
-      vm_host = instance_double(VmHost)
-      expect(vm_host).to receive(:total_hugepages_1g).and_return(10)
-      expect(vm_host).to receive(:used_hugepages_1g).and_return(0)
       expect(ss).to receive(:sshable).and_return(sshable)
-      expect(ss).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect { ss.start }.to hop("start_service")
-    end
-
-    it "fails if not enough hugepages" do
-      vm_host = instance_double(VmHost)
-      expect(vm_host).to receive(:total_hugepages_1g).and_return(10)
-      expect(vm_host).to receive(:used_hugepages_1g).and_return(10)
-      expect(ss).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect { ss.start }.to raise_error RuntimeError, "Not enough hugepages"
+      expect { ss.start }.to hop("enable_service")
     end
   end
 
-  describe "#start_service" do
-    it "exits, reducing number of hugepages" do
+  describe "#enable_service" do
+    it "enables spdk and exits" do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with("sudo systemctl enable home-spdk-hugepages.mount")
       expect(sshable).to receive(:cmd).with("sudo systemctl enable spdk")
-      expect(sshable).to receive(:cmd).with("sudo systemctl start spdk")
-      vm_host = instance_double(VmHost)
-      expect(vm_host).to receive(:used_hugepages_1g).and_return(0)
-      expect(vm_host).to receive(:update).with(used_hugepages_1g: 1)
       expect(ss).to receive(:sshable).and_return(sshable).at_least(:once)
-      expect(ss).to receive(:vm_host).and_return(vm_host).at_least(:once)
       expect(ss).to receive(:pop).with("SPDK was setup")
-      ss.start_service
+      ss.enable_service
     end
   end
 end


### PR DESCRIPTION
This simplifies the code abit by moving all host reboot logic to one place, and also does more verifications after host reboots.

Note that we remove explicit SPDK hugepage accounting since it will automatically try to start on boot, which will reserve hugepages, which we will account for when checking free hugepages.