### PR TITLE
Run E2E tests every hour

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,11 +3,11 @@ name: E2E CI
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 0 * * *'
+    - cron:  '0 */1 * * *'
 
 jobs:
   run-ci:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud
     environment: E2E-CI
     timeout-minutes: 30
     concurrency: e2e_environment


### PR DESCRIPTION
Currently, E2E tests run every midnight. They're quite stable, with a success rate of 100%.

It takes approximately 14 minutes. We could run these tests hourly to detect potential issues sooner.

This strategy is similar to synthetic testing.

I also updated it to run on ubicloud. Because 2000 free GitHub Actions minutes are insufficient.

14 * 24 * 30 = 10.080 minutes