### PR TITLE
Remove last use of .first in invoice generation

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -21,10 +21,10 @@ class InvoiceGenerator
 
         project_content[:resources] = []
         project_content[:subtotal] = 0
-        project_records.group_by { |pr| pr[:resource_id] }.each do |resource_id, line_items|
+        project_records.group_by { |pr| [pr[:resource_id], pr[:resource_name]] }.each do |(resource_id, resource_name), line_items|
           resource_content = {}
           resource_content[:resource_id] = resource_id
-          resource_content[:resource_name] = line_items.first[:resource_name]
+          resource_content[:resource_name] = resource_name
 
           resource_content[:line_items] = []
           resource_content[:cost] = 0


### PR DESCRIPTION
We want to group project resources and resource line items together and then iterate over each array for cost calculation. Some fields in those arrays are same since they are grouped together. We used to use .first when we need to access those fields since any of them would work, however using .first is confusing in this context as it implies .first element is special in some way. With this commit, we eliminate the need of using .first. Instead we assign the values we would need at the group_by phase.