### PR TITLE
Pass mac address to the cloud-init in a yaml safe form

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -319,7 +319,7 @@ DNSMASQ_CONF
       <<ETHERNETS
   #{yq("enx" + mac.tr(":", "").downcase)}:
     match:
-      macaddress: #{mac}
+      macaddress: "#{mac}"
     dhcp6: true
     dhcp4: true
 ETHERNETS


### PR DESCRIPTION
We had issues in production that some of the provisionings were abruptly
failing with a complaint on the provided mac address form. Such as;
[4.449504] cloud-init[462]: Stderr:
/etc/netplan/50-cloud-init.yaml:12:29: Error in network definition:
Invalid MAC address '40626667100', must be XX:XX:XX:XX:XX:XX or
XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX [
4.451490] cloud-init[462]: macaddress: 40626667100

Looking into the documentation, it looks like the mac_address needs to
be passed in quotes to be safe
(https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v1.html#mac-address-mac-address)

Another interesting thing is how the YAML library doesn't really
interpret these mac addresses properly and add quotes. Looks like pyyaml
has the same issue as ruby yaml library. You can see it here
https://stackoverflow.com/questions/43872999/pyyaml-converts-mac-address-to-number

The source of the problem is that yaml supports sexagecimal numbers
(why?) and some of the generated mac addresses can be interpreted as
integers as it is explained here https://stackoverflow.com/a/43873228

The only way to make this properly working is to add quotes.