### PR TITLE
Replace 'cp' with the idempotent 'mv' in the runner environment setup

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -139,7 +139,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # the golden image. However, it needs to be moved to the home directory because
     # the runner creates some configuration files at the script location. The "runner"
     # user doesn't have write permission for the "/usr/local/share/" directory.
-    vm.sshable.cmd("sudo cp -a /usr/local/share/actions-runner ./")
+    vm.sshable.cmd("sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./")
     vm.sshable.cmd("sudo chown -R runner:runner actions-runner")
 
     # ./env.sh sets some variables for runner to run properly

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     expect(sshable).to receive(:cmd).with("sudo usermod -a -G docker,adm,systemd-journal runner")
     expect(sshable).to receive(:cmd).with(/\/opt\/post-generation/)
     expect(sshable).to receive(:invalidate_cache_entry)
-    expect(sshable).to receive(:cmd).with("sudo cp -a /usr/local/share/actions-runner ./")
+    expect(sshable).to receive(:cmd).with("sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./")
     expect(sshable).to receive(:cmd).with("sudo chown -R runner:runner actions-runner")
     expect(sshable).to receive(:cmd).with("./actions-runner/env.sh")
     expect(sshable).to receive(:cmd).with("echo \"PATH=$PATH\" >> ./actions-runner/.env")


### PR DESCRIPTION
The `mv` command is not idempotent because it removes the source file upon execution. We substituted it with `cp` in commit 6131840, but this introduced another problem. The `actions-runner` directory is 730MB. While `mv` takes only 0.002 seconds, `cp` requires 1.5 seconds. We aim to avoid adding unnecessary time to our runner provisioning. Therefore, I'm reverting back to `mv`, ensuring idempotency by checking the source file first: `[ ! -d /usr/local/share/actions-runner ]`