### PR TITLE
Bud allows subject_id overwrite

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -149,8 +149,8 @@ end
        stack: [new_frame] + strand.stack, retval: nil})
   end
 
-  def bud(prog, new_frame = nil, label = "start")
-    new_frame = (new_frame || {}).merge("subject_id" => @subject_id)
+  def bud(prog, new_frame = {}, label = "start")
+    new_frame = {"subject_id" => @subject_id}.merge(new_frame)
     strand.add_child(
       id: Strand.generate_uuid,
       prog: Strand.prog_verify(prog),


### PR DESCRIPTION
With this commit, we are able to overwrite the subject_id of the budded prog. If it's not specified, we simply continue to use the strand_id as subject_id.