### PR TITLE
Change the string representation of models

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -48,6 +48,10 @@ module ResourceMethods
     @ubid ||= UBID.from_uuidish(id).to_s.downcase
   end
 
+  def to_s
+    "#{self.class.name}[#{ubid}]"
+  end
+
   NON_ARCHIVED_MODELS = ["DeletedRecord", "Semaphore"]
   def before_destroy
     model_name = self.class.name

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -157,7 +157,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       response = github_client.get("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")
       unless response[:busy]
         github_runner.incr_destroy
-        puts "Destroying GithubRunner[#{github_runner.ubid}] because it does not pick a job in two minutes"
+        puts "#{github_runner} Not pick a job in two minutes, destroying it"
         nap 0
       end
     end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -116,7 +116,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     register_deadline(nil, 10 * 60)
 
     if private_subnet.nics.any? { |n| !n.vm_id.nil? }
-      puts "Cannot destroy subnet with active nics, first clean up the attached resources"
+      puts "#{private_subnet} Cannot destroy subnet with active nics, first clean up the attached resources"
       nap 5
     end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
       expect do
         expect { nx.wait }.to nap(0)
-      end.to output("Destroying GithubRunner[#{github_runner.ubid}] because it does not pick a job in two minutes\n").to_stdout
+      end.to output("GithubRunner[#{github_runner.ubid}] Not pick a job in two minutes, destroying it\n").to_stdout
     end
 
     it "does not destroy runner if it doesn not pick a job but two minutes not pass yet" do

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
 
       expect do
         expect { nx.destroy }.to nap(5)
-      end.to output("Cannot destroy subnet with active nics, first clean up the attached resources\n").to_stdout
+      end.to output("PrivateSubnet[#{ps.ubid}] Cannot destroy subnet with active nics, first clean up the attached resources\n").to_stdout
     end
 
     it "increments the destroy semaphore of nics" do


### PR DESCRIPTION
The default string representation ("#<VmHost:0x000000010745e2c0>") is not very informative. I have updated it to include the class name and UBID ("VmHost[vhjb7qes85460kzqmpbh2n0nxg]"). While the UBID already contains class information, it looks better with the class name.

I have also added a resource suffix to the logs in progs.