### PR TITLE
Use JSON-RPC directly to communicate with SPDK.

### DIFF
--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -2,23 +2,23 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
-require_relative "../lib/spdk"
+require_relative "../lib/spdk_path"
 require "fileutils"
 
 # spdk dependencies
 r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev"
 
 # spdk binaries
-FileUtils.cd Spdk.install_prefix do
+FileUtils.cd SpdkPath.install_prefix do
   r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/7adbcfb/spdk-7adbcfb.tar.gz"
   r "tar -xzf /tmp/spdk.tar.gz"
 end
 
-q_user = Spdk.user.shellescape
-q_hugepages_dir = Spdk.hugepages_dir.shellescape
+q_user = SpdkPath.user.shellescape
+q_hugepages_dir = SpdkPath.hugepages_dir.shellescape
 
 begin
-  r "adduser #{q_user} --disabled-password --gecos '' --home #{Spdk.home.shellescape}"
+  r "adduser #{q_user} --disabled-password --gecos '' --home #{SpdkPath.home.shellescape}"
 rescue CommandFail => ex
   raise unless /adduser: The user `.*' already exists\./.match?(ex.message)
 end
@@ -26,8 +26,8 @@ end
 r "sudo --user=#{q_user} mkdir -p #{q_hugepages_dir}"
 
 # Directory to put vhost sockets.
-FileUtils.mkdir_p(Spdk.vhost_dir)
-FileUtils.chown Spdk.user, Spdk.user, Spdk.vhost_dir
+FileUtils.mkdir_p(SpdkPath.vhost_dir)
+FileUtils.chown SpdkPath.user, SpdkPath.user, SpdkPath.vhost_dir
 
 File.write("/lib/systemd/system/home-spdk-hugepages.mount", <<SPDK_HUGEPAGES_MOUNT
 [Unit]
@@ -50,11 +50,11 @@ Description=Block Storage Service
 Requires=home-spdk-hugepages.mount
 [Service]
 Type=simple
-Environment="XDG_RUNTIME_DIR=#{Spdk.home.shellescape}"
-ExecStart=#{Spdk.bin("vhost")} -S #{Spdk.vhost_dir.shellescape} \
+Environment="XDG_RUNTIME_DIR=#{SpdkPath.home.shellescape}"
+ExecStart=#{SpdkPath.bin("vhost")} -S #{SpdkPath.vhost_dir.shellescape} \
 --huge-dir #{q_hugepages_dir} \
 --iova-mode va \
---rpc-socket #{Spdk.rpc_sock.shellescape} \
+--rpc-socket #{SpdkPath.rpc_sock.shellescape} \
 --cpumask [0] \
 --disable-cpumask-locks
 ExecReload=/bin/kill -HUP $MAINPID

--- a/rhizome/host/lib/json_rpc_client.rb
+++ b/rhizome/host/lib/json_rpc_client.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "json"
+require "socket"
+
+class JsonRpcError < StandardError
+  attr_reader :code
+
+  def initialize(message, code)
+    super(message)
+    @code = code
+  end
+end
+
+class JsonRpcClient
+  def initialize(socket_path, timeout = 5, response_size_limit = 1048576)
+    @socket_path = socket_path
+    @timeout = timeout
+    @response_size_limit = response_size_limit
+  end
+
+  def call(method, params = {})
+    # id is used to correlate the context between request and response.
+    # See https://www.jsonrpc.org/specification
+    id = rand(10000000)
+
+    payload = {
+      jsonrpc: "2.0",
+      method: method,
+      params: params,
+      id: id
+    }
+
+    unix_socket = UNIXSocket.new(@socket_path)
+    unix_socket.write_nonblock(payload.to_json + "\n")
+
+    response = JSON.parse(read_response(unix_socket))
+    if (err = response["error"])
+      raise JsonRpcError.new(err.fetch("message"), err.fetch("code"))
+    end
+
+    unix_socket.close
+
+    response["result"]
+  end
+
+  def read_response(socket)
+    buffer = +""
+    start_time = Time.now
+
+    begin
+      # Use IO.select to wait for data with a timeout. Subtract elapsed time,
+      # since this can be called multiple times.
+      elapsed_time = Time.now - start_time
+      ready_sockets = IO.select([socket], nil, nil, @timeout - elapsed_time)
+
+      # If ready_sockets is nil, it means timeout occurred
+      unless ready_sockets
+        socket.close
+        raise "The request timed out after #{@timeout} seconds."
+      end
+
+      # Loop until the whole JSON response is received.
+      loop do
+        buffer << socket.read_nonblock(4096)
+        break if valid_json?(buffer)
+        raise "Response size limit exceeded." if buffer.length > @response_size_limit
+      end
+    rescue IO::WaitReadable
+      retry
+    end
+
+    buffer
+  end
+
+  def valid_json?(json_str)
+    JSON.parse(json_str)
+    true
+  rescue JSON::ParserError
+    false
+  end
+end

--- a/rhizome/host/lib/spdk_path.rb
+++ b/rhizome/host/lib/spdk_path.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Spdk
+module SpdkPath
   def self.user
     "spdk"
   end
@@ -35,10 +35,5 @@ module Spdk
 
   def self.bin(n)
     File.join(install_prefix, "spdk", "bin", n)
-  end
-
-  def self.rpc_py
-    bin = File.join(install_prefix, "spdk", "scripts", "rpc.py")
-    "#{bin} -s #{rpc_sock}"
   end
 end

--- a/rhizome/host/lib/spdk_rpc.rb
+++ b/rhizome/host/lib/spdk_rpc.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "spdk_path"
+require_relative "json_rpc_client"
+
+class SpdkRpc
+  def client
+    @client ||= JsonRpcClient.new(SpdkPath.rpc_sock)
+  end
+
+  def bdev_aio_create(name, filename, block_size)
+    params = {
+      name: name,
+      filename: filename,
+      block_size: block_size,
+      readonly: false
+    }
+    client.call("bdev_aio_create", params)
+  end
+
+  def bdev_aio_delete(name, if_exists = true)
+    client.call("bdev_aio_delete", {name: name})
+  rescue JsonRpcError => e
+    raise e unless if_exists && e.message.include?("No such device")
+  end
+
+  def bdev_crypto_create(name, base_bdev_name, key_name)
+    params = {
+      name: name,
+      base_bdev_name: base_bdev_name,
+      key_name: key_name
+    }
+    client.call("bdev_crypto_create", params)
+  end
+
+  def bdev_crypto_delete(name, if_exists = true)
+    client.call("bdev_crypto_delete", {name: name})
+  rescue JsonRpcError => e
+    raise e unless if_exists && e.message.include?("No such device")
+  end
+
+  def vhost_create_blk_controller(name, bdev)
+    params = {
+      ctrlr: name,
+      dev_name: bdev
+    }
+    client.call("vhost_create_blk_controller", params)
+  end
+
+  def vhost_delete_controller(name, if_exists = true)
+    client.call("vhost_delete_controller", {ctrlr: name})
+  rescue JsonRpcError => e
+    raise e unless if_exists && e.message.include?("No such device")
+  end
+
+  def accel_crypto_key_create(name, cipher, key, key2)
+    params = {
+      name: name,
+      cipher: cipher,
+      key: key,
+      key2: key2
+    }
+    client.call("accel_crypto_key_create", params)
+  end
+
+  def accel_crypto_key_destroy(name, if_exists = true)
+    client.call("accel_crypto_key_destroy", {key_name: name})
+  rescue JsonRpcError => e
+    raise e unless if_exists && e.message.include?("No key object found")
+  end
+end

--- a/rhizome/host/spec/json_rpc_client_spec.rb
+++ b/rhizome/host/spec/json_rpc_client_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "../lib/json_rpc_client"
+
+RSpec.describe JsonRpcClient do
+  subject(:client) {
+    described_class.new("/sock", 5, 100)
+  }
+
+  describe "#call" do
+    let(:unix_socket) { instance_double(UNIXSocket) }
+
+    before do
+      allow(UNIXSocket).to receive(:new).and_return(unix_socket)
+    end
+
+    it "can call a method" do
+      params = {"x" => "y"}
+      expect(unix_socket).to receive(:write_nonblock)
+      expect(client).to receive(:read_response).with(unix_socket).and_return('{"result": "response"}')
+      expect(unix_socket).to receive(:close)
+      expect(client.call("url", params)).to eq("response")
+    end
+
+    it "raises an exception if response is an error" do
+      params = {"x" => "y"}
+      response = {
+        error: {
+          message: "an error happened",
+          code: -5
+        }
+      }.to_json
+      expect(unix_socket).to receive(:write_nonblock)
+      expect(client).to receive(:read_response).with(unix_socket).and_return(response)
+      expect { client.call("url", params) }.to raise_error JsonRpcError, "an error happened"
+    end
+  end
+
+  describe "#read_response" do
+    let(:unix_socket) { instance_double(UNIXSocket) }
+
+    it "can read a valid response" do
+      response = {a: "b", c: 1}.to_json
+      expect(IO).to receive(:select).and_return(1)
+      expect(unix_socket).to receive(:read_nonblock).and_return(response)
+      expect(client.read_response(unix_socket)).to eq(response)
+    end
+
+    it "throws a timeout exception if select returns nil" do
+      expect(IO).to receive(:select).and_return(nil)
+      expect(unix_socket).to receive(:close)
+      expect { client.read_response(unix_socket) }.to raise_error RuntimeError, "The request timed out after 5 seconds."
+    end
+
+    it "throws an exception if response exceeds the limit" do
+      expect(IO).to receive(:select).and_return(1)
+      expect(unix_socket).to receive(:read_nonblock).and_return("a" * 200)
+      expect { client.read_response(unix_socket) }.to raise_error RuntimeError, "Response size limit exceeded."
+    end
+
+    it "can read a multi-part valid response" do
+      response = {a: "b", c: 1}.to_json
+      expect(IO).to receive(:select).and_return(1, 1)
+      expect(unix_socket).to receive(:read_nonblock).and_invoke(
+        ->(_) { response[..5] },
+        ->(_) { raise IO::EAGAINWaitReadable },
+        ->(_) { response[6..] }
+      )
+      expect(client.read_response(unix_socket)).to eq(response)
+    end
+  end
+
+  describe "#valid_json?" do
+    it "returns true for a valid json" do
+      expect(client.valid_json?({"a" => 1}.to_json)).to be(true)
+    end
+
+    it "returnf alse for an incomplete json" do
+      expect(client.valid_json?({"a" => 1}.to_json[..5])).to be(false)
+    end
+  end
+end

--- a/rhizome/host/spec/spdk_rpc_spec.rb
+++ b/rhizome/host/spec/spdk_rpc_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "../lib/spdk_rpc"
+
+RSpec.describe SpdkRpc do
+  subject(:sr) {
+    described_class.new
+  }
+
+  let(:rpc_client) {
+    instance_double(JsonRpcClient)
+  }
+
+  before do
+    allow(sr).to receive(:client).and_return(rpc_client)
+  end
+
+  describe "#bdev_aio_create" do
+    it "can create an aio bdev" do
+      expect(rpc_client).to receive(:call).with("bdev_aio_create", {
+        name: "name",
+        filename: "filename",
+        block_size: 512,
+        readonly: false
+      })
+      sr.bdev_aio_create("name", "filename", 512)
+    end
+  end
+
+  describe "#bdev_aio_delete" do
+    it "can delete an aio bdev" do
+      expect(rpc_client).to receive(:call).with("bdev_aio_delete", {
+        name: "name"
+      })
+      sr.bdev_aio_delete("name")
+    end
+
+    it "ignores exception if bdev doesn't exist and if_exists=true" do
+      expect(rpc_client).to receive(:call).with("bdev_aio_delete", {
+        name: "name"
+      }).and_raise JsonRpcError.new("No such device", -19)
+      sr.bdev_aio_delete("name")
+    end
+
+    it "raises exception if bdev doesn't exist and if_exists=false" do
+      expect(rpc_client).to receive(:call).with("bdev_aio_delete", {
+        name: "name"
+      }).and_raise JsonRpcError.new("No such device", -19)
+      expect { sr.bdev_aio_delete("name", false) }.to raise_error JsonRpcError, "No such device"
+    end
+  end
+
+  describe "#bdev_crypto_create" do
+    it "can create an crypto bdev" do
+      expect(rpc_client).to receive(:call).with("bdev_crypto_create", {
+        name: "name",
+        base_bdev_name: "base",
+        key_name: "key"
+      })
+      sr.bdev_crypto_create("name", "base", "key")
+    end
+  end
+
+  describe "#bdev_crypto_delete" do
+    it "can delete an crypto bdev" do
+      expect(rpc_client).to receive(:call).with("bdev_crypto_delete", {
+        name: "name"
+      })
+      sr.bdev_crypto_delete("name")
+    end
+
+    it "ignores exception if bdev doesn't exist and if_exists=true" do
+      expect(rpc_client).to receive(:call).with("bdev_crypto_delete", {
+        name: "name"
+      }).and_raise JsonRpcError.new("No such device", -19)
+      sr.bdev_crypto_delete("name")
+    end
+
+    it "raises exception if bdev doesn't exist and if_exists=false" do
+      expect(rpc_client).to receive(:call).with("bdev_crypto_delete", {
+        name: "name"
+      }).and_raise JsonRpcError.new("No such device", -19)
+      expect { sr.bdev_crypto_delete("name", false) }.to raise_error JsonRpcError, "No such device"
+    end
+  end
+
+  describe "#vhost_create_blk_controller" do
+    it "can create a vhost block controller" do
+      expect(rpc_client).to receive(:call).with("vhost_create_blk_controller", {
+        ctrlr: "name",
+        dev_name: "bdev"
+      })
+      sr.vhost_create_blk_controller("name", "bdev")
+    end
+  end
+
+  describe "#vhost_delete_controller" do
+    it "can delete an vhost controller" do
+      expect(rpc_client).to receive(:call).with("vhost_delete_controller", {
+        ctrlr: "name"
+      })
+      sr.vhost_delete_controller("name")
+    end
+
+    it "ignores exception if controller doesn't exist and if_exists=true" do
+      expect(rpc_client).to receive(:call).with("vhost_delete_controller", {
+        ctrlr: "name"
+      }).and_raise JsonRpcError.new("No such device", -32602)
+      sr.vhost_delete_controller("name")
+    end
+
+    it "raises exception if controller doesn't exist and if_exists=false" do
+      expect(rpc_client).to receive(:call).with("vhost_delete_controller", {
+        ctrlr: "name"
+      }).and_raise JsonRpcError.new("No such device", -32602)
+      expect { sr.vhost_delete_controller("name", false) }.to raise_error JsonRpcError, "No such device"
+    end
+  end
+
+  describe "#accel_crypto_key_create" do
+    it "can create a crypto key" do
+      expect(rpc_client).to receive(:call).with("accel_crypto_key_create", {
+        name: "name",
+        cipher: "cipher",
+        key: "key",
+        key2: "key2"
+      })
+      sr.accel_crypto_key_create("name", "cipher", "key", "key2")
+    end
+  end
+
+  describe "#accel_crypto_key_destroy" do
+    it "can delete an crypto key" do
+      expect(rpc_client).to receive(:call).with("accel_crypto_key_destroy", {
+        key_name: "name"
+      })
+      sr.accel_crypto_key_destroy("name")
+    end
+
+    it "ignores exception if crypto key doesn't exist and if_exists=true" do
+      expect(rpc_client).to receive(:call).with("accel_crypto_key_destroy", {
+        key_name: "name"
+      }).and_raise JsonRpcError.new("No key object found", -32602)
+      sr.accel_crypto_key_destroy("name")
+    end
+
+    it "raises exception if crypto key doesn't exist and if_exists=false" do
+      expect(rpc_client).to receive(:call).with("accel_crypto_key_destroy", {
+        key_name: "name"
+      }).and_raise JsonRpcError.new("No key object found", -32602)
+      expect { sr.accel_crypto_key_destroy("name", false) }.to raise_error JsonRpcError, "No key object found"
+    end
+  end
+end


### PR DESCRIPTION
Previously we used SPDK's `rpc.py` to send commands to SPDK. This had couple of drawbacks: (1) `rpc.py` is not normally installed with SPDK's `make install` and we needed to manually add it to the package. (2) We didn't parse the errors and treated all errors as equal.

This PR adds a simple JsonRpcClient class which is used by SpdkRpc to communicate with SPDK.

I considered 2 existing json-rpc gems (jimson and json-rpc-client), but when I tried them they weren't able to connect to unix sockets, and also they didn't seem mature. Implementing a simple JsonRpc client was easy, so I did that.

In addition to refactoring, this PR also fixes the issue that we failed purge if SPDK objects didn't exist. After this PR, we don't raise an error if a bdev/key/vhost controller to be delete doesn't exist.