### PR TITLE
Use bdev_ubi to provide storage.

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -61,7 +61,7 @@ module Validation
   end
 
   def self.validate_storage_volumes(storage_volumes, boot_disk_index)
-    allowed_keys = [:encrypted, :size_gib, :boot]
+    allowed_keys = [:encrypted, :size_gib, :boot, :use_bdev_ubi]
     fail ValidationFailed.new({storage_volumes: "At least one storage volume is required."}) if storage_volumes.empty?
     if boot_disk_index < 0 || boot_disk_index >= storage_volumes.length
       fail ValidationFailed.new({boot_disk_index: "Boot disk index must be between 0 and #{storage_volumes.length - 1}"})

--- a/migrate/20231123_bdev_ubi.rb
+++ b/migrate/20231123_bdev_ubi.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_storage_volume) do
+      add_column :use_bdev_ubi, :bool, null: false, default: false
+    end
+  end
+end

--- a/model/spdk_installation.rb
+++ b/model/spdk_installation.rb
@@ -11,4 +11,10 @@ class SpdkInstallation < Sequel::Model
   def self.generate_uuid
     UBID.generate(UBID::TYPE_ETC).to_uuid
   end
+
+  def supports_bdev_ubi?
+    # We version stock SPDK releases similar to v23.09, and add a ubi version
+    # suffix if we package bdev_ubi along with it, similar to v23.09-ubi-0.1.
+    version.match?(/^v[0-9]+\.[0-9]+-ubi-.*/)
+  end
 end

--- a/rhizome/host/lib/spdk_rpc.rb
+++ b/rhizome/host/lib/spdk_rpc.rb
@@ -40,6 +40,22 @@ class SpdkRpc
     raise e unless if_exists
   end
 
+  def bdev_ubi_create(name, base_bdev_name, image_path, stripe_size_mb = 1)
+    params = {
+      name: name,
+      base_bdev: base_bdev_name,
+      image_path: image_path,
+      stripe_size_mb: stripe_size_mb
+    }
+    call("bdev_ubi_create", params)
+  end
+
+  def bdev_ubi_delete(name, if_exists = true)
+    call("bdev_ubi_delete", {name: name})
+  rescue SpdkNotFound => e
+    raise e unless if_exists
+  end
+
   def vhost_create_blk_controller(name, bdev)
     params = {
       ctrlr: name,

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe StorageVolume do
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/2/")
       expect(encrypted_sv).to receive(:verify_imaged_disk_size).with(no_args)
       expect(encrypted_sv).to receive(:setup_data_encryption_key).with(key_wrapping_secrets).and_return(encryption_key)
-      expect(encrypted_sv).to receive(:encrypted_image_copy).with(encryption_key)
+      expect(encrypted_sv).to receive(:encrypted_image_copy).with(encryption_key, image_path)
       encrypted_sv.prep(key_wrapping_secrets)
     end
 
@@ -170,8 +170,8 @@ RSpec.describe StorageVolume do
     it "can copy an image to an encrypted volume" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
       expect(encrypted_sv).to receive(:create_empty_disk_file).with(no_args)
-      expect(encrypted_sv).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0 --bs=[0-9]+$/, stdin: /{.*}/)
-      encrypted_sv.encrypted_image_copy(encryption_key)
+      expect(encrypted_sv).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0 --bs=[0-9]+\s*$/, stdin: /{.*}/)
+      encrypted_sv.encrypted_image_copy(encryption_key, image_path)
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -427,18 +427,25 @@ RSpec.describe Prog::Vm::Nexus do
       si_1 = SpdkInstallation.new(allocation_weight: 0)
       si_2 = SpdkInstallation.new(allocation_weight: 0)
 
-      expect { nx.allocate_spdk_installation([si_1, si_2]) }.to raise_error "Total weight of all spdk_installations shouldn't be zero."
+      expect { nx.allocate_spdk_installation([si_1, si_2], use_bdev_ubi: false) }.to raise_error "Total weight of all eligible spdk_installations shouldn't be zero."
+    end
+
+    it "fails if requested use_bdev_ubi, but no installations with bdev_ubi supports are available" do
+      si_1 = SpdkInstallation.new(allocation_weight: 100, version: "v23.09")
+      si_2 = SpdkInstallation.new(allocation_weight: 100, version: "v25.00")
+
+      expect { nx.allocate_spdk_installation([si_1, si_2], use_bdev_ubi: true) }.to raise_error "Total weight of all eligible spdk_installations shouldn't be zero."
     end
 
     it "chooses the only one if one provided" do
       si_1 = SpdkInstallation.new(allocation_weight: 100) { _1.id = SpdkInstallation.generate_uuid }
-      expect(nx.allocate_spdk_installation([si_1])).to eq(si_1.id)
+      expect(nx.allocate_spdk_installation([si_1], use_bdev_ubi: false)).to eq(si_1.id)
     end
 
     it "doesn't return the one with zero weight" do
       si_1 = SpdkInstallation.new(allocation_weight: 0) { _1.id = SpdkInstallation.generate_uuid }
       si_2 = SpdkInstallation.new(allocation_weight: 100) { _1.id = SpdkInstallation.generate_uuid }
-      expect(nx.allocate_spdk_installation([si_1, si_2])).to eq(si_2.id)
+      expect(nx.allocate_spdk_installation([si_1, si_2], use_bdev_ubi: false)).to eq(si_2.id)
     end
   end
 


### PR DESCRIPTION
bdev_ubi implements copy-on-access for SPDK, so setting up storage doesn't require the initial copy operation which can take several minutes. Thus, improving the provisioning time.

Before being able to create a bdev_ubi enabled VM, you need to install a SPDK release with `-ubi-x.y` suffix:

```
> Prog::Storage::SetupSpdk.assemble(
  vm_host.id,
  "v23.09-ubi-0.1",
  start_service: true,
  allocation_weight: 100
)
```

Then you can set the `use_bdev_ubi` parameter of a disk when creating a VM:

```
> Prog::Vm::Nexus.assemble(..., storage_volumes: [{use_bdev_ubi: true}], ...)
```

For more information about bdev_ubi, see https://github.com/ubicloud/bdev_ubi

Follow-up PRs will enable using bdev_ubi automatically.
