### PR TITLE
Print ubids when paging

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -92,7 +92,7 @@ SQL
       next unless (deadline_at = frame["deadline_at"])
 
       if Time.now > Time.parse(deadline_at.to_s)
-        Prog::PageNexus.assemble("Strand[#{id}] has an expired deadline! #{prog} did not reach #{frame["deadline_target"]} on time", id, prog, frame["deadline_target"])
+        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog} did not reach #{frame["deadline_target"]} on time", id, prog, frame["deadline_target"])
 
         modified!(:stack)
       end


### PR DESCRIPTION
It's more terse, and easier to double-click these to select, plus the first two bytes can convey useful type information.

There is a small downside: previously, `Strand[uuid]` was closer to an expression to *always* get a strand value, and often, the first thing I want to do with a deadline violation is `.run`.

But seeing that selection with the `-[]` characters is hard, and what's printed isn't even a valid expression anyway (no quotes), let's move to UBID and I think there are other ways to streamline getting the Strand value.