### PR TITLE
Enable logging cloud-hypervisor's info!() logs.

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -518,7 +518,7 @@ Requires=spdk.service
 NetworkNamespacePath=/var/run/netns/#{@vm_name}
 ExecStartPre=/usr/bin/rm -f #{vp.ch_api_sock}
 
-ExecStart=/opt/cloud-hypervisor/v#{CloudHypervisor::VERSION}/cloud-hypervisor \
+ExecStart=/opt/cloud-hypervisor/v#{CloudHypervisor::VERSION}/cloud-hypervisor -v \
 --api-socket path=#{vp.ch_api_sock} \
 --kernel #{CloudHypervisor.firmware} \
 #{disk_params.join("\n")}


### PR DESCRIPTION
Cloud-hypervisor by default will only log warn!() and error!() logs, and info!() and debug!() logs are disabled. To enable info logs we can use `-v`, and to enable info+debug logs we can use `-vv`.

Info logs is used for sporadic and infrequent message [1], and contains mostly information about peripheral setup. A test run that I did had only 119 log lines for the entire VM lifetime. These information can be useful when we are debugging a failure.

Therefore, this PR enables info logs for our deployments. These logs will be available by using `journalctl -u vm123456`.

[1] https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/logging.md