### PR TITLE
Support multiple storage volumes.

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -51,4 +51,11 @@ module Validation
     msg = "OS user name must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also have max length of 32."
     fail ValidationFailed.new({user: msg}) unless os_user_name.match(ALLOWED_OS_USER_NAME_PATTERN)
   end
+
+  def self.validate_storage_volumes(storage_volumes, boot_disk_index)
+    fail ValidationFailed.new({storage_volumes: "At least one storage volume is required."}) if storage_volumes.empty?
+    if boot_disk_index < 0 || boot_disk_index >= storage_volumes.length
+      fail ValidationFailed.new({boot_disk_index: "Boot disk index must be between 0 and #{storage_volumes.length - 1}"})
+    end
+  end
 end

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -29,6 +29,20 @@ class Prog::Test::Vm < Prog::Base
     sshable.cmd("sudo apt update")
     sshable.cmd("sudo apt install -y build-essential")
 
+    hop_verify_extra_disks
+  end
+
+  label def verify_extra_disks
+    vm.vm_storage_volumes[1..].each_with_index { |volume, disk_index|
+      mount_path = "/home/ubi/mnt#{disk_index}"
+      sshable.cmd("mkdir -p #{mount_path}")
+      sshable.cmd("sudo mkfs.ext4 #{volume.device_path.shellescape}")
+      sshable.cmd("sudo mount #{volume.device_path.shellescape} #{mount_path}")
+      sshable.cmd("sudo chown ubi #{mount_path}")
+      sshable.cmd("dd if=/dev/random of=#{mount_path}/1.txt bs=512 count=10000")
+      sshable.cmd("sync #{mount_path}/1.txt")
+    }
+
     hop_ping_google
   end
 

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -34,24 +34,29 @@ class Prog::Test::VmGroup < Prog::Base
     keypair_2 = SshKey.generate
     keypair_3 = SshKey.generate
 
+    storage_encrypted = frame.fetch("storage_encrypted", true)
+
     vm1_s = Prog::Vm::Nexus.assemble(
       keypair_1.public_key, project.id,
       private_subnet_id: subnet1_s.id,
-      storage_encrypted: frame["storage_encrypted"],
+      storage_volumes: [
+        {encrypted: storage_encrypted},
+        {encrypted: storage_encrypted, size_gib: 5}
+      ],
       enable_ip4: true
     )
 
     vm2_s = Prog::Vm::Nexus.assemble(
       keypair_2.public_key, project.id,
       private_subnet_id: subnet1_s.id,
-      storage_encrypted: frame["storage_encrypted"],
+      storage_volumes: [{encrypted: storage_encrypted}],
       enable_ip4: true
     )
 
     vm3_s = Prog::Vm::Nexus.assemble(
       keypair_3.public_key, project.id,
       private_subnet_id: subnet2_s.id,
-      storage_encrypted: frame["storage_encrypted"],
+      storage_volumes: [{encrypted: storage_encrypted}],
       enable_ip4: true
     )
 

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -26,9 +26,8 @@ class Prog::Vm::GithubRunner < Prog::Base
         unix_user: "runner",
         location: "github-runners",
         boot_image: "github-ubuntu-2204",
-        storage_size_gib: 86,
-        enable_ip4: true,
-        storage_encrypted: false
+        storage_volumes: [{size_gib: 86, encrypted: false}],
+        enable_ip4: true
       )
 
       Sshable.create(

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -99,5 +99,20 @@ RSpec.describe Validation do
         end
       end
     end
+
+    describe "#validate_storage_volumes" do
+      it "succeeds if there's at least one volume" do
+        expect(described_class.validate_storage_volumes([{encrypted: true}], 0)).to be_nil
+      end
+
+      it "fails if no volumes" do
+        expect { described_class.validate_storage_volumes([], 0) }.to raise_error described_class::ValidationFailed
+      end
+
+      it "fails if boot_disk_index out of range" do
+        expect { described_class.validate_storage_volumes([{encrypted: true}], -1) }.to raise_error described_class::ValidationFailed
+        expect { described_class.validate_storage_volumes([{encrypted: true}], 1) }.to raise_error described_class::ValidationFailed
+      end
+    end
   end
 end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates with custom storage size if provided" do
-      st = described_class.assemble("some_ssh_key", prj.id, storage_size_gib: 40)
+      st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{size_gib: 40}])
       expect(st.vm.storage_size_gib).to eq(40)
     end
 
@@ -156,15 +156,15 @@ RSpec.describe Prog::Vm::Nexus do
       }.to raise_error RuntimeError, "Given subnet is not available in the given project"
     end
 
-    it "creates without encryption key if storage_encrypted not" do
-      st = described_class.assemble("some_ssh_key", prj.id, storage_encrypted: false)
+    it "creates without encryption key if storage is not encrypted" do
+      st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{encrypted: false}])
       expect(StorageKeyEncryptionKey.count).to eq(0)
       expect(st.vm.vm_storage_volumes.first.key_encryption_key_1_id).to be_nil
       expect(described_class.new(st).storage_secrets.count).to eq(0)
     end
 
-    it "creates with encryption key if storage_encrypted" do
-      st = described_class.assemble("some_ssh_key", prj.id, storage_encrypted: true)
+    it "creates with encryption key if storage is encrypted" do
+      st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{encrypted: true}])
       expect(StorageKeyEncryptionKey.count).to eq(1)
       expect(st.vm.vm_storage_volumes.first.key_encryption_key_1_id).not_to be_nil
       expect(described_class.new(st).storage_secrets.count).to eq(1)


### PR DESCRIPTION
Changes the parameter list of `Prog::Vm::Nexus.assemble()` so we can create multiple storage volumes for a VM.

To do this, provide the `storage_volumes` to `assemble`. First item in this array represents boot disk.

For example, the following command will create 2 disks for the VM, an unencrypted boot disk with size 100G, and an encrypted extra disk with size 10G:

```
st1 = Prog::Vm::Nexus.assemble(mykey, dev_project.id,  storage_volumes:
  [{size_gib: 100, encrypted: false}, {size_gib: 10, encrypted: true}])
```

If you eliminate `size_gib` and/or `encrypted`, defaults will be used. So the following will create a boot disk with default size and encryption, and an extra disk with size 5 and not encrypted:

```
st1 = Prog::Vm::Nexus.assemble(mykey, dev_project.id,  storage_volumes:
  [{}, {size_gib: 5, encrypted: false}])
```