### PR TITLE
Remove total_nodes learning

### DIFF
--- a/prog/learn_cores.rb
+++ b/prog/learn_cores.rb
@@ -5,19 +5,18 @@ require "json"
 class Prog::LearnCores < Prog::Base
   subject_is :sshable
 
-  CpuTopology = Struct.new(:total_cpus, :total_cores, :total_nodes, :total_dies, :total_sockets, keyword_init: true)
+  CpuTopology = Struct.new(:total_cpus, :total_cores, :total_dies, :total_sockets, keyword_init: true)
 
   def parse_count(s, dies)
     parsed = JSON.parse(s).fetch("cpus").map { |cpu|
-      [cpu.fetch("socket"), cpu.fetch("node"), cpu.fetch("core")]
+      [cpu.fetch("socket"), cpu.fetch("core")]
     }
     cpus = parsed.count
-    sockets = parsed.map { |socket, _, _| socket }.uniq.count
-    nodes = parsed.map { |socket, node, _| [socket, node] }.uniq.count
+    sockets = parsed.map { |socket, _| socket }.uniq.count
     cores = parsed.uniq.count
 
     CpuTopology.new(total_cpus: cpus, total_cores: cores, total_dies: dies,
-      total_nodes: nodes, total_sockets: sockets)
+      total_sockets: sockets)
   end
 
   def count_dies

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -68,7 +68,6 @@ class Prog::Vm::HostNexus < Prog::Base
       when "LearnCores"
         kwargs = {
           total_sockets: st.exitval.fetch("total_sockets"),
-          total_nodes: st.exitval.fetch("total_nodes"),
           total_dies: st.exitval.fetch("total_dies"),
           total_cores: st.exitval.fetch("total_cores"),
           total_cpus: st.exitval.fetch("total_cpus")

--- a/spec/prog/learn_cores_spec.rb
+++ b/spec/prog/learn_cores_spec.rb
@@ -12,84 +12,36 @@ RSpec.describe Prog::LearnCores do
    "cpus": [
       {
          "cpu": 0,
-         "node": 0,
          "socket": 0,
-         "core": 0,
-         "l1d:l1i:l2:l3": "0:0:0:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.0060
+         "core": 0
       },{
          "cpu": 1,
-         "node": 0,
          "socket": 0,
-         "core": 0,
-         "l1d:l1i:l2:l3": "1:1:1:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.1600
+         "core": 0
       },{
          "cpu": 2,
-         "node": 1,
          "socket": 0,
-         "core": 1,
-         "l1d:l1i:l2:l3": "2:2:2:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.0340
+         "core": 1
       },{
          "cpu": 3,
-         "node": 1,
          "socket": 0,
-         "core": 1,
-         "l1d:l1i:l2:l3": "3:3:3:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.1680
+         "core": 1
       },{
          "cpu": 4,
-         "node": 2,
          "socket": 1,
-         "core": 0,
-         "l1d:l1i:l2:l3": "0:0:0:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.0060
+         "core": 0
       },{
          "cpu": 5,
-         "node": 2,
          "socket": 1,
-         "core": 0,
-         "l1d:l1i:l2:l3": "1:1:1:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.1600
+         "core": 0
       },{
          "cpu": 6,
-         "node": 3,
          "socket": 1,
-         "core": 1,
-         "l1d:l1i:l2:l3": "2:2:2:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.0340
+         "core": 1
       },{
          "cpu": 7,
-         "node": 3,
          "socket": 1,
-         "core": 1,
-         "l1d:l1i:l2:l3": "3:3:3:0",
-         "online": true,
-         "maxmhz": 4500.0000,
-         "minmhz": 800.0000,
-         "mhz": 800.1680
+         "core": 1
       }
    ]
 }
@@ -108,7 +60,7 @@ JSON
       ).and_return("4")
 
       expect(lc).to receive(:sshable).and_return(sshable).twice
-      expect { lc.start }.to exit({total_sockets: 2, total_cores: 4, total_dies: 4, total_nodes: 4, total_cpus: 8})
+      expect { lc.start }.to exit({total_sockets: 2, total_cores: 4, total_dies: 4, total_cpus: 8})
     end
   end
 end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -129,12 +129,12 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
       expect(vm_host).to receive(:update).with(arch: "arm64")
-      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_nodes: 3, total_dies: 3, total_sockets: 2)
+      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2)
       expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),
         instance_double(Strand, prog: "LearnArch", exitval: {"arch" => "arm64"}),
-        instance_double(Strand, prog: "LearnCores", exitval: {"total_sockets" => 2, "total_nodes" => 3, "total_dies" => 3, "total_cores" => 4, "total_cpus" => 5}),
+        instance_double(Strand, prog: "LearnCores", exitval: {"total_sockets" => 2, "total_dies" => 3, "total_cores" => 4, "total_cpus" => 5}),
         instance_double(Strand, prog: "LearnStorage", exitval: {"total_storage_gib" => 300, "available_storage_gib" => 500}),
         instance_double(Strand, prog: "ArbitraryOtherProg")
       ])

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Prog::Vm::Nexus do
 
       sshable = instance_spy(Sshable)
       vmh = instance_double(VmHost, sshable: sshable,
-        total_cpus: 80, total_cores: 80, total_nodes: 1, total_sockets: 1, ndp_needed: false)
+        total_cpus: 80, total_cores: 80, total_sockets: 1, ndp_needed: false)
       expect(vm).to receive(:vm_host).and_return(vmh)
 
       expect(sshable).to receive(:cmd).with(/echo (.|\n)* \| sudo -u vm[0-9a-z]+ tee/) do
@@ -330,7 +330,6 @@ RSpec.describe Prog::Vm::Nexus do
       args = {allocation_state: "accepting",
               location: "somewhere-normal",
               total_sockets: 1,
-              total_nodes: 4,
               total_cores: 80,
               total_cpus: 80,
               total_mem_gib: 640,


### PR DESCRIPTION
Once we learn dies, there's no current need to record NUMA nodes as a proxy.  A test fixture has been reduced; it was already artificially manipulated to improve the power of the test, all the extra node and cache dross only makes it harder to see what's going on.

**Note: should be deployed after use of learned dies is mature**