### PR TITLE
Add support email to UI

### DIFF
--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -101,6 +101,10 @@
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
     <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
   </svg>
+<% when "hero-envelope" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+  </svg>
 <% else %>
   <p>Not found icon</p>
 <% end %>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -20,9 +20,9 @@
         "Update your account details such as name, password.",
         "/account"
       ], [
-        "hero-command-line", "bg-yellow-50 text-yellow-700", "API Reference",
-        "Manage your resources programmatically using conventional HTTP requests.",
-        "#"
+        "hero-envelope", "bg-yellow-50 text-yellow-700", "Get Support",
+        "If you need any help with Ubicloud, reach out to our support team for help at support@ubicloud.com.",
+        "mailto:support@ubicloud.com"
       ]
     ].each do |icon, color, title, description, link| %>
       <div

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -57,6 +57,16 @@
             <%== yield %>
           </div>
         </div>
+        <div class="mt-10 flex justify-center space-x-5">
+          <a href="https://github.com/ubicloud/ubicloud" target="_blank" class="text-gray-400 hover:text-gray-500">
+            <span class="sr-only">GitHub</span>
+            <%== render("components/icon", locals: { name: "github" }) %>
+          </a>
+          <a href="mailto:support@ubicloud.com" class="text-gray-400 hover:text-gray-500">
+            <span class="sr-only">Support</span>
+            <%== render("components/icon", locals: { name: "hero-envelope" }) %>
+          </a>
+        </div>
       </div>
     <% end %>
     <%== assets(:js) %>

--- a/views/project/dashboard.erb
+++ b/views/project/dashboard.erb
@@ -27,9 +27,9 @@
         "Access policies help to specify who can perform particular actions on your project's resources.",
         "#{@project_data[:path]}/policy"
       ], [
-        "hero-command-line", "bg-yellow-50 text-yellow-700", "API Reference",
-        "Manage your resources programmatically using conventional HTTP requests.",
-        "#"
+        "hero-envelope", "bg-yellow-50 text-yellow-700", "Get Support",
+        "If you need any help with Ubicloud, reach out to our support team for help at support@ubicloud.com.",
+        "mailto:support@ubicloud.com"
       ]
     ].each do |icon, color, title, description, link| %>
       <div


### PR DESCRIPTION
We don't have public documentation for API yet. I replaced them with support email links.

Fixes #466

<img width="492" alt="Screenshot 2023-08-17 at 15 03 40" src="https://github.com/ubicloud/ubicloud/assets/993199/413d3de0-8400-4df7-858d-99f4e099ed29">

-------

<img width="897" alt="Screenshot 2023-08-17 at 15 03 52" src="https://github.com/ubicloud/ubicloud/assets/993199/753ea20d-b8aa-4c2f-a388-81dc7896b2ce">
