### PR TITLE
Push a heartbeat event every 10 seconds

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -5,6 +5,12 @@ require_relative "../loader"
 
 d = Scheduling::Dispatcher.new
 
+if Config.heartbeat_url
+  puts "Starting heartbeat prog"
+  # We always insert the heartbeat using the same UBID ("stheartbeatheartbheartheaz")
+  Strand.dataset.insert_conflict.insert(id: "8b958d2d-cad4-5f3a-5634-b8b958d45caf", schedule: Time.now, prog: "Heartbeat", label: "wait")
+end
+
 loop do
   d.start_cohort
   next if d.wait_cohort > 0

--- a/config.rb
+++ b/config.rb
@@ -48,6 +48,7 @@ module Config
   optional :stripe_public_key, string, clear: true
   optional :stripe_secret_key, string, clear: true
   optional :postgres_service_project_id, string
+  optional :heartbeat_url, string
 
   # :nocov:
   override :mail_driver, (production? ? :smtp : :logger), symbol

--- a/prog/heartbeat.rb
+++ b/prog/heartbeat.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "excon"
+
+class Prog::Heartbeat < Prog::Base
+  label def wait
+    DB["SELECT 1"].first
+    Excon.get(Config.heartbeat_url)
+    nap 10
+  end
+end

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::Heartbeat do
+  subject(:hb) {
+    described_class.new(Strand.new(prog: "Heartbeat"))
+  }
+
+  describe "#wait" do
+    before { allow(Config).to receive(:heartbeat_url).and_return("http://localhost:3000") }
+
+    it "fails if it can't connect to the database" do
+      expect(DB).to receive(:[]).with("SELECT 1").and_raise(Sequel::DatabaseConnectionError)
+
+      expect { hb.wait }.to raise_error Sequel::DatabaseConnectionError
+    end
+
+    it "pushes a heartbeat and naps" do
+      stub_request(:get, "http://localhost:3000").to_return(status: 200)
+
+      expect { hb.wait }.to nap(10)
+    end
+  end
+end


### PR DESCRIPTION
Our control plane is currently hosted on Heroku EU. Unfortunately, an incident on Heroku (https://status.heroku.com/incidents/2590) impacted our control plane too. We discovered this issue incidentally, as we received no alert for it.

At present, we have two sources of alerts.

- StatusCake monitors our console and sends a page if it's down. We didn't receive this alert because the web dyno was up.
- We receive apage  if a strand fails to reach the expected label before its deadline. However, this logic is handled by respirate, and as respirate was down, we didn't get a page.

This incident underscores the need to monitor respirate`s health as well. Since respirate is just a worker without a web interface, services like StatusCake can't ping it directly. Instead, we reverse monitoring direction, also known as heartbeat monitoring, to check respirate's health. respirate sends a heartbeat to a URL, and the listening service notifies the relevant contacts if the heartbeat is missing.

StatusCake offers a "Push Monitoring" service for this purpose. If it doesn't receive a push within a specified timeframe (60 seconds for us), it creates a page.

`Prog::Heartbeat` ensures database connectivity before sending a heartbeat. Additionally, if the HEARTBEAT_URL is set and no heartbeat strand exists, one is created when respirate starts.