### PR TITLE
Switch `from_uuidish` from `to_i` to `Integer`

### DIFF
--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -3,7 +3,7 @@
 class Serializers::Web::Invoice < Serializers::Base
   def self.base(inv)
     {
-      ubid: inv.ubid,
+      ubid: inv.id ? inv.ubid : "current",
       path: inv.path,
       name: inv.name,
       filename: "Ubicloud-#{inv.begin_time.strftime("%Y-%m")}-#{inv.invoice_number}",

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Prog::Vm::GithubRunner do
   }
 
   let(:vm) {
-    Vm.new(family: "standard", cores: 1, name: "dummy-vm", location: "hetzner-hel1")
+    Vm.new(family: "standard", cores: 1, name: "dummy-vm", location: "hetzner-hel1").tap {
+      _1.id = "788525ed-d6f0-4937-a844-323d4fd91946"
+    }
   }
   let(:sshable) { instance_double(Sshable) }
   let(:client) { instance_double(Octokit::Client) }
@@ -412,7 +414,7 @@ JSON
       host_ssh = instance_double(Sshable)
       expect(nx.vm).to receive(:vm_host).and_return(instance_double(VmHost, sshable: host_ssh)).at_least(:once)
       expect(host_ssh).to receive(:cmd).with(
-        "sudo -- ip --detail --json --netns 00000000 link"
+        "sudo -- ip --detail --json --netns 9qf22jbv link"
       ).and_return(ip_netns_detail_json_fixture)
 
       expect(nx.vm.vm_host).to receive(:sshable).and_return(host_ssh)

--- a/ubid.rb
+++ b/ubid.rb
@@ -100,7 +100,7 @@ class UBID
   end
 
   def self.from_uuidish(uuidish)
-    value = uuidish.to_s.tr("-", "").to_i(16)
+    value = Integer(uuidish.to_s.tr("-", ""), 16)
     new(value)
   end
 


### PR DESCRIPTION
Switch `from_uuidish` from `to_i` to `Integer`

I don't think this was written with the intention that malformed input
would result in the all-zeros UBID, rather than crashing:

Before:

    > UBID.from_uuidish('').to_s
    => "00000000000000000000000000"
    > UBID.from_uuidish('').to_uuid
    => "00000000-0000-0000-0000-000000000000"
    > UBID.from_uuidish('hello world').to_uuid
    => "00000000-0000-0000-0000-000000000000"

After:

    > UBID.from_uuidish('')
    ArgumentError: invalid value for Integer(): ""

    > UBID.from_uuidish('hello world')
    ArgumentError: invalid value for Integer(): "hello world"

