### PR TITLE
Change the invoice filename format

### DIFF
--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -6,6 +6,7 @@ class Serializers::Web::Invoice < Serializers::Base
       ubid: inv.ubid,
       path: inv.path,
       name: inv.name,
+      filename: "Ubicloud-#{inv.begin_time.strftime("%Y-%m")}-#{inv.invoice_number}",
       date: inv.created_at.strftime("%B %d, %Y"),
       begin_time: inv.begin_time.strftime("%b %d, %Y"),
       end_time: inv.end_time.strftime("%b %d, %Y"),

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -247,6 +247,17 @@ RSpec.describe Clover, "billing" do
         expect(page).to have_content "$%0.02f" % invoice_current.content["cost"]
       end
 
+      it "show invoice full page for generating PDF" do
+        expect(Stripe::Customer).to receive(:retrieve).with(billing_info.stripe_id).and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}}).at_least(:once)
+        bi = billing_record(Time.parse("2023-06-01"), Time.parse("2023-07-01"))
+        invoice = InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true).run.first
+
+        visit "#{project.path}/billing/invoice/#{invoice.ubid}?print=1"
+
+        expect(page.status_code).to eq(200)
+        expect(page.title).to eq("Ubicloud-2023-06-#{invoice.invoice_number}")
+      end
+
       it "raises not found when invoice not exists" do
         visit "#{project.path}/billing/invoice/08s56d4kaj94xsmrnf5v5m3mav"
 

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
-    <title><%= ["Ubicloud", @page_title].compact.join(" - ") %></title>
+    <title><%= @full_page ? @page_title : ["Ubicloud", @page_title].compact.join(" - ") %></title>
     <%== assets(:css) %>
     <script
       src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -1,4 +1,4 @@
-<% @page_title = "#{@invoice_data[:name]} - Invoice" %>
+<% @page_title = @full_page ? @invoice_data[:filename] : "#{@invoice_data[:name]} - Invoice" %>
 
 <% if @full_page %>
   <div class="print-page"></div>


### PR DESCRIPTION
The invoice filenames are crucial for those who collect invoices. We can generate invoice files with more desirable names for accounting purposes with minimal effort. We want the invoice names to include a sortable date and be fully qualified. Additionally, they should have a unique id to search easily.

The new format is `Ubicloud-<YEAR>-<MONTH>-<INVOICE_NUMBER>.pdf`.

The PDF view derives the filename from the page's title. Currently, we append the `Ubicloud -` prefix to all titles. However, it contains spaces, which are undesirable in filenames. Therefore, if `@full_page` is true, we omit this prefix and use the invoice filename as the title.