### PR TITLE
Add additional data invoice to use at UI

### DIFF
--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -16,4 +16,15 @@ class BillingRate
   def self.from_id(billing_rate_id)
     rates.find { _1["id"] == billing_rate_id }
   end
+
+  def self.line_item_description(resource_type, resource_family, amount)
+    case resource_type
+    when "VmCores"
+      "#{resource_family}-#{(amount * 2).to_i} Virtual Machine"
+    when "IPAddress"
+      "#{resource_family} Address"
+    else
+      fail "BUG: Unknown resource type for line item description"
+    end
+  end
 end

--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "time"
+require "stripe"
 
 class InvoiceGenerator
   def initialize(begin_time, end_time, save_result = false)
@@ -18,6 +19,7 @@ class InvoiceGenerator
 
         project_content[:project_id] = project.id
         project_content[:project_name] = project.name
+        project_content[:billing_info] = Serializers::Web::BillingInfo.serialize(project.billing_info)
 
         project_content[:resources] = []
         project_content[:subtotal] = 0
@@ -33,8 +35,10 @@ class InvoiceGenerator
             line_item_content[:location] = li[:location]
             line_item_content[:resource_type] = li[:resource_type]
             line_item_content[:resource_family] = li[:resource_family]
-            line_item_content[:amount] = li[:amount]
-            line_item_content[:cost] = li[:cost]
+            line_item_content[:description] = BillingRate.line_item_description(li[:resource_type], li[:resource_family], li[:amount])
+            line_item_content[:amount] = li[:amount].to_f
+            line_item_content[:duration] = li[:duration]
+            line_item_content[:cost] = li[:cost].to_f
 
             resource_content[:line_items].push(line_item_content)
             resource_content[:cost] += line_item_content[:cost]
@@ -47,14 +51,16 @@ class InvoiceGenerator
         # We first apply discounts then credits, this is more beneficial for users as it
         # would be possible to cover total cost with fewer credits.
         project_content[:cost] = project_content[:subtotal]
+        project_content[:discount] = 0
         if project.discount > 0
-          project_content[:cost] *= (100.0 - project.discount) / 100.0
+          project_content[:discount] = project_content[:cost] * (project.discount / 100.0)
+          project_content[:cost] -= project_content[:discount]
         end
 
-        credit_used = 0
+        project_content[:credit] = 0
         if project.credit > 0
-          credit_used = [project_content[:cost], project.credit].min
-          project_content[:cost] -= credit_used
+          project_content[:credit] = [project_content[:cost], project.credit].min
+          project_content[:cost] -= project_content[:credit]
         end
 
         invoices.push(project_content)
@@ -64,21 +70,21 @@ class InvoiceGenerator
           invoice_order = format("%04d", project.invoices.count + 1)
           invoice_number = "#{invoice_month}-#{invoice_customer}-#{invoice_order}"
 
-          Invoice.create_with_id(project_id: project.id, invoice_number: invoice_number, content: project_content)
+          Invoice.create_with_id(project_id: project.id, invoice_number: invoice_number, content: project_content, begin_time: @begin_time, end_time: @end_time)
 
-          if credit_used > 0
+          if project_content[:credit] > 0
             # We don't use project.credit here, because credit might get updated between
             # the time we read and write. Referencing credit column here prevents such
             # race conditions. If credit got increased, then there is no problem. If it
             # got decreased, CHECK constraint in the DB will prevent credit balance to go
             # negative.
             # We also need to disable Sequel validations, because Sequel simplychecks if
-            # the new value is BigDecimal, but "Sequel[:credit] - credit_used" expression
+            # the new value is BigDecimal, but "Sequel[:credit] - project_content[:credit]" expression
             # is Sequel::SQL::NumericExpression, not BigDecimal. Eventhough it resolves to
             # BigDecimal, it fails the check.
             # Finally, we use save_changes instead of update because it is not possible to
             # pass validate: false to update.
-            project.credit = Sequel[:credit] - credit_used
+            project.credit = Sequel[:credit] - project_content[:credit]
             project.save_changes(validate: false)
           end
         end
@@ -89,7 +95,7 @@ class InvoiceGenerator
   end
 
   def active_billing_records
-    active_billing_records = BillingRecord.eager(project: :invoices)
+    active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices])
       .where { |br| Sequel.pg_range(br.span).overlaps(Sequel.pg_range(@begin_time...@end_time)) }
       .all
 
@@ -106,7 +112,8 @@ class InvoiceGenerator
         resource_type: br.billing_rate["resource_type"],
         resource_family: br.billing_rate["resource_family"],
         amount: br.amount,
-        cost: (br.amount * duration * br.billing_rate["unit_price"])
+        cost: (br.amount * duration * br.billing_rate["unit_price"]),
+        duration: duration
       }
     end
   end

--- a/migrate/20230831_add_dates_to_invoice.rb
+++ b/migrate/20230831_add_dates_to_invoice.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:invoice) do
+      add_column :begin_time, :timestamptz, null: false
+      add_column :end_time, :timestamptz, null: false
+      add_column :status, String, collate: '"C"', null: false, default: "unpaid"
+    end
+  end
+end

--- a/serializers/base.rb
+++ b/serializers/base.rb
@@ -39,6 +39,7 @@ module Serializers
     end
 
     def serialize(object)
+      return if object.nil?
       if object.respond_to?(:map) && !object.is_a?(Hash)
         object.map { |item| serializer.call(item) }
       else

--- a/spec/lib/billing_rate_spec.rb
+++ b/spec/lib/billing_rate_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe BillingRate do
+  describe ".line_item_description" do
+    it "returns for VmCores" do
+      expect(described_class.line_item_description("VmCores", "standard", 4)).to eq("standard-8 Virtual Machine")
+    end
+
+    it "returns for IPAddress" do
+      expect(described_class.line_item_description("IPAddress", "IPv4", 1)).to eq("IPv4 Address")
+    end
+
+    it "raises exception for unknown type" do
+      expect { described_class.line_item_description("NewType", "NewFamily", 1) }.to raise_error("BUG: Unknown resource type for line item description")
+    end
+
+    it "each resource type has a description" do
+      described_class.rates.each do |rate|
+        expect(described_class.line_item_description(rate["resource_type"], rate["resource_family"], 1)).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
While I was working on invoice UI, I needed extra data. I don't want to mix data PR and UI PR. I'm adding data fields first.

- Duplicate billing info at time of invoice generation
- Add user friendly description to line items to show at invoice
- Add duration to line item to show how much used
- Convert amount and cost to float because numeric showed as scientific notation
- Add begin and end time to invoice for records
- Add status to invoice to determine active invoices
- Persist credit and discount amount to show on invoice