### PR TITLE
Add a helper to redeliver failed GitHub webhook deliveries

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -31,4 +31,29 @@ module Github
   def self.runner_labels
     @@runner_labels ||= YAML.load_file("config/github_runner_labels.yml").to_h { [_1["name"], _1] }
   end
+
+  def self.failed_deliveries(since)
+    client = Github.app_client
+    all_deliveries = client.get("/app/hook/deliveries?per_page=100")
+    while (next_url = client.last_response.rels[:next]&.href) && (since < all_deliveries.last[:delivered_at])
+      all_deliveries += client.get(next_url)
+    end
+
+    all_deliveries
+      .reject { _1[:delivered_at] < since }
+      .group_by { _1[:guid] }
+      .values
+      .reject { |group| group.any? { _1[:status] == "OK" } }
+      .map { |group| group.max_by { _1[:delivered_at] } }
+  end
+
+  def self.redeliver_failed_deliveries(since)
+    client = Github.app_client
+    failed_deliveries = Github.failed_deliveries(since)
+    failed_deliveries.each do |delivery|
+      Clog.emit("redelivering failed delivery") { {delivery: delivery} }
+      client.post("/app/hook/deliveries/#{delivery[:id]}/attempts")
+    end
+    Clog.emit("redelivered failed deliveries")
+  end
 end

--- a/spec/lib/github_spec.rb
+++ b/spec/lib/github_spec.rb
@@ -26,4 +26,41 @@ RSpec.describe Github do
 
     described_class.installation_client(installation_id)
   end
+
+  it ".failed_deliveries" do
+    time = Time.now
+    app_client = instance_double(Octokit::Client)
+    expect(described_class).to receive(:app_client).and_return(app_client)
+    expect(app_client).to receive(:get).with("/app/hook/deliveries?per_page=100").and_return([
+      {guid: "1", status: "Fail", delivered_at: time + 5},
+      {guid: "2", status: "Fail", delivered_at: time + 4},
+      {guid: "3", status: "OK", delivered_at: time + 3}
+    ])
+    next_url = "/app/hook/deliveries?per_page=100&cursor=next_page"
+    expect(app_client).to receive(:last_response).and_return(instance_double(Sawyer::Response, rels: {next: instance_double(Sawyer::Relation, href: next_url)}))
+    expect(app_client).to receive(:last_response).and_return(instance_double(Sawyer::Response, rels: {next: nil}))
+    expect(app_client).to receive(:get).with(next_url).and_return([
+      {guid: "2", status: "OK", delivered_at: time + 2},
+      {guid: "4", status: "Fail", delivered_at: time + 2},
+      {guid: "4", status: "Fail", delivered_at: time + 1},
+      {guid: "5", status: "Fail", delivered_at: time - 2},
+      {guid: "6", status: "OK", delivered_at: time - 3}
+    ])
+
+    failed_deliveries = described_class.failed_deliveries(time)
+    expect(failed_deliveries).to eq([
+      {guid: "1", status: "Fail", delivered_at: time + 5},
+      {guid: "4", status: "Fail", delivered_at: time + 2}
+    ])
+  end
+
+  it ".redeliver_failed_deliveries" do
+    time = Time.now
+    app_client = instance_double(Octokit::Client)
+    expect(described_class).to receive(:app_client).and_return(app_client)
+    expect(described_class).to receive(:failed_deliveries).with(time).and_return([{id: "1"}, {id: "2"}])
+    expect(app_client).to receive(:post).with("/app/hook/deliveries/1/attempts")
+    expect(app_client).to receive(:post).with("/app/hook/deliveries/2/attempts")
+    described_class.redeliver_failed_deliveries(time)
+  end
 end


### PR DESCRIPTION
GitHub does not resend webhook deliveries that have failed. It is necessary to inspect the failed deliveries and redeliver them in case of missed deliveries due to deployments or incidents.

The "/app/hook/deliveries" endpoint lacks a filter, necessitating pagination until the specified date. It also returns all attempts for each delivery packet. Each delivery packet has a unique "guid".

We group deliveries by "guid". If there isn't a successful delivery within a "guid" group, we initiate redelivery for that particular packet.

    # Get failed deliveries for last 10 minutes
    Github.failed_deliveries(Time.now - 10 * 60)

    # Redeliver failed deliveries for last 10 minutes
    Github.redeliver_failed_deliveries(Time.now - 10 * 60)

Since it paginates until the specified date is reached, avoid providing a very old date as it could result in an excessive number of pagination requests.

GitHub also recommends to use such a script to redeliver failed deliveries

https://docs.github.com/en/webhooks/using-webhooks/automatically-redelivering-failed-deliveries-for-a-github-app-webhook