### PR TITLE
Fix available storage size update while destroying vm

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -362,13 +362,13 @@ SQL
       end
 
       vm.assigned_vm_address_dataset.destroy
-      vm.vm_storage_volumes_dataset.destroy
 
       VmHost.dataset.where(id: vm.vm_host_id).update(
         used_cores: Sequel[:used_cores] - vm.cores,
         used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib,
         available_storage_gib: Sequel[:available_storage_gib] + vm.storage_size_gib
       )
+      vm.vm_storage_volumes_dataset.destroy
       vm.projects.map { vm.dissociate_with_project(_1) }
 
       vm.destroy


### PR DESCRIPTION
We increase available_storage_gib at vm_host update query. But we delete vm storage volumes before this query. So `vm.storage_size_gib` returns 0

We need to fix value for production hosts.