### PR TITLE
Use ARM runners to build the linux/arm64 docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: Build
 on:
   workflow_dispatch:
     inputs:
-      tags:
-        description: 'Full tag names seperated by comma. i.e.: ubicloud/ubicloud:0.1, ubicloud/ubicloud:latest'
-        required: true
-        type: string
+      push_image:
+        description: 'Push the image to Docker Hub'
+        default: false
+        type: boolean
   push:
     branches:
       - 'main'
@@ -15,7 +15,6 @@ on:
 
 env:
   IMAGE_NAME: ubicloud/ubicloud
-  PUSH_IMAGE: ${{ github.event_name == 'workflow_dispatch' }}
 jobs:
   docker:
     runs-on: ubicloud-standard-8
@@ -35,13 +34,13 @@ jobs:
           labels: |
             org.opencontainers.image.licenses=Elastic-2.0
           tags: |
+            type=sha,prefix=
             type=ref,event=branch
-            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Log in to Docker Hub
-        if: ${{ env.PUSH_IMAGE }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -52,8 +51,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ env.PUSH_IMAGE }}
-          tags: ${{ github.event_name == 'workflow_dispatch' && inputs.tags || steps.meta.outputs.tags }}
+          push: ${{ inputs.push_image }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,73 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.push_image }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ inputs.push_image }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: ${{ inputs.push_image }}
+    runs-on: ubicloud
+    needs:
+      - docker
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.licenses=Elastic-2.0
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,16 @@ env:
   IMAGE_NAME: ubicloud/ubicloud
 jobs:
   docker:
-    runs-on: ubicloud-standard-8
+    name: Docker ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubicloud-standard-8
+            platform: linux/amd64
+          - runner: ubicloud-standard-8-arm
+            platform: linux/arm64
 
     steps:
       - name: Check out code
@@ -51,10 +60,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ubicloud-${{ matrix.runner }}
+          cache-to: type=gha,mode=max,scope=ubicloud-${{ matrix.runner }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest


### PR DESCRIPTION
### Extract sha and latest tags automatically with docker/metadata-action

Currently, I manually release our docker image and specify image tags. While working on building our docker images on multiple runners, I revisited the "docker/metadata-action" documentation. https://github.com/docker/metadata-action#tags-input. It can automatically extract short SHA and latest tags.

When I initiate the build, it generates images with the following tags: `<BRANCH_NAME>`, `<SHORT_SHA>`, and `latest` if it's the default branch.

### Separate docker build and push operations into different runners

We build and push docker images for both amd64 and arm64 architectures on a single runner machine. Due to the slow build of arm64 images on an x64 runner, we intend to use separate runners for each architecture.

The main challenge lies in building docker images on different runners and pushing them to the registry using the same tag but different architectures.

To address this, I followed the [Distribute build across multiple runners](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners) example, which allows us to build images on multiple runners and publish them after a merge.

`docker` jobs build images digests and upload them as artifacts. `merge` job merges digests and push them to Docker Hub.

### Build arm64 docker image on an ARM runner

ARM-based machines have recently gained popularity. Thanks to Apple's M and AWS Graviton processors, the amd64 image is no longer enough. An arm64 docker image is now essential for popular open-source projects. We already build arm64 docker images using docker buildx with QEMU emulation. However, this process is quite slow, taking ~20 minutes to build the ARM image with emulation. In contrast, building our image on a machine with the same architecture typically takes about 2 minutes.

The previous commit allows us to build images on the different runners. `merge` job merges them to the single tag.

Fixes https://github.com/ubicloud/ubicloud/issues/138