### PR TITLE
Purge tombstoned dns records after they are seen by all DNS servers

### DIFF
--- a/migrate/20231025_add_purge_to_dns_zones.rb
+++ b/migrate/20231025_add_purge_to_dns_zones.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:dns_zone) do
+      add_column :last_purged_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+  end
+end


### PR DESCRIPTION
No need to keep these records around and bloat the already big dns_records and
seen_dns_records_by_dns_servers tables. It also better fits to the our current
model of deleting entities from their respective database tables after they are
no longer being used.