### PR TITLE
Add strand label to the page summary

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -101,7 +101,7 @@ SQL
       next unless (deadline_at = frame["deadline_at"])
 
       if Time.now > Time.parse(deadline_at.to_s)
-        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog} did not reach #{frame["deadline_target"]} on time", id, prog, frame["deadline_target"])
+        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog}.#{label} did not reach #{frame["deadline_target"]} on time", id, prog, frame["deadline_target"])
 
         modified!(:stack)
       end


### PR DESCRIPTION
The label of the strand provides clues about the incident. When we encounter a incident storm, it's beneficial to understand what's happening before manually checking each strand's label via pry.