### PR TITLE
Delete vm's associations with association_dependencies plugin

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -12,6 +12,8 @@ class Vm < Sequel::Model
   one_to_many :vm_storage_volumes, key: :vm_id
   one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
 
+  plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy
+
   dataset_module Authorization::Dataset
 
   include ResourceMethods

--- a/prog/postgres/postgres_nexus.rb
+++ b/prog/postgres/postgres_nexus.rb
@@ -241,7 +241,6 @@ SQL
 
     if vm
       vm.private_subnets.each { _1.incr_destroy }
-      vm.sshable&.destroy
       vm.incr_destroy
       nap 5
     end

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -151,7 +151,6 @@ class Prog::Test::VmGroup < Prog::Base
   label def destroy_vms
     frame["vms"].each { |vm_id|
       Vm[vm_id].incr_destroy
-      Sshable[vm_id].destroy
     }
 
     hop_wait_vms_destroyed

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -237,7 +237,6 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     if vm
       vm.private_subnets.each { _1.incr_destroy }
-      vm.sshable.destroy
       vm.incr_destroy
     end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -353,14 +353,11 @@ SQL
         nic.incr_destroy
       end
 
-      vm.assigned_vm_address_dataset.destroy
-
       VmHost.dataset.where(id: vm.vm_host_id).update(
         used_cores: Sequel[:used_cores] - vm.cores,
         used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib,
         available_storage_gib: Sequel[:available_storage_gib] + vm.storage_size_gib
       )
-      vm.vm_storage_volumes_dataset.destroy
       vm.projects.map { vm.dissociate_with_project(_1) }
       vm.destroy
     end

--- a/spec/prog/postgres/postgres_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_nexus_spec.rb
@@ -344,12 +344,10 @@ RSpec.describe Prog::Postgres::PostgresNexus do
       expect(postgres_resource).to receive(:hostname)
       expect(dns_zone).to receive(:delete_record)
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
-      expect(sshable).to receive(:destroy)
       expect(vm).to receive(:private_subnets).and_return([])
       expect(vm).to receive(:incr_destroy)
       expect { nx.destroy }.to nap(5)
 
-      expect(vm).to receive(:sshable).and_return(nil)
       expect(vm).to receive(:private_subnets).and_return([])
       expect(vm).to receive(:incr_destroy)
       expect { nx.destroy }.to nap(5)

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -292,7 +292,6 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)
-      expect(sshable).to receive(:destroy)
       expect(vm).to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")
@@ -303,7 +302,6 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)
       expect(github_runner).to receive(:vm).and_return(nil)
-      expect(sshable).not_to receive(:destroy)
       expect(vm).not_to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")


### PR DESCRIPTION
When we delete models, we manually clear some associations, while others are automatically deleted by the :association_dependencies plugin. It's easy to overlook the manual cleaning of associations, which can lead to database failures due to some foreign keys. Whenever I need to delete something, I constantly check the code to determine what requires manual deletion and what is deleted automatically. I believe that unifying the deletion behavior of associations would simplify the developers' life. I initiated this refactoring with the vm model.