### PR TITLE
Add related model data to failure logs

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -55,11 +55,11 @@ class Prog::Vm::GithubRunner < Prog::Base
         amount: 1
       )
 
-      puts "Pool is used for #{label}"
+      puts "#{project} Pool is used for #{label}"
       return vm
     end
 
-    puts "Pool is empty for #{label}, creating a new VM"
+    puts "#{project} Pool is empty for #{label}, creating a new VM"
     ubid = GithubRunner.generate_ubid
     ssh_key = SshKey.generate
     # We use unencrypted storage for now, because provisioning 86G encrypted

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -171,7 +171,7 @@ SQL
 
   def allocate
     vm_host_id = allocation_dataset.limit(1).get(:id)
-    fail "no space left on any eligible hosts" unless vm_host_id
+    fail "#{vm} no space left on any eligible hosts for #{vm.location}" unless vm_host_id
 
     # N.B. check constraint required to address concurrency.  By
     # injecting a crash from overbooking, it gives us the opportunity

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       st = nil
       expect {
         st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud")
-      }.to output("Pool is empty for ubicloud, creating a new VM\n").to_stdout
+      }.to output("Project[#{project.ubid}] Pool is empty for ubicloud, creating a new VM\n").to_stdout
 
       runner = GithubRunner[st.id]
       expect(runner).not_to be_nil
@@ -52,7 +52,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       st = nil
       expect {
         st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud-standard-8")
-      }.to output("Pool is empty for ubicloud-standard-8, creating a new VM\n").to_stdout
+      }.to output("Project[#{project.ubid}] Pool is empty for ubicloud-standard-8, creating a new VM\n").to_stdout
 
       runner = GithubRunner[st.id]
       expect(runner).not_to be_nil
@@ -78,7 +78,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       vm = nil
       expect {
         vm = described_class.pick_vm("ubicloud-standard-4", project)
-      }.to output("Pool is empty for ubicloud-standard-4, creating a new VM\n").to_stdout
+      }.to output("Project[#{project.ubid}] Pool is empty for ubicloud-standard-4, creating a new VM\n").to_stdout
       expect(vm).not_to be_nil
       expect(vm.sshable.unix_user).to eq("runner")
       expect(vm.family).to eq("standard")
@@ -94,7 +94,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       vm = nil
       expect {
         vm = described_class.pick_vm("ubicloud-standard-4", project)
-      }.to output("Pool is empty for ubicloud-standard-4, creating a new VM\n").to_stdout
+      }.to output("Project[#{project.ubid}] Pool is empty for ubicloud-standard-4, creating a new VM\n").to_stdout
       expect(vm).not_to be_nil
       expect(vm.sshable.unix_user).to eq("runner")
       expect(vm.family).to eq("standard")
@@ -118,7 +118,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       vm = nil
       expect {
         vm = described_class.pick_vm("ubicloud-standard-4", project)
-      }.to output("Pool is used for ubicloud-standard-4\n").to_stdout
+      }.to output("Project[#{project.ubid}] Pool is used for ubicloud-standard-4\n").to_stdout
       expect(vm).not_to be_nil
       expect(vm.name).to eq("dummy-vm")
     end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -307,13 +307,13 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if there are no VmHosts" do
-      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
+      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
     end
 
     it "only matches when location matches" do
       vm.location = "somewhere-normal"
       vmh = new_host(location: "somewhere-weird").save_changes
-      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
+      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
 
       vm.location = "somewhere-weird"
       expect(nx.allocate).to eq vmh.id
@@ -322,13 +322,13 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "does not match if there is not enough ram capacity" do
       new_host(total_mem_gib: 1).save_changes
-      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
+      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
     end
 
     it "does not match if there is not enough storage capacity" do
       new_host(available_storage_gib: 10).save_changes
       expect(vm.storage_size_gib).to eq(20)
-      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
+      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
     end
 
     it "prefers the host with a more snugly fitting RAM ratio, even if busy" do


### PR DESCRIPTION
Without this information, the failure logs aren't very actionable.