### PR TITLE
Avoid leasing exited strands

### DIFF
--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -22,16 +22,6 @@ RSpec.describe Strand do
       expect(did_it).to be :did_it
     end
 
-    it "deletes semaphores if the strand has exited" do
-      st.exitval = {status: "exited"}
-      st.save_changes
-      Semaphore.incr(st.id, :bogus)
-
-      expect {
-        expect(st.take_lease_and_reload { :never_happens }).to be_nil
-      }.to change { Semaphore.where(strand_id: st.id).any? }.from(true).to(false)
-    end
-
     it "does an integrity check that deleted records are gone" do
       st.label = "hop_exit"
       st.save_changes


### PR DESCRIPTION
We were seeing some pretty scary "BUG: lease violated" exceptions being raised, which indicate some kind of mutual exclusion issue.

And indeed there was one, but fortunately, in a limited case.

Basically, there was disagreement in the code as to how exited strands should relate to the lease. This resulted in something like this:

                            Exited child strand acquires lease

    Parent strand reaps (a DELETE on exitval <> NULL)

                            Exited child strand attempts to clear lease

The last step crashes: since strand deletion was prevents the lease-clearing UPDATE from functioning, interpreted as an unexpected clearing of the lease, raising an exception.

This manifested as every case of the `BUG: lease violated` error being child strands with `Clog.emit` `exited` metadata set to `true`. But, the good news is that because `exitval` being set prevents running any strand Prog, and thus prevents "interesting" side effects, the downside is minimal.

The way I chose to solve this problem is to make exited strands un-leasable, even momentarily. In doing so, I had to move the Semaphore clean-up code into the parent strand responsible for reaping a child strand.

There are some other ways I could have solved this. In both cases, they'd increase the number of database interactions, and I didn't see the advantage.

* Reaping could require a lease to delete.

* Deletion of the record could be pushed into the interlock of the exited Strand, e.g. remove deletion from `reap`, and set a special semaphore instead.

What these have in common is retaining the ability of the exited strand to have interlock, rather than transferring final responsibilities to the parent, and relying on the latter's interlock to control access.