### PR TITLE
Fixes IPv4 connectivity after host reboot

### DIFF
--- a/model/nic.rb
+++ b/model/nic.rb
@@ -11,7 +11,7 @@ class Nic < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   semaphore :destroy, :detach_vm, :start_rekey, :trigger_outbound_update,
-    :old_state_drop_trigger, :setup_nic
+    :old_state_drop_trigger, :setup_nic, :repopulate
 
   plugin :column_encryption do |enc|
     enc.column :encryption_key

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -11,6 +11,7 @@ class Strand < Sequel::Model
   LEASE_EXPIRATION = 120
   many_to_one :parent, key: :parent_id, class: self
   one_to_many :children, key: :parent_id, class: self
+  one_to_many :semaphores
 
   NAVIGATE = %w[vm vm_host sshable].freeze
 

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -91,7 +91,7 @@ class Prog::Test::HetznerServer < Prog::Base
   end
 
   label def test_host_encrypted
-    strand.add_child(Prog::Test::VmGroup.assemble(storage_encrypted: true))
+    strand.add_child(Prog::Test::VmGroup.assemble(storage_encrypted: true, test_reboot: true))
 
     hop_wait_test_host_encrypted
   end
@@ -105,7 +105,7 @@ class Prog::Test::HetznerServer < Prog::Base
   end
 
   label def test_host_unencrypted
-    strand.add_child(Prog::Test::VmGroup.assemble(storage_encrypted: false))
+    strand.add_child(Prog::Test::VmGroup.assemble(storage_encrypted: false, test_reboot: false))
 
     hop_wait_test_host_unencrypted
   end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -368,6 +368,7 @@ SQL
 
     host.sshable.cmd("sudo host/bin/recreate-unpersisted #{params_path.shellescape}", stdin: secrets_json)
     host.sshable.cmd("sudo systemctl start #{q_vm}")
+    vm.nics.each { _1.incr_repopulate }
 
     vm.update(display_state: "running")
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -14,20 +14,20 @@ RSpec.describe Prog::Test::VmGroup do
   end
 
   describe "#setup_vms" do
-    it "hops to wait_children_created" do
-      expect { vg_test.setup_vms }.to hop("wait_children_created", "Test::VmGroup")
+    it "hops to wait_children_ready" do
+      expect { vg_test.setup_vms }.to hop("wait_children_ready", "Test::VmGroup")
     end
   end
 
-  describe "#wait_children_created" do
+  describe "#wait_children_ready" do
     it "hops to children_ready if children idle" do
       expect(vg_test).to receive(:children_idle).and_return(true)
-      expect { vg_test.wait_children_created }.to hop("children_ready", "Test::VmGroup")
+      expect { vg_test.wait_children_ready }.to hop("children_ready", "Test::VmGroup")
     end
 
     it "donates if children not idle" do
       expect(vg_test).to receive(:children_idle).and_return(false)
-      expect { vg_test.wait_children_created }.to nap(0)
+      expect { vg_test.wait_children_ready }.to nap(0)
     end
   end
 
@@ -41,14 +41,53 @@ RSpec.describe Prog::Test::VmGroup do
   end
 
   describe "#wait_subtests" do
-    it "hops to destroy_vms if children idle" do
+    it "hops to destroy_vms if children idle and not test_reboot" do
       expect(vg_test).to receive(:children_idle).and_return(true)
+      expect(vg_test).to receive(:frame).and_return({"test_reboot" => false})
       expect { vg_test.wait_subtests }.to hop("destroy_vms", "Test::VmGroup")
+    end
+
+    it "hops to test_reboot if children idle and test_reboot" do
+      expect(vg_test).to receive(:children_idle).and_return(true)
+      expect(vg_test).to receive(:frame).and_return({"test_reboot" => true})
+      expect { vg_test.wait_subtests }.to hop("test_reboot", "Test::VmGroup")
     end
 
     it "donates if children not idle" do
       expect(vg_test).to receive(:children_idle).and_return(false)
       expect { vg_test.wait_subtests }.to nap(0)
+    end
+  end
+
+  describe "#test_reboot" do
+    it "hops to wait_reboot" do
+      host = instance_double(VmHost)
+      expect(vg_test).to receive(:host).and_return(host)
+      expect(host).to receive(:incr_reboot).with(no_args)
+      expect { vg_test.test_reboot }.to hop("wait_reboot", "Test::VmGroup")
+    end
+  end
+
+  describe "#wait_reboot" do
+    let(:st) {
+      instance_double(Strand)
+    }
+
+    before do
+      host = instance_double(VmHost)
+      allow(vg_test).to receive(:host).and_return(host)
+      allow(host).to receive(:strand).and_return(st)
+    end
+
+    it "naps if strand is busy" do
+      expect(st).to receive(:label).and_return("reboot")
+      expect { vg_test.wait_reboot }.to nap(30)
+    end
+
+    it "runs vm tests if reboot done" do
+      expect(st).to receive(:label).and_return("wait")
+      expect(st).to receive(:semaphores).and_return([])
+      expect { vg_test.wait_reboot }.to hop("wait_children_ready", "Test::VmGroup")
     end
   end
 
@@ -108,6 +147,16 @@ RSpec.describe Prog::Test::VmGroup do
       st = Strand.create_with_id(prog: "Prog", label: "label")
       allow(vg_test).to receive(:strand).and_return(st)
       expect(vg_test.children_idle).to be(true)
+    end
+  end
+
+  describe "#host" do
+    it "returns first VM's host" do
+      sshable = Sshable.create_with_id
+      host = VmHost.create(location: "A") { _1.id = sshable.id }
+      vm = Vm.create_with_id(unix_user: "root", public_key: "", name: "xyz", location: "a", boot_image: "b", family: "z", cores: 1, vm_host_id: host.id)
+      expect(vg_test).to receive(:frame).and_return({"vms" => [vm.id]})
+      expect(vg_test.host).to eq(host)
     end
   end
 end


### PR DESCRIPTION
Fixes #756. The issue mentions the connectivity loss after host reboot for IPv4. This is related to the ipv4 private subnet not being persistently added to the tuntap* interface. In this PR, we are simply repopulating that and getting into the rekeying sequence to also keep the private networking connectivity. Because we also lost the ip xfrm state and policy objects at the host reboot.