### PR TITLE
Don't try to purge_storage if storage hasn't been created yet.

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -114,6 +114,9 @@ class VmSetup
   end
 
   def purge_storage
+    # Storage hasn't been created yet, so nothing to purge.
+    return if !File.exist?(vp.storage_root)
+
     params = JSON.parse(File.read(vp.prep_json))
     params["storage_volumes"].each { |disk|
       device_id = disk["device_id"]

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -229,6 +229,7 @@ RSpec.describe VmSetup do
         ]
       })
 
+      expect(File).to receive(:exist?).with("/var/storage/test").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
 
       # delete the unencrypted volume
@@ -245,6 +246,11 @@ RSpec.describe VmSetup do
 
       expect(FileUtils).to receive(:rm_r).with("/var/storage/test")
 
+      vs.purge_storage
+    end
+
+    it "exits silently if storage hasn't been created yet" do
+      expect(File).to receive(:exist?).with("/var/storage/test").and_return(false)
       vs.purge_storage
     end
   end


### PR DESCRIPTION
If a VM is destroyed early on before anything has been created, then storage artifacts won't exist, and there's nothing there to be deleted.

We got to know of this issue when we get an exception which tried to read `prep.json` in `purge_storage` and it didn't exist. In which case if everything was done in correct order, storage root shouldn't also exist, and this patch handles that case.

On the other hand, if `prep.json` doesn't exist and storage root exists, that's an exceptional case and we should still raise an error.