### PR TITLE
Only register deadline if allocation is successful

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -197,10 +197,6 @@ SQL
 
   label def start
     register_deadline(:wait, 10 * 60)
-    hop_allocate_vm
-  end
-
-  label def allocate_vm
     vm_host_id = allocate
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -228,14 +228,9 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#start" do
-    it "registers a deadline and hops" do
-      expect(nx).to receive(:register_deadline)
-      expect { nx.start }.to hop("allocate_vm")
-    end
-  end
-
-  describe "#allocate_vm" do
     it "allocates the vm to a host" do
+      expect(nx).to receive(:register_deadline)
+
       vmh_id = "46ca6ded-b056-4723-bd91-612959f52f6f"
       vmh = VmHost.new(
         net6: NetAddr.parse_net("2a01:4f9:2b:35a::/64"),
@@ -249,7 +244,7 @@ RSpec.describe Prog::Vm::Nexus do
         expect(args[:vm_host_id]).to match vmh_id
       end
 
-      expect { nx.allocate_vm }.to hop("create_unix_user")
+      expect { nx.start }.to hop("create_unix_user")
     end
 
     it "allocates the vm to a host with IPv4 address" do
@@ -268,7 +263,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(AssignedVmAddress).to receive(:create_with_id).and_return(assigned_address)
       expect(vm).to receive(:update)
 
-      expect { nx.allocate_vm }.to hop("create_unix_user")
+      expect { nx.start }.to hop("create_unix_user")
     end
 
     it "fails if there is no ip address available but the vm is ip4 enabled" do
@@ -283,7 +278,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vmh).to receive(:ip4_random_vm_network).and_return([nil, nil])
       expect(vm).to receive(:ip4_enabled).and_return(true).at_least(:once)
 
-      expect { nx.allocate_vm }.to raise_error(RuntimeError, /no ip4 addresses left/)
+      expect { nx.start }.to raise_error(RuntimeError, /no ip4 addresses left/)
     end
   end
 


### PR DESCRIPTION
If we register deadlines during start, when there is a capacity problem we get page storm. As a quick fix, we start to register deadlines only if allocation is succeeded. This creates a blind spot for capacity issues, in a subsequent PR, we will create a separate page to monitor capacity problems.