### PR TITLE
Add End-to-End CI which runs on a Hetzner Server.

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../loader"
+
+st = Prog::Test::HetznerServer.assemble
+
+loop do
+  ret = st.run 300
+  if ret.is_a?(Prog::Base::Nap)
+    sleep ret.seconds
+  elsif ret.is_a?(Prog::Base::Exit)
+    puts "Exited with: #{ret}"
+    exit 0
+  else
+    puts "Unexpected return value: #{ret}"
+    exit 1
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -76,6 +76,7 @@ module Config
   override :versioning, false, bool
   optional :hetzner_user, string, clear: true
   optional :hetzner_password, string, clear: true
+  override :ci_hetzner_sacrificial_server_id, string
   override :providers, "hetzner", array(string)
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
   override :managed_service, false, bool

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "net/ssh"
+
+module Util
+  # A minimal, non-cached SSH implementation.
+  #
+  # It must log into an account that can escalate to root via "sudo,"
+  # which typically includes the "root" account reflexively.  The
+  # ssh-agent is employed by default here, since personnel are thought
+  # to be involved with preparing new VmHosts.
+  def self.rootish_ssh(host, user, keys, cmd)
+    Net::SSH.start(host, user,
+      Sshable::COMMON_SSH_ARGS.merge(key_data: keys,
+        use_agent: Config.development?)) do |ssh|
+      ret = ssh.exec!(cmd)
+      fail "Ssh command failed: #{ret}" unless ret.exitstatus.zero?
+      ret
+    end
+  end
+end

--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -1,29 +1,12 @@
 # frozen_string_literal: true
 
-require "net/ssh"
+require_relative "../lib/util"
 
 class Prog::BootstrapRhizome < Prog::Base
   subject_is :sshable
 
   def user
     @user ||= frame.fetch("user", "root")
-  end
-
-  # A minimal, non-cached SSH implementation that is good enough to be
-  # make a given Sshable work with the `rhizome` user.
-  #
-  # It must log into an account that can escalate to root via "sudo,"
-  # which typically includes the "root" account reflexively.  The
-  # ssh-agent is employed by default here, since personnel are thought
-  # to be involved with preparing new VmHosts.
-  def rootish_ssh(cmd)
-    Net::SSH.start(sshable.host, user,
-      Sshable::COMMON_SSH_ARGS.merge(key_data: sshable.keys.map(&:private_key),
-        use_agent: Config.development?)) do |ssh|
-      ret = ssh.exec!(cmd)
-      fail "Could not bootstrap rhizome" unless ret.exitstatus.zero?
-      ret
-    end
   end
 
   label def start
@@ -34,7 +17,8 @@ class Prog::BootstrapRhizome < Prog::Base
   label def setup
     pop "rhizome user bootstrapped and source installed" if retval&.dig("msg") == "installed rhizome"
 
