### PR TITLE
Remove SPI from policy creation

### DIFF
--- a/rhizome/lib/ipsec_tunnel.rb
+++ b/rhizome/lib/ipsec_tunnel.rb
@@ -81,8 +81,7 @@ class IPSecTunnel
       "dst #{@dst_private_subnet} dir #{@direction} " \
       "tmpl src #{@src_clover_ephemeral} " \
       "dst #{@dst_clover_ephemeral} " \
-      "spi #{@spi} proto esp reqid 1 " \
-      "mode tunnel"
+      "proto esp reqid #{(@direction == "out") ? 1 : 0} mode tunnel"
   end
 
   def add_policy_command4
@@ -91,7 +90,6 @@ class IPSecTunnel
       "dst #{@dst_private_subnet4} dir #{@direction} " \
       "tmpl src #{@src_clover_ephemeral} " \
       "dst #{@dst_clover_ephemeral} " \
-      "spi #{@spi4} proto esp reqid 1 " \
-      "mode tunnel"
+      "proto esp reqid #{(@direction == "out") ? 1 : 0} mode tunnel"
   end
 end


### PR DESCRIPTION
SPI is not really necessary in policies. For outgoing connections, once the template is matched the correct SA is identified locally via reqid. For incoming connections, if the template matches, spi is already in the header of the packet, which is used to match the correct SA. Therefore, we do not need spi in policy.
When we implement rekeying, this change will be handy since we won't be dealing with destination policies separately.