### PR TITLE
Fix rhizome tests to run on an OS that doesn't have systemd such as macOS

### DIFF
--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:purge_storage)
       expect(vs).to receive(:unmount_hugepages)
       expect(vs).to receive(:r).with("deluser --remove-home test")
+      expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_return("test.service")
 
       vs.purge
     end


### PR DESCRIPTION
rhizome test expects the running system to have systemd. However, not all operating systems, such as macOS, have systemd. The test fails with the following error:

    Failure/Error: vs.purge
     Errno::ENOENT:
       No such file or directory - systemd-escape
     # ./rhizome/host/lib/vm_path.rb:31:in `popen'
     # ./rhizome/host/lib/vm_path.rb:31:in `systemd_service'
     # ./rhizome/host/lib/vm_setup.rb:102:in `purge'
     # ./rhizome/host/spec/vm_setup_spec.rb:269:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:69:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:68:in `block (2 levels) in <top (required)>'

Our dataplane code is currently operational solely on Ubuntu 22.04. Therefore, it's not required to be macOS compatible. However, I have not found an alternative method to successfully run tests on macOS.