### PR TITLE
Use bigger runner for build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   PUSH_IMAGE: ${{ github.event_name == 'workflow_dispatch' }}
 jobs:
   docker:
-    runs-on: ubicloud
+    runs-on: ubicloud-standard-8
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Building docker image has CPU bottleneck. Let's use bigger runners to build it. We are the landlord.

I didn't change runner size for test pipeline because more CPU power doesn't speed it up.