### PR TITLE
Disable Sequel/ColumnDefault rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,3 +74,6 @@ RSpec/FilePath:
 RSpec/SpecFilePathFormat:
   Exclude:
     - 'spec/routes/**/*.rb'
+
+Sequel/ColumnDefault:
+  Enabled: false


### PR DESCRIPTION
This is likely to become the default in a new version of rubocop-sequel.  It was intended to prevent full-table rewrites, which new versions of Postgres avoid in common cases and we don't care particularly much about anyway:

https://github.com/rubocop/rubocop-sequel/issues/32

Eventually setting this explicitly to false will be obsolete, once this commit reaches a release:

https://github.com/rubocop/rubocop-sequel/pull/33