### PR TITLE
Allow deleting VMs from any state

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -100,7 +100,9 @@ SQL
 
     DB.transaction do
       SemSnap.use(id) do |snap|
-        load(snap).public_send(label)
+        prg = load(snap)
+        prg.public_send(:before_run) if prg.respond_to?(:before_run)
+        prg.public_send(label)
       end
     rescue Prog::Base::Nap => e
       save_changes

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -193,6 +193,15 @@ SQL
     vm_host_id
   end
 
+  def before_run
+    when_destroy_set? do
+      if strand.label != "destroy"
+        vm.active_billing_record.update(span: Sequel.pg_range(vm.active_billing_record.span.begin...Time.now))
+        hop :destroy
+      end
+    end
+  end
+
   def start
     register_deadline(:wait, 10 * 60)
 
@@ -271,11 +280,6 @@ SQL
   end
 
   def wait
-    when_destroy_set? do
-      vm.active_billing_record.update(span: Sequel.pg_range(vm.active_billing_record.span.begin...Time.now))
-      hop :destroy
-    end
-
     when_refresh_mesh_set? do
       hop :refresh_mesh
     end

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -31,11 +31,13 @@ class Prog::Vnet::NicNexus < Prog::Base
     @nic ||= Nic[strand.id]
   end
 
-  def wait
+  def before_run
     when_destroy_set? do
-      hop :destroy
+      hop :destroy if strand.label != "destroy"
     end
+  end
 
+  def wait
     when_refresh_mesh_set? do
       hop :refresh_mesh
     end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -5,7 +5,7 @@ if (suite = ENV.delete("COVERAGE"))
 
   SimpleCov.start do
     enable_coverage :branch
-    minimum_coverage line: 99.9, branch: 98.96
+    minimum_coverage line: 99.9, branch: 99.01
     minimum_coverage_by_file line: 96.5, branch: 81.25
 
     command_name suite

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe Prog::Base do
     }.to change { Semaphore.where(strand_id: st.id).any? }.from(true).to(false)
   end
 
+  it "calls before_run if it is available" do
+    st = Strand.create_with_id(prog: "Prog::Vm::Nexus", label: "wait")
+    prg = instance_double(Prog::Vm::Nexus)
+    expect(st).to receive(:load).and_return(prg)
+    expect(prg).to receive(:before_run)
+    expect(prg).to receive(:wait).and_raise(Prog::Base::Nap.new(30))
+    st.unsynchronized_run
+  end
+
   context "when rendering FlowControl strings" do
     it "can render hop" do
       expect(

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -373,14 +373,22 @@ RSpec.describe Prog::Vm::Nexus do
     end
   end
 
+  describe "#before_run" do
+    it "hops to destroy when needed" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "does not hop to destroy if already in the destroy state" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect { nx.before_run }.not_to hop("destroy")
+    end
+  end
+
   describe "#wait" do
     it "naps when nothing to do" do
       expect { nx.wait }.to nap(30)
-    end
-
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.wait }.to hop("destroy")
     end
 
     it "hops to refresh_mesh when needed" do

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
   end
 
+  describe "#before_run" do
+    it "hops to destroy when needed" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "does not hop to destroy if already in the destroy state" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect { nx.before_run }.not_to hop("destroy")
+    end
+  end
+
   describe "#wait" do
     it "naps if nothing to do" do
       expect {
@@ -70,13 +83,6 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect {
         nx.wait
       }.to hop("refresh_mesh")
-    end
-
-    it "hops to destroy if needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect {
-        nx.wait
-      }.to hop("destroy")
     end
 
     it "hops to detach vm if needed" do


### PR DESCRIPTION
With this commit we are starting to call "before_run" method before running any logic from Prog labels, if before_run is defined. Since it is called every time no matter the label, before_run is perfect place to do things that we would want to do every time, such as checking incr_destroy semaphore and if set starting VM delete.