### PR TITLE
Decrease MTU for all packets to 1400

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -313,6 +313,7 @@ dhcp-authoritative
 dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
 #{private_ip_dhcp}
 dhcp-option=option6:dns-server,2620:fe::fe,2620:fe::9
+dhcp-option=26,1400
 DNSMASQ_CONF
 
     ethernets = nics.map do |net6, net4, tapname, mac|


### PR DESCRIPTION
This is not ideal since we decrease it to 1400 for all but necessary. We
want to spare some bits for the private networking related additions
(IPSec encryption). We cannot currently separate private and public
communication since they all get in or out from the same interface
(tap). Route mtu setting via dhcp requires more research, but we want to
eliminate packet fragmentations on our virtual networks with high
certainty.