### PR TITLE
Moves BillingRecord Finalize to DB

### DIFF
--- a/model/billing_record.rb
+++ b/model/billing_record.rb
@@ -27,8 +27,8 @@ class BillingRecord < Sequel::Model
     (duration_end - duration_begin) / 60
   end
 
-  def finalize(end_time = Time.now)
-    update(span: Sequel.pg_range(span.begin...end_time))
+  def finalize
+    self.class.where(id: id).update(span: Sequel.lit("tstzrange(lower(span), now())"))
   end
 
   def billing_rate

--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -25,8 +25,8 @@ class VmPool < Sequel::Model
 
       # the billing records are updated here because the VM will be assigned
       # to a customer.
-      picked_vm.active_billing_record.finalize(Time.now - 1)
-      picked_vm.assigned_vm_address&.active_billing_record&.finalize(Time.now - 1)
+      picked_vm.active_billing_record.finalize
+      picked_vm.assigned_vm_address&.active_billing_record&.finalize
 
       picked_vm
     end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "hops to destroy if billing record is not found for ipv4" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(vm.active_billing_record).to receive(:update)
+      expect(vm.active_billing_record).to receive(:finalize)
       assigned_adr = instance_double(AssignedVmAddress)
       expect(vm).to receive(:assigned_vm_address).and_return(assigned_adr)
       expect(assigned_adr).to receive(:active_billing_record).and_return(nil)


### PR DESCRIPTION
With this commit, we are moving the finalize Time.now() decision completely to the DB. This way, our updates while changing the billing record will not be impacted by the timestamp difference in between controlplane and the DB. We had 3 instances of VmPool reassignment failure because of this issue. The problem is, the previous finalize logic depended on the time setting of the controlplane process while the entity creation sets the span.begin to db's time (now()). This happens only if the controlplane's time setting is further than the DB's because of the following scenario;
```
billing_record.update(begin_time, CONTROLPLANE_TIME.NOW())
billing_record.create(POSTGRES_TIME.now, null)
```
So, if PG is behind controlplane, the above code will have span conflicting error.