### PR TITLE
Add head_branch info to the GitHub runners

### DIFF
--- a/migrate/20230919_add_branch_to_github_runner.rb
+++ b/migrate/20230919_add_branch_to_github_runner.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:github_runner) do
+      add_column :head_branch, :text, collate: '"C"'
+    end
+  end
+end

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -86,7 +86,8 @@ class CloverWeb
         job_id: data["workflow_job"]["id"],
         job_name: data["workflow_job"]["name"],
         run_id: data["workflow_job"]["run_id"],
-        workflow_name: data["workflow_job"]["workflow_name"]
+        workflow_name: data["workflow_job"]["workflow_name"],
+        head_branch: data["workflow_job"]["head_branch"]
       )
 
       success("GithubRunner[#{runner.ubid}] picked job #{runner.job_id}")

--- a/serializers/web/github_runner.rb
+++ b/serializers/web/github_runner.rb
@@ -15,6 +15,7 @@ class Serializers::Web::GithubRunner < Serializers::Base
       job_name: runner.job_name,
       job_url: runner.job_url,
       workflow_name: runner.workflow_name,
+      head_branch: runner.head_branch,
 
       vm: runner.vm ? {
         name: runner.vm.name,

--- a/views/project/github.erb
+++ b/views/project/github.erb
@@ -33,6 +33,7 @@
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Repository</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Label</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Vm</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Branch</th>
               <th scope="col" class="relative py-3.5 pl-3 pr-4 text-left text-sm font-semibold text-gray-900 sm:pr-6">Workflow Job</th>
             </tr>
           </thead>
@@ -56,6 +57,9 @@
                     <% else %>
                       -
                     <% end %>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <%= runner[:head_branch] || "-" %>
                   </td>
                   <td class="whitespace-nowrap py-4 pl-3 pr-4 text-sm sm:pr-6">
                     <% if runner[:job_id] %>


### PR DESCRIPTION
Customers want to quickly see what triggered the job. GitHub only sends "head_branch" information during the "workflow_job" event related to this topic. We need to make an additional request to gather more information. For now, I've only added head_branch. If customers need more information, it justifies making an extra API call.

<img width="2560" alt="Screenshot 2023-09-19 at 17 16 21" src="https://github.com/ubicloud/ubicloud/assets/993199/0f55edaf-b102-4564-a741-fb079e954efb">
