### PR TITLE
Persist more workflow_job data from webhooks to the runner model

### DIFF
--- a/migrate/20231125_drop_runner_columns.rb
+++ b/migrate/20231125_drop_runner_columns.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:github_runner) do
+      drop_column :job_id
+      drop_column :job_name
+      drop_column :run_id
+      drop_column :workflow_name
+      drop_column :head_branch
+    end
+  end
+
+  down do
+    alter_table(:github_runner) do
+      add_column :job_id, :bigint
+      add_column :job_name, :text, collate: '"C"'
+      add_column :run_id, :bigint
+      add_column :workflow_name, :text, collate: '"C"'
+      add_column :head_branch, :text, collate: '"C"'
+    end
+  end
+end

--- a/migrate/20231125_runner_job_data.rb
+++ b/migrate/20231125_runner_job_data.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:github_runner) do
+      add_column :workflow_job, :jsonb
+    end
+  end
+end

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -13,11 +13,11 @@ class GithubRunner < Sequel::Model
   semaphore :destroy
 
   def run_url
-    "http://github.com/#{repository_name}/actions/runs/#{run_id}"
+    "http://github.com/#{repository_name}/actions/runs/#{workflow_job["run_id"]}"
   end
 
   def job_url
-    "http://github.com/#{repository_name}/actions/runs/#{run_id}/job/#{job_id}"
+    "http://github.com/#{repository_name}/actions/runs/#{workflow_job["run_id"]}/job/#{workflow_job["id"]}"
   end
 
   def runner_url

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -229,7 +229,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     end
 
     # If the runner doesn't pick a job in two minutes, destroy it
-    if github_runner.job_id.nil? && Time.now > github_runner.ready_at + 60 * 2
+    if github_runner.workflow_job.nil? && Time.now > github_runner.ready_at + 60 * 2
       response = github_client.get("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")
       unless response[:busy]
         github_runner.incr_destroy

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -83,6 +83,8 @@ class CloverWeb
 
     return error("Unregistered runner") unless runner
 
+    runner.update(workflow_job: job.except("steps"))
+
     case data["action"]
     when "in_progress"
       runner.update(

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -87,15 +87,7 @@ class CloverWeb
 
     case data["action"]
     when "in_progress"
-      runner.update(
-        job_id: job.fetch("id"),
-        job_name: job.fetch("name"),
-        run_id: job.fetch("run_id"),
-        workflow_name: job.fetch("workflow_name"),
-        head_branch: job.fetch("head_branch")
-      )
-
-      success("GithubRunner[#{runner.ubid}] picked job #{runner.job_id}")
+      success("GithubRunner[#{runner.ubid}] picked job #{job.fetch("id")}")
     when "completed"
       runner.incr_destroy
 

--- a/serializers/web/github_runner.rb
+++ b/serializers/web/github_runner.rb
@@ -9,13 +9,15 @@ class Serializers::Web::GithubRunner < Serializers::Base
       repository_name: runner.repository_name,
       runner_id: runner.runner_id,
       runner_url: runner.runner_url,
-      run_id: runner.run_id,
-      run_url: runner.run_url,
-      job_id: runner.job_id,
-      job_name: runner.job_name,
-      job_url: runner.job_url,
-      workflow_name: runner.workflow_name,
-      head_branch: runner.head_branch,
+      workflow_job: runner.workflow_job ? {
+        run_id: runner.workflow_job["run_id"],
+        run_url: runner.run_url,
+        job_id: runner.workflow_job["id"],
+        job_name: runner.workflow_job["name"],
+        job_url: runner.job_url,
+        workflow_name: runner.workflow_job["workflow_name"],
+        head_branch: runner.workflow_job["head_branch"]
+      } : nil,
       vm_state: if runner.vm
                   runner.vm.display_state
                 elsif runner.strand.label == "wait_vm_destroy"

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "destroys runner if it does not pick a job in two minutes and not busy" do
-      expect(github_runner).to receive(:job_id).and_return(nil)
+      expect(github_runner).to receive(:workflow_job).and_return(nil)
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 3 * 60)
       expect(client).to receive(:get).and_return({busy: false})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
@@ -311,7 +311,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "does not destroy runner if it doesn not pick a job but two minutes not pass yet" do
-      expect(github_runner).to receive(:job_id).and_return(nil)
+      expect(github_runner).to receive(:workflow_job).and_return(nil)
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 1 * 60)
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect(github_runner).not_to receive(:incr_destroy)
@@ -335,7 +335,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "naps if the runner-script is running" do
-      expect(github_runner).to receive(:job_id).and_return(123)
+      expect(github_runner).to receive(:workflow_job).and_return({"id" => 123})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
 
       expect { nx.wait }.to nap(15)

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -89,10 +89,12 @@ RSpec.describe Clover, "github" do
         label: "ubicloud",
         repository_name: "my-repo",
         runner_id: 2,
-        job_id: 123,
-        job_name: "test-job",
-        run_id: 456,
-        workflow_name: "test-workflow",
+        workflow_job: {
+          "id" => 123,
+          "name" => "test-job",
+          "run_id" => 456,
+          "workflow_name" => "test-workflow"
+        },
         vm_id: vm.id
       )
       Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo")
@@ -107,8 +109,8 @@ RSpec.describe Clover, "github" do
       expect(page).to have_content "creating"
       expect(page).to have_content "not_created"
       expect(page).to have_content "deleted"
