### PR TITLE
    Add and use "husk" process to diagnose slow termination issues     

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+web: bundle exec ./bin/husk puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 respirate: bin/respirate

--- a/bin/husk
+++ b/bin/husk
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+child = Process.spawn(*ARGV, close_others: true, in: $stdin, out: $stdout, err: $stderr)
+
+Signal.trap("SIGTERM") do
+  Process.kill("SIGTERM", child)
+  sleep 2
+  begin
+    Process.kill("SIGQUIT", child)
+  rescue Errno::ESRCH
+    puts "husk: subprocess exited normally from SIGTERM"
+  end
+end
+
+_, status = Process.wait2 child
+Kernel.exit!(status.exitstatus || status.termsig + 128)

--- a/lib/thread_printer.rb
+++ b/lib/thread_printer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ThreadPrinter
+  def self.run
+    Thread.list.each do |thread|
+      puts "Thread: #{thread.inspect}"
+      puts thread.backtrace&.join("\n")
+    end
+  end
+end

--- a/loader.rb
+++ b/loader.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "lib/thread_printer"
+Signal.trap("QUIT") do
+  ThreadPrinter.run
+  Kernel.exit!(Signal.list["QUIT"] + 128)
+end
+
 require "bundler/setup"
 Bundler.setup
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -21,13 +21,6 @@ class Scheduling::Dispatcher
     ).order_by(:schedule).limit(idle_connections)
   end
 
-  def self.print_thread_dump
-    Thread.list.each do |thread|
-      puts "Thread: #{thread.inspect}"
-      puts thread.backtrace&.join("\n")
-    end
-  end
-
   def start_strand(strand)
     strand_id = strand.id.freeze
 
@@ -38,7 +31,7 @@ class Scheduling::Dispatcher
 
       if ready.nil?
         # Timed out, dump threads and exit
-        self.class.print_thread_dump
+        ThreadPrinter.run
         Kernel.exit!
 
         # rubocop:disable Lint/UnreachableCode

--- a/spec/lib/thread_printer_spec.rb
+++ b/spec/lib/thread_printer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe ThreadPrinter do
+  describe "#print" do
+    it "can dump threads" do
+      expect(described_class).to receive(:puts).with(/Thread: #<Thread:.*>/)
+      expect(described_class).to receive(:puts).with(/backtrace/)
+      described_class.run
+    end
+
+    it "can handle threads with a nil backtrace" do
+      # The documentation calls out that the backtrace is an array or
+      # nil.
+      expect(described_class).to receive(:puts).with(/Thread: #<InstanceDouble.*>/)
+      expect(described_class).to receive(:puts).with(nil)
+      expect(Thread).to receive(:list).and_return([instance_double(Thread, backtrace: nil)])
+      described_class.run
+    end
+  end
+end

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -15,23 +15,6 @@ RSpec.describe Scheduling::Dispatcher do
     end
   end
 
-  describe "#print_thread_dump" do
-    it "can dump threads" do
-      expect(described_class).to receive(:puts).with(/Thread: #<Thread:.*>/)
-      expect(described_class).to receive(:puts).with(/backtrace/)
-      described_class.print_thread_dump
-    end
-
-    it "can handle threads with a nil backtrace" do
-      # The documentation calls out that the backtrace is an array or
-      # nil.
-      expect(described_class).to receive(:puts).with(/Thread: #<InstanceDouble.*>/)
-      expect(described_class).to receive(:puts).with(nil)
-      expect(Thread).to receive(:list).and_return([instance_double(Thread, backtrace: nil)])
-      described_class.print_thread_dump
-    end
-  end
-
   describe "#wait_cohort" do
     it "operates when no threads are running" do
       expect { di.wait_cohort }.not_to raise_error
@@ -94,7 +77,7 @@ RSpec.describe Scheduling::Dispatcher do
     end
 
     it "can trigger thread dumps and exit if the Prog takes too long" do
-      expect(described_class).to receive(:print_thread_dump)
+      expect(ThreadPrinter).to receive(:run)
       expect(Kernel).to receive(:exit!)
 
       Thread.new do


### PR DESCRIPTION

    `husk` can be a catch-all place to put process supervision code.
    
    Right now, we're interested in reviewing threads that are still
    running briefly after a SIGTERM is sent.  This is done by sending a
    subsequent SIGQUIT after a little while.
    
    To try it out, do something like this, in two terminals.  One should run:
    
        $ ./bin/husk ruby -e "Signal.trap('SIGTERM') { }; sleep 86400"
    
    The other can run:
    
        pkill -SIGTERM -f husk
    
    In the first terminal, you can check the exit status:
    
        $ echo $?
        131
    
    This is the expected exit status for a SIGQUIT:
    
        clover-development(main)> Signal.list["QUIT"] + 128
        => 131
