### PR TITLE
Fix error raised when the user has no projects

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -202,7 +202,11 @@ class CloverWeb < Roda
   end
 
   hash_branch("after-login") do |r|
-    r.redirect "#{@current_user.projects.first.path}/dashboard"
+    if (project = @current_user.projects_dataset.order(:created_at).first)
+      r.redirect "#{project.path}/dashboard"
+    else
+      r.redirect "/project"
+    end
   end
 
   route do |r|

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -7,7 +7,7 @@ TEST_USER_EMAIL = "user@example.com"
 TEST_USER_PASSWORD = "Secret@Password123"
 TEST_LOCATION = "hetzner-hel1"
 
-def create_account(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
+def create_account(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD, with_project: true)
   hash = Argon2::Password.new({
     t_cost: 1,
     m_cost: 5,
@@ -16,6 +16,6 @@ def create_account(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
 
   account = Account.create_with_id(email: email, status_id: 2)
   DB[:account_password_hashes].insert(id: account.id, password_hash: hash)
-  account.create_project_with_default_policy("Default")
+  account.create_project_with_default_policy("Default") if with_project
   account
 end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -78,6 +78,17 @@ RSpec.describe Clover, "auth" do
     expect(page.title).to eq("Ubicloud - Reset Password")
   end
 
+  it "can login to an account without projects" do
+    create_account(with_project: false)
+
+    visit "/login"
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Password", with: TEST_USER_PASSWORD
+    click_button "Sign in"
+
+    expect(page.title).to eq("Ubicloud - Projects")
+  end
+
   it "can not login if the account is suspended" do
     account = create_account
 

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -7,11 +7,13 @@
 <div class="grid gap-6">
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 lg:gap-10">
     <% [
-      [
-        "hero-server-stack", "bg-teal-50 text-teal-700", "Create Virtual Machine",
-        "Linux-based virtual machines that run on top of virtualized hardware. Comprehensive, cost-effective cloud computing.",
-        "#{@current_user.projects.first.path}/vm/create"
-      ], [
+      if (project = @current_user.projects_dataset.order(:created_at).first)
+        [
+          "hero-server-stack", "bg-teal-50 text-teal-700", "Create Virtual Machine",
+          "Linux-based virtual machines that run on top of virtualized hardware. Comprehensive, cost-effective cloud computing.",
+          "#{project.path}/vm/create"
+        ]
+      end, [
         "hero-folder-open", "bg-purple-50 text-purple-700", "Create New Project",
         "Projects are the central point for grouping resources and working with others within Ubicloud.",
         "/project/create"
@@ -24,7 +26,7 @@
         "If you need any help with Ubicloud, reach out to our support team for help at support@ubicloud.com.",
         "mailto:support@ubicloud.com"
       ]
-    ].each do |icon, color, title, description, link| %>
+    ].reject { !_1 }.each do |icon, color, title, description, link| %>
       <div
         class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-orange-600"
       >


### PR DESCRIPTION
I noticed several HTTP 500 responses in our web server logs, each accompanied by the following exception:

    "NoMethodError: undefined method `path' for nil:NilClass"

We use @current_user.projects.first.path in two paths: /dashboard and /after-login. If the user deletes all their projects, they can't access these paths.

I resolved this issue by redirecting to different endpoints when the user has no projects.