### PR TITLE
Make setup_environment shorter

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -125,38 +125,43 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def setup_environment
-    # runner unix user needed access to manipulate the Docker daemon.
-    # Default GitHub hosted runners have additional adm,systemd-journal groups.
-    vm.sshable.cmd("sudo usermod -a -G docker,adm,systemd-journal runner")
+    command = <<~COMMAND
+      # runner unix user needed access to manipulate the Docker daemon.
+      # Default GitHub hosted runners have additional adm,systemd-journal groups.
+      sudo usermod -a -G docker,adm,systemd-journal runner
 
-    # Some configuration files such as $PATH related to the user's home directory
-    # need to be changed. GitHub recommends to run post-generation scripts after
-    # initial boot.
-    # The important point, scripts use latest record at /etc/passwd as default user.
-    # So we need to run these scripts before bootstrap_rhizome to use runner user,
-    # instead of rhizome user.
-    # https://github.com/actions/runner-images/blob/main/docs/create-image-and-azure-resources.md#post-generation-scripts
-    vm.sshable.cmd("sudo su -c \"find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} ';'\"")
+      # Some configuration files such as $PATH related to the user's home directory
+      # need to be changed. GitHub recommends to run post-generation scripts after
+      # initial boot.
+      # The important point, scripts use latest record at /etc/passwd as default user.
+      # So we need to run these scripts before bootstrap_rhizome to use runner user,
+      # instead of rhizome user.
+      # https://github.com/actions/runner-images/blob/main/docs/create-image-and-azure-resources.md#post-generation-scripts
+      sudo su -c "find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} ';'"
 
-    # Post-generation scripts write some variables at /etc/environment file.
-    # We need to reconnect machine to load environment variables again.
-    vm.sshable.invalidate_cache_entry
+      # Post-generation scripts write some variables at /etc/environment file.
+      # We need to reload environment variables again.
+      source /etc/environment
 
-    # We placed the script in the "/usr/local/share/" directory while generating
-    # the golden image. However, it needs to be moved to the home directory because
-    # the runner creates some configuration files at the script location. The "runner"
-    # user doesn't have write permission for the "/usr/local/share/" directory.
-    vm.sshable.cmd("sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./")
-    vm.sshable.cmd("sudo chown -R runner:runner actions-runner")
+      # We placed the script in the "/usr/local/share/" directory while generating
+      # the golden image. However, it needs to be moved to the home directory because
+      # the runner creates some configuration files at the script location. The "runner"
+      # user doesn't have write permission for the "/usr/local/share/" directory.
+      sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./
+      sudo chown -R runner:runner actions-runner
 
-    # ./env.sh sets some variables for runner to run properly
-    vm.sshable.cmd("./actions-runner/env.sh")
+      # ./env.sh sets some variables for runner to run properly
+      ./actions-runner/env.sh
 
