### PR TITLE
Use proc as stack's default value

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -6,7 +6,7 @@ require "time"
 
 class Strand < Sequel::Model
   Strand.plugin :defaults_setter, cache: true
-  Strand.default_values[:stack] = [{}]
+  Strand.default_values[:stack] = proc { [{}] }
 
   LEASE_EXPIRATION = 120
   many_to_one :parent, key: :parent_id, class: self


### PR DESCRIPTION
Without proc, default_value is shared for all instances of the Strand and when one of the callers of Strand.new updates the value of stack, it also modifies the default value.

Fixes #408 