### PR TITLE
Add custom systemd-resolved configuration to GitHub runners

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -95,6 +95,15 @@ class Prog::Vm::GithubRunner < Prog::Base
     # https://github.com/microsoft/azure-pipelines-agent/issues/3461
     vm.sshable.cmd("echo \"PATH=$PATH\" >> .env")
 
+    # Docker containers can't resolve DNS addresses by default on our networking
+    # setup. We will investigate it in depth, and try to find more generic solution.
+    # Related issue: https://github.com/ubicloud/ubicloud/issues/507
+    # Until proper fix, we add custom systemd-resolved configuration.
+    # Docker gets resolve.conf content from systemd-resolved service.
+    vm.sshable.cmd("sudo mkdir -p /etc/systemd/resolved.conf.d")
+    vm.sshable.cmd("sudo sh -c 'echo \"[Resolve]\nDNS=9.9.9.9 149.112.112.112 2620:fe::fe 2620:fe::9\" > /etc/systemd/resolved.conf.d/Ubicloud.conf'")
+    vm.sshable.cmd("sudo systemctl restart systemd-resolved.service")
+
     hop_bootstrap_rhizome
   end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -97,6 +97,9 @@ RSpec.describe Prog::Vm::GithubRunner do
     expect(sshable).to receive(:cmd).with(/\/opt\/post-generation/)
     expect(sshable).to receive(:invalidate_cache_entry)
     expect(sshable).to receive(:cmd).with("echo \"PATH=$PATH\" >> .env")
+    expect(sshable).to receive(:cmd).with("sudo mkdir -p /etc/systemd/resolved.conf.d")
+    expect(sshable).to receive(:cmd).with("sudo sh -c 'echo \"[Resolve]\nDNS=9.9.9.9 149.112.112.112 2620:fe::fe 2620:fe::9\" > /etc/systemd/resolved.conf.d/Ubicloud.conf'")
+    expect(sshable).to receive(:cmd).with("sudo systemctl restart systemd-resolved.service")
 
     expect { nx.setup_environment }.to hop("bootstrap_rhizome")
   end


### PR DESCRIPTION
While testing some GitHub Actions workflows, I found that docker containers on the GitHub runner can't resolve DNS addresses and fails with:

    failed to solve: ruby:3.2.2-alpine3.17: failed to do request:
    Head "https://registry-1.docker.io/v2/library/ruby/manifests/3.2.2-alpine3.17":
    dial tcp: lookup registry-1.docker.io on 192.168.0.1:53: read udp
    172.17.0.2:48484->192.168.0.1:53: i/o timeout

Even simple `docker run -it alpine:3:17 ping google.com` can't resolve DNS.

It looks like somehow depends on our networking setup. Containers on my local docker setup can resolve DNS by default. Also Digital Ocean has "/etc/systemd/resolved.conf.d/DigitalOcean.conf" config.

Docker gets resolve.conf content from systemd-resolved service. We can add additional DNS records to it. Until proper fix, we add custom systemd-resolved configuration.

https://github.com/ubicloud/ubicloud/issues/507