### PR TITLE
Add "Dedicated CPU" mark to vm creation page

### DIFF
--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -101,7 +101,7 @@
               </div>
               <div class="col-span-full">
                 <div class="space-y-2">
-                  <label for="size" class="text-sm font-medium leading-6 text-gray-900">Server size</label>
+                  <label for="size" class="text-sm font-medium leading-6 text-gray-900">Server size (Dedicated CPU)</label>
                   <fieldset class="radio-small-cards" id="size-radios">
                     <legend class="sr-only">Server size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">


### PR DESCRIPTION
We are giving users dedicated vCPUs rather than over-provisioned ones.