### PR TITLE
Change email style to match with our website

### DIFF
--- a/views/email/button.erb
+++ b/views/email/button.erb
@@ -4,10 +4,10 @@
       <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
         <tr>
           <td align="center">
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation">
+            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td>
-                  <a href="<%= link %>" class="button button-primary" target="_blank" rel="noopener"><%= title %></a>
+                  <a href="<%= link %>" class="button button-primary" target="_blank" rel="noopener" style="color: #FFFFFF"><%= title %></a>
                 </td>
               </tr>
             </table>

--- a/views/email/style.erb
+++ b/views/email/style.erb
@@ -67,7 +67,7 @@
       -premailer-cellpadding: 0;
       -premailer-cellspacing: 0;
       -premailer-width: 100%;
-      background-color: #edf2f7;
+      background-color: #fef4ea;
       margin: 0;
       padding: 0;
       width: 100%;
@@ -108,7 +108,7 @@
       -premailer-cellpadding: 0;
       -premailer-cellspacing: 0;
       -premailer-width: 100%;
-      background-color: #edf2f7;
+      background-color: #fef4ea;
       border-bottom: 1px solid #edf2f7;
       border-top: 1px solid #edf2f7;
       margin: 0;
@@ -122,7 +122,7 @@
       -premailer-width: 570px;
       background-color: #ffffff;
       border-color: #e8e5ef;
-      border-radius: 2px;
+      border-radius: 24px;
       border-width: 1px;
       box-shadow: 0 2px 0 rgba(0, 0, 150, 0.025), 2px 4px 0 rgba(0, 0, 150, 0.015);
       margin: 0 auto;
@@ -194,6 +194,8 @@
       display: inline-block;
       overflow: hidden;
       text-decoration: none;
+      text-align: center;
+      width: 100%;
   }
 
   .button-primary {


### PR DESCRIPTION
We have launched our new website at ubicloud.com. I've updated the email template to align with our current branding.

**Before:**
<img width="828" alt="Screenshot 2023-09-27 at 10 10 42" src="https://github.com/ubicloud/ubicloud/assets/993199/ffc9bc56-386e-4871-b33d-3a3f3aed2053">

**After:**
<img width="891" alt="after2" src="https://github.com/ubicloud/ubicloud/assets/993199/40401474-9cdd-442a-8f0f-8d11263b4a93">

