### PR TITLE
Stop early incrementing update_firewall_rules for runner VMs

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -54,8 +54,11 @@ class Prog::Vm::GithubRunner < Prog::Base
     )
 
     ps = vm_st.subject.private_subnets.first
+    # We don't need to incr_update_firewall_rules semaphore here because the VM
+    # is just created and the firewall rules are not applied in the SubnetNexus,
+    # yet. When NicNexus switches from "wait_vm" to "setup_nic", it will
+    # increment the semaphore, already.
     ps.firewall_rules.map(&:destroy)
-    ps.incr_update_firewall_rules
     Clog.emit("Pool is empty") { {github_runner: {label: github_runner.label, repository_name: github_runner.repository_name, cores: vm_st.subject.cores}} }
     vm_st.subject
   end

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -41,8 +41,11 @@ class Prog::Vm::VmPool < Prog::Base
     )
 
     ps = st.subject.private_subnets.first
+    # We don't need to incr_update_firewall_rules semaphore here because the VM
+    # is just created and the firewall rules are not applied in the SubnetNexus,
+    # yet. When NicNexus switches from "wait_vm" to "setup_nic", it will
+    # increment the semaphore, already.
     ps.firewall_rules.map(&:destroy)
-    ps.incr_update_firewall_rules
 
     hop_wait
   end


### PR DESCRIPTION
We used to increment the update_firewall_rules semaphore immediately when we create the new VMs adter deleting the firewall_rules but that's not necessary, because we have just created the VM entity and nothing is processed yet. As long as we simply clear the firewall_rules that allowAll, we should be good, because the firewall rules are processes when the VM becomes trully ready in the NicNexus. When we increment the semaphore early on, the subnet gets into update_firewall_rules state earlier than necessary, which in turn causes issues since the VM network namespace is not yet ready. We started to see these error messages;
	stderr: Cannot open network namespace "vm0tcpph": No such file
	or directory.