### PR TITLE
Register deadlines before hopping to the new label

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -96,6 +96,7 @@ class Prog::Vm::GithubRunner < Prog::Base
   def before_run
     when_destroy_set? do
       unless ["destroy", "wait_vm_destroy"].include?(strand.label)
+        register_deadline(nil, 10 * 60)
         hop_destroy
       end
     end
@@ -216,8 +217,6 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def destroy
-    register_deadline(nil, 10 * 60)
-
     decr_destroy
 
     # Waiting 404 Not Found response for get runner request

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -189,6 +189,7 @@ SQL
       if strand.label != "destroy"
         vm.active_billing_record&.finalize
         vm.assigned_vm_address&.active_billing_record&.finalize
+        register_deadline(nil, 5 * 60)
         hop_destroy
       end
     end
@@ -307,6 +308,7 @@ SQL
 
   label def wait
     when_start_after_host_reboot_set? do
+      register_deadline(:wait, 5 * 60)
       hop_start_after_host_reboot
     end
 
@@ -314,8 +316,6 @@ SQL
   end
 
   label def destroy
-    register_deadline(nil, 5 * 60)
-
     decr_destroy
 
     vm.update(display_state: "deleting")
@@ -358,8 +358,6 @@ SQL
   end
 
   label def start_after_host_reboot
-    register_deadline(:wait, 5 * 60)
-
     vm.update(display_state: "starting")
 
     secrets_json = JSON.generate({

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#before_run" do
     it "hops to destroy when needed" do
       expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx).to receive(:register_deadline)
       expect { nx.before_run }.to hop("destroy")
     end
 
@@ -277,7 +278,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "destroys resources and hops if runner deregistered" do
-      expect(nx).to receive(:register_deadline)
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)
@@ -288,7 +288,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "does not destroy vm if it's already destroyed" do
-      expect(nx).to receive(:register_deadline)
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)


### PR DESCRIPTION
We have a known issue #718. If the label that we register deadline fails, we can't persist the deadline information to the strand's stack.

If destroy or start_after_host_reboot fails for some reasons, we will not get a page.