### PR TITLE
Do not raise an exception while destroying a private subnet has active nics

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -113,8 +113,11 @@ class Prog::Vnet::SubnetNexus < Prog::Base
   end
 
   label def destroy
+    register_deadline(nil, 10 * 60)
+
     if private_subnet.nics.any? { |n| !n.vm_id.nil? }
-      fail "Cannot destroy subnet with active nics, first clean up the attached resources"
+      puts "Cannot destroy subnet with active nics, first clean up the attached resources"
+      nap 5
     end
 
     decr_destroy

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -363,7 +363,10 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "fails if there are active resources" do
       expect(ps).to receive(:nics).and_return([nic])
       expect(nic).to receive(:vm_id).and_return("vm-id")
-      expect { nx.destroy }.to raise_error RuntimeError, "Cannot destroy subnet with active nics, first clean up the attached resources"
+
+      expect do
+        expect { nx.destroy }.to nap(5)
+      end.to output("Cannot destroy subnet with active nics, first clean up the attached resources\n").to_stdout
     end
 
     it "increments the destroy semaphore of nics" do


### PR DESCRIPTION
A private subnet cannot be deleted if it has active nics. Currently, it raises an exception in such cases. However, raising exceptions doesn't offer any benefits and only clutters the logs with stack traces. Additionally, when a deletion attempt fails, it immediately retries. Daniel has implemented a backoff mechanism (#607), but let's reserve it for handling unexpected errors.

This situation is expected when both the private subnet's destroy semaphore and the virtual machine's destroy semaphore are increased. Eventually, the virtual machine will be deleted, followed by the deletion of the private subnet.

In addition, printing a log message and adding a 5-second nap reduce the load on respirate. Otherwise, it would repeatedly run 'PrivateSubnetNexus' until the virtual machine is deleted.

I registered a page for it; if it gets stuck indefinitely, we'll receive a page.

The recent increase in these logs is due to my actions. When destroying a GitHub runner, I simultaneously increase the destroy semaphore for both the subnet and the vm. I cannot wait for the vm's deletion before destroying the private subnet because the runner can only access the private subnet through the vm. Once the vm is deleted, the private subnet record becomes inaccessible from the runner