### PR TITLE
Do not show the runner link until it's registered to GitHub

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -21,6 +21,6 @@ class GithubRunner < Sequel::Model
   end
 
   def runner_url
-    "http://github.com/#{repository_name}/settings/actions/runners/#{runner_id}"
+    "http://github.com/#{repository_name}/settings/actions/runners/#{runner_id}" if runner_id
   end
 end

--- a/views/project/github.erb
+++ b/views/project/github.erb
@@ -42,7 +42,11 @@
               <% @runners.each do |runner| %>
                 <tr id="github-installation-<%= runner[:id]%>">
                   <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-                    <a href="<%= runner[:runner_url] %>" class="text-orange-600 hover:text-orange-700" target="_blank"><%= runner[:ubid] %></a>
+                    <% if runner[:runner_url] %>
+                      <a href="<%= runner[:runner_url] %>" class="text-orange-600 hover:text-orange-700" target="_blank"><%= runner[:ubid] %></a>
+                    <% else %>
+                      <%= runner[:ubid] %>
+                    <% end %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= runner[:repository_name] %>


### PR DESCRIPTION
The GithubRunner gets a runner_id once it's registered to GitHub. This runner_id is determined by GitHub. Until registration is complete, the runner link remains invalid and therefore does not need to be displayed.