### PR TITLE
Update MinioCluster project URL to use - instead of _

### DIFF
--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -24,7 +24,7 @@ class MinioCluster < Sequel::Model
   end
 
   def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{location}/minio_cluster/#{name}"
+    "project/#{project.ubid}/location/#{location}/minio-cluster/#{name}"
   end
 
   def generate_etc_hosts_entry

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -61,6 +61,6 @@ RSpec.describe MinioCluster do
 
   it "returns hyper tag name properly" do
     project = instance_double(Project, ubid: "project-ubid")
-    expect(mc.hyper_tag_name(project)).to eq("project/project-ubid/location/hetzner-hel1/minio_cluster/minio-cluster-name")
+    expect(mc.hyper_tag_name(project)).to eq("project/project-ubid/location/hetzner-hel1/minio-cluster/minio-cluster-name")
   end
 end


### PR DESCRIPTION
This commit updates the MinioCluster project URL for the sake of naming convention.

Regarding the discussion at #682 