### PR TITLE
Clean up nap/hop/exit expectations in specs

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -6,7 +6,7 @@ class Prog::Base
   def initialize(strand, snap = nil)
     @snap = snap || SemSnap.new(strand.id)
     @strand = strand
-    @subject_id = frame&.dig("subject_id") || @strand.id
+    @subject_id = frame.dig("subject_id") || @strand.id
   end
 
   def self.subject_is(*names)

--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -39,7 +39,6 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
     if nic.src_ipsec_tunnels.empty? && nic.dst_ipsec_tunnels.empty?
       nic.vm.vm_host.sshable.cmd("sudo ip -n #{nic.vm.inhost_name.shellescape} xfrm state deleteall")
       pop "drop_old_state is complete early"
-      return
     end
 
     new_spis = [nic.rekey_payload["spi4"], nic.rekey_payload["spi6"]]

--- a/spec/prog/learn_cores_spec.rb
+++ b/spec/prog/learn_cores_spec.rb
@@ -103,8 +103,7 @@ JSON
         eight_thread_four_core_four_numa_two_socket
       )
       expect(lc).to receive(:sshable).and_return(sshable)
-      expect(lc).to receive(:pop).with(total_sockets: 2, total_cores: 4, total_nodes: 4, total_cpus: 8)
-      lc.start
+      expect { lc.start }.to exit({total_sockets: 2, total_cores: 4, total_nodes: 4, total_cpus: 8})
     end
   end
 end

--- a/spec/prog/learn_memory_spec.rb
+++ b/spec/prog/learn_memory_spec.rb
@@ -20,8 +20,7 @@ EOS
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with("sudo /usr/sbin/dmidecode -t memory | fgrep Size:").and_return(four_units)
       expect(lm).to receive(:sshable).and_return(sshable)
-      expect(lm).to receive(:pop).with(mem_gib: 64)
-      lm.start
+      expect { lm.start }.to exit({mem_gib: 64})
     end
   end
 

--- a/spec/prog/learn_network_spec.rb
+++ b/spec/prog/learn_network_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnNetwork do
-  subject(:lm) { described_class.new(Strand.new(stack: [])) }
+  subject(:lm) { described_class.new(Strand.new(stack: [{}])) }
 
   let(:ip6_interface_output) do
     <<JSON
@@ -44,8 +44,7 @@ JSON
       expect(vm_host).to receive(:update).with(ip6: "2a01:4f8:173:1ed3::2", net6: "2a01:4f8:173:1ed3::/64")
       expect(lm).to receive(:sshable).and_return(sshable)
       expect(lm).to receive(:vm_host).and_return(vm_host)
-      expect(lm).to receive(:pop).with("learned network information")
-      lm.start
+      expect { lm.start }.to exit({"msg" => "learned network information"})
     end
   end
 

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -12,10 +12,8 @@ RSpec.describe Prog::LearnStorage do
 1B-blocks     Avail
 494384795648 299711037440
 EOS
-
       expect(ls).to receive(:sshable).and_return(sshable).at_least(:once)
-      expect(ls).to receive(:pop).with(total_storage_gib: 460, available_storage_gib: 274)
-      ls.start
+      expect { ls.start }.to exit({total_storage_gib: 460, available_storage_gib: 274})
     end
   end
 

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -73,9 +73,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(nx).to receive(:register_deadline)
       expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
       expect(nx).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "minio", "subject_id" => vm.id, "user" => "minio-user"})
-      expect {
-        nx.start
-      }.to hop("wait_bootstrap_rhizome")
+      expect { nx.start }.to hop("wait_bootstrap_rhizome")
       expect(vm.sshable.host).to eq "1.1.1.1"
     end
   end
@@ -157,8 +155,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(nx.minio_server.vm.nics.first).to receive(:incr_destroy)
       expect(nx.minio_server.vm).to receive(:incr_destroy)
       expect(nx.minio_server).to receive(:destroy)
