### PR TITLE
Fix UBID type to class conversation

### DIFF
--- a/ubid.rb
+++ b/ubid.rb
@@ -96,7 +96,7 @@ class UBID
     s.delete_prefix("TYPE").split("_").map(&:capitalize).join
   end
 
-  TYPE2CLASS = constants.select { _1.start_with?("TYPE_") }
+  TYPE2CLASS = constants.select { _1.start_with?("TYPE_") }.reject { _1.to_s == "TYPE_ETC" }
     .map { [const_get(_1), Object.const_get(camelize(_1.to_s).to_s)] }.to_h
 
   def self.decode(ubid)


### PR DESCRIPTION
My application began to crash with the following boot error:

    ➜  ubicloud git:(main) ./bin/respirate
    /Users/enescakir/dev/ubicloud/ubid.rb:100:in `const_get': uninitialized constant Etc (NameError)

        .map { [const_get(_1), Object.const_get(camelize(_1.to_s).to_s)] }.to_h
                                     ^^^^^^^^^^
            from /Users/enescakir/dev/ubicloud/ubid.rb:100:in `block in <class:UBID>'
            from /Users/enescakir/dev/ubicloud/ubid.rb:100:in `map'
            from /Users/enescakir/dev/ubicloud/ubid.rb:100:in `<class:UBID>'
            from /Users/enescakir/dev/ubicloud/ubid.rb:8:in `<top (required)>'
            from <internal:/Users/enescakir/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
            from <internal:/Users/enescakir/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
            from /Users/enescakir/dev/ubicloud/model.rb:49:in `ubid'
            from /Users/enescakir/dev/ubicloud/scheduling/dispatcher.rb:30:in `start_strand'
            from /Users/enescakir/dev/ubicloud/scheduling/dispatcher.rb:72:in `block in start_cohort'
            from /Users/enescakir/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/sequel-5.74.0/lib/sequel/dataset/actions.rb:162:in `block in each'
            ...
            from /Users/enescakir/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/sequel-5.74.0/lib/sequel/dataset/actions.rb:162:in `each'
            from /Users/enescakir/dev/ubicloud/scheduling/dispatcher.rb:71:in `start_cohort'
            from ./bin/respirate:20:in `block in <main>'
            from ./bin/respirate:19:in `loop'
            from ./bin/respirate:19:in `<main>'

We retrieve all constants that follow the "TYPE_<CLASS_NAME>" pattern and determine their respective classes in the UBID class.

"TYPE_ETC" is an exception and we don't have a class named "Etc". It functioned previously but started failing this morning.

I'm uncertain how it operated given that we don't have an "Etc" class.