### PR TITLE
Move storage record creation to after VmHost allocation.

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -61,10 +61,16 @@ module Validation
   end
 
   def self.validate_storage_volumes(storage_volumes, boot_disk_index)
+    allowed_keys = [:encrypted, :size_gib, :boot]
     fail ValidationFailed.new({storage_volumes: "At least one storage volume is required."}) if storage_volumes.empty?
     if boot_disk_index < 0 || boot_disk_index >= storage_volumes.length
       fail ValidationFailed.new({boot_disk_index: "Boot disk index must be between 0 and #{storage_volumes.length - 1}"})
     end
+    storage_volumes.each { |volume|
+      volume.each_key { |key|
+        fail ValidationFailed.new({storage_volumes: "Invalid key: #{key}"}) unless allowed_keys.include?(key)
+      }
+    }
   end
 
   def self.validate_postgres_size(size)

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Validation do
 
     describe "#validate_storage_volumes" do
       it "succeeds if there's at least one volume" do
-        expect(described_class.validate_storage_volumes([{encrypted: true}], 0)).to be_nil
+        expect { described_class.validate_storage_volumes([{encrypted: true}], 0) }.not_to raise_error
       end
 
       it "fails if no volumes" do
@@ -112,6 +112,10 @@ RSpec.describe Validation do
       it "fails if boot_disk_index out of range" do
         expect { described_class.validate_storage_volumes([{encrypted: true}], -1) }.to raise_error described_class::ValidationFailed
         expect { described_class.validate_storage_volumes([{encrypted: true}], 1) }.to raise_error described_class::ValidationFailed
+      end
+
+      it "fails if contains an invalid key" do
+        expect { described_class.validate_storage_volumes([xyz: 1], 0) }.to raise_error described_class::ValidationFailed
       end
     end
 

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(st.label).to eq "start"
       expect(MinioServer.first.pool).to eq minio_pool
       expect(Vm.count).to eq 1
-      expect(Vm.first.vm_storage_volumes.count).to eq 2
       expect(Vm.first.unix_user).to eq "minio-user"
       expect(Vm.first.sshable.host).to eq "temp_#{Vm.first.id}"
       expect(Vm.first.private_subnets.first.id).to eq ps.id


### PR DESCRIPTION
Storage volume parameters can vary depending on what SPDK version is installed on the VmHost, so move volume record creation to after host allocation.

This PR is just a refactor, and there will be follow-up changes to use SPDK installation parameters.