### PR TITLE
Adds additional logging for vm allocation

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -200,6 +200,7 @@ SQL
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled
 
+    Clog.emit("vm allocated") { {allocation: {vm_host_id: vm_host_id, ip4: ip4, address: address&.cidr&.to_s, routed_to: address&.routed_to_host_id}} }
     fail "no ip4 addresses left" if vm.ip4_enabled && !ip4
 
     DB.transaction do


### PR DESCRIPTION
Recently we found a bug in production that an ip address of a VM is allocated from a different host's aassigned_subnets block. This log will help us to pin point the issue.