### PR TITLE
Program to restart SPDK.

### DIFF
--- a/migrate/20231110_add_host_updating.rb
+++ b/migrate/20231110_add_host_updating.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_enum_value(:allocation_state, "updating")
+  end
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -139,8 +139,12 @@ class Vm < Sequel::Model
     id.to_s[0..7]
   end
 
+  def self.uuid_to_name(uuid)
+    ubid_to_name(UBID.from_uuidish(uuid))
+  end
+
   def inhost_name
-    self.class.ubid_to_name(UBID.from_uuidish(id))
+    self.class.uuid_to_name(id)
   end
 
   def storage_size_gib

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -176,6 +176,10 @@ class VmHost < Sequel::Model
     Strand.create_with_id(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id, target_folder: "host"}])
   end
 
+  def restart_spdk
+    Strand.create_with_id(schedule: Time.now, prog: "Storage::RestartSpdk", label: "start", stack: [{subject_id: id}])
+  end
+
   # Introduced for downloading a new boot image via REPL.
   # Use with caution as the vm_host will not accept a new vm during the image download.
   def download_boot_image(image_name, custom_url = nil)

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -18,4 +18,24 @@ class VmStorageVolume < Sequel::Model
   def device_path
     "/dev/disk/by-id/virtio-#{device_id}"
   end
+
+  def params_hash
+    {
+      "boot" => boot,
+      "image" => boot ? vm.boot_image : nil,
+      "size_gib" => size_gib,
+      "device_id" => device_id,
+      "disk_index" => disk_index,
+      "encrypted" => !key_encryption_key_1.nil?,
+      "vm_inhost_name" => Vm.uuid_to_name(vm_id)
+    }
+  end
+
+  def self.storage_secrets_hash(storage_volumes_dataset)
+    storage_volumes_dataset.filter_map { |s|
+      if !s.key_encryption_key_1.nil?
+        [s.device_id, s.key_encryption_key_1.secret_key_material_hash]
+      end
+    }.to_h
+  end
 end

--- a/prog/storage/restart_spdk.rb
+++ b/prog/storage/restart_spdk.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class Prog::Storage::RestartSpdk < Prog::Base
+  subject_is :sshable, :vm_host
+
+  label def start
+    # We will send volume information to `storage-ctl`. Temporarily don't accept
+    # new VMs on this host to make we don't miss any volumes in the payload
+    # because of concurrency.
+    #
+    # Concurrent VM deletions might still happen, and `storage-ctl` should
+    # handle the cases where a volume has been deleted.
+    raise "Host not in accepting mode" if vm_host.allocation_state != "accepting"
+    vm_host.update(allocation_state: "updating")
+    hop_wait_until_vms_idle
+  end
+
+  label def wait_until_vms_idle
+    nap 30 if vms_not_waiting != 0
+
+    hop_restart
+  end
+
+  label def restart
+    params_json = JSON.generate({
+      volumes: storage_volumes_dataset.map { |s| s.params_hash },
+      secrets: storage_secrets_hash
+    })
+
+    # We only have 60 seconds (hard-coded in cloud-hypervisor's code) after
+    # stopping SPDK to start all volumes. So, do these 3 commands back-to-back
+    # instead of breaking them into multiple state machine steps.
+    sshable.cmd("sudo systemctl stop spdk")
+    sshable.cmd("sudo systemctl start spdk")
+    sshable.cmd("sudo host/bin/storage-ctl start-volumes", stdin: params_json)
+
+    vm_host.update(allocation_state: "accepting")
+    pop "SPDK was restarted"
+  end
+
+  def storage_volumes_dataset
+    @storage_volumes ||=
+      VmStorageVolume
+        .where(vm_id: vm_host.vms_dataset.select(:id))
+  end
+
+  def storage_secrets_hash
+    @storage_secrets_hash ||=
+      VmStorageVolume.storage_secrets_hash(storage_volumes_dataset)
+  end
+
+  def vms_not_waiting
+    Strand.where(id: vm_host.vms_dataset.select(:id))
+      .exclude(label: "wait")
+      .count
+  end
+end

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Prog::SetupSpdk < Prog::Base
+class Prog::Storage::SetupSpdk < Prog::Base
   subject_is :sshable, :vm_host
 
   label def start

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -98,7 +98,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def setup_spdk
-    bud Prog::SetupSpdk
+    bud Prog::Storage::SetupSpdk
     hop_wait_setup_spdk
   end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -137,23 +137,12 @@ class Prog::Vm::Nexus < Prog::Base
 
   def storage_volumes
     @storage_volumes ||= vm.vm_storage_volumes.map { |s|
-      {
-        "boot" => s.boot,
-        "image" => s.boot ? vm.boot_image : nil,
-        "size_gib" => s.size_gib,
-        "device_id" => s.device_id,
-        "disk_index" => s.disk_index,
-        "encrypted" => !s.key_encryption_key_1.nil?
-      }
+      s.params_hash
     }
   end
 
   def storage_secrets
