### PR TITLE
Change default gateway not to be network address for ubuntu2004

### DIFF
--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -4,7 +4,8 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
   subject_is :nic
 
   label def add_subnet_addr
-    nic.vm.vm_host.sshable.cmd("sudo ip -n #{nic.vm.inhost_name.shellescape} addr replace #{nic.private_subnet.net4} dev #{nic.ubid_to_tap_name}")
+    addr = nic.vm.boot_image.include?("ubuntu-2004") ? (nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s) : nic.private_subnet.net4.to_s
+    nic.vm.vm_host.sshable.cmd("sudo ip -n #{nic.vm.inhost_name.shellescape} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
     pop "add_subnet_addr is complete"
   end
 

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm addr replace 1.1.1.0/26 dev ncname")
       expect { nx.add_subnet_addr }.to exit({"msg" => "add_subnet_addr is complete"})
     end
+
+    it "adds the subnet net4 address+1 to the nic for ubuntu-2004" do
+      allow(tunnel.src_nic.vm).to receive_messages(ephemeral_net6: NetAddr.parse_net("2a01:4f8:10a:128b:4919::/80"), inhost_name: "hellovm", boot_image: "ubuntu-2004")
+      expect(tunnel.src_nic).to receive(:ubid_to_tap_name).and_return("ncname")
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm addr replace 1.1.1.1/26 dev ncname")
+      expect { nx.add_subnet_addr }.to exit({"msg" => "add_subnet_addr is complete"})
+    end
   end
 
   describe "#setup_inbound" do


### PR DESCRIPTION
Looks like the behaviour for default gateway changed from linux kernel 5.4 to 5.15. In the new versions of the Kernel, we can use the network address of a subnet as the default gateway in the VMs. Our DHCP system sends the gateway from the route (the ip address in the tap device). With 5.4 kernel, if we send the network address as the gateway, dhcp procedure fails to add the default route. Therefore, we are making a small change and using the next address of the network address as a gateway.