### PR TITLE
Colour the prompt of the VmHost for production hosts

### DIFF
--- a/prog/vm/prep_host.rb
+++ b/prog/vm/prep_host.rb
@@ -4,7 +4,7 @@ class Prog::Vm::PrepHost < Prog::Base
   subject_is :sshable, :vm_host
 
   label def start
-    sshable.cmd("sudo host/bin/prep_host.rb #{vm_host.ubid.shellescape}")
+    sshable.cmd("sudo host/bin/prep_host.rb #{vm_host.ubid.shellescape} #{Config.rack_env.shellescape}")
     pop "host prepared"
   end
 end

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -12,10 +12,21 @@ unless (hostname = ARGV.shift)
   exit 1
 end
 
+unless (env_type = ARGV.shift)
+  puts "need environment type as argument"
+  exit 1
+end
+
 original_hostname = Socket.gethostname
 
 safe_write_to_file("/etc/hosts", File.read("/etc/hosts").gsub(original_hostname, hostname))
 r "sudo hostnamectl set-hostname " + hostname
+
+if env_type == "production"
+  bashrc_content = File.read("/root/.bashrc")
+  colored_prompt_code = '\e[0;41m[\u@\h \W]\$ \e[m'
+  safe_write_to_file("/root/.bashrc", "#{bashrc_content}\n PS1='#{colored_prompt_code}'")
+end
 
 ch_dir = CloudHypervisor::VERSION.dir
 FileUtils.mkdir_p(ch_dir)

--- a/spec/prog/vm/prep_host_spec.rb
+++ b/spec/prog/vm/prep_host_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prog::Vm::PrepHost do
     it "prepare host" do
       sshable = instance_double(Sshable)
       vm_host = instance_double(VmHost, ubid: "vmhostubid")
-      expect(sshable).to receive(:cmd).with("sudo host/bin/prep_host.rb " + vm_host.ubid)
+      expect(sshable).to receive(:cmd).with("sudo host/bin/prep_host.rb #{vm_host.ubid} test")
       expect(ph).to receive(:sshable).and_return(sshable)
       expect(ph).to receive(:vm_host).and_return(vm_host)
 


### PR DESCRIPTION
Make the prompt color red for production hosts to warn the operator.