### PR TITLE
Adds an explanation to hetzner api for not fetching additional IPv6s

### DIFF
--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -9,10 +9,12 @@ class Hosting::HetznerApis
   end
 
   # Fetches and processes the IPs, subnets, and failovers from the Hetzner API.
-  # It then calls `find_matching_ips` to retrieve IP addresses that match with the host's IP address.
-  # This whole thing is needed because Hetzner API is simply not good enough to do this in one call.
-  # Also the failover IP implementation depends on the host server and the IP continues to live under the original server.
-  # host even if the failover is performed. So we need to check the failover IP separately.
+  # It then calls `find_matching_ips` to retrieve IP addresses that match with
+  # the host's IP address. This whole thing is needed because Hetzner API is
+  # simply not good enough to do this in one call. Also the failover IP
+  # implementation depends on the host server and the IP continues to live under
+  # the original server. host even if the failover is performed. So we need to
+  # check the failover IP separately.
   def pull_ips
     connection = Excon.new(@host.connection_string, user: @host.user, password: @host.password)
     response = connection.get(path: "/subnet")
@@ -59,6 +61,13 @@ class Hosting::HetznerApis
 
   IpInfo = Struct.new(:ip_address, :source_host_ip, :is_failover, keyword_init: true)
 
+  # Finds IP addresses that match with the host's IP address. An important
+  # detail about this function is that; Hetzner API returns the failover IPv6
+  # addresses with active_server_ip set to the host's IPv6 address. Here in the
+  # below, you will realize that we only check the sshable.host address which is
+  # the host's IPv4 address. Therefore, the additional IPv6 subnets will be
+  # filtered out. If in future, this needs to be fixed, we'll have to find a way
+  # to also add the IPv6 subnets.
   def find_matching_ips(result)
     host_address = @host.vm_host.sshable.host
     (


### PR DESCRIPTION
Recently we realized that when we added an IPv6 block (additional, by mistake),
and the VmHost.create_addresses did not create the ipv6 block entity in the
database. Looking into the pull_ips, I realized that the ipv6 blocks come with
active_server_ip as the main ipv6 address of the server, not the ipv4. Since the
find_matching_ips function filters the ip addresses according to the host
address in sshable, this was expected. It's harmless for now but we should
tackle this once we start implementing extra ipv6 block support. That's why the
comment is added to show guidance for future.