### PR TITLE
Basic firewall rules for GitHub runners

### DIFF
--- a/migrate/20231107_add_basic_fw.rb
+++ b/migrate/20231107_add_basic_fw.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:firewall_rule) do
+      column :id, :uuid, primary_key: true, default: nil
+      column :ip, :cidr
+      foreign_key :private_subnet_id, :private_subnet, null: false, type: :uuid
+    end
+  end
+end

--- a/model/firewall_rule.rb
+++ b/model/firewall_rule.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class FirewallRule < Sequel::Model
+  many_to_one :private_subnet
+
+  include ResourceMethods
+
+  def ip6?
+    ip.to_s.include?(":")
+  end
+end

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -6,6 +6,7 @@ class PrivateSubnet < Sequel::Model
   many_to_many :vms, join_table: Nic.table_name, left_key: :private_subnet_id, right_key: :vm_id
   one_to_many :nics, key: :private_subnet_id
   one_to_one :strand, key: :id
+  one_to_many :firewall_rules
 
   PRIVATE_SUBNET_RANGES = [
     "10.0.0.0/8",
@@ -36,7 +37,7 @@ class PrivateSubnet < Sequel::Model
   end
 
   include SemaphoreMethods
-  semaphore :destroy, :refresh_keys, :add_new_nic
+  semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
 
   def self.random_subnet
     PRIVATE_SUBNET_RANGES.sample

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -71,6 +71,10 @@ class Prog::Vm::GithubRunner < Prog::Base
       storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: false}],
       enable_ip4: true
     )
+
+    ps = vm_st.subject.private_subnets.first
+    ps.firewall_rules.map(&:destroy)
+    ps.incr_update_firewall_rules
     Clog.emit("Pool is empty") { {github_runner: {label: github_runner.label, repository_name: github_runner.repository_name, cores: vm_st.subject.cores}} }
     vm_st.subject
   end

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -29,7 +29,7 @@ class Prog::Vm::VmPool < Prog::Base
   end
 
   label def create_new_vm
-    Prog::Vm::Nexus.assemble_with_sshable(
+    st = Prog::Vm::Nexus.assemble_with_sshable(
       "runner",
       Config.vm_pool_project_id,
       size: vm_pool.vm_size,
@@ -39,6 +39,10 @@ class Prog::Vm::VmPool < Prog::Base
       enable_ip4: true,
       pool_id: vm_pool.id
     )
+
+    ps = st.subject.private_subnets.first
+    ps.firewall_rules.map(&:destroy)
+    ps.incr_update_firewall_rules
 
     hop_wait
   end

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -30,6 +30,7 @@ class Prog::Vnet::NicNexus < Prog::Base
   label def wait_vm
     nap 60 unless nic.vm
     when_setup_nic_set? do
+      nic.private_subnet.incr_update_firewall_rules
       hop_add_subnet_addr
     end
     nap 1
@@ -75,6 +76,7 @@ class Prog::Vnet::NicNexus < Prog::Base
 
   label def repopulate
     bud Prog::Vnet::RekeyNicTunnel, {}, :add_subnet_addr
+    nic.private_subnet.incr_update_firewall_rules
     hop_wait_repopulate
   end
 

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Prog::Vnet::UpdateFirewallRules < Prog::Base
+  subject_is :vm
+
+  label def update_firewall_rules
+    rules = vm.private_subnets.map(&:firewall_rules).flatten
+    allowed_ingress_ip4 = rules.select { !_1.ip6? }.map { _1.ip.to_s }
+    allowed_ingress_ip6 = rules.select { _1.ip6? }.map { _1.ip.to_s }
+
+    vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<TEMPLATE)
+flush set inet fw_table allowed_ipv4_ips;
+flush set inet fw_table allowed_ipv6_ips;
+table inet fw_table {
+  set allowed_ipv4_ips {
+    type ipv4_addr;
+    flags interval;
+#{allowed_ingress_ip4.any? ? "elements = {#{allowed_ingress_ip4.join(",")}}" : ""}
+  }
+
+  set allowed_ipv6_ips {
+    type ipv6_addr;
+    flags interval;
+#{allowed_ingress_ip6.any? ? "elements = {#{allowed_ingress_ip6.join(",")}}" : ""}
+  }
+}
+TEMPLATE
+    pop "firewall rule is added"
+  end
+end

