### PR TITLE
Add exponential backoff

### DIFF
--- a/migrate/20230914_add_exponential_backoff.rb
+++ b/migrate/20230914_add_exponential_backoff.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :strand do
+      add_column :try, Integer, default: 0, null: false
+    end
+  end
+end


### PR DESCRIPTION
On the basis of previous experience, it's been bothering me for some
time that strands that crash or fail to terminate will be scheduled
often, and in fact, more often than code that takes even a short nap,
since "schedule" is set to "now()", to implement a round-robin
approach (bc4911fae065b19d9e1175e557b826bab8ca28a0).

This patch implements an exponential backoff algorithm with jitter, so
that strands that do not raise `FlowControl` exceptions per normal
will receive less execution time.

The most important, subtle aspect of this patch is how failure is
*assumed* in the initial lease-taking `UPDATE` statement, and only on
successful executions is the `try` count re-set to zero.  The reason
for this is that the code executed by Strand is capable of
non-termination.  Thus, the code is written such that failure is
assumed, and effectively backed-out when a `FlowControl` exception is
raised, and schedule is overwritten a second time.  The previous,
simpler, always-round-robin-at-least code from before was designed on
a similar principle, updating first, then updating again.

However, this forward-dating and back-dating of both `try` and
`schedule` can piggyback on other queries and can be HOT updated in
Postgres, so the anticipated added cost is minuscule.
