### PR TITLE
Update used hugepages when destroying a Vm.

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -334,7 +334,8 @@ SQL
       vm.vm_storage_volumes_dataset.destroy
 
       VmHost.dataset.where(id: vm.vm_host_id).update(
-        used_cores: Sequel[:used_cores] - vm.cores
+        used_cores: Sequel[:used_cores] - vm.cores,
+        used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib
       )
       vm.projects.map { vm.dissociate_with_project(_1) }
 


### PR DESCRIPTION
We increase number of used hugepages when allocating a Vm. A Vm will
fail to allocate if there are not enough hugepages.

Previously we didn't update the number of hugepages when destroying
a Vm, which caused in not being able to allocate new Vms.

This PR fixes that by updating number of used hugepages when destroying
a Vm.