### PR TITLE
Add country select input component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "pry"
 gem "excon"
 gem "jwt"
 gem "pagerduty", ">= 4.0"
+gem "countries"
 
 group :development do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
     chunky_png (1.4.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    countries (5.6.0)
+      unaccent (~> 0.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -227,6 +229,7 @@ GEM
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.4.2)
     warning (1.3.0)
     webmock (3.18.1)
@@ -247,6 +250,7 @@ DEPENDENCIES
   bcrypt_pbkdf
   brakeman
   capybara
+  countries
   database_cleaner-sequel
   ed25519
   erb-formatter!

--- a/config.rb
+++ b/config.rb
@@ -76,4 +76,5 @@ module Config
   override :providers, "hetzner", array(string)
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
   override :managed_service, false, bool
+  override :sanctioned_countries, "CU,IR,KP,SY", array(string)
 end

--- a/views/components/form/country_select.erb
+++ b/views/components/form/country_select.erb
@@ -1,0 +1,26 @@
+<% name = (defined?(name) && name) ? name : "country" %>
+<% label = (defined?(label) && label) ? label : "Country" %>
+<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
+<% error = defined?(error) ? error : flash.dig("errors", name) %>
+<% description = defined?(description) ? description : nil %>
+<% attributes = defined?(attributes) ? attributes : {} %>
+
+<%== render(
+  "components/form/select",
+  locals: {
+    name: name,
+    label: label,
+    selected: selected,
+    placeholder: "Select a Country",
+    options:
+      ISO3166::Country
+        .all
+        .reject { Config.sanctioned_countries.include?(_1.alpha2) }
+        .sort_by(&:common_name)
+        .map { |c| [c.alpha2, c.common_name] }
+        .to_h,
+    error: error,
+    description: description,
+    attributes: attributes
+  }
+) %>


### PR DESCRIPTION
Two-letter country codes (ISO 3166-1 alpha-2) are commonly used for representing countries. Also Stripe accepts them too.

I used `countries` gem to get list of all country codes.

We can't provide services to sanctioned countries. `sanctioned_countries` config has list of these countries.