### PR TITLE
Make Sshable unix_user configurable.

### DIFF
--- a/migrate/20230825_add_sshable_user.rb
+++ b/migrate/20230825_add_sshable_user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:sshable) do
+      add_column :unix_user, :text, collate: '"C"', null: false, default: "rhizome"
+    end
+  end
+end

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Sshable do
     described_class.new(
       id: described_class.generate_uuid,
       host: "test.localhost",
+      unix_user: "testuser",
       raw_private_key_1: key
     )
   }
@@ -58,7 +59,7 @@ RSpec.describe Sshable do
       sa.connect
       expect {
         sa.invalidate_cache_entry
-      }.to change { Thread.current[:clover_ssh_cache] }.from({"test.localhost" => sess}).to({})
+      }.to change { Thread.current[:clover_ssh_cache] }.from({["test.localhost", "testuser"] => sess}).to({})
     end
 
     it "can reset caches when has cached connection" do
@@ -67,7 +68,7 @@ RSpec.describe Sshable do
       sa.connect
       expect {
         described_class.reset_cache
-      }.to change { Thread.current[:clover_ssh_cache] }.from({"test.localhost" => sess}).to({})
+      }.to change { Thread.current[:clover_ssh_cache] }.from({["test.localhost", "testuser"] => sess}).to({})
     end
 
     it "can reset caches when has no cached connection" do


### PR DESCRIPTION
We use usernames different than "rhizome" for VMs and we create Sshables
for VMs in the CI tool. Previously Sshable assumed a fixed "rhizome"
username. This PR makes that configurable.

One restriction is that we can only specify one ssh user per host as it
has a unique constraint.