### PR TITLE
Make VmPool wait until VM is destroyed to provision new VMs

### DIFF
--- a/migrate/20231015_make_vm_unique_to_runner.rb
+++ b/migrate/20231015_make_vm_unique_to_runner.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:github_runner) do
+      add_unique_constraint :vm_id
+    end
+  end
+end

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -40,14 +40,17 @@ RSpec.describe VmPool do
     }
 
     it "returns the vm if there is one in running state" do
+      locking_vms = class_double(Vm)
+      expect(pool).to receive(:vms_dataset).and_return(locking_vms).at_least(:once)
+      expect(locking_vms).to receive_message_chain(:for_update, :all).and_return([])  # rubocop:disable RSpec/MessageChain
       vms_dataset = [vm]
-      expect(pool).to receive_message_chain(:vms_dataset, :for_update, :where).and_return(vms_dataset) # rubocop:disable RSpec/MessageChain
+      expect(pool).to receive_message_chain(:vms_dataset, :left_join, :where, :select).and_return(vm.id) # rubocop:disable RSpec/MessageChain
+      expect(Vm).to receive(:where).and_return(vms_dataset) # rubocop:disable RSpec/MessageChain
 
       ps = instance_double(PrivateSubnet)
       expect(vm).to receive(:private_subnets).and_return([ps])
       expect(ps).to receive(:dissociate_with_project).with(prj)
       expect(vm).to receive(:dissociate_with_project).with(prj).and_call_original
-      expect(vm).to receive(:update).with(pool_id: nil).and_call_original
       expect(vm).to receive(:active_billing_record).and_return(instance_double(BillingRecord)).at_least(:once)
       adr = instance_double(AssignedVmAddress, active_billing_record: instance_double(BillingRecord))
       expect(vm).to receive(:assigned_vm_address).and_return(adr).at_least(:once)
@@ -57,10 +60,14 @@ RSpec.describe VmPool do
     end
 
     it "skips updating billing of addresses if there is no address, still returns vm" do
+      locking_vms = class_double(Vm)
+      expect(pool).to receive(:vms_dataset).and_return(locking_vms).at_least(:once)
+      expect(locking_vms).to receive_message_chain(:for_update, :all).and_return([])  # rubocop:disable RSpec/MessageChain
       vms_dataset = [vm]
-      expect(pool).to receive_message_chain(:vms_dataset, :for_update, :where).and_return(vms_dataset) # rubocop:disable RSpec/MessageChain
+      expect(pool).to receive_message_chain(:vms_dataset, :left_join, :where, :select).and_return(vm.id) # rubocop:disable RSpec/MessageChain
+      expect(Vm).to receive(:where).and_return(vms_dataset) # rubocop:disable RSpec/MessageChain
+
       expect(vm).to receive(:dissociate_with_project).with(prj).and_call_original
-      expect(vm).to receive(:update).with(pool_id: nil).and_call_original
       expect(vm).to receive(:active_billing_record).and_return(instance_double(BillingRecord)).at_least(:once)
       expect(vm.active_billing_record).to receive(:finalize)
       expect(pool.pick_vm.id).to eq(vm.id)


### PR DESCRIPTION
This commit simply skips the pool_id set nil step in pick_vm. This way, the VM will be seen as part of the pool until it is destroyed. This will result in much softer pool provisioning characteristics. We will make sure that we will only provision a new VM only when the one in the pool is destroyed. This change decreases the capacity need to use pool to 2x at the worst case scenario, while it was 3x in the previous implementation. To make sure the VM is not allocated twice to different GithubRunners, we check the entities in the pick_vm function. We have also added a new unique constraint to the github_runner table just to avoid any bug.