### PR TITLE
Adds private_subnet_id argument to PostgresNexus

### DIFF
--- a/prog/postgres/postgres_nexus.rb
+++ b/prog/postgres/postgres_nexus.rb
@@ -12,7 +12,7 @@ class Prog::Postgres::PostgresNexus < Prog::Base
 
   semaphore :initial_provisioning, :restart, :destroy
 
-  def self.assemble(project_id, location, server_name, vm_size, storage_size_gib)
+  def self.assemble(project_id, location, server_name, vm_size, storage_size_gib, private_subnet_id: nil)
     unless (project = Project[project_id])
       fail "No existing project"
     end
@@ -36,7 +36,8 @@ class Prog::Postgres::PostgresNexus < Prog::Base
           {encrypted: true, size_gib: storage_size_gib}
         ],
         boot_image: "ubuntu-jammy",
-        enable_ip4: true
+        enable_ip4: true,
+        private_subnet_id: private_subnet_id
       )
 
       Sshable.create(

--- a/spec/prog/postgres/postgres_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_nexus_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe Prog::Postgres::PostgresNexus do
       expect(postgres_server.vm).not_to be_nil
       expect(postgres_server.vm.sshable).not_to be_nil
     end
+
+    it "creates postgres server and vm with sshable in the given private subnet" do
+      ps_st = Prog::Vnet::SubnetNexus.assemble(Config.postgres_service_project_id)
+      st = described_class.assemble(project.id, "hetzner-hel1", "pg-server-name", "standard-2", 100, private_subnet_id: ps_st.id)
+
+      postgres_server = PostgresServer[st.id]
+      expect(postgres_server).not_to be_nil
+      expect(postgres_server.vm).not_to be_nil
+      expect(postgres_server.vm.sshable).not_to be_nil
+      expect(postgres_server.vm.private_subnets.first.id).to eq(ps_st.id)
+    end
   end
 
   describe "#before_run" do


### PR DESCRIPTION
This is required to be able to create a postgres server in a given private subnet.