### PR TITLE
Do not allow to create GitHub runner without a valid payment method

### DIFF
--- a/routes/web/project/github.rb
+++ b/routes/web/project/github.rb
@@ -12,12 +12,16 @@ class CloverWeb
     r.get true do
       @installations = Serializers::Web::GithubInstallation.serialize(@project.github_installations)
       @runners = Serializers::Web::GithubRunner.serialize(@project.github_installations_dataset.eager(runners: :vm).flat_map(&:runners).sort_by(&:created_at).reverse)
+      @has_valid_payment_method = @project.has_valid_payment_method?
 
       view "project/github"
     end
 
     r.on "installation" do
       r.get "create" do
+        unless @project.has_valid_payment_method?
+          fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"})
+        end
         session[:github_installation_project_id] = @project.id
 
         r.redirect "https://github.com/apps/#{Config.github_app_name}/installations/new", 302

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -50,6 +50,23 @@ RSpec.describe Clover, "github" do
       expect(page.driver.request.session["login_redirect"]).to eq("/apps/runner-app/installations/new")
     end
 
+    it "can not connect GitHub account if project has no valid payment method" do
+      expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
+      expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
+
+      visit "#{project.path}/github"
+
+      expect(page.title).to eq("Ubicloud - GitHub Runners")
+      expect(page).to have_content "Project doesn't have valid billing information"
+
+      click_link "Connect New Account"
+
+      expect(page.status_code).to eq(200)
+      expect(page.title).to eq("Ubicloud - GitHub Runners")
+      expect(page).to have_content "Project doesn't have valid billing information"
+      expect(page.driver.request.session["login_redirect"]).not_to eq("/apps/runner-app/installations/new")
+    end
+
     it "can list installations" do
       ins1 = GithubInstallation.create_with_id(installation_id: 111, name: "test-user", type: "User", project_id: project.id)
       ins2 = GithubInstallation.create_with_id(installation_id: 222, name: "test-org", type: "Organization", project_id: project.id)

--- a/views/components/billing_warning.erb
+++ b/views/components/billing_warning.erb
@@ -1,0 +1,17 @@
+<% unless @has_valid_payment_method %>
+  <div class="-mt-6 mb-2 rounded-md bg-red-50 p-4">
+    <div class="flex items-center">
+      <div class="flex-shrink-0">
+        <%== render("components/icon", locals: { name: "hero-banknotes", classes: "h-9 w-9 text-red-400" }) %>
+      </div>
+      <div class="ml-3">
+        <h3 class="text-sm font-medium text-red-700">
+          Project doesn't have valid billing information. You have to create project's billing details first.
+          <br>
+          <a href="<%= @project_data[:path] %>/billing" class="font-bold text-red-800">Click here</a>
+          to create billing details.
+        </h3>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/views/project/github.erb
+++ b/views/project/github.erb
@@ -1,5 +1,7 @@
 <% @page_title = "GitHub Runners" %>
 
+<%== render("components/billing_warning") %>
+
 <% if @installations.count > 0 %>
   <div class="space-y-1">
     <%== render(

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -1,20 +1,6 @@
 <% @page_title = "Create Virtual Machine" %>
 
-<% unless @has_valid_payment_method %>
-  <div class="-mt-6 mb-2 rounded-md bg-red-50 p-4">
-    <div class="flex items-center">
-      <div class="flex-shrink-0">
-        <%== render("components/icon", locals: { name: "hero-banknotes", classes: "h-9 w-9 text-red-400" }) %>
-      </div>
-      <div class="ml-3">
-        <h3 class="text-sm font-medium text-red-700">
-          Project doesn't have valid billing information. You have to create project's billing details first. <br>
-          <a href="<%= @project_data[:path] %>/billing" class="font-bold text-red-800">Click here</a> to create billing details.
-        </h3>
-      </div>
-    </div>
-  </div>
-<% end %>
+<%== render("components/billing_warning") %>
 
 <div class="space-y-1">
   <%== render(


### PR DESCRIPTION
We don't allow the creation of new virtual machines without a valid payment method.

We need to implement a similar check for GitHub runners, ensuring that GitHub accounts cannot be connected without a valid payment method.