### PR TITLE
Switch emit representation from uuid to ubid

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -200,7 +200,12 @@ SQL
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled
 
-    Clog.emit("vm allocated") { {allocation: {vm_host_id: vm_host_id, ip4: ip4, address: address&.cidr&.to_s, routed_to: address&.routed_to_host_id}} }
+    Clog.emit("vm allocated") do
+      {allocation: {vm_host_ubid: vm_host.ubid, ip4: ip4, address: address&.cidr&.to_s,
+                    routed_to: if (ahid = address&.routed_to_host_id)
+                                 UBID.from_uuidish(ahid).to_s
+                               end}}
+    end
     fail "no ip4 addresses left" if vm.ip4_enabled && !ip4
 
     DB.transaction do


### PR DESCRIPTION
I think this would be more usable, e.g. when re-entering the data in a query.