### PR TITLE
Fix broken symbolic link for WAL directory

### DIFF
--- a/rhizome/postgres/bin/install_postgres
+++ b/rhizome/postgres/bin/install_postgres
@@ -14,6 +14,6 @@ r "apt-get -y install postgresql-16"
 
 r "mkdir -p /dat/16"
 r "ln -sf /var/lib/postgresql/16/main /dat/16/data"
-r "ln -sf /var/lib/postgresql/wal/16/main /dat/16/wal"
+r "ln -sf /var/lib/postgresql/16/main/pg_wal /dat/16/wal"
 
 r "chown --recursive postgres /dat"


### PR DESCRIPTION
We changed the location of WALs, but didn't update the symbolic link. With this commit, we are fixing the broken symbolic link.