### PR TITLE
Send a Slack notification if the E2E pipeline fails

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,3 +58,37 @@ jobs:
         HETZNER_USER: ${{ secrets.HETZNER_USER }}
         HETZNER_PASSWORD: ${{ secrets.HETZNER_PASSWORD }}
       run: bin/ci
+
+    - name: Send notification if failed
+      if: ${{ failure() && github.ref_name == 'main' }}
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        payload: |
+          {
+            "text": "*E2E Tests Failed* :this-is-fine-fire:",
+            "attachments": [
+              {
+                "color": "E33122",
+                "fields": [
+                  {
+                    "title": "Event",
+                    "short": true,
+                    "value": "${{ github.event_name }}"
+                  },
+                  {
+                    "title": "Reference",
+                    "short": true,
+                    "value": "<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.ref_name }}>"
+                  },
+                  {
+                    "title": "Action",
+                    "short": false,
+                    "value": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_PAGER_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Our E2E test suite runs every hour. If it fails, it indicates an issue. The on-call engineer should investigate it. Notifications are sent to Slack via a webhook.

I created a Slack App called "Herald", this was a job position, a messenger who carries news. I created a webhook for the pager channel.

<img width="714" alt="Screenshot 2023-09-26 at 17 19 20" src="https://github.com/ubicloud/ubicloud/assets/993199/eeff41d4-97f9-4c59-8140-2e42b77be3bf">

