### PR TITLE
Keep github-actions workflows updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,13 @@ updates:
       docker-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    allow:
+      - dependency-type: "all"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot has begun supporting the 'github-actions' package ecosystem. It's beneficial to keep all our dependencies updated.