### PR TITLE
Move VM subnet to the customer project as well for pooled vms

### DIFF
--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -19,6 +19,7 @@ class VmPool < Sequel::Model
       return nil unless picked_vm
 
       picked_vm.dissociate_with_project(picked_vm.projects.first)
+      picked_vm.private_subnets.each { |ps| ps.dissociate_with_project(picked_vm.projects.first) }
 
       # the billing records are updated here because the VM will be assigned
       # to a customer.

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -37,6 +37,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     if (vm = pool&.pick_vm)
       vm.associate_with_project(project)
+      vm.private_subnets.each { |ps| ps.associate_with_project(project) }
 
       BillingRecord.create_with_id(
         project_id: project.id,

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe VmPool do
     it "returns the vm if there is one in running state" do
       vms_dataset = [vm]
       expect(pool).to receive_message_chain(:vms_dataset, :for_update, :where).and_return(vms_dataset) # rubocop:disable RSpec/MessageChain
+
+      ps = instance_double(PrivateSubnet)
+      expect(vm).to receive(:private_subnets).and_return([ps])
+      expect(ps).to receive(:dissociate_with_project).with(prj)
       expect(vm).to receive(:dissociate_with_project).with(prj).and_call_original
       expect(vm).to receive(:update).with(pool_id: nil).and_call_original
       billing_record = instance_double(BillingRecord, span: Sequel.pg_range(Time.now - 1...Time.now))

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe Prog::Vm::GithubRunner do
       git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners")
       expect(VmPool).to receive(:where).with(vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners").and_return([git_runner_pool])
       expect(git_runner_pool).to receive(:pick_vm).and_return(vm)
+
+      ps = instance_double(PrivateSubnet)
+      expect(vm).to receive(:private_subnets).and_return([ps])
+      expect(ps).to receive(:associate_with_project).with(project).and_return(true)
       expect(vm).to receive(:associate_with_project).with(project).and_return(true)
       expect(BillingRecord).to receive(:create_with_id).and_return(nil)
       expect(BillingRecord).to receive(:create_with_id).and_return(nil)


### PR DESCRIPTION
We forgot to move subnets from the pool project to the 
customer project in 4ed3778c9142cc3773a3509912501ad2932df3b1. This PR does that.