### PR TITLE
Make the tag unique for only active pages

### DIFF
--- a/migrate/20231102_make_active_page_tag_unique.rb
+++ b/migrate/20231102_make_active_page_tag_unique.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  up do
+    alter_table(:page) do
+      drop_constraint :page_tag_key, type: :unique
+      add_index :tag, unique: true, where: {resolved_at: nil}, concurrently: true
+    end
+  end
+
+  down do
+    alter_table(:page) do
+      drop_index [:tag], concurrently: true
+      add_unique_constraint :tag
+    end
+  end
+end

--- a/model/page.rb
+++ b/model/page.rb
@@ -42,6 +42,6 @@ class Page < Sequel::Model
 
   def self.from_tag_parts(*tag_parts)
     tag = Page.generate_tag(tag_parts)
-    Page[tag: tag]
+    Page.active.where(tag: tag).first
   end
 end


### PR DESCRIPTION
We implemented tag parts to avoid creating duplicate pages. However, `Page.from_tag_parts` also returns previously resolved pages. This implies that if we've already created and resolved a page, we cannot create a new one with the same tag parts.

I discovered this issue when we encountered a capacity problem today and didn't get a page. This was due to an existing resolved page with `["NoCapacity", vm.location]` tag parts.

The same issue applies to deadline pages. If we have a resolved page with `[id, prog, stack.first["deadline_target"]]` tag parts, we are unable to generate a new page for the same target within the same prog.