### PR TITLE
Add Project:billing and Project:github actions to documentation

### DIFF
--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -309,6 +309,16 @@ RSpec.describe Clover, "project" do
         expect(page.status_code).to eq(404)
         expect(page).to have_content "Resource not found"
       end
+
+      it "shows all default actions at documentation" do
+        visit "#{project.path}/policy"
+
+        default_actions = Authorization.generate_default_acls(nil, nil)[:acls].flat_map { _1[:actions] }
+
+        within "table" do
+          default_actions.each { expect(page).to have_content(_1) }
+        end
+      end
     end
 
     describe "delete" do

--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -80,6 +80,14 @@
               <td class="px-2 py-2 border">Grants permission to update Project's access policies</td>
             </tr>
             <tr>
+              <td class="px-2 py-2 border">Project:billing</td>
+              <td class="px-2 py-2 border">Grants permission to manage Project's billing informations</td>
+            </tr>
+            <tr>
+              <td class="px-2 py-2 border">Project:github</td>
+              <td class="px-2 py-2 border">Grants permission to manage Project's GitHub runner integration</td>
+            </tr>
+            <tr>
               <td class="px-2 py-2 border">PrivateSubnet:view</td>
               <td class="px-2 py-2 border">Grants permission to view Private Subnet details.</td>
             </tr>


### PR DESCRIPTION
We have a short documentation at access policy page. I forgot to add new feature actions to it.

Also I wrote a test case to not forget it again.