### PR TITLE
Allocate VMs in a host with low memory/core ratio.

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -167,8 +167,7 @@ class Prog::Vm::Nexus < Prog::Base
     DB[<<SQL, vm.cores, vm.mem_gib_ratio, vm.mem_gib, vm.storage_size_gib, vm.location]
 SELECT *, vm_host.total_mem_gib / vm_host.total_cores AS mem_ratio
 FROM vm_host
-WHERE vm_host.used_cores + ? < vm_host.total_cores
-AND vm_host.total_mem_gib / vm_host.total_cores >= ?
+WHERE vm_host.used_cores + ? < least(vm_host.total_cores, vm_host.total_mem_gib / ?)
 AND vm_host.used_hugepages_1g + ? < vm_host.total_hugepages_1g
 AND vm_host.available_storage_gib > ?
 AND vm_host.allocation_state = 'accepting'


### PR DESCRIPTION
Previously we expected the host memory/core ratio be >= VMs memory/core ratio. Now that we use 8GiB memory/core ratio, allocating VMs in a an empty AX161 host failed, because it had 4GiB memory/core ratio (32 cores and 128GiB memory).

But we could actually allocate VMs in that case by limiting the number of cores that could be assigned to VMs instead. For example in the AX161 case, instead of failing the allocation we could limit ourselves only to 16 cores so we can still maintain the 8GiB memory/core ratio.

This PR does that.