### PR TITLE
Set connection timeout for the heartbeat requests

### DIFF
--- a/prog/heartbeat.rb
+++ b/prog/heartbeat.rb
@@ -5,7 +5,10 @@ require "excon"
 class Prog::Heartbeat < Prog::Base
   label def wait
     DB["SELECT 1"].first
-    Excon.get(Config.heartbeat_url)
+    Excon.get(Config.heartbeat_url, read_timeout: 2, write_timeout: 2, connect_timeout: 2)
+    nap 10
+  rescue Excon::Error::Timeout => e
+    Clog.emit("heartbeat request timed out") { {exception: {message: e.message}} }
     nap 10
   end
 end

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Prog::Heartbeat do
       expect { hb.wait }.to raise_error Sequel::DatabaseConnectionError
     end
 
+    it "naps if it can't send request in expected time" do
+      stub_request(:get, "http://localhost:3000").and_raise(Excon::Error::Timeout)
+      expect(Clog).to receive(:emit).with("heartbeat request timed out")
+      expect { hb.wait }.to nap(10)
+    end
+
     it "pushes a heartbeat and naps" do
       stub_request(:get, "http://localhost:3000").to_return(status: 200)
 


### PR DESCRIPTION
The heartbeat prog attempts to connect to the database and send GET requests to the heartbeat URL every 10 seconds. Although this process is relatively straightforward, we've noticed that some heartbeat runs can take 10-20 seconds at production, which could indicate a connection issue.

Excon, by default, has a 60-second timeout. I reduced this to 2 seconds to prevent excessive blocking of the respirate thread. If the respirate cannot send a request to the heartbeat URL within 2 seconds, there may be an issue either with our system or our 3rd-party monitoring service.