### PR TITLE
arm64

### DIFF
--- a/rhizome/common/lib/arch.rb
+++ b/rhizome/common/lib/arch.rb
@@ -1,26 +1,5 @@
 # frozen_string_literal: true
 
-require "rbconfig"
-
-ArchClass = Struct.new(:sym) {
-  def self.from_system
-    new case RbConfig::CONFIG.fetch("target_cpu").downcase
-    when /arm64|aarch64/
-      "arm64"
-    when /amd64|x86_64|x64/
-      "x64"
-    else
-      fail "BUG: could not detect architecture"
-    end.intern
-  end
-
-  def arm64?
-    sym == :arm64
-  end
-
-  def x64?
-    sym == :x64
-  end
-}
+require_relative "arch_class"
 
 Arch = ArchClass.from_system

--- a/rhizome/common/lib/arch_class.rb
+++ b/rhizome/common/lib/arch_class.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+ArchClass = Struct.new(:sym) {
+  def self.from_system
+    new case RbConfig::CONFIG.fetch("target_cpu").downcase
+    when /arm64|aarch64/
+      "arm64"
+    when /amd64|x86_64|x64/
+      "x64"
+    else
+      fail "BUG: could not detect architecture"
+    end.intern
+  end
+
+  def arm64?
+    sym == :arm64
+  end
+
+  def x64?
+    sym == :x64
+  end
+
+  def render(x64: sym, arm64: sym)
+    if x64?
+      x64
+    elsif arm64?
+      arm64
+    else
+      fail "BUG: could not detect architecture"
+    end.to_s
+  end
+}

--- a/rhizome/common/spec/arch_class_spec.rb
+++ b/rhizome/common/spec/arch_class_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../lib/arch"
+
+RSpec.describe ArchClass do
+  describe "#render" do
+    it "selects the user string of the matching architecture" do
+      expect(described_class.new(:x64).render(x64: "test-x64", arm64: "test-arm64")).to eq("test-x64")
+      expect(described_class.new(:arm64).render(x64: "test-x64", arm64: "test-arm64")).to eq("test-arm64")
+    end
+
+    it "has default representations for nil input to render" do
+      expect(described_class.new(:x64).render).to eq("x64")
+      expect(described_class.new(:arm64).render).to eq("arm64")
+    end
+  end
+end

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -5,20 +5,20 @@ require_relative "../../common/lib/util"
 require_relative "../lib/cloud_hypervisor"
 require "fileutils"
 
-ch_dir = "/opt/cloud-hypervisor/v#{CloudHypervisor::VERSION}"
+ch_dir = CloudHypervisor::VERSION.dir
 FileUtils.mkdir_p(ch_dir)
 FileUtils.cd ch_dir do
-  r "curl -L3 -O https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{CloudHypervisor::VERSION}/ch-remote"
+  r "curl -L3 -o ch-remote #{CloudHypervisor::VERSION.ch_remote_url.shellescape}"
   FileUtils.chmod "a+x", "ch-remote"
-  r "curl -L3 -O https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{CloudHypervisor::VERSION}/cloud-hypervisor"
+  r "curl -L3 -o cloud-hypervisor #{CloudHypervisor::VERSION.url.shellescape}"
   FileUtils.chmod "a+x", "cloud-hypervisor"
 end
 
 # edk2 firmware
-fw_dir = File.dirname(CloudHypervisor.firmware)
+fw_dir = File.dirname(CloudHypervisor::FIRMWARE.path)
 FileUtils.mkdir_p(fw_dir)
 FileUtils.cd fw_dir do
-  r "curl -L3 -o #{CloudHypervisor.firmware.shellescape} https://github.com/fdr/edk2/releases/download/#{CloudHypervisor::FIRMWARE_VERSION}/CLOUDHV.fd"
+  r "curl -L3 -o #{CloudHypervisor::FIRMWARE.name.shellescape} #{CloudHypervisor::FIRMWARE.url.shellescape}"
 end
 
 # Err towards listing ('l') and not restarting services by default,

--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -1,6 +1,7 @@
 #!/bin/env ruby
 # frozen_string_literal: true
 
+require_relative "../../common/lib/arch"
 require_relative "../../common/lib/util"
 require_relative "../lib/spdk_path"
 require "fileutils"
@@ -10,7 +11,14 @@ r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev l
 
 # spdk binaries
 FileUtils.cd SpdkPath.install_prefix do
-  r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/7adbcfb/spdk-7adbcfb.tar.gz"
+  if Arch.arm64?
+    r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/v23.09/spdk-arm64.tar.gz"
+  elsif Arch.x64?
+    r "curl -L3 -o /tmp/spdk.tar.gz https://github.com/ubicloud/spdk/releases/download/7adbcfb/spdk-7adbcfb.tar.gz"
+  else
+    fail "BUG: unexpected architecture"
+  end
+
   r "tar -xzf /tmp/spdk.tar.gz"
 end
 

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -1,10 +1,53 @@
 # frozen_string_literal: true
 
-module CloudHypervisor
-  VERSION = "31.0"
-  FIRMWARE_VERSION = "edk2-stable202302"
+require_relative "../../common/lib/arch"
 
-  def self.firmware
-    "/opt/fw/#{FIRMWARE_VERSION}/x64/CLOUDHV.fd"
+module CloudHypervisor
+  FirmwareClass = Struct.new(:version, :name) {
+    def url
+      "https://github.com/fdr/edk2/releases/download/#{version}/#{name}"
+    end
+
+    def path
+      "/opt/fw/#{version}/#{Arch.sym}/#{name}"
+    end
+  }
+
+  FIRMWARE = if Arch.arm64?
+    FirmwareClass.new("edk2-stable202308", "CLOUDHV_EFI.fd")
+  elsif Arch.x64?
+    FirmwareClass.new("edk2-stable202302", "CLOUDHV.fd")
+  else
+    fail "BUG: unexpected architecture"
+  end
+
+  VersionClass = Struct.new(:version) {
+    def ch_remote_url
+      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/ch-remote" + Arch.render(x64: "", arm64: "-static-aarch64")
+    end
+
+    def url
+      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/cloud-hypervisor" + Arch.render(x64: "", arm64: "-static-aarch64")
+    end
+
+    def dir
+      "/opt/cloud-hypervisor/v#{version}"
+    end
+
+    def bin
+      File.join(dir, "cloud-hypervisor")
+    end
+
+    def ch_remote_bin
+      File.join(dir, "ch-remote")
+    end
+  }
+
+  VERSION = if Arch.arm64?
+    VersionClass.new("35.0")
+  elsif Arch.x64?
+    VersionClass.new("31.0")
+  else
+    fail "BUG: unexpected architecture"
   end
 end


### PR DESCRIPTION
Refactor some data structures to move towards coping with the
additional complexity, but fundamentally, add branches to download and
use different binaries on different platforms.

Having applied this patch, and having prepared hosts with a current
Rhizome, it is possible to provision an arm64 VM like so:

    Prog::Vm::Nexus.assemble("pubkey", dev_project.id, arch: "arm64")

As the host architectures are "learned" from teh host, there is no
need to change how `Prog::Vm::HostNexus.assemble` is called.