### PR TITLE
Introduce account suspension feature

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -126,6 +126,16 @@ class CloverWeb < Roda
     already_logged_in { redirect login_redirect }
     after_login { remember_login if request.params["remember-me"] == "on" }
 
+    before_login do
+      if Account[account_id].suspended_at
+        flash["error"] = "Your account has been suspended. " \
+          "If you believe there's a mistake, or if you need further assistance, " \
+          "please reach out to our support team at support@ubicloud.com."
+
+        redirect login_route
+      end
+    end
+
     create_account_view { view "auth/create_account", "Create Account" }
     create_account_redirect { login_route }
     create_account_set_password? true

--- a/migrate/20231122_add_account_suspend.rb
+++ b/migrate/20231122_add_account_suspend.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:accounts) do
+      add_column :suspended_at, :timestamptz
+    end
+  end
+end

--- a/model/account.rb
+++ b/model/account.rb
@@ -24,4 +24,9 @@ class Account < Sequel::Model(:accounts)
     )
     project
   end
+
+  def suspend
+    update(suspended_at: Time.now)
+    DB[:account_active_session_keys].where(account_id: id).delete(force: true)
+  end
 end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -78,6 +78,26 @@ RSpec.describe Clover, "auth" do
     expect(page.title).to eq("Ubicloud - Reset Password")
   end
 
+  it "can not login if the account is suspended" do
+    account = create_account
+
+    visit "/login"
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Password", with: TEST_USER_PASSWORD
+    click_button "Sign in"
+    expect(page.title).to eq("Ubicloud - #{account.projects.first.name} Dashboard")
+
+    account.suspend
+
+    visit "/login"
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Password", with: TEST_USER_PASSWORD
+    click_button "Sign in"
+
+    expect(page.title).to eq("Ubicloud - Login")
+    expect(page).to have_content("Your account has been suspended")
+  end
+
   describe "authenticated" do
     before do
       create_account


### PR DESCRIPTION
When a user violates our terms of service, we delete their resources. However, they can still recreate these resources using the same account.

Upon account suspension, we terminate all of the user's active sessions and prevent further logins to their accounts.

Users can contact us for further assistance.

You can suspend an account as follows:

    Account[ID].suspend
    
    

<img width="1554" alt="Screenshot 2023-11-22 at 22 58 58" src="https://github.com/ubicloud/ubicloud/assets/993199/d717b553-14d5-499b-96b0-99bdb35cee40">
