### PR TITLE
Fix in-memory data structure while reaping

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -194,7 +194,7 @@ end
       child.id
     end.freeze
 
-    strand.children.delete_if { reaped_ids.include?(_1) }
+    strand.children.delete_if { reaped_ids.include?(_1.id) }
 
     reapable
   end

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -53,6 +53,12 @@ class Prog::Test < Prog::Base
     donate
   end
 
+  label def reap_exit_no_children
+    reap
+    pop({msg: "reap_exit_no_children"}) if leaf?
+    donate
+  end
+
   label def napper
     nap(123)
   end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe Prog::Base do
     }.from(false).to(true)
   end
 
+  it "keeps children array state in sync even in consecutive-run mode" do
+    parent = Strand.create_with_id(prog: "Test", label: "reap_exit_no_children")
+    Strand.create_with_id(parent_id: parent.id, prog: "Test", label: "popper")
+    expect(parent).to receive(:unsynchronized_run).twice.and_call_original
+    parent.run(10)
+  end
+
   describe "#pop" do
     it "can reject unanticipated values" do
       expect {


### PR DESCRIPTION
In production this mistake in modifying the `children` list caused `leaf?` to not function properly, returning `false` when it would have been beneficial to return `true`.

It wasn't visible immediately, because eventually progress would be made, when a `run(seconds)` session ended and the entire strand got reloaded.  But instead of taking a few milliseconds, it would take `seconds` time, spinning unproductive logs all the while.  Eventually enough Strands got into this state, causing intermittent failures in the heartbeat monitoring that tipped us off to an abnormality.

Reviewing log throughput of an affected prog label clearly showed the problem and its duration correlating with the deployment of 44316cef651e2169f0556924f6d96e74063049e5.

The test included fails when the fix to `reap` is likewise removed.