### PR TITLE
Donate while wait_add_subnet_addr has children

### DIFF
--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -45,7 +45,7 @@ class Prog::Vnet::NicNexus < Prog::Base
       nic.private_subnet.incr_add_new_nic
       hop_wait_setup
     end
-    nap 1
+    donate
   end
 
   label def wait_setup

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -95,12 +95,12 @@ RSpec.describe Prog::Vnet::NicNexus do
       allow(nx).to receive(:nic).and_return(nic)
     end
 
-    it "naps if nothing to do" do
+    it "donates if nothing to do" do
       expect(nx).to receive(:reap).and_return(true)
       expect(nx).to receive(:leaf?).and_return(false)
       expect {
         nx.wait_add_subnet_addr
-      }.to nap(1)
+      }.to nap(0)
     end
 
     it "starts to wait_setup and pings subnet" do


### PR DESCRIPTION
Previously running the NicNexus strand didn't progress its children. When adding CI, it's desirable to have everything rooted at a Strand and run the root. For that to work, we need each node to progress its subtree.