### PR TITLE
Add a fail helper to Clog that emits logs prior to an exception

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -3,6 +3,8 @@
 require "json"
 
 class Clog
+  Fail = Class.new(RuntimeError)
+
   @@mutex = Mutex.new
 
   def self.emit(message)
@@ -29,5 +31,10 @@ class Clog
       puts raw
     end
     nil
+  end
+
+  def self.fail(message, &block)
+    emit(message, &block)
+    Kernel.fail Fail.new(message)
   end
 end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -181,7 +181,7 @@ SQL
 
   def allocate
     vm_host_id = allocation_dataset.limit(1).get(:id)
-    fail "#{vm} no space left on any eligible hosts for #{vm.location}" unless vm_host_id
+    Clog.fail("no space left on any eligible hosts") { {vm: vm.values} } unless vm_host_id
 
     fail "concurrent allocation_state modification requires re-allocation" if VmHost.dataset
       .where(id: vm_host_id, allocation_state: "accepting")

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -357,13 +357,13 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if there are no VmHosts" do
-      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
+      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
     end
 
     it "only matches when location matches" do
       vm.location = "somewhere-normal"
       vmh = new_host(location: "somewhere-weird").save_changes
-      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
+      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
 
       vm.location = "somewhere-weird"
       expect(nx.allocate).to eq vmh.id
@@ -372,13 +372,13 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "does not match if there is not enough ram capacity" do
       new_host(total_mem_gib: 1).save_changes
-      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
+      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
     end
 
     it "does not match if there is not enough storage capacity" do
       new_host(available_storage_gib: 10).save_changes
       expect(vm.storage_size_gib).to eq(35)
-      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
+      expect { nx.allocate }.to raise_error RuntimeError, "no space left on any eligible hosts"
     end
 
     it "prefers the host with a more snugly fitting RAM ratio, even if busy" do


### PR DESCRIPTION
Sometimes, we deliberately cause the code to fail to indicate that something is wrong. However, when we raise an exception directly, it's difficult to determine which model or strand is responsible for the exception. The method Clog.fail first emits a log, then raises the exception. This approach allows us to search the log with `thread:UBID` and see the associated exceptions.