### PR TITLE
Lease refactor

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -20,7 +20,7 @@ class Strand < Sequel::Model
     one_to_one _1.intern, key: :id
   end
 
-  def lease
+  def take_lease
     affected = DB[<<SQL, id].first
 UPDATE strand
 SET lease = now() + '120 seconds', try = try + 1, schedule = #{SCHEDULE}
@@ -139,7 +139,7 @@ SQL
   def run(seconds = 0)
     fail "already deleted" if @deleted
     deadline = Time.now + seconds
-    lease do
+    take_lease do
       loop do
         ret = unsynchronized_run
         now = Time.now

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Strand do
   context "when leasing" do
     it "can take a lease only if one is not already taken" do
       st.save_changes
-      did_it = st.lease {
-        expect(st.lease {
+      did_it = st.take_lease {
+        expect(st.take_lease {
                  :never_happens
                }).to be false
 
@@ -28,7 +28,7 @@ RSpec.describe Strand do
       Semaphore.incr(st.id, :bogus)
 
       expect {
-        expect(st.lease { :never_happens }).to be_nil
+        expect(st.take_lease { :never_happens }).to be_nil
       }.to change { Semaphore.where(strand_id: st.id).any? }.from(true).to(false)
     end
   end


### PR DESCRIPTION
I was doing some stuff for #632 and found some unfortunate code in here that I wrote last January.

**Make Stand#take_lease integrity checks more stringent, and test**

Erring even more on the side of caution, check that `@deleted`
comports with the state of records in the `strand` table, without
regard a possible lease time mismatch.

**Rename `Strand#lease` to `take_lease`**

This method clashes with the attribute name in the database, and its
generated method from Sequel.  We don't frequently type `st.lease`, so
give it a longer, non-conflicting name.


**Inline Strand leasing mechanism**

I was adding some logging that involved `@deleted`, when I realized
that the class method `def self.lease` was using an instance variable,
`@deleted`, that was never set in that context, and so never worked
properly.

Upon fixing it (by inlining), a look at the integrity check shows it
is nonsense, so, fix that too.

Alas.

Most of the time, I would use an accessor method to get a crash in
such a case, but seeing as this caused no problem and is terse and
efficient in a frequent, rarely changed code path, let's give me
another chance to get it right this time, and reduce the amount of
code, too.

