### PR TITLE
PostgreSQL UI

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -182,21 +182,28 @@ function setupLocationBasedPrices() {
   $("input.location-based-price").each(function(i, obj) {
     let name = $(this).attr("name");
     let value = $(this).val();
-    let resource_type = $(this).data("resource-type");
-    let resource_family = $(this).data("resource-family");
-    let amount = $(this).data("amount");
+    let resource_type = Array.isArray($(this).data("resource-type")) ? $(this).data("resource-type") : [$(this).data("resource-type")];
+    let resource_family = Array.isArray($(this).data("resource-family")) ? $(this).data("resource-family") : [$(this).data("resource-family")];
+    let amount = Array.isArray($(this).data("amount")) ? $(this).data("amount") : [$(this).data("amount")];
     let is_default = $(this).data("default");
-    if (monthlyPrice = prices?.[resource_type]?.[resource_family]?.["monthly"]) {
-      let monthly = monthlyPrice * amount;
-      $(`.${name}-${value}`).show();
-      $(`.${name}-${value}-monthly-price`).text(`$${monthly.toFixed(2)}`);
-      count[name] = (count[name] || 0) + 1;
-    } else {
-      $(`.${name}-${value}`).hide();
-      if (!is_default) {
-        $(this).prop('checked', false);
+    
+    let monthly = 0;
+    for(var i = 0; i < resource_type.length; i++) {
+      if (monthlyPrice = prices?.[resource_type[i]]?.[resource_family[i]]?.["monthly"]) {
+        monthly += monthlyPrice * amount[i];
+      } else {
+        $(`.${name}-${value}`).hide();
+        if (!is_default) {
+          $(this).prop('checked', false);
+        }
+
+        return;
       }
     }
+
+    $(`.${name}-${value}`).show();
+    $(`.${name}-${value}-monthly-price`).text(`$${monthly.toFixed(2)}`);
+    count[name] = (count[name] || 0) + 1;
   });
 }
 

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -55,7 +55,8 @@ module Authorization
       acls: [
         {subjects: [subject], actions: ["Project:view", "Project:delete", "Project:user", "Project:policy", "Project:billing", "Project:github"], objects: [object]},
         {subjects: [subject], actions: ["Vm:view", "Vm:create", "Vm:delete"], objects: [object]},
-        {subjects: [subject], actions: ["PrivateSubnet:view", "PrivateSubnet:create", "PrivateSubnet:delete", "PrivateSubnet:nic"], objects: [object]}
+        {subjects: [subject], actions: ["PrivateSubnet:view", "PrivateSubnet:create", "PrivateSubnet:delete", "PrivateSubnet:nic"], objects: [object]},
+        {subjects: [subject], actions: ["Postgres:view", "Postgres:create", "Postgres:delete"], objects: [object]}
       ]
     }
   end

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -31,4 +31,11 @@ module Option
   VmSizes = [2, 4, 8, 16].map {
     VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 25)
   }.freeze
+
+  PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :storage_size_gib) do
+    alias_method :display_name, :name
+  end
+  PostgresSizes = [2, 4, 8, 16].map {
+    PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 128)
+  }.freeze
 end

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -50,7 +50,7 @@ module Validation
 
   def self.validate_vm_size(size)
     unless (vm_size = Option::VmSizes.find { _1.name == size })
-      fail ValidationFailed.new({size: "\"#{size}\" is not a valid virtual machine size. Available providers: #{Option::VmSizes.map(&:name)}"})
+      fail ValidationFailed.new({size: "\"#{size}\" is not a valid virtual machine size. Available sizes: #{Option::VmSizes.map(&:name)}"})
     end
     vm_size
   end
@@ -65,5 +65,12 @@ module Validation
     if boot_disk_index < 0 || boot_disk_index >= storage_volumes.length
       fail ValidationFailed.new({boot_disk_index: "Boot disk index must be between 0 and #{storage_volumes.length - 1}"})
     end
