### PR TITLE
Provide more storage for the larger GitHub runners

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -1,13 +1,13 @@
-- { name: ubicloud, vm_size: standard-2, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-2, vm_size: standard-2, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-4, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-8, vm_size: standard-8, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-16, vm_size: standard-16, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-2-ubuntu-2204, vm_size: standard-2, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-4-ubuntu-2204, vm_size: standard-4, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-8-ubuntu-2204, vm_size: standard-8, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-16-ubuntu-2204, vm_size: standard-16, boot_image: github-ubuntu-2204, location: github-runners }
-- { name: ubicloud-standard-2-ubuntu-2004, vm_size: standard-2, boot_image: github-ubuntu-2004, location: github-runners }
-- { name: ubicloud-standard-4-ubuntu-2004, vm_size: standard-4, boot_image: github-ubuntu-2004, location: github-runners }
-- { name: ubicloud-standard-8-ubuntu-2004, vm_size: standard-8, boot_image: github-ubuntu-2004, location: github-runners }
-- { name: ubicloud-standard-16-ubuntu-2004, vm_size: standard-16, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud,                         vm_size: standard-2,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2,              vm_size: standard-2,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-4,              vm_size: standard-4,  storage_size_gib: 150, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-8,              vm_size: standard-8,  storage_size_gib: 200, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-16,             vm_size: standard-16, storage_size_gib: 300, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2-ubuntu-2204,  vm_size: standard-2,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-4-ubuntu-2204,  vm_size: standard-4,  storage_size_gib: 150, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-8-ubuntu-2204,  vm_size: standard-8,  storage_size_gib: 200, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-16-ubuntu-2204, vm_size: standard-16, storage_size_gib: 300, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2-ubuntu-2004,  vm_size: standard-2,  storage_size_gib: 86,  boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-4-ubuntu-2004,  vm_size: standard-4,  storage_size_gib: 150, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-8-ubuntu-2004,  vm_size: standard-8,  storage_size_gib: 200, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-16-ubuntu-2004, vm_size: standard-16, storage_size_gib: 300, boot_image: github-ubuntu-2004, location: github-runners }

--- a/migrate/20231027_add_storage_to_vm_pool.rb
+++ b/migrate/20231027_add_storage_to_vm_pool.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:vm_pool) do
+      add_column :storage_size_gib, :bigint
+    end
+
+    run <<~SQL
+      UPDATE vm_pool SET storage_size_gib = CASE
+          WHEN vm_size = 'standard-2' THEN 86
+          WHEN vm_size = 'standard-4' THEN 150
+          WHEN vm_size = 'standard-8' THEN 200
+          WHEN vm_size = 'standard-16' THEN 300
+          ELSE storage_size_gib END
+      WHERE location = 'github-runners';
+    SQL
+
+    alter_table(:vm_pool) do
+      set_column_not_null :storage_size_gib
+    end
+  end
+
+  down do
+    alter_table(:vm_pool) do
+      drop_column :storage_size_gib
+    end
+  end
+end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -30,7 +30,8 @@ class Prog::Vm::GithubRunner < Prog::Base
     pool = VmPool.where(
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
-      location: label_data["location"]
+      location: label_data["location"],
+      storage_size_gib: label_data["storage_size_gib"]
     ).first
 
     if (picked_vm = pool&.pick_vm)
@@ -71,7 +72,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       unix_user: "runner",
       location: label_data["location"],
       boot_image: label_data["boot_image"],
-      storage_volumes: [{size_gib: 86, encrypted: false}],
+      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: false}],
       enable_ip4: true
     )
 

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -7,13 +7,14 @@ class Prog::Vm::VmPool < Prog::Base
 
   semaphore :destroy
 
-  def self.assemble(size:, vm_size:, boot_image:, location:)
+  def self.assemble(size:, vm_size:, boot_image:, location:, storage_size_gib:)
     DB.transaction do
       vm_pool = VmPool.create_with_id(
         size: size,
         vm_size: vm_size,
         boot_image: boot_image,
-        location: location
+        location: location,
+        storage_size_gib: storage_size_gib
       )
       Strand.create(prog: "Vm::VmPool", label: "create_new_vm") { _1.id = vm_pool.id }
     end
@@ -37,7 +38,7 @@ class Prog::Vm::VmPool < Prog::Base
         unix_user: "runner",
         location: vm_pool.location,
         boot_image: vm_pool.boot_image,
-        storage_volumes: [{size_gib: 86, encrypted: false}],
+        storage_volumes: [{size_gib: vm_pool.storage_size_gib, encrypted: false}],
         enable_ip4: true,
         pool_id: vm_pool.id
       )

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe VmPool do
       size: 3,
       vm_size: "standard-2",
       boot_image: "img",
-      location: "loc"
+      location: "loc",
+      storage_size_gib: 86
     )
   }
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "provisions a new vm if pool is valid but there is no vm" do
-      git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners")
-      expect(VmPool).to receive(:where).with(vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners").and_return([git_runner_pool])
+      git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150)
+      expect(VmPool).to receive(:where).with(vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150).and_return([git_runner_pool])
       expect(git_runner_pool).to receive(:pick_vm).and_return(nil)
       expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
       vm = nil
@@ -99,8 +99,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses the existing vm if pool can pick one" do
-      git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners")
-      expect(VmPool).to receive(:where).with(vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners").and_return([git_runner_pool])
+      git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150)
+      expect(VmPool).to receive(:where).with(vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150).and_return([git_runner_pool])
       expect(git_runner_pool).to receive(:pick_vm).and_return(vm)
 
       ps = instance_double(PrivateSubnet)

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe ".assemble" do
     it "creates the entity and strand properly" do
-      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1")
+      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
       pool = VmPool[st.id]
       expect(pool).not_to be_nil
       expect(pool.size).to eq(3)
@@ -27,7 +27,7 @@ RSpec.describe Prog::Vm::VmPool do
 
     it "creates a new vm and hops to wait" do
       expect(Config).to receive(:vm_pool_project_id).and_return(prj.id)
-      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1")
+      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
       st.update(label: "create_new_vm")
       expect(SshKey).to receive(:generate).and_call_original
       expect(nx).to receive(:vm_pool).and_return(VmPool[st.id]).at_least(:once)
@@ -42,7 +42,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#wait" do
     let(:pool) {
-      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1")
+      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
     }
 
     it "waits if nothing to do" do
@@ -72,7 +72,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#destroy" do
     let(:pool) {
-      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1")
+      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
     }
 
     it "increments vms' destroy semaphore and hops to wait_vms_destroy" do
@@ -88,7 +88,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#wait_vms_destroy" do
     let(:pool) {
-      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1")
+      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
     }
 
     it "pops if vms are all destroyed" do


### PR DESCRIPTION
We configured our GitHub runner images to be 86GB, with ~16GB of free space, excluding all installed software. This might suffice for small tasks, but for heavy workload jobs that require powerful runners, it might not be enough. We encountered workflows where this free space was insufficient.

Additionally, larger GitHub runners offer more storage: 4vCPU provides 150GB, 8vCPU provides 300GB, and 16vCPU provides 600GB.

We initially opted for slightly lower storage figures. The rationale behind our decision is that it's easier to scale up storage sizes as required in the future, whereas reducing them would be more challenging.

    standard-2 runner     86GB
    standard-4 runner    150GB
    standard-8 runner    200GB
    standard-16 runner   300GB
