### PR TITLE
Increase atomicity of Clog output

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -24,9 +24,9 @@ class Clog
       out[:thread] = thread_name
     end
 
-    raw = JSON.generate(out).freeze
+    raw = (JSON.generate(out) << "\n").freeze
     @@mutex.synchronize do
-      puts raw
+      $stdout.write(raw)
     end
     nil
   end

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe Clog do
   it "will add the thread name to the structure data, if defined" do
     Thread.new do
       Thread.current.name = "test thread name"
-      expect(described_class).to receive(:puts).with('{"message":"hello","thread":"test thread name"}')
+      expect($stdout).to receive(:write).with('{"message":"hello","thread":"test thread name"}' + "\n")
       described_class.emit "hello"
     end.join
   end
 
   it "doesn't include a thread name if it is not set" do
-    expect(described_class).to receive(:puts).with('{"message":"hello"}')
+    expect($stdout).to receive(:write).with('{"message":"hello"}' + "\n")
     described_class.emit "hello"
   end
 
   it "writes an error when an invalid type is yield from the block" do
-    expect(described_class).to receive(:puts).with('{"invalid_type":"Integer","message":"ngmi"}')
+    expect($stdout).to receive(:write).with('{"invalid_type":"Integer","message":"ngmi"}' + "\n")
     described_class.emit("ngmi") { 1 }
   end
 end


### PR DESCRIPTION
The mechanism for this is sending the desired log line including terminating newline in one system call and contiguous memory region.

As I was sifting through some interleaved log output lately, I noted JSON parse-breaking interleaving overwhelmingly occurs right before the terminating newline for `puts`.

While broken JSON parsing is to be expected in the general case, the structure of the interleaving suggests the implementation does not emit output in the most atomic fashion possible.  Indeed, it does not, here's what `puts` does:

    // Write the line:
    int n = 0;
    if (RSTRING_LEN(line) == 0) {
        args[n++] = rb_default_rs;
    }
    else {
        args[n++] = line;
        if (!rb_str_end_with_asciichar(line, '\n')) {
            args[n++] = rb_default_rs;
        }
    }

    rb_io_writev(out, n, args);

`JSON.generate` does not have a trailing newline, `puts` notices and emits a `writev` call with two args: the JSON string, and a newline string.

I think by submitting the entire buffer in one contiguous region, our common case outcome will be better when there is stdout contention.