### PR TITLE
Add active and finalize helpers to BillingRecord

### DIFF
--- a/model/assigned_vm_address.rb
+++ b/model/assigned_vm_address.rb
@@ -5,7 +5,7 @@ require_relative "../model"
 class AssignedVmAddress < Sequel::Model
   one_to_one :vm, key: :dst_vm_id
   many_to_one :address, key: :address_id
-  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
+  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
 
   include ResourceMethods
 end

--- a/model/billing_record.rb
+++ b/model/billing_record.rb
@@ -5,6 +5,12 @@ require_relative "../model"
 class BillingRecord < Sequel::Model
   many_to_one :project
 
+  dataset_module do
+    def active
+      where { {Sequel.function(:upper, :span) => nil} }
+    end
+  end
+
   include ResourceMethods
 
   def duration(begin_time, end_time)
@@ -19,6 +25,10 @@ class BillingRecord < Sequel::Model
     duration_begin = [span.begin, begin_time].max
     duration_end = span.unbounded_end? ? end_time : [span.end, end_time].min
     (duration_end - duration_begin) / 60
+  end
+
+  def finalize(end_time = Time.now)
+    update(span: Sequel.pg_range(span.begin...end_time))
   end
 
   def billing_rate

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -6,7 +6,7 @@ class PostgresServer < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :project
   many_to_one :vm
-  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
+  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
 
   include ResourceMethods
   include SemaphoreMethods

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -10,7 +10,7 @@ class Vm < Sequel::Model
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
   one_to_many :vm_storage_volumes, key: :vm_id
-  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
+  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
 
   dataset_module Authorization::Dataset
 

--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -23,8 +23,8 @@ class VmPool < Sequel::Model
 
       # the billing records are updated here because the VM will be assigned
       # to a customer.
-      picked_vm.active_billing_record.update(span: Sequel.pg_range(picked_vm.active_billing_record.span.begin...(Time.now - 1)))
-      picked_vm.assigned_vm_address&.active_billing_record&.update(span: Sequel.pg_range(picked_vm.assigned_vm_address.active_billing_record.span.begin...(Time.now - 1)))
+      picked_vm.active_billing_record.finalize(Time.now - 1)
+      picked_vm.assigned_vm_address&.active_billing_record&.finalize(Time.now - 1)
 
       # remove the VM from the pool
       picked_vm.update(pool_id: nil)

--- a/prog/postgres/postgres_nexus.rb
+++ b/prog/postgres/postgres_nexus.rb
@@ -60,10 +60,7 @@ class Prog::Postgres::PostgresNexus < Prog::Base
   def before_run
     when_destroy_set? do
       if strand.label != "destroy"
-        postgres_server.active_billing_records.each do |br|
-          br.update(span: Sequel.pg_range(br.span.begin...Time.now))
-        end
-
+        postgres_server.active_billing_records.each(&:finalize)
         hop_destroy
       end
     end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -186,10 +186,8 @@ SQL
   def before_run
     when_destroy_set? do
       if strand.label != "destroy"
-        vm.active_billing_record&.update(span: Sequel.pg_range(vm.active_billing_record.span.begin...Time.now))
-        if (vm_adr = vm.assigned_vm_address)
-          vm_adr.active_billing_record&.update(span: Sequel.pg_range(vm_adr.active_billing_record.span.begin...Time.now))
-        end
+        vm.active_billing_record&.finalize
+        vm.assigned_vm_address&.active_billing_record&.finalize
         hop_destroy
       end
     end

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -48,13 +48,11 @@ RSpec.describe VmPool do
       expect(ps).to receive(:dissociate_with_project).with(prj)
       expect(vm).to receive(:dissociate_with_project).with(prj).and_call_original
       expect(vm).to receive(:update).with(pool_id: nil).and_call_original
-      billing_record = instance_double(BillingRecord, span: Sequel.pg_range(Time.now - 1...Time.now))
-      addr_billing_record = instance_double(BillingRecord, span: Sequel.pg_range(Time.now - 1...Time.now))
-      adr = instance_double(AssignedVmAddress, active_billing_record: addr_billing_record)
-      expect(vm).to receive(:active_billing_record).and_return(billing_record).at_least(:once)
+      expect(vm).to receive(:active_billing_record).and_return(instance_double(BillingRecord)).at_least(:once)
+      adr = instance_double(AssignedVmAddress, active_billing_record: instance_double(BillingRecord))
       expect(vm).to receive(:assigned_vm_address).and_return(adr).at_least(:once)
-      expect(billing_record).to receive(:update)
-      expect(addr_billing_record).to receive(:update)
+      expect(vm.active_billing_record).to receive(:finalize)
+      expect(adr.active_billing_record).to receive(:finalize)
       expect(pool.pick_vm.id).to eq(vm.id)
     end
 
@@ -63,9 +61,8 @@ RSpec.describe VmPool do
       expect(pool).to receive_message_chain(:vms_dataset, :for_update, :where).and_return(vms_dataset) # rubocop:disable RSpec/MessageChain
       expect(vm).to receive(:dissociate_with_project).with(prj).and_call_original
       expect(vm).to receive(:update).with(pool_id: nil).and_call_original
-      billing_record = instance_double(BillingRecord, span: Sequel.pg_range(Time.now - 1...Time.now))
-      expect(vm).to receive(:active_billing_record).and_return(billing_record).at_least(:once)
-      expect(billing_record).to receive(:update)
+      expect(vm).to receive(:active_billing_record).and_return(instance_double(BillingRecord)).at_least(:once)
+      expect(vm.active_billing_record).to receive(:finalize)
       expect(pool.pick_vm.id).to eq(vm.id)
     end
   end

--- a/spec/prog/postgres/postgres_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_nexus_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Prog::Postgres::PostgresNexus do
 
   describe "#before_run" do
     it "hops to destroy and stops billing records when needed" do
-      br = instance_double(BillingRecord, span: (Time.now - 100)..(Time.now))
-      expect(br).to receive(:update).twice
+      br = instance_double(BillingRecord)
+      expect(br).to receive(:finalize).twice
       expect(postgres_server).to receive(:active_billing_records).and_return([br, br])
       expect(nx).to receive(:when_destroy_set?).and_yield
       expect { nx.before_run }.to hop("destroy")

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -415,12 +415,11 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "stops billing before hops to destroy" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(vm.active_billing_record).to receive(:update)
+      expect(vm.active_billing_record).to receive(:finalize)
       assigned_adr = instance_double(AssignedVmAddress)
-      br = instance_double(BillingRecord, span: Sequel.pg_range(Time.now...Time.now))
       expect(vm).to receive(:assigned_vm_address).and_return(assigned_adr)
-      expect(assigned_adr).to receive(:active_billing_record).and_return(br).twice
-      expect(br).to receive(:update)
+      expect(assigned_adr).to receive(:active_billing_record).and_return(instance_double(BillingRecord)).at_least(:once)
+      expect(assigned_adr.active_billing_record).to receive(:finalize)
       expect { nx.before_run }.to hop("destroy")
     end
 


### PR DESCRIPTION
An active billing record implies that its span does not have an upper bound. We perform this condition check in multiple places. The ﻿`active` dataset helper allows us to perform this check effortlessly.

When we wish to conclude a billing record, we update its upper limit with `Time.now`. We can encapsulate this operation using the `finalize` helper.
