### PR TITLE
Show vm state as "deleting" after delete button clicked

### DIFF
--- a/migrate/20230814_add_vm_deleting.rb
+++ b/migrate/20230814_add_vm_deleting.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_enum_value(:vm_display_state, "deleting")
+  end
+end

--- a/model.rb
+++ b/model.rb
@@ -17,6 +17,9 @@ end
 
 module SemaphoreMethods
   def self.included(base)
+    base.class_eval do
+      one_to_many :semaphores, key: :strand_id
+    end
     base.extend(ClassMethods)
   end
 
@@ -26,6 +29,10 @@ module SemaphoreMethods
       names.each do |name|
         define_method "incr_#{name}" do
           Semaphore.incr(id, name)
+        end
+
+        define_method "#{name}_set?" do
+          semaphores.any? { |s| s.name == name.to_s }
         end
       end
     end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -38,6 +38,11 @@ class Vm < Sequel::Model
     assigned_vm_address&.ip
   end
 
+  def display_state
+    return "deleting" if destroy_set?
+    super
+  end
+
   Product = Struct.new(:prefix, :cores) do |klass|
     klass.define_singleton_method :parse do |s|
       fail "BUG: cannot parse product" unless s =~ /\A(\w+)-(\d+)\z/

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -327,6 +327,8 @@ SQL
   def destroy
     register_deadline(nil, 5 * 60)
 
+    vm.update(display_state: "deleting")
+
     unless host.nil?
       begin
         host.sshable.cmd("sudo systemctl stop #{q_vm}")

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -5,7 +5,7 @@ class CloverApi
     @serializer = Serializers::Api::Vm
 
     r.get true do
-      vms = @project.vms_dataset.where(location: @location).authorized(@current_user.id, "Vm:view").all
+      vms = @project.vms_dataset.where(location: @location).authorized(@current_user.id, "Vm:view").eager(:semaphores).all
 
       serialize(vms)
     end

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -5,7 +5,7 @@ class CloverWeb
     @serializer = Serializers::Web::Vm
 
     r.get true do
-      @vms = serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").all)
+      @vms = serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").eager(:semaphores).all)
 
       view "vm/index"
     end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -3,7 +3,18 @@
 require_relative "spec_helper"
 
 RSpec.describe Vm do
-  subject(:vm) { described_class.new }
+  subject(:vm) { described_class.new(display_state: "creating") }
+
+  describe "#display_state" do
+    it "returns deleting if destroy semaphore increased" do
+      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "destroy")])
+      expect(vm.display_state).to eq("deleting")
+    end
+
+    it "return same if semaphores not increased" do
+      expect(vm.display_state).to eq("creating")
+    end
+  end
 
   describe "#product" do
     it "crashes if a bogus product is passed" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -456,6 +456,7 @@ RSpec.describe Prog::Vm::Nexus do
 
       before do
         expect(vm).to receive(:vm_host).and_return(vm_host)
+        expect(vm).to receive(:update).with(display_state: "deleting")
       end
 
       it "absorbs an already deleted errors as a success" do
@@ -501,6 +502,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nic).to receive(:update).with(vm_id: nil)
       expect(nic).to receive(:incr_destroy)
       expect(vm).to receive(:nics).and_return([nic])
+      expect(vm).to receive(:update).with(display_state: "deleting")
       expect(vm).to receive(:destroy)
 
       expect { nx.destroy }.to exit({"msg" => "vm deleted"})

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -3,6 +3,8 @@
   <% color = "bg-green-100 text-green-800" %>
 <% when "creating", "rebooting", "starting" %>
   <% color = "bg-yellow-100 text-yellow-800" %>
+<% when "deleting" %>
+  <% color = "bg-red-100 text-red-800" %>
 <% else %>
   <% color = "bg-slate-100 text-slate-800" %>
 <% end %>


### PR DESCRIPTION
This PR doesn't simply set display_state as "deleting" at "destroy" label because our operations are async. When user clicked "delete" button, web service increases "destroy" semaphore, and respirate moves nexus to destroy label. Until respirate fetches strand and run, state isn't changed. In addition, destroying vm is quick, so probably vm's disappeared when user reload page again.

To fix this delayed display_state issue, I override method to decide display state for some special semaphores. In this PR, if "destroy" semaphore is increased, vm.display_state returns "deleting" immediately.

I added `one_to_many :semaphores` relation to model to use eager loading. Otherwise fetching semaphores for each vm separately at vm listing page causes N+1 query issue.

Instead of all this mambo jambo, I might just update display_state as "deleting" at place where we increase destroy semaphore. This place is route file. Updating vm model at outside of its nexus felt like antipattern. I didn't do that.

Fixes #438

<img width="1507" alt="Screenshot 2023-08-14 at 21 18 44" src="https://github.com/ubicloud/ubicloud/assets/993199/f15ca74c-1840-4c89-b501-3342eda351f2">

