### PR TITLE
Enable credits and discounts

### DIFF
--- a/migrate/20230830_add_credits_to_project.rb
+++ b/migrate/20230830_add_credits_to_project.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:project) do
+      add_column :credit, :numeric, null: false, default: 0
+      add_constraint(:min_credit_amount) { credit >= 0 }
+      add_column :discount, :Integer, null: false, default: 0
+      add_constraint(:max_discount_amount) { discount <= 100 }
+    end
+  end
+end


### PR DESCRIPTION
With this commit, we gain the ability of applying credits and discounts to projects. Currently both are implemented as columns in project table for simplicity. I considered putting each (or at least credits) to a separate table, which would make some future features easier to implement, such as;
- Applying multiple credits
- Applying credits with an expiration date
- Applying credits for particular SKU

However I prefered the simpler approach for now and moving to columns to tables is a quite simple migration (and moving to other direction is bit more complex).

One thing to note is that if both credits and discounts are defined for a project, we first apply discounts then credits, which favors the users as the final amount we charge would be less.