+  end
+
+  def self.validate_postgres_size(size)
+    unless (postgres_size = Option::PostgresSizes.find { _1.name == size })
+      fail ValidationFailed.new({size: "\"#{size}\" is not a valid PostgreSQL database size. Available sizes: #{Option::PostgresSizes.map(&:name)}"})
+    end
+    postgres_size
   end
 end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -36,11 +36,11 @@ class PostgresResource < Sequel::Model
     if Config.postgres_service_hostname
       "#{server_name}.#{Config.postgres_service_hostname}"
     else
-      server.vm.ephemeral_net4.to_s
+      server&.vm&.ephemeral_net4&.to_s
     end
   end
 
   def connection_string
-    URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s
+    URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s if hostname
   end
 end

--- a/model/project.rb
+++ b/model/project.rb
@@ -70,4 +70,6 @@ class Project < Sequel::Model
       end
     end
   end
+
+  feature_flag :enable_postgres
 end

--- a/model/project.rb
+++ b/model/project.rb
@@ -11,6 +11,7 @@ class Project < Sequel::Model
   many_to_many :vms, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :minio_clusters, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :private_subnets, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :postgres_resources, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
 
   one_to_many :invoices, order: Sequel.desc(:created_at)
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -235,12 +235,8 @@ SQL
   label def destroy
     decr_destroy
 
-    if vm
-      vm.private_subnets.each { _1.incr_destroy }
-      vm.incr_destroy
-      nap 5
-    end
-
+    vm.private_subnets.each { _1.incr_destroy }
+    vm.incr_destroy
     postgres_server.destroy
 
     pop "postgres server is deleted"

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -25,6 +25,10 @@ class CloverApi
         r.halt
       end
 
+      unless @project.user_ids.include?(@current_user.id)
+        fail Authorization::Unauthorized
+      end
+
       r.get true do
         Authorization.authorize(@current_user.id, "Project:view", @project.id)
 

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -31,6 +31,10 @@ class CloverWeb
         r.halt
       end
 
+      unless @project.user_ids.include?(@current_user.id)
+        fail Authorization::Unauthorized
+      end
+
       @project_data = serialize(@project)
       @project_permissions = Authorization.all_permissions(@current_user.id, @project.id)
 
@@ -65,12 +69,6 @@ class CloverWeb
       end
 
       r.get "dashboard" do
-        # Even if user doesn't have access to the project details if it's added to the project,
-        # we still show the dashboard.
-        unless @project.user_ids.include?(@current_user.id)
-          fail Authorization::Unauthorized
-        end
-
         view "project/dashboard"
       end
 

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CloverWeb
+  hash_branch(:project_location_prefix, "postgres") do |r|
+    unless @project.get_enable_postgres
+      response.status = 404
+      r.halt
+    end
+
+    @serializer = Serializers::Web::Postgres
+
+    r.on String do |pg_name|
+      pg = @project.postgres_resources_dataset.where(location: @location).where { {Sequel[:postgres_resource][:server_name] => pg_name} }.first
+
+      unless pg
+        response.status = 404
+        r.halt
+      end
+      @pg = serialize(pg)
+
+      r.get true do
+        Authorization.authorize(@current_user.id, "Postgres:view", pg.id)
+        view "postgres/show"
+      end
+
+      r.delete true do
+        Authorization.authorize(@current_user.id, "Postgres:delete", pg.id)
+        pg.incr_destroy
+        return {message: "Deleting #{pg.server_name}"}.to_json
+      end
+    end
+  end
+end

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class CloverWeb
+  hash_branch(:project_prefix, "postgres") do |r|
+    unless @project.get_enable_postgres
+      response.status = 404
+      r.halt
+    end
+
+    @serializer = Serializers::Web::Postgres
+
+    r.get true do
+      @postgres_databases = serialize(@project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).all)
+
+      view "postgres/index"
+    end
+
+    r.post true do
+      Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
+      fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
+
+      parsed_size = Validation.validate_postgres_size(r.params["size"])
+      st = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: @project.id,
+        location: r.params["location"],
+        server_name: r.params["name"],
+        target_vm_size: parsed_size.vm_size,
+        target_storage_size_gib: parsed_size.storage_size_gib
+      )
+
+      flash["notice"] = "'#{r.params["name"]}' will be ready in a few minutes"
+
+      r.redirect "#{@project.path}#{PostgresResource[st.id].path}"
+    end
+
+    r.on "create" do
+      r.get true do
+        Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
+
+        @prices = fetch_location_based_prices("PostgresCores", "PostgresStorage")
+        @has_valid_payment_method = @project.has_valid_payment_method?
+
+        view "postgres/create"
+      end
+    end
+  end
+end

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -38,21 +38,7 @@ class CloverWeb
       r.get true do
         Authorization.authorize(@current_user.id, "Vm:create", @project.id)
         @subnets = Serializers::Web::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
