### PR TITLE
Use stdin rather than shell quoting for sending file contents

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -338,7 +338,7 @@ SQL
     host.sshable.cmd("sudo usermod -a -G kvm #{q_vm}")
 
     # put prep.json
-    host.sshable.cmd("echo #{params_json.shellescape} | sudo -u #{q_vm} tee #{params_path.shellescape}")
+    host.sshable.cmd("sudo -u #{q_vm} tee #{params_path.shellescape}", stdin: params_json)
 
     host.sshable.cmd("sudo host/bin/prepvm.rb #{params_path.shellescape}", stdin: secrets_json)
     hop_run

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -206,9 +206,9 @@ RSpec.describe Prog::Vm::Nexus do
         total_cpus: 80, total_cores: 80, total_sockets: 1, ndp_needed: false)
       expect(vm).to receive(:vm_host).and_return(vmh)
 
-      expect(sshable).to receive(:cmd).with(/echo (.|\n)* \| sudo -u vm[0-9a-z]+ tee/) do
+      expect(sshable).to receive(:cmd).with(/sudo -u vm[0-9a-z]+ tee/, stdin: String) do |**kwargs|
         require "json"
-        params = JSON(_1.shellsplit[1])
+        params = JSON(kwargs.fetch(:stdin))
         expect(params).to include({
           "public_ipv6" => "fe80::/64",
           "unix_user" => "test_user",


### PR DESCRIPTION
As-is, this results in a very large and kind of ugly shell-quoted JSON.  Using stdin cleans things up and makes it more idiomatic.

The previous code is doubly ancient, predating the Sshable#cmd `stdin` option, which explains why it was done that way, see dates on 25f33c606a114b385775224db3c97e565416dbc2,
d3cfd6f62db40e41eb73909a0db1a708bc2541be