### PR TITLE
Add new location for GitHub Actions runners

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -8,14 +8,15 @@ module Option
     [Provider::HETZNER, "Hetzner"]
   ].map { |args| [args[0], Provider.new(*args)] }.to_h.freeze
 
-  Location = Struct.new(:provider, :name, :display_name)
+  Location = Struct.new(:provider, :name, :display_name, :visible)
   Locations = [
-    [Providers[Provider::HETZNER], "hetzner-hel1", "Finland"],
-    [Providers[Provider::HETZNER], "hetzner-fsn1", "Germany"]
+    [Providers[Provider::HETZNER], "hetzner-hel1", "Finland", true],
+    [Providers[Provider::HETZNER], "hetzner-fsn1", "Germany", true],
+    [Providers[Provider::HETZNER], "github-runners", "GitHub Runner", false]
   ].map { |args| Location.new(*args) }.freeze
 
-  def self.locations_for_provider(provider)
-    Option::Locations.select { provider.nil? || _1.provider.name == provider }
+  def self.locations_for_provider(provider, only_visible: true)
+    Option::Locations.select { (!only_visible || _1.visible) && (provider.nil? || _1.provider.name == provider) }
   end
 
   BootImage = Struct.new(:name, :display_name)

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -35,7 +35,7 @@ module Validation
   end
 
   def self.validate_location(location, provider = nil)
-    available_locs = Option.locations_for_provider(provider).map(&:name)
+    available_locs = Option.locations_for_provider(provider, only_visible: false).map(&:name)
     msg = "\"#{location}\" is not a valid location for provider \"#{provider}\". Available locations: #{available_locs}"
     fail ValidationFailed.new({provider: msg}) unless available_locs.include?(location)
   end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -24,7 +24,7 @@ class Prog::Vm::GithubRunner < Prog::Base
         name: ubid.to_s,
         size: "standard-2",
         unix_user: "runner",
-        location: "hetzner-hel1",
+        location: "github-runners",
         boot_image: "github-ubuntu-2204",
         storage_size_gib: 86,
         enable_ip4: true,

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe Validation do
       it "valid locations" do
         [
           ["hetzner-hel1", nil],
-          ["hetzner-hel1", "hetzner"]
+          ["hetzner-hel1", "hetzner"],
+          ["github-runners", "hetzner"]
         ].each do |location, provider|
           expect(described_class.validate_location(location, provider)).to be_nil
         end

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -184,6 +184,15 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content "Project doesn't have valid billing information"
       end
 
+      it "can not select invisible location" do
+        project
+        visit "#{project.path}/vm/create"
+
+        expect(page.title).to eq("Ubicloud - Create Virtual Machine")
+
+        expect { choose option: "github-runners" }.to raise_error Capybara::ElementNotFound
+      end
+
       it "can not create vm in a project when does not have permissions" do
         project_wo_permissions
         visit "#{project_wo_permissions.path}/vm/create"


### PR DESCRIPTION
Self-hosted GitHub Actions runner image is 86GB. While provisioning a vm, we copy base image. It takes too much time.

As a workaround, we use "cp --reflink=auto" instead of "spdk_dd" for unencrypted disks at 3fe151b. This will make copying on file systems that support reflink much faster. It will just do a shallow copy and will copy blocks on write.

We format storage disk as btrfs at some VmHost, and set location for them as "github-runners"