### PR TITLE
Group the line items in the invoice

### DIFF
--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -199,7 +199,9 @@ RSpec.describe Clover, "billing" do
       it "show invoice details" do
         expect(Stripe::Customer).to receive(:retrieve).with(billing_info.stripe_id).and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}}).at_least(:once)
         bi = billing_record(Time.parse("2023-06-01"), Time.parse("2023-07-01"))
-        billing_record(Time.parse("2023-06-01"), Time.parse("2023-06-01") + 10)
+        10.times do
+          billing_record(Time.parse("2023-06-01"), Time.parse("2023-06-01") + 10)
+        end
         InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true).run
         invoice = Invoice.first
 
@@ -208,7 +210,7 @@ RSpec.describe Clover, "billing" do
         expect(page.status_code).to eq(200)
         expect(page.title).to eq("Ubicloud - #{invoice.name} - Invoice")
         expect(page).to have_content invoice.name
-        expect(page).to have_content "less than $0.001"
+        expect(page).to have_content "Aggregated"
       end
 
       it "show current invoice when no usage" do
@@ -245,6 +247,7 @@ RSpec.describe Clover, "billing" do
         click_link href: "#{project.path}/billing/invoice/current"
         expect(page).to have_content "Current Usage Summary"
         expect(page).to have_content "$%0.02f" % invoice_current.content["cost"]
+        expect(page).to have_content "less than $0.001"
       end
 
       it "show invoice full page for generating PDF" do

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -93,7 +93,7 @@
             <tr>
               <th scope="col" class="py-3 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">RESOURCE</th>
               <th scope="col" class="px-3 py-3 text-left text-sm font-semibold text-gray-900">DESCRIPTION</th>
-              <th scope="col" class="px-3 py-3 text-left text-sm font-semibold text-gray-900">USAGE</th>
+              <th scope="col" class="px-3 py-3 text-right text-sm font-semibold text-gray-900">USAGE</th>
               <th scope="col" class="py-3 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6">AMOUNT</th>
             </tr>
           </thead>
@@ -103,8 +103,8 @@
               <tr>
                 <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= item[:name] %></td>
                 <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= item[:description] %></td>
-                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= item[:duration] %> minutes</td>
-                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-right text-sm text-gray-500 sm:pr-6"><%= item[:cost] %></td>
+                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 text-right"><%= item[:duration] %> minutes</td>
+                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-right text-sm text-gray-500 sm:pr-6"><%= item[:cost_humanized] %></td>
               </tr>
             <% end %>
             <% else %>


### PR DESCRIPTION
We display each line item on the invoice. However, since GitHub runners are ephemeral, some customers generate approximately 2000 line items per day. This results in roughly 60,000 line items on a monthly invoice, rendering the invoice details page ineffective.

I have decided to group invoice line items if the description group contains more than five items.

In the future, we could add an interactive button to expand combined items.

<img width="1197" alt="invoice2" src="https://github.com/ubicloud/ubicloud/assets/993199/c86fa3ab-eb90-4338-af0d-850c7a788064">

----------

<img width="1194" alt="invoice1" src="https://github.com/ubicloud/ubicloud/assets/993199/46bc7802-3613-4b47-a2cc-85828671348c">
