### PR TITLE
Destroy the private subnets while deprovisioning a vm pool

### DIFF
--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -56,6 +56,7 @@ class Prog::Vm::VmPool < Prog::Base
 
   label def destroy
     vm_pool.vms.each do |vm|
+      vm.private_subnets.each { _1.incr_destroy }
       vm.incr_destroy
     end
     hop_wait_vms_destroy

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -70,10 +70,12 @@ RSpec.describe Prog::Vm::VmPool do
     }
 
     it "increments vms' destroy semaphore and hops to wait_vms_destroy" do
-      vm = instance_double(Vm)
+      ps = instance_double(PrivateSubnet)
+      vm = instance_double(Vm, private_subnets: [ps])
       expect(nx).to receive(:vm_pool).and_return(pool)
       expect(pool).to receive(:vms).and_return([vm])
       expect(vm).to receive(:incr_destroy)
+      expect(ps).to receive(:incr_destroy)
       expect { nx.destroy }.to hop("wait_vms_destroy")
     end
   end


### PR DESCRIPTION
When we destroy a VM, the associated private subnet is not automatically deleted. We must explicitly initiate its destroy.