### PR TITLE
Do not create billing records for the VMs in internal projects

### DIFF
--- a/migrate/20231124_project_billable.rb
+++ b/migrate/20231124_project_billable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:project) do
+      add_column :billable, :boolean, null: false, default: true
+    end
+  end
+end


### PR DESCRIPTION
Our internal projects generate thousands of billing records for GitHub runners. However, these aren't particularly useful since we maintain a 'deleted_record' table for auditing. We decided to refrain from creating billing records for our internal projects until we implement a data warehouse solution.

I moved the creation of billing records to a separate label, after 'wait_sshable'. This ensures that customers are not charged if the VM is stuck in 'wait_sshable'. Additionally, having an individual label similar to the postgres resource has enhanced clarity.