### PR TITLE
Create billing record for IPv4 address

### DIFF
--- a/migrate/20230808_add_ipv4_billing.rb
+++ b/migrate/20230808_add_ipv4_billing.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    DB[:billing_rate].truncate(cascade: true)
+    copy_into :billing_rate, data: <<COPY
+139d9a67-8182-8578-a303-235cabd5161c	VmCores	standard	hetzner-fsn1	0.000171296
+08c502f7-df5d-8978-9896-feafa0ec5c40	VmCores	standard	hetzner-hel1	0.000154167
+118b7e2d-fa8d-8d78-910d-1f62fcc657ec	IPAddress	IPv4	hetzner-fsn1	0.0000694444
+1bde2200-545a-8d78-960e-08a303111e3d	IPAddress	IPv4	hetzner-hel1	0.0000694444
+COPY
+  end
+end

--- a/model/assigned_vm_address.rb
+++ b/model/assigned_vm_address.rb
@@ -5,6 +5,7 @@ require_relative "../model"
 class AssignedVmAddress < Sequel::Model
   one_to_one :vm, key: :dst_vm_id
   many_to_one :address, key: :address_id
+  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
 
   include ResourceMethods
 end


### PR DESCRIPTION
IPv4 is a very scarce resource, and it starts to cost. Other cloud providers charge extra when user enable IPv4. We decided to charge $3 monthly for IPv4.