### PR TITLE
Resolve pages created from budded Progs at exit time

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -86,6 +86,9 @@ end
     else
       fail "BUG: expect no stacks exceeding depth 1 with no back-link" if strand.stack.length > 1
 
+      pg = Page.from_tag_parts(strand.id, strand.prog, strand.stack.first["deadline_target"])
+      pg&.incr_resolve
+
       # Child strand with zero or one stack frames, set exitval. Clear
       # retval to avoid confusion, as it would have been set in a
       # previous intra-strand stack pop.

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -93,6 +93,11 @@ class Prog::Test < Prog::Base
     push Prog::Test, {}, :set_popping_deadline2
   end
 
+  label def set_popping_deadline_via_bud
+    bud Prog::Test, {}, :set_popping_deadline2
+    hop_reaper
+  end
+
   label def set_popping_deadline2
     register_deadline(:pusher2, -1)
     hop_popper

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -184,6 +184,23 @@ RSpec.describe Prog::Base do
       }.to change { Page.active.count }.from(1).to(0)
     end
 
+    it "resolves the page of the budded prog when pop" do
+      st = Strand.create_with_id(prog: "Test", label: :set_popping_deadline_via_bud)
+      st.unsynchronized_run
+      st.unsynchronized_run
+      expect {
+        st.unsynchronized_run
+      }.to change { Page.active.count }.from(0).to(1)
+
+      expect {
+        st.unsynchronized_run
+
+        page_id = Page.first.id
+        Strand[page_id].unsynchronized_run
+        Strand[page_id].unsynchronized_run
+      }.to change { Page.active.count }.from(1).to(0)
+    end
+
     it "resolves the page once the target is reached" do
       st = Strand.create_with_id(prog: "Test", label: :napper)
       page_id = Prog::PageNexus.assemble("dummy-summary", st.id, st.prog, :napper).id


### PR DESCRIPTION
We simply missed this branch. Without this change if budded progs creates a page, then exits, we don't automatically resolve the created page. This is because budded Progs don't have back link, thus they hit else branch in pop, which used to not resolve pages.