### PR TITLE
Remove openSUSE Leap 15.4 support

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -404,7 +404,6 @@ EOS
     urls = {
       "ubuntu-jammy" => "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img",
       "almalinux-9.1" => "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2",
-      "opensuse-leap-15.4" => "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-Minimal-VM.x86_64-OpenStack-Cloud.qcow2",
       "github-ubuntu-2204" => nil,
       "github-ubuntu-2004" => nil
     }


### PR DESCRIPTION
This was added in ancient times (April) to test the range of firmware compatibility, but is not exposed in the UI.  It's now a slightly obsolete version of Leap, and I think it makes sense to remove this development residue now that it can impose a higher cost to itemize its arm64 variant image.

See:

5c9794d Add openSUSE Leap 15.4 support
ba152e0 Switch to edk2 firmware