### PR TITLE
Enable multiqueue tap

### DIFF
--- a/rhizome/host/bin/recreate-unpersisted
+++ b/rhizome/host/bin/recreate-unpersisted
@@ -48,6 +48,11 @@ unless (mem_gib = params["mem_gib"])
   exit 1
 end
 
+unless (max_vcpus = params["max_vcpus"])
+  puts "need max_vcpus in parameters json"
+  exit 1
+end
+
 ndp_needed = params.fetch("ndp_needed", false)
 
 unless (storage_volumes = params["storage_volumes"])
@@ -60,5 +65,6 @@ require_relative "../lib/vm_setup"
 nics = nics_arr.map { |args| VmSetup::Nic.new(*args) }.freeze
 VmSetup.new(vm_name).recreate_unpersisted(
   gua, ip4, local_ip4, nics, mem_gib,
-  ndp_needed, storage_volumes, storage_secrets
+  ndp_needed, storage_volumes, storage_secrets,
+  multiqueue: max_vcpus > 1
 )

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -141,7 +141,7 @@ class VmSetup
     # result is a race condition that *sometimes* worked.
     r "ip link add vetho#{q_vm} addr #{gen_mac.shellescape} type veth peer name vethi#{q_vm} addr #{gen_mac.shellescape} netns #{q_vm}"
     nics.each do |nic|
-      r "ip -n #{q_vm} tuntap add dev #{nic.tap} mode tap user #{q_vm}"
+      r "ip -n #{q_vm} tuntap add dev #{nic.tap} mode tap user #{q_vm} multi_queue vnet_hdr"
     end
   rescue CommandFail => ex
     errors = [
@@ -547,7 +547,7 @@ DNSMASQ_SERVICE
     spdk_after = spdk_services.map { |s| "After=#{s}" }.join("\n")
     spdk_requires = spdk_services.map { |s| "Requires=#{s}" }.join("\n")
 
-    net_params = nics.map { "--net mac=#{_1.mac},tap=#{_1.tap},ip=,mask=" }
+    net_params = nics.map { "--net mac=#{_1.mac},tap=#{_1.tap},ip=,mask=,num_queues=#{max_vcpus * 2 + 1}" }
 
     # YYY: Do something about systemd escaping, i.e. research the
     # rules and write a routine for it.  Banning suspicious strings

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -44,7 +44,7 @@ class VmSetup
   end
 
   def prep(unix_user, public_key, nics, gua, ip4, local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_volumes, storage_secrets)
-    setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed)
+    setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
     cloudinit(unix_user, public_key, nics)
     download_boot_image(boot_image)
     storage_params = storage(storage_volumes, storage_secrets, true)
@@ -52,13 +52,13 @@ class VmSetup
     install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics)
   end
 
-  def recreate_unpersisted(gua, ip4, local_ip4, nics, mem_gib, ndp_needed, storage_params, storage_secrets)
-    setup_networking(true, gua, ip4, local_ip4, nics, ndp_needed)
+  def recreate_unpersisted(gua, ip4, local_ip4, nics, mem_gib, ndp_needed, storage_params, storage_secrets, multiqueue:)
+    setup_networking(true, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: multiqueue)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
   end
 
-  def setup_networking(skip_persisted, gua, ip4, local_ip4, nics, ndp_needed)
+  def setup_networking(skip_persisted, gua, ip4, local_ip4, nics, ndp_needed, multiqueue:)
     ip4 = nil if ip4.empty?
     guest_ephemeral, clover_ephemeral = subdivide_network(NetAddr.parse_net(gua))
 
@@ -75,7 +75,7 @@ class VmSetup
       end
     end
 
-    interfaces(nics)
+    interfaces(nics, multiqueue)
     setup_veths_6(guest_ephemeral, clover_ephemeral, gua, ndp_needed)
     setup_taps_6(gua, nics)
     routes4(ip4, local_ip4, nics)
@@ -130,7 +130,7 @@ class VmSetup
     r "mount -t hugetlbfs -o uid=#{q_vm},size=#{mem_gib}G nodev #{vp.q_hugepages}"
   end
 
-  def interfaces(nics)
+  def interfaces(nics, multiqueue)
     r "ip netns add #{q_vm}"
 
     # Generate MAC addresses rather than letting Linux do it to avoid