-    rootish_ssh(<<SH)
+    key_data = sshable.keys.map(&:private_key)
+    Util.rootish_ssh(sshable.host, user, key_data, <<SH)
 set -ueo pipefail
 sudo apt update && sudo apt-get -y install ruby-bundler
 sudo userdel -rf rhizome || true

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/util"
+
+class Prog::Test::HetznerServer < Prog::Base
+  def self.assemble
+    server_id = Config.ci_hetzner_sacrificial_server_id
+    if server_id.nil? || server_id.empty?
+      fail "CI_HLETZNER_SACRIFICIAL_SERVER_ID must be a nonempty string"
+    end
+    Strand.create_with_id(
+      prog: "Test::HetznerServer",
+      label: "start",
+      stack: [{server_id: server_id}]
+    )
+  end
+
+  label def start
+    hop_fetch_hostname
+  end
+
+  label def fetch_hostname
+    current_frame = strand.stack.first
+    current_frame["hostname"] = hetzner_api.get_main_ip4
+    strand.modified!(:stack)
+    strand.save_changes
+
+    hop_add_ssh_key
+  end
+
+  label def add_ssh_key
+    keypair = SshKey.generate
+
+    hetzner_api.add_key("ubicloud_ci_key_#{strand.ubid}", keypair.public_key)
+
+    current_frame = strand.stack.first
+    current_frame["hetzner_ssh_keypair"] = Base64.encode64(keypair.keypair)
+    strand.modified!(:stack)
+    strand.save_changes
+
+    hop_reset
+  end
+
+  label def reset
+    hetzner_api.reset(
+      frame["server_id"],
+      hetzner_ssh_key: hetzner_ssh_keypair.public_key
+    )
+
+    hop_wait_reset
+  end
+
+  label def wait_reset
+    begin
+      Util.rootish_ssh(frame["hostname"], "root", [hetzner_ssh_keypair.private_key], "echo 1")
+    rescue
+      nap 15
+    end
+
+    hop_setup_host
+  end
+
+  label def setup_host
+    st = Prog::Vm::HostNexus.assemble(
+      frame["hostname"],
+      provider: "hetzner",
+      hetzner_server_identifier: frame["server_id"]
+    )
+
+    current_frame = strand.stack.first
+    current_frame["vm_host_id"] = st.id
+    strand.modified!(:stack)
+    strand.save_changes
+
+    # BootstrapRhizome::start will override raw_private_key_1, so save the key in
+    # raw_private_key_2. This will allow BootstrapRhizome::setup to do a root
+    # ssh into the server.
+    Sshable[st.id].update(raw_private_key_2: hetzner_ssh_keypair.keypair)
+
+    strand.add_child(st)
+
+    hop_wait_setup_host
+  end
+
+  label def wait_setup_host
+    reap
+
+    hop_test_host if children_idle
+
+    donate
+  end
+
+  label def test_host
+    bud Prog::Test::VmGroup
+
+    hop_wait_test_host
+  end
+
+  label def wait_test_host
+    reap
+
+    hop_delete_key if children_idle
+
+    donate
+  end
+
+  def children_idle
+    active_children = strand.children_dataset.where(Sequel.~(label: "wait"))
+    active_semaphores = strand.children_dataset.join(:semaphore, strand_id: :id)
+
+    active_children.count == 0 and active_semaphores.count == 0
+  end
+
+  label def delete_key
+    hetzner_api.delete_key(hetzner_ssh_keypair.public_key)
+
+    hop_finish
+  end
+
+  label def finish
+    Strand[vm_host.id].destroy
+    vm_host.destroy
+    sshable.destroy
+
+    pop "HetznerServer tests finished!"
+  end
+
+  def hetzner_api
+    @hetzner_api ||= Hosting::HetznerApis.new(
+      HetznerHost.new(server_identifier: frame["server_id"])
+    )
+  end
+
+  def hetzner_ssh_keypair
+    @hetzner_ssh_keypair ||= SshKey.from_binary(Base64.decode64(frame["hetzner_ssh_keypair"]))
+  end
+
+  def vm_host
+    @vm_host ||= VmHost[frame["vm_host_id"]]
+  end
+
+  def sshable
+    @sshable ||= Sshable[frame["vm_host_id"]]
+  end
+end

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -6,7 +6,7 @@ class Prog::Test::HetznerServer < Prog::Base
   def self.assemble
     server_id = Config.ci_hetzner_sacrificial_server_id
     if server_id.nil? || server_id.empty?
