### PR TITLE
MinIO Client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "pagerduty", ">= 4.0"
 gem "stripe"
 gem "countries"
 gem "octokit"
+gem "argon2-kdf"
 
 group :development do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     argon2 (2.3.0)
       ffi (~> 1.15)
       ffi-compiler (~> 1.0)
+    argon2-kdf (0.2.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.862.0)
@@ -290,6 +291,7 @@ PLATFORMS
 
 DEPENDENCIES
   argon2
+  argon2-kdf
   aws-sdk-s3
   bcrypt_pbkdf
   brakeman

--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "excon"
+require "nokogiri"
+require "cgi"
+
+REGION = "us-east-1"
+ADMIN_URI_PATH = "/minio/admin/v3"
+
+class Minio::Client
+  def initialize(endpoint:, access_key:, secret_key:)
+    @creds = {access_key: access_key, secret_key: secret_key}
+    @endpoint = endpoint
+    @client = Excon.new(endpoint)
+    @signer = Minio::HeaderSigner.new
+  end
+
+  private def s3_uri(path)
+    URI.parse("#{@endpoint}/#{path}")
+  end
+
+  def create_bucket(bucket_name)
+    response = send_request("PUT", s3_uri(bucket_name))
+    response.status
+  end
+
+  def delete_bucket(bucket_name)
+    response = send_request("DELETE", s3_uri(bucket_name))
+    response.status
+  end
+
+  def bucket_exists?(bucket_name)
+    response = send_request("GET", s3_uri(bucket_name))
+
+    response.status == 200
+  end
+
+  def list_objects(bucket_name, folder_path, max_keys: 1000)
+    objects = []
+    query = URI.encode_www_form({
+      "delimiter" => "",
+      "encoding-type" => "url",
+      "list-type" => 2,
+      "prefix" => folder_path,
+      "max-keys" => max_keys
+    })
+    response = send_request("GET", s3_uri("#{bucket_name}?#{query}"))
+    parsed_objects = parse_list_objects(response.data[:body])
+    objects.concat(parsed_objects[0])
+
+    is_truncated = parsed_objects[1]
+    continuation_token = parsed_objects[2]
+    while is_truncated
+      query = URI.encode_www_form({
+        "continuation-token" => continuation_token,
+        "delimiter" => "",
+        "encoding-type" => "url",
+        "list-type" => 2,
+        "prefix" => folder_path,
+        "max-keys" => max_keys,
+        "start-after" => continuation_token
+      })
+      response = send_request("GET", s3_uri("#{bucket_name}?#{query}"))
+      parsed_objects = parse_list_objects(response.data[:body])
+      objects.concat(parsed_objects[0])
+      is_truncated = parsed_objects[1]
+      continuation_token = parsed_objects[2]
+    end
+
+    objects
+  end
+
+  def send_request(method, uri, body = nil)
+    headers = @signer.build_headers(method, uri, body, @creds, REGION)
+
+    full_path = uri.path + (uri.query ? "?" + uri.query : "")
+    response = @client.request(method: method, path: full_path, headers: headers, body: body)
+    if [200, 204, 206, 404].include?(response.status)
+      response
+    else
+      raise "Error: #{response.body}"
+    end
+  end
+
+  private
+
+  def parse_list_objects(response)
+    # Parse the XML response
+    doc = Nokogiri::XML(response)
+    bucket_name = doc.xpath("//xmlns:Name").text
+    encoding_type = doc.xpath("//xmlns:EncodingType").text
+    # Process 'Contents' elements
+    objects = doc.xpath("//xmlns:Contents").map do |node|
+      Blob.from_xml(node, bucket_name, encoding_type: encoding_type)
+    end
+
+    # Note to future: We may need to process 'CommonPrefixes' elements
+    # when we implement new APIs.
+    is_truncated = doc.xpath("//xmlns:IsTruncated").text.casecmp("true").zero?
+    continuation_token = doc.xpath("//xmlns:NextContinuationToken").text
+    if continuation_token && encoding_type == "url"
+      continuation_token = CGI.escape(continuation_token)
+    end
+    [objects, is_truncated, continuation_token]
+  end
+
+  class Blob
+    attr_accessor :bucket_name, :key, :last_modified, :etag, :size,
+      :version_id, :is_latest, :storage_class, :owner_id, :owner_name,
+      :metadata, :is_delete_marker
+
+    def initialize(bucket_name, object_name, last_modified: nil, etag: nil, size: nil,
+      version_id: nil, is_latest: nil, storage_class: nil, owner_id: nil,
+      owner_name: nil, metadata: {}, is_delete_marker: false)
+      @bucket_name = bucket_name
+      @key = object_name
+      @last_modified = last_modified
+      @etag = etag
+      @size = size
+      @version_id = version_id
+      @is_latest = is_latest
+      @storage_class = storage_class
+      @owner_id = owner_id
+      @owner_name = owner_name
+      @metadata = metadata
+      @is_delete_marker = is_delete_marker
+    end
+
+    def self.from_xml(element, bucket_name, encoding_type: nil, is_delete_marker: false)
+      last_modified = element.at_xpath("xmlns:LastModified")&.text
+      last_modified = Time.parse(last_modified) if last_modified
+      etag = element.at_xpath("xmlns:ETag")&.text&.delete('"')
+      size = element.at_xpath("xmlns:Size")&.text&.to_i
+      owner = element.at_xpath("xmlns:Owner")
+      owner_id = owner&.at_xpath("xmlns:ID")&.text
+      owner_name = owner&.at_xpath("xmlns:DisplayName")&.text
+
+      metadata = {}
+      element.xpath("xmlns:UserMetadata").each do |child|
+        key = child.name.split("}").last
+        metadata[key] = child.text
+      end
+
+      key = element.at_xpath("xmlns:Key").text
+      key = CGI.unescape(key) if encoding_type == "url"
+
+      new(bucket_name, key, last_modified: last_modified, etag: etag, size: size,
+        version_id: element.at_xpath("xmlns:VersionId")&.text,
+        is_latest: element.at_xpath("xmlns:IsLatest")&.text,
+        storage_class: element.at_xpath("xmlns:StorageClass")&.text,
+        owner_id: owner_id, owner_name: owner_name, metadata: metadata,
+        is_delete_marker: is_delete_marker)
+    end
+  end
+end