-    @storage_secrets ||= vm.vm_storage_volumes.filter_map { |s|
-      if !s.key_encryption_key_1.nil?
-        [s.device_id, s.key_encryption_key_1.secret_key_material_hash]
-      end
-    }.to_h
+    @storage_secrets ||= VmStorageVolume.storage_secrets_hash(vm.vm_storage_volumes)
   end
 
   def allocation_dataset

--- a/rhizome/host/bin/storage-ctl
+++ b/rhizome/host/bin/storage-ctl
@@ -1,0 +1,33 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../lib/storage_ctl"
+
+params = JSON.parse($stdin.read)
+
+unless (action = ARGV.shift)
+  puts "expected action as argument"
+  exit 1
+end
+
+storage_ctl = StorageCtl.new
+
+case action
+when "start-volumes"
+  unless (volumes = params["volumes"])
+    puts "need volumes in params"
+    exit 1
+  end
+
+  unless (storage_secrets = params["secrets"])
+    puts "need secrets in params"
+    exit 1
+  end
+
+  storage_ctl.start_volumes(volumes, storage_secrets)
+
+else
+  puts "invalid action : #{action}"
+  exit 1
+end

--- a/rhizome/host/lib/storage_ctl.rb
+++ b/rhizome/host/lib/storage_ctl.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "vm_path"
+require_relative "storage_volume"
+
+class StorageCtl
+  def start_volumes(volumes, storage_secrets)
+    first_exception = nil
+
+    volumes.each { |params|
+      device_id = params["device_id"]
+      storage_volume = StorageVolume.new(params)
+      begin
+        storage_volume.start(storage_secrets[device_id])
+      rescue => e
+        # Volumes might get deleted concurrently, don't raise errors if we
+        # can't start a deleted volume.
+        first_exception ||= e if !storage_volume.deleted?
+      end
+    }
+
+    raise first_exception if first_exception
+  end
+end

--- a/rhizome/host/lib/storage_key_tool.rb
+++ b/rhizome/host/lib/storage_key_tool.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../common/lib/util"
 require_relative "vm_path"
-require_relative "../lib/storage_key_encryption"
+require_relative "storage_key_encryption"
 
 class StorageKeyTool
   def initialize(vm_name, disk_index)

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -12,8 +12,8 @@ require_relative "spdk_rpc"
 require_relative "storage_key_encryption"
 
 class StorageVolume
-  def initialize(vm_name, params)
-    @vm_name = vm_name
+  def initialize(params)
+    @vm_name = params["vm_inhost_name"]
     @disk_index = params["disk_index"]
     @device_id = params["device_id"]
     @encrypted = params["encrypted"]
@@ -251,5 +251,9 @@ class StorageVolume
     FileUtils.chown @vm_name, @vm_name, vp.vhost_sock(@disk_index)
 
     vp.vhost_sock(@disk_index)
+  end
+
+  def deleted?
+    !File.exist? @disk_file
   end
 end

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe StorageVolume do
       "device_id" => "xyz01",
       "encrypted" => false,
       "size_gib" => 12,