-      expect(nx).to receive(:pop).with("minio server destroyed")
-      nx.destroy
+      expect { nx.destroy }.to exit({"msg" => "minio server destroyed"})
     end
   end
 
@@ -175,15 +172,13 @@ RSpec.describe Prog::Minio::MinioServerNexus do
 
     it "does not hop to destroy if destroy is not set" do
       expect(nx).to receive(:when_destroy_set?).and_return(false)
-      expect(nx).not_to receive(:hop_destroy)
-      nx.before_run
+      expect { nx.before_run }.not_to hop("destroy")
     end
 
     it "does not hop to destroy if strand label is destroy" do
       expect(nx).to receive(:when_destroy_set?).and_yield
       expect(nx.strand).to receive(:label).and_return("destroy")
-      expect(nx).not_to receive(:hop_destroy)
-      nx.before_run
+      expect { nx.before_run }.not_to hop("destroy")
     end
   end
 end

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -46,33 +46,24 @@ RSpec.describe Prog::Minio::SetupMinio do
   describe ".install_minio" do
     it "pops if minio is installed" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check install_minio").and_return("Succeeded")
-      expect(nx).to receive(:pop).with("minio is installed")
-      expect {
-        nx.install_minio
-      }.to nap(5)
+      expect { nx.install_minio }.to exit({"msg" => "minio is installed"})
     end
 
     it "installs minio if failed" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check install_minio").and_return("Failed")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'minio/bin/install_minio minio_20231007150738.0.0_amd64' install_minio")
-      expect {
-        nx.install_minio
-      }.to nap(5)
+      expect { nx.install_minio }.to nap(5)
     end
 
     it "naps if check returns unknown" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check install_minio").and_return("Unknown")
-      expect {
-        nx.install_minio
-      }.to nap(5)
+      expect { nx.install_minio }.to nap(5)
     end
 
     it "installs minio if NotStarted" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check install_minio").and_return("NotStarted")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'minio/bin/install_minio minio_20231007150738.0.0_amd64' install_minio")
-      expect {
-        nx.install_minio
-      }.to nap(5)
+      expect { nx.install_minio }.to nap(5)
     end
   end
 
@@ -89,8 +80,7 @@ SH
 192.168.0.0 minio-cluster-name0.minio.ubicloud.com
 SH
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("sudo chown -R minio-user:minio-user /etc/default/minio")
-      expect(nx).to receive(:pop).with("minio is configured")
-      nx.configure_minio
+      expect { nx.configure_minio }.to exit({"msg" => "minio is configured"})
     end
   end
 
@@ -103,26 +93,19 @@ SH
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("sudo common/bin/add_to_fstab /dev/dummy /minio/dat1 xfs defaults 0 0")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("sudo mount /dev/dummy /minio/dat1")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("sudo chown -R minio-user:minio-user /minio")
-      expect(nx).to receive(:pop).with("data disks are mounted")
-      expect {
-        nx.mount_data_disks
-      }.to nap(5)
+      expect { nx.mount_data_disks }.to exit({"msg" => "data disks are mounted"})
     end
 
     it "formats data disks" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check format_disks").and_return("Failed")
       expect(nx.minio_server.vm).to receive_message_chain(:vm_storage_volumes_dataset, :order_by, :where, :all).and_return([instance_double(VmStorageVolume, boot: false, device_path: "/dev/dummy")]) # rubocop:disable RSpec/MessageChain
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo mkfs --type xfs /dev/dummy' format_disks")
-      expect {
-        nx.mount_data_disks
-      }.to nap(5)
+      expect { nx.mount_data_disks }.to nap(5)
     end
 
     it "naps if check returns unknown" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check format_disks").and_return("Unknown")
-      expect {
-        nx.mount_data_disks
-      }.to nap(5)
+      expect { nx.mount_data_disks }.to nap(5)
     end
   end
 end

