### PR TITLE
Allow multiple billing records per resource

### DIFF
--- a/migrate/20230914_multiple_billing_records_per_resource.rb
+++ b/migrate/20230914_multiple_billing_records_per_resource.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:billing_record) do
+      drop_constraint(:billing_record_resource_id_span_excl)
+      add_exclusion_constraint([[:resource_id, "="], [:billing_rate_id, "="], [:span, "&&"]])
+    end
+  end
+
+  down do
+    alter_table(:billing_record) do
+      drop_constraint(:billing_record_resource_id_billing_rate_id_span_excl)
+      add_exclusion_constraint([[:resource_id, "="], [:span, "&&"]])
+    end
+  end
+end


### PR DESCRIPTION
Some resources might have multiple components that are billed separately. For example PostgreSQL resource would have vCPU and storage components. Currently the exclusion constraint doesn't allow multiple billing records per resource. This commit adds billing_rate_id to the exclusion constraint to allow multiple billing records per resource as long as their billing_rate_id is different.