### PR TITLE
Adds Datacenter information for VmHost

### DIFF
--- a/lib/hosting/apis.rb
+++ b/lib/hosting/apis.rb
@@ -17,4 +17,12 @@ class Hosting::Apis
       raise "unknown provider #{vm_host.provider}"
     end
   end
+
+  def self.pull_data_center(vm_host)
+    if vm_host.provider == HetznerHost::PROVIDER_NAME
+      vm_host.hetzner_host.api.pull_dc(vm_host.hetzner_host.server_identifier)
+    else
+      raise "unknown provider #{vm_host.provider}"
+    end
+  end
 end

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -167,4 +167,14 @@ class Hosting::HetznerApis
       end
     )
   end
+
+  def pull_dc(server_id)
+    connection = Excon.new(@host.connection_string, user: @host.user, password: @host.password)
+    response = connection.get(path: "/server/#{server_id}")
+    if response.status != 200
+      raise "unexpected status #{response.status}"
+    end
+    json_server = JSON.parse(response.body)
+    json_server.dig("server", "dc")
+  end
 end

--- a/migrate/20231004_add_host_data_center.rb
+++ b/migrate/20231004_add_host_data_center.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      add_column :data_center, :text, collate: '"C"'
+    end
+  end
+end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -181,6 +181,10 @@ class VmHost < Sequel::Model
     end
   end
 
+  def set_data_center
+    update(data_center: Hosting::Apis.pull_data_center(self))
+  end
+
   def reset
     unless Config.development?
       fail "BUG: reset is only allowed in development"

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -14,6 +14,7 @@ class Prog::Vm::HostNexus < Prog::Base
       if provider == HetznerHost::PROVIDER_NAME
         HetznerHost.create(server_identifier: hetzner_server_identifier) { _1.id = vmh.id }
         vmh.create_addresses
+        vmh.set_data_center
       else
         Address.create(cidr: sshable_hostname, routed_to_host_id: vmh.id) { _1.id = vmh.id }
         AssignedHostAddress.create_with_id(ip: sshable_hostname, address_id: vmh.id, host_id: vmh.id)

--- a/spec/lib/hosting/apis_spec.rb
+++ b/spec/lib/hosting/apis_spec.rb
@@ -43,4 +43,16 @@ RSpec.describe Hosting::Apis do
       expect { described_class.reset_server(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
     end
   end
+
+  describe "pull_dc" do
+    it "can set dc of a server" do
+      expect(hetzner_apis).to receive(:pull_dc).with(123).and_return("dc1")
+      described_class.pull_data_center(vm_host)
+    end
+
+    it "raises an error if the provider is unknown" do
+      expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
+      expect { described_class.pull_data_center(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
+    end
+  end
 end

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe Hosting::HetznerApis do
     end
   end
 
+  describe "pull_dc" do
+    it "can get the dc info" do
+      Excon.stub({path: "/server/123", method: :get}, {status: 200, body: "{\"server\": {\"dc\": \"fsn1-dc8\"}}"})
+      expect(hetzner_apis.pull_dc(123)).to eq "fsn1-dc8"
+    end
+
+    it "raises an error if getting the dc info fails" do
+      Excon.stub({path: "/server/123", method: :get}, {status: 400, body: ""})
+      expect { hetzner_apis.pull_dc(123) }.to raise_error RuntimeError, "unexpected status 400"
+    end
+  end
+
   describe "hetzner_pull_ips" do
     it "can pull empty data from the API" do
       stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([]))

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
     it "creates addresses properly for a hetzner host" do
       expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
+      expect(Hosting::Apis).to receive(:pull_data_center).and_return("fsn1-dc14")
       st = described_class.assemble("127.0.0.1", provider: "hetzner", hetzner_server_identifier: "1")
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
@@ -40,6 +41,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(st.vm_host.assigned_host_addresses.count).to eq(1)
       expect(st.vm_host.assigned_host_addresses.first.ip.to_s).to eq("127.0.0.1/32")
       expect(st.vm_host.provider).to eq("hetzner")
+      expect(st.vm_host.data_center).to eq("fsn1-dc14")
     end
   end
 


### PR DESCRIPTION
With this commit we add data_center field to the host table. It will be
initially used for minio but not only that. This is a good information
to store about our hosts for future.