### PR TITLE
Verify all SPDK installations on host reboot.

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -154,8 +154,10 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def verify_spdk
-    q_version = frame["spdk_version"].shellescape
-    sshable.cmd("sudo host/bin/setup-spdk verify #{q_version}")
+    vm_host.spdk_installations.each { |installation|
+      q_version = installation.version.shellescape
+      sshable.cmd("sudo host/bin/setup-spdk verify #{q_version}")
+    }
 
     hop_verify_hugepages
   end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -288,7 +288,12 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "verify_spdk hops to verify_hugepages if spdk started" do
-      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-spdk verify #{Config.spdk_version}")
+      expect(vm_host).to receive(:spdk_installations).and_return([
+        SpdkInstallation.new(version: "v1.0"),
+        SpdkInstallation.new(version: "v3.0")
+      ])
+      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-spdk verify v1.0")
+      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-spdk verify v3.0")
       expect { nx.verify_spdk }.to hop("verify_hugepages")
     end
 


### PR DESCRIPTION
Relying on `frame["spdk_version"]` as the currently installed SPDK version caused some problems:

* Legacy hosts didn't have `frame["spdk_version"]` set which made verify_spdk fail.
* Set of SPDK installations could change during lifetime of a host. They can be added or removed.

This PR fixes that by fetching list of SPDK installations to verify from the database.