### PR TITLE
Streamline expression in lib/arch.rb

### DIFF
--- a/rhizome/common/lib/arch.rb
+++ b/rhizome/common/lib/arch.rb
@@ -4,7 +4,7 @@ require "rbconfig"
 
 ArchClass = Struct.new(:sym) {
   def self.from_system
-    sym = case RbConfig::CONFIG.fetch("target_cpu").downcase
+    new case RbConfig::CONFIG.fetch("target_cpu").downcase
     when /arm64|aarch64/
       "arm64"
     when /amd64|x86_64|x64/
@@ -12,7 +12,6 @@ ArchClass = Struct.new(:sym) {
     else
       fail "BUG: could not detect architecture"
     end.intern
-    new sym
   end
 
   def arm64?


### PR DESCRIPTION
Previously this triggered an infinite loop in rubocop, but we just had the opportunity (given the `standard` gem) to upgrade to the newest version that fixes it.

I reported that bug: https://github.com/rubocop/rubocop/issues/12307