### PR TITLE
Don't install rhizome's spec files by default.

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -172,8 +172,8 @@ class VmHost < Sequel::Model
   # Operational Functions
 
   # Introduced for refreshing rhizome programs via REPL.
-  def install_rhizome
-    Strand.create_with_id(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id, target_folder: "host"}])
+  def install_rhizome(install_specs: false)
+    Strand.create_with_id(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id, target_folder: "host", install_specs: install_specs}])
   end
 
   # Introduced for downloading a new boot image via REPL.

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -11,6 +11,7 @@ class Prog::InstallRhizome < Prog::Base
     Gem::Package::TarWriter.new(tar) do |writer|
       base = Config.root + "/rhizome"
       Dir.glob(["Gemfile", "Gemfile.lock", "common/**/*", "#{frame["target_folder"]}/**/*"], base: base).map do |file|
+        next if !frame["install_specs"] && file.end_with?("_spec.rb")
         full_path = base + "/" + file
         stat = File.stat(full_path)
         if stat.directory?

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe VmHost do
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     expect(Strand).to receive(:create) do |args|
       expect(args[:prog]).to eq("InstallRhizome")
-      expect(args[:stack]).to eq([subject_id: vh.id, target_folder: "host"])
+      expect(args[:stack]).to eq([subject_id: vh.id, target_folder: "host", install_specs: false])
     end
     vh.install_rhizome
   end

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prog::InstallRhizome do
   let(:sshable) { instance_double(Sshable) }
 
   before do
-    expect(ir).to receive(:sshable).and_return(sshable).at_least(:once)
+    allow(ir).to receive(:sshable).and_return(sshable)
   end
 
   describe "#start" do
@@ -21,6 +21,13 @@ RSpec.describe Prog::InstallRhizome do
         expect(kwargs[:stdin][257..261]).to eq "ustar"
       end
       expect { ir.start }.to hop("install_gems")
+    end
+
+    it "writes tar including specs" do
+      ir_spec = described_class.new(Strand.new(stack: [{"target_folder" => "host", "install_specs" => true}]))
+      expect(ir_spec).to receive(:sshable).and_return(sshable).at_least(:once)
+      expect(sshable).to receive(:cmd)
+      expect { ir_spec.start }.to hop("install_gems")
     end
   end
 


### PR DESCRIPTION
Installing rhizome's spec files in production might not be safe, so this PR excludes them by default. They can be included if needed (e.g. for E2E CI tests).

```
vm_host.install_rhizome(install_specs: false)
```