### PR TITLE
Add a wrapper for Vm.assemble to create Sshable for the service vms

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -30,14 +30,10 @@ class Prog::Test::VmGroup < Prog::Base
     strand.add_child(subnet1_s)
     strand.add_child(subnet2_s)
 
-    keypair_1 = SshKey.generate
-    keypair_2 = SshKey.generate
-    keypair_3 = SshKey.generate
-
     storage_encrypted = frame.fetch("storage_encrypted", true)
 
-    vm1_s = Prog::Vm::Nexus.assemble(
-      keypair_1.public_key, project.id,
+    vm1_s = Prog::Vm::Nexus.assemble_with_sshable(
+      "ubi", project.id,
       private_subnet_id: subnet1_s.id,
       storage_volumes: [
         {encrypted: storage_encrypted},
@@ -46,37 +42,19 @@ class Prog::Test::VmGroup < Prog::Base
       enable_ip4: true
     )
 
-    vm2_s = Prog::Vm::Nexus.assemble(
-      keypair_2.public_key, project.id,
+    vm2_s = Prog::Vm::Nexus.assemble_with_sshable(
+      "ubi", project.id,
       private_subnet_id: subnet1_s.id,
       storage_volumes: [{encrypted: storage_encrypted}],
       enable_ip4: true
     )
 
-    vm3_s = Prog::Vm::Nexus.assemble(
-      keypair_3.public_key, project.id,
+    vm3_s = Prog::Vm::Nexus.assemble_with_sshable(
+      "ubi", project.id,
       private_subnet_id: subnet2_s.id,
       storage_volumes: [{encrypted: storage_encrypted}],
       enable_ip4: true
     )
-
-    Sshable.create(
-      unix_user: "ubi",
-      host: "temp_#{vm1_s.id}",
-      raw_private_key_1: keypair_1.keypair
-    ) { _1.id = vm1_s.id }
-
-    Sshable.create(
-      unix_user: "ubi",
-      host: "temp_#{vm2_s.id}",
-      raw_private_key_1: keypair_2.keypair
-    ) { _1.id = vm2_s.id }
-
-    Sshable.create(
-      unix_user: "ubi",
-      host: "temp_#{vm3_s.id}",
-      raw_private_key_1: keypair_3.keypair
-    ) { _1.id = vm3_s.id }
 
     strand.add_child(vm1_s)
     strand.add_child(vm2_s)

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -29,25 +29,16 @@ class Prog::Vm::VmPool < Prog::Base
   end
 
   label def create_new_vm
-    ssh_key = SshKey.generate
-    DB.transaction do
-      vm_st = Prog::Vm::Nexus.assemble(
-        ssh_key.public_key,
-        Config.vm_pool_project_id,
-        size: vm_pool.vm_size,
-        unix_user: "runner",
-        location: vm_pool.location,
-        boot_image: vm_pool.boot_image,
-        storage_volumes: [{size_gib: vm_pool.storage_size_gib, encrypted: false}],
-        enable_ip4: true,
-        pool_id: vm_pool.id
-      )
-      Sshable.create(
-        unix_user: "runner",
-        host: "temp_#{vm_st.id}",
-        raw_private_key_1: ssh_key.keypair
-      ) { _1.id = vm_st.id }
-    end
+    Prog::Vm::Nexus.assemble_with_sshable(
+      "runner",
+      Config.vm_pool_project_id,
+      size: vm_pool.vm_size,
+      location: vm_pool.location,
+      boot_image: vm_pool.boot_image,
+      storage_volumes: [{size_gib: vm_pool.storage_size_gib, encrypted: false}],
+      enable_ip4: true,
+      pool_id: vm_pool.id
+    )
 
     hop_wait
   end

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -71,10 +71,8 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       vm = nx.minio_server.vm
       vm.strand.update(label: "wait")
       expect(nx).to receive(:register_deadline)
-      expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
       expect(nx).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "minio", "subject_id" => vm.id, "user" => "minio-user"})
       expect { nx.start }.to hop("wait_bootstrap_rhizome")
-      expect(vm.sshable.host).to eq "1.1.1.1"
     end
   end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -74,11 +74,9 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect { nx.start }.to nap(5)
     end
 
-    it "update sshable host and hops" do
+    it "hops if vm is ready" do
       expect(postgres_resource).to receive(:incr_initial_provisioning)
       expect(vm).to receive(:strand).and_return(Strand.new(label: "wait"))
-      expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
-      expect(sshable).to receive(:update).with(host: "1.1.1.1")
       expect { nx.start }.to hop("bootstrap_rhizome")
     end
   end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -150,11 +150,9 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect { nx.wait_vm }.to nap(5)
     end
 
-    it "update sshable host and hops" do
+    it "hops if vm is ready" do
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(vm).to receive(:strand).and_return(Strand.new(label: "wait"))
-      expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
-      expect(sshable).to receive(:update).with(host: "1.1.1.1")
       expect { nx.wait_vm }.to hop("install_nftables_rules")
     end
   end


### PR DESCRIPTION
We manage customer virtual machines, as well as the virtual machines utilized by our other services. The latter are managed by the control plane, which connects these virtual machines via SSH. Or services like GitHub runners, PostgreSQL, MinIO, and E2E tests all rely on these virtual machines. Each service generates an Sshable, assembles the virtual machine, and then updates the host of the Sshable once the machine is ready. To streamline this process, I've consolidated the generation and testing from 4 different locations into one.

`Vm::Nexus.assemble_with_sshable` serves as a wrapper for `Vm::Nexus.assemble`, sharing the same signature with one key difference: it receives a `unix_user` as the first argument instead of a `public_key`.  Consequently, it generates an Sshable for the virtual machine