### PR TITLE
Add active and finalize helpers to BillingRecord

### DIFF
--- a/model/assigned_vm_address.rb
+++ b/model/assigned_vm_address.rb
@@ -5,7 +5,9 @@ require_relative "../model"
 class AssignedVmAddress < Sequel::Model
   one_to_one :vm, key: :dst_vm_id
   many_to_one :address, key: :address_id
-  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
+  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds|
+    ds.active
+  end
 
   include ResourceMethods
 end

--- a/model/billing_record.rb
+++ b/model/billing_record.rb
@@ -5,6 +5,12 @@ require_relative "../model"
 class BillingRecord < Sequel::Model
   many_to_one :project
 
+  dataset_module do
+    def active
+      where { {Sequel.function(:upper, :span) => nil} }
+    end
+  end
+
   include ResourceMethods
 
   def duration(begin_time, end_time)
@@ -19,6 +25,10 @@ class BillingRecord < Sequel::Model
     duration_begin = [span.begin, begin_time].max
     duration_end = span.unbounded_end? ? end_time : [span.end, end_time].min
     (duration_end - duration_begin) / 60
+  end
+
+  def finalize
+    update(span: Sequel.pg_range(span.begin...Time.now))
   end
 
   def billing_rate

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -10,7 +10,9 @@ class Vm < Sequel::Model
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
   one_to_many :vm_storage_volumes, key: :vm_id
-  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
+  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds|
+    ds.active
+  end
 
   dataset_module Authorization::Dataset
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -189,9 +189,9 @@ SQL
   def before_run
     when_destroy_set? do
       if strand.label != "destroy"
-        vm.active_billing_record&.update(span: Sequel.pg_range(vm.active_billing_record.span.begin...Time.now))
+        vm.active_billing_record&.finalize
         if (vm_adr = vm.assigned_vm_address)
-          vm_adr.active_billing_record&.update(span: Sequel.pg_range(vm_adr.active_billing_record.span.begin...Time.now))
+          vm_adr.active_billing_record&.finalize
         end
         hop_destroy
       end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -413,8 +413,8 @@ RSpec.describe Prog::Vm::Nexus do
       assigned_adr = instance_double(AssignedVmAddress)
       br = instance_double(BillingRecord, span: Sequel.pg_range(Time.now...Time.now))
       expect(vm).to receive(:assigned_vm_address).and_return(assigned_adr)
-      expect(assigned_adr).to receive(:active_billing_record).and_return(br).twice
-      expect(br).to receive(:update)
+      expect(assigned_adr).to receive(:active_billing_record).and_return(br)
+      expect(br).to receive(:finalize)
       expect { nx.before_run }.to hop("destroy")
     end
 


### PR DESCRIPTION
Active billing record means that its span doesn't have upper bound. We do this condition check several places. With `active` dataset helpers, we can make this check easily.

When we want to end a billing record, we update its upper bound with Time.now. So we can encapsulate this operation in `finalize` helpers.