### PR TITLE
Raise more specific error types for SPDK RPC exceptions.

### DIFF
--- a/rhizome/host/lib/spdk_rpc.rb
+++ b/rhizome/host/lib/spdk_rpc.rb
@@ -8,6 +8,12 @@ class SpdkRpc
     @client ||= JsonRpcClient.new(SpdkPath.rpc_sock)
   end
 
+  def rpc_call(name, params)
+    client.call(name, params)
+  rescue JsonRpcError => e
+    raise SpdkRpcError.from_json_rpc_error(e)
+  end
+
   def bdev_aio_create(name, filename, block_size)
     params = {
       name: name,
@@ -15,13 +21,13 @@ class SpdkRpc
       block_size: block_size,
       readonly: false
     }
-    client.call("bdev_aio_create", params)
+    rpc_call("bdev_aio_create", params)
   end
 
   def bdev_aio_delete(name, if_exists = true)
-    client.call("bdev_aio_delete", {name: name})
-  rescue JsonRpcError => e
-    raise e unless if_exists && e.message.include?("No such device")
+    rpc_call("bdev_aio_delete", {name: name})
+  rescue SpdkNotFound => e
+    raise e unless if_exists
   end
 
   def bdev_crypto_create(name, base_bdev_name, key_name)
@@ -30,13 +36,13 @@ class SpdkRpc
       base_bdev_name: base_bdev_name,
       key_name: key_name
     }
-    client.call("bdev_crypto_create", params)
+    rpc_call("bdev_crypto_create", params)
   end
 
   def bdev_crypto_delete(name, if_exists = true)
-    client.call("bdev_crypto_delete", {name: name})
-  rescue JsonRpcError => e
-    raise e unless if_exists && e.message.include?("No such device")
+    rpc_call("bdev_crypto_delete", {name: name})
+  rescue SpdkNotFound => e
+    raise e unless if_exists
   end
 
   def vhost_create_blk_controller(name, bdev)
@@ -44,13 +50,13 @@ class SpdkRpc
       ctrlr: name,
       dev_name: bdev
     }
-    client.call("vhost_create_blk_controller", params)
+    rpc_call("vhost_create_blk_controller", params)
   end
 
   def vhost_delete_controller(name, if_exists = true)
-    client.call("vhost_delete_controller", {ctrlr: name})
-  rescue JsonRpcError => e
-    raise e unless if_exists && e.message.include?("No such device")
+    rpc_call("vhost_delete_controller", {ctrlr: name})
+  rescue SpdkNotFound => e
+    raise e unless if_exists
   end
 
   def accel_crypto_key_create(name, cipher, key, key2)
@@ -60,12 +66,45 @@ class SpdkRpc
       key: key,
       key2: key2
     }
-    client.call("accel_crypto_key_create", params)
+    rpc_call("accel_crypto_key_create", params)
   end
 
   def accel_crypto_key_destroy(name, if_exists = true)
-    client.call("accel_crypto_key_destroy", {key_name: name})
-  rescue JsonRpcError => e
-    raise e unless if_exists && e.message.include?("No key object found")
+    rpc_call("accel_crypto_key_destroy", {key_name: name})
+  rescue SpdkNotFound => e
+    raise e unless if_exists
   end
+end
+
+class SpdkRpcError < StandardError
+  attr_reader :code
+
+  def initialize(message, code)
+    super(message)
+    @code = code
+  end
+
+  def self.from_json_rpc_error(e)
+    # Check if we can return a specific subclass.
+    case e.code
+    when -Errno::EEXIST::Errno
+      return SpdkExists.new(e.message, e.code)
+    when -Errno::ENODEV::Errno
+      return SpdkNotFound.new(e.message, e.code)
+    when -32602 # SPDK_JSONRPC_ERROR_INVALID_PARAMS
+      if e.message.match?(/File exists|rc -17/)
+        return SpdkExists.new(e.message, e.code)
+      elsif e.message.match?(/No key object found|No such device/)
+        return SpdkNotFound.new(e.message, e.code)
+      end
+    end
+
+    SpdkRpcError.new(e.message, e.code)
+  end
+end
+
+class SpdkExists < SpdkRpcError
+end
+
+class SpdkNotFound < SpdkRpcError
 end


### PR DESCRIPTION
Previously we just handled or re-raised the JsonRpcError in SpdkRpc methods. This PR adds logic to parse error codes and messages to return a more specific error type.

* `SpdkExists < SpdkRpcError` when the object to be created already exists.
* `SpdkNotFound < SpdRpcError` when the object to be deleted doesn't exist.
* `SpdkRpcError` for all other cases.

This refactor paves the road for a follow-up PR to make VM's SPDK setup idempotent.