### PR TITLE
Remove dead code dump_timeout

### DIFF
--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -4,8 +4,7 @@ class Scheduling::Dispatcher
   attr_reader :threads
 
   def initialize
-    @dump_timeout = 1
-    @apoptosis_timeout = Strand::LEASE_EXPIRATION - @dump_timeout - 29
+    @apoptosis_timeout = Strand::LEASE_EXPIRATION - 29
     @threads = []
   end
 

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe Scheduling::Dispatcher do
         th[:clover_test_in] = r
 
         di.instance_variable_set(:@apoptosis_timeout, 0)
-        di.instance_variable_set(:@dump_timeout, 0)
         Strand.create_with_id(prog: "Test", label: "wait_exit")
         di.start_cohort
         w.close


### PR DESCRIPTION
This code dates back to stall supervision/watchdogs were based on Ractors, in a bid to get better isolation.  Ractor usage was removed in e6f82420cb956a5d4bd9940365fbf2b6cf80936d, leaving this code without function.