### PR TITLE
Start using Kea for DHCP4

### DIFF
--- a/prog/install_networking_tools.rb
+++ b/prog/install_networking_tools.rb
@@ -42,7 +42,8 @@ class Prog::InstallNetworkingTools < Prog::Base
   end
 
   label def install_build_dependencies
-    sshable.cmd("sudo apt-get -y install make gcc pkg-config automake bison flex")
+    sshable.cmd("curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-2-4/setup.deb.sh' | sudo -E bash && " \
+      "sudo apt-get -y install make gcc pkg-config automake bison flex isc-kea-dhcp4")
     pop "installed build dependencies"
   end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -320,20 +320,8 @@ SQL
     vm.update(display_state: "deleting")
 
     unless host.nil?
-      begin
-        host.sshable.cmd("sudo systemctl stop #{q_vm}")
-      rescue Sshable::SshError => ex
-        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
-      end
-
-      begin
-        host.sshable.cmd("sudo systemctl stop #{q_vm}-dnsmasq")
-      rescue Sshable::SshError => ex
-        raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
-      end
-
-      begin
-        host.sshable.cmd("sudo systemctl stop #{q_vm}-radvd")
+      [q_vm, "#{q_vm}-dnsmasq", "#{q_vm}-radvd", "#{q_vm}-kea-dhcp4"].each do |unit|
+        host.sshable.cmd("sudo systemctl stop #{unit}")
       rescue Sshable::SshError => ex
         raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
       end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -26,6 +26,18 @@ class VmPath
     write(dnsmasq_service, s)
   end
 
+  def kea
+    "/vm/#{@vm_name}/kea"
+  end
+
+  def kea_dhcp4_service
+    "/etc/systemd/system/#{@vm_name}-kea-dhcp4.service"
+  end
+
+  def write_kea_dhcp4_service(s)
+    write(kea_dhcp4_service, s)
+  end
+
   def radvd_service
     "/etc/systemd/system/#{@vm_name}-radvd.service"
   end
@@ -76,6 +88,7 @@ class VmPath
     nftables_conf
     prep.json
     radvd.conf
+    kea_dhcp4.conf
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
     fail "BUG" if method_defined?(method_name)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -254,6 +254,7 @@ RSpec.describe VmSetup do
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-radvd.service")
+      expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-kea-dhcp4.service")
       expect(vs).to receive(:r).with("systemctl daemon-reload")
       expect(vs).to receive(:purge_storage)
       expect(vs).to receive(:r).with("umount /vm/test/hugepages")

--- a/spec/prog/install_networking_tools_spec.rb
+++ b/spec/prog/install_networking_tools_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe Prog::InstallNetworkingTools do
   describe "#install_build_dependencies" do
     it "installs dependencies and pops" do
       sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with "sudo apt-get -y install make gcc pkg-config automake bison flex"
+      expect(sshable).to receive(:cmd).with "curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-2-4/setup.deb.sh' | sudo -E bash && " \
+        "sudo apt-get -y install make gcc pkg-config automake bison flex isc-kea-dhcp4"
       expect(idm).to receive(:sshable).and_return(sshable)
 
       expect { idm.install_build_dependencies }.to exit({"msg" => "installed build dependencies"})

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -488,6 +488,9 @@ RSpec.describe Prog::Vm::Nexus do
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-radvd/).and_raise(
           Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil)
         )
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp4/).and_raise(
+          Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil)
+        )
         expect(sshable).to receive(:cmd).with(/sudo.*bin\/deletevm.rb.*#{nx.vm_name}/)
         expect(vm).to receive(:destroy).and_return(true)
 
@@ -516,10 +519,20 @@ RSpec.describe Prog::Vm::Nexus do
         expect { nx.destroy }.to raise_error ex
       end
 
+      it "raises other stop-kea-dhcp4 errors" do
+        ex = Sshable::SshError.new("stop", "", "unknown error", 1, nil)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-radvd/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp4/).and_raise(ex)
+        expect { nx.destroy }.to raise_error ex
+      end
+
       it "deletes and pops when all commands are succeeded" do
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/)
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/)
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-radvd/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp4/)
         expect(sshable).to receive(:cmd).with(/sudo.*bin\/deletevm.rb.*#{nx.vm_name}/)
 
         expect(vm).to receive(:destroy)


### PR DESCRIPTION
With this commit, we are moving the DHCP4 functionality from Dnsmasq to
Kea. Main reason to do so is to that Dnsmasq doesn't support prefix
delegation for DHCP6, so we decided that we will use Kea for DHCP in
general. This is the first step. In this commit, we also prepare host
with the related packages. Therefore, the DHCP6 path will simply
implement the dhcp6 configuration and daemon.