-      "image" => "kubuntu"
+      "image" => "kubuntu",
+      "vm_inhost_name" => "test"
     }
-    described_class.new("test", params)
+    described_class.new(params)
   }
 
   let(:encrypted_sv) {
@@ -22,9 +23,10 @@ RSpec.describe StorageVolume do
       "device_id" => "xyz01",
       "encrypted" => true,
       "size_gib" => 12,
-      "image" => "kubuntu"
+      "image" => "kubuntu",
+      "vm_inhost_name" => "test"
     }
-    described_class.new("test", params)
+    described_class.new(params)
   }
   let(:image_path) {
     "/var/storage/images/kubuntu.raw"
@@ -43,7 +45,7 @@ RSpec.describe StorageVolume do
 
   describe "#prep" do
     it "can prep a non-imaged unencrypted disk" do
-      vol = described_class.new("test", {"disk_index" => 1, "encrypted" => false})
+      vol = described_class.new({"disk_index" => 1, "encrypted" => false, "vm_inhost_name" => "test"})
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/1/")
       expect(vol).to receive(:create_empty_disk_file).with(no_args)
       vol.prep(nil)
@@ -51,7 +53,7 @@ RSpec.describe StorageVolume do
 
     it "can prep a non-imaged encrypted disk" do
       key_wrapping_secrets = "key_wrapping_secrets"
-      vol = described_class.new("test", {"disk_index" => 1, "encrypted" => true})
+      vol = described_class.new({"disk_index" => 1, "encrypted" => true, "vm_inhost_name" => "test"})
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/1/")
       expect(vol).to receive(:setup_data_encryption_key).with(key_wrapping_secrets)
       expect(vol).to receive(:create_empty_disk_file).with(no_args)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -82,12 +82,14 @@ RSpec.describe VmSetup do
   describe "#purge_storage" do
     it "can purge storage" do
       vol_1_params = {
+        "vm_inhost_name" => "test",
         "size_gib" => 20,
         "device_id" => "test_0",
         "disk_index" => 0,
         "encrypted" => false
       }
       vol_2_params = {
+        "vm_inhost_name" => "test",
         "size_gib" => 20,
         "device_id" => "test_1",
         "disk_index" => 1,
@@ -100,12 +102,12 @@ RSpec.describe VmSetup do
 
       # delete the unencrypted volume
       sv_1 = instance_double(StorageVolume)
-      expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
+      expect(StorageVolume).to receive(:new).with(vol_1_params).and_return(sv_1)
       expect(sv_1).to receive(:purge_spdk_artifacts)
 
       # delete the encrypted volume
       sv_2 = instance_double(StorageVolume)
-      expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
+      expect(StorageVolume).to receive(:new).with(vol_2_params).and_return(sv_2)
       expect(sv_2).to receive(:purge_spdk_artifacts)
 
       expect(FileUtils).to receive(:rm_r).with("/var/storage/test")
@@ -164,8 +166,8 @@ RSpec.describe VmSetup do
   describe "#storage" do
     let(:storage_params) {
       [
-        {"boot" => true, "size_gib" => 20, "device_id" => "test_0", "disk_index" => 0, "encrypted" => false},
-        {"boot" => false, "size_gib" => 20, "device_id" => "test_1", "disk_index" => 1, "encrypted" => true}
+        {"vm_inhost_name" => "test", "boot" => true, "size_gib" => 20, "device_id" => "test_0", "disk_index" => 0, "encrypted" => false},
+        {"vm_inhost_name" => "test", "boot" => false, "size_gib" => 20, "device_id" => "test_1", "disk_index" => 1, "encrypted" => true}
       ]
     }
     let(:storage_secrets) {
@@ -181,8 +183,8 @@ RSpec.describe VmSetup do
     }
 
     before do
-      expect(StorageVolume).to receive(:new).with("test", storage_params[0]).and_return(storage_volumes[0])
-      expect(StorageVolume).to receive(:new).with("test", storage_params[1]).and_return(storage_volumes[1])
+      expect(StorageVolume).to receive(:new).with(storage_params[0]).and_return(storage_volumes[0])
+      expect(StorageVolume).to receive(:new).with(storage_params[1]).and_return(storage_volumes[1])
     end
 
     it "can setup storage (prep)" do

--- a/spec/prog/storage/restart_spdk_spec.rb
+++ b/spec/prog/storage/restart_spdk_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Storage::RestartSpdk do
+  subject(:rs) {
+    described_class.new(vm_host.restart_spdk)
+  }
+
+  let(:vm_host) {
+    ubid = VmHost.generate_ubid
+    Sshable.create(host: "hostname") { _1.id = ubid.to_uuid }
+    vm_host = VmHost.create(location: "xyz") { _1.id = ubid.to_uuid }
+
+    vm = Vm.create_with_id(vm_host_id: vm_host.id, unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
+    VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false)
+
+    vm_host
+  }
+
+  describe "#start" do
+    it "transitions to wait_until_vms_idle if vm_host is accepting" do
+      allow(rs).to receive(:vm_host).and_return(vm_host)
+      expect(vm_host).to receive(:allocation_state).and_return("accepting")
+      expect(vm_host).to receive(:update).with(allocation_state: "updating")
+      expect { rs.start }.to hop("wait_until_vms_idle")
+    end
+
+    it "fails if vm_host is not accepting" do
+      expect { rs.start }.to raise_error RuntimeError, "Host not in accepting mode"
+    end
+  end
+
+  describe "#wait_until_vms_idle" do
+    it "hops to restart if vms are idle" do
+      expect(rs).to receive(:vms_not_waiting).and_return(0)
+      expect { rs.wait_until_vms_idle }.to hop("restart")
+    end
+
+    it "naps if some vms are not waiting" do
+      expect(rs).to receive(:vms_not_waiting).and_return(1)
+      expect { rs.wait_until_vms_idle }.to nap(30)
+    end
+  end
+
+  describe "#restart" do
+    it "enables spdk and exits" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop spdk")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start spdk")
+      expect(sshable).to receive(:cmd).with("sudo host/bin/storage-ctl start-volumes", stdin: /{.*}/)
+      expect(rs).to receive(:sshable).and_return(sshable).at_least(:once)
+      expect { rs.restart }.to exit({"msg" => "SPDK was restarted"})
+    end
+  end
+
+  describe "#vms_not_waiting" do
+    it "returns number of not waiting VMs" do
+      expect(rs.vms_not_waiting).to eq(0)
+    end
+  end
+end

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "../model/spec_helper"
+require_relative "../../model/spec_helper"
 
-RSpec.describe Prog::SetupSpdk do
+RSpec.describe Prog::Storage::SetupSpdk do
   subject(:ss) {
-    described_class.new(Strand.new(prog: "SetupSpdk"))
+    described_class.new(Strand.new(prog: "Storage::SetupSpdk"))
   }
 
   describe "#start" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#setup_spdk" do
     it "buds the spdk program" do
-      expect(nx).to receive(:bud).with(Prog::SetupSpdk)
+      expect(nx).to receive(:bud).with(Prog::Storage::SetupSpdk)
       expect { nx.setup_spdk }.to hop("wait_setup_spdk")
     end
   end


### PR DESCRIPTION
We will need to restart SPDK when we upgrade it. This patch makes that possible by introducing `Prog::Storage::RestartSpdk`, which can be invoked as follows:

```
st = vm_host.restart_spdk
st.run 300
```

Note that VMs aren't stopped when SPDK is being restarted. However, they might see a big delay in I/O operations while the restart completes. After SPDK goes down, cloud-hypervisor will try to connect to SPDK for 60 seconds before announcing a VM as failed. This timeout is hard-coded in cloud-hypervisor, and is not configurable [1].


[1] https://github.com/cloud-hypervisor/cloud-hypervisor/blob/ffb9a051c3bc9f1f417863f9635b105343b71653/virtio-devices/src/vhost_user/vu_common_ctrl.rs#L405