### PR TITLE
Add retry logic to bin/ci.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ jobs:
   run-ci:
     runs-on: ubicloud
     environment: E2E-CI
-    timeout-minutes: 30
+    timeout-minutes: 45
     concurrency: e2e_environment
 
     env:

--- a/bin/ci
+++ b/bin/ci
@@ -8,10 +8,28 @@ def main
   st = Prog::Test::HetznerServer.assemble
 
   strand_states = update_status({})
+  retries = 0
 
   loop do
-    ret = st.run
+    begin
+      ret = st.run
+    rescue RuntimeError => e
+      log "Exception: #{e}"
+      # retry 5 times, for total of 7:45 minutes before announcing failure
+      # sometimes there's some transient network failures which will resolved if retried.
+      if retries < 5
+        sleep_duration = 15 * 2**retries
+        log "Retrying in #{sleep_duration} seconds ..."
+        sleep sleep_duration
+        retries += 1
+        next
+      else
+        raise
+      end
+    end
+
     strand_states = update_status(strand_states)
+    retries = 0
 
     if ret.is_a?(Prog::Base::Nap)
       sleep ret.seconds


### PR DESCRIPTION
Sometimes Prog::Test::Vm failed because connection to VM failed. When I reproduced it locally after several attempts, it got resolved after retrying for few minutes. So this PR is adding the logic to retry failures in exponentially increasing intervals for 5 times before giving up.

Also increasing workflow timeout to 45 minutes to allow retries of few steps.