--- a/spec/prog/setup_hugepages_spec.rb
+++ b/spec/prog/setup_hugepages_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe Prog::SetupHugepages do
       expect(sshable).to receive(:cmd).with("sudo update-grub")
       expect(sh).to receive(:sshable).and_return(sshable).at_least(:once)
       expect(sh).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect(sh).to receive(:pop).with("hugepages installed")
-      sh.start
+      expect { sh.start }.to exit({"msg" => "hugepages installed"})
     end
   end
 end

--- a/spec/prog/setup_spdk_spec.rb
+++ b/spec/prog/setup_spdk_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe Prog::SetupSpdk do
       expect(sshable).to receive(:cmd).with("sudo systemctl enable home-spdk-hugepages.mount")
       expect(sshable).to receive(:cmd).with("sudo systemctl enable spdk")
       expect(ss).to receive(:sshable).and_return(sshable).at_least(:once)
-      expect(ss).to receive(:pop).with("SPDK was setup")
-      ss.enable_service
+      expect { ss.enable_service }.to exit({"msg" => "SPDK was setup"})
     end
   end
 end

--- a/spec/prog/vm/prep_host_spec.rb
+++ b/spec/prog/vm/prep_host_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe Prog::Vm::PrepHost do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with("sudo host/bin/prep_host.rb")
       expect(ph).to receive(:sshable).and_return(sshable)
-      expect(ph).to receive(:pop).with("host prepared")
 
-      ph.start
+      expect { ph.start }.to exit({"msg" => "host prepared"})
     end
   end
 end

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -31,9 +31,7 @@ RSpec.describe Prog::Vm::VmPool do
       st.update(label: "create_new_vm")
       expect(SshKey).to receive(:generate).and_call_original
       expect(nx).to receive(:vm_pool).and_return(VmPool[st.id]).at_least(:once)
-      expect {
-        nx.create_new_vm
-      }.to hop("wait")
+      expect { nx.create_new_vm }.to hop("wait")
       pool = VmPool[st.id]
       expect(pool.vms.count).to eq(1)
       expect(pool.vms.first.sshable).not_to be_nil
@@ -47,17 +45,13 @@ RSpec.describe Prog::Vm::VmPool do
 
     it "waits if nothing to do" do
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
-      expect {
-        nx.wait
-      }.to nap(30)
+      expect { nx.wait }.to nap(30)
     end
 
     it "hops to create_new_vm, if vm count is less than the size and there are no waiting GithubRunners" do
       pool.update(size: 1)
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
-      expect {
-        nx.wait
-      }.to hop("create_new_vm")
+      expect { nx.wait }.to hop("create_new_vm")
     end
 
     it "waits even if the vm count is less when there are waiting GithubRunners" do
@@ -80,9 +74,7 @@ RSpec.describe Prog::Vm::VmPool do
       expect(nx).to receive(:vm_pool).and_return(pool)
       expect(pool).to receive(:vms).and_return([vm])
       expect(vm).to receive(:incr_destroy)
-      expect {
-        nx.destroy
-      }.to hop("wait_vms_destroy")
+      expect { nx.destroy }.to hop("wait_vms_destroy")
     end
   end
 
@@ -95,17 +87,14 @@ RSpec.describe Prog::Vm::VmPool do
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       expect(pool).to receive(:destroy)
       expect(pool).to receive(:vms).and_return([])
-      expect(nx).to receive(:pop).with("pool destroyed")
 
-      nx.wait_vms_destroy
+      expect { nx.wait_vms_destroy }.to exit({"msg" => "pool destroyed"})
     end
 
     it "naps if there are still vms" do
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       expect(pool).to receive(:vms).and_return([true])
-      expect {
-        nx.wait_vms_destroy
-      }.to nap(10)
+      expect { nx.wait_vms_destroy }.to nap(10)
     end
   end
 

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -83,35 +83,27 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "naps 60 if nothing to do and vm doesn't exist" do
-      expect {
-        nx.wait_vm
-      }.to nap(60)
+      expect { nx.wait_vm }.to nap(60)
     end
 
     it "naps 1 if nothing to do and vm exists" do
       vm = instance_double(Vm)
       expect(nic).to receive(:vm).and_return(vm)
