### PR TITLE
Drop obsolete vm_host.total_nodes column

### DIFF
--- a/migrate/20231129_delete_total_nodes.rb
+++ b/migrate/20231129_delete_total_nodes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      drop_column :total_nodes
+    end
+  end
+end


### PR DESCRIPTION
We think we haven't used total_nodes in a while, and recently have stopped writing data into the column, and after some time, should finally remove it.

See 146364aa1ebd5e10d360aa31005908e1eaa683be,
7427e66dc8cf092a486f46a5ef3be351e6136c7c