-
-        # We use 1 month = 672 hours for conversion. Number of hours
-        # in a month changes between 672 and 744, We are  also capping
-        # billable hours to 672 while generating invoices. This ensures
-        # that users won't see higher price in their invoice compared
-        # to price calculator and also we charge same amount no matter
-        # the number of days in a given month.
-        types = ["VmCores", "IPAddress"].freeze
-        @prices = BillingRate.rates.filter { types.include?(_1["resource_type"]) }
-          .each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
-          hash[br["location"]][br["resource_type"]][br["resource_family"]] = {
-            hourly: br["unit_price"].to_f * 60,
-            monthly: br["unit_price"].to_f * 60 * 672
-          }
-        end
+        @prices = fetch_location_based_prices("VmCores", "IPAddress")
         @has_valid_payment_method = @project.has_valid_payment_method?
 
         view "vm/create"

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Serializers::Web::Postgres < Serializers::Base
+  def self.base(pg)
+    {
+      id: pg.id,
+      ubid: pg.ubid,
+      path: pg.path,
+      name: pg.server_name,
+      state: pg.display_state,
+      location: pg.location,
+      connection_string: pg.connection_string,
+      vm_size: pg.target_vm_size,
+      storage_size_gib: pg.target_storage_size_gib
+    }
+  end
+
+  structure(:default) do |pg|
+    base(pg)
+  end
+end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -144,5 +144,15 @@ RSpec.describe Validation do
         end
       end
     end
+
+    describe "#validate_postgres_size" do
+      it "valid postgres size" do
+        expect(described_class.validate_postgres_size("standard-2").name).to eq("standard-2")
+      end
+
+      it "invalid postgres size" do
+        expect { described_class.validate_postgres_size("standard-3") }.to raise_error described_class::ValidationFailed
+      end
+    end
   end
 end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -31,4 +31,19 @@ RSpec.describe PostgresResource do
       expect(inspect_output).not_to include column_key.to_s
     end
   end
+
+  it "returns running as display state if the database is ready" do
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
+    expect(postgres_resource.display_state).to eq("running")
+  end
+
+  it "returns deleting as display state if the database is being destroyed" do
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy")).twice
+    expect(postgres_resource.display_state).to eq("deleting")
+  end
+
+  it "returns creating as display state for other cases" do
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server")).twice
+    expect(postgres_resource.display_state).to eq("creating")
+  end
 end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -11,13 +11,18 @@ RSpec.describe PostgresResource do
   }
 
   it "returns connection string" do
-    expect(Config).to receive(:postgres_service_hostname).and_return("postgres.ubicloud.com").twice
+    expect(Config).to receive(:postgres_service_hostname).and_return("postgres.ubicloud.com").at_least(:once)
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-server-name.postgres.ubicloud.com")
   end
 
   it "returns connection string with ip address if config is not set" do