-      expect {
-        nx.wait_vm
-      }.to nap(1)
+      expect { nx.wait_vm }.to nap(1)
     end
 
     it "starts setup and pings subnet" do
       vm = instance_double(Vm)
       expect(nic).to receive(:vm).and_return(vm)
       expect(nx).to receive(:when_setup_nic_set?).and_yield
-      expect {
-        nx.wait_vm
-      }.to hop("add_subnet_addr")
+      expect { nx.wait_vm }.to hop("add_subnet_addr")
     end
   end
 
   describe "#add_subnet_addr" do
     it "buds RekeyNicTunnel with add_subnet_addr" do
       expect(nx).to receive(:bud).with(Prog::Vnet::RekeyNicTunnel, {}, :add_subnet_addr)
-      expect {
-        nx.add_subnet_addr
-      }.to hop("wait_add_subnet_addr")
+      expect { nx.add_subnet_addr }.to hop("wait_add_subnet_addr")
     end
   end
 
@@ -125,9 +117,7 @@ RSpec.describe Prog::Vnet::NicNexus do
     it "donates if nothing to do" do
       expect(nx).to receive(:reap).and_return(true)
       expect(nx).to receive(:leaf?).and_return(false)
-      expect {
-        nx.wait_add_subnet_addr
-      }.to nap(0)
+      expect { nx.wait_add_subnet_addr }.to nap(0)
     end
 
     it "starts to wait_setup and pings subnet" do
@@ -137,63 +127,47 @@ RSpec.describe Prog::Vnet::NicNexus do
 
       expect(nx).to receive(:leaf?).and_return(true)
       expect(nx).to receive(:reap).and_return(true)
-      expect {
-        nx.wait_add_subnet_addr
-      }.to hop("wait_setup")
+      expect { nx.wait_add_subnet_addr }.to hop("wait_setup")
     end
   end
 
   describe "#wait_setup" do
     it "naps if nothing to do" do
-      expect {
-        nx.wait_setup
-      }.to nap(5)
+      expect { nx.wait_setup }.to nap(5)
     end
 
     it "starts rekeying if setup is triggered" do
       expect(nx).to receive(:when_start_rekey_set?).and_yield
       expect(nx).to receive(:decr_setup_nic)
-      expect {
-        nx.wait_setup
-      }.to hop("start_rekey")
+      expect { nx.wait_setup }.to hop("start_rekey")
     end
   end
 
   describe "#wait" do
     it "naps if nothing to do" do
-      expect {
-        nx.wait
-      }.to nap(30)
+      expect { nx.wait }.to nap(30)
     end
 
     it "hops to detach vm if needed" do
       expect(nx).to receive(:when_detach_vm_set?).and_yield
-      expect {
-        nx.wait
-      }.to hop("detach_vm")
+      expect { nx.wait }.to hop("detach_vm")
     end
 
     it "hops to start rekey if needed" do
       expect(nx).to receive(:when_start_rekey_set?).and_yield
-      expect {
-        nx.wait
-      }.to hop("start_rekey")
+      expect { nx.wait }.to hop("start_rekey")
     end
 
     it "hops to repopulate if needed" do
       expect(nx).to receive(:when_repopulate_set?).and_yield
-      expect {
-        nx.wait
-      }.to hop("repopulate")
+      expect { nx.wait }.to hop("repopulate")
     end
   end
 
   describe "#repopulate" do
     it "buds RekeyNicTunnel with add_subnet_addr" do
       expect(nx).to receive(:bud).with(Prog::Vnet::RekeyNicTunnel, {}, :add_subnet_addr)
