### PR TITLE
Increase argon memory cost to new minimum for 2.3

### DIFF
--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -10,7 +10,7 @@ TEST_LOCATION = "hetzner-hel1"
 def create_account(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
   hash = Argon2::Password.new({
     t_cost: 1,
-    m_cost: 3,
+    m_cost: 5,
     secret: Config.clover_session_secret
   }).create(password)
 


### PR DESCRIPTION
Argon2 2.3 needs this higher value to complete the tests.  After being applied, the dependabot rebase should function.

This is the smallest value that worked, "4" produced test failures.

https://github.com/ubicloud/ubicloud/pull/547