### PR TITLE
Update available storage size when destroying a Vm

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -337,7 +337,8 @@ SQL
 
       VmHost.dataset.where(id: vm.vm_host_id).update(
         used_cores: Sequel[:used_cores] - vm.cores,
-        used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib
+        used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib,
+        available_storage_gib: Sequel[:available_storage_gib] + vm.storage_size_gib
       )
       vm.projects.map { vm.dissociate_with_project(_1) }
 


### PR DESCRIPTION
We decrease vmhost available storage size when allocating a Vm. A Vm will fail to allocate if there are not enough available storage.

Previously we didn't update the size of available storage when destroying a Vm, which caused in not being able to allocate new Vms.

This PR fixes that by updating available storage size when destroying a Vm.