-      expect {
-        nx.repopulate
-      }.to hop("wait_repopulate")
+      expect { nx.repopulate }.to hop("wait_repopulate")
     end
   end
 
@@ -207,9 +181,7 @@ RSpec.describe Prog::Vnet::NicNexus do
     it "donates if nothing to do" do
       expect(nx).to receive(:reap).and_return(true)
       expect(nx).to receive(:leaf?).and_return(false)
-      expect {
-        nx.wait_repopulate
-      }.to nap(0)
+      expect { nx.wait_repopulate }.to nap(0)
     end
 
     it "starts to wait and increments refresh_keys if bud is complete" do
@@ -219,9 +191,7 @@ RSpec.describe Prog::Vnet::NicNexus do
 
       expect(nx).to receive(:leaf?).and_return(true)
       expect(nx).to receive(:reap).and_return(true)
-      expect {
-        nx.wait_repopulate
-      }.to hop("wait")
+      expect { nx.wait_repopulate }.to hop("wait")
     end
   end
 
@@ -234,41 +204,31 @@ RSpec.describe Prog::Vnet::NicNexus do
 
     it "buds rekey with setup_inbound and hops to wait_rekey_inbound" do
       expect(nx).to receive(:bud).with(Prog::Vnet::RekeyNicTunnel, {}, :setup_inbound).and_return(true)
-      expect {
-        nx.start_rekey
-      }.to hop("wait_rekey_inbound")
+      expect { nx.start_rekey }.to hop("wait_rekey_inbound")
     end
 
     it "reaps and donates if setup_inbound is continuing" do
       expect(nx).to receive(:leaf?).and_return(false)
       expect(nx).to receive(:reap).and_return(true)
-      expect {
-        nx.wait_rekey_inbound
-      }.to nap(0)
+      expect { nx.wait_rekey_inbound }.to nap(0)
     end
 
     it "reaps and hops to wait_rekey_outbound_trigger if setup_inbound is completed" do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(nx).to receive(:reap).and_return(true)
       expect(nx).to receive(:decr_start_rekey).and_return(true)
-      expect {
-        nx.wait_rekey_inbound
-      }.to hop("wait_rekey_outbound_trigger")
+      expect { nx.wait_rekey_inbound }.to hop("wait_rekey_outbound_trigger")
     end
 
     it "if outbound setup is not triggered, just donate" do
       expect(nx).to receive(:when_trigger_outbound_update_set?).and_return(false)
-      expect {
-        nx.wait_rekey_outbound_trigger
-      }.to nap(5)
+      expect { nx.wait_rekey_outbound_trigger }.to nap(5)
     end
 
     it "if outbound setup is triggered, hops to setup_outbound" do
       expect(nx).to receive(:when_trigger_outbound_update_set?).and_yield
       expect(nx).to receive(:bud).with(Prog::Vnet::RekeyNicTunnel, {}, :setup_outbound).and_return(true)
-      expect {
-        nx.wait_rekey_outbound_trigger
-      }.to hop("wait_rekey_outbound")
+      expect { nx.wait_rekey_outbound_trigger }.to hop("wait_rekey_outbound")
     end
 
     it "wait_rekey_outbound reaps and donates if setup_outbound is continuing" do
@@ -282,25 +242,19 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(nx).to receive(:reap).and_return(true)
       expect(nx).to receive(:decr_trigger_outbound_update).and_return(true)
-      expect {
-        nx.wait_rekey_outbound
-      }.to hop("wait_rekey_old_state_drop_trigger")
+      expect { nx.wait_rekey_outbound }.to hop("wait_rekey_old_state_drop_trigger")
     end
 
     it "wait_rekey_old_state_drop_trigger donates if trigger is not set" do
       expect(nx).to receive(:when_old_state_drop_trigger_set?).and_return(false)
 
