### PR TITLE
Add "flat" support to loader

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -31,15 +31,15 @@ AUTOLOAD_CONSTANTS = []
 # Set up autoloads using Unreloader using a style much like Zeitwerk:
 # directories are modules, file names are classes.
 autoload_normal = ->(subdirectory, include_first: false) do
+  absolute = File.join(__dir__, subdirectory)
+  rgx = Regexp.new('\A' + Regexp.escape((File.file?(absolute) ? File.dirname(absolute) : absolute) + "/") + '(.*)\.rb\z')
+  last_namespace = nil
+
   # Copied from sequel/model/inflections.rb's camelize, to convert
   # file paths into module and class names.
   camelize = ->(s) do
     s.gsub(/\/(.?)/) { |x| "::#{x[-1..].upcase}" }.gsub(/(^|_)(.)/) { |x| x[-1..].upcase }
   end
-
-  absolute = File.join(__dir__, subdirectory)
-  rgx = Regexp.new('\A' + Regexp.escape((File.file?(absolute) ? File.dirname(absolute) : absolute) + "/") + '(.*)\.rb\z')
-  last_namespace = nil
 
   Unreloader.autoload(absolute) do |f|
     full_name = camelize.call((include_first ? subdirectory + File::SEPARATOR : "") + rgx.match(f)[1])


### PR DESCRIPTION

In the case of models, I think it'd be useful to load all constants
into a flat, topmost namespace even if the files are organized in a
directory format.

There are two motivators:

1. Sequel requires specifying "class:" keywords onto every association
   if the target is not in the same module, e.g.:

        one_to_one :strand, key: :id, class: Strand

    It would be nice not to have to specify this all the time.

2. It encourages repetitive identifiers, e.g.

        class Postgres::PostgresServer

   To name this `Postgres::Server`, causes Sequel's to presume the
   database table name is also `server`

Both issues can be resolved by telegraphing information to Sequel in a
few annoying places per occurrence, but why bother?  I think it's
enough that directories allow running `git log $subdirectory` or
viewing `git diff --stat` and see what's going on.  It's not strictly
necessary they organize into modules/namespaces in Ruby.

So, with that in mind, load `models` differently, with the new `flat`
flag that ignores directories as it comes to module
creation/namespaces.

Example:

    $ mkdir model/test
    $ echo 'class Nested; end' > model/test/nested.rb
    $ ./bin/pry
    > Nested
    Nested