--- a/lib/minio/crypto.rb
+++ b/lib/minio/crypto.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "openssl"
+require "securerandom"
+require "argon2/kdf"
+
+NONCE_LEN = 8
+SALT_LEN = 32
+
+class Minio::Crypto
+  class AesGcmCipherProvider
+    def self.get_cipher(key, nonce, encrypt: false)
+      OpenSSL::Cipher.new("aes-256-gcm").tap do |cipher|
+        if encrypt
+          cipher.encrypt
+        else
+          cipher.decrypt
+        end
+        cipher.key = key
+        cipher.iv = nonce
+      end
+    end
+  end
+
+  def encrypt(payload, password)
+    # Generate nonce and salt
+    nonce = SecureRandom.random_bytes(NONCE_LEN)
+    salt = SecureRandom.random_bytes(SALT_LEN)
+
+    # Generate the key using Argon2
+    key = generate_key(password, salt)
+
+    # Prepare the padded nonce
+    padded_nonce = Array.new(NONCE_LEN + 4, 0)
+    nonce.bytes.each_with_index { |byte, index| padded_nonce[index] = byte }
+
+    # Select cipher provider and create cipher
+    cipher_provider = AesGcmCipherProvider
+
+    # Generate additional data
+    add_data = generate_additional_data(cipher_provider, key, padded_nonce.pack("C*"))
+
+    padded_nonce[8] = 1
+    cipher = cipher_provider.get_cipher(key, padded_nonce.pack("C*"), encrypt: true)
+    cipher.auth_data = add_data
+
+    # Encrypt the payload
+    encrypted_data = cipher.update(payload) + cipher.final
+    mac = cipher.auth_tag
+
+    # Construct the final encrypted payload
+    salt + [0].pack("C") + nonce + encrypted_data + mac
+  end
+
+  def decrypt(payload, password)
+    pos = 0
+    salt = payload.byteslice(pos, SALT_LEN)
+    pos += SALT_LEN
+
+    cipher_id = payload.byteslice(pos).ord
+    pos += 1
+
+    raise "Unsupported cipher ID: #{cipher_id}" unless cipher_id.zero?
+    cipher_provider = AesGcmCipherProvider
+
+    nonce = payload.byteslice(pos, NONCE_LEN)
+
+    pos += NONCE_LEN
+
+    encrypted_data = payload.byteslice(pos...-16)
+    hmac_tag = payload.byteslice(-16, 16)
+
+    key = generate_key(password, salt)
+
+    # looks like NONCE should have 12 bytes but MinIO uses 8 bytes
+    padded_nonce = Array.new(12, 0)
+    nonce.bytes.each_with_index { |byte, index| padded_nonce[index] = byte }
+    add_data = generate_additional_data(cipher_provider, key, padded_nonce.pack("C*"))
+    padded_nonce[8] = 1
+
+    cipher = cipher_provider.get_cipher(key, padded_nonce.pack("C*"))
+    cipher.auth_tag = hmac_tag
+    cipher.auth_data = add_data
+
+    cipher.update(encrypted_data) + cipher.final
+  end
+
+  def generate_key(password, salt)
+    Argon2::KDF.argon2id(password.encode, salt: salt, t: 1, m: 16, p: 4, length: 32)
+  end
+
+  def generate_additional_data(cipher_provider, key, padded_nonce)
+    # Initialize the cipher with the provided key and nonce
+    cipher = cipher_provider.get_cipher(key, padded_nonce, encrypt: true)
+
+    # In Ruby, for AES-GCM, the tag is generated after finalizing the encryption
+    # For this function, we'll perform a dummy encryption to generate the tag
+    cipher.auth_data = ""
+    cipher.update("") << cipher.final
+
+    # Construct the new tag array
+    new_tag = [0x80] + cipher.auth_tag.bytes
+
+    # Return the new tag array as a byte string
+    new_tag.pack("C*")
+  end
+end

