### PR TITLE
Rename Clog's `msg` field to `message`

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -3,7 +3,7 @@
 require "json"
 
 class Clog
-  def self.emit(msg)
+  def self.emit(message)
     out = if block_given?
       case v = yield
       when Hash
@@ -16,7 +16,7 @@ class Clog
     end
 
     return if Config.test?
-    out[:msg] = msg
+    out[:message] = message
 
     if (thread_name = Thread.current.name)
       out[:thread] = thread_name

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe Clog do
   it "will add the thread name to the structure data, if defined" do
     Thread.new do
       Thread.current.name = "test thread name"
-      expect(described_class).to receive(:puts).with('{"msg":"hello","thread":"test thread name"}')
+      expect(described_class).to receive(:puts).with('{"message":"hello","thread":"test thread name"}')
       described_class.emit "hello"
     end.join
   end
 
   it "doesn't include a thread name if it is not set" do
-    expect(described_class).to receive(:puts).with('{"msg":"hello"}')
+    expect(described_class).to receive(:puts).with('{"message":"hello"}')
     described_class.emit "hello"
   end
 
   it "writes an error when an invalid type is yield from the block" do
-    expect(described_class).to receive(:puts).with('{"invalid_type":"Integer","msg":"ngmi"}')
+    expect(described_class).to receive(:puts).with('{"invalid_type":"Integer","message":"ngmi"}')
     described_class.emit("ngmi") { 1 }
   end
 end


### PR DESCRIPTION
Per manual, to improve the rendering in Mezmo:
https://docs.mezmo.com/docs/log-parsing#json-parsing

> If your JSON has a message field, it will be used for display and
> search in the log viewer. We also parse out, and override any
> existing, log levels if you include a level field.