### PR TITLE
E2E Continuous Integration, local branch

### DIFF
--- a/migrate/20230825_add_sshable_user.rb
+++ b/migrate/20230825_add_sshable_user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:sshable) do
+      add_column :unix_user, :text, null: false, default: "rhizome"
+    end
+  end
+end

--- a/model/access_tag.rb
+++ b/model/access_tag.rb
@@ -8,3 +8,5 @@ class AccessTag < Sequel::Model
 
   include ResourceMethods
 end
+
+AccessTag.plugin :association_dependencies, applied_tags: :destroy

--- a/model/project.rb
+++ b/model/project.rb
@@ -35,3 +35,5 @@ class Project < Sequel::Model
     "/project/#{ubid}"
   end
 end
+
+Project.plugin :association_dependencies, access_tags: :destroy, access_policies: :destroy, billing_info: :destroy

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -88,7 +88,7 @@ class Sshable < Sequel::Model
     end
 
     # Cache miss.
-    sess = Net::SSH.start(host, "rhizome", **COMMON_SSH_ARGS.merge(key_data: keys.map(&:private_key)))
+    sess = Net::SSH.start(host, unix_user, **COMMON_SSH_ARGS.merge(key_data: keys.map(&:private_key)))
     Thread.current[:clover_ssh_cache][host] = sess
     sess
   end