--- a/lib/minio/header_signer.rb
+++ b/lib/minio/header_signer.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "digest"
+require "openssl"
+
+# This is a ruby implementation of the AWS Signature Version 4 signing process.
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html
+# This algorithm uses secret_key, date and the region to create a signing key.
+# This signing key is then used to sign the request header payload that contains
+# the request method, uri, headers, date and region. The signature is then
+# added to the Authorization header of the request.
+# As a result, we get an authorization header that is valid only until server
+# time is within the acceptable time range. According to the MinIO source code,
+# the acceptable time range is 15 minutes.
+# https://github.com/minio/minio/blob/7926df0b80f557d0160153c5156b9b6d6b12b42e/cmd/globals.go#L93
+class Minio::HeaderSigner
+  SERVICE_NAME = "s3"
+  def build_headers(method, uri, body, creds, region)
+    @headers = {}
+    @date = Time.now.utc
+    @headers["Host"] = uri.host + ":" + uri.port.to_s
+    @headers["User-Agent"] = "MinIO Ubicloud"
+    @headers["Content-Type"] = "application/octet-stream"
+    @headers["x-amz-content-sha256"] = sha256_hash(body)
+    @headers["x-amz-date"] = @date.strftime("%Y%m%dT%H%M%SZ")
+    @headers["Content-Length"] = body.length.to_s if body
+    sign_v4_s3(method, uri, region, creds)
+  end
+
+  def sign_v4_s3(method, uri, region, credentials)
+    scope = get_scope(@date, region)
+    canonical_request_hash, signed_headers = get_canonical_request_hash(method, uri, @headers)
+    string_to_sign = get_string_to_sign(@date, scope, canonical_request_hash)
+    signing_key = get_signing_key(credentials[:secret_key], @date, region)
+    signature = hmac_hash(signing_key, string_to_sign.encode("UTF-8"), true)
+    authorization = get_authorization(credentials[:access_key], scope, signed_headers, signature)
+    @headers["Authorization"] = authorization
+
+    @headers
+  end
+
+  private
+
+  def get_authorization(access_key, scope, signed_headers, signature)
+    "AWS4-HMAC-SHA256 Credential=#{access_key}/#{scope}, SignedHeaders=#{signed_headers}, Signature=#{signature}"
+  end
+
+  def get_signing_key(secret_key, date, region)
+    date_key = hmac_hash("AWS4#{secret_key}", date.strftime("%Y%m%d"))
+    date_region_key = hmac_hash(date_key, region)
+    date_region_service_key = hmac_hash(date_region_key, SERVICE_NAME)
+    hmac_hash(date_region_service_key, "aws4_request")
+  end
+
+  def get_string_to_sign(date, scope, canonical_request_hash)
+    "AWS4-HMAC-SHA256\n#{date.strftime("%Y%m%dT%H%M%SZ")}\n#{scope}\n#{canonical_request_hash}"
+  end
+
+  def get_canonical_request_hash(method, uri, headers)
+    canonical_headers, signed_headers = get_canonical_headers(headers)
+    canonical_query_string = get_canonical_query_string(uri.query)
+
+    canonical_request = [
+      method,
+      uri.path,
+      canonical_query_string,
+      canonical_headers,
+      "",
+      signed_headers,
+      headers["x-amz-content-sha256"]
+    ].join("\n")
+
+    [sha256_hash(canonical_request), signed_headers]
+  end
+
+  def get_canonical_query_string(query)
+    query ||= ""
+    pairs = query.split("&").map { |param| param.split("=") }
+    pairs.sort.map { |key, value| "#{key}=#{value}" }.join("&")
+  end
+
+  def get_canonical_headers(headers)
+    canonical_headers = {}
+    headers.each do |key, value|
+      key = key.downcase
+      next if (key == "authorization") || (key == "user-agent")
+      value = value.gsub(/\s+/, " ")
+      canonical_headers[key] = value
+    end
+    canonical_headers = canonical_headers.sort.to_h
+    signed_headers = canonical_headers.keys.join(";")
+    headers_string = canonical_headers.map { |k, v| "#{k}:#{v}" }.join("\n")
+    [headers_string, signed_headers]
+  end
+
+  def get_scope(date, region)
+    "#{date.strftime("%Y%m%d")}/#{region}/#{SERVICE_NAME}/aws4_request"
+  end
+
+  def sha256_hash(data)
+    # Ensure data is not nil, default to an empty string if it is
+    data ||= ""
+    # Compute SHA-256 hash
+    Digest::SHA256.hexdigest(data)
+  end
+
+  def hmac_hash(key, data, hexdigest = false)
+    digest = OpenSSL::Digest.new("sha256")
+    hmac = OpenSSL::HMAC.digest(digest, key, data)
+    hexdigest ? hmac.unpack1("H*") : hmac
+  end
+end

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -5,6 +5,38 @@ RSpec.describe Minio::Client do
   let(:access_key) { "minioadmin" }
   let(:secret_key) { "minioadmin" }
 
