### PR TITLE
Refactor tunnel creation and nic setup 

### DIFF
--- a/migrate/20230824_add_tunnel_nic_const.rb
+++ b/migrate/20230824_add_tunnel_nic_const.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:ipsec_tunnel) do
+      add_unique_constraint [:src_nic_id, :dst_nic_id]
+    end
+  end
+end

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -66,12 +66,4 @@ class PrivateSubnet < Sequel::Model
 
     addr
   end
-
-  def add_nic(nic)
-    nics.each do |n|
-      next if n.id == nic.id
-      IpsecTunnel.create_with_id(src_nic_id: n.id, dst_nic_id: nic.id)
-      IpsecTunnel.create_with_id(src_nic_id: nic.id, dst_nic_id: n.id)
-    end
-  end
 end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -53,7 +53,6 @@ class Prog::Vm::Nexus < Prog::Base
         raise("Given nic is not available in the given project") unless project.private_subnets.any? { |ps| ps.id == nic.private_subnet_id }
 
         subnet = nic.private_subnet
-        subnet.add_nic(nic)
       end
 
       unless nic
@@ -68,7 +67,6 @@ class Prog::Vm::Nexus < Prog::Base
         end
         nic_s = Prog::Vnet::NicNexus.assemble(subnet.id, name: "#{name}-nic")
         nic = Nic[nic_s.id]
