### PR TITLE
Add created_at column to Vm and VmHost

### DIFF
--- a/migrate/20230920_add_vm_created_at.rb
+++ b/migrate/20230920_add_vm_created_at.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+    alter_table(:vm_host) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+  end
+end

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -5,7 +5,7 @@ class CloverWeb
     @serializer = Serializers::Web::Vm
 
     r.get true do
-      @vms = serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").eager(:semaphores).all)
+      @vms = serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").eager(:semaphores).order(Sequel.desc(:created_at)).all)
 
       view "vm/index"
     end


### PR DESCRIPTION
The "created_at" field is a useful property for various reasons. It's particularly beneficial during debugging. Moreover, in the event of breaking changes, we can modify behavior based on the age of the resource, or decide which resources to migrate based on their creation date.

Additionally, we don't display virtual machines in any specific order. The order is arbitrary, determined by PostgreSQL. However, I have now changed it to display from the newest to the oldest, top to bottom.