+  describe "admin_info" do
+    it "sends a GET request to /minio/admin/v3/info" do
+      stub_request(:get, "#{endpoint}/minio/admin/v3/info").to_return(status: 200, body: "test")
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_info.data[:body]).to eq("test")
+    end
+  end
+
+
+  describe "admin_policy_list" do
+    it "sends a GET request to /minio/admin/v3/list-canned-policies" do
+      stub_request(:get, "#{endpoint}/minio/admin/v3/list-canned-policies").to_return(status: 200, body: "test")
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_policy_list.data[:body]).to eq("test")
+    end
+  end
+
+  describe "admin_policy_add" do
+    it "sends a PUT request to /minio/admin/v3/add-canned-policy" do
+      stub_request(:put, "#{endpoint}/minio/admin/v3/add-canned-policy?name=test").to_return(status: 200)
+      policy = {"Version" => "2012-10-17", "Statement" => [{"Action" => ["s3:GetBucketLocation"], "Effect" => "Allow", "Principal" => {"AWS" => ["*"]}, "Resource" => ["arn:aws:s3:::test"], "Sid" => ""}]}
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_policy_add("test", policy)).to eq(200)
+    end
+  end
+
+  describe "admin_policy_info" do
+    it "sends a GET request to /minio/admin/v3/info-canned-policy" do
+      stub_request(:get, "#{endpoint}/minio/admin/v3/info-canned-policy?name=test").to_return(status: 200, body: "test")
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_policy_info("test").data[:body]).to eq("test")
+    end
+  end
 
   describe "put_bucket" do
     it "sends a PUT request to /bucket_name" do

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe Minio::Client do
+  let(:endpoint) { "http://localhost:9000" }
+  let(:access_key) { "minioadmin" }
+  let(:secret_key) { "minioadmin" }
+
+
+  describe "put_bucket" do
+    it "sends a PUT request to /bucket_name" do
+      stub_request(:put, "#{endpoint}/test").to_return(status: 200)
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).create_bucket("test")).to eq(200)
+    end
+  end
+
+  describe "delete_bucket" do
+    it "sends a DELETE request to /bucket_name" do
+      stub_request(:delete, "#{endpoint}/test").to_return(status: 200)
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).delete_bucket("test")).to eq(200)
+    end
+  end
+
+  describe "bucket_exists?" do
+    it "sends a GET request to /bucket_name" do
+      stub_request(:get, "#{endpoint}/test").to_return(status: 200)
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).bucket_exists?("test")).to be(true)
+    end
+
+    it "returns false if the bucket does not exist" do
+      stub_request(:get, "#{endpoint}/test").to_return(status: 404)
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).bucket_exists?("test")).to be(false)
+    end
+  end
+
+  describe "list_objects" do
+    let(:xml_with_continuation_token) do
+      <<~XML
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>vers</Name>
+  <Prefix>Screenshot</Prefix>
+  <NextContinuationToken>ct</NextContinuationToken>
+  <KeyCount>1</KeyCount>
+  <MaxKeys>1</MaxKeys>
+  <IsTruncated>true</IsTruncated>
+  <Contents>
+    <Key>name1</Key>
+    <ETag>&#34;49fda56ffd02844cd6c10effc3a69375&#34;</ETag>
+    <StorageClass>STANDARD</StorageClass>
+    <UserMetadata>
+      <content-type>image/png</content-type>
+      <x-amz-object-lock-mode>COMPLIANCE</x-amz-object-lock-mode>
+      <x-amz-object-lock-retain-until-date>2023-12-02T10:46:35.273Z</x-amz-object-lock-retain-until-date>
+    </UserMetadata>
+  </Contents>
+  <EncodingType>url</EncodingType>
+</ListBucketResult>
+      XML
+    end
+
+    let(:xml_without_continuation_token) do
+      <<~XML
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>vers</Name>
+  <Prefix>Screenshot</Prefix>
+  <KeyCount>1</KeyCount>
+  <MaxKeys>1</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>name2</Key>
+    <LastModified>2023-12-01T10:46:32.832Z</LastModified>
+    <Size>1144893</Size>
+    <Owner>
+      <ID>minioadmin</ID>
+      <DisplayName>minioadmin</DisplayName>
+    </Owner>
+    <VersionId>1</VersionId>
+    <IsLatest>true</IsLatest>
+  </Contents>
+</ListBucketResult>
+      XML
+    end
+
+    it "properly lists objects with or without continuation-token" do
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1").to_return(status: 200, body: xml_with_continuation_token)
+      stub_request(:get, "#{endpoint}/test?continuation-token=ct&delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1&start-after=ct").to_return(status: 200, body: xml_without_continuation_token)
+      mc = described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key)
+      expect(mc.list_objects("test", "folder_path", max_keys: 1).map(&:key)).to eq(["name1", "name2"])
+    end
+  end
+end

