### PR TITLE
Download the ubuntu image from the release instead of daily builds directory

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -450,7 +450,7 @@ EOS
 
   def download_boot_image(boot_image, custom_url: nil)
     urls = {
-      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/jammy/20231010/jammy-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
+      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
       "almalinux-9.1" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-latest.#{_1}.qcow2" },
       "github-ubuntu-2204" => nil,
       "github-ubuntu-2004" => nil

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe VmSetup do
         expect(path).to eq("/tmp/ubuntu-jammy.img.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
-      expect(vs).to receive(:r).with("curl -L10 -o /tmp/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/jammy/20231010/jammy-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("curl -L10 -o /tmp/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-amd64.img")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /tmp/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw")
       expect(FileUtils).to receive(:rm_r).with("/tmp/ubuntu-jammy.img.tmp")
 


### PR DESCRIPTION
We have switched to using a specific version of the Ubuntu Jammy image instead of the current one at a085608 due to a kernel issue.

The directory https://cloud-images.ubuntu.com/jammy/ only keeps daily builds. Old versions are regularly cleaned up.

The directory https://cloud-images.ubuntu.com/releases/jammy/ maintains all release versions.