### PR TITLE
Add PostgreSQL database restore functionality to the UI

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,6 +4,7 @@ $(function() {
   setupLocationBasedOptions();
   setupAutoRefresh();
   setupPrint();
+  setupDatePicker();
 });
 
 $(".toggle-mobile-menu").on("click", function (event) {
@@ -186,7 +187,7 @@ function setupLocationBasedPrices() {
     let resource_family = Array.isArray($(this).data("resource-family")) ? $(this).data("resource-family") : [$(this).data("resource-family")];
     let amount = Array.isArray($(this).data("amount")) ? $(this).data("amount") : [$(this).data("amount")];
     let is_default = $(this).data("default");
-    
+
     let monthly = 0;
     for(var i = 0; i < resource_type.length; i++) {
       if (monthlyPrice = prices?.[resource_type[i]]?.[resource_family[i]]?.["monthly"]) {
@@ -227,5 +228,39 @@ function setupAutoRefresh() {
 function setupPrint() {
   $("div.print-page").each(function() {
     window.print();
+  });
+}
+
+function setupDatePicker() {
+  if (!$.prototype.flatpickr) { return; }
+
+  $(".datepicker").each(function() {
+    let options = {
+      enableTime: true,
+      time_24hr: true,
+      altInput: true,
+      altFormat: "F j, Y H:i \\U\\T\\C",
+      dateFormat: "Y-m-d H:i",
+      monthSelectorType: "static",
+      parseDate(dateStr, dateFormat) {
+        // flatpicker uses browser timezone, but we want to customer to select UTC
+        date = new Date(dateStr);
+        return new Date(date.getUTCFullYear(), date.getUTCMonth(),
+          date.getUTCDate(), date.getUTCHours(),
+          date.getUTCMinutes(), date.getUTCSeconds());
+      }
+    };
+
+    if ($(this).data("maxdate")) {
+      options.maxDate = $(this).data("maxdate");
+    }
+    if ($(this).data("mindate")) {
+      options.minDate = $(this).data("mindate");
+    }
+    if ($(this).data("defaultdate")) {
+      options.defaultDate = $(this).data("defaultdate");
+    }
+
+    $(this).flatpickr(options);
   });
 }

--- a/clover_web.rb
+++ b/clover_web.rb
@@ -17,10 +17,10 @@ class CloverWeb < Roda
 
   plugin :content_security_policy do |csp|
     csp.default_src :none
-    csp.style_src :self
+    csp.style_src :self, "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css"
     csp.img_src :self, "data: image/svg+xml"
     csp.form_action :self, "https://checkout.stripe.com"
-    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
+    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js", "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"
     csp.connect_src :self
     csp.base_uri :none
     csp.frame_ancestors :none

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 module Validation
   class ValidationFailed < StandardError
     attr_reader :errors
@@ -78,5 +80,14 @@ module Validation
       fail ValidationFailed.new({size: "\"#{size}\" is not a valid PostgreSQL database size. Available sizes: #{Option::PostgresSizes.map(&:name)}"})
     end
     postgres_size
+  end
+
+  def self.validate_date(date, param = "date")
+    # I use DateTime.parse instead of Time.parse because it uses UTC as default
+    # timezone but Time.parse uses local timezone
+    DateTime.parse(date.to_s).to_time
+  rescue ArgumentError
+    msg = "\"#{date}\" is not a valid date for \"#{param}\"."
+    fail ValidationFailed.new({param => msg})
   end
 end

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -28,6 +28,25 @@ class CloverWeb
         pg.incr_destroy
         return {message: "Deleting #{pg.server_name}"}.to_json
       end
+
+      r.post "restore" do
+        Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
+        Authorization.authorize(@current_user.id, "Postgres:view", pg.id)
+
+        st = Prog::Postgres::PostgresResourceNexus.assemble(
+          project_id: @project.id,
+          location: pg.location,
+          server_name: r.params["name"],
+          target_vm_size: pg.target_vm_size,
+          target_storage_size_gib: pg.target_storage_size_gib,
+          parent_id: pg.id,
+          restore_target: r.params["restore_target"]
+        )
+
+        flash["notice"] = "'#{r.params["name"]}' will be ready in a few minutes"
+
+        r.redirect "#{@project.path}#{st.subject.path}"
+      end
     end
   end
 end

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -22,8 +22,8 @@ class Serializers::Web::Postgres < Serializers::Base
     base(pg).merge({
       connection_string: pg.connection_string
     }).merge(pg.server.primary? ? {
-      earliest_restore_time: pg.timeline.earliest_restore_time&.iso8601,
-      latest_restore_time: pg.timeline.latest_restore_time&.iso8601
+      earliest_restore_time: pg.timeline.earliest_restore_time&.utc&.iso8601,
+      latest_restore_time: pg.timeline.latest_restore_time&.utc&.iso8601
     } : {})
   end
 end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -158,5 +158,18 @@ RSpec.describe Validation do
         expect { described_class.validate_postgres_size("standard-3") }.to raise_error described_class::ValidationFailed
       end
     end
+
+    describe "#validate_date" do
+      it "valid date" do
+        expect(described_class.validate_date("2023-11-30 11:41")).to eq(Time.new(2023, 11, 30, 11, 41, 0, "UTC"))
+        expect(described_class.validate_date(Time.new(2023, 11, 30, 11, 41))).to eq(Time.new(2023, 11, 30, 11, 41))
+      end
+
+      it "invalid date" do
+        expect { described_class.validate_date("") }.to raise_error described_class::ValidationFailed, "Validation failed for following fields: date"
+        expect { described_class.validate_date(nil) }.to raise_error described_class::ValidationFailed, "Validation failed for following fields: date"
+        expect { described_class.validate_date("invalid-date", "restore_date") }.to raise_error described_class::ValidationFailed, "Validation failed for following fields: restore_date"
+      end
+    end
   end
 end

--- a/views/components/form/datepicker.erb
+++ b/views/components/form/datepicker.erb
@@ -1,0 +1,24 @@
+<% @enable_datepicker = true %>
+
+<% name = defined?(name) ? name : nil %>
+<% label = defined?(label) ? label : nil %>
+<% default_date = defined?(default_date) ? default_date : nil %>
+<% min_date = defined?(min_date) ? min_date : nil %>
+<% max_date = defined?(max_date) ? max_date : nil %>
+
+<%== render(
+  "components/form/text",
+  locals: {
+    label: label,
+    name: name,
+    extra_class: "datepicker",
+    attributes: {
+      "required" => true,
+      "placeholder" => "YYYY-MM-DD HH:MM",
+      "data-maxDate" => max_date,
+      "data-minDate" => min_date,
+      "data-defaultDate" => default_date,
+      "hidden" => true
+    }
+  }
+) %>

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -5,6 +5,7 @@
 <% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
 <% description = (defined?(description) && description) ? description : nil %>
 <% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
+<% extra_class = defined?(extra_class) ? extra_class : nil %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>
@@ -17,7 +18,7 @@
     <% if value %>
     value="<%= value %>"
     <% end %>
-    class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%>"
+    class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%> <%= extra_class %>"
     <% attributes.each do |atr_key, atr_value| %>
     <%= atr_key %>="<%= atr_value %>"
     <% end%>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -18,6 +18,19 @@
       integrity="sha256-QigBQMy2be3IqJD2ezKJUJ5gycSmyYlRHj2VGBuITpU="
       crossorigin="anonymous"
     ></script>
+    <% if @enable_datepicker %>
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css"
+        integrity="sha256-GzSkJVLJbxDk36qko2cnawOGiqz/Y8GsQv/jMTUrx1Q="
+        crossorigin="anonymous"
+      >
+      <script
+        src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"
+        integrity="sha256-Huqxy3eUcaCwqqk92RwusapTfWlvAasF6p2rxV6FJaE="
+        crossorigin="anonymous"
+      ></script>
+    <% end %>
   </head>
 
   <body class="h-full">

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -37,6 +37,44 @@
     data.push(["Connection String", @pg[:connection_string], { copieble: true, revealable: true }])
   end %>
   <%== render("components/kv_data_card", locals: { data: data }) %>
+  <!-- Fork database -->
+  <% if @pg[:earliest_restore_time] && @pg[:latest_restore_time] > @pg[:earliest_restore_time] %>
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div class="px-4 py-5 sm:p-6">
+        <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restore" %>" role="form" method="POST">
+          <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restore") %>
+          <div class="space-y-4">
+            <div>
+              <h2 class="text-lg font-medium leading-6 text-gray-900">Fork PostgreSQL database</h2>
+              <p class="mt-1 text-sm text-gray-500">
+                When you fork your existing PostgreSQL database, a new server will be provisioned.
+              </p>
+            </div>
+            <div class="grid grid-cols-12 gap-6">
+              <div class="col-span-12 sm:col-span-5">
+                <%== render("components/form/text", locals: { label: "New server name", name: "name", attributes: { required: true } }) %>
+              </div>
+              <div class="col-span-12 sm:col-span-5">
+                <%== render(
+                  "components/form/datepicker",
+                  locals: {
+                    label: "Target Time (UTC)",
+                    name: "restore_target",
+                    default_date: @pg[:latest_restore_time],
+                    max_date: @pg[:latest_restore_time],
+                    min_date: @pg[:earliest_restore_time]
+                  }
+                ) %>
+              </div>
+              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                <%== render("components/form/submit_button", locals: { text: "Fork" }) %>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  <% end %>
   <!-- Delete Card -->
   <% if Authorization.has_permission?(@current_user.id, "Postgres:delete", @pg[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">


### PR DESCRIPTION
### Add a datepicker component to UI

We require a date picker to select the target restore date for our PostgreSQL databases. This is our first time needing such a feature. Several alternative date picker libraries exist, including flatpickr, jQuery UI Datepicker, Datepicker.js, Air Datepicker, and pickadate.js. I evaluated these libraries based on various factors: popularity, aesthetic appeal, dependencies, package size, and the ability to set minimum/maximum dates.

I chose [flatpickr](https://github.com/flatpickr/flatpickr). It offers a modern interface with no dependencies and displays the native OS picker on mobile devices, thus providing an excellent UX. I pass the picker configurations from Ruby to JavaScript using `data-*` attributes.

To optimize page loads, I introduced the `@enable_datepicker` flag. This ensures that the package files are loaded only on pages that require a date picker.


### Add date validation helper
It helps us ensure that the provided date is valid. If a `Time` object is provided instead of a string, it returns the similar object.

I added the `param` argument to raise a validation error with the correct input name for display on the UI.


### Add PostgreSQL database restore functionality to the UI
We allow users to restore the database from a target date within the range of the earliest and latest restore times. This is enforced on the console using flatpickr's minDate/maxDate configurations. However, merely enforcing this on the UI is insufficient, as the forced value can be easily altered via inspect element. Thus, we also validate the restore target on the backend.

If the server lacks an earliest_restore_time value, we do not display the restore card at all.

<img width="1152" alt="Screenshot 2023-12-01 at 22 38 56" src="https://github.com/ubicloud/ubicloud/assets/993199/648759c2-d968-445c-8a00-e327eb314672">