### PR TITLE
Test unencrypted storage in CI

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -85,18 +85,32 @@ class Prog::Test::HetznerServer < Prog::Base
   label def wait_setup_host
     reap
 
-    hop_test_host if children_idle
+    hop_test_host_encrypted if children_idle
 
     donate
   end
 
-  label def test_host
-    bud Prog::Test::VmGroup
+  label def test_host_encrypted
+    strand.add_child(Prog::Test::VmGroup.assemble(storage_encrypted: true))
 
-    hop_wait_test_host
+    hop_wait_test_host_encrypted
   end
 
-  label def wait_test_host
+  label def wait_test_host_encrypted
+    reap
+
+    hop_test_host_unencrypted if children_idle
+
+    donate
+  end
+
+  label def test_host_unencrypted
+    strand.add_child(Prog::Test::VmGroup.assemble(storage_encrypted: false))
+
+    hop_wait_test_host_unencrypted
+  end
+
+  label def wait_test_host_unencrypted
     reap
 
     hop_delete_key if children_idle

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -3,8 +3,12 @@
 require "net/ssh"
 
 class Prog::Test::VmGroup < Prog::Base
-  def self.assemble
-    Strand.create_with_id(prog: "Test::VmGroup", label: "start", stack: [{}])
+  def self.assemble(storage_encrypted: true)
+    Strand.create_with_id(
+      prog: "Test::VmGroup",
+      label: "start",
+      stack: [{"storage_encrypted" => storage_encrypted}]
+    )
   end
 
   label def start
@@ -33,18 +37,21 @@ class Prog::Test::VmGroup < Prog::Base
     vm1_s = Prog::Vm::Nexus.assemble(
       keypair_1.public_key, project.id,
       private_subnet_id: subnet1_s.id,
+      storage_encrypted: frame["storage_encrypted"],
       enable_ip4: true
     )
 
     vm2_s = Prog::Vm::Nexus.assemble(
       keypair_2.public_key, project.id,
       private_subnet_id: subnet1_s.id,
+      storage_encrypted: frame["storage_encrypted"],
       enable_ip4: true
     )
 
     vm3_s = Prog::Vm::Nexus.assemble(
       keypair_3.public_key, project.id,
       private_subnet_id: subnet2_s.id,
+      storage_encrypted: frame["storage_encrypted"],
       enable_ip4: true
     )
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe Prog::Test::HetznerServer do
   end
 
   describe "#wait_setup_host" do
-    it "hops to test_host if children idle" do
+    it "hops to test_host_encrypted if children idle" do
       expect(hs_test).to receive(:children_idle).and_return(true)
-      expect { hs_test.wait_setup_host }.to hop("test_host", "Test::HetznerServer")
+      expect { hs_test.wait_setup_host }.to hop("test_host_encrypted", "Test::HetznerServer")
     end
 
     it "donates if children not idle" do
@@ -89,21 +89,39 @@ RSpec.describe Prog::Test::HetznerServer do
     end
   end
 
-  describe "#test_host" do
-    it "hops to wait_test_host" do
-      expect { hs_test.test_host }.to hop("wait_test_host", "Test::HetznerServer")
+  describe "#test_host_encrypted" do
+    it "hops to wait_test_host_encrypted" do
+      expect { hs_test.test_host_encrypted }.to hop("wait_test_host_encrypted", "Test::HetznerServer")
     end
   end
 
-  describe "#wait_test_host" do
-    it "hops to delete_key if children idle" do
+  describe "#wait_test_host_encrypted" do
+    it "hops to test_host_unencrypted if children idle" do
       expect(hs_test).to receive(:children_idle).and_return(true)
-      expect { hs_test.wait_test_host }.to hop("delete_key", "Test::HetznerServer")
+      expect { hs_test.wait_test_host_encrypted }.to hop("test_host_unencrypted", "Test::HetznerServer")
     end
 
     it "donates if children not idle" do
       expect(hs_test).to receive(:children_idle).and_return(false)
-      expect { hs_test.wait_test_host }.to nap(0)
+      expect { hs_test.wait_test_host_encrypted }.to nap(0)
+    end
+  end
+
+  describe "#test_host_unencrypted" do
+    it "hops to wait_test_host_unencrypted" do
+      expect { hs_test.test_host_unencrypted }.to hop("wait_test_host_unencrypted", "Test::HetznerServer")
+    end
+  end
+
+  describe "#wait_test_host_unencrypted" do
+    it "hops to delete_key if children idle" do
+      expect(hs_test).to receive(:children_idle).and_return(true)
+      expect { hs_test.wait_test_host_unencrypted }.to hop("delete_key", "Test::HetznerServer")
+    end
+
+    it "donates if children not idle" do
+      expect(hs_test).to receive(:children_idle).and_return(false)
+      expect { hs_test.wait_test_host_unencrypted }.to nap(0)
     end
   end
 


### PR DESCRIPTION
We previously tested only VMs with encrypted storage in CI. Code paths for how we provision encrypted and unencrypted storage will diverge for performance reasons, so it is worthwhile to also test the unencrypted case independently.