-      fail "CI_HLETZNER_SACRIFICIAL_SERVER_ID must be a nonempty string"
+      fail "CI_HETZNER_SACRIFICIAL_SERVER_ID must be a nonempty string"
     end
     Strand.create_with_id(
       prog: "Test::HetznerServer",

--- a/spec/lib/util_spec.rb
+++ b/spec/lib/util_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rspec"
+require_relative "../../lib/util"
+
+RSpec.describe Util do
+  describe "#rootish_ssh" do
+    it "can execute a command" do
+      expected_options = Sshable::COMMON_SSH_ARGS.merge(key_data: ["key1", "key2"])
+      expect(Net::SSH).to receive(:start).with("hostname", "user", expected_options) do |&blk|
+        sess = instance_double(Net::SSH::Connection::Session)
+        expect(sess).to receive(:exec!).with("test command").and_return(
+          Net::SSH::Connection::Session::StringWithExitstatus.new("it worked", 0)
+        )
+        blk.call sess
+      end
+
+      described_class.rootish_ssh("hostname", "user", ["key1", "key2"], "test command")
+    end
+
+    it "fails if a command fails" do
+      expect(Net::SSH).to receive(:start) do |&blk|
+        sess = instance_double(Net::SSH::Connection::Session)
+        expect(sess).to receive(:exec!).with("failing command").and_return(
+          Net::SSH::Connection::Session::StringWithExitstatus.new("it didn't work", 1)
+        )
+        blk.call sess
+      end
+
+      expect { described_class.rootish_ssh("hostname", "user", [], "failing command") }.to raise_error RuntimeError, "Ssh command failed: it didn't work"
+    end
+  end
+end

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Test::HetznerServer do
+  subject(:hs_test) {
+    expect(Config).to receive(:ci_hetzner_sacrificial_server_id).and_return("1.1.1.1")
+    described_class.new(described_class.assemble)
+  }
+
+  let(:hetzner_api) {
+    instance_double(Hosting::HetznerApis)
+  }
+
+  let(:sshable) {
+    Sshable.create_with_id
+  }
+
+  before {
+    vm_host = VmHost.create(location: "l") { _1.id = sshable.id }
+    Strand.create(prog: "Prog", label: "label") { _1.id = sshable.id }
+    allow(hs_test).to receive_messages(frame: {"vm_host_id" => vm_host.id,
+                                               "hetzner_ssh_keypair" => "oOtAbOGFVHJjFyeQBgSfghi+YBuyQzBRsKABGZhOmDpmwxqx681mscsGBLaQ\n2iWQsOYBBVLDtQWe/gf3NRNyBw==\n",
+                                               "server_id" => "1234"}, hetzner_api: hetzner_api)
+  }
+
+  describe "#assemble" do
+    it "fails if CI_HETZNER_SACRIFICIAL_SERVER_ID not provided" do
+      expect(Config).to receive(:ci_hetzner_sacrificial_server_id).and_return("")
+      expect { described_class.assemble }.to raise_error RuntimeError, "CI_HETZNER_SACRIFICIAL_SERVER_ID must be a nonempty string"
+    end
+  end
+
+  describe "#start" do
+    it "hops to setup_vms" do
+      expect { hs_test.start }.to hop("fetch_hostname", "Test::HetznerServer")
+    end
+  end
+
+  describe "#fetch_hostname" do
+    it "can fetch hostname" do
+      expect(hetzner_api).to receive(:get_main_ip4)
+      expect { hs_test.fetch_hostname }.to hop("add_ssh_key", "Test::HetznerServer")
+    end
+  end
+
+  describe "#add_ssh_key" do
+    it "can add ssh key" do
+      expect(hetzner_api).to receive(:add_key)
+      expect { hs_test.add_ssh_key }.to hop("reset", "Test::HetznerServer")
+    end
+  end
+
+  describe "#reset" do
+    it "can reset" do
+      expect(hetzner_api).to receive(:reset).with("1234", hetzner_ssh_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbDGrHrzWaxywYEtpDaJZCw5gEFUsO1BZ7+B/c1E3IH")
+      expect { hs_test.reset }.to hop("wait_reset", "Test::HetznerServer")
+    end
+  end
+
+  describe "#wait_reset" do
+    it "hops to setup_host if children idle" do
+      expect(Util).to receive(:rootish_ssh)
+      expect { hs_test.wait_reset }.to hop("setup_host", "Test::HetznerServer")
+    end
+
+    it "donates if children not idle" do
+      expect(Util).to receive(:rootish_ssh).and_raise RuntimeError, "ssh failed"
+      expect { hs_test.wait_reset }.to nap(15)
+    end
+  end
+
+  describe "#setup_host" do
+    it "hops to wait_setup_host" do
+      allow(Prog::Vm::HostNexus).to receive(:assemble).and_return(Strand[sshable.id])
+      expect { hs_test.setup_host }.to hop("wait_setup_host", "Test::HetznerServer")
+    end
+  end
+
+  describe "#wait_setup_host" do
+    it "hops to test_host if children idle" do
+      expect(hs_test).to receive(:children_idle).and_return(true)
+      expect { hs_test.wait_setup_host }.to hop("test_host", "Test::HetznerServer")
+    end
+
+    it "donates if children not idle" do
+      expect(hs_test).to receive(:children_idle).and_return(false)
+      expect { hs_test.wait_setup_host }.to nap(0)
+    end
+  end
+
+  describe "#test_host" do
+    it "hops to wait_test_host" do
+      expect { hs_test.test_host }.to hop("wait_test_host", "Test::HetznerServer")
+    end
+  end
+
+  describe "#wait_test_host" do
+    it "hops to delete_key if children idle" do
+      expect(hs_test).to receive(:children_idle).and_return(true)
+      expect { hs_test.wait_test_host }.to hop("delete_key", "Test::HetznerServer")
+    end
+
+    it "donates if children not idle" do
+      expect(hs_test).to receive(:children_idle).and_return(false)
+      expect { hs_test.wait_test_host }.to nap(0)
+    end
+  end
+
+  describe "#delete_key" do
+    it "deletes key" do
+      expect(hetzner_api).to receive(:delete_key).with("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbDGrHrzWaxywYEtpDaJZCw5gEFUsO1BZ7+B/c1E3IH")
+      expect { hs_test.delete_key }.to hop("finish", "Test::HetznerServer")
+    end
+  end
+
+  describe "#finish" do
+    it "exits" do
+      expect { hs_test.finish }.to exit({"msg" => "HetznerServer tests finished!"})
+    end
+  end
+
+  describe "#children_idle" do
+    it "returns true if no children" do
+      st = Strand.create_with_id(prog: "Prog", label: "label")
+      allow(hs_test).to receive(:strand).and_return(st)
+      expect(hs_test.children_idle).to be(true)
+    end
+  end
+
+  describe "#hetzner_api" do
+    it "can create a HetznerApis instance" do
+      allow(hs_test).to receive(:hetzner_api).and_call_original
+      expect(hs_test.hetzner_api).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Adds a test program which resets a Hetzner server & then runs the Prog::Test::VmGroup tests on it.

To use this, you need to setup following env variables: `HETZNER_USER`, `HETZNER_PASSWORD`, and `CI_HETZNER_SACRIFICIAL_SERVER_ID`.

And then use the `bin/ci` utility program which creates an instance of `Prog::Test::HetznerServer` and runs it until finish or error.