### PR TITLE
Remove extra space at the top of auth page

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -195,6 +195,10 @@ class CloverWeb < Roda
     require_bcrypt? false
   end
 
+  def csrf_tag(*)
+    "<input type=\"hidden\" name=\"#{csrf_field}\" value=\"#{csrf_token(*)}\" hidden/>"
+  end
+
   def redirect_back_with_inputs
     flash["old"] = request.params
     request.redirect env["HTTP_REFERER"]

--- a/views/auth/reset_password_request.erb
+++ b/views/auth/reset_password_request.erb
@@ -5,7 +5,9 @@
 <form action="<%= rodauth.reset_password_request_path %>" class="rodauth space-y-6" role="form" method="POST">
   <%== rodauth.csrf_tag(rodauth.reset_password_request_path) %>
 
-  <p class="leading-6 text-sm"><%== rodauth.reset_password_explanatory_text %></p>
+  <div>
+    <p class="leading-6 text-sm"><%== rodauth.reset_password_explanatory_text %></p>
+  </div>
 
   <%== render(
     "components/form/text",

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -53,9 +53,7 @@
 
         <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
           <div class="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10">
-            <div class="pt-4">
-              <%== render("components/flash_message") %>
-            </div>
+            <div class="pt-4 empty:hidden"><%== render("components/flash_message") %></div>
             <%== yield %>
           </div>
         </div>


### PR DESCRIPTION
Our auth pages have an unwanted space at the top, originating from two different sources.

1. The `flash_message` component displayed with `pt-4` on the auth pages. `pt-4` adds padding to the top even when there's no flash message. The `empty:hidden` class hides the div if it contains no content.

2. The `space-y-6` class is used to create space between form components. We have a hidden `csrf_tag` at the all forms. The `space-y-6` adds space even between hidden components. However, it doesn't add space if the element has a 'hidden' attribute [^1]. I have overwritten Roda's default `csrf_tag` method [^2] to address this.

(1) red space, (2) blue space
<img width="1447" alt="Screenshot 2023-11-29 at 00 19 49" src="https://github.com/ubicloud/ubicloud/assets/993199/5d5e3da2-fab6-4b24-bb82-9a0d3f7fc682">

[^1]: https://github.com/tailwindlabs/tailwindcss/issues/3112#issuecomment-747147443
[^2]: https://github.com/jeremyevans/roda/blob/6eddd39e890f3be5206abd9410fc485b84143fb8/lib/roda/plugins/route_csrf.rb#L257