--- a/spec/model/firewall_rule_spec.rb
+++ b/spec/model/firewall_rule_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe FirewallRule do
+  describe "FirewallRule" do
+    let(:ps) {
+      PrivateSubnet.create_with_id(net6: "0::0", net4: "0.0.0.0/0", name: "x", location: "x")
+    }
+
+    it "returns ip6? properly" do
+      fw_rule = described_class.create_with_id(ip: "::/0", private_subnet_id: ps.id)
+      expect(fw_rule.ip6?).to be true
+      fw_rule.update(ip: "0.0.0.0/0")
+      expect(fw_rule.ip6?).to be false
+    end
+  end
+end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(VmPool).to receive(:where).and_return([])
       expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
       expect(Clog).to receive(:emit).with("Pool is empty").and_call_original
+      expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
       vm = nx.pick_vm
       expect(vm).not_to be_nil
       expect(vm.sshable.unix_user).to eq("runner")
@@ -87,6 +88,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(git_runner_pool).to receive(:pick_vm).and_return(nil)
       expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
       expect(Clog).to receive(:emit).with("Pool is empty").and_call_original
+      expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
       vm = nx.pick_vm
       expect(vm).not_to be_nil
       expect(vm.sshable.unix_user).to eq("runner")

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "starts setup and pings subnet" do
+      expect(ps).to receive(:incr_update_firewall_rules)
+      expect(nic).to receive(:private_subnet).and_return(ps)
       vm = instance_double(Vm)
       expect(nic).to receive(:vm).and_return(vm)
       expect(nx).to receive(:when_setup_nic_set?).and_yield
@@ -166,6 +168,10 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#repopulate" do
     it "buds RekeyNicTunnel with add_subnet_addr" do
