### PR TITLE
Add auto-refresh to the GitHub runner page

### DIFF
--- a/views/project/github.erb
+++ b/views/project/github.erb
@@ -3,6 +3,7 @@
 <%== render("components/billing_warning") %>
 
 <% if @installations.count > 0 %>
+  <div class="auto-refresh hidden" data-interval="10"></div>
   <div class="space-y-1">
     <%== render(
       "components/breadcrumb",


### PR DESCRIPTION
Previously, users had to refresh the page manually to see if active runners had changed.

I added auto-refresh on the GitHub runners page, which reloads the page every 10 seconds.

The vm detail and listing pages already have auto-refresh enabled.