### PR TITLE
Group Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,24 @@ updates:
       interval: 'daily'
     allow:
       - dependency-type: "all"
+    groups:
+      ruby-dependencies:
+        pattern: "*"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'
     allow:
       - dependency-type: "all"
+    groups:
+      js-dependencies:
+        pattern: "*"
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
       interval: 'daily'
     allow:
       - dependency-type: "all"
+    groups:
+      docker-dependencies:
+        pattern: "*"


### PR DESCRIPTION
Dependabot creates PR for each version update. It makes git history longer. Last month, grouped version updates are announced: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

I hope it will make version updates less noisy.