### PR TITLE
Check the backup before restore and add earliest/latest restore times to the PostgreSQL resource

### DIFF
--- a/migrate/20231130_postgres_earliest_backup.rb
+++ b/migrate/20231130_postgres_earliest_backup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:postgres_timeline) do
+      add_column :earliest_backup_completed_at, :timestamptz
+    end
+  end
+end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -53,7 +53,7 @@ PGHOST=/var/run/postgresql
 
   def last_backup_label_before_target(target:)
     backup = backups.sort_by(&:last_modified).reverse.find { _1.last_modified < target }
-    backup.key.delete_prefix("basebackups_005/").delete_suffix("_backup_stop_sentinel.json")
+    backup.key.delete_prefix("basebackups_005/").delete_suffix("_backup_stop_sentinel.json") if backup
   end
 
   def blob_storage

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -56,6 +56,29 @@ PGHOST=/var/run/postgresql
     backup.key.delete_prefix("basebackups_005/").delete_suffix("_backup_stop_sentinel.json") if backup
   end
 
+  def refresh_earliest_backup_completion_time
+    update(earliest_backup_completed_at: backups.map(&:last_modified).min)
+    earliest_backup_completed_at
+  end
+
+  # The "earliest_backup_completed_at" column is used to cache the value,
+  # eliminating the need to query the blob storage every time. The
+  # "earliest_backup_completed_at" value can be changed when a new backup is
+  # created or an existing backup is deleted. It's nil when the server is
+  # created, so we get it from the blob storage until the first backup
+  # completed. Currently, we lack a backup cleanup feature. Once it is
+  # implemented, we can invoke the "refresh_earliest_backup_completion_time"
+  # method at the appropriate points.
+  def earliest_restore_time
+    if (earliest_backup = (earliest_backup_completed_at || refresh_earliest_backup_completion_time))
+      earliest_backup + 5 * 60
+    end
+  end
+
+  def latest_restore_time
+    Time.now
+  end
+
   def blob_storage
     @blob_storage ||= Project[Config.postgres_service_project_id].minio_clusters.first
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -129,7 +129,9 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     when "Succeeded"
       hop_refresh_certificates
     when "Failed", "NotStarted"
-      backup_label = postgres_server.timeline.last_backup_label_before_target(target: postgres_server.resource.restore_target)
+      unless (backup_label = postgres_server.timeline.last_backup_label_before_target(target: postgres_server.resource.restore_target))
+        fail "BUG: no backup found"
+      end
       vm.sshable.cmd("common/bin/daemonizer 'sudo postgres/bin/initialize-database-from-backup #{backup_label}' initialize_database_from_backup")
     end
 

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -16,7 +16,7 @@ class CloverWeb
         response.status = 404
         r.halt
       end
-      @pg = serialize(pg)
+      @pg = serialize(pg, :detailed)
 
       r.get true do
         Authorization.authorize(@current_user.id, "Postgres:view", pg.id)

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -10,7 +10,7 @@ class CloverWeb
     @serializer = Serializers::Web::Postgres
 
     r.get true do
-      @postgres_databases = serialize(@project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).all)
+      @postgres_databases = serialize(@project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand, :server, :timeline).all)
 
       view "postgres/index"
     end

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -9,7 +9,6 @@ class Serializers::Web::Postgres < Serializers::Base
       name: pg.server_name,
       state: pg.display_state,
       location: pg.location,
-      connection_string: pg.connection_string,
       vm_size: pg.target_vm_size,
       storage_size_gib: pg.target_storage_size_gib
     }
@@ -17,5 +16,14 @@ class Serializers::Web::Postgres < Serializers::Base
 
   structure(:default) do |pg|
     base(pg)
+  end
+
+  structure(:detailed) do |pg|
+    base(pg).merge({
+      connection_string: pg.connection_string
+    }).merge(pg.server.primary? ? {
+      earliest_restore_time: pg.timeline.earliest_restore_time&.iso8601,
+      latest_restore_time: pg.timeline.latest_restore_time&.iso8601
+    } : {})
   end
 end

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -85,18 +85,27 @@ PGHOST=/var/run/postgresql
     end
   end
 
