### PR TITLE
Add nokogiri gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.2.2"
 
 gem "argon2"
 gem "aws-sdk-s3"
+gem "nokogiri"
 gem "bcrypt_pbkdf"
 gem "ed25519"
 gem "net-ssh"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,7 @@ DEPENDENCIES
   mail
   net-ssh
   netaddr
+  nokogiri
   octokit
   pagerduty (>= 4.0)
   pry


### PR DESCRIPTION
98ae59c6a1b2328bf2f649adc1816a31a9a4cbf8 crashes when run with only the production gem set:

    > BUNDLE_WITHOUT=development:test bundle exec -- ./bin/pry
    [1] clover-development(main)> require 'aws-sdk-s3'
    RuntimeError: Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml
    from /home/fdr/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.185.2/lib/aws-sdk-core/xml/parser.rb:74:in `set_default_engine'

So, add Nokogiri to avoid crashing at runtime, since it's what our other gems in test and development use already.