### PR TITLE
Initial DHCPv6 with Kea Server without Prefix Delegation

### DIFF
--- a/prog/install_networking_tools.rb
+++ b/prog/install_networking_tools.rb
@@ -43,7 +43,7 @@ class Prog::InstallNetworkingTools < Prog::Base
 
   label def install_build_dependencies
     sshable.cmd("curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-2-4/setup.deb.sh' | sudo -E bash && " \
-      "sudo apt-get -y install make gcc pkg-config automake bison flex isc-kea-dhcp4")
+      "sudo apt-get -y install make gcc pkg-config automake bison flex isc-kea-dhcp4 isc-kea-dhcp6")
     pop "installed build dependencies"
   end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -320,7 +320,7 @@ SQL
     vm.update(display_state: "deleting")
 
     unless host.nil?
-      [q_vm, "#{q_vm}-dnsmasq", "#{q_vm}-radvd", "#{q_vm}-kea-dhcp4"].each do |unit|
+      [q_vm, "#{q_vm}-dnsmasq", "#{q_vm}-radvd", "#{q_vm}-kea-dhcp4", "#{q_vm}-kea-dhcp6"].each do |unit|
         host.sshable.cmd("sudo systemctl stop #{unit}")
       rescue Sshable::SshError => ex
         raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -38,6 +38,14 @@ class VmPath
     write(kea_dhcp4_service, s)
   end
 
+  def kea_dhcp6_service
+    "/etc/systemd/system/#{@vm_name}-kea-dhcp6.service"
+  end
+
+  def write_kea_dhcp6_service(s)
+    write(kea_dhcp6_service, s)
+  end
+
   def radvd_service
     "/etc/systemd/system/#{@vm_name}-radvd.service"
   end
@@ -89,6 +97,7 @@ class VmPath
     prep.json
     radvd.conf
     kea_dhcp4.conf
+    kea_dhcp6.conf
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
     fail "BUG" if method_defined?(method_name)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -289,10 +289,6 @@ EOS
 
     vp.write_dnsmasq_conf(<<DNSMASQ_CONF)
 pid-file=
-leasefile-ro
-# dhcp-authoritative
-# dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
-dhcp-option=option6:dns-server,2620:fe::fe,2620:fe::9
 DNSMASQ_CONF
 
     kea_ip4_subnets = nics.map do |net6, net4, tapname, mac|
@@ -338,7 +334,7 @@ KEA_SUBNET
 KEA_DHCP4_CONF
 
     private_pools = nics.map do |net6, net4, tapname, mac|
-<<KEA_DHCP6_PRIVATE_POOL
+      <<KEA_DHCP6_PRIVATE_POOL
       {
         "interface": "#{tapname}",
         "subnet": "#{NetAddr::IPv6Net.parse(net6)}",
@@ -368,8 +364,7 @@ KEA_DHCP6_PRIVATE_POOL
         "output_options": [ {
             "output": "/vm/#{@vm_name}/kea/kea-dhcp6.log"
         } ],
-        "severity": "DEBUG",
-        "debuglevel": 99
+        "severity": "INFO"
     } ],
     "subnet6": [
       # Public prefix
@@ -378,7 +373,7 @@ KEA_DHCP6_PRIVATE_POOL
         "subnet": "#{guest_network}",
         "pools": [
           {
-              "pool": "#{guest_network.nth(2)}-#{guest_network.nth(1000)}"
+              "pool": "#{guest_network.nth(2)}-#{guest_network.nth(2)}"
           }
         ]
       },
@@ -386,7 +381,7 @@ KEA_DHCP6_PRIVATE_POOL
       #{private_pools}
     ],
     "interfaces-config": {
-      "interfaces": ["*"],
+      "interfaces": ["#{nics.map { |n| n[2] }.join(",")}"],
       "service-sockets-max-retries": 5,
       "service-sockets-retry-wait-time": 5000
     },
@@ -465,6 +460,8 @@ RADVD_CONF
       macaddress: #{mac}
     dhcp6: true
     dhcp4: true
+    addresses: 
+      - #{NetAddr::IPv6Net.parse(net6).nth(2)}/80
 ETHERNETS
     end.join("\n")
 
@@ -800,8 +797,8 @@ Environment=KEA_LOCKFILE_DIR=/vm/#{@vm_name}/kea
 User=#{@vm_name}
 Group=#{@vm_name}
 NetworkNamespacePath=/var/run/netns/#{@vm_name}
-CapabilityBoundingSet=CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
-AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE
 ProtectSystem=strict
 PrivateDevices=yes
 PrivateTmp=yes
@@ -829,8 +826,8 @@ Environment=KEA_LOCKFILE_DIR=/vm/#{@vm_name}/kea
 User=#{@vm_name}
 Group=#{@vm_name}
 NetworkNamespacePath=/var/run/netns/#{@vm_name}
-CapabilityBoundingSet=CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
-AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE
 ProtectSystem=strict
 PrivateDevices=yes
 PrivateTmp=yes

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -255,6 +255,7 @@ RSpec.describe VmSetup do
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-radvd.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-kea-dhcp4.service")
+      expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-kea-dhcp6.service")
       expect(vs).to receive(:r).with("systemctl daemon-reload")
       expect(vs).to receive(:purge_storage)
       expect(vs).to receive(:r).with("umount /vm/test/hugepages")

--- a/spec/prog/install_networking_tools_spec.rb
+++ b/spec/prog/install_networking_tools_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Prog::InstallNetworkingTools do
     it "installs dependencies and pops" do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with "curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-2-4/setup.deb.sh' | sudo -E bash && " \