+      ps = instance_double(PrivateSubnet)
+      nic = instance_double(Nic, private_subnet: ps)
+      expect(nx).to receive(:nic).and_return(nic)
+      expect(ps).to receive(:incr_update_firewall_rules)
       expect(nx).to receive(:bud).with(Prog::Vnet::RekeyNicTunnel, {}, :add_subnet_addr)
       expect { nx.repopulate }.to hop("wait_repopulate")
     end

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "uses ipv6_addr if passed and creates entities" do
-      ps = instance_double(PrivateSubnet)
+      ps = instance_double(PrivateSubnet, id: "57afa8a7-2357-4012-9632-07fbe13a3133")
       expect(ps).to receive(:associate_with_project).with(prj).and_return(true)
       expect(PrivateSubnet).to receive(:create).with(
         name: "default-ps",
@@ -35,6 +35,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       ).and_return(ps)
       expect(described_class).to receive(:random_private_ipv4).and_return("10.0.0.0/26")
       expect(Strand).to receive(:create).with(prog: "Vnet::SubnetNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
+      expect(FirewallRule).to receive(:create_with_id).at_least(:once)
       described_class.assemble(
         prj.id,
         name: "default-ps",
@@ -44,7 +45,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "uses ipv4_addr if passed and creates entities" do
-      ps = instance_double(PrivateSubnet)
+      ps = instance_double(PrivateSubnet, id: "57afa8a7-2357-4012-9632-07fbe13a3133")
       expect(ps).to receive(:associate_with_project).with(prj).and_return(true)
       expect(PrivateSubnet).to receive(:create).with(
         name: "default-ps",
@@ -55,6 +56,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       ).and_return(ps)
       expect(described_class).to receive(:random_private_ipv6).and_return("fd10:9b0b:6b4b:8fbb::/64")
       expect(Strand).to receive(:create).with(prog: "Vnet::SubnetNexus", label: "wait").and_yield(Strand.new).and_return(Strand.new)
+      expect(FirewallRule).to receive(:create_with_id).at_least(:once)
       described_class.assemble(
         prj.id,
         name: "default-ps",
@@ -114,6 +116,12 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect { nx.wait }.to hop("add_new_nic")
     end
 
+    it "hops to update_furewall_rules if when_update_firewall_rules_set?" do
+      expect(nx).to receive(:when_update_firewall_rules_set?).and_yield
+      expect(ps).to receive(:update).with(state: "updating_firewall_rules").and_return(true)
+      expect { nx.wait }.to hop("update_firewall_rules")
+    end
+
     it "increments refresh_keys if it passed more than a day" do
       expect(ps).to receive(:last_rekey_at).and_return(Time.now - 60 * 60 * 24 - 1)
       expect(ps).to receive(:incr_refresh_keys).and_return(true)
@@ -122,6 +130,33 @@ RSpec.describe Prog::Vnet::SubnetNexus do
 
     it "naps if nothing to do" do
       expect { nx.wait }.to nap(30)
+    end
+  end
+
+  describe "#update_firewall_rules" do
+    let(:vm) {
+      instance_double(Vm, id: "vm-id")
+    }
+
+    it "buds UpdateFirewallRules and hops to wait_fw_rules" do
+      expect(ps).to receive(:vms).and_return([vm]).at_least(:once)
+      expect(nx).to receive(:bud).with(Prog::Vnet::UpdateFirewallRules, {subject_id: "vm-id"}, :update_firewall_rules)
+      expect { nx.update_firewall_rules }.to hop("wait_fw_rules")
+    end
+  end
+
+  describe "#wait_fw_rules" do
+    it "donates if there are active buds" do
+      expect(nx).to receive(:reap).and_return(true)
+      expect(nx).to receive(:leaf?).and_return(false)
+      expect { nx.wait_fw_rules }.to nap(0)
+    end
+
+    it "hops to wait if there are no active buds" do
+      expect(nx).to receive(:reap).and_return(true)
+      expect(nx).to receive(:leaf?).and_return(true)
+      expect(ps).to receive(:update).with(state: "waiting").and_return(true)
+      expect { nx.wait_fw_rules }.to hop("wait")
     end
   end
 

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::UpdateFirewallRules do
+  subject(:nx) {
+    described_class.new(st)
+  }
+
+  let(:st) { Strand.new }
+  let(:ps) {
+    instance_double(PrivateSubnet)
+  }
+  let(:vm) {
+    vmh = instance_double(VmHost, sshable: instance_double(Sshable, cmd: nil))
+    instance_double(Vm, private_subnets: [ps], vm_host: vmh, inhost_name: "x")
+  }
+
+  describe "update_firewall_rules" do
+    it "populates elements if there are fw rules" do
+      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
+      expect(ps).to receive(:firewall_rules).and_return([
+        instance_double(FirewallRule, ip6?: false, ip: "0.0.0.0/0"),
+        instance_double(FirewallRule, ip6?: false, ip: "1.1.1.1/32"),
+        instance_double(FirewallRule, ip6?: true, ip: "::/0"),
+        instance_double(FirewallRule, ip6?: true, ip: "fd00::1/128")
+      ])
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
+flush set inet fw_table allowed_ipv4_ips;
+flush set inet fw_table allowed_ipv6_ips;
+table inet fw_table {
+  set allowed_ipv4_ips {
+    type ipv4_addr;
+    flags interval;
+elements = {0.0.0.0/0,1.1.1.1/32}
+  }
+
+  set allowed_ipv6_ips {
+    type ipv6_addr;
+    flags interval;
+elements = {::/0,fd00::1/128}
+  }
+}
+ADD_RULES
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rule is added"})
+    end
+
+    it "does not pass elements if there are not fw rules" do
+      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
+      expect(ps).to receive(:firewall_rules).and_return([])
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
+flush set inet fw_table allowed_ipv4_ips;
+flush set inet fw_table allowed_ipv6_ips;
+table inet fw_table {
+  set allowed_ipv4_ips {
+    type ipv4_addr;
+    flags interval;
+
+  }
+
+  set allowed_ipv6_ips {
+    type ipv6_addr;
+    flags interval;
+
+  }
+}
+ADD_RULES
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rule is added"})
+    end
+  end
+end

--- a/ubid.rb
+++ b/ubid.rb
@@ -63,7 +63,7 @@ class UBID
   TYPE_DNS_ZONE = "dz"
   TYPE_DNS_RECORD = "dr"
   TYPE_DNS_SERVER = "ds"
-
+  TYPE_FIREWALL_RULE = "fr"
   CURRENT_TIMESTAMP_TYPES = [TYPE_STRAND, TYPE_SEMAPHORE]
 
   def self.generate(type)


### PR DESCRIPTION
With this commit, we are adding basic firewall rule support for github
actions runners. The model is very simply and the main objective of this
commit is to have an initial implementation to work on for further
development. For now, this implementation adds a basic nftables table
for firewall rules which allows denies incomming traffic by default. We
make use of that table by adding a rule to allow all ip addresses
(0.0.0.0/0, ::/0) for regular VMs and we add another pair of rules to
block all ip addresses for github runners. Since the current rule
execution order denies in case of deny x allow, it works as a denying
rule.

We chose to allow tcp dport 22 by default because that is the ssh port
and we have to be able to continue opening ssh connections.

We chose to allow all communication in the private network.

We also chose to allow all outgoing communication in a stateful way.

We changed the NAT logic because the previous one was not tracking the
connections which causes the logic to allow ssh connections to fail.
Simply changing saddr or daddr causes the conntrack object to not be
tracked properly for the ssh connections. Therefore, it did not work.
With this current logic, we handle the DNAT and SNAT properly and in a
tracked way which allows us to implement the tcp dport 22 allow.

For now, this commit only works for ingress even if the database table
has a type which is fine, considering we will have to work on firewall
rules and implement ingress/egress rules anyway.

The FirewallRules are added directly to the PrivateSubnet entity. It is
possible that in future we will have an independent firewall entity
which will have the rules as part of it. For now, that's harmless.