### PR TITLE
Add more labels for GitHub runners to choose vm size

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -1,0 +1,5 @@
+- { name: ubicloud, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2, vm_size: standard-2, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-4, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-8, vm_size: standard-8, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-16, vm_size: standard-16, boot_image: github-ubuntu-2204, location: github-runners }

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -2,6 +2,7 @@
 
 require "octokit"
 require "jwt"
+require "yaml"
 
 module Github
   def self.oauth_client
@@ -25,5 +26,9 @@ module Github
     access_token = app_client.create_app_installation_access_token(installation_id)[:token]
 
     Octokit::Client.new(access_token: access_token)
+  end
+
+  def self.runner_labels
+    @@runner_labels ||= YAML.load_file("config/github_runner_labels.yml").to_h { [_1["name"], _1] }
   end
 end

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -57,7 +57,7 @@ class CloverWeb
     unless (installation = GithubInstallation[installation_id: data["installation"]["id"]])
       return error("Unregistered installation")
     end
-    unless data["workflow_job"]["labels"].include?("ubicloud")
+    unless (label = data["workflow_job"]["labels"].find { Github.runner_labels.key?(_1) })
       return error("Unmatched label")
     end
 
@@ -65,7 +65,7 @@ class CloverWeb
       st = Prog::Vm::GithubRunner.assemble(
         installation,
         repository_name: data["repository"]["full_name"],
-        label: "ubicloud"
+        label: label
       )
       runner = GithubRunner[st.id]
 


### PR DESCRIPTION
 We use runner labels determine runner size.

Label format is `ubicloud-<size>`.

For example when user specify workflow label as `runs-on: ubicloud-standard-8`, we provision runner as standard-8.

When user doesn't specify size, we use default "standard-4" for it.
Some valid labels:
```
label                           vm_size
ubicloud                        standard-4
ubicloud-standard-2             standard-2
ubicloud-standard-8             standard-8
```

We keep list of valid runner labels at "config/github_runner_labels.yml". Hard-coded list makes easier to read and maintain.

I'm planning to add boot_image and location to labels too, but currently we have only a special location and ubuntu-2204 for runners. I will add it when we have GitHub Actions runners at all locations.
