### PR TITLE
Refactor rodauth's verify login change view and email

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -161,6 +161,18 @@ class CloverWeb < Roda
     change_login_route "account/change-login"
     change_login_view { view "account/change_login", "My Account" }
 
+    verify_login_change_view { view "auth/verify_login_change", "Verify Email Change" }
+    send_verify_login_change_email do |new_login|
+      user = Account[account_id]
+      scope.send_email(email_to, "Please Verify New Email Address for Ubicloud",
+        greeting: "Hello #{user.name},",
+        body: ["We received a request to change your account email to '#{new_login}'. To verify new email, click the button below.",
+          "If you did not initiate this request, no action is needed. Current email address can be used to login your account.",
+          "For any questions or assistance, reach out to our team at support@ubicloud.com."],
+        button_title: "Verify Email",
+        button_link: verify_login_change_email_link)
+    end
+
     close_account_redirect "/login"
     close_account_route "account/close-account"
     close_account_view { view "account/close_account", "My Account" }

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -97,5 +97,21 @@ RSpec.describe Clover, "auth" do
 
       expect(page.title).to eq("Ubicloud - Login")
     end
+
+    it "can change email" do
+      new_email = "new@example.com"
+      visit "/account/change-login"
+
+      fill_in "New Email Address", with: new_email
+
+      click_button "Change Email"
+
+      expect(page).to have_content("An email has been sent to you with a link to verify your login change")
+      expect(Mail::TestMailer.deliveries.length).to eq 1
+      verify_link = Mail::TestMailer.deliveries.first.html_part.body.match(/(\/verify-login-change.+?)"/)[1]
+
+      visit verify_link
+      expect(page.title).to eq("Ubicloud - Verify New Email")
+    end
   end
 end

--- a/views/auth/verify_login_change.erb
+++ b/views/auth/verify_login_change.erb
@@ -1,0 +1,39 @@
+<% @page_title = "Verify New Email" %>
+
+<% if rodauth.authenticated? %>
+  <div class="space-y-1">
+    <%== render(
+      "components/breadcrumb",
+      locals: {
+        back: "/account",
+        parts: [["My Account", "/account"], ["Verify New Email", "#"]]
+      }
+    ) %>
+    <%== render("components/page_header", locals: { title: "My Account" }) %>
+  </div>
+
+  <div class="grid gap-6">
+    <form role="form" method="POST">
+      <%== rodauth.csrf_tag %>
+      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+        <div class="px-4 py-5 sm:p-6">
+          <%== render("account/tab") %>
+          <div class="mt-6">
+            <%== render("components/form/submit_button", locals: { text: "Click to Verify New Email" }) %>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+<% else %>
+  <% @page_message = "Verify your new email" %>
+
+  <form class="rodauth space-y-6" role="form" method="POST">
+    <%== rodauth.csrf_tag %>
+
+    <div class="flex flex-col text-center">
+      <%== render("components/form/submit_button", locals: { text: "Click to Verify New Email" }) %>
+      <a href="/login" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Sign in to an another account</a>
+    </div>
+  </form>
+<% end %>


### PR DESCRIPTION
We don't use built-in rodauth views and emails. I already refactored other views, I missed this one.

Fixes #468