### PR TITLE
Run CI on ubicloud self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   PUSH_IMAGE: ${{ github.event_name == 'workflow_dispatch' }}
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud
 
     env:
       DB_USER: clover


### PR DESCRIPTION
I run install scripts manually to prepare self-hosted runners. https://github.com/actions/runner-images/blob/main/images/linux/ubuntu2204.pkr.hcl

There are one standard-4 machine at Germany, and one standard-4 machine at Finland.

I attached `ubicloud` and `ubicloud-standard-4` labels to them, so we can use both of them at `runs-on` property.

I added DNS records manually to runners to fix DNS resolving issue on docker containers. Ref: https://github.com/ubicloud/ubicloud/issues/507

Our runners:
<img width="1245" alt="Screenshot 2023-08-25 at 01 25 05" src="https://github.com/ubicloud/ubicloud/assets/993199/4a8683fa-1596-438f-bf4a-182501479a0c">
