### PR TITLE
Enable certificate rotation for PostgreSQL

### DIFF
--- a/migrate/20231023_rotate_pg_certificates.rb
+++ b/migrate/20231023_rotate_pg_certificates.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:postgres_server) do
+      add_column :root_cert_2, :text, collate: '"C"'
+      add_column :root_cert_key_2, :text, collate: '"C"'
+      add_column :certificate_last_checked_at, :timestamptz, null: false, default: Sequel.lit("now()")
+      rename_column :root_cert, :root_cert_1
+      rename_column :root_cert_key, :root_cert_key_1
+    end
+  end
+
+  down do
+    alter_table(:postgres_server) do
+      drop_column :root_cert_2
+      drop_column :root_cert_key_2
+      drop_column :certificate_last_checked_at
+      rename_column :root_cert_1, :root_cert
+      rename_column :root_cert_key_1, :root_cert_key
+    end
+  end
+end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -48,7 +48,9 @@ class PostgresServer < Sequel::Model
         tcp_keepalives_count: 4,
         tcp_keepalives_idle: 2,
         tcp_keepalives_interval: 2,
-        work_mem: "#{vm.mem_gib / 8}MB"
+        work_mem: "#{vm.mem_gib / 8}MB",
+        ssl_cert_file: "'/var/lib/postgresql/16/main/server.crt'",
+        ssl_key_file: "'/var/lib/postgresql/16/main/server.key'"
       },
       private_subnets: vm.private_subnets.map {
         {

--- a/rhizome/postgres/bin/install_postgres
+++ b/rhizome/postgres/bin/install_postgres
@@ -9,8 +9,6 @@ r "apt-get update"
 r "apt-get -y install postgresql-common"
 
 r "echo \"initdb_options = '--data-checksums'\" | sudo tee -a /etc/postgresql-common/createcluster.conf"
-r "echo \"ssl_cert_file = '/var/lib/postgresql/16/main/server.crt'\" | sudo tee -a /etc/postgresql-common/createcluster.conf"
-r "echo \"ssl_key_file = '/var/lib/postgresql/16/main/server.key'\" | sudo tee -a /etc/postgresql-common/createcluster.conf"
 
 r "apt-get -y install postgresql-16"
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -55,7 +55,9 @@ RSpec.describe PostgresServer do
         tcp_keepalives_count: 4,
         tcp_keepalives_idle: 2,
         tcp_keepalives_interval: 2,
-        work_mem: "1MB"
+        work_mem: "1MB",
+        ssl_cert_file: "'/var/lib/postgresql/16/main/server.crt'",
+        ssl_key_file: "'/var/lib/postgresql/16/main/server.key'"
       },
       private_subnets: [
         {


### PR DESCRIPTION
Since creating and rotating certificates are quite similar, with few small
extra steps, we also got free certificate rotation. I even initially did the
initial certificate creation and certificate rotation in a single label, but
overall readability of the solution was not that good, so eventually decided
to have two separate labels with the cost of few extra lines.

We set the validity of the root certificates as 10 years and rotate them once
every 5 years. Each root certificate is used to sign new server certificates
between its 4th and 9th years. That means, depending on the the when the root
certs are downloaded, users can go 4 to 9 years without needing to re-download
root certificates. If they download the root certificates just after cluster
creation, they don't need to download the root certificates again for about 9
years. The worst case is when users download the root certificates just before
the rotation time. In this case, they would need to download the certificates
in 4 years.

Validity of the server certificate is 6 months. 1 month before the expiry of
the server certificate, we create a new server certificate using the older of
the two root certificates unless there is less than 1 year left to the expiry
of the older certificate. In that case, we use the newer one. Because in few
months, we would rotate the old certificate and we don't want to have a server
certificate that is signed by the almost expired root certificate.