### PR TITLE
Register the vm provisioning deadline under a separate label

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -195,7 +195,10 @@ SQL
 
   label def start
     register_deadline(:wait, 10 * 60)
+    hop_allocate_vm
+  end
 
+  label def allocate_vm
     vm_host_id = allocate
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -225,6 +225,13 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#start" do
+    it "registers a deadline and hops" do
+      expect(nx).to receive(:register_deadline)
+      expect { nx.start }.to hop("allocate_vm")
+    end
+  end
+
+  describe "#allocate_vm" do
     it "allocates the vm to a host" do
       vmh_id = "46ca6ded-b056-4723-bd91-612959f52f6f"
       vmh = VmHost.new(
@@ -239,7 +246,7 @@ RSpec.describe Prog::Vm::Nexus do
         expect(args[:vm_host_id]).to match vmh_id
       end
 
-      expect { nx.start }.to hop("create_unix_user")
+      expect { nx.allocate_vm }.to hop("create_unix_user")
     end
 
     it "allocates the vm to a host with IPv4 address" do
@@ -258,7 +265,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(AssignedVmAddress).to receive(:create_with_id).and_return(assigned_address)
       expect(vm).to receive(:update)
 
-      expect { nx.start }.to hop("create_unix_user")
+      expect { nx.allocate_vm }.to hop("create_unix_user")
     end
 
     it "fails if there is no ip address available but the vm is ip4 enabled" do
@@ -273,7 +280,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vmh).to receive(:ip4_random_vm_network).and_return([nil, nil])
       expect(vm).to receive(:ip4_enabled).and_return(true).at_least(:once)
 
-      expect { nx.start }.to raise_error(RuntimeError, /no ip4 addresses left/)
+      expect { nx.allocate_vm }.to raise_error(RuntimeError, /no ip4 addresses left/)
     end
   end
 


### PR DESCRIPTION
We have a known issue #718. If the label that we register deadline fails, we can't persist the deadline information to the strand's stack. When there is no space left, an exception is raised, preventing the vm strand from saving the deadline. We don't receive pages due to slow provisioning if the delay is caused by capacity issues.

I moved the deadline registration to a different label until we find an elegant solution for issue #718.