### PR TITLE
Fix cloudify_server script

### DIFF
--- a/demo/cloudify_server
+++ b/demo/cloudify_server
@@ -54,7 +54,7 @@ puts "\n\nCloudifying '#{hostname}' server for '#{LOCATIONS[location]}' \n\n"
 strand = Prog::Vm::HostNexus.assemble(hostname, location: location)
 
 puts "Waiting public SSH keys\n\n"
-until (ssh_key = strand.reload.sshable.keys.map(&:public_key).first)
+until (ssh_key = strand.reload.subject.sshable.keys.map(&:public_key).first)
   sleep 2
 end
 puts "Add following public SSH key to '/root/.ssh/authorized_keys' on your machine\n\n"


### PR DESCRIPTION
I've changed the way to access the subject of the strand in commit 02328ae. Now, we should access it via 'subject' when the prog context isn't loaded and the 'subject_is' helper is unavailable.