### PR TITLE
Make the project mandatory in Nexus assemblies, even for development

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -15,11 +15,10 @@ class Prog::Vm::Nexus < Prog::Base
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
     enable_ip4: false, pool_id: nil)
 
-    project = Project[project_id]
-    unless project || Config.development?
+    unless (project = Project[project_id])
       fail "No existing project"
     end
-    Validation.validate_location(location, project&.provider)
+    Validation.validate_location(location, project.provider)
     vm_size = Validation.validate_vm_size(size)
 
     storage_volumes ||= [{

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -60,13 +60,6 @@ RSpec.describe Prog::Vm::Nexus do
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: provider"
     end
 
-    it "accepts all locations if project not provided" do
-      expect(Config).to receive(:development?).and_return(true).twice
-      expect {
-        described_class.assemble("some_ssh_key", nil, location: "hetzner-hel1")
-      }.to change(Vm, :count).from(0).to(1)
-    end
-
     it "creates Subnet and Nic if not passed" do
       expect {
         described_class.assemble("some_ssh_key", prj.id)

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -23,26 +23,6 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       }.to raise_error RuntimeError, "No existing project"
     end
 
-    it "accepts in development without project" do
-      ps = instance_double(PrivateSubnet)
-      expect(PrivateSubnet).to receive(:create).with(
-        name: "default-ps",
-        location: "hetzner-hel1",
-        net6: "fd10:9b0b:6b4b:8fbb::/64",
-        net4: "10.0.0.0/26",
-        state: "waiting"
-      ).and_return(ps)
-      expect(described_class).to receive(:random_private_ipv4).and_return("10.0.0.0/26")
-      expect(Strand).to receive(:create).with(prog: "Vnet::SubnetNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
-      expect(Config).to receive(:development?).and_return(true)
-      described_class.assemble(
-        nil,
-        name: "default-ps",
-        location: "hetzner-hel1",
-        ipv6_range: "fd10:9b0b:6b4b:8fbb::/64"
-      )
-    end
-
     it "uses ipv6_addr if passed and creates entities" do
       ps = instance_double(PrivateSubnet)
       expect(ps).to receive(:associate_with_project).with(prj).and_return(true)


### PR DESCRIPTION
We allowed the creation of resources without a project in development mode to simplify the developers' workflow. However, even if we allow an empty project, nexus will become stuck in subsequent steps. Furthermore, we have a 'dev_project' helper in pry, eliminating the need to allow nil project in assemble.