### PR TITLE
Show PostgresStorage amount as integer instead of decimal

### DIFF
--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -26,7 +26,7 @@ class BillingRate
     when "PostgresCores"
       "#{resource_family}-#{(amount * 2).to_i} backed PostgreSQL Database"
     when "PostgresStorage"
-      "#{amount} GiB Storage for PostgreSQL Database"
+      "#{amount.to_i} GiB Storage for PostgreSQL Database"
     when "GitHubRunnerMinutes"
       "#{resource_family} GitHub Runner"
     else


### PR DESCRIPTION
The amount is a decimal, which is converted to a string using scientific notation. An integer is better suited for representing GiB values on invoices.

<img width="365" alt="Screenshot 2023-11-11 at 18 57 20" src="https://github.com/ubicloud/ubicloud/assets/993199/76fa09f0-ed1e-4626-b5d5-30e98e564552">
