### PR TITLE
Add CPU architecture printing

### DIFF
--- a/migrate/20231014_arm64.rb
+++ b/migrate/20231014_arm64.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_enum(:arch, %w[x64 arm64])
+
+    alter_table(:vm_host) do
+      add_column :arch, :arch
+    end
+
+    alter_table(:vm) do
+      add_column :arch, :arch, default: "x64", null: false
+    end
+  end
+end

--- a/rhizome/common/lib/arch.rb
+++ b/rhizome/common/lib/arch.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+ArchClass = Struct.new(:sym) {
+  def self.from_system
+    sym = case RbConfig::CONFIG.fetch("target_cpu").downcase
+    when /arm64|aarch64/
+      "arm64"
+    when /amd64|x86_64|x64/
+      "x64"
+    else
+      fail "BUG: could not detect architecture"
+    end.intern
+    new sym
+  end
+
+  def arm64?
+    sym == :arm64
+  end
+
+  def x64?
+    sym == :x64
+  end
+}
+
+Arch = ArchClass.from_system

--- a/rhizome/host/bin/arch
+++ b/rhizome/host/bin/arch
@@ -1,0 +1,6 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/arch"
+
+puts Arch.sym


### PR DESCRIPTION
This is the first deploy to do arm64, I chipped it out of #800. It requires a rhizome backport across all servers, as the next step will be to use `common/bin/arch` to fill a database field...and ergo, it must be present to not crash the VmHost learning step.