--- a/prog/test/main.rb
+++ b/prog/test/main.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "net/ssh"
+
+# st2 = Strand.create_with_id(prog: 'Test::Main', label: 'start', stack: [{subject_id: VmHost.first.id}])
+
+class Prog::Test::Main < Prog::Base
+  subject_is :sshable, :vm_host
+
+  def start
+    project = Project.create_with_id(name: "project 1", provider: "hetzner")
+    project.create_hyper_tag(project)
+
+    subnet1_s = Prog::Vnet::SubnetNexus.assemble(
+      project.id, name: "the-first-subnet", location: "hetzner-hel1"
+    )
+    nic1_s = Prog::Vnet::NicNexus.assemble(subnet1_s.id, name: "nic-1")
+    nic2_s = Prog::Vnet::NicNexus.assemble(subnet1_s.id, name: "nic-2")
+
+    subnet2_s = Prog::Vnet::SubnetNexus.assemble(
+      project.id, name: "the-second-subnet", location: "hetzner-hel1"
+    )
+    nic3_s = Prog::Vnet::NicNexus.assemble(subnet2_s.id, name: "nic-3")
+
+    strand.add_child(subnet1_s)
+    strand.add_child(subnet2_s)
+    strand.add_child(nic1_s)
+    strand.add_child(nic2_s)
+    strand.add_child(nic3_s)
+
+    keypair_1 = SshKey.generate
+    keypair_2 = SshKey.generate
+    keypair_3 = SshKey.generate
+
+    vm1_s = Prog::Vm::Nexus.assemble(
+      keypair_1.public_key, project.id,
+      private_subnet_id: subnet1_s.id,
+      nic_id: nic1_s.id,
+      enable_ip4: true
+    )
+
+    vm2_s = Prog::Vm::Nexus.assemble(
+      keypair_2.public_key, project.id,
+      private_subnet_id: subnet1_s.id,
+      nic_id: nic2_s.id,
+      enable_ip4: true
+    )
+
+    vm3_s = Prog::Vm::Nexus.assemble(
+      keypair_3.public_key, project.id,
+      private_subnet_id: subnet2_s.id,
+      nic_id: nic3_s.id,
+      enable_ip4: true
+    )
+
+    Sshable.create(
+      unix_user: "ubi",
+      host: "temp_#{vm1_s.id}",
+      raw_private_key_1: keypair_1.keypair
+    ) { _1.id = vm1_s.id }
+
+    Sshable.create(
+      unix_user: "ubi",
+      host: "temp_#{vm2_s.id}",
+      raw_private_key_1: keypair_2.keypair
+    ) { _1.id = vm2_s.id }
+
+    Sshable.create(
+      unix_user: "ubi",
+      host: "temp_#{vm3_s.id}",
+      raw_private_key_1: keypair_3.keypair
+    ) { _1.id = vm3_s.id }
+
+    strand.add_child(vm1_s)
+    strand.add_child(vm2_s)
+    strand.add_child(vm3_s)
+
+    current_frame = strand.stack.first
+    current_frame["vms"] = [vm1_s.id, vm2_s.id, vm3_s.id]
+    current_frame["subnets"] = [subnet1_s.id, subnet2_s.id]
+    current_frame["nics"] = [nic1_s.id, nic2_s.id, nic3_s.id]
+    current_frame["project_id"] = project.id
+    strand.modified!(:stack)
+    strand.save_changes
+
+    hop :wait_children_created
+  end
+
+  def children_idle
+    active_children = strand.children_dataset.where(Sequel.~(label: "wait"))
+    active_semaphores = strand.children_dataset.join(:semaphore, strand_id: :id)
+
+    active_children.count == 0 and active_semaphores.count == 0
+  end
+
+  def wait_children_created
+    reap
+
+    hop :children_ready if children_idle
+
+    donate
+  end
+
+  def children_ready
+    current_frame = strand.stack.first
+    current_frame["vms"].each { |vm_id|
+      Sshable[vm_id].update(host: Vm[vm_id].ephemeral_net4.to_s)
+    }
+
+    # add sub-tests
+    strand.add_child(
+      Strand.create_with_id(
+        prog: "Test::Vm",
+        label: "start",
+        stack: [{subject_id: current_frame["vms"].first}]
+      )
+    )
+
+    hop :wait_subtests
+  end
+
+  def wait_subtests
+    reap
+
+    hop :destroy_vms if children_idle
+
+    donate
+  end
+
+  def destroy_vms
+    current_frame = strand.stack.first
+    current_frame["vms"].each { |vm_id|
+      Vm[vm_id].incr_destroy
+      Sshable[vm_id].destroy
+    }
+
+    hop :wait_vms_destroyed
+  end
+
+  def wait_vms_destroyed
+    reap
+
+    hop :destroy_subnets if children_idle
+
+    donate
+  end
+
+  def destroy_subnets
+    current_frame = strand.stack.first
+    current_frame["subnets"].each { |subnet_id|
+      PrivateSubnet[subnet_id].incr_destroy
+    }
+
+    hop :wait_subnets_destroyed
+  end
+
+  def wait_subnets_destroyed
+    reap
+
+    hop :finish if children_idle
+
+    donate
+  end
+
+  def finish
+    current_frame = strand.stack.first
+    Project[current_frame["project_id"]].destroy
+
+    pop "Tests finished!"
+  end
+end

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# st3 = Strand.create_with_id(prog: 'Test::Vm', label: 'start', stack: [{subject_id: Vm.first.id}])
+class Prog::Test::Vm < Prog::Base
+  subject_is :sshable, :vm
+
+  def start
+    hop :verify_dd
+  end
+
+  def verify_dd
+    # Verifies basic block device health
+    # See https://github.com/ubicloud/ubicloud/issues/276
+    sshable.cmd("dd if=/dev/random of=~/1.txt bs=512 count=1000000")
+    sshable.cmd("sync ~/1.txt")
+    size_info = sshable.cmd("ls -s ~/1.txt").split
+
+    unless size_info[0].to_i.between?(500000, 500100)
+      fail "unexpected size after dd"
+    end
+
+    hop :install_packages
+  end
+
+  def install_packages
+    sshable.cmd("sudo apt update")
+    sshable.cmd("sudo apt install -y build-essential")
+
+    hop :compile_program
+  end
+
+  def compile_program
+    sshable.cmd <<WRITE_PROGRAM
+        cat <<EOL > ~/1.c
+        #include <stdio.h>
+        int main() {
+        printf("Hello World.\\n");
+        return 0;
+        }
+EOL
+WRITE_PROGRAM
+
+    sshable.cmd("gcc ~/1.c -o ~/1.out")
+    sshable.cmd("~/1.out").strip
+
+    unless sshable.cmd("~/1.out").strip == "Hello World."
+      fail "Unexpected output for hello world program"
+    end
+
+    hop :ping_google
+  end
+
+  def ping_google
+    sshable.cmd("ping -c 2 google.com")
+    hop :ping_vms_in_subnet
+  end
+
+  def ping_vms_in_subnet
+    vms_with_same_subnet.each { |x|
+      # ping public IPs
+      sshable.cmd("ping -c 2 #{x.ephemeral_net4}")
+      sshable.cmd("ping -c 2 #{x.ephemeral_net6.nth(2)}")
+
+      # ping private IPs
+      nic = x.nics.first
+      private_ip6 = nic.private_ipv6.nth(2).to_s
+      private_ip4 = nic.private_ipv4.network.to_s
+      sshable.cmd("ping -c 2 #{private_ip6}")
+      sshable.cmd("ping -c 2 #{private_ip4}")
+    }
+
+    hop :ping_vms_not_in_subnet
+  end
+
+  def ping_vms_not_in_subnet
+    vms_with_different_subnet.each { |x|
+      # ping public IPs should work
+      sshable.cmd("ping -c 2 #{x.ephemeral_net4}")
+      sshable.cmd("ping -c 2 #{x.ephemeral_net6.nth(2)}")
+
+      # ping private IPs shouldn't work
+      nic = x.nics.first
+      private_ip6 = nic.private_ipv6.nth(2).to_s
+      private_ip4 = nic.private_ipv4.network.to_s
+
+      begin
+        sshable.cmd("ping -c 2 #{private_ip6}")
+      rescue Sshable::SshError
+      else
+        raise "Unexpected successful ping to private ip6 of a vm in different subnet"
+      end
+
+      begin
+        sshable.cmd("ping -c 2 #{private_ip4}")
+      rescue Sshable::SshError
+      else
+        raise "Unexpected successful ping to private ip4 of a vm in different subnet"
+      end
+    }
+
+    hop :finish
+  end
+
+  def finish
+    pop "Verified VM!"
+  end
+
+  def vms_in_same_project
+    vm.projects.first.vms_dataset.all.filter { |x|
+      x.id != vm.id
+    }
+  end
+
+  def vms_with_same_subnet
+    my_subnet = vm.private_subnets.first.id
+    vms_in_same_project.filter { |x|
+      x.private_subnets.first.id == my_subnet
+    }
+  end
+
+  def vms_with_different_subnet
+    my_subnet = vm.private_subnets.first.id
+    vms_in_same_project.filter { |x|
+      x.private_subnets.first.id != my_subnet
+    }
+  end
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -337,6 +337,8 @@ SQL
   def destroy
     register_deadline(nil, 5 * 60)
 
