### PR TITLE
(WIP) Use Ubi custom spdk module to provide storage.

### DIFF
--- a/migrate/20231002_add_ubi.rb
+++ b/migrate/20231002_add_ubi.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_storage_volume) do
+      add_column :use_ubi, :bool, null: false, default: false
+    end
+  end
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -105,6 +105,7 @@ class Prog::Vm::Nexus < Prog::Base
           boot: disk_index == boot_disk_index,
           size_gib: volume[:size_gib],
           disk_index: disk_index,
+          use_ubi: volume[:use_ubi],
           key_encryption_key_1_id: key_encryption_key&.id
         )
       end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -31,6 +31,7 @@ class Prog::Vm::Nexus < Prog::Base
     storage_volumes.each do |volume|
       volume[:size_gib] ||= vm_size.storage_size_gib
       volume[:encrypted] = true if !volume.has_key? :encrypted
+      volume[:use_ubi] ||= false
     end
 
     Validation.validate_storage_volumes(storage_volumes, boot_disk_index)
@@ -143,7 +144,8 @@ class Prog::Vm::Nexus < Prog::Base
         "size_gib" => s.size_gib,
         "device_id" => s.device_id,
         "disk_index" => s.disk_index,
-        "encrypted" => !s.key_encryption_key_1.nil?
+        "encrypted" => !s.key_encryption_key_1.nil?,
+        "use_ubi" => s.use_ubi
       }
     }
   end

--- a/rhizome/host/bin/install-liburing
+++ b/rhizome/host/bin/install-liburing
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Spdk requires liburing 2.2. The liburing available in apt repositories
+# for Ubuntu 22.04 is 2.1, so we need to install it from source.
+
+GIT_REPO_LIBURING=https://github.com/axboe/liburing.git
+liburing_dir=/usr/local/src/liburing
+
+if [[ -d $liburing_dir ]]; then
+    echo "liburing source already present, not cloning"
+else
+    mkdir -p $liburing_dir
+    git clone "${GIT_REPO_LIBURING}" "$liburing_dir"
+fi
+
+git -C "$liburing_dir" checkout liburing-2.2
+cd "$liburing_dir" && ./configure --libdir=/usr/lib64 --libdevdir=/usr/lib64 && make install
+echo /usr/lib64 > /etc/ld.so.conf.d/spdk-liburing.conf
+ldconfig

--- a/rhizome/host/bin/recreate-unpersisted
+++ b/rhizome/host/bin/recreate-unpersisted
@@ -55,9 +55,15 @@ unless (storage_volumes = params["storage_volumes"])
   exit 1
 end
 
+unless (boot_image = params["boot_image"])
+  puts "need boot_image in parameters json"
+  exit 1
+end
+
 require_relative "../lib/vm_setup"
 
 VmSetup.new(vm_name).recreate_unpersisted(
   gua, ip4, local_ip4, nics, mem_gib,
-  ndp_needed, storage_volumes, storage_secrets
+  ndp_needed, storage_volumes, storage_secrets,
+  boot_image
 )

--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -9,7 +9,7 @@ require "fileutils"
 r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev"
 
 # liburing
-install_liburing = File.join(__dir__, 'install-liburing')
+install_liburing = File.join(__dir__, "install-liburing")
 r install_liburing
 
 # spdk binaries

--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -8,6 +8,10 @@ require "fileutils"
 # spdk dependencies
 r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev"
 
+# liburing
+install_liburing = File.join(__dir__, 'install-liburing')
+r install_liburing
+
 # spdk binaries
 FileUtils.cd Spdk.install_prefix do
   r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/ubi0.1/spdk-ubi.tar.gz"

--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -10,7 +10,7 @@ r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev l
 
 # spdk binaries
 FileUtils.cd Spdk.install_prefix do
-  r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/7adbcfb/spdk-7adbcfb.tar.gz"
+  r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/ubi0.1/spdk-ubi.tar.gz"
   r "tar -xzf /tmp/spdk.tar.gz"
 end
 


### PR DESCRIPTION
bdev_ubi implements copy-on-access for SPDK, so setting up storage doesn't require the initial copy operation which can take several minutes. Thus improving the provisioning time.