### PR TITLE
Set first location as default in VM creation page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -185,11 +185,6 @@ function setupLocationBasedPrices() {
         $(this).prop('checked', false);
       }
     }
-    if (count[name]) {
-      $("#" + name + "-description").hide();
-    } else {
-      $("#" + name + "-description").show();
-    }
   });
 }
 

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -58,15 +58,17 @@
                 ) %>
               </div>
               <div class="col-span-full">
+                <% locations = Option
+                    .locations_for_provider(@project_data.dig(:provider, :name))
+                    .map { |l| [l.name, l.display_name, @prices[l.name].to_json] }
+                %>
                 <%== render(
                   "components/form/radio_small_cards",
                   locals: {
                     name: "location",
                     label: "Location",
-                    options:
-                      Option
-                        .locations_for_provider(@project_data.dig(:provider, :name))
-                        .map { |l| [l.name, l.display_name, @prices[l.name].to_json] },
+                    options: locations,
+                    selected: locations.first[0],
                     attributes: {
                       required: true
                     }
@@ -146,8 +148,6 @@
                       <% end %>
                     </div>
                   </fieldset>
-                  <p id="size-description" class="text-sm text-gray-500 leading-6">
-                    Select location to see available server sizes</p>
                 </div>
               </div>
               <div class="col-span-full">


### PR DESCRIPTION
We don't display prices or size info before selecting location, which is confusing for users as they expect to see price info and might be hesitant to play with form.