### PR TITLE
Start billing when/if only vm is accessible to the customer

### DIFF
--- a/spec/routes/api/vm_spec.rb
+++ b/spec/routes/api/vm_spec.rb
@@ -56,8 +56,6 @@ RSpec.describe Clover, "vm" do
 
     describe "create" do
       it "success" do
-        expect(BillingRecord).to receive(:create)
-
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm", {
           public_key: "ssh key",
           name: "test-vm",

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe Clover, "vm" do
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
-        expect(BillingRecord).to receive(:create_with_id)
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
@@ -121,7 +120,6 @@ RSpec.describe Clover, "vm" do
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
-        expect(BillingRecord).to receive(:create_with_id)
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")


### PR DESCRIPTION
Before this commit, we created billing records way early in the nexus. With this
commit, we move them to the run state. That way, if a provisioning fails
in earlier stages, we won't immediately start billing the customer.
There was also a consideration to use wait_sshable but we wanted to
avoid that since in future, we may just have VMs without ssh access.