--- a/spec/lib/minio/crypto_spec.rb
+++ b/spec/lib/minio/crypto_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "base64"
+RSpec.describe Minio::Crypto do
+  describe "encrypt" do
+    it "can encrypt a payload" do
+      expect(SecureRandom).to receive(:random_bytes).with(8).and_return("noncenon")
+      expect(SecureRandom).to receive(:random_bytes).with(32).and_return("saltsaltsaltsaltsaltsaltsaltsalt")
+      payload = "test"
+      password = "password"
+      expect(Base64.encode64(described_class.new.encrypt(payload, password))).to eq("c2FsdHNhbHRzYWx0c2FsdHNhbHRzYWx0c2FsdHNhbHQAbm9uY2Vub24Q8NnE\ng9RvKzKmwFclyEJrPFFKJA==\n")
+    end
+  end
+
+  describe "decrypt" do
+    it "can decrypt a payload" do
+      payload = "c2FsdHNhbHRzYWx0c2FsdHNhbHRzYWx0c2FsdHNhbHQAbm9uY2Vub24Q8NnE\ng9RvKzKmwFclyEJrPFFKJA==\n"
+      password = "password"
+      expect(described_class.new.decrypt(Base64.decode64(payload), password)).to eq("test")
+    end
+
+    it "fails if cipher is not known" do
+      payload = "111111111111111111111111111111111111111111111111111111111111\ng9RvKzKmwFclyEJrPFFKJA==\n"
+      password = "password"
+      expect {
+        described_class.new.decrypt(Base64.decode64(payload), password)
+      }.to raise_error RuntimeError, "Unsupported cipher ID: 117"
+    end
+  end
+end

