### PR TITLE
Adds start and finish duration logs for unsynchronized_run

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -81,7 +81,8 @@ SQL
   end
 
   def unsynchronized_run
-    Clog.emit("starting strand") { {strand: values} }
+    start_time = Time.now
+    Clog.emit("starting strand") { {strand: values, time: start_time} }
 
     if label == stack.first["deadline_target"].to_s
       if (pg = Page.from_tag_parts(id, prog, stack.first["deadline_target"]))
@@ -143,7 +144,8 @@ SQL
       fail "BUG: Prog #{prog}##{label} did not provide flow control"
     end
   ensure
-    Clog.emit("finished strand") { {strand: values} }
+    finish_time = Time.now
+    Clog.emit("finished strand") { {strand: values, time: finish_time, duration: finish_time - start_time} }
   end
 
   def run(seconds = 0)


### PR DESCRIPTION
This is necessary for us to be able to figure out long running states. 