-    expect(postgres_resource).to receive(:server).and_return(instance_double(PostgresServer, vm: instance_double(Vm, ephemeral_net4: "1.2.3.4")))
+    expect(postgres_resource).to receive(:server).and_return(instance_double(PostgresServer, vm: instance_double(Vm, ephemeral_net4: "1.2.3.4"))).at_least(:once)
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@1.2.3.4")
+  end
+
+  it "returns connection string as nil if there is no server" do
+    expect(postgres_resource).to receive(:server).and_return(nil).at_least(:once)
+    expect(postgres_resource.connection_string).to be_nil
   end
 
   it "hides sensitive and long columns" do

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Project do
   end
 
   it "sets and gets feature flags" do
-    described_class.feature_flag(:enable_postgres)
     project = described_class.create_with_id(name: "dummy-name")
 
     expect(project.get_enable_postgres).to be_nil

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -379,16 +379,9 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe "#destroy" do
-    it "waits vm deletion" do
+    it "deletes resources and exits" do
       expect(postgres_server.vm).to receive(:private_subnets).and_return([])
       expect(postgres_server.vm).to receive(:incr_destroy)
-      expect(postgres_server).not_to receive(:destroy)
-
-      expect { nx.destroy }.to nap(5)
-    end
-
-    it "if vm is deleted destroys the entity and exits" do
-      expect(postgres_server).to receive(:vm).and_return(nil)
       expect(postgres_server).to receive(:destroy)
 
       expect { nx.destroy }.to exit({"msg" => "postgres server is deleted"})

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(404)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
       end
+
+      it "not authorized" do
+        u = create_account("test@test.com")
+        p = u.create_project_with_default_policy("project-1")
+        get "/api/project/#{p.ubid}"
+
+        expect(last_response.status).to eq(403)
+        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, you don't have permission to continue with this request.")
+      end
     end
   end
 end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "postgres" do
