### PR TITLE
Don't fail destroy if hugepages hasn't been allocated

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -104,7 +104,7 @@ class VmSetup
     r "systemctl daemon-reload"
 
     purge_storage
-    r "umount #{vp.q_hugepages}"
+    unmount_hugepages
 
     begin
       r "deluser --remove-home #{q_vm}"
@@ -140,6 +140,12 @@ class VmSetup
     }
 
     rm_if_exists(vp.storage_root)
+  end
+
+  def unmount_hugepages
+    r "umount #{vp.q_hugepages}"
+  rescue CommandFail => ex
+    raise unless /(no mount point specified)|(not mounted)|(No such file or directory)/.match?(ex.stderr)
   end
 
   def hugepages(mem_gib)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -262,10 +262,27 @@ RSpec.describe VmSetup do
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
       expect(vs).to receive(:r).with("systemctl daemon-reload")
       expect(vs).to receive(:purge_storage)
-      expect(vs).to receive(:r).with("umount /vm/test/hugepages")
+      expect(vs).to receive(:unmount_hugepages)
       expect(vs).to receive(:r).with("deluser --remove-home test")
 
       vs.purge
+    end
+  end
+
+  describe "#unmount_hugepages" do
+    it "can unmount hugepages" do
+      expect(vs).to receive(:r).with("umount /vm/test/hugepages")
+      vs.unmount_hugepages
+    end
+
+    it "exits silently if hugepages isn't mounted" do
+      expect(vs).to receive(:r).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: no mount point specified."))
+      vs.unmount_hugepages
+    end
+
+    it "fails if umount fails with an unexpected error" do
+      expect(vs).to receive(:r).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: wait, what?"))
+      expect { vs.unmount_hugepages }.to raise_error CommandFail
     end
   end
 


### PR DESCRIPTION
If VM provisioning didn't finish, then hugepage mount doesn't exist. Previously we errored out with something like the following:

```
umount: /vm/vm012345/hugepages: no mount point specified.
```

This patch handles that by allowing the mount point to not exist, or it not being mounted.