### PR TITLE
 HostNexus ensures disconnect before waiting for reboot

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -109,11 +109,15 @@ class Prog::Vm::HostNexus < Prog::Base
       vm.update(display_state: "rebooting")
     }
 
-    sshable.cmd("sudo systemctl reboot")
-
     decr_reboot
 
-    hop_wait_reboot
+    begin
+      sshable.cmd("sudo reboot")
+    rescue Net::SSH::Disconnect, Errno::ECONNRESET, IOError
+      hop_wait_reboot
+    end
+
+    raise "reboot failed: unexpected ssh command success"
   end
 
   label def wait_reboot


### PR DESCRIPTION
Previously we used async reboot and then immediately hopped to
wait_reboot. This caused two issues:

* On machines with fast network connection to host, the subsequent
  ssh command in wait_reboot could make it before reboot started, so
  HostNexus::verify_boot_id_changed failed.
* On machines with slow network connection to host, sometimes the
  disconnection message arrived before the async reboot result arrived,
  so HostNexus::reboot failed.

In this PR we change the code to use sync reboot and rescue disconnect
from host to solve both problems.