### PR TITLE
Install Sysstat.

### DIFF
--- a/prog/setup_sysstat.rb
+++ b/prog/setup_sysstat.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Prog::SetupSysstat < Prog::Base
+  subject_is :sshable
+
+  label def start
+    sshable.cmd("sudo host/bin/setup-sysstat")
+    pop "Sysstat was setup"
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -53,6 +53,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnCores
     bud Prog::LearnStorage
     bud Prog::InstallDnsmasq
+    bud Prog::SetupSysstat
     hop_wait_prep
   end
 

--- a/rhizome/host/bin/setup-sysstat
+++ b/rhizome/host/bin/setup-sysstat
@@ -1,0 +1,26 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+
+# install the package
+r "apt update && apt-get install -y sysstat"
+
+# Increase historical archive length to 60 days
+r "sed -i -E 's/HISTORY=[0-9]+/HISTORY=60/g' /etc/sysstat/sysstat"
+
+# Collect every minute. Default was every 10 minutes.
+FileUtils.mkdir_p "/etc/systemd/system/sysstat-collect.timer.d/"
+File.write("/etc/systemd/system/sysstat-collect.timer.d/override.conf", <<SYSSTAT_TIMER_OVERRIDE
+[Unit]
+Description=Run system activity accounting tool every minute
+
+[Timer]
+OnCalendar=*:00/1
+SYSSTAT_TIMER_OVERRIDE
+)
+
+# Enable and start the service
+r "systemctl enable sysstat"
+r "systemctl start sysstat"

--- a/spec/prog/setup_sysstat_spec.rb
+++ b/spec/prog/setup_sysstat_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::SetupSysstat do
+  subject(:ss) {
+    described_class.new(Strand.new(prog: "SetupSysstat"))
+  }
+
+  describe "#start" do
+    it "Sets it up and pops" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-sysstat")
+      expect(ss).to receive(:sshable).and_return(sshable)
+      expect { ss.start }.to exit({"msg" => "Sysstat was setup"})
+    end
+  end
+end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe Prog::Vm::HostNexus do
         Prog::LearnArch,
         Prog::LearnCores,
         Prog::LearnStorage,
-        Prog::InstallDnsmasq
+        Prog::InstallDnsmasq,
+        Prog::SetupSysstat
       ])
     end
 


### PR DESCRIPTION
Having access to historical performance counters will be useful when we encounter performance issues. This PR creates a program to install sysstat on VmHosts to enable that.

After this, sysstat will collect a performance counter samples every minute, which can be analyzed using the sar command:

```
$ sar -f /var/log/sysstat/sa[date] [options]
```