### PR TITLE
Rename idiomatic Project `let` in tests from `p` to `prj`

### DIFF
--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Prog::Vnet::NicNexus do
   }
 
   let(:st) { Strand.new }
-
   let(:ps) {
     PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
       net4: "10.0.0.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
   }
 
   let(:st) { Strand.new }
-  let(:p) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+  let(:prj) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
   let(:ps) {
     PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
       net4: "1.1.1.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
@@ -25,7 +25,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
 
     it "uses ipv6_addr if passed and creates entities" do
       ps = instance_double(PrivateSubnet)
-      expect(ps).to receive(:associate_with_project).with(p).and_return(true)
+      expect(ps).to receive(:associate_with_project).with(prj).and_return(true)
       expect(PrivateSubnet).to receive(:create).with(
         name: "default-ps",
         location: "hetzner-hel1",
@@ -36,7 +36,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(described_class).to receive(:random_private_ipv4).and_return("10.0.0.0/26")
       expect(Strand).to receive(:create).with(prog: "Vnet::SubnetNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
       described_class.assemble(
-        p.id,
+        prj.id,
         name: "default-ps",
         location: "hetzner-hel1",
         ipv6_range: "fd10:9b0b:6b4b:8fbb::/64"
@@ -45,7 +45,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
 
     it "uses ipv4_addr if passed and creates entities" do
       ps = instance_double(PrivateSubnet)
-      expect(ps).to receive(:associate_with_project).with(p).and_return(true)
+      expect(ps).to receive(:associate_with_project).with(prj).and_return(true)
       expect(PrivateSubnet).to receive(:create).with(
         name: "default-ps",
         location: "hetzner-hel1",
@@ -56,7 +56,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(described_class).to receive(:random_private_ipv6).and_return("fd10:9b0b:6b4b:8fbb::/64")
       expect(Strand).to receive(:create).with(prog: "Vnet::SubnetNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
       described_class.assemble(
-        p.id,
+        prj.id,
         name: "default-ps",
         location: "hetzner-hel1",
         ipv4_range: "10.0.0.0/26"
@@ -174,8 +174,8 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "deletes and pops if nics are destroyed" do
       expect(ps).to receive(:destroy).and_return(true)
       expect(ps).to receive(:nics).and_return([]).at_least(:once)
-      expect(ps).to receive(:projects).and_return([p]).at_least(:once)
-      expect(ps).to receive(:dissociate_with_project).with(p).and_return(true)
+      expect(ps).to receive(:projects).and_return([prj]).at_least(:once)
+      expect(ps).to receive(:dissociate_with_project).with(prj).and_return(true)
       expect(nx).to receive(:pop).with("subnet destroyed").and_return(true)
       nx.destroy
     end


### PR DESCRIPTION
`p` is used for printing, and too short to skim through the code with a search besides.  Two characters or more would be better. In this case I use three.