+  let(:user) { create_account }
+  let(:project) { user.create_project_with_default_policy("project-1") }
+  let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", policy_body: []) }
+
+  let(:pg) do
+    Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: project.id,
+      location: "hetzner-hel1",
+      server_name: "pg-with-permission",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 100
+    ).subject
+  end
+
+  let(:pg_wo_permission) do
+    Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: project_wo_permissions.id,
+      location: "hetzner-hel1",
+      server_name: "pg-without-permission",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 100
+    ).subject
+  end
+
+  describe "unauthenticated" do
+    it "can not list without login" do
+      visit "/postgres"
+
+      expect(page.title).to eq("Ubicloud - Login")
+    end
+
+    it "can not create without login" do
+      visit "/postgres/create"
+
+      expect(page.title).to eq("Ubicloud - Login")
+    end
+  end
+
+  describe "authenticated but without feature flag" do
+    before do
+      postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
+      login(user.email)
+    end
+
+    it "cannot list postgres databases" do
+      visit "#{project.path}/postgres"
+      expect(page.title).to eq("Ubicloud - Resource not found")
+    end
+
+    it "cannot create postgres databases" do
+      visit "#{project.path}/postgres/create"
+      expect(page.title).to eq("Ubicloud - Resource not found")
+    end
+
+    it "cannot show postgres databases" do
+      visit "#{project.path}#{pg.path}"
+      expect(page.title).to eq("Ubicloud - Resource not found")
+    end
+  end
+
+  describe "authenticated" do
+    before do
+      postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
+      login(user.email)
+      project.set_enable_postgres(true)
+      project_wo_permissions.set_enable_postgres(true)
+    end
+
+    describe "list" do
+      it "can list when there is no postgres databases" do
+        visit "#{project.path}/postgres"
+
+        expect(page.title).to eq("Ubicloud - PostgreSQL Databases")
+        expect(page).to have_content "No PostgreSQL databases"
+
+        click_link "New PostgreSQL Database"
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+      end
+
+      it "can list only the postgres databases which has permissions to" do
+        pg
+        pg_wo_permission
+        visit "#{project.path}/postgres"
+
+        expect(page.title).to eq("Ubicloud - PostgreSQL Databases")
+        expect(page).to have_content pg.server_name
+        expect(page).not_to have_content pg_wo_permission.server_name
+      end
+    end
+
+    describe "create" do
+      it "can create new PostgreSQL database" do
+        visit "#{project.path}/postgres/create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+        name = "new-pg-db"
+        fill_in "Name", with: name
+        choose option: "hetzner-hel1"
+        choose option: "standard-2"
+
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - #{name}")
+        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(PostgresResource.count).to eq(1)
+        expect(PostgresResource.first.projects.first.id).to eq(project.id)
+      end
+
+      it "can not create PostgreSQL database with invalid name" do
+        visit "#{project.path}/postgres/create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+
+        fill_in "Name", with: "invalid name"
+        choose option: "hetzner-hel1"
+        choose option: "standard-2"
+
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+        expect(page).to have_content "Name must only contain"
+        expect((find "input[name=name]")["value"]).to eq("invalid name")
+      end
+
+      it "can not create PostgreSQL database with same name" do
+        visit "#{project.path}/postgres/create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+
+        fill_in "Name", with: pg.server_name
+        choose option: "hetzner-hel1"
+        choose option: "standard-2"
+
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+        expect(page).to have_content "name is already taken"
+      end
+
+      it "can not create PostgreSQL database if project has no valid payment method" do
+        expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
+        expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
+
+        visit "#{project.path}/postgres/create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+        expect(page).to have_content "Project doesn't have valid billing information"
+
+        fill_in "Name", with: "new-pg-db"
+        choose option: "hetzner-hel1"
+        choose option: "standard-2"
+
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+        expect(page).to have_content "Project doesn't have valid billing information"
+      end
+
+      it "can not select invisible location" do
+        visit "#{project.path}/postgres/create"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+
+        expect { choose option: "github-runners" }.to raise_error Capybara::ElementNotFound
+      end
+
+      it "can not create PostgreSQL database in a project when does not have permissions" do
+        project_wo_permissions
+        visit "#{project_wo_permissions.path}/postgres/create"
+
+        expect(page.title).to eq("Ubicloud - Forbidden")
+        expect(page.status_code).to eq(403)
+        expect(page).to have_content "Forbidden"
+      end
+    end
+
+    describe "show" do
+      it "can show PostgreSQL database details" do
+        pg
+        visit "#{project.path}/postgres"
+
+        expect(page.title).to eq("Ubicloud - PostgreSQL Databases")
+        expect(page).to have_content pg.server_name
+
+        click_link "Show", href: "#{project.path}#{pg.path}"
+
+        expect(page.title).to eq("Ubicloud - #{pg.server_name}")
+        expect(page).to have_content pg.server_name
+      end
+
+      it "raises forbidden when does not have permissions" do
+        visit "#{project_wo_permissions.path}#{pg_wo_permission.path}"
+
+        expect(page.title).to eq("Ubicloud - Forbidden")
+        expect(page.status_code).to eq(403)
+        expect(page).to have_content "Forbidden"
+      end
+
+      it "raises not found when PostgreSQL database not exists" do
+        visit "#{project.path}/location/hetzner-hel1/postgres/08s56d4kaj94xsmrnf5v5m3mav"
+
+        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.status_code).to eq(404)
+        expect(page).to have_content "Resource not found"
+      end
+    end
+
+    describe "delete" do
+      it "can delete PostgreSQL database" do
+        visit "#{project.path}#{pg.path}"
+
+        # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
+        # UI tests run without a JavaScript enginer.
+        btn = find ".delete-btn"
+        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+        expect(page.body).to eq({message: "Deleting #{pg.server_name}"}.to_json)
+        expect(SemSnap.new(pg.id).set?("destroy")).to be true
+      end
+
+      it "can not delete PostgreSQL database when does not have permissions" do
+        # Give permission to view, so we can see the detail page
+        project_wo_permissions.access_policies.first.update(body: {
+          acls: [
+            {subjects: user.hyper_tag_name, actions: ["Postgres:view"], objects: project_wo_permissions.hyper_tag_name}
+          ]
+        })
+
+        visit "#{project_wo_permissions.path}#{pg_wo_permission.path}"
+
+        expect { find ".delete-btn" }.to raise_error Capybara::ElementNotFound
+      end
+    end
+  end
+end

