### PR TITLE
Eliminate database access for common fixture in Vm Nexus spec

### DIFF
--- a/spec/model/billing_record_spec.rb
+++ b/spec/model/billing_record_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe BillingRecord do
+  it "can filter for active records" do
+    expected = described_class.create_with_id(
+      project_id: "50089dcf-b472-8ad2-9ca6-b3e70d12759d",
+      resource_id: "2464de61-7501-8374-9ab0-416caebe31da",
+      resource_name: "whatever",
+      billing_rate_id: BillingRate.from_resource_properties("VmCores", "standard", "hetzner-fsn1")["id"],
+      amount: 1
+    )
+    expect(described_class.active.all).to eq([expected])
+  end
+end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -25,14 +25,13 @@ RSpec.describe Prog::Vm::Nexus do
       _1.vm_storage_volumes.append(disk_2)
       disk_1.vm = _1
       disk_2.vm = _1
+      allow(_1).to receive(:active_billing_record).and_return(BillingRecord.new(
+        project_id: SecureRandom.uuid,
+        resource_name: _1.name,
+        billing_rate_id: BillingRate.from_resource_properties("VmCores", _1.family, _1.location)["id"],
+        amount: _1.cores
+      ))
     }
-    BillingRecord.create_with_id(
-      project_id: SecureRandom.uuid,
-      resource_id: vm.id,
-      resource_name: vm.name,
-      billing_rate_id: BillingRate.from_resource_properties("VmCores", vm.family, vm.location)["id"],
-      amount: vm.cores
-    )
     vm
   }
   let(:prj) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }


### PR DESCRIPTION
This fixture otherwise uses `new` and is not reliant on writes to the database via `create_with_id`, which speeds things up.

However, the size of this fixture is a code smell: a not so many tests require a billing record at all, yet the mock is always present.