### PR TITLE
Add GitHub runner unix user to more groups

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -93,6 +93,9 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   label def register_runner
     unless github_runner.runner_id
+      # runner unix user needed access to manipulate the Docker daemon.
+      # Default GitHub hosted runners have additional adm,systemd-journal groups.
+      vm.sshable.cmd("sudo usermod -a -G docker,adm,systemd-journal runner")
       # We use generate-jitconfig instead of registration-token because it's
       # recommended by GitHub for security reasons.
       # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-just-in-time-runners

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#register_runner" do
     it "generates runner if not runner id not set and hops" do
       expect(github_runner).to receive(:runner_id).and_return(nil)
+      expect(sshable).to receive(:cmd).with("sudo usermod -a -G docker,adm,systemd-journal runner")
       expect(client).to receive(:post).with(/.*generate-jitconfig/, anything).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC"})
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo -u runner /home/runner/run.sh --jitconfig AABBCC' runner-script")
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check runner-script").and_return("InProgress")


### PR DESCRIPTION
While testing container based workflows, I found that the GitHub runner unix user needed access to manipulate the Docker daemon, otherwise crashing with:

    permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.

Fixing this is normally achieved by adding the user to the `docker` group, but suspecting that our implementation may be missing other groups, I ran `groups` on GitHub's implementation of the runners, and it returned the following:

    docker adm systemd-journal

This patch reaches parity with their implementation.
