### PR TITLE
Add Hetzner Server Reset API support

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -80,4 +80,5 @@ module Config
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)
+  override :hetzner_ssh_key, string
 end

--- a/lib/hosting/apis.rb
+++ b/lib/hosting/apis.rb
@@ -9,4 +9,12 @@ class Hosting::Apis
       raise "unknown provider #{vm_host.provider}"
     end
   end
+
+  def self.reset_server(vm_host)
+    if vm_host.provider == HetznerHost::PROVIDER_NAME
+      vm_host.hetzner_host.api.reset(vm_host.hetzner_host.server_identifier)
+    else
+      raise "unknown provider #{vm_host.provider}"
+    end
+  end
 end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -178,4 +178,12 @@ class VmHost < Sequel::Model
       create_addresses
     end
   end
+
+  def reset
+    unless Config.development?
+      fail "BUG: reset is only allowed in development"
+    end
+
+    Hosting::Apis.reset_server(self)
+  end
 end

--- a/spec/lib/hosting/apis_spec.rb
+++ b/spec/lib/hosting/apis_spec.rb
@@ -10,7 +10,15 @@ RSpec.describe Hosting::Apis do
   }
   let(:connection) { instance_double(Excon::Connection) }
   let(:hetzner_apis) { instance_double(Hosting::HetznerApis, pull_ips: []) }
-  let(:hetzner_host) { instance_double(HetznerHost, connection_string: "str", user: "user1", password: "pass", api: hetzner_apis) }
+  let(:hetzner_host) {
+    instance_double(
+      HetznerHost,
+      connection_string: "str",
+      user: "user1", password: "pass",
+      api: hetzner_apis,
+      server_identifier: 123
+    )
+  }
 
   describe "pull_ips" do
     it "can pull data from the API" do
@@ -21,6 +29,18 @@ RSpec.describe Hosting::Apis do
     it "raises an error if the provider is unknown" do
       expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
       expect { described_class.pull_ips(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
+    end
+  end
+
+  describe "reset_server" do
+    it "can reset a server" do
+      expect(hetzner_apis).to receive(:reset).with(123).and_return(true)
+      described_class.reset_server(vm_host)
+    end
+
+    it "raises an error if the provider is unknown" do
+      expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
+      expect { described_class.reset_server(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
     end
   end
 end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -120,6 +120,19 @@ RSpec.describe VmHost do
     vh.hetznerify("12")
   end
 
+  it "reset server fails for non development" do
+    expect(Config).to receive(:development?).and_return(false)
+    expect {
+      vh.reset
+    }.to raise_error(RuntimeError, "BUG: reset is only allowed in development")
+  end
+
+  it "resets the server in development" do
+    expect(Config).to receive(:development?).and_return(true)
+    expect(Hosting::Apis).to receive(:reset_server).with(vh)
+    vh.reset
+  end
+
   it "create_addresses fails if a failover ip of non existent server is being added" do
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
     expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)


### PR DESCRIPTION
In development, now we can reset the host server programmatically. For this to work properly, you should make sure all the VMs are destroyed. Call VmHost.reset function and then set the strand label to "start". It will give you a fresh new host.