### PR TITLE
Optimize out extra update before deletion

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -122,12 +122,13 @@ SQL
 
       hp
     rescue Prog::Base::Exit => ext
-      update(exitval: ext.exitval, retval: nil)
       if parent_id.nil?
         # No parent Strand to reap here, so self-reap.
         Semaphore.where(strand_id: id).destroy
         destroy
         @deleted = true
+      else
+        update(exitval: ext.exitval, retval: nil)
       end
 
       ext

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -89,6 +89,6 @@ SQL
     st.save_changes
     expect {
       st.run(10)
-    }.to change { [st.label, st.exitval] }.from(["hop_entry", nil]).to(["hop_exit", {msg: "hop finished"}])
+    }.to change { st.instance_variable_get(:@deleted) }.from(nil).to(true)
   end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -65,9 +65,10 @@ RSpec.describe Prog::Base do
     expect(st.retval).to eq({"msg" => "2"})
 
     st.run
-    expect(st.exitval).to eq({"msg" => "1"})
 
+    expect(st.instance_variable_get(:@deleted)).to be true
     expect { st.run }.to raise_error "already deleted"
+
     expect { st.reload }.to raise_error Sequel::NoExistingObject
   end
 


### PR DESCRIPTION
There's not much point updating the record before it gets deleted. 

A nice side effect this had was keeping the strand's exitval in-memory state in sync, but this property is only used in two tests, and is replaceable.