### PR TITLE
Add example ssh command to Vm detail page

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -35,6 +35,7 @@ class CloverWeb < Roda
   plugin :Integer_matcher_max
   plugin :typecast_params_sized_integers, sizes: [64], default_size: 64
   plugin :hash_branch_view_subdir
+  plugin :h
 
   plugin :not_found do
     @error = {

--- a/serializers/web/vm.rb
+++ b/serializers/web/vm.rb
@@ -13,7 +13,8 @@ class Serializers::Web::Vm < Serializers::Base
       storage_size_gib: vm.storage_size_gib,
       storage_encryption: vm.storage_encrypted? ? "encrypted" : "not encrypted",
       ip6: vm.ephemeral_net6&.nth(2),
-      ip4: vm.ephemeral_net4
+      ip4: vm.ephemeral_net4,
+      unix_user: vm.unix_user
     }
   end
 

--- a/views/components/kv_data_card.erb
+++ b/views/components/kv_data_card.erb
@@ -9,6 +9,8 @@
               <span class="copy-content cursor-pointer" data-content="<%= value %>" data-message="Copied <%= name %>">
                 <%= value %>
               </span>
+            <% elsif opts && opts[:escape] == false %>
+              <%== value %>
             <% else %>
               <%= value.nil? ? "-" : value %>
             <% end %>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -34,7 +34,12 @@
         ["Size", @vm[:size]],
         ["Storage", "#{@vm[:storage_size_gib]}GB (#{@vm[:storage_encryption]})"],
         ["IPv4", @vm[:ip4], { copieble: true }],
-        ["IPv6", @vm[:ip6], { copieble: true }]
+        ["IPv6", @vm[:ip6], { copieble: true }],
+        [
+          "SSH Command",
+          "<span class='bg-slate-100 text-rose-500 font-mono px-2 py-1 rounded'>#{h("ssh -i <PRAVATE_KEY_PATH> #{@vm[:unix_user]}@#{@vm[:ip4] || @vm[:ip6]}")}</span>",
+          { escape: false }
+        ]
       ]
     }
   ) %>


### PR DESCRIPTION
I added `escape` option to allow putting HTML to value of `components/kv_data_card`. But unix_user is user input, I escaped it when rendered with `h` plugin.

Fixes #454

<img width="1396" alt="Screenshot 2023-08-22 at 15 27 50" src="https://github.com/ubicloud/ubicloud/assets/993199/796c4eaf-ede7-4182-ab0d-f5fad4f9dbcc">
