### PR TITLE
Remove unused variable names from tests

### DIFF
--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -4,8 +4,7 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::BootstrapRhizome do
   subject(:br) {
-    described_class.new(Strand.new(prog: "BootstrapRhizome",
-      stack: [{sshable_id: "bogus"}]))
+    described_class.new(Strand.new(prog: "BootstrapRhizome"))
   }
 
   describe "#start" do

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -4,14 +4,13 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::InstallDnsmasq do
   subject(:idm) {
-    described_class.new(Strand.new(prog: "InstallDnsmasq",
-      stack: [{sshable_id: "bogus"}]))
+    described_class.new(Strand.new(prog: "InstallDnsmasq"))
   }
 
   describe "#start" do
     it "starts sub-programs to install dependencies and download dnsmasq concurrently" do
-      expect(idm).to receive(:bud).with(described_class, {sshable_id: "bogus"}, :install_build_dependencies)
-      expect(idm).to receive(:bud).with(described_class, {sshable_id: "bogus"}, :git_clone_dnsmasq)
+      expect(idm).to receive(:bud).with(described_class, {}, :install_build_dependencies)
+      expect(idm).to receive(:bud).with(described_class, {}, :git_clone_dnsmasq)
 
       expect { idm.start }.to hop("wait_downloads")
     end

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::InstallRhizome do
-  subject(:ir) { described_class.new(Strand.new(stack: [{sshable_id: "bogus"}])) }
+  subject(:ir) { described_class.new(Strand.new) }
 
   let(:sshable) { instance_double(Sshable) }
 

--- a/spec/prog/learn_cores_spec.rb
+++ b/spec/prog/learn_cores_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnCores do
-  subject(:lc) { described_class.new(Strand.new(stack: [{sshable_id: "bogus"}])) }
+  subject(:lc) { described_class.new(Strand.new) }
 
   # Gin up a topologically complex processor to test summations.
   let(:eight_thread_four_core_four_numa_two_socket) do

--- a/spec/prog/learn_memory_spec.rb
+++ b/spec/prog/learn_memory_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnMemory do
-  subject(:lm) { described_class.new(Strand.new(stack: [{sshable_id: "bogus"}])) }
+  subject(:lm) { described_class.new(Strand.new) }
 
   let(:four_units) do
     <<EOS

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnStorage do
-  subject(:ls) { described_class.new(Strand.new(stack: [{sshable_id: "bogus"}])) }
+  subject(:ls) { described_class.new(Strand.new) }
 
   describe "#start" do
     it "exits, popping total storage and available storage" do

--- a/spec/prog/rotate_storage_kek_spec.rb
+++ b/spec/prog/rotate_storage_kek_spec.rb
@@ -4,8 +4,7 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::RotateStorageKek do
   subject(:rsk) {
-    described_class.new(Strand.new(prog: "RotateStorageKek",
-      stack: [{vm_storage_volume_id: "bogus"}]))
+    described_class.new(Strand.new(prog: "RotateStorageKek"))
   }
 
   let(:sshable) {

--- a/spec/prog/setup_hugepages_spec.rb
+++ b/spec/prog/setup_hugepages_spec.rb
@@ -4,8 +4,7 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::SetupHugepages do
   subject(:sh) {
-    described_class.new(Strand.new(prog: "SetupHugepages",
-      stack: [{sshable_id: "bogus"}]))
+    described_class.new(Strand.new(prog: "SetupHugepages"))
   }
 
   describe "#start" do

--- a/spec/prog/setup_spdk_spec.rb
+++ b/spec/prog/setup_spdk_spec.rb
@@ -4,8 +4,7 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::SetupSpdk do
   subject(:ss) {
-    described_class.new(Strand.new(prog: "SetupSpdk",
-      stack: [{sshable_id: "bogus"}]))
+    described_class.new(Strand.new(prog: "SetupSpdk"))
   }
 
   describe "#start" do


### PR DESCRIPTION
There is no sshable_id or vm_storage_volume_id anymore. These are left over from old refactors. I found these randomly, probably there are other unused variables in tests but I didn't do an exhaustive search.