### PR TITLE
Add invoices to UI

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,6 +3,7 @@ $(function() {
   setupLocationBasedPrices();
   setupLocationBasedOptions();
   setupAutoRefresh();
+  setupPrint();
 });
 
 $(".toggle-mobile-menu").on("click", function (event) {
@@ -202,5 +203,11 @@ function setupAutoRefresh() {
     setTimeout(function() {
       location.reload();
     }, interval * 1000);
+  });
+}
+
+function setupPrint() {
+  $("div.print-page").each(function() {
+    window.print();
   });
 }

--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -20,6 +20,13 @@ class InvoiceGenerator
         project_content[:project_id] = project.id
         project_content[:project_name] = project.name
         project_content[:billing_info] = Serializers::Web::BillingInfo.serialize(project.billing_info)
+        project_content[:issuer_info] = {
+          address: "310 Santa Ana Avenue",
+          country: "US",
+          city: "San Francisco",
+          state: "CA",
+          postal_code: "94127"
+        }
 
         project_content[:resources] = []
         project_content[:subtotal] = 0

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -4,4 +4,12 @@ require_relative "../model"
 
 class Invoice < Sequel::Model
   include ResourceMethods
+
+  def path
+    "/invoice/#{ubid}"
+  end
+
+  def name
+    begin_time.strftime("%B %Y")
+  end
 end

--- a/serializers/web/billing_info.rb
+++ b/serializers/web/billing_info.rb
@@ -6,7 +6,8 @@ class Serializers::Web::BillingInfo < Serializers::Base
   def self.base(bi)
     {
       id: bi.id,
-      ubid: bi.ubid,
+      ubid: bi.ubid
+    }.merge(bi.stripe_data ? {
       name: bi.stripe_data["name"],
       email: bi.stripe_data["email"],
       address: [bi.stripe_data["address"]["line1"], bi.stripe_data["address"]["line2"]].compact.join(" "),
@@ -14,7 +15,7 @@ class Serializers::Web::BillingInfo < Serializers::Base
       city: bi.stripe_data["address"]["city"],
       state: bi.stripe_data["address"]["state"],
       postal_code: bi.stripe_data["address"]["postal_code"]
-    }
+    } : {})
   end
 
   structure(:default) do |bi|

--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Serializers::Web::Invoice < Serializers::Base
+  def self.base(inv)
+    {
+      ubid: inv.ubid,
+      path: inv.path,
+      name: inv.name,
+      date: inv.created_at.strftime("%B %d, %Y"),
+      subtotal: "$%0.02f" % inv.content["subtotal"],
+      credit: "$%0.02f" % inv.content["credit"],
+      discount: "$%0.02f" % inv.content["discount"],
+      total: "$%0.02f" % inv.content["cost"],
+      status: inv.status,
+      invoice_number: inv.invoice_number,
+      billing_name: inv.content.dig("billing_info", "name"),
+      billing_address: inv.content.dig("billing_info", "address"),
+      billing_country: ISO3166::Country.new(inv.content.dig("billing_info", "country"))&.common_name,
+      billing_city: inv.content.dig("billing_info", "city"),
+      billing_state: inv.content.dig("billing_info", "state"),
+      billing_postal_code: inv.content.dig("billing_info", "postal_code"),
+      issuer_address: inv.content.dig("issuer_info", "address"),
+      issuer_country: ISO3166::Country.new(inv.content.dig("issuer_info", "country")).common_name,
+      issuer_city: inv.content.dig("issuer_info", "city"),
+      issuer_state: inv.content.dig("issuer_info", "state"),
+      issuer_postal_code: inv.content.dig("issuer_info", "postal_code"),
+      items: inv.content["resources"].flat_map do |resource|
+        resource["line_items"].map do |line_item|
+          {
+            name: resource["resource_name"],
+            description: line_item["description"],
+            duration: line_item["duration"].to_i,
+            cost: (line_item["cost"] < 0.001) ? "less than $0.001" : "$%0.03f" % line_item["cost"]
+          }
+        end
+      end.sort_by { _1[:description] }
+    }
+  end
+
+  structure(:default) do |inv|
+    base(inv)
+  end
+end

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe InvoiceGenerator do
       project_id: project.id,
       project_name: project.name,
       billing_info: Serializers::Web::BillingInfo.serialize(project.billing_info),
