### PR TITLE
Delete temporary image file after converted it to .raw format

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -572,6 +572,8 @@ EOS
       # Images are presumed to be atomically renamed into the path,
       # i.e. no partial images will be passed to qemu-image.
       r "qemu-img convert -p -f qcow2 -O raw #{temp_path.shellescape} #{image_path.shellescape}"
+
+      rm_if_exists(temp_path)
     end
 
     image_path

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -166,6 +166,7 @@ RSpec.describe VmSetup do
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
       expect(vs).to receive(:r).with("curl -L10 -o /tmp/ubuntu-jammy.qcow2.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /tmp/ubuntu-jammy.qcow2.tmp /var/storage/images/ubuntu-jammy.raw")
+      expect(FileUtils).to receive(:rm_r).with("/tmp/ubuntu-jammy.qcow2.tmp")
 
       vs.download_boot_image("ubuntu-jammy")
     end


### PR DESCRIPTION
We don't need initial image after conversion. It takes up too much space for big images. i.e. GitHub runner image is 86GB.