### PR TITLE
Idempotent & race condition free user create

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -237,7 +237,8 @@ SQL
   label def create_unix_user
     # create vm's user and home directory
     begin
-      host.sshable.cmd("sudo adduser --disabled-password --gecos '' --home #{vm_home.shellescape} #{q_vm}")
+      uid = rand(1100..59999)
+      host.sshable.cmd("sudo adduser --disabled-password --gecos '' --home #{vm_home.shellescape} --uid #{uid} #{q_vm}")
     rescue Sshable::SshError => ex
       raise unless /adduser: The user `.*' already exists\./.match?(ex.stderr)
     end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -235,13 +235,12 @@ SQL
   end
 
   label def create_unix_user
+    host.sshable.cmd("sudo userdel --remove --force #{q_vm} || true")
+    host.sshable.cmd("sudo groupdel -f #{q_vm} || true")
+
     # create vm's user and home directory
-    begin
-      uid = rand(1100..59999)
-      host.sshable.cmd("sudo adduser --disabled-password --gecos '' --home #{vm_home.shellescape} --uid #{uid} #{q_vm}")
-    rescue Sshable::SshError => ex
-      raise unless /adduser: The user `.*' already exists\./.match?(ex.stderr)
-    end
+    uid = rand(1100..59999)
+    host.sshable.cmd("sudo adduser --disabled-password --gecos '' --home #{vm_home.shellescape} --uid #{uid} #{q_vm}")
 
     hop_prep
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -172,32 +172,15 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#create_unix_user" do
-    let(:sshable) { instance_double(Sshable) }
-    let(:vm_host) { instance_double(VmHost, sshable: sshable) }
-
-    before do
-      expect(vm).to receive(:vm_host).and_return(vm_host)
-    end
-
     it "runs adduser" do
+      sshable = instance_double(Sshable)
+      vm_host = instance_double(VmHost, sshable: sshable)
+      expect(vm).to receive(:vm_host).and_return(vm_host)
+      expect(sshable).to receive(:cmd).with(/sudo.*userdel.*#{nx.vm_name}/)
+      expect(sshable).to receive(:cmd).with(/sudo.*groupdel.*#{nx.vm_name}/)
       expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/)
 
       expect { nx.create_unix_user }.to hop("prep")
-    end
-
-    it "absorbs an already-exists error as a success" do
-      expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/).and_raise(
-        Sshable::SshError.new("adduser", "", "adduser: The user `vmabc123' already exists.", 1, nil)
-      )
-
-      expect { nx.create_unix_user }.to hop("prep")
-    end
-
-    it "raises other errors" do
-      ex = Sshable::SshError.new("allocate a lot", "", "out of memory", 1, nil)
-      expect(sshable).to receive(:cmd).with(/sudo.*adduser.*#{nx.vm_name}/).and_raise(ex)
-
-      expect { nx.create_unix_user }.to raise_error ex
     end
   end
 


### PR DESCRIPTION
**Prevent race conditions in adduser**
In production, we hit multiple cases of group being created but user did not.
After closer inspection, we realized that adduser runs few subcommands like
useradd and groupadd. If there are concurrent adduser commands running, it is
possible that the first useradd and second groupadd command pick same id due
to race condition, thus causing adduser command to fail in midway and leave
half created users in the system. When there are half created users in the
system, next run of create_unix_user fails with "adduser: The group `xxxxxx'
already exists" and stucks.

As a solution, we assign random id between 1100 and 59999. Ids smaller than
1000 and larger than 59999 are soft-reserved by OS. We also reserve 100 ids
for our own users such as rhizome and spdk. If randomly generated id is in
use already, which has low probability because we wouldn't create more than
few hundred users on one host even in the case of shared cores, the command
would fail and we would retry adding user with a different id in next run.

**Make create_unix_user idempotent**
If adduser command fails midway, it can leave half created users behind. Trying
to recreate them in next iteration of the prog fails with "adduser: The group
`xxxxxx' already exists." error. We are deleting users and groups to make user
creation idempotent.