### PR TITLE
Hop to the correct label when reboot is requested.

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -182,7 +182,7 @@ class Prog::Vm::HostNexus < Prog::Base
 
   label def wait
     when_reboot_set? do
-      hop_reboot
+      hop_prep_reboot
     end
 
     nap 30

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -218,9 +218,9 @@ RSpec.describe Prog::Vm::HostNexus do
       expect { nx.wait }.to nap(30)
     end
 
-    it "hops to reboot when needed" do
+    it "hops to prep_reboot when needed" do
       expect(nx).to receive(:when_reboot_set?).and_yield
-      expect { nx.wait }.to hop("reboot")
+      expect { nx.wait }.to hop("prep_reboot")
     end
   end
 


### PR DESCRIPTION
In #674 we changed the label which initiated reboot from `reboot` to `prep_reboot`. We do reboot in 2 cases:

1. When setting up host
2. On VmHost.incr_reboot

We had updated the label to be hopped at for case 1, but we had missed updating the label for case 2. This PR fixes that.

To initiate reboot, you can do `vm_host.incr_reboot`.