### PR TITLE
Add auto-refresh to vm show and index page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,6 +2,7 @@ $(function() {
   setupPolicyEditor();
   setupLocationBasedPrices();
   setupLocationBasedOptions();
+  setupAutoRefresh();
 });
 
 $(".toggle-mobile-menu").on("click", function (event) {
@@ -198,4 +199,13 @@ function setupLocationBasedOptions() {
   if (selectedLocation) {
     $(`.location-based-option.${selectedLocation}`).show().prop('disabled', false);
   }
+}
+
+function setupAutoRefresh() {
+  $("div.auto-refresh").each(function() {
+    const interval = $(this).data("interval");
+    setTimeout(function() {
+      location.reload();
+    }, interval * 1000);
+  });
 }

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Virtual Machines" %>
+<div class="auto-refresh hidden" data-interval="10"></div>
 
 <% if @vms.count > 0 %>
   <div class="space-y-1">

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -1,4 +1,5 @@
 <% @page_title = @vm[:name] %>
+<div class="auto-refresh hidden" data-interval="10"></div>
 
 <div class="space-y-1">
   <%== render(


### PR DESCRIPTION
Users need to refresh the page manually to see if VM creation is completed.

I added auto-refresh to VM creation and VM listing page. It reloads page every 10 seconds.

Fixes #437