### PR TITLE
Do not attempt to install gems if there is no Gemfile in InstallRhizome

### DIFF
--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -37,7 +37,9 @@ class Prog::InstallRhizome < Prog::Base
 
   label def install_gems
     sshable.cmd("bundle install --gemfile common/Gemfile --path common/vendor/bundle")
-    sshable.cmd("bundle install --gemfile #{frame["target_folder"]}/Gemfile --path #{frame["target_folder"]}/vendor/bundle")
+    if File.exist?("#{Config.root}/rhizome/#{frame["target_folder"]}/Gemfile")
+      sshable.cmd("bundle install --gemfile #{frame["target_folder"]}/Gemfile --path #{frame["target_folder"]}/vendor/bundle")
+    end
     pop "installed rhizome"
   end
 end

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -30,5 +30,12 @@ RSpec.describe Prog::InstallRhizome do
       expect(sshable).to receive(:cmd).with("bundle install --gemfile host/Gemfile --path host/vendor/bundle")
       expect { ir.install_gems }.to exit({"msg" => "installed rhizome"})
     end
+
+    it "does not install gems if there is no Gemfile" do
+      expect(File).to receive(:exist?).and_return(false)
+      expect(sshable).to receive(:cmd).with("bundle install --gemfile common/Gemfile --path common/vendor/bundle")
+      expect(sshable).not_to receive(:cmd).with("bundle install --gemfile host/Gemfile --path host/vendor/bundle")
+      expect { ir.install_gems }.to exit({"msg" => "installed rhizome"})
+    end
   end
 end


### PR DESCRIPTION
This is another preparation for the new services. Not every service would need gems and they wouldn't have their own Gemfiles. The primary goal here is making BootstrapRhizome and InstallRhizome useable, not just for host but also for VMs created by other services.