### PR TITLE
Explicitly set StrictHostKeyChecking

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -100,7 +100,7 @@ class Sshable < Sequel::Model
   # timeout).
   COMMON_SSH_ARGS = {non_interactive: true, timeout: 10,
                      user_known_hosts_file: [], global_known_hosts_file: [],
-                     keys: [], key_data: [], use_agent: false,
+                     verify_host_key: :accept_new, keys: [], key_data: [], use_agent: false,
                      keepalive: true, keepalive_interval: 3, keepalive_maxcount: 5}.freeze
 
   def connect


### PR DESCRIPTION
Without explicitly setting these, net-ssh uses whatever default is set in the
operating system, which might be different that what we want. In wait_sshable
we want to always check the host key because we determine if the server is up
by expecting "Host key verification failed." error message. In sshable.cmd(),
don't want to verify host key because IP addresses can be reassigned to other  
servers over time. In the future we might want to keep host keys in our DB and
do verification for extra security, but it is not in the scope of this commit.