### PR TITLE
Add a helper function to retrieve the subject of the strand

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -20,6 +20,10 @@ class Strand < Sequel::Model
     one_to_one _1.intern, key: :id
   end
 
+  def subject
+    UBID.decode(ubid)
+  end
+
   def take_lease_and_reload
     affected = DB[<<SQL, id].first
 UPDATE strand

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -12,13 +12,7 @@ class Strand < Sequel::Model
   many_to_one :parent, key: :parent_id, class: self
   one_to_many :children, key: :parent_id, class: self
 
-  NAVIGATE = %w[vm vm_host sshable].freeze
-
   include ResourceMethods
-
-  NAVIGATE.each do
-    one_to_one _1.intern, key: :id
-  end
 
   def subject
     UBID.decode(ubid)

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -81,9 +81,9 @@ class Prog::Test::VmGroup < Prog::Base
     strand.add_child(vm1_s)
     strand.add_child(vm2_s)
     strand.add_child(vm3_s)
-    strand.add_child(Strand[vm1_s.vm.nics.first.id])
-    strand.add_child(Strand[vm2_s.vm.nics.first.id])
-    strand.add_child(Strand[vm3_s.vm.nics.first.id])
+    strand.add_child(Strand[vm1_s.subject.nics.first.id])
+    strand.add_child(Strand[vm2_s.subject.nics.first.id])
+    strand.add_child(Strand[vm3_s.subject.nics.first.id])
 
     current_frame = strand.stack.first
     current_frame["vms"] = [vm1_s.id, vm2_s.id, vm3_s.id]

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -80,7 +80,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       host: "temp_#{vm_st.id}",
       raw_private_key_1: ssh_key.keypair
     ) { _1.id = vm_st.id }
-    vm_st.vm
+    vm_st.subject
   end
 
   SERVICE_NAME = "runner-script"

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -24,7 +24,7 @@ class CloverApi
         boot_image: r.params["boot_image"]
       )
 
-      serialize(st.vm)
+      serialize(st.subject)
     end
 
     r.is String do |vm_name|

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -31,7 +31,7 @@ class CloverWeb
 
       flash["notice"] = "'#{r.params["name"]}' will be ready in a few minutes"
 
-      r.redirect "#{@project.path}#{st.vm.path}"
+      r.redirect "#{@project.path}#{st.subject.path}"
     end
 
     r.on "create" do

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Authorization do
     ]
   }
   let(:projects) { (0..1).map { users[_1].create_project_with_default_policy("project-#{_1}") } }
-  let(:vms) { (0..3).map { Prog::Vm::Nexus.assemble("key", projects[_1 / 2].id, name: "vm#{_1}") }.map(&:vm) }
+  let(:vms) { (0..3).map { Prog::Vm::Nexus.assemble("key", projects[_1 / 2].id, name: "vm#{_1}") }.map(&:subject) }
   let(:access_policy) { projects[0].access_policies.first }
 
   after do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe Prog::Vm::HostNexus do
       st = described_class.assemble("127.0.0.1")
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
-      expect(st.vm_host.assigned_subnets.count).to eq(1)
-      expect(st.vm_host.assigned_subnets.first.cidr.to_s).to eq("127.0.0.1/32")
+      expect(st.subject.assigned_subnets.count).to eq(1)
+      expect(st.subject.assigned_subnets.first.cidr.to_s).to eq("127.0.0.1/32")
 
-      expect(st.vm_host.assigned_host_addresses.count).to eq(1)
-      expect(st.vm_host.assigned_host_addresses.first.ip.to_s).to eq("127.0.0.1/32")
-      expect(st.vm_host.provider).to be_nil
+      expect(st.subject.assigned_host_addresses.count).to eq(1)
+      expect(st.subject.assigned_host_addresses.first.ip.to_s).to eq("127.0.0.1/32")
+      expect(st.subject.provider).to be_nil
     end
 
     it "creates addresses properly for a hetzner host" do
@@ -43,13 +43,13 @@ RSpec.describe Prog::Vm::HostNexus do
       st = described_class.assemble("127.0.0.1", provider: "hetzner", hetzner_server_identifier: "1")
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
-      expect(st.vm_host.assigned_subnets.count).to eq(3)
-      expect(st.vm_host.assigned_subnets.map { _1.cidr.to_s }.sort).to eq(["127.0.0.1/32", "30.30.30.32/29", "2a01:4f8:10a:128b::/64"].sort)
+      expect(st.subject.assigned_subnets.count).to eq(3)
+      expect(st.subject.assigned_subnets.map { _1.cidr.to_s }.sort).to eq(["127.0.0.1/32", "30.30.30.32/29", "2a01:4f8:10a:128b::/64"].sort)
 
