### PR TITLE
Hide sidebar items when no permission

### DIFF
--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -32,6 +32,7 @@ class CloverWeb
       end
 
       @project_data = serialize(@project)
+      @project_permissions = Authorization.all_permissions(@current_user.id, @project.id)
 
       r.get true do
         Authorization.authorize(@current_user.id, "Project:view", @project.id)

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe Clover, "project" do
         expect(page.status_code).to eq(403)
         expect(page).to have_content "Forbidden"
       end
+
+      it "not show on sidebar when does not have permissions" do
+        visit "#{project_wo_permissions.path}/dashboard"
+
+        within find_by_id("desktop-menu") do
+          expect { click_link "Users" }.to raise_error Capybara::ElementNotFound
+          expect { click_link "Access Policy" }.to raise_error Capybara::ElementNotFound
+          expect { click_link "Billing" }.to raise_error Capybara::ElementNotFound
+          expect { click_link "Settings" }.to raise_error Capybara::ElementNotFound
+        end
+      end
     end
 
     describe "details" do

--- a/views/components/empty_state.erb
+++ b/views/components/empty_state.erb
@@ -1,9 +1,15 @@
+<% description = (defined?(description) && description) ? description : nil %>
+<% button_link = (defined?(button_link) && button_link) ? button_link : nil %>
+<% button_title = (defined?(button_title) && button_title) ? button_title : nil %>
+
 <div class="text-center">
   <%== render("components/icon", locals: { name: icon, classes: "mx-auto h-12 w-12 text-gray-400" }) %>
   <h3 class="mt-2 text-sm font-semibold text-gray-900"><%= title %></h3>
-  <p class="mt-1 text-sm text-gray-500"><%= description %></p>
+  <% if description %>
+    <p class="mt-1 text-sm text-gray-500"><%= description %></p>
+  <% end %>
   <div class="mt-6">
-    <% if defined?(button_link) && button_link %>
+    <% if button_link %>
       <a
         href="<%= button_link %>"
         class="inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600"
@@ -11,7 +17,7 @@
         <%== render("components/icon", locals: { name: "hero-plus", classes: "ml-0.5 mr-1.5 h-5 w-5" }) %>
         <%= button_title %>
       </a>
-    <% else %>
+    <% elsif button_title %>
       <div class="flex justify-center">
         <%== render("components/form/submit_button", locals: { text: button_title }) %>
       </div>

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -65,7 +65,7 @@
           <% end %>
         </ul>
       </li>
-      <% if @project_data %>
+      <% if @project_data && (@project_permissions & ["Project:user", "Project:policy", "Project:billing", "Project:view"]).any? %>
         <li>
           <div class="text-xs font-semibold leading-6 text-orange-200">Project Details</div>
           <ul role="list" class="-mx-2 mt-2 space-y-1">
@@ -75,7 +75,8 @@
                 name: "Users",
                 url: "#{@project_data[:path]}/user",
                 is_active: request.path.start_with?("#{@project_data[:path]}/user"),
-                icon: "hero-users"
+                icon: "hero-users",
+                has_permission: @project_permissions.include?("Project:user")
               }
             ) %>
             <%== render(
@@ -84,7 +85,8 @@
                 name: "Access Policy",
                 url: "#{@project_data[:path]}/policy",
                 is_active: request.path.start_with?("#{@project_data[:path]}/policy"),
-                icon: "hero-key"
+                icon: "hero-key",
+                has_permission: @project_permissions.include?("Project:policy")
               }
             ) %>
             <% if Config.stripe_secret_key %>
@@ -94,7 +96,8 @@
                   name: "Billing",
                   url: "#{@project_data[:path]}/billing",
                   is_active: request.path.start_with?("#{@project_data[:path]}/billing"),
-                  icon: "hero-banknotes"
+                  icon: "hero-banknotes",
+                  has_permission: @project_permissions.include?("Project:billing")
                 }
               ) %>
             <% end %>
@@ -104,7 +107,8 @@
                 name: "Settings",
                 url: @project_data[:path],
                 is_active: request.path == @project_data[:path],
-                icon: "hero-cog-6-tooth"
+                icon: "hero-cog-6-tooth",
+                has_permission: @project_permissions.include?("Project:view")
               }
             ) %>
           </ul>

--- a/views/layouts/sidebar/item.erb
+++ b/views/layouts/sidebar/item.erb
@@ -1,9 +1,11 @@
-<li>
-  <a
-    href="<%= url %>"
-    class="<%= is_active ? "bg-orange-700 text-white" : "text-orange-100 hover:text-white hover:bg-orange-700" %> group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"
-  >
-    <%== render("components/icon", locals: { name: icon, classes: "h-6 w-6 shrink-0 text-white" }) %>
-    <%= name %>
-  </a>
-</li>
+<% if !defined?(has_permission) || has_permission%>
+  <li>
+    <a
+      href="<%= url %>"
+      class="<%= is_active ? "bg-orange-700 text-white" : "text-orange-100 hover:text-white hover:bg-orange-700" %> group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"
+    >
+      <%== render("components/icon", locals: { name: icon, classes: "h-6 w-6 shrink-0 text-white" }) %>
+      <%= name %>
+    </a>
+  </li>
+<% end %>

--- a/views/private_subnet/index.erb
+++ b/views/private_subnet/index.erb
@@ -14,9 +14,9 @@
       "components/page_header",
       locals: {
         title: "Private Subnets",
-        right_items: [
+        right_items: @project_permissions.include?("PrivateSubnet:create") ? [
           "<a href='private-subnet/create' class='inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600'>Create Private Subnet</a>"
-        ]
+        ] : []
       }
     ) %>
   </div>
@@ -57,9 +57,11 @@
     locals: {
       icon: "hero-globe-alt",
       title: "No private subnets",
+      description: "You don't have permission to create private subnet."
+    }.merge(@project_permissions.include?("PrivateSubnet:create") ? {
       description: "Get started by creating a new private subnet.",
       button_link: "#{@project_data[:path]}/private-subnet/create",
       button_title: "New Private Subnet"
-    }
+    } : {})
   ) %>
 <% end %>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -15,9 +15,9 @@
       "components/page_header",
       locals: {
         title: "Virtual Machines",
-        right_items: [
+        right_items: @project_permissions.include?("Vm:create") ? [
           "<a href='vm/create' class='inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600'>Create Virtual Machine</a>"
-        ]
+        ] : []
       }
     ) %>
   </div>
@@ -75,9 +75,11 @@
     locals: {
       icon: "hero-server-stack",
       title: "No virtual machines",
+      description: "You don't have permission to create virtual machines."
+    }.merge(@project_permissions.include?("Vm:create") ? {
       description: "Get started by creating a new virtual machine.",
       button_link: "#{@project_data[:path]}/vm/create",
       button_title: "New Virtual Machine"
-    }
+    } : {})
   ) %>
 <% end %>


### PR DESCRIPTION
To decide show sidebar item to user, we need to check user's permission on project. We check one by one, but I don't want it. It runs a query for each check.

I made `actions` argument optional in our authorization query. If it's not provided, it returns all matched policies that user has permission on given object. So we can fetch this list once, and check permission from it.

Also we don't show create buttons if user doesn't have create permission for Vm or Private Subnet.

Fixes #436