--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -105,6 +105,10 @@
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
     <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
   </svg>
+<% when "hero-circle-stack" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+  </svg>
 <% else %>
   <p>Not found icon</p>
 <% end %>

--- a/views/components/pg_state_label.erb
+++ b/views/components/pg_state_label.erb
@@ -1,0 +1,18 @@
+<% case state %>
+<% when "running" %>
+  <% color = "bg-green-100 text-green-800" %>
+<% when "creating" %>
+  <% color = "bg-yellow-100 text-yellow-800" %>
+<% when "deleting" %>
+  <% color = "bg-red-100 text-red-800" %>
+<% else %>
+  <% color = "bg-slate-100 text-slate-800" %>
+<% end %>
+<% extra_class = defined?(extra_class) ? extra_class : nil %>
+
+<span
+  class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>"
+>
+  <%== render("components/icon", locals: { name: "dot", classes: "mr-1.5 h-2 w-2" }) %>
+  <%= state %>
+</span>

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -34,6 +34,17 @@
                 icon: "hero-globe-alt"
               }
             ) %>
+            <% if @project.get_enable_postgres %>
+              <%== render(
+                "layouts/sidebar/item",
+                locals: {
+                  name: "PostgreSQL",
+                  url: "#{@project_data[:path]}/postgres",
+                  is_active: request.path.start_with?("#{@project_data[:path]}/postgres"),
+                  icon: "hero-circle-stack"
+                }
+              ) %>
+            <% end %>
           <% else %>
             <%== render(
               "layouts/sidebar/item",

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -1,0 +1,125 @@
+<% @page_title = "Create PostgreSQL Database" %>
+
+<%== render("components/billing_warning") %>
+
+<div class="space-y-1">
+  <%== render(
+    "components/breadcrumb",
+    locals: {
+      back: "#{@project_data[:path]}/postgres",
+      parts: [
+        %w[Projects /project],
+        [@project_data[:name], @project_data[:path]],
+        ["PostgreSQL Databases", "#{@project_data[:path]}/postgres"],
+        %w[Create #]
+      ]
+    }
+  ) %>
+  <%== render("components/page_header", locals: { title: "Create PostgreSQL Database" }) %>
+</div>
+
+<div class="grid gap-6">
+  <form action="<%= "#{@project_data[:path]}/postgres" %>" method="POST">
+    <%== csrf_tag("#{@project_data[:path]}/postgres") %>
+    <!-- Create Card -->
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div class="px-4 py-5 sm:p-6">
+        <div class="space-y-12">
+          <div>
+            <h2 class="text-base font-semibold leading-7 text-gray-900">Details</h2>
+            <p class="mt-1 text-sm leading-6 text-gray-600">Enter details for your PostgreSQL database.</p>
+            <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+              <div class="sm:col-span-3">
+                <%== render(
+                  "components/form/text",
+                  locals: {
+                    name: "name",
+                    label: "Name",
+                    attributes: {
+                      required: true,
+                      placeholder: "Enter name"
+                    }
+                  }
+                ) %>
+              </div>
+              <div class="col-span-full">
+                <% locations = Option
+                    .locations_for_provider(@project_data.dig(:provider, :name))
+                    .map { |l| [l.name, l.display_name, @prices[l.name].to_json] }
+                %>
+                <%== render(
+                  "components/form/radio_small_cards",
+                  locals: {
+                    name: "location",
+                    label: "Location",
+                    options: locations,
+                    selected: locations.first[0],
+                    attributes: {
+                      required: true
+                    }
+                  }
+                ) %>
+              </div>
+              <div class="col-span-full">
+                <div class="space-y-2">
+                  <label for="size" class="text-sm font-medium leading-6 text-gray-900">Server size (Dedicated CPU)</label>
+                  <fieldset class="radio-small-cards" id="size-radios">
+                    <legend class="sr-only">Server size</legend>
+                    <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+                      <% Option::PostgresSizes.each do |size| %>
+                        <label class="size-<%= size.name %>">
+                          <input
+                            type="radio"
+                            name="size"
+                            value="<%= size.name %>"
+                            class="peer sr-only location-based-price"
+                            data-resource-type="[&quot;PostgresCores&quot;, &quot;PostgresStorage&quot;]"
+                            data-resource-family="[&quot;<%= size.family %>&quot;, &quot;<%= size.family %>&quot;]"
+                            data-amount="[<%= size.vcpu / 2 %>, <%= size.storage_size_gib %>]"
+                            required
+                            <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>
+                          >
+                          <span
+                            class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
+                                ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
+                                peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700"
+                          >
+                            <span class="flex flex-col">
+                              <span class="text-md font-semibold"><%= size.display_name %></span>
+                              <span class="text-sm opacity-80">
+                                <span class="block sm:inline">
+                                  <%= size.vcpu %>
+                                  vCPUs /
+                                  <%= size.memory %>
+                                  GB
+                                </span>
+                                <span class="hidden sm:mx-0.5 sm:inline" aria-hidden="true">&middot;</span>
+                                <span class="block sm:inline"><%= size.storage_size_gib %>
+                                  GB disk</span>
+                              </span>
+                            </span>
+                            <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
+                              <span class="font-medium size-<%= size.name %>-monthly-price">-</span>
+                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                            </span>
+                          </span>
+                        </label>
+                      <% end %>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="px-4 py-5 sm:p-6">
+        <div class="flex items-center justify-end gap-x-6">
+          <a href="/postgres" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>
+          <%== render("components/form/submit_button", locals: { text: "Create" }) %>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -1,0 +1,67 @@
+<% @page_title = "PostgreSQL Databases" %>
+
+<% if @postgres_databases.count > 0 %>
+  <div class="space-y-1">
+    <%== render(
+      "components/breadcrumb",
+      locals: {
+        back: @project_data[:path],
+        parts: [%w[Projects /project], [@project_data[:name], @project_data[:path]], ["PostgreSQL Databases", "#"]]
+      }
+    ) %>
+
+    <%== render(
+      "components/page_header",
+      locals: {
+        title: "PostgreSQL Databases",
+        right_items: @project_permissions.include?("Postgres:create") ? [
+          "<a href='postgres/create' class='inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600'>Create PostgreSQL Database</a>"
+        ] : []
+      }
+    ) %>
+  </div>
+
+  <div class="grid gap-6">
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Location</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
+            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+              <span class="sr-only">Show</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @postgres_databases.each do |pg| %>
+            <tr>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= pg[:name] %></td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= pg[:location] %></td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                <%== render("components/pg_state_label", locals: { state: pg[:state] }) %>
+              </td>
+              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                <a href="<%= @project_data[:path] %><%= pg[:path] %>" class="text-orange-600 hover:text-orange-700">Show</a>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% else %>
+  <%== render(
+    "components/empty_state",
+    locals: {
+      icon: "hero-circle-stack",
+      title: "No PostgreSQL databases",
+      description: "You don't have permission to create PostgreSQL database."
+    }.merge(@project_permissions.include?("Postgres:create") ? {
+      description: "Get started by creating a new PostgreSQL database.",
+      button_link: "#{@project_data[:path]}/postgres/create",
+      button_title: "New PostgreSQL Database"
+    } : {})
+  ) %>
+<% end %>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -1,0 +1,68 @@
+<% @page_title = @pg[:name] %>
+
+<div class="space-y-1">
+  <%== render(
+    "components/breadcrumb",
+    locals: {
+      back: "#{@project_data[:path]}/postgres",
+      parts: [
+        %w[Projects /project],
+        [@project_data[:name], @project_data[:path]],
+        ["PostgreSQL Databases", "#{@project_data[:path]}/postgres"],
+        [@pg[:name], "#"]
+      ]
+    }
+  ) %>
+  <%== render(
+    "components/page_header",
+    locals: {
+      title: @pg[:name],
+      right_items: [render("components/pg_state_label", locals: { state: @pg[:state], extra_class: "text-md" })]
+    }
+  ) %>
+</div>
+<div class="grid gap-6">
+  <!-- Detail Card -->
+  <% data = [
+    ["ID", @pg[:ubid]],
+    ["Name", @pg[:name]],
+    ["Location", @pg[:location]],
+    ["Compute", @pg[:vm_size]],
+    ["Storage", "#{@pg[:storage_size_gib]} GB"]
+  ]
+  
+  if @pg[:connection_string] == ""
+    data.push(["Connection String", "Waiting for host to be ready..."])
+  else
+    data.push(["Connection String", @pg[:connection_string], { copieble: true, revealable: true }])
+  end %>
+  <%== render("components/kv_data_card", locals: { data: data }) %>
+  <!-- Delete Card -->
+  <% if Authorization.has_permission?(@current_user.id, "Postgres:delete", @pg[:id]) %>
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div class="px-4 py-5 sm:p-6">
+        <div class="sm:flex sm:items-center sm:justify-between">
+          <div>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete PostgreSQL database</h3>
+            <div class="mt-2 text-sm text-gray-500">
+              <p>This action will permanently delete this PostgreSQL database.</p>
+            </div>
+          </div>
+          <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+            <button
+              type="button"
+              data-url="<%= request.path %>"
+              data-csrf="<%= csrf_token(request.path, "DELETE") %>"
+              data-confirmation="<%= @pg[:name] %>"
+              data-redirect="<%= "#{@project_data[:path]}/postgres" %>"
+              class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
+            >
+              <%== render("components/icon", locals: { name: "hero-trash", classes: "-ml-0.5 mr-1.5 h-5 w-5" }) %>
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -103,6 +103,18 @@
               <td class="px-2 py-2 border">PrivateSubnet:nic</td>
               <td class="px-2 py-2 border">Grants permission to manage Private Subnet NICs.</td>
             </tr>
+            <tr>
+              <td class="px-2 py-2 border">Postgres:view</td>
+              <td class="px-2 py-2 border">Grants permission to view PostgreSQL database details.</td>
+            </tr>
+            <tr>
+              <td class="px-2 py-2 border">Postgres:create</td>
+              <td class="px-2 py-2 border">Grants permission to create PostgreSQL database.</td>
+            </tr>
+            <tr>
+              <td class="px-2 py-2 border">Postgres:delete</td>
+              <td class="px-2 py-2 border">Grants permission to delete PostgreSQL database.</td>
+            </tr>
           </tbody>
         </table>
         <p>


### PR DESCRIPTION
**Don't wait vm deletion while deleting PostgresServer**
PostgresServer has foreign key to the Vm, thus Vm cannot be deleted before
PostgresServer. To be able to wait, we have two options;
- Don't create foreign key
- Create foreign key but use CASCADE SET NULL

Both are not ideal. I think it would be better to skip waiting Vm deletion.
From user perspective, the deletion would complete faster and we would handle
the deletion in background, so it ends up as a better user experience. Also
Vm deletion has its own deadline, so we would be notified. If we wait for Vm
deletion, we would get two pages.

**Handle nil vm case while generating hostname**
We create Vm along with PostgresServer, so it should always have a Vm. However
in the deletion path, Vm would be deleted before PostgresServer. If we need to
generate hostname at that time, we would crash, which can happen if user wants
to display PostgresResource details. With this commit we are handling that nil
vm case, by returning empty string as hostname and connection_string.

**Add option to calculate price based on multiple billing meters**
If data is passed as arrays, setupLocationBasedPrices will calculate prices as
total of individual costs for eash billing meter. This is useful for services
like PostgreSQL, which has two billing meters (for core and storage).

**Add new policy to manage PostgreSQL resources**

**Postgres UI**
This commits adds UI for basic PostgreSQL functionality like listing, viewing,
creating and deleting PostgreSQL resources. We will add UI for other features
like changing superuser password or restart separately.