-      expect(page).to have_link runner2.workflow_name, href: runner2.run_url
-      expect(page).to have_link runner2.job_name, href: runner2.job_url
+      expect(page).to have_link runner2.workflow_job["workflow_name"], href: runner2.run_url
+      expect(page).to have_link runner2.workflow_job["name"], href: runner2.job_url
     end
   end
 end

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Clover, "github" do
 
       expect(page.status_code).to eq(200)
       expect(page.body).to eq({message: "GithubRunner[#{runner.ubid}] picked job 232323"}.to_json)
-      expect(runner.reload.job_id).to eq(232323)
+      expect(runner.reload.workflow_job["id"]).to eq(232323)
     end
 
     it "destroys runner when receive completed action" do

--- a/views/project/github.erb
+++ b/views/project/github.erb
@@ -54,13 +54,13 @@
                     <%== render("components/vm_state_label", locals: { state: runner[:vm_state] }) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <%= runner[:head_branch] || "-" %>
+                    <%= runner.dig(:workflow_job, :head_branch) || "-" %>
                   </td>
                   <td class="whitespace-nowrap py-4 pl-3 pr-4 text-sm sm:pr-6">
-                    <% if runner[:job_id] %>
-                      <a href="<%= runner[:run_url] %>" class="text-orange-600 hover:text-orange-700" target="_blank"><%= runner[:workflow_name] %></a>
+                    <% if (workflow_job = runner[:workflow_job]) %>
+                      <a href="<%= workflow_job[:run_url] %>" class="text-orange-600 hover:text-orange-700" target="_blank"><%= workflow_job[:workflow_name] %></a>
                       -
-                      <a href="<%= runner[:job_url] %>" class="text-orange-600 hover:text-orange-700" target="_blank"><%= runner[:job_name] %></a>
+                      <a href="<%= workflow_job[:job_url] %>" class="text-orange-600 hover:text-orange-700" target="_blank"><%= workflow_job[:job_name] %></a>
                     <% else %>
                       Runner doesn't have a job yet
                     <% end %>


### PR DESCRIPTION
### Add migration file to add workflow_job column to runner

The GithubRunner model retains information about its assigned
workflow_job, which is displayed in the UI. This data also proves useful
when investigating incidents. Previously, we didn't store the job's
status and conclusion, despite needing them on several occasions. We
need to do lots of API calls to fetch this information. I have decided to
persist these as well. However, adding numerous columns about the job to
the runner model didn't seem appropriate. Hence, I decided to
consolidate all workflow-related data into the workflow_job column.

### Persist the workflow_job data from webhooks to the runner model.

Before eliminating individual job data columns, we need to populate our
new, consolidated `workflow_job` data to ensure proper integration
functioning. Given the ephemeral nature of GitHub runners, all runners
will eventually possess `workflow_job`. After this, I will proceed with
deployment.

I have excluded the `.steps` property due to its potential for
containing large amounts of data.
Here is an example of a `workflow_job` payload:

    {
      "workflow_job": {
        "id": 18573479297,
        "run_id": 6828737633,
        "workflow_name": "CI",
        "head_branch": "build-test",
        "run_url": "https://api.github.com/repos/enescakir/ubicloud/actions/runs/6828737633",
        "run_attempt": 1,
        "node_id": "CR_kwDOKTBNac8AAAAEUxDNgQ",
        "head_sha": "2bd13725a66c3f9fc859b5f92e51cc6485a8acb7",
        "url": "https://api.github.com/repos/enescakir/ubicloud/actions/jobs/18573479297",
        "html_url": "https://github.com/enescakir/ubicloud/actions/runs/6828737633/job/18573479297",
        "status": "completed",
        "conclusion": "success",
        "created_at": "2023-11-10T19:11:51Z",
        "started_at": "2023-11-10T19:16:43Z",
        "completed_at": "2023-11-10T19:18:51Z",
        "name": "CI ubicloud",
        "steps": [
          {
            "name": "Set up job",
            "status": "completed",
            "conclusion": "success",
            "number": 1,
            "started_at": "2023-11-10T19:16:42.000Z",
            "completed_at": "2023-11-10T19:16:45.000Z"
          },
          .
          .
          .
          {
            "name": "Stop containers",
            "status": "completed",
            "conclusion": "success",
            "number": 14,
            "started_at": "2023-11-10T19:18:50.000Z",
            "completed_at": "2023-11-10T19:18:50.000Z"
          },
          {
            "name": "Complete job",
            "status": "completed",
            "conclusion": "success",
            "number": 15,
            "started_at": "2023-11-10T19:18:50.000Z",
            "completed_at": "2023-11-10T19:18:50.000Z"
          }
        ],
        "check_run_url": "https://api.github.com/repos/enescakir/ubicloud/check-runs/18573479297",
        "labels": [
          "ubicloud"
        ],
        "runner_id": 957,
        "runner_name": "grb9nkxs40824mag6906fz1wpt",
        "runner_group_id": 1,
        "runner_group_name": "Default"
    }}

### Use workflow_job data from new JSONB column

The previous commit consolidates all data related to workflow jobs into
the `workflow_job` JSONB column. This commit uses data from this column,
rather than from individual columns.

### Drop unused workflow job related columns
