### PR TITLE
Add Github Storage Policy for gradual bdev_ubi rollout.

### DIFF
--- a/lib/github_storage_policy.rb
+++ b/lib/github_storage_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class GithubStoragePolicy
+  def initialize(rules)
+    @rules = rules || {}
+  end
+
+  def use_bdev_ubi?
+    rand < @rules.fetch("use_bdev_ubi_rate", 0.0)
+  end
+
+  def skip_sync?
+    rand < @rules.fetch("skip_sync_rate", 0.0)
+  end
+end

--- a/model/project.rb
+++ b/model/project.rb
@@ -72,5 +72,5 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :enable_postgres
+  feature_flag :enable_postgres, :github_storage_policy
 end

--- a/spec/lib/github_storage_policy_spec.rb
+++ b/spec/lib/github_storage_policy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe GithubStoragePolicy do
+  subject(:sp) {
+    described_class.new({
+      "github_installation_name" => "A",
+      "use_bdev_ubi_rate" => 0.2,
+      "skip_sync_rate" => 0.8,
+      "encrypted_rate" => 0.5
+    })
+  }
+
+  describe "#use_bdev_ubi?" do
+    it "returns true with the expected rate" do
+      expect(sp).to receive(:rand).and_return(0.15)
+      expect(sp.use_bdev_ubi?).to be(true)
+    end
+
+    it "returns false with the expected rate" do
+      expect(sp).to receive(:rand).and_return(0.55)
+      expect(sp.use_bdev_ubi?).to be(false)
+    end
+  end
+
+  describe "#skip_sync?" do
+    it "returns true with the expected rate" do
+      expect(sp).to receive(:rand).and_return(0.75)
+      expect(sp.skip_sync?).to be(true)
+    end
+
+    it "returns false with the expected rate" do
+      expect(sp).to receive(:rand).and_return(0.9)
+      expect(sp.skip_sync?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Enables rolling out `bdev_ubi` gradually by adding a feature flag for each Github installation.

After making sure some of the hosts have a bdev_ubi enabled SPDK installed (See #918 for instructions), you can do:

```
> installation.project.set_github_storage_policy({
         use_bdev_ubi_rate: 0.2,
         skip_sync_rate: 1.0
})
```

Then for this github installation, bdev_ubi will be enabled 20% of time, skip_sync will always be enabled, and encrypted will never be enabled.