-      expect {
-        nx.wait_rekey_old_state_drop_trigger
-      }.to nap(5)
+      expect { nx.wait_rekey_old_state_drop_trigger }.to nap(5)
     end
 
     it "wait_rekey_old_state_drop_trigger hops to wait_rekey_old_state_drop if trigger is set" do
       expect(nx).to receive(:when_old_state_drop_trigger_set?).and_yield
       expect(nx).to receive(:bud).with(Prog::Vnet::RekeyNicTunnel, {}, :drop_old_state).and_return(true)
-      expect {
-        nx.wait_rekey_old_state_drop_trigger
-      }.to hop("wait_rekey_old_state_drop")
+      expect { nx.wait_rekey_old_state_drop_trigger }.to hop("wait_rekey_old_state_drop")
     end
 
     it "wait_rekey_old_state_drop reaps and donates if drop_old_state is continuing" do
@@ -314,9 +268,7 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(nx).to receive(:reap).and_return(true)
       expect(nx).to receive(:decr_old_state_drop_trigger).and_return(true)
-      expect {
-        nx.wait_rekey_old_state_drop
-      }.to hop("wait")
+      expect { nx.wait_rekey_old_state_drop }.to hop("wait")
     end
   end
 
@@ -351,9 +303,8 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(nic).to receive(:dst_ipsec_tunnels_dataset).and_return(ipsec_tunnels[1])
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(ps).to receive(:incr_refresh_keys).and_return(true)
-      expect(nx).to receive(:pop).with("nic deleted").and_return(true)
       expect(nic).to receive(:destroy).and_return(true)
-      nx.destroy
+      expect { nx.destroy }.to exit({"msg" => "nic deleted"})
     end
 
     it "fails if there is vm attached" do
@@ -396,9 +347,7 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(ps).to receive(:incr_refresh_keys).and_return(true)
 
-      expect {
-        nx.detach_vm
-      }.to hop("wait")
+      expect { nx.detach_vm }.to hop("wait")
     end
   end
 

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       allow(tunnel.src_nic.vm).to receive_messages(ephemeral_net6: NetAddr.parse_net("2a01:4f8:10a:128b:4919::/80"), inhost_name: "hellovm")
       expect(tunnel.src_nic).to receive(:ubid_to_tap_name).and_return("ncname")
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm addr replace 1.1.1.0/26 dev ncname")
-      expect(nx).to receive(:pop).with("add_subnet_addr is complete")
-      nx.add_subnet_addr
+      expect { nx.add_subnet_addr }.to exit({"msg" => "add_subnet_addr is complete"})
     end
   end
 
@@ -62,8 +61,7 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm policy add src 10.0.0.1/32 dst 10.0.0.2/32 dir fwd tmpl src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp reqid 0 mode tunnel").and_return(true)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm policy show src fd10:9b0b:6b4b:8fbb:abc::/128 dst fd10:9b0b:6b4b:8fbb:def::/128 dir fwd").and_return("")
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm policy add src fd10:9b0b:6b4b:8fbb:abc::/128 dst fd10:9b0b:6b4b:8fbb:def::/128 dir fwd tmpl src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp reqid 0 mode tunnel").and_return(true)
-      expect(nx).to receive(:pop).with("inbound_setup is complete").and_return(true)
-      nx.setup_inbound
+      expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})
     end
 
     it "skips policies if they exist" do
@@ -71,14 +69,12 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state add src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp spi 0xe3333333 reqid 86879 mode tunnel aead 'rfc4106(gcm(aes))' 0x736f6d655f656e6372797074696f6e5f6b6579 128 ").and_return(true)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm policy show src 10.0.0.1/32 dst 10.0.0.2/32 dir fwd").and_return("not_empty")
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm policy show src fd10:9b0b:6b4b:8fbb:abc::/128 dst fd10:9b0b:6b4b:8fbb:def::/128 dir fwd").and_return("not_empty")
-      expect(nx).to receive(:pop).with("inbound_setup is complete").and_return(true)
-      nx.setup_inbound
+      expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})
     end
 
     it "skips tunnel if its src_nic doesn't have rekey_payload" do
       expect(tunnel.src_nic).to receive(:rekey_payload).and_return(nil)
