### PR TITLE
Generate invoice numbers

### DIFF
--- a/migrate/20230829_restrict_project_id.rb
+++ b/migrate/20230829_restrict_project_id.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  change do
+    alter_table(:project) do
+      add_index Sequel.lit("right(id::text, 10)"), unique: true, concurrently: true
+    end
+
+    alter_table(:invoice) do
+      add_column :invoice_number, :text, collate: '"C"', null: false
+    end
+  end
+end

--- a/model/project.rb
+++ b/model/project.rb
@@ -10,6 +10,8 @@ class Project < Sequel::Model
   many_to_many :vms, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :private_subnets, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
 
+  one_to_many :invoices
+
   dataset_module Authorization::Dataset
 
   plugin :association_dependencies, access_tags: :destroy, access_policies: :destroy, billing_info: :destroy

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe InvoiceGenerator do
 
     described_class.new(begin_time, end_time, true).run
     expect(Invoice.count).to eq(1)
+
+    expect(Invoice.first.invoice_number).to eq("#{begin_time.strftime("%y%m")}-#{p1.id[-10..]}-0001")
   end
 end
 


### PR DESCRIPTION
After checking many sources, it seems there is (almost) no hard rule regarding invoice numbers. Some countries prefers global sequentially increasing number, which is fine but leaks number of invoices. Some countries prefer per customer sequentially increasing number, prefixed by customer identifier. The primary requirement is that having sequentially increasing number with no gaps in between.

Also, many companies prefer to add prefixes/suffixes that are meaningful to them. One good convention is adding date to the invoice so it is easier to identify invoice date just from the invoice number.

When all things considered, we opted to use the following format; YYMM-CCCCCCCC-DDDD

YY: Last 2 digits of the year
MM: Month number, 0-padded
CCCCCCCC: 10 character customer identifier; same as last 10 characters of the project's UBID. We chose last 10 characters rather than first because it is easier to extend that to 12 characters if we need without hitting "-"
DDDD: Sequentially increasing number for this particular project, 0-padded

Using last 10 characters of the project in invoice number requires that 10 characters to be unique. We ensure that by creating a unique constraint on the last 10 characters of the project id. 16^10 = 1099511627776, which is 1 trillion projects.