### PR TITLE
Add charge function to invoice

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -82,4 +82,5 @@ module Config
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)
   override :hetzner_ssh_key, string
+  override :minimum_invoice_charge_threshold, 1.0, float
 end

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../model"
+require "stripe"
 
 class Invoice < Sequel::Model
   include ResourceMethods
@@ -12,4 +13,61 @@ class Invoice < Sequel::Model
   def name
     begin_time.strftime("%B %Y")
   end
+
+  def charge
+    unless (Stripe.api_key = Config.stripe_secret_key)
+      puts "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
+      return
+    end
+
+    if status != "unpaid"
+      puts "Invoice[#{ubid}] already charged: #{status}"
+      return
+    end
+
+    if content["cost"] < Config.minimum_invoice_charge_threshold
+      update(status: "below_minimum_threshold")
+      puts "Invoice[#{ubid}] cost is less than minimum charge cost: $#{content["cost"]}"
+      return
+    end
+
+    unless (billing_info = BillingInfo[content.dig("billing_info", "id")])
+      puts "Invoice[#{ubid}] doesn't have billing info"
+      return
+    end
+
+    payment_methods = billing_info.payment_methods_dataset.order(:order).all
+
+    payment_methods.each do |payment_method|
+      amount = content["cost"].to_f.round(2)
+      payment_intent = Stripe::PaymentIntent.create({
+        amount: (amount * 100).to_i, # 100 cents to charge $1.00
+        currency: "usd",
+        confirm: true,
+        off_session: true,
+        customer: billing_info.stripe_id,
+        payment_method: payment_method.stripe_id
+      })
+
+      if payment_intent.status == "succeeded"
+        puts "Invoice[#{ubid}] charged with PaymentMethod[#{payment_method.ubid}] for $#{amount}"
+        self.status = "paid"
+        content.merge!({
+          "payment_method" => {
+            "id" => payment_method.id,
+            "stripe_id" => payment_method.stripe_id
+          },
+          "payment_intent" => payment_intent.id
+        })
+        save(columns: [:status, :content])
+        return payment_intent.id
+      end
+
+      puts "Invoice[#{ubid}] couldn't charge with PaymentMethod[#{payment_method.ubid}]: #{payment_intent.status}"
+    end
+
+    puts "Invoice[#{ubid}] couldn't charge with any payment method"
+  end
 end
+
+Invoice.unrestrict_primary_key

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Invoice do
+  subject(:invoice) { described_class.new(id: "50d5aae4-311c-843b-b500-77fbc7778050", content: {"cost" => 10}, status: "unpaid") }
+
+  let(:billing_info) { BillingInfo.create_with_id(stripe_id: "cs_1234567890") }
+  let(:payment_method) { PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_1234567890") }
+
+  describe ".charge" do
+    it "not charge if Stripe not enabled" do
+      allow(Config).to receive(:stripe_secret_key).and_return(nil)
+      expect do
+        expect(invoice.charge).to be_nil
+      end.to output("Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing.\n").to_stdout
+    end
+
+    it "not charge if already charged" do
+      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      invoice.status = "paid"
+      expect do
+        expect(invoice.charge).to be_nil
+      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] already charged: paid\n").to_stdout
+    end
+
+    it "not charge if less than minimum charge threshold" do
+      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      invoice.content["cost"] = 0.5
+      expect(invoice).to receive(:update).with(status: "below_minimum_threshold")
+      expect do
+        expect(invoice.charge).to be_nil
+      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] cost is less than minimum charge cost: $0.5\n").to_stdout
+    end
+
+    it "not charge if doesn't have billing info" do
+      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      expect do
+        expect(invoice.charge).to be_nil
+      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] doesn't have billing info\n").to_stdout
+    end
+
+    it "not charge if no payment methods" do
+      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      invoice.content["billing_info"] = {"id" => billing_info.id}
+      expect do
+        expect(invoice.charge).to be_nil
+      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] couldn't charge with any payment method\n").to_stdout
+    end
+
+    it "not charge if payment method fails" do
+      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      invoice.content["billing_info"] = {"id" => billing_info.id}
+      expect(Stripe::PaymentIntent).to receive(:create).and_return(OpenStruct.new(status: "failed")).at_least(:once)
+      expect do
+        expect(invoice.charge).to be_nil
+      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] couldn't charge with PaymentMethod[#{payment_method.ubid}]: failed
+Invoice[1va3atns1h3j3pm07fyy7ey050] couldn't charge with any payment method\n").to_stdout
+    end
+
+    it "can charge" do
+      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      invoice.content["billing_info"] = {"id" => billing_info.id}
+
+      expect(Stripe::PaymentIntent).to receive(:create).and_return(OpenStruct.new(status: "succeeded", id: "pi_1234567890")).with(hash_including(
+        amount: 1000,
+        customer: billing_info.stripe_id,
+        payment_method: payment_method.stripe_id
+      )).at_least(:once)
+      expect(invoice).to receive(:save).with(columns: [:status, :content])
+      expect do
+        expect(invoice.charge).to eq("pi_1234567890")
+      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] charged with PaymentMethod[#{payment_method.ubid}] for $10.0\n").to_stdout
+      expect(invoice.status).to eq("paid")
+      expect(invoice.content["payment_method"]["id"]).to eq(payment_method.id)
+      expect(invoice.content["payment_intent"]).to eq("pi_1234567890")
+    end
+  end
+end


### PR DESCRIPTION
We already saved customer's credit card information at the beginning. We are charging cost of invoice using saved card.

Stripe processes some fee for each transaction. For $1.00, fee is $0.33. Charging less than $1 doesn't make sense.

Billing information might have multiple payment method. We try them one by one.

It prints error and returns nil, instead of raising an error. I did it because probably we will charge them manually at the beginning. I want to fail soft.
