### PR TITLE
Decrement destroy semaphores

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -317,6 +317,8 @@ SQL
   label def destroy
     register_deadline(nil, 5 * 60)
 
+    decr_destroy
+
     vm.update(display_state: "deleting")
 
     unless host.nil?

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -121,6 +121,8 @@ class Prog::Vnet::NicNexus < Prog::Base
       fail "Cannot destroy nic with active vm, first clean up the attached resources"
     end
 
+    decr_destroy
+
     DB.transaction do
       nic.src_ipsec_tunnels_dataset.destroy
       nic.dst_ipsec_tunnels_dataset.destroy

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -129,6 +129,8 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       fail "Cannot destroy subnet with active nics, first clean up the attached resources"
     end
 
+    decr_destroy
+
     if private_subnet.nics.empty?
       DB.transaction do
         private_subnet.projects.each { |p| private_subnet.dissociate_with_project(p) }


### PR DESCRIPTION
Otherwise these semaphores will leak, and removing the parent Strand from database will fail. This is handy in the CI tool which cleans up strands after it finishes work.