### PR TITLE
Change no active runner text

### DIFF
--- a/views/project/github.erb
+++ b/views/project/github.erb
@@ -68,10 +68,11 @@
             <% else %>
               <tr>
                 <td colspan="5">
-                  <div class="text-center text-xl p-4">
-                    No active runners. Change
-                    <span class="text-rose-500 bg-slate-200 py-0.5 px-2 rounded font-mono">runs-on: ubicloud</span>
-                    in a workflow file and trigger workflow to start a runner.
+                  <div class="text-center p-4">
+                    No active runners. In your workflow file, change the
+                    <span class="text-rose-500 bg-slate-100 py-0.5 px-2 rounded font-mono whitespace-nowrap">runs-on: ...</span>
+                    line to
+                    <span class="text-rose-500 bg-slate-100 py-0.5 px-2 rounded font-mono whitespace-nowrap">runs-on: ubicloud</span>. Then, trigger your workflow to start a runner.
                   </div>
                 </td>
               </tr>


### PR DESCRIPTION
It was bigger than other texts at page. It was looking odd. Also we made text a little bit clear.

Before:
<img width="1512" alt="before" src="https://github.com/ubicloud/ubicloud/assets/993199/3b55ce28-983e-4327-8bb5-73b09a09c1bf">

After:
<img width="1511" alt="after" src="https://github.com/ubicloud/ubicloud/assets/993199/a35c8305-cfce-4a59-9475-6a62542a96d8">
