### PR TITLE
Wait until VM is sshable before declaring running

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -294,8 +294,17 @@ SQL
 
   def run
     host.sshable.cmd("sudo systemctl start #{q_vm}")
-    vm.update(display_state: "running")
-    hop :wait
+    hop :wait_sshable
+  end
+
+  def wait_sshable
+    addr = vm.ephemeral_net4 || vm.ephemeral_net6.nth(2)
+    out = `ssh -o BatchMode=yes -o ConnectTimeout=1 -o PreferredAuthentications=none user@#{addr} 2>&1`
+    if out.include? "Host key verification failed."
+      vm.update(display_state: "running")
+      hop :wait
+    end
+    nap 1
   end
 
   def wait


### PR DESCRIPTION
We introduce a new state to verify the vm is up, running and the ssh agent is up. We perform a quick, doomed to fail ssh command and simply check the output. If it returns "Host key verification failed.", it means ssh-agent is also up and responsive.