### PR TITLE
Make location based pricing more generic on vm creation page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,6 @@
 $(function() {
   setupPolicyEditor();
-  setupVmSizes();
+  setupLocationBasedPrices();
 });
 
 $(".toggle-mobile-menu").on("click", function (event) {
@@ -156,29 +156,34 @@ function jsonHighlight(str) {
   });
 }
 
-$("input[type=radio]").on("change", function (event) {
-  setupVmSizes();
+$("input[name=location]").on("change", function (event) {
+  setupLocationBasedPrices();
 });
 
-function setupVmSizes() {
+function setupLocationBasedPrices() {
   let selectedLocation = $("input[name=location]:checked")
   let prices = selectedLocation.length ? selectedLocation.data("details") : {};
-  $("input[name=size]").each(function(i, obj) {
-    let details = $(this).data("details");
-    let sizeCount = 0
-    if (pricePerCore = prices?.VmCores?.[details?.family]) {
-      let monthly = pricePerCore * details.vcpu * 60 * 24 * 30;
+  $("input.location-based-price").each(function(i, obj) {
+    let name = $(this).attr("name");
+    let value = $(this).val();
+    let resource_type = $(this).data("resource-type");
+    let resource_family = $(this).data("resource-family");
+    let amount = $(this).data("amount");
+
+    let count = 0
+    if (monthlyPrice = prices?.[resource_type]?.[resource_family]?.["monthly"]) {
+      let monthly = monthlyPrice * amount;
       $(this).parent().show();
-      $(this).parent().find(".price").text(`$${monthly.toFixed(2)}`);
-      sizeCount++;
+      $("." + value  + "-monthly-price").text(`$${monthly.toFixed(2)}`);
+      count++;
     } else {
       $(this).parent().hide();
       $(this).prop('checked', false);
     }
-    if (sizeCount) {
-      $("#size-description").hide();
+    if (count) {
+      $("#" + name + "-description").hide();
     } else {
-      $("#size-description").show();
+      $("#" + name + "-description").show();
     }
   });
 }

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -37,9 +37,8 @@ class CloverWeb
         Authorization.authorize(@current_user.id, "Vm:create", @project.id)
         @subnets = Serializers::Web::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
         @prices = BillingRate.all.each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
-          hash[br.location][br.resource_type][br.resource_family] = br.unit_price.to_f
+          hash[br.location][br.resource_type][br.resource_family] = {hourly: br.unit_price.to_f * 60, monthly: br.unit_price.to_f * 60 * 24 * 30}
         end
-
         view "vm/create"
       end
     end

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -108,8 +108,10 @@
                             type="radio"
                             name="size"
                             value="<%= size.name %>"
-                            class="peer sr-only"
-                            data-details="<%= {family: size.name.split(".").first, vcpu: size.vcpu}.to_json %>"
+                            class="peer sr-only location-based-price"
+                            data-resource-type="VmCores"
+                            data-resource-family="<%= size.name.split("-").first %>"
+                            data-amount="<%= size.vcpu / 2 %>"
                             required
                             <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>
                           >
@@ -128,7 +130,7 @@
                               </span>
                             </span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
-                              <span class="font-medium price">-</span>
+                              <span class="font-medium <%= size.name %>-monthly-price">-</span>
                               <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
                             </span>
                           </span>


### PR DESCRIPTION
Previously price calculation is  done on front-end side. It makes hard to detect required changes on UI side when something changed on backend side.
For example, we changed naming format of vm sizes, and UI side is broken. But we couldn't detect it.

I moved all logic to backend side and make it more generic. Frontend side just fetch required metadata and show monthly price times amount.