### PR TITLE
Use `bundle exec rake` in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Apply migrations
       env:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: rake test_up
+      run: bundle exec rake test_up
 
     - name: Run tests
       env:


### PR DESCRIPTION
This otherwise crashes when `rake` is updated, due to confusion about the version of rake to use.  Similar changes are seen in 06ae6a0338bc86349eb46fa4bb54c95ad52a5525.