### PR TITLE
Fix race condition in dispatcher test

### DIFF
--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -36,10 +36,7 @@ RSpec.describe Scheduling::Dispatcher do
 
   describe "#start_cohort" do
     after do
-      Thread.list.each do
-        _1.join if (nm = _1.name) && nm.start_with?("apoptosis:")
-      end
-      expect(Thread.list.count).to eq(1)
+      Thread.list.each { _1.join if _1 != Thread.current }
     end
 
     it "can create threads" do


### PR DESCRIPTION
6e46eac624a7c749795938063db4bab7f2a53136 thought it had exposed -- and fixed -- this bug, but it did so incompletely. It can happen that this still fails, probably because the apoptosis thread has gotten so little time scheduled it hasn't bound its name yet.

I've only seen this in CI, not locally, which is why I write "probably."

It suffices to join every thread, then. This will tend to convert bugs exposed by the tests into a hang instead of a crash, which is perhaps less good, but we hardly mess with these tests at this point now anyway.