### PR TITLE
Add destroy label to the vm host nexus

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -15,7 +15,7 @@ class VmHost < Sequel::Model
 
   include ResourceMethods
   include SemaphoreMethods
-  semaphore :reboot
+  semaphore :reboot, :destroy
 
   def host_prefix
     net6.netmask.prefix_len

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -128,14 +128,21 @@ class Prog::Test::HetznerServer < Prog::Base
   label def delete_key
     hetzner_api.delete_key(hetzner_ssh_keypair.public_key)
 
-    hop_finish
+    hop_delete_host
+  end
+
+  label def delete_host
+    vm_host.incr_destroy
+    hop_wait_host_destroyed
+  end
+
+  label def wait_host_destroyed
+    reap
+    hop_finish if children_idle
+    donate
   end
 
   label def finish
-    Strand[vm_host.id].destroy
-    vm_host.destroy
-    sshable.destroy
-
     pop "HetznerServer tests finished!"
   end
 
@@ -151,9 +158,5 @@ class Prog::Test::HetznerServer < Prog::Base
 
   def vm_host
     @vm_host ||= VmHost[frame["vm_host_id"]]
-  end
-
-  def sshable
-    @sshable ||= Sshable[frame["vm_host_id"]]
   end
 end

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -128,7 +128,25 @@ RSpec.describe Prog::Test::HetznerServer do
   describe "#delete_key" do
     it "deletes key" do
       expect(hetzner_api).to receive(:delete_key).with("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbDGrHrzWaxywYEtpDaJZCw5gEFUsO1BZ7+B/c1E3IH")
-      expect { hs_test.delete_key }.to hop("finish", "Test::HetznerServer")
+      expect { hs_test.delete_key }.to hop("delete_host", "Test::HetznerServer")
+    end
+  end
+
+  describe "#delete_host" do
+    it "deletes host" do
+      expect { hs_test.delete_host }.to hop("wait_host_destroyed", "Test::HetznerServer")
+    end
+  end
+
+  describe "#wait_host_destroyed" do
+    it "hops to delete_key if children idle" do
+      expect(hs_test).to receive(:children_idle).and_return(true)
+      expect { hs_test.wait_host_destroyed }.to hop("finish", "Test::HetznerServer")
+    end
+
+    it "donates if children not idle" do
+      expect(hs_test).to receive(:children_idle).and_return(false)
+      expect { hs_test.wait_host_destroyed }.to nap(0)
     end
   end
 


### PR DESCRIPTION
Recently, we decommissioned existing vm hosts and reconfigured them as GitHub runner vm hosts. I handled the deletion of the vm hosts manually.
However, it's beneficial to automate the condition checks. It changes the allocation state and then waits. Since allocation can occur simultaneously with the updating of the 'allocation_state' bit, it's good to wait for 5 seconds to ensure that no virtual machine is assigned to this host during the process. Subsequently, it waits to confirm that no virtual machine host exists before proceeding with the destruction.