### PR TITLE
Add Ubuntu 20.04 support for GitHub runners

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -3,3 +3,11 @@
 - { name: ubicloud-standard-4, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-8, vm_size: standard-8, boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-16, vm_size: standard-16, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2-ubuntu-2204, vm_size: standard-2, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-4-ubuntu-2204, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-8-ubuntu-2204, vm_size: standard-8, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-16-ubuntu-2204, vm_size: standard-16, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2-ubuntu-2004, vm_size: standard-2, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-4-ubuntu-2004, vm_size: standard-4, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-8-ubuntu-2004, vm_size: standard-8, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-16-ubuntu-2004, vm_size: standard-16, boot_image: github-ubuntu-2004, location: github-runners }

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -559,7 +559,8 @@ EOS
       "ubuntu-jammy" => "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img",
       "almalinux-9.1" => "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2",
       "opensuse-leap-15.4" => "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-Minimal-VM.x86_64-OpenStack-Cloud.qcow2",
-      "github-ubuntu-2204" => nil
+      "github-ubuntu-2204" => nil,
+      "github-ubuntu-2004" => nil
     }
 
     download = urls.fetch(boot_image) || custom_url


### PR DESCRIPTION
We provide support for Ubuntu 22.04 on GitHub runners. The default GitHub runners also support Ubuntu 20.04, and there is a packer template available for this version. I've applied our custom packer provisioning steps to Ubuntu 20.04, similar to what's done for 22.04, and was able to generate a golden image for Ubuntu 20.04. The only difference is that Ubuntu 20.04 doesn't come with `nftables`, which we use to block incoming ports by default. However, I installed nftables during the image generation process. To allow customers to choose the boot image, I've added the boot image as a suffix to our current labels, `ubicloud-standard-2-ubuntu-2004`. If the customer doesn't specify an OS, Ubuntu 22.04 remains the default.