### PR TITLE
Do not try to take backup if blob storage is not configured

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -47,13 +47,15 @@ class PostgresServer < Sequel::Model
       lc_time: "'C.UTF-8'"
     }
 
-    if primary?
-      configs[:archive_mode] = "on"
-      configs[:archive_timeout] = "60"
-      configs[:archive_command] = "'/usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env'"
-    else
-      configs[:recovery_target_time] = "'#{resource.restore_target}'"
-      configs[:restore_command] = "'/usr/bin/wal-g wal-fetch %f %p --config /etc/postgresql/wal-g.env'"
+    if timeline.blob_storage_endpoint
+      if primary?
+        configs[:archive_mode] = "on"
+        configs[:archive_timeout] = "60"
+        configs[:archive_command] = "'/usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env'"
+      else
+        configs[:recovery_target_time] = "'#{resource.restore_target}'"
+        configs[:restore_command] = "'/usr/bin/wal-g wal-fetch %f %p --config /etc/postgresql/wal-g.env'"
+      end
     end
 
     {

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -30,7 +30,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   label def start
-    blob_storage_client.create_bucket(bucket_name: postgres_timeline.ubid)
+    blob_storage_client.create_bucket(bucket_name: postgres_timeline.ubid) if postgres_timeline.blob_storage_endpoint
     hop_wait_leader
   end
 

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PostgresTimeline do
   end
 
   it "returns walg config" do
-    expect(Project).to receive(:[]).and_return(instance_double(Project, minio_clusters: [instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"])]))
+    expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
 
     walg_config = <<-WALG_CONF
 WALG_S3_PREFIX=s3://#{postgres_timeline.ubid}
@@ -40,12 +40,19 @@ PGHOST=/var/run/postgresql
       allow(postgres_timeline).to receive(:leader).and_return(leader).at_least(:once)
     end
 
+    it "returns false as backup needed if there is no backup endpoint is set" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return(nil)
+      expect(postgres_timeline.need_backup?).to be(false)
+    end
+
     it "returns false as backup needed if there is recent backup status check" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
       expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now).twice
       expect(postgres_timeline.need_backup?).to be(false)
     end
 
     it "returns true as backup needed if there is no backup process or the last backup failed" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint").twice
       expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).exactly(4).times
       expect(sshable).to receive(:cmd).and_return("NotStarted")
       expect(postgres_timeline.need_backup?).to be(true)
@@ -55,6 +62,7 @@ PGHOST=/var/run/postgresql
     end
 
     it "returns true as backup needed if previous backup started more than a day ago and is succeeded" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
       expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).twice
       expect(postgres_timeline).to receive(:last_backup_started_at).and_return(Time.now - 60 * 60 * 25).twice
       expect(sshable).to receive(:cmd).and_return("Succeeded")
@@ -62,6 +70,7 @@ PGHOST=/var/run/postgresql
     end
 
     it "returns false as backup needed if previous backup started less than a day ago" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
       expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).twice
       expect(postgres_timeline).to receive(:last_backup_started_at).and_return(Time.now - 60 * 60 * 23).twice
       expect(sshable).to receive(:cmd).and_return("Succeeded")
@@ -69,6 +78,7 @@ PGHOST=/var/run/postgresql
     end
 
     it "returns false as backup needed if previous backup started is in progress" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
       expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).twice
       expect(sshable).to receive(:cmd).and_return("InProgress")
       expect(postgres_timeline.need_backup?).to be(false)
@@ -90,7 +100,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns list of backups" do
-    expect(Project).to receive(:[]).and_return(instance_double(Project, minio_clusters: [instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"])]))
+    expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
 
     s3_client = Aws::S3::Client.new(stub_responses: true)
     s3_client.stub_responses(:list_objects_v2, {is_truncated: false, contents: [{key: "backup_stop_sentinel.json"}, {key: "unrelated_file"}]})
@@ -99,8 +109,24 @@ PGHOST=/var/run/postgresql
     expect(postgres_timeline.backups.map(&:key)).to eq(["backup_stop_sentinel.json"])
   end
 
-  it "returns blob storage client from cache" do
+  it "returns blob storage endpoint" do
     expect(Project).to receive(:[]).and_return(instance_double(Project, minio_clusters: [instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"])]))
+    expect(postgres_timeline.blob_storage_endpoint).to eq("https://blob-endpoint")
+  end
+
+  it "returns nil as blob storage endpoint if no minio cluster is found" do
+    expect(Project).to receive(:[]).and_return(instance_double(Project, minio_clusters: []))
+    expect(postgres_timeline.blob_storage_endpoint).to be_nil
+  end
+
+  it "raises exception if no minio cluster in production" do
+    expect(Config).to receive(:production?).and_return(true)
+    expect(Project).to receive(:[]).and_return(instance_double(Project, minio_clusters: []))
+    expect { postgres_timeline.blob_storage_endpoint }.to raise_error "BUG: Missing blob storage configuration"
+  end
+
+  it "returns blob storage client from cache" do
+    expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
     expect(MinioClient).to receive(:new).and_return("dummy-client").once
     expect(postgres_timeline.blob_storage_client).to eq("dummy-client")
     expect(postgres_timeline.blob_storage_client).to eq("dummy-client")

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     instance_double(
       PostgresTimeline,
       ubid: "ptp99pd7gwyp4jcvnzgrsd443g",
+      blob_storage_endpoint: "https://blob-endpoint",
       blob_storage_client: instance_double(MinioClient)
     )
   }
@@ -42,6 +43,12 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
   describe "#start" do
     it "creates bucket and hops" do
       expect(postgres_timeline.blob_storage_client).to receive(:create_bucket).with(bucket_name: postgres_timeline.ubid)
+      expect { nx.start }.to hop("wait_leader")
+    end
+
+    it "hops without creating bucket if blob storage is not configures" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return(nil)
+      expect(postgres_timeline.blob_storage_client).not_to receive(:create_bucket)
       expect { nx.start }.to hop("wait_leader")
     end
   end


### PR DESCRIPTION
For development environments, it is quite likely that we don't have all the dependencies of PostgreSQL service ready. In such cases, it is important to fail gracefully. We already did this for DnsZone dependency. With this commit we are also doing that for blob storage dependency. If blob storage is not configured, everything except backup/restore would continue to work. Of course many other things such as HA, scale up/down etc. depends on backup/restore. Only remaining serious feature is provisioning, which is good enough for most development needs.