### PR TITLE
Start encrypting and forgetting nic encryption key

### DIFF
--- a/migrate/20230809_allow_nil_encr_key.rb
+++ b/migrate/20230809_allow_nil_encr_key.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:nic) do
+      set_column_allow_null :encryption_key
+    end
+  end
+end

--- a/model/nic.rb
+++ b/model/nic.rb
@@ -12,6 +12,10 @@ class Nic < Sequel::Model
   include SemaphoreMethods
   semaphore :destroy, :refresh_mesh, :detach_vm
 
+  plugin :column_encryption do |enc|
+    enc.column :encryption_key
+  end
+
   def self.ubid_to_name(ubid)
     ubid.to_s[0..7]
   end

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -16,15 +16,10 @@ class Prog::Vnet::NicNexus < Prog::Base
 
     DB.transaction do
       nic = Nic.create(private_ipv6: ipv6_addr, private_ipv4: ipv4_addr, mac: gen_mac,
-        encryption_key: gen_encryption_key, name: name,
-        private_subnet_id: private_subnet_id) { _1.id = ubid.to_uuid }
+        name: name, private_subnet_id: private_subnet_id) { _1.id = ubid.to_uuid }
       subnet.add_nic(nic)
       Strand.create(prog: "Vnet::NicNexus", label: "wait") { _1.id = ubid.to_uuid }
     end
-  end
-
-  def self.gen_encryption_key
-    "0x" + SecureRandom.bytes(36).unpack1("H*")
   end
 
   def nic

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -23,12 +23,10 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(ps).to receive(:random_private_ipv4).and_return("10.0.0.12/32")
       expect(ps).not_to receive(:random_private_ipv6)
       expect(described_class).to receive(:gen_mac).and_return("00:11:22:33:44:55")
-      expect(described_class).to receive(:gen_encryption_key).and_return("0x30613961313636632d653765372d343434372d616232392d376561343432623562623065")
       expect(Nic).to receive(:create).with(
         private_ipv6: "fd10:9b0b:6b4b:8fbb::/128",
         private_ipv4: "10.0.0.12/32",
         mac: "00:11:22:33:44:55",
-        encryption_key: "0x30613961313636632d653765372d343434372d616232392d376561343432623562623065",
         private_subnet_id: "57afa8a7-2357-4012-9632-07fbe13a3133",
         name: "demonic"
       ).and_return(true)
@@ -41,12 +39,10 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(ps).to receive(:random_private_ipv6).and_return("fd10:9b0b:6b4b:8fbb::/128")
       expect(ps).not_to receive(:random_private_ipv4)
       expect(described_class).to receive(:gen_mac).and_return("00:11:22:33:44:55")
-      expect(described_class).to receive(:gen_encryption_key).and_return("0x30613961313636632d653765372d343434372d616232392d376561343432623562623065")
       expect(Nic).to receive(:create).with(
         private_ipv6: "fd10:9b0b:6b4b:8fbb::/128",
         private_ipv4: "10.0.0.12/32",
         mac: "00:11:22:33:44:55",
-        encryption_key: "0x30613961313636632d653765372d343434372d616232392d376561343432623562623065",
         private_subnet_id: "57afa8a7-2357-4012-9632-07fbe13a3133",
         name: "demonic"
       ).and_return(true)

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "refreshes mesh and hops to wait_refresh_mesh" do
       expect(ps).to receive(:nics).and_return([nic])
       expect(nic).to receive(:incr_refresh_mesh).and_return(true)
+      expect(SecureRandom).to receive(:bytes).with(36).and_return("cr\x99tnpn\x8F\x89\xCBma2\x01\x1C\xF9\xA3\xCD\xF7\xC0\xEF@w\xA9\x85\x7F\x1E\xB3T\xE3~\xB7\xFD7l\x91")
+      expect(nic).to receive(:update).with(encryption_key: "0x637299746e706e8f89cb6d6132011cf9a3cdf7c0ef4077a9857f1eb354e37eb7fd376c91").and_return(true)
       expect {
         nx.refresh_mesh
       }.to hop("wait_refresh_mesh")
@@ -118,8 +120,9 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "hops back to wait if nics are done" do
       expect(ss).to receive(:set?).and_return(false)
       expect(SemSnap).to receive(:new).with(nic.id).and_return(ss)
-      expect(ps).to receive(:nics).and_return([nic])
+      expect(ps).to receive(:nics).and_return([nic]).at_least(:once)
       expect(ps).to receive(:update).with(state: "waiting").and_return(true)
+      expect(nic).to receive(:update).with(encryption_key: nil).and_return(true)
       expect(nx).to receive(:decr_refresh_mesh).and_return(true)
       expect {
         nx.wait_refresh_mesh


### PR DESCRIPTION
With this commit, we start to store encryption key in the database in encrypted form instead of plain text. We also start to clean encryption key from the database at the end of the mesh refreshing.