### PR TITLE
Fix N+1 query issue on the vm listing page

### DIFF
--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -5,7 +5,7 @@ class CloverWeb
     @serializer = Serializers::Web::Vm
 
     r.get true do
-      @vms = serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").eager(:semaphores).order(Sequel.desc(:created_at)).all)
+      @vms = serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").eager(:semaphores, :assigned_vm_address, :vm_storage_volumes).order(Sequel.desc(:created_at)).all)
 
       view "vm/index"
     end


### PR DESCRIPTION
We display the storage size and IPv4 address of the virtual machines on the vm listing page. The storage size requires the 'vm_storage_volumes' relation and the IPv4 address requires associated 'assigned_vm_address'. Without eager loading, these requirements cause an N+1 query problem.