### PR TITLE
Do not hop to destroy label if it's already passed for GitHub runner

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -59,7 +59,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if strand.label != "destroy"
+      unless ["destroy", "wait_vm_destroy"].include?(strand.label)
         hop_destroy
       end
     end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(nx.strand).to receive(:label).and_return("destroy")
       expect { nx.before_run }.not_to hop("destroy")
     end
+
+    it "does not hop to destroy if already in the wait_vm_destroy state" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.strand).to receive(:label).and_return("wait_vm_destroy")
+      expect { nx.before_run }.not_to hop("destroy")
+    end
   end
 
   describe "#start" do


### PR DESCRIPTION
"destroy" semaphore has priority. When it's increased, strand hops to destroy label regardless of the current label. Only it's not hop if it's already hopped destroy.

GithubRunner prog has a label after destroy label and waits associated vm to be destroyed. While waiting, if destroy semaphore increased again (i.e. GitHub sent a completed event to webhook), runner hops to destroy label again.

If runner is waiting vm destroy already, should not hop back to destroy.

https://github.com/ubicloud/ubicloud/pull/594 fixes symptom, this one fixes root cause.

Still we need to fix symptom, because vm can be deleted without runner's involvement.