### PR TITLE
Learn dies

### DIFF
--- a/migrate/20231107_add_total_dies.rb
+++ b/migrate/20231107_add_total_dies.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      add_column :total_dies, Integer
+    end
+  end
+end

--- a/prog/learn_cores.rb
+++ b/prog/learn_cores.rb
@@ -5,9 +5,9 @@ require "json"
 class Prog::LearnCores < Prog::Base
   subject_is :sshable
 
-  CpuTopology = Struct.new(:total_cpus, :total_cores, :total_nodes, :total_sockets, keyword_init: true)
+  CpuTopology = Struct.new(:total_cpus, :total_cores, :total_nodes, :total_dies, :total_sockets, keyword_init: true)
 
-  def parse_count(s)
+  def parse_count(s, dies)
     parsed = JSON.parse(s).fetch("cpus").map { |cpu|
       [cpu.fetch("socket"), cpu.fetch("node"), cpu.fetch("core")]
     }
@@ -16,12 +16,16 @@ class Prog::LearnCores < Prog::Base
     nodes = parsed.map { |socket, node, _| [socket, node] }.uniq.count
     cores = parsed.uniq.count
 
-    CpuTopology.new(total_cpus: cpus, total_cores: cores,
+    CpuTopology.new(total_cpus: cpus, total_cores: cores, total_dies: dies,
       total_nodes: nodes, total_sockets: sockets)
   end
 
+  def count_dies
+    Integer(sshable.cmd("cat /sys/devices/system/cpu/cpu*/topology/die_id | sort -n | uniq | wc -l"))
+  end
+
   label def start
-    topo = parse_count(sshable.cmd("/usr/bin/lscpu -Jye"))
+    topo = parse_count(sshable.cmd("/usr/bin/lscpu -Jye"), count_dies)
     pop(**topo.to_h)
   end
 end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -68,6 +68,7 @@ class Prog::Vm::HostNexus < Prog::Base
         kwargs = {
           total_sockets: st.exitval.fetch("total_sockets"),
           total_nodes: st.exitval.fetch("total_nodes"),
+          total_dies: st.exitval.fetch("total_dies"),
           total_cores: st.exitval.fetch("total_cores"),
           total_cpus: st.exitval.fetch("total_cpus")
         }

--- a/spec/prog/learn_cores_spec.rb
+++ b/spec/prog/learn_cores_spec.rb
@@ -102,8 +102,13 @@ JSON
       expect(sshable).to receive(:cmd).with("/usr/bin/lscpu -Jye").and_return(
         eight_thread_four_core_four_numa_two_socket
       )
-      expect(lc).to receive(:sshable).and_return(sshable)
-      expect { lc.start }.to exit({total_sockets: 2, total_cores: 4, total_nodes: 4, total_cpus: 8})
+
+      expect(sshable).to receive(:cmd).with(
+        "cat /sys/devices/system/cpu/cpu*/topology/die_id | sort -n | uniq | wc -l"
+      ).and_return("4")
+
+      expect(lc).to receive(:sshable).and_return(sshable).twice
+      expect { lc.start }.to exit({total_sockets: 2, total_cores: 4, total_dies: 4, total_nodes: 4, total_cpus: 8})
     end
   end
 end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -128,12 +128,12 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
       expect(vm_host).to receive(:update).with(arch: "arm64")
-      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_nodes: 3, total_sockets: 2)
+      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_nodes: 3, total_dies: 3, total_sockets: 2)
       expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),
         instance_double(Strand, prog: "LearnArch", exitval: {"arch" => "arm64"}),
-        instance_double(Strand, prog: "LearnCores", exitval: {"total_sockets" => 2, "total_nodes" => 3, "total_cores" => 4, "total_cpus" => 5}),
+        instance_double(Strand, prog: "LearnCores", exitval: {"total_sockets" => 2, "total_nodes" => 3, "total_dies" => 3, "total_cores" => 4, "total_cpus" => 5}),
         instance_double(Strand, prog: "LearnStorage", exitval: {"total_storage_gib" => 300, "available_storage_gib" => 500}),
         instance_double(Strand, prog: "ArbitraryOtherProg")
       ])


### PR DESCRIPTION
Previously, in the ancient era (April, in
https://github.com/ubicloud/ubicloud/commit/d30c157f2f1b2f3d7146824b836da7f4d6aa3973), I used NUMA nodes, the main
die-correlated statistic out of `lscpu` to compute the cpu topology.
However, in practice, we wind up with far fewer NUMA nodes because
BIOS configurations tend to interleave die memory access.

But, this is wrong: we can do better.

The first step is to learn the die count, and that is what this patch
does.  The second step, not done yet, is to use that die count to
calculate arguments to `cloud-hypervisor`.

== Background

Recently, I did some kernel source code reading, and learned that dies
can be used in the scheduler to try to take advantage of cache
unification and power management, and that they were exposed in
`/sys/devices/system/cpu/`, and are not returned decisively anywhere I
can see in `lscpu`, which is how I missed it back in April.

In addition, dies are not used as an abstraction in arm64, and in fact
cloud-hypervisor rejects non-`1` settings for it on that platform:

https://github.com/cloud-hypervisor/cloud-hypervisor/commit/0fc3fad363ffe43708252c9094477a12e36e5c9f

In newer versions of Linux -- not including Ubuntu 22.04 Jammy's Linux
5.15 -- `/sys/devices/system/cpu/` will learn the `cluster` level of
core aggregation, which is yet another level of hierarchy, and this
one applies to both arm64 and x64.  As-is, cloud-hypervisor is
hardcoded to place all exposed processors in a single cluster, and it
is not part of the `topology` flag passed to cloud-hypervisor.

https://lists.gnu.org/archive/html/qemu-devel/2021-03/msg09848.html
discusses how arm64 will have a four-level hierarchy, and x64 will
have a five-level one (from `dies`).

So, it looks like this is an active area of change in the last few
years, we should expect some confusion in the software stack on how
and when to best use these fields in the near future.