### PR TITLE
Learn storage of /var/storage instead of /var

### DIFF
--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prog::LearnStorage do
   describe "#start" do
     it "exits, popping total storage and available storage" do
       sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("df -B1 --output=size,avail /var").and_return(<<EOS)
+      expect(sshable).to receive(:cmd).with("if [ -d /var/storage ]; then df -B1 --output=size,avail /var/storage; else df -B1 --output=size,avail /var; fi").and_return(<<EOS)
 1B-blocks     Avail
 494384795648 299711037440
 EOS


### PR DESCRIPTION
For GitHub runner hosts, we mount `/var/storage` from a separate btrfs disk partition. As a result, `/var` does not include the size of `/var/storage`, which has more storage. We manually update the `total_storage_gib` and `available_storage_gib` of the VM host.

We can't check the size of /var/storage directly, because it might not there for other hosts at this step. Until we unify our hosts with ext4 disks, we check /var/storage only if exists.