### PR TITLE
Schedule work continuously in dispatcher

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -6,7 +6,7 @@ require_relative "../loader"
 d = Scheduling::Dispatcher.new
 
 loop do
-  d.wait_cohort
   d.start_cohort
+  next if d.wait_cohort > 0
   sleep 5
 end


### PR DESCRIPTION
The way work is scheduled hasn't gotten an upgrade since it was
introduced, in 87c2b3a21e321ee5bb6e41e3c401b0f94528b9b3.  It became an
acute issue affecting GitHub Action Runners, which were suffering
excessive start-up time, with tens of seconds to over a minute
attributed to Dispatcher scheduling delay.

How did this delay occur with our trivial workloads? The problem was
every five seconds...and *only* every five seconds...a work "cohort"
would be scheduled.  At the next elapsed five second interval, any
completed work threads would be reaped, and new work started in its
place.

This is inefficient when work item completion time is much less than
the polling interval, which is precisely what happens with many
strands in the "wait" label that call "nap" immediately: they finish
execution in milliseconds, but occupy the five-second time slot until
the next cohort scheduling.

To fix this, this patch avoids waiting five seconds for every cohort.
Instead, new work is scheduled almost immediately after old work is
completed.

The way this is done is by using another pipe and the `IO.select`
system call.  Because `select` accepts multiple file descriptors in
one call, it's possible to respond the moment any one them change in
state, e.g. having been closed.  So now, `wait_cohort` blocks until at
least one thread changes in state, by finishing, and one end of the
"notify" pipe.

== Comparing and Contrasting Apoptosis

In this, the code looks similar to the "apoptosis" mechanism used for
mutual exclusion (see cfa975e78188b82b5019ec75195657c015af7062): both
use pipes where the write-half is closed at completion.

However, the two use `IO.select` differently: `apoptosis` uses
`select` for its "timeout" feature, so that it can exit the entire
process before mutual exclusion can be violated.  However, each call
to `IO.select` here only passes one file descriptor.

Whereas, this completion-notification use of `select` doesn't use a
timeout, but instead passes multiple file descriptors at once.  This
allows it to wake up the moment one or more file descriptors change
their state, by being closed by a completed unit of work.