### PR TITLE
Destroy StorageKeyEncryptionKey when VmStorageVolume destroyed

### DIFF
--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -7,6 +7,8 @@ class VmStorageVolume < Sequel::Model
   many_to_one :key_encryption_key_1, class: :StorageKeyEncryptionKey
   many_to_one :key_encryption_key_2, class: :StorageKeyEncryptionKey
 
+  plugin :association_dependencies, key_encryption_key_1: :destroy, key_encryption_key_2: :destroy
+
   include ResourceMethods
 
   def device_id


### PR DESCRIPTION
Currently, we don't delete encryption key for vm storage when we delete
it. It causes a leak.

This PR fixes StorageKeyEncryptionKey leakage.

We need to cleanup leaked storage encryption keys  at production.