### PR TITLE
Render NetAddr columns as string

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -54,7 +54,14 @@ module ResourceMethods
   end
 
   def inspect_values
-    @values.except(*self.class.redacted_columns).inspect
+    @values.except(*self.class.redacted_columns).map do |k, v|
+      case v
+      when NetAddr::IPv4Net, NetAddr::IPv6Net
+        [k, v.to_s]
+      else
+        [k, v]
+      end
+    end.to_h.inspect
   end
 
   NON_ARCHIVED_MODELS = ["DeletedRecord", "Semaphore"]


### PR DESCRIPTION
The rendering of NetAddr.inspect is as follows, and it lacks readability.

    ephemeral_net6=>#<NetAddr::IPv6Net:0x00000001083f7b50
    @m128=#<NetAddr::Mask128:0x00000001083f8910 @prefix_len=79,
    @mask=340282366920938463463374044481814790144>,
    @base=#<NetAddr::IPv6:0x00000001083f7b00
    @addr=55832868898496376683401584332754649088>>

The `to_s` output for a `NetAddr` is significantly better.

    :ephemeral_net6=>"2a01:4f8:173:1ed3:647e::/79"