### PR TITLE
Retry reboot until boot id changes

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -17,7 +17,7 @@ def main
     rescue Exception => e
       log "Exception: #{e}"
       # retry 5 times, for total of 7:45 minutes before announcing failure
-      # sometimes there's some transient network failures which will resolved if retried.
+      # sometimes there's some transient network failures which will be resolved if retried.
       if retries < 5
         sleep_duration = 15 * 2**retries
         log "Retrying in #{sleep_duration} seconds ..."

--- a/rhizome/host/bin/reboot-host
+++ b/rhizome/host/bin/reboot-host
@@ -1,0 +1,17 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+unless (previous_boot_id = ARGV.shift)
+  puts "expected previous_boot_id as argument"
+  exit 1
+end
+
+boot_id = File.read("/proc/sys/kernel/random/boot_id").strip
+
+if boot_id == previous_boot_id
+  r("sudo systemctl reboot")
+else
+  $stdout.write(boot_id)
+end


### PR DESCRIPTION
Previously we had bunch of problems when detecting if reboot happened or not. This was partly because `/sbin/reboot` is async and depending on system status could return successfully or close connection.

This PR changes the approach by trying to send a reboot message to host until boot id changes, or Vm::HostNexus's deadline arrives. Currently deadline for HostNexus is 15 minutes.