### PR TITLE
Change the default GitHub runner size from 4vCPU to 2vCPU

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -1,4 +1,4 @@
-- { name: ubicloud, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud, vm_size: standard-2, boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-2, vm_size: standard-2, boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-4, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-8, vm_size: standard-8, boot_image: github-ubuntu-2204, location: github-runners }


### PR DESCRIPTION
The current VM size for the default "ubicloud" label is "standard-4". This means that when a customer adds "runs-on: ubicloud" to their workflow file, we create standard-4 runners. However, GitHub uses 2vCPU runners by default. So when a user migrates to our runners, we implicitly change the vCPU count.

Furthermore, our value proposition is x10 cost reduction, achievable with the same vCPU count.

Therefore, we have decided to change the default runner size to "standard-2".

If a customer desires a larger machine, they can use another labels, such as "ubicloud-standard-8".