### PR TITLE
Implement a prog to download a boot image to the vm host

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -129,11 +129,6 @@ class VmHost < Sequel::Model
     selected_addr
   end
 
-  # Introduced for refreshing rhizome programs via REPL.
-  def install_rhizome
-    Strand.create_with_id(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id, target_folder: "host"}])
-  end
-
   def sshable_address
     assigned_host_addresses.find { |a| a.ip.version == 4 }
   end
@@ -172,6 +167,19 @@ class VmHost < Sequel::Model
         end
       end
     end
+  end
+
+  # Operational Functions
+
+  # Introduced for refreshing rhizome programs via REPL.
+  def install_rhizome
+    Strand.create_with_id(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id, target_folder: "host"}])
+  end
+
+  # Introduced for downloading a new boot image via REPL.
+  # Use with caution as the vm_host will not accept a new vm during the image download.
+  def download_boot_image(image_name, custom_url = nil)
+    Strand.create_with_id(schedule: Time.now, prog: "DownloadBootImage", label: "start", stack: [{subject_id: id, image_name: image_name, custom_url: custom_url}])
   end
 
   def hetznerify(server_id)

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class Prog::DownloadBootImage < Prog::Base
+  subject_is :sshable, :vm_host
+
+  def image_name
+    @image_name ||= frame.fetch("image_name")
+  end
+
+  def custom_url
+    @custom_url ||= frame.fetch("custom_url")
+  end
+
+  label def start
+    vm_host.update(allocation_state: "draining")
+    hop_wait_draining
+  end
+
+  label def wait_draining
+    unless vm_host.vms.empty?
+      nap 15
+    end
+    sshable.cmd("sudo rm -f /var/storage/images/#{image_name.shellescape}.raw")
+    hop_download
+  end
+
+  label def download
+    case sshable.cmd("common/bin/daemonizer --check download_#{image_name.shellescape}")
+    when "Succeeded"
+      hop_learn_storage
+    when "NotStarted"
+      sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image #{image_name.shellescape} #{custom_url.shellescape}' download_#{image_name.shellescape}")
+    when "Failed"
+      puts "#{vm_host} Failed to download '#{image_name}' image"
+    end
+
+    nap 15
+  end
+
+  label def learn_storage
+    bud Prog::LearnStorage
+    hop_wait_learn_storage
+  end
+
+  label def wait_learn_storage
+    reap.each do |st|
+      case st.prog
+      when "LearnStorage"
+        kwargs = {
+          total_storage_gib: st.exitval.fetch("total_storage_gib"),
+          available_storage_gib: st.exitval.fetch("available_storage_gib")
+        }
+
+        vm_host.update(**kwargs)
+      end
+    end
+
+    if leaf?
+      hop_activate_host
+    end
+    donate
+  end
+
+  label def activate_host
+    vm_host.update(allocation_state: "accepting")
+
+    pop "#{image_name} downloaded"
+  end
+end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe VmHost do
     vh.install_rhizome
   end
 
