### PR TITLE
Create root and server certificates for PostgreSQL

### DIFF
--- a/migrate/20231020_add_cert_to_pg.rb
+++ b/migrate/20231020_add_cert_to_pg.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:postgres_server) do
+      add_column :root_cert, :text, collate: '"C"'
+      add_column :root_cert_key, :text, collate: '"C"'
+      add_column :server_cert, :text, collate: '"C"'
+      add_column :server_cert_key, :text, collate: '"C"'
+    end
+  end
+end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -17,6 +17,8 @@ class PostgresServer < Sequel::Model
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password
+    enc.column :root_cert_key
+    enc.column :server_cert_key
   end
 
   def hyper_tag_name(project)

--- a/rhizome/postgres/bin/install_postgres
+++ b/rhizome/postgres/bin/install_postgres
@@ -9,6 +9,8 @@ r "apt-get update"
 r "apt-get -y install postgresql-common"
 
 r "echo \"initdb_options = '--data-checksums'\" | sudo tee -a /etc/postgresql-common/createcluster.conf"
+r "echo \"ssl_cert_file = '/var/lib/postgresql/16/main/server.crt'\" | sudo tee -a /etc/postgresql-common/createcluster.conf"
+r "echo \"ssl_key_file = '/var/lib/postgresql/16/main/server.key'\" | sudo tee -a /etc/postgresql-common/createcluster.conf"
 
 r "apt-get -y install postgresql-16"
 


### PR DESCRIPTION
**Add utility function to create certificates**

This commit adds a create_certificiate utility function to be able to create
root and server certificates for PostgreSQL service, but it can be used by
other products as well.

Single create_certificate function can be used to create both self-signed root
certificates as well as other certificates issued by given root certificate. To
be able to create a root certificate issuer_cert/key fields must not be set and
also "basicConstraints=CA:TRUE" extension must be added to extensions array. It
is good idea to add "keyUsage=cRLSign,keyCertSign" extension as well, otherwise
created root certificate wouldn't be any useful.

Here are some example usages for create_extension function:

```ruby
#Creating root certificate:
root_cert, root_cert_key = Util.create_certificate(
  subject: "/C=US/O=Ubicloud/CN=Root Certificate Authority",
  extensions: ["basicConstraints=CA:TRUE", "keyUsage=cRLSign,keyCertSign", "subjectKeyIdentifier=hash"],
  duration: 60 * 60 * 24 * 365 * 10 # 10 years
)

#Creating server certificates:
server_cert, server_cert_key = Util.create_certificate(
  subject: "/C=US/O=Ubicloud/CN=Server Certificate",
  extensions: ["subjectAltName=DNS:test.ubicloud.com", "keyUsage=digitalSignature,keyEncipherment", "subjectKeyIdentifier=hash", "extendedKeyUsage=serverAuth"],
  duration: 60 * 60 * 24 * 30 * 6, # ~6months
  issuer_cert: root_cert,
  issuer_key: root_cert_key
)
```

**Create root and server certificates for PG**

We added a new label that uses Util.create_certificate for creating root and
server certificates. We are creating a root certificate per postgres server,
which saves us from storing a central and very powerful root certificate. On
the other hand, this means customers would need to use different root certs for
every server if they want to validate the server certificates. In the future
we might move to a root per organization (or whatever construct we would use
for aggregating projects).

Instead of creating our own CA, we also considered using one of the publicly
trusted CAs. However we decided against it because;
- Adding a network dependency reduces overall reliability.
- Any outage in the 3rd party system would cause outage in ours as well.
- It is slow to get certificates from these CAs, so it would increase our
provisioning times.
- It would also affect ease of development in negative way.

Some of these issues can be mitigated by creating a certificate pools but that
requires investment and would complicate the overall architecture.