### PR TITLE
Use GitHub Actions default runners instead of our custom runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   PUSH_IMAGE: ${{ github.event_name == 'workflow_dispatch' }}
 jobs:
   docker:
-    runs-on: ubicloud
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubicloud
+    runs-on: ubuntu-latest
 
     env:
       DB_USER: clover


### PR DESCRIPTION
I added runners manually. We will switch to GitHub App integration this week.