### PR TITLE
Cache repeated access to `strand.children` in reap

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -179,7 +179,8 @@ end
   end
 
   def reap
-    deleted = strand.children.filter_map { |child|
+    children = strand.children
+    deleted = children.filter_map { |child|
       next unless child.exitval
 
       # Clear any semaphores that get added to a exited Strand prog,
@@ -191,7 +192,7 @@ end
       child.destroy
     }
 
-    strand.children.delete_if { deleted.include?(_1) }
+    children.delete_if { deleted.include?(_1) }
     deleted
   end
 


### PR DESCRIPTION
This makes (near-future) tests easier to write.  Even before this change, correct operation requires `strand.children` be pass-by-reference, so, there should be no loss of correctness here.