### PR TITLE
Encrypt PostgreSQL's root cert keys

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -17,7 +17,8 @@ class PostgresResource < Sequel::Model
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password
-    enc.column :root_cert_key
+    enc.column :root_cert_key_1
+    enc.column :root_cert_key_2
     enc.column :server_cert_key
   end
 


### PR DESCRIPTION
After adding second root cert and renaming the first one, we didn't update the list of columns we encrypt. This commit adds missing columns to the encryption list.