### PR TITLE
Link vm storage size with vm size

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -24,10 +24,10 @@ module Option
     ["almalinux-9.1", "AlmaLinux 9.1"]
   ].map { |args| BootImage.new(*args) }.freeze
 
-  VmSize = Struct.new(:name, :vcpu, :memory) do
+  VmSize = Struct.new(:name, :vcpu, :memory, :storage_size_gib) do
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16].map {
-    VmSize.new("standard-#{_1}", _1, _1 * 4)
+    VmSize.new("standard-#{_1}", _1, _1 * 4, (_1 / 2) * 25)
   }.freeze
 end

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -32,4 +32,11 @@ module Validation
     msg = "\"#{location}\" is not a valid location for provider \"#{provider}\". Available locations: #{available_locs}"
     fail ValidationFailed.new({provider: msg}) unless available_locs.include?(location)
   end
+
+  def self.validate_vm_size(size)
+    unless (vm_size = Option::VmSizes.find { _1.name == size })
+      fail ValidationFailed.new({size: "\"#{size}\" is not a valid virtual machine size. Available providers: #{Option::VmSizes.map(&:name)}"})
+    end
+    vm_size
+  end
 end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -11,7 +11,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
-    private_subnet_id: nil, nic_id: nil, storage_size_gib: 20, storage_encrypted: true,
+    private_subnet_id: nil, nic_id: nil, storage_size_gib: nil, storage_encrypted: true,
     enable_ip4: false)
 
     project = Project[project_id]
@@ -19,6 +19,8 @@ class Prog::Vm::Nexus < Prog::Base
       fail "No existing project"
     end
     Validation.validate_location(location, project&.provider)
+    vm_size = Validation.validate_vm_size(size)
+    storage_size_gib ||= vm_size.storage_size_gib
 
     ubid = Vm.generate_ubid
     name ||= Vm.ubid_to_name(ubid)

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -14,6 +14,7 @@ class CloverWeb
       Authorization.authorize(@current_user.id, "Vm:create", @project.id)
       ps_id = r.params["private-subnet-id"].empty? ? nil : UBID.parse(r.params["private-subnet-id"]).to_uuid
       Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps_id)
+
       st = Prog::Vm::Nexus.assemble(
         r.params["public-key"],
         @project.id,
@@ -22,7 +23,6 @@ class CloverWeb
         size: r.params["size"],
         location: r.params["location"],
         boot_image: r.params["boot-image"],
-        storage_size_gib: r.params["storage-size-gib"].to_i,
         private_subnet_id: ps_id,
         enable_ip4: r.params.key?("enable-ip4")
       )

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe Validation do
       end
     end
 
+    describe "#validate_vm_size" do
+      it "valid vm size" do
+        expect(described_class.validate_vm_size("standard-2").name).to eq("standard-2")
+      end
+
+      it "invalid vm size" do
+        expect { described_class.validate_vm_size("standard-3") }.to raise_error described_class::ValidationFailed
+      end
+    end
+
     describe "#validate_location" do
       it "valid locations" do
         [

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe Prog::Vm::Nexus do
       described_class.assemble("some_ssh_key", prj.id, nic_id: nic.id, location: "hetzner-hel1")
     end
 
+    it "creates with default storage size from vm size" do
+      st = described_class.assemble("some_ssh_key", prj.id)
+      expect(st.vm.storage_size_gib).to eq(Option::VmSizes.first.storage_size_gib)
+    end
+
+    it "creates with custom storage size if provided" do
+      st = described_class.assemble("some_ssh_key", prj.id, storage_size_gib: 40)
+      expect(st.vm.storage_size_gib).to eq(40)
+    end
+
     it "fails if given nic_id is not valid" do
       expect {
         described_class.assemble("some_ssh_key", prj.id, nic_id: nic.id)

--- a/spec/routes/api/vm_spec.rb
+++ b/spec/routes/api/vm_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Clover, "vm" do
           public_key: "ssh key",
           name: "invalid name",
           unix_user: "ubi",
-          size: "c5a.2x",
+          size: "standard-2",
           boot_image: "ubuntu-jammy"
         }
 

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -80,28 +80,11 @@
                 ) %>
               </div>
               <div class="col-span-full">
-                <%== render(
-                  "components/form/range_slider",
-                  locals: {
-                    name: "storage-size-gib",
-                    label: "Storage Size",
-                    range_labels: (1..10).map { "#{_1 * 10}GB" },
-                    value: 40,
-                    attributes: {
-                      min: 10,
-                      max: 100,
-                      step: 10,
-                      required: true
-                    }
-                  }
-                ) %>
-              </div>
-              <div class="col-span-full">
                 <div class="space-y-2">
                   <label for="size" class="text-sm font-medium leading-6 text-gray-900">Server size</label>
                   <fieldset class="radio-small-cards" id="size-radios">
                     <legend class="sr-only">Server size</legend>
-                    <div class="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 xl:grid-cols-4">
+                    <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
                       <% Option::VmSizes.each do |size| %>
                         <label>
                           <input
@@ -123,10 +106,15 @@
                             <span class="flex flex-col">
                               <span class="text-md font-semibold"><%= size.display_name %></span>
                               <span class="text-sm opacity-80">
-                                <span class="block sm:inline"><%= size.vcpu %>
+                                <span class="block sm:inline">
+                                  <%= size.vcpu %>
                                   vCPUs /
                                   <%= size.memory %>
-                                  GB</span>
+                                  GB
+                                </span>
+                                <span class="hidden sm:mx-0.5 sm:inline" aria-hidden="true">&middot;</span>
+                                <span class="block sm:inline"><%= size.storage_size_gib %>
+                                  GB disk</span>
                               </span>
                             </span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">


### PR DESCRIPTION
Currently we allow user to select storage size. It's a slider between 10-100GB. 100GB is low, but what's the suitable maximum storage size is another good question.

Allowing custom storage size introduces another allocation problem. A user can create a virtual machine with high storage but low cores count. It causes an idle VmHost that we can't allocate new virtual machine on that because of not enough storage.

We decided to link storage size with core count. Some other cloud providers do same thing. They give less storage for small machines. Digital Ocean gives 25GB per core, and Hetzner Cloud gives 40GB per core.
Our current AX161 machines have 1843 GB total storage, and 32 cores. Currently I set 25GB storage for each cores. It means storage will be 32x25=800GB at maximum for now.

We can revisit our strategy when we introduce network based storage or after several customer feedbacks.

We don't charge our customers for storage, because it's local storage and it's already in monthly single core cost calculations.

<img width="1219" alt="storage" src="https://github.com/ubicloud/ubicloud/assets/993199/fc253c30-816a-43a8-ac89-4c2bb3563861">

