### PR TITLE
Adds nftables rules to block dhcp ports on vethi*

### DIFF
--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -266,6 +266,11 @@ table ip raw {
 ip saddr 192.168.5.50 ip daddr != { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } ip saddr set 123.123.123.123 notrack
 
   }
+  chain postrouting {
+    type filter hook postrouting priority raw; policy accept;
+    # avoid dhcp ports to be used for spoofing
+    oifname vethitest udp sport { 67, 68 } udp dport { 67, 68 } drop
+  }
 }
 table ip6 raw {
   chain prerouting {


### PR DESCRIPTION
With this commit we further block the dhcp packets further spilling out of vethi* interface. The previous commit 1eb6eda introduced rules to block ip spoofing but we had to allow dhcp ports. This fixes that. We still allow dhcp packets as long as they stay inside the namespace.