### PR TITLE
Make vm selection asynchronous for the GitHub runners

### DIFF
--- a/migrate/20231016_runner_allow_null_vm.rb
+++ b/migrate/20231016_runner_allow_null_vm.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:github_runner) do
+      set_column_allow_null :vm_id
+    end
+  end
+end


### PR DESCRIPTION
Currently, we select the VM at the "assemble" method of the GithubRunner, which is invoked at the GitHub webhook endpoint. To prevent a race condition while selecting a VM for the GitHub runner, we lock the VM pool. However, this lock reduces concurrency and introduces additional latency to the endpoint, which is heavily loaded. Thus, improving its speed is crucial.

Instead of selecting a VM at the endpoint, we could do so at the first label of the prog, allowing the VM to be selected asynchronously by respirate.

Given that we pass two properties of the runner to "pick_vm", I refactored it as an instance method, rather than a class method.