-  it "returns most recent backup before given target" do
-    stub_const("Backup", Struct.new(:last_modified))
-    most_recent_backup_time = Time.now
-    expect(postgres_timeline).to receive(:backups).and_return(
-      [
-        instance_double(Backup, key: "basebackups_005/0001_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 200),
-        instance_double(Backup, key: "basebackups_005/0002_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 100),
-        instance_double(Backup, key: "basebackups_005/0003_backup_stop_sentinel.json", last_modified: most_recent_backup_time)
-      ]
-    )
+  describe "#last_backup_label_before_target" do
+    it "returns most recent backup before given target" do
+      stub_const("Backup", Struct.new(:last_modified))
+      most_recent_backup_time = Time.now
+      expect(postgres_timeline).to receive(:backups).and_return(
+        [
+          instance_double(Backup, key: "basebackups_005/0001_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 200),
+          instance_double(Backup, key: "basebackups_005/0002_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 100),
+          instance_double(Backup, key: "basebackups_005/0003_backup_stop_sentinel.json", last_modified: most_recent_backup_time)
+        ]
+      )
 
-    expect(postgres_timeline.last_backup_label_before_target(target: most_recent_backup_time - 50)).to eq("0002")
+      expect(postgres_timeline.last_backup_label_before_target(target: most_recent_backup_time - 50)).to eq("0002")
+    end
+
+    it "returns nil if no backups before given target" do
+      stub_const("Backup", Struct.new(:last_modified))
+      expect(postgres_timeline).to receive(:backups).and_return([])
+
+      expect(postgres_timeline.last_backup_label_before_target(target: Time.now)).to be_nil
+    end
   end
 
   it "returns list of backups" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -243,6 +243,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check initialize_database_from_backup").and_return("Unknown")
       expect { nx.initialize_database_from_backup }.to nap(5)
     end
+
+    it "fails if the timeline has no backup" do
+      expect(postgres_server.resource).to receive(:restore_target).and_return(Time.now)
+      expect(postgres_server.timeline).to receive(:last_backup_label_before_target).and_return(nil)
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check initialize_database_from_backup").and_return("NotStarted")
+      expect { nx.initialize_database_from_backup }.to raise_error RuntimeError, "BUG: no backup found"
+    end
   end
 
   describe "#refresh_certificates" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -71,6 +71,9 @@ RSpec.describe Clover, "postgres" do
       login(user.email)
       project.set_enable_postgres(true)
       project_wo_permissions.set_enable_postgres(true)
+
+      client = instance_double(MinioClient, list_objects: [])
+      allow(MinioClient).to receive(:new).and_return(client)
     end
 
     describe "list" do

--- a/spec/serializers/web/postgres_spec.rb
+++ b/spec/serializers/web/postgres_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe Serializers::Web::Postgres do
+  let(:pg) { PostgresResource.new(server_name: "pg-server-name").tap { _1.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
+
+  it "can serialize when no earliest/latest restore times" do
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
+    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).twice
+    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).twice
+    data = described_class.new(:detailed).serialize(pg)
+    expect(data[:earliest_restore_time]).to be_nil
+    expect(data[:latest_restore_time]).to be_nil
+  end
+
+  it "can serialize when have earliest/latest restore times" do
+    time = Time.now
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
+    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).twice
+    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).twice
+    data = described_class.new(:detailed).serialize(pg)
+    expect(data[:earliest_restore_time]).to eq(time.iso8601)
+    expect(data[:latest_restore_time]).to eq(time.iso8601)
+  end
+
+  it "can serialize when not primary" do
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
+    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: false, vm: nil)).twice
+    data = described_class.new(:detailed).serialize(pg)
+    expect(data[:earliest_restore_time]).to be_nil
+    expect(data[:latest_restore_time]).to be_nil
+  end
+end


### PR DESCRIPTION
### Fail if no backup exists before the target restore time

Currently, if no backups are available before the target restore time, the `key.delete_prefix` method chain raises an exception. Normally, we should not allow to restore a database without a backup. However, if this occurs, let's display a more appropriate log.

### Add migration file to add earliest_backup_at to postgres

### Add earliest/latest restore time helpers to the pg timeline

We need to determine earliest/latest restore times to provide a specific time range for the user on the UI.

We don't allow to restore the destroyed databases for now. So the latest restore time is the current time.

The earliest restore time is little bit tricky. Determining the earliest restore time is straightforward; simply query the blob storage and select the oldest entry. However, we aim to avoid querying the blob storage service each time a user opens the page in the UI. The "earliest_backup_completed_at" column is used to cache the value, eliminating the need to query the blob storage every time. The "earliest_backup_completed_at" value can be changed when a new backup is created or an existing backup is deleted. It's nil when the server is created, so we get it from the blob storage until the first backup completed. Currently, we lack a backup cleanup feature.  Once it is implemented, we can invoke the "refresh_earliest_backup_completion_time" method at the appropriate points.

We return earliest/latest restore times only if the server is primary.