### PR TITLE
Use bdev_ubi in E2E tests.

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -3,11 +3,15 @@
 require "net/ssh"
 
 class Prog::Test::VmGroup < Prog::Base
-  def self.assemble(storage_encrypted: true, test_reboot: true)
+  def self.assemble(storage_encrypted: true, test_reboot: true, use_bdev_ubi: true)
     Strand.create_with_id(
       prog: "Test::VmGroup",
       label: "start",
-      stack: [{"storage_encrypted" => storage_encrypted, "test_reboot" => test_reboot}]
+      stack: [{
+        "storage_encrypted" => storage_encrypted,
+        "test_reboot" => test_reboot,
+        "use_bdev_ubi" => use_bdev_ubi
+      }]
     )
   end
 
@@ -31,12 +35,13 @@ class Prog::Test::VmGroup < Prog::Base
     strand.add_child(subnet2_s)
 
     storage_encrypted = frame.fetch("storage_encrypted", true)
+    use_bdev_ubi = frame.fetch("use_bdev_ubi", true)
 
     vm1_s = Prog::Vm::Nexus.assemble_with_sshable(
       "ubi", project.id,
       private_subnet_id: subnet1_s.id,
       storage_volumes: [
-        {encrypted: storage_encrypted},
+        {encrypted: storage_encrypted, use_bdev_ubi: use_bdev_ubi},
         {encrypted: storage_encrypted, size_gib: 5}
       ],
       enable_ip4: true
@@ -45,14 +50,14 @@ class Prog::Test::VmGroup < Prog::Base
     vm2_s = Prog::Vm::Nexus.assemble_with_sshable(
       "ubi", project.id,
       private_subnet_id: subnet1_s.id,
-      storage_volumes: [{encrypted: storage_encrypted}],
+      storage_volumes: [{encrypted: storage_encrypted, use_bdev_ubi: use_bdev_ubi}],
       enable_ip4: true
     )
 
     vm3_s = Prog::Vm::Nexus.assemble_with_sshable(
       "ubi", project.id,
       private_subnet_id: subnet2_s.id,
-      storage_volumes: [{encrypted: storage_encrypted}],
+      storage_volumes: [{encrypted: storage_encrypted, use_bdev_ubi: use_bdev_ubi}],
       enable_ip4: true
     )
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -135,7 +135,25 @@ RSpec.describe Prog::Test::HetznerServer do
       expect(sshable).to receive(:cmd).with(
         "sudo RUN_E2E_TESTS=1 SPDK_TESTS_TMP_DIR=#{tmp_dir} bundle exec rspec host/e2e"
       )
-      expect { hs_test.run_integration_specs }.to hop("test_host_encrypted", "Test::HetznerServer")
+      expect { hs_test.run_integration_specs }.to hop("install_bdev_ubid", "Test::HetznerServer")
+    end
+  end
+
+  describe "#install_bdev_ubid" do
+    it "hops to wait_install_bdev_ubid" do
+      expect { hs_test.install_bdev_ubid }.to hop("wait_install_bdev_ubid", "Test::HetznerServer")
+    end
+  end
+
+  describe "#wait_install_bdev_ubid" do
+    it "hops to test_host_encrypted if children idle" do
+      expect(hs_test).to receive(:children_idle).and_return(true)
+      expect { hs_test.wait_install_bdev_ubid }.to hop("test_host_encrypted", "Test::HetznerServer")
+    end
+
+    it "donates if children not idle" do
+      expect(hs_test).to receive(:children_idle).and_return(false)
+      expect { hs_test.wait_install_bdev_ubid }.to nap(0)
     end
   end
 


### PR DESCRIPTION
Install SPDK v23.09-ubi-0.1 and use bdev_ubi for boot volumes in E2E tests. This helps us do some testing on bdev_ubi before we enable it for customers.