### PR TITLE
Add a semaphore to defer vm destroy

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -18,7 +18,7 @@ class Vm < Sequel::Model
 
   include ResourceMethods
   include SemaphoreMethods
-  semaphore :destroy, :start_after_host_reboot
+  semaphore :destroy, :start_after_host_reboot, :prevent_destroy
 
   include Authorization::HyperTagMethods
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -479,6 +479,13 @@ RSpec.describe Prog::Vm::Nexus do
     end
   end
 
+  describe "#prevent_destroy" do
+    it "registers a deadline and naps while preventing" do
+      expect(nx).to receive(:register_deadline)
+      expect { nx.prevent_destroy }.to nap(30)
+    end
+  end
+
   describe "#destroy" do
     before do
       st.stack.first["deadline_at"] = Time.now + 1
@@ -529,6 +536,12 @@ RSpec.describe Prog::Vm::Nexus do
 
         expect { nx.destroy }.to exit({"msg" => "vm deleted"})
       end
+    end
+
+    it "prevents destroy if the semaphore set" do
+      expect(nx).to receive(:when_prevent_destroy_set?).and_yield
+      expect(Clog).to receive(:emit).with("Destroy prevented by the semaphore")
+      expect { nx.destroy }.to hop("prevent_destroy")
     end
 
     it "detaches from nic" do


### PR DESCRIPTION
In both production and development environments, I found it necessary to delay the destroy of GitHub runner virtual machines. In the development, I achieved this by commenting out the `incr_destroy` lines. In production, I added a `sleep 100000` command into the workflow. However, it's important to note that I cannot modify workflow files all the times. Therefore, having a semaphore in place would be beneficial in keeping virtual machines in a production environment for incident investigations.

    # Prevent destroy
    vm.incr_prevent_destroy

    # Destroy deferred vm
    vm.strand.load.decr_prevent_destroy
    vm.incr_destroy

We are planning to add a script that creates a page when suspicious network activity is detected. We need to delay the destroy of the VM to investigate such incidents.
