### PR TITLE
Page when we are out of capacity

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -76,7 +76,7 @@ SQL
     Clog.emit("starting strand") { {strand: values, time: start_time, prog_label: prog_label} }
 
     if label == stack.first["deadline_target"].to_s
-      if (pg = Page.from_tag_parts(id, prog, stack.first["deadline_target"]))
+      if (pg = Page.from_tag_parts("Deadline", id, prog, stack.first["deadline_target"]))
         pg.incr_resolve
       end
 
@@ -90,7 +90,7 @@ SQL
       next unless (deadline_at = frame["deadline_at"])
 
       if Time.now > Time.parse(deadline_at.to_s)
-        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog}.#{label} did not reach #{frame["deadline_target"]} on time", id, prog, frame["deadline_target"])
+        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog}.#{label} did not reach #{frame["deadline_target"]} on time", "Deadline", id, prog, frame["deadline_target"])
 
         modified!(:stack)
       end

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -72,7 +72,7 @@ end
       # This is a multi-level stack with a back-link, i.e. one prog
       # calling another in the same Strand of execution.  The thing to
       # do here is pop the stack entry.
-      pg = Page.from_tag_parts(strand.id, strand.prog, strand.stack.first["deadline_target"])
+      pg = Page.from_tag_parts("Deadline", strand.id, strand.prog, strand.stack.first["deadline_target"])
       pg&.incr_resolve
 
       old_prog = strand.prog
@@ -86,7 +86,7 @@ end
     else
       fail "BUG: expect no stacks exceeding depth 1 with no back-link" if strand.stack.length > 1
 
-      pg = Page.from_tag_parts(strand.id, strand.prog, strand.stack.first["deadline_target"])
+      pg = Page.from_tag_parts("Deadline", strand.id, strand.prog, strand.stack.first["deadline_target"])
       pg&.incr_resolve
 
       # Child strand with zero or one stack frames, set exitval. Clear
@@ -213,7 +213,7 @@ end
         Time.parse(deadline_at.to_s) > Time.now + deadline_in ||
         (old_deadline_target = current_frame["deadline_target"]) != deadline_target
 
-      if old_deadline_target != deadline_target && (pg = Page.from_tag_parts(strand.id, strand.prog, old_deadline_target))
+      if old_deadline_target != deadline_target && (pg = Page.from_tag_parts("Deadline", strand.id, strand.prog, old_deadline_target))
         pg.incr_resolve
       end
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Prog::Base do
 
     it "resolves the page once the target is reached" do
       st = Strand.create_with_id(prog: "Test", label: :napper)
-      page_id = Prog::PageNexus.assemble("dummy-summary", st.id, st.prog, :napper).id
+      page_id = Prog::PageNexus.assemble("dummy-summary", "Deadline", st.id, st.prog, :napper).id
 
       st.stack.first["deadline_target"] = :napper
       st.stack.first["deadline_at"] = Time.now - 1
@@ -226,7 +226,7 @@ RSpec.describe Prog::Base do
 
     it "resolves the page once a new deadline is registered" do
       st = Strand.create_with_id(prog: "Test", label: :start)
-      page_id = Prog::PageNexus.assemble("dummy-summary", st.id, st.prog, :napper).id
+      page_id = Prog::PageNexus.assemble("dummy-summary", "Deadline", st.id, st.prog, :napper).id
 
       st.stack.first["deadline_target"] = :napper
       st.stack.first["deadline_at"] = Time.now - 1


### PR DESCRIPTION
**Add page type identifier to the list of tags**
Two different types of pages can have same tags, but they should not interfere
with each other. Because of that, we started to add type of the page as one of
the tags we use for deduplication.

**Create a page if no capacity is left**
Ideally we would create a page when capacity is low, but the purpose of this
commit it fixing the blind spot we added in https://github.com/ubicloud/ubicloud/commit/cfa245c3b3e82657558fec08e4d3048669230db5, not having full blown capacity
monitoring system. In that commit, to prevent page storms, we stopped generating
one page per each unsuccessful allocation. With this commit, we create one page
for all failed allocations that are due to lack of capacity. We do this by deduplicating
pages based on tags "NoCapacity" and the location of the requested VM.