### PR TITLE
Only listen to SSH on GitHub runners

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -113,6 +113,11 @@ class Prog::Vm::GithubRunner < Prog::Base
   label def setup_environment
     register_deadline(:wait, 10 * 60)
 
+    # Prevent other ports listening to traffic unless they send
+    # traffic first, i.e. "outbound only" connections, save SSH that
+    # clover uses to manipulate things.
+    install_ssh_listen_only_nftables_chain
+
     # runner unix user needed access to manipulate the Docker daemon.
     # Default GitHub hosted runners have additional adm,systemd-journal groups.
     vm.sshable.cmd("sudo usermod -a -G docker,adm,systemd-journal runner")
@@ -218,5 +223,71 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     github_runner.destroy
     pop "github runner deleted"
+  end
+
+  def tun_mac_addresses
+    load_ip_netns_link.filter_map { _1.dig("linkinfo", "info_kind") == "tun" && _1.fetch("address") }
+  end
+
+  def load_ip_netns_link
+    JSON.parse(vm.vm_host.sshable.cmd("sudo -- ip --detail --json --netns #{vm.inhost_name.shellescape} link"))
+  end
+
+  def install_ssh_listen_only_nftables_chain
+    vm.sshable.cmd("sudo nft --file -", stdin: template_ssh_only_listen_nftable_conf)
+  end
+
+  def template_ssh_only_listen_nftable_conf
+    internet_routing_mac_nft_set = '{"' + tun_mac_addresses.join('", "') + '"}'
+
+    <<NFTABLES_CONF
+# An nftables idiom for idempotent re-create of a named entity: merge
+# in an empty table (a no-op if the table already exists) and then
+# delete, before creating with a new definition.
+table inet clover_github_actions;
+delete table inet clover_github_actions;
+
+table inet clover_github_actions {
+  chain input {
+    type filter hook input priority 0;
+
+    # If a conntrack has been instantiated for a flow, allow the
+    # packet through.
+
+    # The trick in the rest of all this is to allow only the
+    # current host to initiate the creation of entries in the
+    # conntrack table, and they cannot be initiated from other
+    # hosts on the Internet, with a notable exception for SSH.
+    ct state vmap { established : accept, related : accept, invalid : drop }
+
+    # Needed for neighbor solicitation at least to establish new
+    # connections on IPv6, including DNS queries to IPv6 servers,
+    # but on consideration of the goal of blocking attacks on
+    # vulnerable GitHub Action payloads, it's okay to enable the
+    # full ICMP suite for IPv4 and IPv6.
+    meta l4proto { icmp, icmpv6 } accept
+
+    # An exception to the "no connections initiated from the
+    # Internet" rule, allow port 22/SSH to receive packets from the
+    # internet without a conntrack state already established.
+    # This is how Clover connects and controls the runner, so it's
+    # obligatory.
+    tcp dport 22 accept
+
+    # Allow all other traffic that doesn't come from the host
+    # forwarding, e.g. between interfaces on the system, as in
+    # some uses of containers.  Our control over that is limited,
+    # we want to not be debugging our interactions with GitHub's
+    # pretty involved definition if we can avoid it.  Thus,
+    # correlating it with a feature of the host's routing is one
+    # way to narrowly define the behavior we want.
+    ether saddr != #{internet_routing_mac_nft_set} accept
+
+    # Finally, if passing no other conditions, drop all traffic
+    # that comes from the host router hop.
+    ether saddr #{internet_routing_mac_nft_set} drop
+  }
+}
+NFTABLES_CONF
   end
 end


### PR DESCRIPTION
This patch is an expedient attempt to prevent malicious connections to
test workloads.

Some fellow staff members did some analysis of GitHub's runners and
the firewall situation, and with this patch, we end up much closer to
how GitHub's system works.

Substantially, this patch brings us to a similar situation at GitHub:
that is, connections initiated by the VM are permissive, and via
conntrack, allow return traffic.  But packets from the Internet that
attempt to establish new connections to the VM will be dropped.

We are more lax than GitHub in two respects:

1. As an exception, this patch allows SSH to listen.
2. We allow all ICMP, GitHub at least blocks ping.

(1) is for Clover to connect. In this case, we need a new connection
initiated from the Internet.

(2) Was mostly was spurred by IPv6, which at least needs neighbor
discovery protocol to work, but on consideration, other ICMP features,
such as Path MTU discovery, may also be useful.  This is the most
concise, useful definition.

The expediency relates it being more robust to do this packet
filtering on the VM Host, not allowing the guest to possibly gain root
and modify the nftables configuration.  But, that is more invasive,
so, I don't do it that way, yet.

== The Theory of Design

The GitHub runner image is a relatively complex beast, including use
of multiple containers for services, and implementing those containers
can have some number of extra network interfaces in the Vm that need
to communicate.

I'd also prefer to avoid an invasive patch to host behavior for this
expedient bit of firewall work.  So I try to do the necessary work
from within the VM hosting the GitHub runner.

The goal is to allow free communication within the Github Runner's VM,
including between virtual network interfaces and loopback connections,
without allowing Internet connections to be established to that
computer.

However, it should be able to initiate connections and receive return
traffic for them.  This is stateful, so, `conntrack` is going to be
used.

To square this circle, I elected to use something we know about
Internet traffic that's not true about other kinds of intra-Vm
traffic: it's always routed by the host, and carries the same source
mac address, from the host side of the TAP/TUN device.

== A Test Model

My model was like:

1. Start an ubicloud VM
2. Demonstrate that `nc -l $nat_inner_ipaddr 3000` can be connected to
   from home, using `echo oh snap | nc $nat_outer_ipaddr 3000`.  The
   listening side will print `oh snap`.
3. Use `sudo nft -f-` to install some rules like those seen in this
   patch, filling in the MAC address of the host side of the TAP/TUN
   device.  You can see the automated version in the code in this
   patch.
4. Flush conntrack information using `sudo conntrack -F` (otherwise,
   you can get path dependency between runs)
5. Demonstrate that `echo oh snap | nc $nat_outer_ipaddr 3000` doesn't
   work from my home ISP.
6. However, `echo oh snap | nc $nat_inner_ipaddr 3000` should on the
   instance, and it does not reject the traffic originating
   internally.
7. Also, `curl https://ubicloud.com`, and other Internet domains,
   should work.
8. Finally, check that new SSH connections can be established from the
   Internet, as Clover needs this to control the Runner's progression.

