### PR TITLE
Simplify the logic for waiting on child strands

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -199,6 +199,13 @@ end
     strand.children.empty?
   end
 
+  def when_children_done?(reaper = nil)
+    reaped_children = reap
+    reaped_children.each { reaper.call(_1) } if reaper
+    yield if leaf?
+    donate
+  end
+
   # A hop is a kind of jump, as in, like a jump instruction.
   private def dynamic_hop(label)
     fail "BUG: #hop only accepts a symbol" unless label.is_a? Symbol

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -43,22 +43,17 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   label def wait_learn_storage
-    reap.each do |st|
+    reaper = proc do |st|
       case st.prog
       when "LearnStorage"
         kwargs = {
           total_storage_gib: st.exitval.fetch("total_storage_gib"),
           available_storage_gib: st.exitval.fetch("available_storage_gib")
         }
-
         vm_host.update(**kwargs)
       end
     end
-
-    if leaf?
-      hop_activate_host
-    end
-    donate
+    when_children_done?(reaper) { hop_activate_host }
   end
 
   label def activate_host

--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -14,9 +14,7 @@ class Prog::InstallDnsmasq < Prog::Base
   end
 
   label def wait_downloads
-    reap
-    hop_compile_and_install if leaf?
-    donate
+    when_children_done? { hop_compile_and_install }
   end
 
   label def compile_and_install

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -68,9 +68,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_setup if leaf?
-    donate
+    when_children_done? { hop_setup }
   end
 
   label def setup
@@ -81,11 +79,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   end
 
   label def wait_setup
-    reap
-    if leaf?
-      hop_minio_start
-    end
-    donate
+    when_children_done? { hop_minio_start }
   end
 
   label def minio_start

--- a/prog/postgres/postgres_nexus.rb
+++ b/prog/postgres/postgres_nexus.rb
@@ -82,9 +82,7 @@ class Prog::Postgres::PostgresNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_mount_data_disk if leaf?
-    donate
+    when_children_done? { hop_mount_data_disk }
   end
 
   label def mount_data_disk

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -40,9 +40,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_prep if leaf?
-    donate
+    when_children_done? { hop_prep }
   end
 
   label def prep
@@ -56,7 +54,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def wait_prep
-    reap.each do |st|
+    reaper = proc do |st|
       case st.prog
       when "LearnMemory"
         mem_gib = st.exitval.fetch("mem_gib")
@@ -79,11 +77,7 @@ class Prog::Vm::HostNexus < Prog::Base
         vm_host.update(**kwargs)
       end
     end
-
-    if leaf?
-      hop_setup_hugepages
-    end
-    donate
+    when_children_done?(reaper) { hop_setup_hugepages }
   end
 
   label def setup_hugepages
@@ -92,9 +86,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def wait_setup_hugepages
-    reap
-    hop_setup_spdk if leaf?
-    donate
+    when_children_done? { hop_setup_spdk }
   end
 
   label def setup_spdk
@@ -103,11 +95,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def wait_setup_spdk
-    reap
-    if leaf?
-      hop_prep_reboot
-    end
-    donate
+    when_children_done? { hop_prep_reboot }
   end
 
   label def prep_reboot

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -41,12 +41,10 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_add_subnet_addr
-    reap
-    if leaf?
+    when_children_done? do
       nic.private_subnet.incr_add_new_nic
       hop_wait_setup
     end
-    donate
   end
 
   label def wait_setup
@@ -75,13 +73,10 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_rekey_inbound
-    reap
-    if leaf?
+    when_children_done? do
       decr_start_rekey
       hop_wait_rekey_outbound_trigger
     end
-
-    donate
   end
 
   label def wait_rekey_outbound_trigger
@@ -94,13 +89,10 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_rekey_outbound
-    reap
-    if leaf?
+    when_children_done? do
       decr_trigger_outbound_update
       hop_wait_rekey_old_state_drop_trigger
     end
-
-    donate
   end
 
   label def wait_rekey_old_state_drop_trigger
@@ -113,13 +105,10 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_rekey_old_state_drop
-    reap
-    if leaf?
+    when_children_done? do
       decr_old_state_drop_trigger
       hop_wait
     end
-
-    donate
   end
 
   label def destroy


### PR DESCRIPTION
When we bud child strands, the parent strand reaps its children and donates its running time to them. If it's a leaf, meaning no children are left, it generally hops to the another label. I've attempted to simplify this logic to avoid repetition across different locations. The action a parent takes when it no longer has any children is more common, so I' passed it as a block. The operation to process reaped children is less common, so I passed it as a proc.