### PR TITLE
Broaden exceptions caught for retry in bin/ci

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -13,7 +13,8 @@ def main
   loop do
     begin
       ret = st.run
-    rescue RuntimeError => e
+    # rubocop:disable Lint/RescueException
+    rescue Exception => e
       log "Exception: #{e}"
       # retry 5 times, for total of 7:45 minutes before announcing failure
       # sometimes there's some transient network failures which will resolved if retried.
@@ -27,6 +28,7 @@ def main
         raise
       end
     end
+    # rubocop:enable Lint/RescueException
 
     strand_states = update_status(strand_states)
     retries = 0


### PR DESCRIPTION
Previously we retried only runtime errors, but it didn't include exceptions like Errno::ECONNRESET which should be retried. So broadening the retried exceptions to all exceptions.