### PR TITLE
Switch to simpler up-check

### DIFF
--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe Prog::Vm::Nexus do
   describe "#wait_sshable" do
     it "naps if not sshable" do
       expect(vm).to receive(:ephemeral_net4).and_return("10.0.0.1")
-      expect(nx).to receive(:`).with("ssh -o BatchMode=yes -o ConnectTimeout=1 -o PreferredAuthentications=none user@10.0.0.1 2>&1").and_return("")
+      expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 5).and_raise Errno::ECONNREFUSED
       expect { nx.wait_sshable }.to nap(1)
     end
 
@@ -483,7 +483,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhhqmsyfvzpy2q9gqb5h0mpde2"))
       vm_addr = instance_double(AssignedVmAddress, id: "46ca6ded-b056-4723-bd91-612959f52f6f", ip: NetAddr::IPv4Net.parse("10.0.0.1"))
       expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)
-      expect(nx).to receive(:`).with("ssh -o BatchMode=yes -o ConnectTimeout=1 -o PreferredAuthentications=none user@10.0.0.1 2>&1").and_return("Host key verification failed.")
+      expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 5)
       expect(vm).to receive(:update).with(display_state: "running").and_return(true)
       expect(Clog).to receive(:emit).with("vm provisioned").and_call_original
       expect { nx.wait_sshable }.to hop("create_billing_record")
@@ -493,7 +493,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:created_at).and_return(Time.now)
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhhqmsyfvzpy2q9gqb5h0mpde2"))
       expect(vm).to receive(:ephemeral_net6).and_return(NetAddr::IPv6Net.parse("2a01:4f8:10a:128b:3bfa::/79"))
-      expect(nx).to receive(:`).with("ssh -o BatchMode=yes -o ConnectTimeout=1 -o PreferredAuthentications=none user@2a01:4f8:10a:128b:3bfa::2 2>&1").and_return("Host key verification failed.")
+      expect(Socket).to receive(:tcp).with("2a01:4f8:10a:128b:3bfa::2", 22, connect_timeout: 5)
       expect(vm).to receive(:update).with(display_state: "running").and_return(true)
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end


### PR DESCRIPTION
The `ssh` program drags in too much possible environmental configuration that can conflict with our intended function here. Also, spawning a process here is wasteful.  For the purposes of this liveness check, opening a TCP connection, then closing it without transmitting anything, suffices.

Note that general presumption of port-22 accessibility on VMs is not sound, but that's a problem for another day.  The current strategy did help us identify the boot-hang seen in some Linux kernel versions with buggy tick code, so, it deserves some credit and can live on a little longer.