### PR TITLE
Add a new serializer structure for the invoice details page

### DIFF
--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -120,7 +120,7 @@ class CloverWeb
 
         r.get true do
           @full_page = r.params["print"] == "1"
-          @invoice_data = serialize(invoice)
+          @invoice_data = serialize(invoice, :detailed)
           view "project/invoice"
         end
       end

--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -15,32 +15,39 @@ class Serializers::Web::Invoice < Serializers::Base
       discount: "$%0.02f" % inv.content["discount"],
       total: "$%0.02f" % inv.content["cost"],
       status: inv.status,
-      invoice_number: inv.invoice_number,
-      billing_name: inv.content.dig("billing_info", "name"),
-      billing_address: inv.content.dig("billing_info", "address"),
-      billing_country: ISO3166::Country.new(inv.content.dig("billing_info", "country"))&.common_name,
-      billing_city: inv.content.dig("billing_info", "city"),
-      billing_state: inv.content.dig("billing_info", "state"),
-      billing_postal_code: inv.content.dig("billing_info", "postal_code"),
-      issuer_address: inv.content.dig("issuer_info", "address"),
-      issuer_country: ISO3166::Country.new(inv.content.dig("issuer_info", "country"))&.common_name,
-      issuer_city: inv.content.dig("issuer_info", "city"),
-      issuer_state: inv.content.dig("issuer_info", "state"),
-      issuer_postal_code: inv.content.dig("issuer_info", "postal_code"),
-      items: inv.content["resources"].flat_map do |resource|
-        resource["line_items"].map do |line_item|
-          {
-            name: resource["resource_name"],
-            description: line_item["description"],
-            duration: line_item["duration"].to_i,
-            cost: (line_item["cost"] < 0.001) ? "less than $0.001" : "$%0.03f" % line_item["cost"]
-          }
-        end
-      end.sort_by { _1[:description] }
+      invoice_number: inv.invoice_number
     }
   end
 
   structure(:default) do |inv|
     base(inv)
+  end
+
+  structure(:detailed) do |inv|
+    base(inv).merge(
+      {
+        billing_name: inv.content.dig("billing_info", "name"),
+        billing_address: inv.content.dig("billing_info", "address"),
+        billing_country: ISO3166::Country.new(inv.content.dig("billing_info", "country"))&.common_name,
+        billing_city: inv.content.dig("billing_info", "city"),
+        billing_state: inv.content.dig("billing_info", "state"),
+        billing_postal_code: inv.content.dig("billing_info", "postal_code"),
+        issuer_address: inv.content.dig("issuer_info", "address"),
+        issuer_country: ISO3166::Country.new(inv.content.dig("issuer_info", "country"))&.common_name,
+        issuer_city: inv.content.dig("issuer_info", "city"),
+        issuer_state: inv.content.dig("issuer_info", "state"),
+        issuer_postal_code: inv.content.dig("issuer_info", "postal_code"),
+        items: inv.content["resources"].flat_map do |resource|
+          resource["line_items"].map do |line_item|
+            {
+              name: resource["resource_name"],
+              description: line_item["description"],
+              duration: line_item["duration"].to_i,
+              cost: (line_item["cost"] < 0.001) ? "less than $0.001" : "$%0.03f" % line_item["cost"]
+            }
+          end
+        end.sort_by { _1[:description] }
+      }
+    )
   end
 end


### PR DESCRIPTION
We currently have a single serializer to serialize data for both the invoice list and invoice detail, which also includes resource line items. However, these line items are not necessary for the invoice list and their inclusion significantly increases data volume, slowing down the invoice listing page. To resolve this, I've introduced a new serializer specifically for the invoice detail page. The `:default` serializer now returns only basic information.