### PR TITLE
Fix page storms by using a tag

### DIFF
--- a/migrate/20230820_add_tag_to_page.rb
+++ b/migrate/20230820_add_tag_to_page.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:page) do
+      add_column :tag, :text, collate: '"C"'
+      add_unique_constraint :tag
+    end
+
+    run "UPDATE page SET tag = id"
+
+    alter_table(:page) do
+      set_column_not_null :tag
+    end
+  end
+
+  down do
+    alter_table(:page) do
+      drop_column :tag
+    end
+  end
+end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -78,12 +78,12 @@ SQL
 
   def unsynchronized_run
     if label == stack.first["deadline_target"].to_s
+      if (pg = Page.from_tag_parts(id, prog, stack.first["deadline_target"]))
+        pg.incr_resolve
+      end
+
       stack.first.delete("deadline_target")
       stack.first.delete("deadline_at")
-      if stack.first["page_id"]
-        Page[stack.first["page_id"]].incr_resolve
-        stack.first.delete("page_id")
-      end
 
       modified!(:stack)
     end
@@ -92,7 +92,7 @@ SQL
       next unless (deadline_at = frame["deadline_at"])
 
       if Time.now > Time.parse(deadline_at.to_s)
-        frame["page_id"] ||= Prog::PageNexus.assemble("Strand[#{id}] has an expired deadline! #{prog} did not reach #{frame["deadline_target"]} on time").id
+        Prog::PageNexus.assemble("Strand[#{id}] has an expired deadline! #{prog} did not reach #{frame["deadline_target"]} on time", id, prog, frame["deadline_target"])
 
         modified!(:stack)
       end

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -60,7 +60,8 @@ end
       # This is a multi-level stack with a back-link, i.e. one prog
       # calling another in the same Strand of execution.  The thing to
       # do here is pop the stack entry.
-      Page[frame["page_id"]].incr_resolve if frame["page_id"]
+      pg = Page.from_tag_parts(strand.id, strand.prog, strand.stack.first["deadline_target"])
+      pg&.incr_resolve
 
       old_prog = strand.prog
       old_label = strand.label
@@ -189,9 +190,8 @@ end
         Time.parse(deadline_at.to_s) > Time.now + deadline_in ||
         (old_deadline_target = current_frame["deadline_target"]) != deadline_target
 
-      if old_deadline_target != deadline_target && (page_id = current_frame["page_id"])
-        Page[page_id].incr_resolve
-        current_frame.delete("page_id")
+      if old_deadline_target != deadline_target && (pg = Page.from_tag_parts(strand.id, strand.prog, old_deadline_target))
+        pg.incr_resolve
       end
 
       current_frame["deadline_target"] = deadline_target

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -4,11 +4,13 @@ class Prog::PageNexus < Prog::Base
   subject_is :page
   semaphore :resolve
 
-  def self.assemble(summary)
+  def self.assemble(summary, *tag_parts)
     DB.transaction do
-      p = Page.create_with_id(summary: summary)
-
-      Strand.create(prog: "PageNexus", label: "start") { _1.id = p.id }
+      pg = Page.from_tag_parts(tag_parts)
+      unless pg
+        pg = Page.create_with_id(summary: summary, tag: Page.generate_tag(tag_parts))
+        Strand.create(prog: "PageNexus", label: "start") { _1.id = pg.id }
+      end
     end
   end
 

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -5,7 +5,7 @@ require_relative "spec_helper"
 require "json"
 
 RSpec.describe Page do
-  subject(:p) { described_class.create_with_id }
+  subject(:p) { described_class.create_with_id(tag: "dummy-tag") }
 
   describe "#trigger" do
     it "triggers a page in Pagerduty if key is present" do

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe UBID do
     semaphore = Semaphore.create_with_id(strand_id: strand.id, name: "z")
     expect(semaphore.ubid).to start_with UBID::TYPE_SEMAPHORE
 
-    page = Page.create_with_id(summary: "x")
+    page = Page.create_with_id(summary: "x", tag: "y")
     expect(page.ubid).to start_with UBID::TYPE_PAGE
   end
 
@@ -233,7 +233,7 @@ RSpec.describe UBID do
     host_adr = AssignedHostAddress.create_with_id(ip: "192.168.1.1", address_id: adr.id, host_id: host.id)
     strand = Strand.create_with_id(prog: "x", label: "y")
     semaphore = Semaphore.create_with_id(strand_id: strand.id, name: "z")
-    page = Page.create_with_id(summary: "x")
+    page = Page.create_with_id(summary: "x", tag: "y")
 
     expect(described_class.decode(vm.ubid)).to eq(vm)
     expect(described_class.decode(sv.ubid)).to eq(sv)


### PR DESCRIPTION
We normally use page_id to deduplicate pages but if an exception occurs, we might not save the page_id to the database, which causes retriggering the page in next iteration. With this commit, we start to use tag as deduplication mechanism.