@@ -140,8 +140,9 @@ class VmSetup
     # /sys/class/net/vethi#{q_vm}/address at two points in time.  The
     # result is a race condition that *sometimes* worked.
     r "ip link add vetho#{q_vm} addr #{gen_mac.shellescape} type veth peer name vethi#{q_vm} addr #{gen_mac.shellescape} netns #{q_vm}"
+    multiqueue_fragment = multiqueue ? " multi_queue vnet_hdr " : " "
     nics.each do |nic|
-      r "ip -n #{q_vm} tuntap add dev #{nic.tap} mode tap user #{q_vm} multi_queue vnet_hdr"
+      r "ip -n #{q_vm} tuntap add dev #{nic.tap} mode tap user #{q_vm} #{multiqueue_fragment}"
     end
   rescue CommandFail => ex
     errors = [

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe VmSetup do
       clover_ephemeral = NetAddr.parse_net("fddf:53d2:4c89:2305:8000::/65")
       ip4 = "192.168.1.100"
 
-      expect(vs).to receive(:interfaces).with([])
+      expect(vs).to receive(:interfaces).with([], true)
       expect(vs).to receive(:setup_veths_6) {
         expect(_1.to_s).to eq(guest_ephemeral.to_s)
         expect(_2.to_s).to eq(clover_ephemeral.to_s)
@@ -230,19 +230,19 @@ RSpec.describe VmSetup do
       expect(vps).to receive(:write_guest_ephemeral).with(guest_ephemeral.to_s)
       expect(vps).to receive(:write_clover_ephemeral).with(clover_ephemeral.to_s)
 
-      vs.setup_networking(false, gua, ip4, "local_ip4", [], false)
+      vs.setup_networking(false, gua, ip4, "local_ip4", [], false, multiqueue: true)
     end
 
     it "can setup networking for empty ip4" do
       gua = "fddf:53d2:4c89:2305:46a0::"
-      expect(vs).to receive(:interfaces).with([])
+      expect(vs).to receive(:interfaces).with([], false)
       expect(vs).to receive(:setup_veths_6)
       expect(vs).to receive(:setup_taps_6).with(gua, [])
       expect(vs).to receive(:routes4).with(nil, "local_ip4", [])
       expect(vs).to receive(:forwarding)
       expect(vs).to receive(:write_nftables_conf)
 
-      vs.setup_networking(true, gua, "", "local_ip4", [], false)
+      vs.setup_networking(true, gua, "", "local_ip4", [], false, multiqueue: false)
     end
 
     it "can generate nftables config" do


### PR DESCRIPTION
While benchmarking, we have encountered bottlenecks in network queue processing.  Scouring the web, we see that a common configuration is to increase the number of queues, and thus the number of cloud-hypervisor queue-pair threads, and thus the number of processors that can be used to move ethernet frames around.

Easy enough: add some tap options, and this works if vcpus>=2.  If you have eight vcpus, allocate 16 + 1 queues, which form eight pairs and one control queue.

Note that this is the maximum, in the above example, allocating eighteen queues is rejected by cloud-hypervisor complaining about insufficient vcpus to have a point.

But, why vcpus >= 2? My patch doesn't work for arm64 with one core. On x64 with SMT, vcpus is always two or greater, since we allocate core-wise.  You can simulate the fault by making a one-vcpu x64 computer out-of-band.

The reason is an an obscure conflict with how we, uncustomary to cloud-hypervisor, do not add the net_admin capability to the cloud-hypervisor binary to let it manage tap devices.  Instead, we elect to create the tap out-of-band ourselves via rhizome.  For this to work, the tap rhizome creates must match what cloud-hypervisor needs exactly.

This has been trivial in event queues = 3, which is the minimum and the default: two are in a data-exchanging pair, and one is the control.  In this case, the simplest tap device definition, the one we've been always up through now, is always used.

But, if and only if num_queues is specified, and greater than 3, the tap must have the vnet_hdr and multiqueue options.  This couples the tap definition to how CPUs are configured, and rhizome is not organized to do that.

So, I wrote this long message because it's the end of my day, but perhaps someone can pick it up in Europe, and we can squeak out a bit of time compression on the overall project.  To take advantage of multiple queues, rhizome will have to be reorganized a little bit, or we have to concede to giving cloud-hypervisor the net-admin capability.  Although ungratfiying, the space of options on tap is pretty short and slow-moving, so I am inclined to add complications to create the taps just right.