### PR TITLE
Delete unnecessary reap in PostgresNexus

### DIFF
--- a/prog/postgres/postgres_nexus.rb
+++ b/prog/postgres/postgres_nexus.rb
@@ -166,7 +166,6 @@ class Prog::Postgres::PostgresNexus < Prog::Base
 
   label def destroy
     register_deadline(nil, 5 * 60)
-    reap
 
     decr_destroy
 

--- a/spec/prog/postgres/postgres_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_nexus_spec.rb
@@ -230,8 +230,6 @@ RSpec.describe Prog::Postgres::PostgresNexus do
   end
 
   describe "#destroy" do
-    before { expect(nx).to receive(:reap).at_least(:once) }
-
     it "triggers vm deletion and waits until it is deleted" do
       expect(sshable).to receive(:destroy)
       expect(vm).to receive(:private_subnets).and_return([])


### PR DESCRIPTION
This was a left over that I missed while refactoring postgres prototype into its current state.