### PR TITLE
Clog improvements

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -7,11 +7,13 @@ class Clog
 
   def self.emit(message)
     out = if block_given?
-      case v = yield
+      case metadata = yield
       when Hash
-        v
+        metadata
+      when Sequel::Model
+        serialize_model(metadata)
       else
-        {invalid_type: v.class.to_s}
+        {invalid_type: metadata.class.to_s}
       end
     else
       {}
@@ -30,5 +32,9 @@ class Clog
       $stdout.write(raw)
     end
     nil
+  end
+
+  private_class_method def self.serialize_model(model)
+    {model.class.table_name => model.values.except(*model.class.redacted_columns)}
   end
 end

--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -10,6 +10,17 @@ class Clog
       case metadata = yield
       when Hash
         metadata
+      when Array
+        metadata.reduce({}) do |hash, item|
+          case item
+          when Hash
+            hash.merge(item)
+          when Sequel::Model
+            hash.merge(serialize_model(item))
+          else
+            hash.merge({invalid_type: item.class.to_s})
+          end
+        end
       when Sequel::Model
         serialize_model(metadata)
       else

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -79,7 +79,7 @@ SQL
   def unsynchronized_run
     start_time = Time.now
     prog_label = "#{prog}.#{label}"
-    Clog.emit("starting strand") { {strand: values, strand_started: {prog_label: prog_label}} }
+    Clog.emit("starting strand") { [self, {strand_started: {prog_label: prog_label}}] }
 
     if label == stack.first["deadline_target"].to_s
       if (pg = Page.from_tag_parts("Deadline", id, prog, stack.first["deadline_target"]))
@@ -145,7 +145,7 @@ SQL
       fail "BUG: Prog #{prog}##{label} did not provide flow control"
     end
   ensure
-    Clog.emit("finished strand") { {strand: values, strand_finished: {duration: Time.now - start_time, prog_label: prog_label}} }
+    Clog.emit("finished strand") { [self, {strand_finished: {duration: Time.now - start_time, prog_label: prog_label}}] }
   end
 
   def run(seconds = 0)

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -269,7 +269,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       github_runner.incr_destroy
       nap 15
     when "failed"
-      Clog.emit("The runner script failed") { {github_runner: github_runner.values} }
+      Clog.emit("The runner script failed") { github_runner }
       github_runner.provision_spare_runner
       github_runner.incr_destroy
       nap 0
@@ -281,7 +281,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     if github_runner.workflow_job.nil? && Time.now > github_runner.ready_at + 5 * 60
       response = github_client.get("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")
       unless response[:busy]
-        Clog.emit("The runner does not pick a job") { {github_runner: github_runner.values} }
+        Clog.emit("The runner does not pick a job") { github_runner }
         github_runner.incr_destroy
         nap 0
       end
@@ -297,7 +297,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     begin
       response = github_client.get("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")
       if response[:busy]
-        Clog.emit("The runner is still running a job") { {github_runner: github_runner.values} }
+        Clog.emit("The runner is still running a job") { github_runner }
         nap 15
       end
       github_client.delete("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")
@@ -328,7 +328,7 @@ class Prog::Vm::GithubRunner < Prog::Base
           # Exclude the "Started" line because it contains sensitive information.
           vm.sshable.cmd("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
         rescue Sshable::SshError
-          Clog.emit("Failed to move serial.log or running journalctl") { {github_runner: github_runner.values} }
+          Clog.emit("Failed to move serial.log or running journalctl") { github_runner }
         end
       end
       vm.incr_destroy

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -230,7 +230,7 @@ class Prog::Vm::HostNexus < Prog::Base
     end
 
     unless vm_host.vms.empty?
-      Clog.emit("Cannot destroy the vm host with active virtual machines, first clean them up") { {vm_host: vm_host.values} }
+      Clog.emit("Cannot destroy the vm host with active virtual machines, first clean them up") { vm_host }
       nap 15
     end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -272,7 +272,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   label def create_billing_record
     vm.update(display_state: "running", provisioned_at: Time.now)
-    Clog.emit("vm provisioned") { {vm: vm.values, provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.allocated_at}} }
+    Clog.emit("vm provisioned") { [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.allocated_at}}] }
     project = vm.projects.first
     hop_wait unless project.billable
 

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -111,7 +111,7 @@ class Prog::Vnet::NicNexus < Prog::Base
 
   label def destroy
     if nic.vm
