### PR TITLE
Enable multiqueue tap

### DIFF
--- a/rhizome/host/bin/recreate-unpersisted
+++ b/rhizome/host/bin/recreate-unpersisted
@@ -48,6 +48,11 @@ unless (mem_gib = params["mem_gib"])
   exit 1
 end
 
+unless (max_vcpus = params["max_vcpus"])
+  puts "need max_vcpus in parameters json"
+  exit 1
+end
+
 ndp_needed = params.fetch("ndp_needed", false)
 
 unless (storage_volumes = params["storage_volumes"])
@@ -60,5 +65,6 @@ require_relative "../lib/vm_setup"
 nics = nics_arr.map { |args| VmSetup::Nic.new(*args) }.freeze
 VmSetup.new(vm_name).recreate_unpersisted(
   gua, ip4, local_ip4, nics, mem_gib,
-  ndp_needed, storage_volumes, storage_secrets
+  ndp_needed, storage_volumes, storage_secrets,
+  multiqueue: max_vcpus > 1
 )

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -155,11 +155,11 @@ RSpec.describe VmSetup do
 
   describe "#recreate_unpersisted" do
     it "can recreate unpersisted state" do
-      expect(vs).to receive(:setup_networking).with(true, "gua", "ip4", "local_ip4", "nics", false)
+      expect(vs).to receive(:setup_networking).with(true, "gua", "ip4", "local_ip4", "nics", false, multiqueue: true)
       expect(vs).to receive(:hugepages).with(4)
       expect(vs).to receive(:storage).with("storage_params", "storage_secrets", false)
 
-      vs.recreate_unpersisted("gua", "ip4", "local_ip4", "nics", 4, false, "storage_params", "storage_secrets")
+      vs.recreate_unpersisted("gua", "ip4", "local_ip4", "nics", 4, false, "storage_params", "storage_secrets", multiqueue: true)
     end
   end
 
@@ -215,7 +215,7 @@ RSpec.describe VmSetup do
       clover_ephemeral = NetAddr.parse_net("fddf:53d2:4c89:2305:8000::/65")
       ip4 = "192.168.1.100"
 
-      expect(vs).to receive(:interfaces).with([])
+      expect(vs).to receive(:interfaces).with([], true)
       expect(vs).to receive(:setup_veths_6) {
         expect(_1.to_s).to eq(guest_ephemeral.to_s)
         expect(_2.to_s).to eq(clover_ephemeral.to_s)
@@ -230,19 +230,19 @@ RSpec.describe VmSetup do
       expect(vps).to receive(:write_guest_ephemeral).with(guest_ephemeral.to_s)
       expect(vps).to receive(:write_clover_ephemeral).with(clover_ephemeral.to_s)
 
-      vs.setup_networking(false, gua, ip4, "local_ip4", [], false)
+      vs.setup_networking(false, gua, ip4, "local_ip4", [], false, multiqueue: true)
     end
 
     it "can setup networking for empty ip4" do
       gua = "fddf:53d2:4c89:2305:46a0::"
-      expect(vs).to receive(:interfaces).with([])
+      expect(vs).to receive(:interfaces).with([], false)
       expect(vs).to receive(:setup_veths_6)
       expect(vs).to receive(:setup_taps_6).with(gua, [])
       expect(vs).to receive(:routes4).with(nil, "local_ip4", [])
       expect(vs).to receive(:forwarding)
       expect(vs).to receive(:write_nftables_conf)
 
-      vs.setup_networking(true, gua, "", "local_ip4", [], false)
+      vs.setup_networking(true, gua, "", "local_ip4", [], false, multiqueue: false)
     end
 
     it "can generate nftables config" do


### PR DESCRIPTION
While benchmarking Postgres in a small-network-packet bottlenecked
manner, a colleague reports poor scalability after four cores.  A
draft version of this improved the benchmark throughput (`SELECT 1`)
by fourfold.

The immediate, and correct, suspicion was that one thread to emulate
the tap device is not enough.  Although a bit dense, I think this is
the best article I found about this subject:

https://blog.cloudflare.com/virtual-networking-101-understanding-tap/

There are a few practical things that took some time to figure out:

1. Each queue *pair* gets one process, and so does the control queue.
   `num_queues=3` results in the (slightly confusing, in nomenclature)
   non-multiqueue TAP arrangement, with a control queue and a single
   queue pair, which, if you are counting, is technically more than
   one queue also. Don't think about the nomenclature quite so hard.

   cloud-hypervisor rejects configurations that produce more device
   queue pair emulating threads than vcpus.  So, for example, an
   eight-vCPU VM can allocate 16 + 1 queues, and no more.

   When looking at the custom thread names in this example, there will
   be eight `netN_qpM` threads, where `N` is a PCI slot number and `M`
   is the queue pair number, in this case, from zero to seven, as well
   as the familiar `netN_ctrl` thread.

2. One of the odd things we do is not run `setcap` on the
   cloud-hypervisor binary to give it `NET_ADMIN` capability,
   preferring since prehistory (last February) to set up tap devices
   with `ip tuntap` ourselves.

   For this to work, the tap interface created must be exactl what
   cloud-hypervisor expects when performing its syscalls, or else
   you'll get a cryptic error like this:

        VmBoot(DeviceManager(CreateVirtioNet(OpenTap(TapOpen(ConfigureTap(Os { code: 22, kind: InvalidInput, message: "Invalid argument" }))))))

3. The `ip tuntap` command, in the right namespace, can be used to
   reflect the flags or lack thereof out to you:

        $ ip tuntap
        nc0qya21kt: tap vnet_hdr persist user 22398

4. The `multiqueue` and flag *cannot* be present when vCPUs = 1, there
   is only one queue pair process, in that case, cloud-hypervisor will
   crash. And if num_queues is set to > 3, it *must* be present.

   I handle the special case of vCPU = 1 through yet another brutal
   but mercifully short addition to the parameter list to make an
   exception for vCPU = 1, adding a new and unforeseen coupling
   between the vCPU configuration and the network configuration.

5. As all our x64 systems are SMT, and we sell in the minimum unit of
   a core, and thus vCPU is at least two on all x64 computers, no x64
   computer is affected by the special vCPU = 1 cut-out.

6. arm64 is affected for the smallest size, standard-2, which could be
   seen as confusing, as we use `cores * 2` indexing of our model
   numbers, regardless of SMT support, to make CPU endowments of x64
   and arm64 more comparable.  Personally, I think we should use cores
   for model numbering in this era where we're far more alert to
   security-relevant microarchitectural bugs, and arm64 without SMT is
   a going concern.  See 5be634bf82d282d89f6a1244d3eb6344d4ad4d8e

7. After this is deployed, all vCPU > 1 VMs must be checked such that
   their systemd units upgraded with num_queues=N, or they will become
   a ticking time bomb for the next time the host is restarted (rare)
   and `recreate-unpersisted` is run, since that will create
   multiqueue taps and the obsolete command line that omits
   `num_queues` will be incompatible with those.
