### PR TITLE
Only add the private subnet private ip classes to routing table

### DIFF
--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -29,6 +29,19 @@ class Prog::Vnet::NicNexus < Prog::Base
 
   def wait_vm
     when_setup_nic_set? do
+      hop :add_subnet_addr
+    end
+    nap 1
+  end
+
+  def add_subnet_addr
+    bud Prog::Vnet::RekeyNicTunnel, {}, :add_subnet_addr
+    hop :wait_add_subnet_addr
+  end
+
+  def wait_add_subnet_addr
+    reap
+    if leaf?
       nic.private_subnet.incr_add_new_nic
       hop :wait_setup
     end

--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -3,6 +3,11 @@
 class Prog::Vnet::RekeyNicTunnel < Prog::Base
   subject_is :nic
 
+  def add_subnet_addr
+    nic.vm.vm_host.sshable.cmd("sudo ip -n #{nic.vm.inhost_name.shellescape} addr replace #{nic.private_subnet.net4} dev #{nic.ubid_to_tap_name}")
+    pop "add_subnet_addr is complete"
+  end
+
   def setup_inbound
     nic.dst_ipsec_tunnels.each do |tunnel|
       args = tunnel.src_nic.rekey_payload

--- a/rhizome/lib/vm_setup.rb
+++ b/rhizome/lib/vm_setup.rb
@@ -247,10 +247,6 @@ class VmSetup
 
       r "ip netns exec #{q_vm} bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethi#{q_vm}/proxy_arp'"
       r "ip netns exec #{q_vm} bash -c 'echo 1 > /proc/sys/net/ipv4/conf/#{tapname}/proxy_arp'"
-
-      r "ip -n #{q_vm} addr replace 192.168.0.1/16 dev #{tapname}"
-      r "ip -n #{q_vm} addr replace 10.0.0.1/8 dev #{tapname}"
-      r "ip -n #{q_vm} addr replace 172.16.0.1/12 dev #{tapname}"
     end
   end
 

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
     nx.instance_variable_set(:@nic, tunnel.src_nic)
   end
 
+  describe "#add_subnet_addr" do
+    it "adds the subnet net4 address to the nic" do
+      allow(tunnel.src_nic.vm).to receive_messages(ephemeral_net6: NetAddr.parse_net("2a01:4f8:10a:128b:4919::/80"), inhost_name: "hellovm")
+      expect(tunnel.src_nic).to receive(:ubid_to_tap_name).and_return("ncname")
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm addr replace 1.1.1.0/26 dev ncname")
+      expect(nx).to receive(:pop).with("add_subnet_addr is complete")
+      nx.add_subnet_addr
+    end
+  end
+
   describe "#setup_inbound" do
     before do
       allow(tunnel.src_nic).to receive(:dst_ipsec_tunnels).and_return([tunnel])


### PR DESCRIPTION
Prior to this commit, we were adding private ipv4 subnet classes A, B, C
all together to the namespace routing table for vethi* device. With this
commit, we reduce it to only include the private subnet net4 address.
The main reason to do that is to cause packet drops when private ip
addresses that are not part of the private subnet is targetted by VM.
The current behavior is causing destination address unreachable errors
when in fact the ip address is non existent, so the packet should simply
drop and we just see packet loss. This change, helps that.