+    decr_destroy
+
     vm.update(display_state: "deleting")
 
     unless host.nil?

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -112,6 +112,8 @@ class Prog::Vnet::NicNexus < Prog::Base
       fail "Cannot destroy nic with active vm, first clean up the attached resources"
     end
 
+    decr_destroy
+
     DB.transaction do
       nic.src_ipsec_tunnels_dataset.destroy
       nic.dst_ipsec_tunnels_dataset.destroy

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -141,6 +141,8 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       fail "Cannot destroy subnet with active nics, first clean up the attached resources"
     end
 
+    decr_destroy
+
     if private_subnet.nics.empty?
       DB.transaction do
         private_subnet.projects.each { |p| private_subnet.dissociate_with_project(p) }

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -17,6 +17,7 @@ if (suite = ENV.delete("COVERAGE"))
     # No need to check coverage for them
     add_filter "/migrate/"
     add_filter "/spec/"
+    add_filter "/prog/test/"
     add_filter "/db.rb"
     add_filter "/model.rb"
     add_filter "/loader.rb"


### PR DESCRIPTION
Adds couple of programs to run automated end-to-end tests.

* `Prog::Test::Main` which creates 2 VMs in one subnet A, and 1 VM in a different subnet B, and then calls `Prog::Test::Vm` for one of the VMs in subnet A, and then cleans up everything and exits.
* `Prog::Test::Vm` which
  * Verifies block storage health
  * Installs some packages
  * Compiles a program and verifies its output
  * Verifies connectivity to google.com
  * Verifies connectivity to other VMs in the same subnet
  * Verifies that it cannot reach private interfaces of other VMs in a different subnet

To run the end-to-end tests, create a VmHost with IPv4 support and then run:

```
st = Strand.create_with_id(prog: 'Test::Main', label: 'start', stack: [{subject_id: VmHost.first.id}])
st.run 300
```
