### PR TITLE
Download custom boot image using azcopy

### DIFF
--- a/rhizome/host/bin/download-boot-image
+++ b/rhizome/host/bin/download-boot-image
@@ -1,0 +1,14 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+unless (boot_image = ARGV.shift)
+  puts "need boot_image as argument"
+  exit 1
+end
+
+custom_url = ARGV.shift
+
+require_relative "../../common/lib/util"
+require_relative "../lib/vm_setup"
+
+VmSetup.new("").download_boot_image(boot_image, custom_url: custom_url)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -171,13 +171,14 @@ RSpec.describe VmSetup do
       vs.download_boot_image("ubuntu-jammy")
     end
 
-    it "can download image with custom URL that has query params" do
+    it "can download image with custom URL that has query params using azcopy" do
       expect(File).to receive(:exist?).with("/var/storage/images/github-ubuntu-2204.raw").and_return(false)
       expect(File).to receive(:open) do |path, *_args|
         expect(path).to eq("/tmp/github-ubuntu-2204.vhd.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
-      expect(vs).to receive(:r).with("curl -L10 -o /tmp/github-ubuntu-2204.vhd.tmp https://images.blob.core.windows.net/images/ubuntu2204.vhd\\?sp\\=r\\&st\\=2023-09-05T22:44:05Z\\&se\\=2023-10-07T06:44:05")
+      expect(vs).to receive(:r).with("which azcopy")
+      expect(vs).to receive(:r).with("AZCOPY_CONCURRENCY_VALUE=5 azcopy copy https://images.blob.core.windows.net/images/ubuntu2204.vhd\\?sp\\=r\\&st\\=2023-09-05T22:44:05Z\\&se\\=2023-10-07T06:44:05 /tmp/github-ubuntu-2204.vhd.tmp")
       expect(vs).to receive(:r).with("qemu-img convert -p -f vpc -O raw /tmp/github-ubuntu-2204.vhd.tmp /var/storage/images/github-ubuntu-2204.raw")
       expect(FileUtils).to receive(:rm_r).with("/tmp/github-ubuntu-2204.vhd.tmp")
 


### PR DESCRIPTION
### Allow to download an image from a custom URL
The assumption is that images without links already exist on the VM host. I manually downloaded the "github-ubuntu-2204" image to the hosts.

We handle runner images differently because GitHub cannot publicly share these images due to legal issues (https://github.com/actions/runner-images/issues/176), and we must respect the same restrictions. Additionally, the image size is 86GB.

Instead of using a hardcoded image link, we provide our download URL at runtime.

The "download-boot-image" executable serves as an interface for downloading an image with or without a custom URL. The creation of an operational prog for it will be my next step.

### Download images from Azure Blob Storage with azcopy
We generate GitHub Actions runner images based on https://github.com/actions/runner-images and store them in Azure Blob Storage.

Since the "github-ubuntu-2204" image is 86GB, it can't be downloaded using "curl". Microsoft's "azcopy" is a specialized tool for downloading/uploading files from/to Azure's storage solutions. It downloads files from blob storage concurrently and manages failures more effectively.

If the custom URL contains "blob.core.windows.net", we use "azcopy" for the download. However, we need to ensure that "azcopy" is installed on the VM host.

azcopy, being a memory-intensive application, optimizes concurrency based on the CPU count. Given the large size of our VM hosts, the concurrency is set high. However, we encounter limitations in available memory due to the use of hugepages.

Initial configuration logs from "azcopy":

        2023/09/13 05:28:03 Number of CPUs: 64
        2023/09/13 05:28:03 Max file buffer RAM 16.000 GB
        2023/09/13 05:28:03 Max concurrent network operations:  will be dynamically tuned up to 3000 (Based on auto-tuning limit. Set AZCOPY_CONCURRENCY_VALUE environment variable to override)
        2023/09/13 05:28:03 Check CPU usage when dynamically tuning concurrency: true (Based on hard-coded default. Set AZCOPY_TUNE_TO_CPU environment variable to true or false override)
        2023/09/13 05:28:03 Max concurrent transfer initiation routines: 64 (Based on hard-coded default. Set AZCOPY_CONCURRENT_FILES environment variable to override)
        2023/09/13 05:28:03 Max enumeration routines: 16 (Based on hard-coded default. Set AZCOPY_CONCURRENT_SCAN environment variable to override)
        2023/09/13 05:28:03 Parallelize getting file properties (file.Stat): false (Based on AZCOPY_PARALLEL_STAT_FILES environment variable)
        2023/09/13 05:28:03 Max open files when downloading: 1044887 (auto-computed)
        2023/09/13 05:28:03 Final job part has been created

Unfortunately, when concurrency is high, the operating system terminates azcopy midway through the download process due to memory exhaustion.

        [Wed Sep 13 07:28:00 2023] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=/,mems_allowed=0,global_oom,task_memcg=/user.slice/user-0.slice/session-103.scope,task=azcopy,pid=41827,uid=0
        [Wed Sep 13 07:28:00 2023] Out of memory: Killed process 41827 (azcopy) total-vm:13900324kB, anon-rss:3503080kB, file-rss:0kB, shmem-rss:0kB, UID:0 pgtables:15932kB oom_score_adj:0

After experimenting with various values, I found that AZCOPY_CONCURRENCY_VALUE=5 was successful. As a result, the image downloaded at a rate of approximately 700MB/s.
