### PR TITLE
Add created_at column to various tables

### DIFF
--- a/migrate/20231024_add_created_at.rb
+++ b/migrate/20231024_add_created_at.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:access_policy) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+    alter_table(:access_tag) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+    alter_table(:accounts) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+    alter_table(:billing_info) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+    alter_table(:payment_method) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+    alter_table(:project) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+  end
+end


### PR DESCRIPTION
The "created_at" field serves various purposes and proves particularly useful during debugging. In case of breaking changes, it allows us to adjust behavior based on the resource's age or decide which resources to migrate based on their creation date.

It is good to see when a user registered, when a project was created, or when an access tag was generated, as it indicates the association of a user or resource with a project.