### PR TITLE
Use the latest version of the GitHub runner script

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -121,9 +121,15 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def install_actions_runner
-    vm.sshable.cmd("curl -o actions-runner-linux-x64-2.308.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.308.0/actions-runner-linux-x64-2.308.0.tar.gz")
-    vm.sshable.cmd("echo '9f994158d49c5af39f57a65bf1438cbae4968aec1e4fec132dd7992ad57c74fa  actions-runner-linux-x64-2.308.0.tar.gz' | shasum -a 256 -c")
-    vm.sshable.cmd("tar xzf ./actions-runner-linux-x64-2.308.0.tar.gz")
+    # Adapted from https://github.com/actions/runner/blob/2908d82845c018193655e68f3c20a5ad03bc0efd/scripts/create-latest-svc.sh#L140
+    vm.sshable.cmd(<<CMD)
+latest_version_label=$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')
+latest_version=$(echo ${latest_version_label:1})
+runner_file="actions-runner-linux-x64-${latest_version}.tar.gz"
+runner_url="https://github.com/actions/runner/releases/download/${latest_version_label}/${runner_file}"
+curl -o "${runner_file}" -L "${runner_url}"
+tar xzf "./${runner_file}"
+CMD
 
     hop_register_runner
   end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -137,10 +137,14 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#install_actions_runner" do
     it "downloads and hops to register_runner" do
-      expect(sshable).to receive(:cmd).with(/curl -o actions-runner-linux-x64.*tar.gz/)
-      expect(sshable).to receive(:cmd).with(/echo.*| shasum -a 256 -c/)
-      expect(sshable).to receive(:cmd).with(/tar xzf.*tar.gz/)
-
+      expect(sshable).to receive(:cmd).with(<<EXPECTED)
+latest_version_label=$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')
+latest_version=$(echo ${latest_version_label:1})
+runner_file="actions-runner-linux-x64-${latest_version}.tar.gz"
+runner_url="https://github.com/actions/runner/releases/download/${latest_version_label}/${runner_file}"
+curl -o "${runner_file}" -L "${runner_url}"
+tar xzf "./${runner_file}"
+EXPECTED
       expect { nx.install_actions_runner }.to hop("register_runner")
     end
   end


### PR DESCRIPTION
When using an older version, GitHub displays the following warning:

    This job failure may be caused by using an out of date self-hosted
    runner. You are currently using runner version 2.308.0. Please
    update to the latest version 2.309.0

It's best to use the latest version

I was inspired by this script:
https://github.com/actions/runner/blob/2908d82845c018193655e68f3c20a5ad03bc0efd/scripts/create-latest-svc.sh#L140