### PR TITLE
Add ubid and debug link to Pagerduty incidents

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -44,7 +44,6 @@ module Config
   optional :versioning_app_name, string
   optional :clover_session_secret, base64, clear: true
   optional :clover_column_encryption_key, base64, clear: true
-  optional :pagerduty_key, string, clear: true
   optional :stripe_public_key, string, clear: true
   optional :stripe_secret_key, string, clear: true
   optional :postgres_service_project_id, string
@@ -99,4 +98,8 @@ module Config
   override :minio_host_name, "minio.ubicloud.com", string
   optional :minio_service_project_id, string
   override :minio_version, "minio_20231007150738.0.0_amd64"
+
+  # Pagerduty
+  optional :pagerduty_key, string, clear: true
+  optional :pagerduty_log_link, string
 end

--- a/migrate/20231102_add_details_to_page.rb
+++ b/migrate/20231102_add_details_to_page.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:page) do
+      add_column :details, :jsonb, null: false, default: "{}"
+    end
+  end
+end

--- a/model/page.rb
+++ b/model/page.rb
@@ -23,8 +23,13 @@ class Page < Sequel::Model
   def trigger
     return unless Config.pagerduty_key
 
+    links = []
+    details.fetch("related_resources", []).each do |ubid|
+      links << {href: Config.pagerduty_log_link.gsub("<ubid>", ubid), text: "View #{ubid} Logs"} if Config.pagerduty_log_link
+    end
+
     incident = pagerduty_client.incident(OpenSSL::HMAC.hexdigest("SHA256", "ubicloud-page-key", tag))
-    incident.trigger(summary: summary, severity: "error", source: "clover")
+    incident.trigger(summary: summary, severity: "error", source: "clover", custom_details: details, links: links)
   end
 
   def resolve

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -90,7 +90,7 @@ SQL
       next unless (deadline_at = frame["deadline_at"])
 
       if Time.now > Time.parse(deadline_at.to_s)
-        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog}.#{label} did not reach #{frame["deadline_target"]} on time", "Deadline", id, prog, frame["deadline_target"])
+        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog}.#{label} did not reach #{frame["deadline_target"]} on time", [ubid], "Deadline", id, prog, frame["deadline_target"])
 
         modified!(:stack)
       end

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -4,11 +4,11 @@ class Prog::PageNexus < Prog::Base
   subject_is :page
   semaphore :resolve
 
-  def self.assemble(summary, *tag_parts)
+  def self.assemble(summary, related_resources, *tag_parts)
     DB.transaction do
       pg = Page.from_tag_parts(tag_parts)
       unless pg
-        pg = Page.create_with_id(summary: summary, tag: Page.generate_tag(tag_parts))
+        pg = Page.create_with_id(summary: summary, details: {"related_resources" => related_resources}, tag: Page.generate_tag(tag_parts))
         Strand.create(prog: "PageNexus", label: "start") { _1.id = pg.id }
       end
     end

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -8,11 +8,25 @@ RSpec.describe Page do
   subject(:p) { described_class.create_with_id(tag: "dummy-tag") }
 
   describe "#trigger" do
-    it "triggers a page in Pagerduty if key is present" do
+    before do
       expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)
       stub_request(:post, "https://events.pagerduty.com/v2/enqueue")
         .to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
+    end
 
+    it "triggers a page in Pagerduty if key is present" do
+      expect(p).to receive(:details).and_return({}).at_least(:once)
+      p.trigger
+    end
+
+    it "triggers a page with custom_details" do
+      expect(p).to receive(:details).and_return({"related_resources" => ["a410a91a-dc31-4119-9094-3c6a1fb49601"]}).at_least(:once)
+      p.trigger
+    end
+
+    it "triggers a page with custom_details and log link" do
+      expect(Config).to receive(:pagerduty_log_link).and_return("https://logviewer.com?q=<ubid>").at_least(:once)
+      expect(p).to receive(:details).and_return({"related_resources" => ["a410a91a-dc31-4119-9094-3c6a1fb49601"]}).at_least(:once)
       p.trigger
     end
   end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Prog::Base do
 
     it "resolves the page once the target is reached" do
       st = Strand.create_with_id(prog: "Test", label: :napper)
-      page_id = Prog::PageNexus.assemble("dummy-summary", "Deadline", st.id, st.prog, :napper).id
+      page_id = Prog::PageNexus.assemble("dummy-summary", [st.ubid], "Deadline", st.id, st.prog, :napper).id
 
       st.stack.first["deadline_target"] = :napper
       st.stack.first["deadline_at"] = Time.now - 1
@@ -226,7 +226,7 @@ RSpec.describe Prog::Base do
 
     it "resolves the page once a new deadline is registered" do
       st = Strand.create_with_id(prog: "Test", label: :start)
-      page_id = Prog::PageNexus.assemble("dummy-summary", "Deadline", st.id, st.prog, :napper).id
+      page_id = Prog::PageNexus.assemble("dummy-summary", [st.ubid], "Deadline", st.id, st.prog, :napper).id
 
       st.stack.first["deadline_target"] = :napper
       st.stack.first["deadline_at"] = Time.now - 1


### PR DESCRIPTION
Copying ubid from the title of Slack message can be challenging since it's a clickable link. To simplify this, I added it into the incident's custom_details. Additionally, a "View Logs" link is now available, enabling direct search for the thread:UBID using a custom line template at Mezmo. Thus, you no longer need to expand lines individually.

I added this as a config to prevent our log view URL from being publicly exposed.

The page lacked structured resource information. I evaluated various options: extracting UBIDs from the summary using regex, adding a 'resource_id' column, or introducing a JSONB column.
By adding a 'details' column, we can associate multiple UBIDs with a single page. Additionally, we can enrich the page details to facilitate easier future investigations.

