### PR TITLE
Remove unnecessary authorization helpers

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -17,7 +17,7 @@ class Prog::Test::VmGroup < Prog::Base
 
   label def setup_vms
     project = Project.create_with_id(name: "project 1", provider: "hetzner")
-    project.create_hyper_tag(project)
+    project.associate_with_project(project)
 
     subnet1_s = Prog::Vnet::SubnetNexus.assemble(
       project.id, name: "the-first-subnet", location: "hetzner-hel1"

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -122,13 +122,13 @@ RSpec.describe Authorization do
       project = Project.create_with_id(name: "test")
       expect(project.hyper_tag(project)).to be_nil
 
-      tag = project.create_hyper_tag(project)
+      tag = project.associate_with_project(project)
       expect(project.hyper_tag(project)).to exist
 
       vms.each { _1.tag(tag) }
-      expect(AppliedTag.where(access_tag_id: tag.id).count).to eq(4)
+      expect(AppliedTag.where(access_tag_id: tag.id).count).to eq(5)
 
-      project.delete_hyper_tag(project)
+      project.dissociate_with_project(project)
       expect(project.hyper_tag(project)).to be_nil
       expect(AppliedTag.where(access_tag_id: tag.id).count).to eq(0)
     end


### PR DESCRIPTION
In the past, I added the delete_hyper_tag helper to clean up applied tags when the access tag was deleted. However, since the AccessTag model has the plugin :association_dependencies, applied_tags: :destroy plugin, there's no need to manually delete them.

The create_hyper_tag helper is used in only one place, so the extra method is unnecessary.