### PR TITLE
Reload in take_lease to avoid state inconsistencies

### DIFF
--- a/prog/test.rb
+++ b/prog/test.rb
@@ -14,12 +14,12 @@ class Prog::Test < Prog::Base
   end
 
   label def pusher2
-    pop frame[:test_level] if retval
+    pop frame["test_level"] if retval
     push Prog::Test, {test_level: "3"}, :pusher3
   end
 
   label def pusher3
-    pop frame[:test_level]
+    pop frame["test_level"]
   end
 
   label def synchronized

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Strand do
   context "when leasing" do
     it "can take a lease only if one is not already taken" do
       st.save_changes
-      did_it = st.take_lease {
-        expect(st.take_lease {
+      did_it = st.take_lease_and_reload {
+        expect(st.take_lease_and_reload {
                  :never_happens
                }).to be false
 
@@ -28,7 +28,7 @@ RSpec.describe Strand do
       Semaphore.incr(st.id, :bogus)
 
       expect {
-        expect(st.take_lease { :never_happens }).to be_nil
+        expect(st.take_lease_and_reload { :never_happens }).to be_nil
       }.to change { Semaphore.where(strand_id: st.id).any? }.from(true).to(false)
     end
 
@@ -78,7 +78,7 @@ SQL
     st.label = "hop_entry"
     expect(st).to receive(:load).and_return Prog::Test.new(st)
     expect {
-      st.run
+      st.unsynchronized_run
     }.to change(st, :label).from("hop_entry").to("hop_exit")
   end
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Prog::Base do
   end
 
   it "can push prog and frames on the stack" do
-    st = Strand.create_with_id(prog: "Test", label: :pusher1)
+    st = Strand.create_with_id(prog: "Test", label: "pusher1")
     expect {
       st.run
     }.to change { st.label }.from("pusher1").to("pusher2")


### PR DESCRIPTION
In production we had an issue where the second lease holder would start from a previous label that is caused because the fields of the strand is not reloaded. Now, we start to do that.