### PR TITLE
Use cp instead of mv to copy the GitHub runner script

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -139,7 +139,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # the golden image. However, it needs to be moved to the home directory because
     # the runner creates some configuration files at the script location. The "runner"
     # user doesn't have write permission for the "/usr/local/share/" directory.
-    vm.sshable.cmd("sudo mv /usr/local/share/actions-runner ./")
+    vm.sshable.cmd("sudo cp -a /usr/local/share/actions-runner ./")
     vm.sshable.cmd("sudo chown -R runner:runner actions-runner")
 
     # ./env.sh sets some variables for runner to run properly

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     expect(sshable).to receive(:cmd).with("sudo usermod -a -G docker,adm,systemd-journal runner")
     expect(sshable).to receive(:cmd).with(/\/opt\/post-generation/)
     expect(sshable).to receive(:invalidate_cache_entry)
-    expect(sshable).to receive(:cmd).with("sudo mv /usr/local/share/actions-runner ./")
+    expect(sshable).to receive(:cmd).with("sudo cp -a /usr/local/share/actions-runner ./")
     expect(sshable).to receive(:cmd).with("sudo chown -R runner:runner actions-runner")
     expect(sshable).to receive(:cmd).with("./actions-runner/env.sh")
     expect(sshable).to receive(:cmd).with("echo \"PATH=$PATH\" >> ./actions-runner/.env")


### PR DESCRIPTION
When the `mv` command is executed, it removes the source file. Therefore, if the label is rerun for any reason, it fails due to the absence of the source file. The `cp` command, however, allows for rerunning. Thus, we use it to ensure the `setup_environment` label is idempotent.

Daniel recommended using the `-a` flag. It functions the same as the `-RpP` options and preserves the structure and attributes of files.