### PR TITLE
Use 5.15.0-86-generic instead of current jammy image

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -450,7 +450,7 @@ EOS
 
   def download_boot_image(boot_image, custom_url: nil)
     urls = {
-      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
+      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/jammy/20231010/jammy-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
       "almalinux-9.1" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-latest.#{_1}.qcow2" },
       "github-ubuntu-2204" => nil,
       "github-ubuntu-2004" => nil

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe VmSetup do
         expect(path).to eq("/tmp/ubuntu-jammy.img.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
-      expect(vs).to receive(:r).with("curl -L10 -o /tmp/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("curl -L10 -o /tmp/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/jammy/20231010/jammy-server-cloudimg-amd64.img")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /tmp/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw")
       expect(FileUtils).to receive(:rm_r).with("/tmp/ubuntu-jammy.img.tmp")
 


### PR DESCRIPTION
Current jammy image with kernel version `5.15.0-89-generic` is failing with the following error when booting up:

```
[   28.129660] watchdog: BUG: soft lockup - CPU#1 stuck for 26s! [systemd-udevd:165]
[   28.130265] Modules linked in: crct10dif_pclmul crc32_pclmul ghash_clmulni_intel aesni_intel crypto_simd cryptd virtio_net(+) net_failover virtio_rng failover virtio_blk
[   28.131396] CPU: 1 PID: 165 Comm: systemd-udevd Not tainted 5.15.0-89-generic #99-Ubuntu
[   28.131997] Hardware name: Cloud Hypervisor cloud-hypervisor, BIOS 0
[   28.132479] RIP: 0010:virtnet_send_command+0x10b/0x170 [virtio_net]
[   28.132951] Code: 0b 83 c1 d8 85 c0 0f 88 d2 6e 00 00 48 8b 7b 08 e8 6a 72 c1 d8 84 c0 75 11 eb 56 48 8b 7b 08 e8 6b 5e c1 d8 84 c0 75 17 f3 90 <48> 8b 7b 08 48 8d b5 6c ff ff ff e8 f5 71 c1 d8 48 85 c0 74 dc 48
[   28.134326] RSP: 0018:ffff9b0c4064f9b8 EFLAGS: 00000246
[   28.134720] RAX: 0000000000000000 RBX: ffff89dfc0d13980 RCX: 0000000000000a20
[   28.135252] RDX: 0000000000000000 RSI: ffff9b0c4064f9bc RDI: ffff89dfc7cc00c0
[   28.135787] RBP: ffff9b0c4064fa50 R08: 0000000000000001 R09: 0000000000000003
[   28.136316] R10: 0000000000000003 R11: 0000000000000002 R12: ffff9b0c4064f9e0
[   28.136851] R13: 0000000000000002 R14: 0000000000000004 R15: ffff89dfc0c49400
[   28.137381] FS:  00007feeba10e8c0(0000) GS:ffff89e0f7d00000(0000) knlGS:0000000000000000
[   28.137981] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[   28.138408] CR2: 00007feeba90a0f8 CR3: 0000000100258000 CR4: 0000000000350ee0
[   28.138940] Call Trace:
[   28.139129]  <IRQ>
[   28.139291]  ? show_trace_log_lvl+0x1d6/0x2ea
[   28.139627]  ? show_trace_log_lvl+0x1d6/0x2ea
[   28.139957]  ? _virtnet_set_queues+0xbb/0x100 [virtio_net]
[   28.140369]  ? show_regs.part.0+0x23/0x29
[   28.140672]  ? show_regs.cold+0x8/0xd
[   28.140950]  ? watchdog_timer_fn+0x1be/0x220
[   28.141273]  ? lockup_detector_update_enable+0x60/0x60
[   28.141657]  ? __hrtimer_run_queues+0x107/0x230
[   28.142011]  ? clockevents_program_event+0xad/0x130
[   28.142377]  ? hrtimer_interrupt+0x101/0x220
[   28.142698]  ? __sysvec_apic_timer_interrupt+0x61/0xe0
[   28.143084]  ? sysvec_apic_timer_interrupt+0x7b/0x90
[   28.143460]  </IRQ>
```