### PR TITLE
Do not allow to delete the last payment method of project

### DIFF
--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -56,6 +56,7 @@ class CloverWeb
 
           # We still keep the project object for billing purposes.
           # These need to be cleaned up manually once in a while.
+          # Don't forget to clean up billing info and payment methods.
           @project.update(visible: false)
         end
 

--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -95,6 +95,11 @@ class CloverWeb
         end
 
         r.delete true do
+          unless payment_method.billing_info.payment_methods.count > 1
+            response.status = 400
+            return {message: "You can't delete the last payment method of a project."}.to_json
+          end
+
           payment_method.destroy
 
           return {message: "Deleting #{payment_method.ubid}"}.to_json


### PR DESCRIPTION
We don't allow to create virtual machines without billing info. But users are able to add billing info, create vm, then delete payment method.

We need to have at least one payment method to charge user.

In the future, we may allow to delete the last payment method if project doesn't have anything to charge.