### PR TITLE
Elide sensitive information in argv via xargs

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -177,8 +177,10 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     # We initiate an API call and a SSH connection under the same label to avoid
     # having to store the encoded_jit_config.
-    command = "./actions-runner/run.sh --jitconfig #{response[:encoded_jit_config].shellescape}"
-    vm.sshable.cmd("sudo systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit #{SERVICE_NAME} --remain-after-exit -- #{command}")
+    vm.sshable.cmd("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner " \
+                   "--working-directory '/home/runner' --unit #{SERVICE_NAME} --remain-after-exit -- " \
+                   "./actions-runner/run.sh --jitconfig {}",
+      stdin: response[:encoded_jit_config])
 
     hop_wait
   rescue Octokit::Conflict => e

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -192,7 +192,8 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#register_runner" do
     it "registers runner hops" do
       expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: github_runner.ubid.to_s, labels: [github_runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC"})
-      expect(sshable).to receive(:cmd).with("sudo systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- ./actions-runner/run.sh --jitconfig AABBCC")
+      expect(sshable).to receive(:cmd).with("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- ./actions-runner/run.sh --jitconfig {}",
+        stdin: "AABBCC")
       expect(github_runner).to receive(:update).with(runner_id: 123, ready_at: anything)
 
       expect { nx.register_runner }.to hop("wait")


### PR DESCRIPTION
With this slight change, it's possible to make sensitive `encoded_jit_config` leakage less likely by passing it via stdin, rather than directly to the shell.

Unfortunately the contents still ends up in the systemd journal, via `systemd-run`'s logs of the post-substitution argument vector.