### PR TITLE
Improve BootstrapRhizome's idempotency

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -37,11 +37,12 @@ class Prog::BootstrapRhizome < Prog::Base
     rootish_ssh(<<SH)
 set -ueo pipefail
 sudo apt update && sudo apt-get -y install ruby-bundler
+sudo userdel -rf rhizome || true
 sudo adduser --disabled-password --gecos '' rhizome
 echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
 sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh
 sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authorized_keys
-echo #{sshable.keys.map(&:public_key).join("\n")} | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+echo #{sshable.keys.map(&:public_key).join("\n").shellescape} | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 SH
 
     push Prog::InstallRhizome

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -34,11 +34,12 @@ RSpec.describe Prog::BootstrapRhizome do
       expect(br).to receive(:rootish_ssh).with <<FIXTURE
 set -ueo pipefail
 sudo apt update && sudo apt-get -y install ruby-bundler
+sudo userdel -rf rhizome || true
 sudo adduser --disabled-password --gecos '' rhizome
 echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
 sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh
 sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authorized_keys
-echo test key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+echo test\\ key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 FIXTURE
 
       expect { br.setup }.to hop("start", "InstallRhizome")


### PR DESCRIPTION
It is possible that setup step of BootstrapRhizome fails and we want to retry it. A retry would have failed before because user "rhizome" and its home directory had been created before.

This PR improves that by deleting the user and its home directory.

Note that `userdel` will fail (even if with the `-rf` args) if the user doesn't exist, hence the `|| true` to ignore its failure.

This was all I had to do to make this retriable if the last `echo` statement failed. To make sure if this is enough changes to ensure idempotency, we need to look more.