### PR TITLE
Introduce daemonizer to trigger non-blocking long running commands

### DIFF
--- a/rhizome/common/bin/daemonizer
+++ b/rhizome/common/bin/daemonizer
@@ -1,0 +1,57 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+
+require_relative "../lib/util"
+
+if ARGV.count != 2
+  fail "Wrong number of arguments. Expected 2, Given #{ARGV.count}"
+end
+
+STATE_MAP = {
+  "dead" => "NotStarted",
+  "running" => "InProgress",
+  "exited" => "Succeeded",
+  "failed" => "Failed"
+}
+def get_state(name)
+  state = r("systemctl show -p SubState --value #{name}.service").chomp
+
+  STATE_MAP[state] || "Unknown"
+end
+
+if ARGV[0] == "--check"
+  name = ARGV[1]
+  print(get_state(name))
+else
+  command = ARGV[0]
+  name = ARGV[1]
+
+  FileUtils.mkdir_p("var/log")
+  FileUtils.mkdir_p("var/proc")
+
+  File.open("var/proc/#{name}.lock", File::RDWR | File::CREAT) do |f|
+    break unless f.flock(File::LOCK_EX || File::LOCK_NB)
+
+    state = get_state(name)
+    case state
+    when "InProgress", "Unknown"
+      break
+    when "Succeeded"
+      r "sudo systemctl stop #{name}.service"
+    when "Failed"
+      r "sudo systemctl reset-failed #{name}.service"
+    end
+
+    dir = Dir.pwd
+    stdin = $stdin.read
+    if stdin != ""
+      safe_write_to_file("var/proc/#{name}.stdin", stdin)
+      command = "#{command} < #{dir}/var/proc/#{name}.stdin"
+    end
+
+    command = "/bin/bash -c '#{command} > #{dir}/var/log/#{name}.stdout 2> #{dir}/var/log/#{name}.stderr'"
+    r "sudo systemd-run --working-directory #{dir} --unit #{name} --remain-after-exit #{command}"
+  end
+end

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -56,3 +56,12 @@ def sync_parent_dir(f)
     fsync_or_fail(_1)
   }
 end
+
+def safe_write_to_file(filename, content)
+  temp_filename = filename + ".tmp"
+  File.open(temp_filename, File::RDWR | File::CREAT) do |f|
+    f.flock(File::LOCK_EX)
+    f.puts(content)
+    File.rename(temp_filename, filename)
+  end
+end


### PR DESCRIPTION
Usually during setup steps, but in general, we need to run commands that take long time to complete. Such commands block the control plane thread. daemonizer is a way to daemonize process, thus running the given command in the background without blocking the current thread.

It comes with few cool features;
- We take a lock, so that only one instance of the command can run.
- Daemonizing itself is idempotent. It cleans up its artifacts before its next run. Assuming the triggered command is idempotent as well, we can run it via daemonizer as much as we want.
- It supports reading from stdin or passing parameters.
- It comes with nice utility to check status of the daemonized command, whether it is still running or completed (and if so, whether with success or failure).

Usage:
daemonizer take 2 parameters, command to run and a name. The name is used for locking, logging and status checking.

Example;
```
# Run bin/install_postgres.rb with sudo privileges
vm.sshable.cmd("common/bin/daemonizer 'sudo install.rb' install")

# Use with stdin
vm.sshable.cmd("common/bin/daemonizer 'sudo configure.rb' configure", stdin: data)

# Check status of a command that is triggered with daemonizer
vm.sshable.cmd("common/bin/daemonizer --check configure")

# Potential E2E usage in Progs
case vm.sshable.cmd("common/bin/daemonizer --check install_postgres") when "Succeeded"
  hop_<next_label>
when "Failed", "NotStarted"
  vm.sshable.cmd("common/bin/daemonizer 'install_postgres.rb' install_postgres")
end
```