-      expect(nx).to receive(:pop).with("inbound_setup is complete")
-      nx.setup_inbound
+      expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})
     end
   end
 
@@ -98,14 +94,12 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm policy update src fd10:9b0b:6b4b:8fbb:abc::/128 dst fd10:9b0b:6b4b:8fbb:def::/128 dir out tmpl src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp reqid 86879 mode tunnel")
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm route replace fd10:9b0b:6b4b:8fbb:def::/128 dev vethihellovm")
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm route replace 10.0.0.2/32 dev vethihellovm")
-      expect(nx).to receive(:pop).with("outbound_setup is complete").and_return(true)
-      nx.setup_outbound
+      expect { nx.setup_outbound }.to exit({"msg" => "outbound_setup is complete"})
     end
 
     it "skips tunnel if its src_nic doesn't have rekey_payload" do
       expect(tunnel.src_nic).to receive(:rekey_payload).and_return(nil)
-      expect(nx).to receive(:pop).with("outbound_setup is complete")
-      nx.setup_outbound
+      expect { nx.setup_outbound }.to exit({"msg" => "outbound_setup is complete"})
     end
   end
 
@@ -146,16 +140,14 @@ sel src 0.0.0.0/0 dst 0.0.0.0/0"
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state").and_return(states_data)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x610a9eb5").and_return(true)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x059e11e6").and_return(true)
-      expect(nx).to receive(:pop).with("drop_old_state is complete").and_return(true)
-      nx.drop_old_state
+      expect { nx.drop_old_state }.to exit({"msg" => "drop_old_state is complete"})
     end
 
     it "skips if there is no tunnel" do
       expect(tunnel.src_nic).to receive(:src_ipsec_tunnels).and_return([])
       expect(tunnel.src_nic).to receive(:dst_ipsec_tunnels).and_return([])
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state deleteall")
-      expect(nx).to receive(:pop).with("drop_old_state is complete early")
-      nx.drop_old_state
+      expect { nx.drop_old_state }.to exit({"msg" => "drop_old_state is complete early"})
     end
 
     it "skips if the dst tunnel nic is not rekeying" do
@@ -165,8 +157,7 @@ sel src 0.0.0.0/0 dst 0.0.0.0/0"
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state").and_return(states_data)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x610a9eb5").and_return(true)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x059e11e6").and_return(true)
-      expect(nx).to receive(:pop).with("drop_old_state is complete").and_return(true)
-      nx.drop_old_state
+      expect { nx.drop_old_state }.to exit({"msg" => "drop_old_state is complete"})
     end
   end
 end

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -99,25 +99,19 @@ RSpec.describe Prog::Vnet::SubnetNexus do
   describe "#wait" do
     it "hops to destroy if when_destroy_set?" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect {
-        nx.wait
-      }.to hop("destroy")
+      expect { nx.wait }.to hop("destroy")
     end
 
     it "hops to refresh_keys if when_refresh_keys_set?" do
       expect(nx).to receive(:when_refresh_keys_set?).and_yield
       expect(ps).to receive(:update).with(state: "refreshing_keys").and_return(true)
-      expect {
-        nx.wait
-      }.to hop("refresh_keys")
+      expect { nx.wait }.to hop("refresh_keys")
     end
 
     it "hops to add_new_nic if when_add_new_nic_set?" do
       expect(nx).to receive(:when_add_new_nic_set?).and_yield
       expect(ps).to receive(:update).with(state: "adding_new_nic").and_return(true)
-      expect {
-        nx.wait
-      }.to hop("add_new_nic")
+      expect { nx.wait }.to hop("add_new_nic")
     end
 
     it "increments refresh_keys if it passed more than a day" do
