### PR TITLE
Rename CI workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  ruby-ci:
     runs-on: ubicloud
 
     env:


### PR DESCRIPTION
The CI job is displayed as 'build' on the GitHub UI, which can be confusing since we also have a docker build job. Using 'build' as the name for the CI job is not ideal.