### PR TITLE
Make a VM's SPDK setup idempotent.

### DIFF
--- a/rhizome/host/e2e/storage_volume_e2e_spec.rb
+++ b/rhizome/host/e2e/storage_volume_e2e_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "../lib/storage_volume"
+require_relative "../../common/lib/util"
+require "fileutils"
+require "openssl"
+require "base64"
+
+return if ENV["RUN_E2E_TESTS"] != "1"
+
+RSpec.describe StorageVolume do
+  let(:vm) { "vm012345" }
+
+  before do
+    r "sudo adduser #{vm}"
+  end
+
+  after do
+    r "sudo userdel --remove #{vm}"
+  end
+
+  describe "#encrypted_storage_volume" do
+    let(:key_wrapping_secrets) {
+      key_wrapping_algorithm = "aes-256-gcm"
+      cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
+      {
+        "algorithm" => key_wrapping_algorithm,
+        "key" => Base64.encode64(cipher.random_key),
+        "init_vector" => Base64.encode64(cipher.random_iv),
+        "auth_data" => "Ubicloud-Storage-Auth"
+      }
+    }
+    let(:encrypted_sv) {
+      described_class.new(vm, {
+        "disk_index" => 0,
+        "device_id" => "#{vm}_0",
+        "encrypted" => true,
+        "size_gib" => 5,
+        "image" => nil
+      })
+    }
+
+    it "ensures encrypted prep, start, and purge are idempotent" do
+      encrypted_sv.prep(key_wrapping_secrets)
+      expect { encrypted_sv.prep(key_wrapping_secrets) }.not_to raise_error
+      encrypted_sv.start(key_wrapping_secrets)
+      expect { encrypted_sv.start(key_wrapping_secrets) }.not_to raise_error
+      encrypted_sv.purge_spdk_artifacts
+      expect { encrypted_sv.purge_spdk_artifacts }.not_to raise_error
+    end
+  end
+
+  describe "#unencrypted_storage_volume" do
+    let(:unencrypted_sv) {
+      described_class.new(vm, {
+        "disk_index" => 1,
+        "device_id" => "#{vm}_1",
+        "encrypted" => false,
+        "size_gib" => 5,
+        "image" => nil
+      })
+    }
+
+    it "ensures unencrypted prep, start, and purge are idempotent" do
+      unencrypted_sv.prep(nil)
+      expect { unencrypted_sv.prep(nil) }.not_to raise_error
+      unencrypted_sv.start(nil)
+      expect { unencrypted_sv.start(nil) }.not_to raise_error
+      unencrypted_sv.purge_spdk_artifacts
+      expect { unencrypted_sv.purge_spdk_artifacts }.not_to raise_error
+    end
+  end
+end

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -111,7 +111,7 @@ class VmSetup
     params = JSON.parse(File.read(vp.prep_json))
     params["storage_volumes"].each { |params|
       volume = StorageVolume.new(@vm_name, params)
-      volume.purge
+      volume.purge_spdk_artifacts
     }
 
     rm_if_exists(vp.storage_root)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -101,12 +101,12 @@ RSpec.describe VmSetup do
       # delete the unencrypted volume
       sv_1 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
-      expect(sv_1).to receive(:purge)
+      expect(sv_1).to receive(:purge_spdk_artifacts)
 
       # delete the encrypted volume
       sv_2 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
-      expect(sv_2).to receive(:purge)
+      expect(sv_2).to receive(:purge_spdk_artifacts)
 
       expect(FileUtils).to receive(:rm_r).with("/var/storage/test")
 


### PR DESCRIPTION
Previously retrying a VM's creation which had failed after SPDK artifacts were created failed with "... exists". This PR fixes that by removing SPDK artifacts if creating them fails because they exist.