### PR TITLE
Redirect back when RouteCsrf::InvalidToken raised

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -69,6 +69,9 @@ class CloverWeb < Roda
     when Validation::ValidationFailed
       flash["errors"] = (flash["errors"] || {}).merge(@error[:details])
       return redirect_back_with_inputs
+    when Roda::RodaPlugins::RouteCsrf::InvalidToken
+      flash["error"] = "An invalid security token submitted with this request, please try again"
+      return redirect_back_with_inputs
     end
 
     # :nocov:

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -4,9 +4,12 @@ require_relative "spec_helper"
 
 RSpec.describe Clover do
   it "handles CSRF token errors" do
-    page.driver.post("/login")
+    visit "/login"
+    find("input[name=_csrf]", visible: false).set("")
+    click_button "Sign in"
 
-    expect(page.title).to eq("Ubicloud - Invalid Security Token")
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("An invalid security token submitted with this request")
   end
 
   it "handles unexpected errors" do


### PR DESCRIPTION
I observed several HTTP 500 responses in our web server logs, accompanied by the following exception:

    #<NoMethodError: undefined method `projects' for nil:NilClass>

Upon investigation, I believe this issue arises from an invalid CSRF token path.

Our POST/DELETE endpoints require a CSRF token for submission. If the token is invalid, a `Roda::RodaPlugins::RouteCsrf::InvalidToken` exception is raised.

The token becomes invalidated when the active session changes. If the user doesn't interact with the page for a long period, their active session may expire. Additionally, if the user logs in or out in another browser tab, the session also changes. If the user submits the old page without refreshing, it triggers an InvalidToken exception.

We check the CSRF token before setting the `@current_user` variable. This approach is beneficial as it prevents to select the current user for an invalid token.

https://github.com/ubicloud/ubicloud/blob/1d08b351233735b812d44307a3fa315de6666572/clover_web.rb#L205

Our exception HTML template includes a sidebar, which contains a project switcher. This switcher uses `@current_user.projects` to list projects. In cases of `InvalidToken`, the `@current_user` is nil, leading to an HTTP 500 exception.

Moreover, displaying a full-page "419 - Invalid Security Token" error message is not user-friendly. The user should be prompted to resubmit the form. Therefore, I decided to redirect to the previous page with an error message, allowing the user to resubmit the form.

When we redirect back, the page will have a fresh csrf token.