### PR TITLE
Reset exponential backoff when hopping

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -118,7 +118,7 @@ SQL
       changed_columns.delete(:schedule)
       e
     rescue Prog::Base::Hop => hp
-      update(**hp.strand_update_args)
+      update(**hp.strand_update_args.merge(try: 0))
 
       hp
     rescue Prog::Base::Exit => ext


### PR DESCRIPTION
Since `hop` is a success situation, it doesn't make sense to carry on the exponential backoff `try` number. Re-setting `try` to `0` makes it consistent with `nap`'s behavior.

This was an oversight in 16bec8e26d4c9a398939f78a99c2fae1db657f41, in which exponential backoff was added altogether.