### PR TITLE
Makes cloudinit function idempotent

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -308,6 +308,7 @@ EOS
 
     write_user_data(unix_user, public_key)
 
+    FileUtils.rm_rf(vp.cloudinit_img)
     r "mkdosfs -n CIDATA -C #{vp.q_cloudinit_img} 8192"
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_user_data} ::"
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_meta_data} ::"


### PR DESCRIPTION
We add a check for cloudinit_img before running mkdosfs command because it is not idempotent. This causes a stuck provisioning in case a failure happens in later stages of vm_setup. Especially because download_boot_image has tendency to crash if concurrent image download is triggered. In that case, the download_boot_image is actually idempotent but since cloudinit call is not, we get a stuck provisioning.