### PR TITLE
Hide sensitive and long columns from inspect output

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -68,4 +68,9 @@ class PostgresServer < Sequel::Model
   def connection_string
     URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s
   end
+
+  def inspect_values
+    hidden_columns = [:superuser_password, :root_cert_1, :root_cert_key_1, :root_cert_2, :root_cert_key_2, :server_cert, :server_cert_key]
+    @values.except(*hidden_columns).inspect
+  end
 end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -73,4 +73,11 @@ RSpec.describe PostgresServer do
   it "returns connection string" do
     expect(pgs.connection_string).to eq("postgres://postgres:dummy-password@pg-server-name.postgres.ubicloud.com")
   end
+
+  it "hides sensitive and long columns" do
+    inspect_output = pgs.inspect
+    ["superuser_password", "root_cert_1", "root_cert_key_1", "root_cert_1", "root_cert_key_2", "server_cert", "server_cert_key"].each do |column_key|
+      expect(inspect_output).not_to include column_key
+    end
+  end
 end


### PR DESCRIPTION
Eventhough they are encrypted, it is better to not print some columns such as superuser_password or root_cert_key1. Apart from that, there are some columns with very long text without human readable info such as root_cert_1. With this commit, we are excluding them them from inspect output to improve overall development and operations experience.