### PR TITLE
Set the level of Unreloader and DB loggers explicitly

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -108,4 +108,7 @@ module Config
   optional :postgres_service_blob_storage_endpoint, string
   optional :postgres_service_blob_storage_access_key, string
   optional :postgres_service_blob_storage_secret_key, string
+
+  # Logging
+  optional :database_logger_level, string
 end

--- a/loader.rb
+++ b/loader.rb
@@ -14,14 +14,7 @@ require "rack/unreloader"
 
 REPL = false unless defined? REPL
 
-Unreloader = Rack::Unreloader.new(
-  reload: Config.development?,
-  autoload: true,
-  logger: if Config.development? && !REPL
-            require "logger"
-            Logger.new($stdout)
-          end
-) { Clover }
+Unreloader = Rack::Unreloader.new(reload: Config.development?, autoload: true) { Clover }
 
 Unreloader.autoload("#{__dir__}/db.rb") { "DB" }
 Unreloader.autoload("#{__dir__}/ubid.rb") { "UBID" }

--- a/model.rb
+++ b/model.rb
@@ -103,11 +103,9 @@ module ResourceMethods
   end
 end
 
-if ENV["RACK_ENV"] == "development" || ENV["RACK_ENV"] == "test"
+if (level = Config.database_logger_level)
   require "logger"
-  LOGGER = Logger.new($stdout)
-  LOGGER.level = Logger::FATAL if ENV["RACK_ENV"] == "test"
-  DB.loggers << LOGGER
+  DB.loggers << Logger.new($stdout, level: level)
 end
 
 module SequelExtensions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,8 +52,6 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    DB.loggers << Logger.new($stdout) if DB.loggers.empty?
-
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation,
       # Skip tables that are filled with migrations.


### PR DESCRIPTION
### Disable Unreloader logs
Unreloader logs were beneficial during our migration from Zeitwerk. We
have completed the migration already. Currently, the Unreloader logs
only clutter the log views. If anyone needs them (which is unlikely),
they can enable them.

### Set the level of DB loggers explicitly
We have implicitly set the level of DB loggers to 'debug' in the
development environment. This action generates a large number of
database query logs. When implementing new features, these noisy logs
can obscure raised exception details, making them difficult to identify.
Previously, I had to manually comment out the logger each time to
disable them. With this update, we can easily disable them using
`.env.rb`.