-      Clog.emit("Cannot destroy nic with active vm, first clean up the attached resources") { {nic: nic.values} }
+      Clog.emit("Cannot destroy nic with active vm, first clean up the attached resources") { nic }
       nap 5
     end
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -141,9 +141,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     if private_subnet.nics.any? { |n| !n.vm_id.nil? }
       register_deadline(nil, 10 * 60, allow_extension: true) if private_subnet.nics.any? { |n| n.vm&.prevent_destroy_set? }
 
-      Clog.emit "Cannot destroy subnet with active nics, first clean up the attached resources" do
-        {private_subnet: private_subnet.values}
-      end
+      Clog.emit("Cannot destroy subnet with active nics, first clean up the attached resources") { private_subnet }
 
       nap 5
     end

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -30,4 +30,10 @@ RSpec.describe Clog do
     expect($stdout).to receive(:write).with('{"vm":{"id":"123"},"message":"model","time":"' + now.to_s + '"}' + "\n")
     described_class.emit("model") { Vm.new(public_key: "redacted_key").tap { _1.id = "123" } }
   end
+
+  it "returns a combined hash when the metadata is an array" do
+    expect($stdout).to receive(:write).with('{"vm":{"id":"123"},"field1":"custom","invalid_type":"String","message":"model","time":"' + now.to_s + '"}' + "\n")
+    vm = Vm.new(public_key: "redacted_key").tap { _1.id = "123" }
+    described_class.emit("model") { [vm, {field1: "custom"}, "invalid"] }
+  end
 end

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -25,4 +25,9 @@ RSpec.describe Clog do
     expect($stdout).to receive(:write).with('{"invalid_type":"Integer","message":"ngmi","time":"' + now.to_s + '"}' + "\n")
     described_class.emit("ngmi") { 1 }
   end
+
+  it "returns the key with redacted values for Sequel::Model" do
+    expect($stdout).to receive(:write).with('{"vm":{"id":"123"},"message":"model","time":"' + now.to_s + '"}' + "\n")
+    described_class.emit("model") { Vm.new(public_key: "redacted_key").tap { _1.id = "123" } }
+  end
 end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -272,7 +272,6 @@ RSpec.describe Prog::Vm::HostNexus do
 
     it "waits draining" do
       expect(vm_host).to receive(:allocation_state).and_return("draining")
-      expect(vm_host).to receive(:values).and_return({allocation_state: "draining"})
       expect(Clog).to receive(:emit).with("Cannot destroy the vm host with active virtual machines, first clean them up").and_call_original
       expect { nx.destroy }.to nap(15)
     end


### PR DESCRIPTION
### Add a special clog representation for Sequel::Model

We redact encrypted and lengthy columns from the .inspect output in our models. It would be wisely to apply the same redaction to our clog metadata as well.

Also, if the `Sequel::Model` is provided as metadata, the model automatically determines the key name from its table name and returns it with redacted values. `{ strand: strand.values }` can be abbreviated as `{ strand }`.

### Allow to log additional fields with models in clog
Sometimes, the model data is insufficient, and we may need to add extra fields to the clog's metadata. The new array metadata feature achieves this.

When the metadata is an array, it parses each element sequentially. If the element is a Sequel::Model, it obtains its clog representation, similar to the previous commit. If the element is a hash, it merges with the intermediate hash.

For example, `[strand, {field1: "a", field2: "b"}]` expands to `{strand: {id: 123, label: "start"}, field1: "a", field2: "b"}`.