### PR TITLE
Redact sensitive and long columns from outputs

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -53,6 +53,10 @@ module ResourceMethods
     "#{self.class.name}[#{ubid}]"
   end
 
+  def inspect_values
+    @values.except(*self.class.redacted_columns).inspect
+  end
+
   NON_ARCHIVED_MODELS = ["DeletedRecord", "Semaphore"]
   def before_destroy
     model_name = self.class.name
@@ -99,6 +103,10 @@ module ResourceMethods
 
     def create_with_id(*, **)
       create(*, **) { _1.id = generate_uuid }
+    end
+
+    def redacted_columns
+      column_encryption_metadata.keys || []
     end
   end
 end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -9,6 +9,11 @@ class PostgresResource < Sequel::Model
   one_to_one :server, class: PostgresServer, key: :resource_id
 
   include ResourceMethods
+
+  def self.redacted_columns
+    super + [:root_cert_1, :root_cert_2, :server_cert]
+  end
+
   include SemaphoreMethods
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -17,6 +17,11 @@ class Vm < Sequel::Model
   dataset_module Authorization::Dataset
 
   include ResourceMethods
+
+  def self.redacted_columns
+    super + [:public_key]
+  end
+
   include SemaphoreMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe PostgresResource do
     expect(postgres_resource).to receive(:server).and_return(instance_double(PostgresServer, vm: instance_double(Vm, ephemeral_net4: "1.2.3.4")))
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@1.2.3.4")
   end
+
+  it "hides sensitive and long columns" do
+    inspect_output = postgres_resource.inspect
+    postgres_resource.class.redacted_columns.each do |column_key|
+      expect(inspect_output).not_to include column_key.to_s
+    end
+  end
 end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -135,4 +135,11 @@ RSpec.describe Vm do
       expect(vm.ephemeral_net4).to be_nil
     end
   end
+
+  it "hides sensitive and long columns" do
+    inspect_output = vm.inspect
+    vm.class.redacted_columns.each do |column_key|
+      expect(inspect_output).not_to include column_key.to_s
+    end
+  end
 end


### PR DESCRIPTION
Even if some columns are encrypted, it's not advisable to print them in logs or inspect results. Additionally, some column values are excessively long, causing the output to be bloated.

The model redacts encrypted columns by default. If the model has additional columns to redact, it can overwrite the existing method as follows:

    def self.redacted_columns
        super + [:root_cert_1, :root_cert_2, :server_cert]
    end