### PR TITLE
Refactor state transitions in PostgresNexus

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -13,7 +13,7 @@ class PostgresServer < Sequel::Model
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
 
-  semaphore :restart, :destroy
+  semaphore :initial_provisioning, :restart, :destroy
 
   def hyper_tag_name(project)
     "project/#{project.ubid}/location/#{location}/postgres/#{server_name}"


### PR DESCRIPTION
This commit fixes few things:
- We move create_billing_record after restart label to prevent charging users earlier than necessary.
- We used to do incr_restart to branch after billing record creation, which is not necessary as we should always go to restart after billing record creation due to previous item.
- As opposed to previous item, now we need branching in configure and restart branches, because we intend to use those labels in scenarios other than initial provisioning. For example we would give users option to restart their database in the future, or we might want to enter into configure in various cases. For such cases, we should go back to wait state, but during provisioning we should go to the next provisioning related label. We are adding such branching in this commit. In future, we can add a check like when_restart_set? to the wait label to enable functionality described above.