### PR TITLE
Add feature flags to the project

### DIFF
--- a/migrate/20231116_project_flag.rb
+++ b/migrate/20231116_project_flag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:project) do
+      add_column :feature_flags, :jsonb, null: false, default: "{}"
+    end
+  end
+end

--- a/model/project.rb
+++ b/model/project.rb
@@ -58,4 +58,16 @@ class Project < Sequel::Model
 
     Invoice.new(project_id: id, content: content, begin_time: begin_time, end_time: end_time, created_at: Time.now, status: "current")
   end
+
+  def self.feature_flag(*flags)
+    flags.map(&:to_s).each do |flag|
+      define_method "set_#{flag}" do |value|
+        update(feature_flags: feature_flags.merge({flag => value}))
+      end
+
+      define_method "get_#{flag}" do
+        feature_flags[flag]
+      end
+    end
+  end
 end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -32,4 +32,13 @@ RSpec.describe Project do
       expect(project.has_valid_payment_method?).to be true
     end
   end
+
+  it "sets and gets feature flags" do
+    described_class.feature_flag(:enable_postgres)
+    project = described_class.create_with_id(name: "dummy-name")
+
+    expect(project.get_enable_postgres).to be_nil
+    project.set_enable_postgres("new-value")
+    expect(project.get_enable_postgres).to eq "new-value"
+  end
 end


### PR DESCRIPTION
These will be useful for deploying some features but not making them available
to all users. For example, soon we will deploy PostgreSQL UI and endpoints but
we don't want to make it visible before the announcement time.