-      expect(st.vm_host.assigned_host_addresses.count).to eq(1)
-      expect(st.vm_host.assigned_host_addresses.first.ip.to_s).to eq("127.0.0.1/32")
-      expect(st.vm_host.provider).to eq("hetzner")
-      expect(st.vm_host.data_center).to eq("fsn1-dc14")
+      expect(st.subject.assigned_host_addresses.count).to eq(1)
+      expect(st.subject.assigned_host_addresses.first.ip.to_s).to eq("127.0.0.1/32")
+      expect(st.subject.provider).to eq("hetzner")
+      expect(st.subject.data_center).to eq("fsn1-dc14")
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "creates with default storage size from vm size" do
       st = described_class.assemble("some_ssh_key", prj.id)
-      expect(st.vm.storage_size_gib).to eq(Option::VmSizes.first.storage_size_gib)
+      expect(st.subject.storage_size_gib).to eq(Option::VmSizes.first.storage_size_gib)
     end
 
     it "creates with custom storage size if provided" do
       st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{size_gib: 40}])
-      expect(st.vm.storage_size_gib).to eq(40)
+      expect(st.subject.storage_size_gib).to eq(40)
     end
 
     it "fails if given nic_id is not valid" do
@@ -155,14 +155,14 @@ RSpec.describe Prog::Vm::Nexus do
     it "creates without encryption key if storage is not encrypted" do
       st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{encrypted: false}])
       expect(StorageKeyEncryptionKey.count).to eq(0)
-      expect(st.vm.vm_storage_volumes.first.key_encryption_key_1_id).to be_nil
+      expect(st.subject.vm_storage_volumes.first.key_encryption_key_1_id).to be_nil
       expect(described_class.new(st).storage_secrets.count).to eq(0)
     end
 
     it "creates with encryption key if storage is encrypted" do
       st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{encrypted: true}])
       expect(StorageKeyEncryptionKey.count).to eq(1)
-      expect(st.vm.vm_storage_volumes.first.key_encryption_key_1_id).not_to be_nil
+      expect(st.subject.vm_storage_volumes.first.key_encryption_key_1_id).not_to be_nil
       expect(described_class.new(st).storage_secrets.count).to eq(1)
     end
   end

--- a/spec/routes/api/vm_spec.rb
+++ b/spec/routes/api/vm_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Clover, "vm" do
   let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", policy_body: []) }
 
   let(:vm) do
-    vm = Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-1").vm
+    vm = Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-1").subject
     vm.update(ephemeral_net6: "2a01:4f8:173:1ed3:aa7c::/79")
     vm.reload # without reload ephemeral_net6 is string and can't call .network
   end

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Clover, "github" do
 
     it "can list active runners" do
       runner1 = GithubRunner.create_with_id(installation_id: installation.id, label: "ubicloud", repository_name: "my-repo", runner_id: 1, vm_id: "46683a25-acb1-4371-afe9-d39f303e44b4")
-      vm = Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "runner-vm").vm
+      vm = Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "runner-vm").subject
       runner2 = GithubRunner.create_with_id(
         installation_id: installation.id,
         label: "ubicloud",

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Clover, "vm" do
   let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", policy_body: []) }
 
   let(:vm) do
-    vm = Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-1").vm
+    vm = Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-1").subject
     vm.update(ephemeral_net6: "2a01:4f8:173:1ed3:aa7c::/79")
     vm.reload # without reload ephemeral_net6 is string and can't call .network
   end
 
-  let(:vm_wo_permission) { Prog::Vm::Nexus.assemble("dummy-public-key", project_wo_permissions.id, name: "dummy-vm-2").vm }
+  let(:vm_wo_permission) { Prog::Vm::Nexus.assemble("dummy-public-key", project_wo_permissions.id, name: "dummy-vm-2").subject }
 
   describe "unauthenticated" do
     it "can not list without login" do


### PR DESCRIPTION
There is a one-to-one correspondence between a strand and its subject, typically sharing the same ID. The strand class has a NAVIGATE list for accessing associated objects. Prog base also provides a 'subject_is' helper, which the prog utilizes to derive the subject. The NAVIGATE list proves particularly beneficial for interacting with strands, especially when they don't load prog or lack the 'subject_is' helper. We have more classes than those listed as strand subjects in NAVIGATE.

Given our ability to identify the source model of the UBID, we can use the subject helper to retrieve it, eliminating the need to add all models to the NAVIGATE list.