-        "sudo apt-get -y install make gcc pkg-config automake bison flex isc-kea-dhcp4"
+        "sudo apt-get -y install make gcc pkg-config automake bison flex isc-kea-dhcp4 isc-kea-dhcp6"
       expect(idm).to receive(:sshable).and_return(sshable)
 
       expect { idm.install_build_dependencies }.to exit({"msg" => "installed build dependencies"})

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -491,6 +491,9 @@ RSpec.describe Prog::Vm::Nexus do
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp4/).and_raise(
           Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil)
         )
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp6/).and_raise(
+          Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil)
+        )
         expect(sshable).to receive(:cmd).with(/sudo.*bin\/deletevm.rb.*#{nx.vm_name}/)
         expect(vm).to receive(:destroy).and_return(true)
 
@@ -528,11 +531,22 @@ RSpec.describe Prog::Vm::Nexus do
         expect { nx.destroy }.to raise_error ex
       end
 
+      it "raises other stop-kea-dhcp6 errors" do
+        ex = Sshable::SshError.new("stop", "", "unknown error", 1, nil)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-radvd/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp4/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp6/).and_raise(ex)
+        expect { nx.destroy }.to raise_error ex
+      end
+
       it "deletes and pops when all commands are succeeded" do
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/)
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/)
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-radvd/)
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp4/)
+        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-kea-dhcp6/)
         expect(sshable).to receive(:cmd).with(/sudo.*bin\/deletevm.rb.*#{nx.vm_name}/)
 
         expect(vm).to receive(:destroy)


### PR DESCRIPTION
This commit adds kea-dhcp6-server and makes the configurations
necessary so that VMs can fetch the ip address from Kea. Our client side
(VM) depends on netplan which delegates the DHCP work into
systemd-networkd. There are 3 places I can find to configure DHCP;
1. /etc/netplan/50-cloud-init.yaml: this is a basic configuration file
for netplan. It just says if it should enable dhcp4/6. It is suggested
to add `accept-ra: true` to this file to enable dhcpv6 prefix delegation
but I didn't realize any change in the behavior.
2. /run/systemd/network/10-netplan-xxxxxxxxxxxxx.network which has DHCP
related configs. Looked to me that this is the place we should have
prefix delegation enabled, manually changed this file with different set
of keywords but I couldn't reach anything meaningful.
3. /etc/systemd/network/ which is empty, ideally, a new config file I
put here should be picked up by systemd-networkd and used to send
SOLICIT messages, I tried to make it send IA_PD SOLICIT messages but
that didn't work either.

So, I was fed up with systemd-networkd. I wanted to try dhclient. That
was interesting. I could verify that it at least sends proper solicit
messages and gets prefixes leased but then I couldn't make it so that
the prefixes are added to the interface. Here is the road I took for
that;
```
root@vm54zgct:/home/ubi# cat dhclient6.conf
interface "ens3" {
	send ia-pd 1;
	send ia-na 1;
	request domain-name-servers;
	request domain-name;
	script "/etc/dhcp/dhclient-script";
};
root@vm54zgct:/home/ubi# cat /etc/dhcp/dhclient-script
if [ "$reason" = "BOUND" ] || [ "$reason" = "RENEW" ] || [ "$reason" = "REBIND" ] || [ "$reason" = "REBOOT" ]; then
    # Check if we have a prefix (assuming it's IPv6)
    if [ "$new_prefix" ]; then
        # We have a prefix, so we'll configure it on another interface
        # First, parse prefix to separate the network and prefix length
        IFS='/' read -ra ADDR <<< "$new_prefix"
        NETWORK=${ADDR[0]}
        PREFIXLEN=${ADDR[1]}

        # Choose a subnet and host within the delegated prefix
        # For this example, we just use subnet 1 and host 1 within that subnet
        SUBNET="1"
        HOST="1"
        FULL_ADDRESS="${NETWORK}${SUBNET}::${HOST}/${PREFIXLEN}"

        # Add this address to the 'eth1' interface (replace with the interface you want)
        ip -6 addr add $FULL_ADDRESS dev eth1
    fi
fi
root@vm54zgct:/home/ubi# sudo dhclient -6 -P -cf dhclient6.conf ens3 -d
```
Which adds the lease!
```
root@vm54zgct:/home/ubi# cat /var/lib/dhcp/dhclient6.leases
default-duid "";
lease6 {
  interface "ens3";
  ia-pd  {
    starts ;
    renew 1000;
    rebind 2000;
    iaprefix PREFIX {
      starts ;
      preferred-life 2500;
      max-life 4000;
    }
  }
  option dhcp6.client-id ;
  option dhcp6.server-id ;
}
```
I removed information that I don't want going public. but I could see
the prefix. I had to make changes to apparmor profile to make this work
with the following;
vi /etc/apparmor.d/sbin.dhclient
I added some permissions so that the script can be run, also of course
chmod +x script.

That's it. I am blocked.

Another example file on how I tried to make systemd-networkd pickup prefix delegation
```
root@vm9pntst:/run/systemd/network# cat 10-netplan-enx4e427befa7eb.network
[Match]
Name=ens3

[Network]
DHCP=yes
LinkLocalAddressing=ipv6

[DHCP]
RouteMetric=100
UseMTU=true
UseRoutes=true

[DHCPv6]
PrefixDelegationHint=::/80
```
Still, I only see IA_NA Solicit messages