### PR TITLE
Fix the eager loading issue in InvoiceGenerator

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -109,7 +109,7 @@ class InvoiceGenerator
     active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices])
       .where { |br| Sequel.pg_range(br.span).overlaps(Sequel.pg_range(@begin_time...@end_time)) }
     active_billing_records = active_billing_records.where(project_id: @project_id) if @project_id
-    active_billing_records.map do |br|
+    active_billing_records.all.map do |br|
       # We cap the billable duration at 672 hours. In this way, we can
       # charge the users same each month no matter the number of days
       # in that month.


### PR DESCRIPTION
InvoiceGenerator retrieves all billing records for a given timeframe and uses them for calculations. It requires the project associated with each billing record. To avoid the N+1 query issue, we preload the project for all billing records using `.eager(project: [:billing_info, :invoices])`.

Without eager loading, some projects have over 60k billing records, which results in more than 60k queries to the database.

We use InvoiceGenerator to display current usage on the billing page.

I discovered that when we call `.map` directly on the dataset, as in `active_billing_records.map`, it doesn't utilize eager loading. This results in over 60k queries to the database.  To use eager loading, we need to call the dataset with `.all`. I have updated this to `active_billing_records.all.map`.