### PR TITLE
Change the hostname of a new VmHost to its ubid

### DIFF
--- a/prog/vm/prep_host.rb
+++ b/prog/vm/prep_host.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Prog::Vm::PrepHost < Prog::Base
-  subject_is :sshable
+  subject_is :sshable, :vm_host
 
   label def start
-    sshable.cmd("sudo host/bin/prep_host.rb")
+    sshable.cmd("sudo host/bin/prep_host.rb #{vm_host.ubid.shellescape}")
     pop "host prepared"
   end
 end

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -5,6 +5,17 @@ require_relative "../../common/lib/util"
 require_relative "../lib/cloud_hypervisor"
 require_relative "../lib/spdk_setup"
 require "fileutils"
+require "socket"
+
+unless (hostname = ARGV.shift)
+  puts "need host name as argument"
+  exit 1
+end
+
+original_hostname = Socket.gethostname
+
+safe_write_to_file("/etc/hosts", File.read("/etc/hosts").gsub(original_hostname, hostname))
+r "sudo hostnamectl set-hostname " + hostname
 
 ch_dir = CloudHypervisor::VERSION.dir
 FileUtils.mkdir_p(ch_dir)

--- a/spec/prog/vm/prep_host_spec.rb
+++ b/spec/prog/vm/prep_host_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe Prog::Vm::PrepHost do
   describe "#start" do
     it "prepare host" do
       sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("sudo host/bin/prep_host.rb")
+      vm_host = instance_double(VmHost, ubid: "vmhostubid")
+      expect(sshable).to receive(:cmd).with("sudo host/bin/prep_host.rb " + vm_host.ubid)
       expect(ph).to receive(:sshable).and_return(sshable)
+      expect(ph).to receive(:vm_host).and_return(vm_host)
 
       expect { ph.start }.to exit({"msg" => "host prepared"})
     end


### PR DESCRIPTION
This makes the hostname of VmHosts' identifiable and easy to understand by setting the hostname as the ubid of the VmHost.