### PR TITLE
Fix pagination issue when retrieving all runners for the repository

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -25,7 +25,9 @@ module Github
   def self.installation_client(installation_id)
     access_token = app_client.create_app_installation_access_token(installation_id)[:token]
 
-    Octokit::Client.new(access_token: access_token)
+    client = Octokit::Client.new(access_token: access_token)
+    client.auto_paginate = true
+    client
   end
 
   def self.runner_labels

--- a/spec/lib/github_spec.rb
+++ b/spec/lib/github_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Github do
     app_client = instance_double(Octokit::Client)
     expect(described_class).to receive(:app_client).and_return(app_client)
     expect(app_client).to receive(:create_app_installation_access_token).with(installation_id).and_return({token: "abcdefg"})
-    expect(Octokit::Client).to receive(:new).with(access_token: "abcdefg")
+    installation_client = instance_double(Octokit::Client)
+    expect(installation_client).to receive(:auto_paginate=).with(true)
+    expect(Octokit::Client).to receive(:new).with(access_token: "abcdefg").and_return(installation_client)
 
     described_class.installation_client(installation_id)
   end


### PR DESCRIPTION
When a runner with the same name already exists, we first delete the runner before adding it again. To do this, we need the runner_id. We retrieve all runners for the repository and locate the specific runner by name.

The runners endpoint returns a paginated result with a maximum per_page value of 100. We must paginate across all pages. The "octokit.rb" library has a `paginate` helper, and we already use it.

https://github.com/ubicloud/ubicloud/blob/d0bec18866fb5ad8c43e9c4a3f9215182fb834bf/prog/vm/github_runner.rb#L184

But it only paginates if `auto_paginate` is set to true.

https://github.com/octokit/octokit.rb/blob/ed692187cf2b8238b820e3e85a517357c42a75e3/lib/octokit/connection.rb#L86C11-L86C11