### PR TITLE
Do not try to destroy runner vm if it's already deleted

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -175,9 +175,11 @@ class Prog::Vm::GithubRunner < Prog::Base
     rescue Octokit::NotFound
     end
 
-    vm.private_subnets.each { _1.incr_destroy }
-    vm.sshable.destroy
-    vm.incr_destroy
+    if vm
+      vm.private_subnets.each { _1.incr_destroy }
+      vm.sshable.destroy
+      vm.incr_destroy
+    end
 
     hop_wait_vm_destroy
   end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -229,6 +229,18 @@ RSpec.describe Prog::Vm::GithubRunner do
 
       expect { nx.destroy }.to hop("wait_vm_destroy")
     end
+
+    it "does not destroy vm if it's already destroyed" do
+      expect(nx).to receive(:register_deadline)
+      expect(nx).to receive(:decr_destroy)
+      expect(client).to receive(:get).and_raise(Octokit::NotFound)
+      expect(client).not_to receive(:delete)
+      expect(github_runner).to receive(:vm).and_return(nil)
+      expect(sshable).not_to receive(:destroy)
+      expect(vm).not_to receive(:incr_destroy)
+
+      expect { nx.destroy }.to hop("wait_vm_destroy")
+    end
   end
 
   describe "#wait_vm_destroy" do


### PR DESCRIPTION
Vm can be deleted via UI or respirate might run label again. So if vm is already deleted, we should not try to delete it. "vm" returns nil, and fails with "NoMethodError".