--- a/spec/lib/minio/header_signer_spec.rb
+++ b/spec/lib/minio/header_signer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Minio::HeaderSigner do
+  let(:headers) {
+    {
+      "Authorization" => "AWS4-HMAC-SHA256 Credential=access_key/20231130/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=981fdbca705978113820de8f327062a9c20c1c9b6ecf3010f3124da3c95c450d",
+      "Content-Length" => "4",
+      "Content-Type" => "application/octet-stream",
+      "Host" => "localhost:9000",
+      "User-Agent" => "MinIO Ubicloud",
+      "x-amz-content-sha256" => "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      "x-amz-date" => "20231130T144358Z"
+    }
+  }
+
+  describe "build_headers" do
+    it "can build headers and sign" do
+      method = "PUT"
+      uri = URI.parse("http://localhost:9000/test")
+      body = "test"
+      allow(Time).to receive(:now).and_return(Time.new("2023-11-30 15:43:58.612009 +0100"))
+      expect(described_class.new.build_headers(method, uri, body, {access_key: "access_key", secret_key: "secret_key"}, "us-east-1")).to eq(headers)
+    end
+  end
+end


### PR DESCRIPTION
### MinIO Client for regular S3 operations 
This part of the SDK implements regular S3 operations. As a full S3
compatible service, MinIO, our request headers should be signed
following S3's directives. It is explained in detail, here;
https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html

Using the access_key, secret_key, date we sign the header, and some
other fields necessary to generate a hash in another hash, we create an
authentication string. Using that in the header, we are able to
introduce ourselves to the server for a short while (until the date is
in the range that server accepts the token).

Furthermore, this commit comes with some basic API implementation, which
are;
1. `create_bucket(bucket_name)`
2. `delete_bucket(bucket_name)`
3. `bucket_exists?(bucket_name)`
4. `list_objects(bucket_name, folder_path, max_keys: 1000)`

The only not simple one is the list_objects API since it implements
pagination on the server side which also requires us to solve it on the
client side. MinIO sends a continuation_token in the respond list that
we can use to fetch the items after the last item that we already got.
For now, we are not implementing the iterator object return but simply
collect all of the items since Postgres usecase will never return more
than 1000 backups for a specific bucket.

### MinIO Client for regular MinIO Admin operations
These APIs are simple MinIO Admin operations that are available as long
as the client is someone with admin privileges. We can simply make use
of these APIs by using the admin path and sign the headers the same way
we do for any S3 request. The implemented endpoints are;
1. `admin_info`: gives information about the cluster in general. The
health status of nodes, drives, everything.
2. `admin_policy_list`: lists all of the policies created in the system
3. `admin_policy_add(policy_name, policy)`: creates the requested policy
that is passed in a regular hash form. An example policy is the
following;
```
{
  "Version" => "2012-10-17",
  "Statement" => [
    {
      "Action" => ["s3:GetBucketLocation"],
      "Effect" => "Allow",
      "Principal" => {
        "AWS" => ["*"]
      },
      "Resource" => ["arn:aws:s3:::test"], "Sid" => ""
    }
  ]
}
```
4. `admin_policy_info(policy_name)`: fetches information regarding the
policy stated with the policy_name.

### MinIO Client for encrypted Admin operations
This commit implements a MinIO specific request encryption/decryption
logic. It is not documented, nor listed anywhere except the oficially
supported SDKs (Python, GO) use these. Therefore, the logic is reverse
engineered from the existing SDKs (https://github.com/minio/minio-py,
https://github.com/minio/madmin-go/tree/main)

Figuring out request body encrypt/decrypt operation by reading other
source code without proper documentation was painful. So, here is my
understanding on how they perform encryption. The decryption is
simply doing the same thing but decrypting instead of encrypting.
1. First 32 bytes of a request body is SALT. That is a set of random
bytes to use together with the secret key to encrypt the data.
2. Next 8 bytes of a request body is NONCE. These are again random bytes
used to encrypt the request body and extra bytes from NONCE because
NONCE should be 12 bytes in Argon but we use only 8 for MinIO.
3. Next bytes until the last 16th byte is the request body in encrypted
form using AesGcmCipherProvider
4. Last 16 bytes are what is called as hmac_tag that is generated by the
full length of nonce (12 bytes) in encrypted form.

This commit comes with 2 API implementation that makes use of both
encrypt and decrypt functionality;
1. `admin_list_users`: lists users and some of their properties. The
response is sent in encrypted form from the server, therefore, we
decrypt it using the credentials and the algorith explained above.
2. `admin_add_user`: adds a new user to the system with access_key and
secret_key. Since keys must not leak outside of the system, the request
body is encrypted using the client user secret_key and the algorithm
explained above.