### PR TITLE
Pin postgres version to 15.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:15.4
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:15.4
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   postgres:
-    image: postgres:15.2
+    image: postgres:15.4
     container_name: ubicloud-postgres
     env_file: .env
     ports:


### PR DESCRIPTION
PostgreSQL 16 has been released, and it includes some changes regarding the bootstrap user. Our CI using the latest tag, so it's using postgres:16 currently.  It  is failing with the following error.

    ERROR:  permission denied to alter role
    DETAIL:  The bootstrap user must have the SUPERUSER attribute.

We are using "postgres 15.4" at development and production.

I pin CI version to 15.4.

When we want to upgrade postgres 16, we may change all of them.