@@ -127,9 +121,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "naps if nothing to do" do
-      expect {
-        nx.wait
-      }.to nap(30)
+      expect { nx.wait }.to nap(30)
     end
   end
 
@@ -165,9 +157,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
           spi6: "0xe3af3a04",
           reqid: 86879
         }).and_return(true)
-      expect {
-        nx.add_new_nic
-      }.to hop("wait_inbound_setup")
+      expect { nx.add_new_nic }.to hop("wait_inbound_setup")
     end
   end
 
@@ -189,9 +179,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
           reqid: 86879
         }).and_return(true)
       expect(nic).to receive(:incr_start_rekey).and_return(true)
-      expect {
-        nx.refresh_keys
-      }.to hop("wait_inbound_setup")
+      expect { nx.refresh_keys }.to hop("wait_inbound_setup")
     end
   end
 
@@ -210,9 +198,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(nic.strand).to receive(:label).and_return("wait_rekey_outbound_trigger")
       expect(ps).to receive(:nics).and_return([nic]).at_least(:once)
       expect(nic).to receive(:incr_trigger_outbound_update).and_return(true)
-      expect {
-        nx.wait_inbound_setup
-      }.to hop("wait_outbound_setup")
+      expect { nx.wait_inbound_setup }.to hop("wait_outbound_setup")
     end
   end
 
@@ -232,9 +218,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(nic.strand).to receive(:label).and_return("wait_rekey_old_state_drop_trigger")
       expect(ps).to receive(:nics).and_return([nic]).at_least(:once)
       expect(nic).to receive(:incr_old_state_drop_trigger).and_return(true)
-      expect {
-        nx.wait_outbound_setup
-      }.to hop("wait_old_state_drop")
+      expect { nx.wait_outbound_setup }.to hop("wait_old_state_drop")
     end
   end
 
@@ -258,9 +242,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(ps).to receive(:nics).and_return([nic]).at_least(:once)
       expect(nic).to receive(:rekey_payload).and_return({})
       expect(nic).to receive(:update).with(encryption_key: nil, rekey_payload: nil).and_return(true)
-      expect {
-        nx.wait_old_state_drop
-      }.to hop("wait")
+      expect { nx.wait_old_state_drop }.to hop("wait")
     end
 
     it "doesn't decrement refresh_keys if there are missed nics" do
@@ -271,9 +253,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(nx).to receive(:rekeying_nics).and_return([nic]).at_least(:once)
       expect(nic).to receive(:update).with(encryption_key: nil, rekey_payload: nil).and_return(true)
       expect(nx).not_to receive(:decr_refresh_keys)
-      expect {
-        nx.wait_old_state_drop
-      }.to hop("wait")
+      expect { nx.wait_old_state_drop }.to hop("wait")
     end
   end
 
@@ -359,8 +339,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(ps).to receive(:nics).and_return([]).at_least(:once)
       expect(ps).to receive(:projects).and_return([prj]).at_least(:once)
       expect(ps).to receive(:dissociate_with_project).with(prj).and_return(true)
-      expect(nx).to receive(:pop).with("subnet destroyed").and_return(true)
-      nx.destroy
+      expect { nx.destroy }.to exit({"msg" => "subnet destroyed"})
     end
   end
 end


### PR DESCRIPTION
We have custom `RSpec::Matchers` for flow control exceptions. There's no need to manually expect to receive these functions. Additionally, we use these matchers in our codebase as a single line in general. There's no need to extend them to 3 lines unless it's too long.

This cleanup has revealed some issues that need fixing:

- learn_network_spec.rb: Our default stack value is `[{}]`. `[]` is not expected, and fails our code when popped.

- rekey_nic_tunnel.rb: `pop` raises an exception, so the code can't run after it. `return` is unnecessary.

- base.rb: Our default stack value is `[{}]`, so `frame&` is unnecessary. We don't need to write extra test to cover this branch. It was covered previously because of the wrong stack value at `learn_network_spec.rb`.