### PR TITLE
Do not create keypair if there is already one in BootstrapRhizome

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -10,7 +10,7 @@ class Prog::BootstrapRhizome < Prog::Base
   end
 
   label def start
-    sshable.update(raw_private_key_1: SshKey.generate.keypair)
+    sshable.update(raw_private_key_1: SshKey.generate.keypair) if sshable.raw_private_key_1.nil?
     hop_setup
   end
 

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -11,15 +11,22 @@ RSpec.describe Prog::BootstrapRhizome do
     before { br.strand.label = "start" }
 
     it "generates a keypair" do
-      sshable = instance_double(Sshable)
+      sshable = instance_double(Sshable, raw_private_key_1: nil)
       expect(sshable).to receive(:update) do |**args|
         key = args[:raw_private_key_1]
         expect(key).to be_instance_of String
         expect(key.length).to eq 64
       end
 
-      expect(br).to receive(:sshable).and_return(sshable)
+      expect(br).to receive(:sshable).and_return(sshable).twice
 
+      expect { br.start }.to hop("setup", "BootstrapRhizome")
+    end
+
+    it "does not generate a keypair if there is already one" do
+      sshable = instance_double(Sshable, raw_private_key_1: "bogus")
+      expect(sshable).not_to receive(:update)
+      expect(br).to receive(:sshable).and_return(sshable)
       expect { br.start }.to hop("setup", "BootstrapRhizome")
     end
   end


### PR DESCRIPTION
This is final change to make BootstrapRhizome/InstallRhizome reusable by other services. The assumption (which is validated while working on postgres service) is that some services would create their own VMs and also own the creating Sshable entity. For such cases, we shouldn't update private key of the Sshable.