+      issuer_info: {
+        address: "310 Santa Ana Avenue",
+        country: "US",
+        city: "San Francisco",
+        state: "CA",
+        postal_code: "94127"
+      },
       resources: [{
         resource_id: vm.id,
         resource_name: vm.name,

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -21,7 +21,9 @@
   </head>
 
   <body class="h-full">
-    <% if rodauth.authenticated? %>
+    <% if @full_page %>
+      <%== yield %>
+    <% elsif rodauth.authenticated? %>
       <div>
         <%== render("layouts/sidebar/desktop") %>
         <%== render("layouts/sidebar/mobile") %>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -180,6 +180,51 @@
         </table>
       </div>
     </div>
+    <!-- Invoices -->
+    <div>
+      <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
+        <div class="min-w-0 flex-1">
+          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+            Invoices
+          </h3>
+        </div>
+      </div>
+      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+        <table class="min-w-full divide-y divide-gray-300">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Invoice</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Amount</th>
+              <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold text-gray-900">Status</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% if @invoices.count > 0 %>
+              <% @invoices.each do |inv| %>
+                <tr id="invoice-<%= inv[:ubid]%>">
+                  <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                    <a href="<%= @project_data[:path] + "/billing" + inv[:path] %>" class="text-orange-600 hover:text-orange-700">
+                      <%= inv[:name] %>
+                    </a>
+                    <span class="text-xs text-gray-400 italic">#<%= inv[:invoice_number] %></span>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <%= inv[:total] %>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <%= inv[:status] %>
+                  </td>
+                </tr>
+              <% end %>
+            <% else %>
+              <tr>
+                <td colspan="3"><div class="text-center text-xl p-4">No invoices. Invoice for current month will be created at the first day of next month.</div></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 <% else %>
   <form action="<%= "#{@project_data[:path]}/billing" %>" method="POST">

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -1,0 +1,128 @@
+<% @page_title = "#{@invoice_data[:name]} - Invoice" %>
+
+<% if @full_page %>
+  <div class="print-page"></div>
+<% else %>
+  <div class="space-y-1">
+    <%== render(
+      "components/breadcrumb",
+      locals: {
+        back: "#{@project_data[:path]}/billing",
+        parts: [
+          %w[Projects /project],
+          [@project_data[:name], @project_data[:path]],
+          ["Billing", "#{@project_data[:path]}/billing"],
+          ["#{@invoice_data[:name]} Invoice", "#"]
+        ]
+      }
+    ) %>
+    <%== render(
+      "components/page_header",
+      locals: {
+        title: "#{@invoice_data[:name]} Invoice",
+        right_items: [
+          "<a href='#{@project_data[:path]}/billing#{@invoice_data[:path]}?print=1' target='_blank' class='inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600'>PDF</a>"
+        ]
+      }
+    ) %>
+  </div>
+<% end %>
+<div class="grid gap-6">
+  <!-- Invoice Card -->
+  <div
+    class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 print:max-w-full print:w-full print:shadow-none print:ring-0"
+  >
+    <div class="px-4 py-5 sm:p-6">
+      <div class="flex justify-between">
+        <div>
+          <img class="h-10 w-auto" src="/logo-orange.png" alt="Ubicloud">
+          <address class="mt-4 not-italic text-gray-800">
+            <%= @invoice_data[:issuer_address] %>,<br>
+            <%= @invoice_data[:issuer_city] %>,
+            <%= @invoice_data[:issuer_state] %>
+            <%= @invoice_data[:issuer_postal_code] %>,<br>
+            <%= @invoice_data[:issuer_country] %><br>
+          </address>
+        </div>
+        <div class="text-right">
+          <h2 class="text-3xl font-semibold text-gray-800">
+            Invoice for <%= @invoice_data[:name] %>
+          </h2>
+          <span class="mt-1 block text-gray-500">#<%= @invoice_data[:invoice_number] %></span>
+        </div>
+      </div>
+      <div class="mt-8 grid grid-cols-2 gap-3">
+        <div>
+          <h3 class="text-lg font-semibold text-gray-800">Bill to:</h3>
+          <h3 class="text-lg font-semibold text-gray-800"><%= @invoice_data[:billing_name] %></h3>
+          <address class="mt-2 not-italic text-gray-500">
+            <%= @invoice_data[:billing_address] %>,<br>
+            <%= @invoice_data[:billing_city] %>,
+            <%= @invoice_data[:billing_state] %>
+            <%= @invoice_data[:billing_postal_code] %>,<br>
+            <%= @invoice_data[:billing_country] %><br>
+          </address>
+        </div>
+
+        <div class="text-right space-y-2">
+          <div class="grid grid-cols-1 gap-2">
+            <dl class="grid grid-cols-5 gap-x-3">
+              <dt class="col-span-3 font-semibold text-gray-800">Invoice date:</dt>
+              <dd class="col-span-2 text-gray-500"><%= @invoice_data[:date] %></dd>
+            </dl>
+            <dl class="grid grid-cols-5 gap-x-3">
+              <dt class="col-span-3 font-semibold text-gray-800">Due date:</dt>
+              <dd class="col-span-2 text-gray-500"><%= @invoice_data[:date] %></dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div class="mt-6">
+        <table class="min-w-full divide-y divide-gray-300 border border-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="py-3 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">RESOURCE</th>
+              <th scope="col" class="px-3 py-3 text-left text-sm font-semibold text-gray-900">DESCRIPTION</th>
+              <th scope="col" class="px-3 py-3 text-left text-sm font-semibold text-gray-900">USAGE</th>
+              <th scope="col" class="py-3 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6">AMOUNT</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% @invoice_data[:items].each do |item| %>
+              <tr>
+                <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= item[:name] %></td>
+                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= item[:description] %></td>
+                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= item[:duration] %> minutes</td>
+                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-right text-sm text-gray-500 sm:pr-6"><%= item[:cost] %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+
+        <div class="mt-8 flex justify-end">
+            <div class="grid gap-2 text-right">
+              <dl class="grid grid-cols-2 gap-x-3">
+                <dt class="text-right font-semibold text-gray-800">Subtotal:</dt>
+                <dd class="text-gray-500"><%= @invoice_data[:subtotal] %></dd>
+              </dl>
+              <% if @invoice_data[:discount] != "$0.00" %>
+                <dl class="grid grid-cols-2 gap-x-3">
+                  <dt class="text-right font-semibold text-gray-800">Discount:</dt>
+                  <dd class="text-gray-500">-<%= @invoice_data[:discount] %></dd>
+                </dl>
+              <% end %>
+              <% if @invoice_data[:credit] != "$0.00" %>
+                <dl class="grid grid-cols-2 gap-x-3">
+                  <dt class="text-right font-semibold text-gray-800">Credit:</dt>
+                  <dd class="text-gray-500">-<%= @invoice_data[:credit] %></dd>
+                </dl>
+              <% end %>
+              <dl class="grid grid-cols-2 gap-x-3 text-2xl">
+                <dt class="text-right font-semibold text-gray-800">Total:</dt>
+                <dd class="text-gray-500"><%= @invoice_data[:total] %></dd>
+              </dl>
+            </div>
+        </div>
+      </div>
+    </div>
+  </div>


### PR DESCRIPTION
I added list of invoices to billing page of project. I used "MonthName Year" as invoice name.

Invoice detail page shows billing info, line items, subtotal etc. I prepared all data at serializer. I didn't put any logic to template file.

If line item cost is less than "$0.001", it's showed as "less than $0.001".

I didn't install any additional package for HTML to PDF conversation, because they require additional binaries to install machine. It makes deployment more complicated. All modern web browsers have "Save as PDF" option at printing page. When user clicked "PDF" button, it shows invoice detail page full screen and trigger print.

## Invoice listing

<img width="1512" alt="Screenshot 2023-08-31 at 16 17 55" src="https://github.com/ubicloud/ubicloud/assets/993199/972df5b6-5676-4a58-bc93-88df0334ebfd">

## Invoice detail
![localhost_9292_project_pjsxw6109r1p7gdymcajkz5zzx_billing_invoice_1vgwn8837b6t3ghf84vve4x7h5 (1)](https://github.com/ubicloud/ubicloud/assets/993199/084a8b57-9d5e-4892-a928-a244e54dc41a)

## Save as PDF

<img width="1512" alt="Screenshot 2023-08-31 at 16 19 54" src="https://github.com/ubicloud/ubicloud/assets/993199/166f7020-aeeb-43e7-ae62-98b1f9c132a0">

