### PR TITLE
Run E2E tests pipeline every midnight

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,12 +2,15 @@ name: E2E CI
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
 
 jobs:
   run-ci:
     runs-on: ubuntu-latest
     environment: E2E-CI
     timeout-minutes: 30
+    concurrency: e2e_environment
 
     env:
       DB_USER: clover


### PR DESCRIPTION
We do not run the E2E CI for each PR because it takes approximately 15 minutes, and we have only one sacrificial server at Hetzner. This would significantly slow down our development speed.

Instead, Hadi runs this pipeline from time to time.

To ensure that everything is working correctly, we may schedule it to run every midnight.

Since we have a single server at Hetzner, I added a 'concurrency' group to ensure that only one job with the same concurrency group will run at a time.