-    # runner script doesn't use global $PATH variable by default. It gets path from
-    # secure_path at /etc/sudoers. Also script load .env file, so we are able to
-    # overwrite default path value of runner script with $PATH.
-    # https://github.com/microsoft/azure-pipelines-agent/issues/3461
-    vm.sshable.cmd("echo \"PATH=$PATH\" >> ./actions-runner/.env")
+      # runner script doesn't use global $PATH variable by default. It gets path from
+      # secure_path at /etc/sudoers. Also script load .env file, so we are able to
+      # overwrite default path value of runner script with $PATH.
+      # https://github.com/microsoft/azure-pipelines-agent/issues/3461
+      echo "PATH=$PATH" >> ./actions-runner/.env
+    COMMAND
+
+    # Remove comments and empty lines before sending them to the machine
+    vm.sshable.cmd(command.gsub(/^(#.*)?\n/, ""))
 
     hop_register_runner
   end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -111,17 +111,20 @@ class Prog::Vm::GithubRunner < Prog::Base
   label def wait_vm
     nap 5 unless vm.strand.label == "wait"
     vm.sshable.update(host: vm.ephemeral_net4)
-    hop_setup_environment
-  end
-
-  label def setup_environment
     register_deadline(:wait, 10 * 60)
 
+    hop_install_nftables_rules
+  end
+
+  label def install_nftables_rules
     # Prevent other ports listening to traffic unless they send
     # traffic first, i.e. "outbound only" connections, save SSH that
     # clover uses to manipulate things.
     install_ssh_listen_only_nftables_chain
+    hop_setup_environment
+  end
 
+  label def setup_environment
     # runner unix user needed access to manipulate the Docker daemon.
     # Default GitHub hosted runners have additional adm,systemd-journal groups.
     vm.sshable.cmd("sudo usermod -a -G docker,adm,systemd-journal runner")

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -160,21 +160,30 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).to receive(:strand).and_return(Strand.new(label: "wait"))
       expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
       expect(sshable).to receive(:update).with(host: "1.1.1.1")
-      expect { nx.wait_vm }.to hop("setup_environment")
+      expect { nx.wait_vm }.to hop("install_nftables_rules")
     end
   end
 
-  it "hops to install_actions_runner" do
-    expect(nx).to receive(:install_ssh_listen_only_nftables_chain)
-    expect(sshable).to receive(:cmd).with("sudo usermod -a -G docker,adm,systemd-journal runner")
-    expect(sshable).to receive(:cmd).with(/\/opt\/post-generation/)
-    expect(sshable).to receive(:invalidate_cache_entry)
-    expect(sshable).to receive(:cmd).with("sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./")
-    expect(sshable).to receive(:cmd).with("sudo chown -R runner:runner actions-runner")
-    expect(sshable).to receive(:cmd).with("./actions-runner/env.sh")
-    expect(sshable).to receive(:cmd).with("echo \"PATH=$PATH\" >> ./actions-runner/.env")
+  describe "#install_nftables_rules" do
+    it "hops to setup_environment" do
+      expect(nx).to receive(:install_ssh_listen_only_nftables_chain)
 
-    expect { nx.setup_environment }.to hop("register_runner")
+      expect { nx.install_nftables_rules }.to hop("setup_environment")
+    end
+  end
+
+  describe "#setup_environment" do
+    it "hops to register_runner" do
+      expect(sshable).to receive(:cmd).with("sudo usermod -a -G docker,adm,systemd-journal runner")
+      expect(sshable).to receive(:cmd).with(/\/opt\/post-generation/)
+      expect(sshable).to receive(:invalidate_cache_entry)
+      expect(sshable).to receive(:cmd).with("sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./")
+      expect(sshable).to receive(:cmd).with("sudo chown -R runner:runner actions-runner")
+      expect(sshable).to receive(:cmd).with("./actions-runner/env.sh")
+      expect(sshable).to receive(:cmd).with("echo \"PATH=$PATH\" >> ./actions-runner/.env")
+
+      expect { nx.setup_environment }.to hop("register_runner")
+    end
   end
 
   describe "#register_runner" do

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -174,13 +174,15 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#setup_environment" do
     it "hops to register_runner" do
-      expect(sshable).to receive(:cmd).with("sudo usermod -a -G docker,adm,systemd-journal runner")
-      expect(sshable).to receive(:cmd).with(/\/opt\/post-generation/)
-      expect(sshable).to receive(:invalidate_cache_entry)
-      expect(sshable).to receive(:cmd).with("sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./")
-      expect(sshable).to receive(:cmd).with("sudo chown -R runner:runner actions-runner")
-      expect(sshable).to receive(:cmd).with("./actions-runner/env.sh")
-      expect(sshable).to receive(:cmd).with("echo \"PATH=$PATH\" >> ./actions-runner/.env")
+      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+        sudo usermod -a -G docker,adm,systemd-journal runner
+        sudo su -c "find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} ';'"
+        source /etc/environment
+        sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./
+        sudo chown -R runner:runner actions-runner
+        ./actions-runner/env.sh
+        echo "PATH=$PATH" >> ./actions-runner/.env
+      COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")
     end


### PR DESCRIPTION
### Move nftables rules from the setup_environment label to a new label
"setup_environment" is one of our longest labels. Almost half of its duration is spent installing nftables rules, according to my local environment benchmarks. Dividing a long label into shorter ones enhances robustness and aids in identifying what consumes time.

### Setup the runner using a single SSH command
We execute multiple commands using `sshable.cmd` to setup the GitHub runner environment. While `sshable.cmd` introduces network overhead, and even simple commands take 0.2 seconds. We can mitigate this by preparing a multiline command string and executing it with a single `sshable.cmd` call. This approach reduces the setup_environment duration by minimizing network overhead. Given that all commands are idempotent, it poses no issue to rerun all commands in the event of failure.

The update eliminates the need for the `sshable.invalidate_cache_entry` line. Previously, we needed it to reload all environment variables. Now, we simply source `/etc/environment` again.