+  it "has a shortcut to download a new boot image" do
+    vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
+    expect(Strand).to receive(:create) do |args|
+      expect(args[:prog]).to eq("DownloadBootImage")
+      expect(args[:stack]).to eq([subject_id: vh.id, image_name: "my-image", custom_url: "https://example.com/my-image.raw"])
+    end
+    vh.download_boot_image("my-image", "https://example.com/my-image.raw")
+  end
+
   it "assigned_subnets returns the assigned subnets" do
     expect(vh).to receive(:assigned_subnets).and_return([address])
     expect(vh).to receive(:vm_addresses).and_return([])

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::DownloadBootImage do
+  subject(:dbi) { described_class.new(Strand.new(stack: [{"image_name" => "my-image", "custom_url" => "https://example.com/my-image.raw"}])) }
+
+  let(:sshable) { Sshable.create_with_id }
+  let(:vm_host) { VmHost.create(location: "hetzner-hel1") { _1.id = sshable.id } }
+
+  before do
+    allow(dbi).to receive_messages(sshable: sshable, vm_host: vm_host)
+  end
+
+  describe "#start" do
+    it "drains vm host and hops" do
+      expect {
+        expect { dbi.start }.to hop("wait_draining")
+      }.to change { vm_host.reload.allocation_state }.from("unprepared").to("draining")
+    end
+  end
+
+  describe "#wait_draining" do
+    it "waits draining" do
+      expect(vm_host).to receive(:vms).and_return([instance_double(Vm)])
+      expect { dbi.wait_draining }.to nap(15)
+    end
+
+    it "hops if it's drained" do
+      expect(vm_host).to receive(:vms).and_return([])
+      expect(sshable).to receive(:cmd).with("sudo rm -f /var/storage/images/my-image.raw")
+      expect { dbi.wait_draining }.to hop("download")
+    end
+  end
+
+  describe "#download" do
+    it "starts to download image if it's not started yet" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("NotStarted")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image my-image https://example.com/my-image.raw' download_my-image")
+      expect { dbi.download }.to nap(15)
+    end
+
+    it "waits manual intervation if it's failed" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("Failed")
+      expect {
+        expect { dbi.download }.to nap(15)
+      }.to output("VmHost[#{vm_host.ubid}] Failed to download 'my-image' image\n").to_stdout
+    end
+
+    it "waits for the download to complete" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("InProgess")
+      expect { dbi.download }.to nap(15)
+    end
+
+    it "hops if it's succeeded" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("Succeeded")
+      expect { dbi.download }.to hop("learn_storage")
+    end
+  end
+
+  describe "#learn_storage" do
+    it "starts a number of sub-programs" do
+      expect(dbi).to receive(:bud).with(Prog::LearnStorage)
+      expect { dbi.learn_storage }.to hop("wait_learn_storage")
+    end
+  end
+
+  describe "#wait_learn_storage" do
+    it "updates the vm_host record from the finished programs" do
+      expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
+      expect(dbi).to receive(:reap).and_return([
+        instance_double(Strand, prog: "LearnStorage", exitval: {"total_storage_gib" => 300, "available_storage_gib" => 500}),
+        instance_double(Strand, prog: "ArbitraryOtherProg")
+      ])
+
+      expect { dbi.wait_learn_storage }.to hop("activate_host")
+    end
+
+    it "crashes if an expected field is not set for LearnStorage" do
+      expect(dbi).to receive(:reap).and_return([instance_double(Strand, prog: "LearnStorage", exitval: {})])
+      expect { dbi.wait_learn_storage }.to raise_error KeyError, "key not found: \"total_storage_gib\""
+    end
+
+    it "donates to children if they are not exited yet" do
+      expect(dbi).to receive(:reap).and_return([])
+      expect(dbi).to receive(:leaf?).and_return(false)
+      expect(dbi).to receive(:donate).and_call_original
+      expect { dbi.wait_learn_storage }.to nap(0)
+    end
+  end
+
+  describe "#activate_host" do
+    it "activates vm host again" do
+      expect {
+        expect { dbi.activate_host }.to exit({"msg" => "my-image downloaded"})
+      }.to change { vm_host.reload.allocation_state }.from("unprepared").to("accepting")
+    end
+  end
+end


### PR DESCRIPTION
Under normal circumstances, the boot image is downloaded during the provisioning process if the vm host doesn't already have it. This isn't usually a problem for smaller images, for instance, ubuntu-jammy, which is 2.2GB, only slightly delays the initial provisioning on the vm host.

However, GitHub runner image is considerably larger at 86GB. The process of downloading and converting it takes approximately 30 minutes, so it's essential to download this image prior to the first provisioning.

Furthermore, GitHub releases new image versions weekly, necessitating updates to our image every week. Therefore, it's beneficial to have a prog that can manage the entire operation.

The vm host cannot accept new vm allocations during image updates because we delete the old image and download the new one. As mentioned, this process takes around 30 minutes for GitHub Actions image, so any runner allocation on that vm host will likely attempt to download the image again and possibly time out.
