### PR TITLE
Cap number of billable hours in month to 672

### DIFF
--- a/config/billing_rates.yml
+++ b/config/billing_rates.yml
@@ -1,4 +1,4 @@
-- { id: 139d9a67-8182-8578-a303-235cabd5161c, resource_type: VmCores,   resource_family: standard, location: hetzner-fsn1, unit_price: 0.000581250 }
-- { id: 08c502f7-df5d-8978-9896-feafa0ec5c40, resource_type: VmCores,   resource_family: standard, location: hetzner-hel1, unit_price: 0.000556250 }
-- { id: 118b7e2d-fa8d-8d78-910d-1f62fcc657ec, resource_type: IPAddress, resource_family: IPv4,     location: hetzner-fsn1, unit_price: 0.000069444 }
-- { id: 1bde2200-545a-8d78-960e-08a303111e3d, resource_type: IPAddress, resource_family: IPv4,     location: hetzner-hel1, unit_price: 0.000069444 }
+- { id: 139d9a67-8182-8578-a303-235cabd5161c, resource_type: VmCores,   resource_family: standard, location: hetzner-fsn1, unit_price: 0.000622768 }
+- { id: 08c502f7-df5d-8978-9896-feafa0ec5c40, resource_type: VmCores,   resource_family: standard, location: hetzner-hel1, unit_price: 0.000595982 }
+- { id: 118b7e2d-fa8d-8d78-910d-1f62fcc657ec, resource_type: IPAddress, resource_family: IPv4,     location: hetzner-fsn1, unit_price: 0.000074405 }
+- { id: 1bde2200-545a-8d78-960e-08a303111e3d, resource_type: IPAddress, resource_family: IPv4,     location: hetzner-hel1, unit_price: 0.000074405 }

--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -60,6 +60,10 @@ class InvoiceGenerator
       .all
 
     active_billing_records.map do |br|
+      # We cap the billable duration at 672 hours. In this way, we can
+      # charge the users same each month no matter the number of days
+      # in that month.
+      duration = [672 * 60, br.duration(@begin_time, @end_time).ceil].min
       {
         project_id: br.project_id,
         project_name: br.project.name,
@@ -69,7 +73,7 @@ class InvoiceGenerator
         resource_type: br.billing_rate["resource_type"],
         resource_family: br.billing_rate["resource_family"],
         amount: br.amount,
-        cost: (br.amount * br.duration(@begin_time, @end_time) * br.billing_rate["unit_price"])
+        cost: (br.amount * duration * br.billing_rate["unit_price"])
       }
     end
   end

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -39,12 +39,16 @@ class CloverWeb
         Authorization.authorize(@current_user.id, "Vm:create", @project.id)
         @subnets = Serializers::Web::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
 
-        # We use 1 month = 730 hours for conversion. Number of hours
-        # in a month changes between 672 and 744, averaging 730.1.
+        # We use 1 month = 672 hours for conversion. Number of hours
+        # in a month changes between 672 and 744, We are  also capping
+        # billable hours to 672 while generating invoices. This ensures
+        # that users won't see higher price in their invoice compared
+        # to price calculator and also we charge same amount no matter
+        # the number of days in a given month.
         @prices = BillingRate.rates.each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
           hash[br["location"]][br["resource_type"]][br["resource_family"]] = {
             hourly: br["unit_price"].to_f * 60,
-            monthly: br["unit_price"].to_f * 60 * 730
+            monthly: br["unit_price"].to_f * 60 * 672
           }
         end
         @has_valid_payment_method = @project.has_valid_payment_method?

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe InvoiceGenerator do
     expect(invoices.count).to eq(1)
 
     br = BillingRate.from_resource_properties("VmCores", vm.family, vm.location)
-    cost = (vm.cores * (duration / 60) * br["unit_price"])
+    cost = vm.cores * [672 * 60, (duration / 60)].min * br["unit_price"]
     expect(invoices.first).to eq({
       project_id: project.id,
       project_name: project.name,
@@ -43,7 +43,7 @@ RSpec.describe InvoiceGenerator do
   }
   let(:vm1) { Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", family: "standard", cores: 2, location: "hetzner-hel1", boot_image: "x") }
 
-  let(:day) { 60 * 60 * 24 }
+  let(:day) { 24 * 60 * 60 }
   let(:begin_time) { Time.parse("2023-06-01") }
   let(:end_time) { Time.parse("2023-07-01") }
 


### PR DESCRIPTION
We use 1 month = 672 hours for conversions. Number of hours in a month changes between 672 and 744, We are also capping number billable hours in month to 672 while generating invoices. This ensures that users won't see higher price in their invoice compared to price calculator and also we charge same amount no matter the number of days in a given month.