-        subnet.add_nic(nic)
       end
 
       vm = Vm.create(public_key: public_key, unix_user: unix_user,

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -28,6 +28,7 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_vm
+    nap 60 unless nic.vm
     when_setup_nic_set? do
       hop_add_subnet_addr
     end
@@ -45,7 +46,7 @@ class Prog::Vnet::NicNexus < Prog::Base
       nic.private_subnet.incr_add_new_nic
       hop_wait_setup
     end
-    nap 1
+    donate
   end
 
   label def wait_setup
@@ -53,7 +54,7 @@ class Prog::Vnet::NicNexus < Prog::Base
       decr_setup_nic
       hop_start_rekey
     end
-    nap 1
+    nap 5
   end
 
   label def wait
@@ -79,6 +80,7 @@ class Prog::Vnet::NicNexus < Prog::Base
       decr_start_rekey
       hop_wait_rekey_outbound_trigger
     end
+
     donate
   end
 
@@ -87,7 +89,8 @@ class Prog::Vnet::NicNexus < Prog::Base
       bud Prog::Vnet::RekeyNicTunnel, {}, :setup_outbound
       hop_wait_rekey_outbound
     end
-    donate
+
+    nap 5
   end
 
   label def wait_rekey_outbound
@@ -96,6 +99,7 @@ class Prog::Vnet::NicNexus < Prog::Base
       decr_trigger_outbound_update
       hop_wait_rekey_old_state_drop_trigger
     end
+
     donate
   end
 
@@ -104,7 +108,8 @@ class Prog::Vnet::NicNexus < Prog::Base
       bud Prog::Vnet::RekeyNicTunnel, {}, :drop_old_state
       hop_wait_rekey_old_state_drop
     end
-    donate
+
+    nap 5
   end
 
   label def wait_rekey_old_state_drop
@@ -113,6 +118,7 @@ class Prog::Vnet::NicNexus < Prog::Base
       decr_old_state_drop_trigger
       hop_wait
     end
+
     donate
   end
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -25,18 +25,6 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     end
   end
 
-  def to_be_added_nics
-    private_subnet.nics.select { _1.strand.label == "wait_setup" }
-  end
-
-  def active_nics
-    private_subnet.nics.select { _1.strand.label == "wait" }
-  end
-
-  def rekeying_nics
-    private_subnet.nics.select { !_1.rekey_payload.nil? }
-  end
-
   label def wait
     when_destroy_set? do
       hop_destroy
@@ -71,15 +59,14 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     SecureRandom.random_number(100000) + 1
   end
 
-  def nics_to_rekey
-    active_nics + to_be_added_nics
-  end
-
   label def add_new_nic
-    nics_to_rekey.each do |nic|
+    nics_snap = nics_to_rekey
+    nics_snap.each do |nic|
       nic.update(encryption_key: gen_encryption_key, rekey_payload: {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid})
       nic.incr_start_rekey
+      create_tunnels(nics_snap, nic)
     end
+
     decr_add_new_nic
     hop_wait_inbound_setup
   end
@@ -100,7 +87,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       hop_wait_outbound_setup
     end
 
-    donate
+    nap 5
   end
 
   label def wait_outbound_setup
@@ -109,7 +96,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       hop_wait_old_state_drop
     end
 
-    donate
+    nap 5
   end
 
   label def wait_old_state_drop
@@ -121,7 +108,8 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
       hop_wait
     end
-    donate
+
+    nap 5
   end
 
   label def destroy
@@ -158,5 +146,29 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     return random_private_ipv4(location) unless PrivateSubnet.where(net4: selected_addr.to_s, location: location).first.nil?
 
     selected_addr
+  end
+
+  def create_tunnels(nics, src_nic)
+    nics.each do |dst_nic|
+      next if src_nic == dst_nic
+      IpsecTunnel.create_with_id(src_nic_id: src_nic.id, dst_nic_id: dst_nic.id) unless IpsecTunnel[src_nic_id: src_nic.id, dst_nic_id: dst_nic.id]
+      IpsecTunnel.create_with_id(src_nic_id: dst_nic.id, dst_nic_id: src_nic.id) unless IpsecTunnel[src_nic_id: dst_nic.id, dst_nic_id: src_nic.id]
+    end
+  end
+
+  def to_be_added_nics
+    private_subnet.nics.select { _1.strand.label == "wait_setup" }
+  end
+
+  def active_nics
+    private_subnet.nics.select { _1.strand.label == "wait" }
+  end
+
+  def nics_to_rekey
+    active_nics + to_be_added_nics
+  end
+
+  def rekeying_nics
+    private_subnet.nics.select { !_1.rekey_payload.nil? }
   end
 end

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -45,21 +45,6 @@ RSpec.describe PrivateSubnet do
     end
   end
 
-  describe "add nic" do
-    it "skips a nic if it exists" do
-      expect(private_subnet).to receive(:nics).and_return([nic])
-      expect(IpsecTunnel).not_to receive(:create)
-      private_subnet.add_nic(nic)
-    end
-
-    it "adds IpsecTunnel when a nic is added" do
-      expect(private_subnet).to receive(:nics).and_return([existing_nic])
-      expect(IpsecTunnel).to receive(:create).with(src_nic_id: existing_nic.id, dst_nic_id: nic.id)
-      expect(IpsecTunnel).to receive(:create).with(src_nic_id: nic.id, dst_nic_id: existing_nic.id)
-      private_subnet.add_nic(nic)
-    end
-  end
-
   describe "uuid to name" do
     it "returns the name" do
       expect(described_class.ubid_to_name("psetv2ff83xj6h3prt2jwavh0q")).to eq "psetv2ff"

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -65,13 +65,40 @@ RSpec.describe Prog::Vnet::NicNexus do
   end
 
   describe "#wait_vm" do
-    it "naps if nothing to do" do
+    let(:ps) {
+      PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
+        net4: "1.1.1.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+    }
+    let(:nic) {
+      Nic.new(private_subnet_id: ps.id,
+        private_ipv6: "fd10:9b0b:6b4b:8fbb:abc::",
+        private_ipv4: "10.0.0.1",
+        mac: "00:00:00:00:00:00",
+        encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579",
+        name: "default-nic").tap { _1.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
+    }
+
+    before do
+      allow(nx).to receive(:nic).and_return(nic)
+    end
+
+    it "naps 60 if nothing to do and vm doesn't exist" do
+      expect {
+        nx.wait_vm
+      }.to nap(60)
+    end
+
+    it "naps 1 if nothing to do and vm exists" do
+      vm = instance_double(Vm)
+      expect(nic).to receive(:vm).and_return(vm)
       expect {
         nx.wait_vm
       }.to nap(1)
     end
 
     it "starts setup and pings subnet" do
+      vm = instance_double(Vm)
+      expect(nic).to receive(:vm).and_return(vm)
       expect(nx).to receive(:when_setup_nic_set?).and_yield
       expect {
         nx.wait_vm
@@ -100,7 +127,7 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(nx).to receive(:leaf?).and_return(false)
       expect {
         nx.wait_add_subnet_addr
-      }.to nap(1)
+      }.to nap(0)
     end
 
     it "starts to wait_setup and pings subnet" do
@@ -120,7 +147,7 @@ RSpec.describe Prog::Vnet::NicNexus do
     it "naps if nothing to do" do
       expect {
         nx.wait_setup
-      }.to nap(1)
+      }.to nap(5)
     end
 
     it "starts rekeying if setup is triggered" do
@@ -171,8 +198,9 @@ RSpec.describe Prog::Vnet::NicNexus do
     it "reaps and donates if setup_inbound is continuing" do
       expect(nx).to receive(:leaf?).and_return(false)
       expect(nx).to receive(:reap).and_return(true)
-      expect(nx).to receive(:donate).and_return(true)
-      nx.wait_rekey_inbound
+      expect {
+        nx.wait_rekey_inbound
+      }.to nap(0)
     end
 
     it "reaps and hops to wait_rekey_outbound_trigger if setup_inbound is completed" do
@@ -186,8 +214,9 @@ RSpec.describe Prog::Vnet::NicNexus do
 
     it "if outbound setup is not triggered, just donate" do
       expect(nx).to receive(:when_trigger_outbound_update_set?).and_return(false)
-      expect(nx).to receive(:donate).and_return(true)
-      nx.wait_rekey_outbound_trigger
+      expect {
+        nx.wait_rekey_outbound_trigger
+      }.to nap(5)
     end
 
     it "if outbound setup is triggered, hops to setup_outbound" do
@@ -216,8 +245,10 @@ RSpec.describe Prog::Vnet::NicNexus do
 
     it "wait_rekey_old_state_drop_trigger donates if trigger is not set" do
       expect(nx).to receive(:when_old_state_drop_trigger_set?).and_return(false)
-      expect(nx).to receive(:donate).and_return(true)
-      nx.wait_rekey_old_state_drop_trigger
+
+      expect {
+        nx.wait_rekey_old_state_drop_trigger
+      }.to nap(5)
     end
 
     it "wait_rekey_old_state_drop_trigger hops to wait_rekey_old_state_drop if trigger is set" do


### PR DESCRIPTION
Here, we are fixing tunnel creation anomalies regarding pre created
Nics. The current production experience is not impacted by non of these
bugs. However, they might come up in development or in future when we
make Nics a separate customer managed product. Main issue is that, we
might create Nics without VMs. In that case, the whole rekeying logic
fails because we try to operate on these Nics as well. The reason is
that we create tunnels very early on. That's true even for Nics that
have no VM attached. This may cause double tunnelling, or different
variety of failures in rekeying for other Nics as well, which are at the
destination side of the tunnel. To fix this, we do bunch of changes;
1. Adding a new constraint to IpsecTunnel to not allow multiple tunnels
in between the same Nics.
2. Moving the tunnel creation to the point where Nic is added to the
subnet (SubnetNexus::add_new_nics).
3. Checking the tunnel existence before creating the new entity.