### PR TITLE
Fix available storage decrease issue when a vm allocated on vm host

### DIFF
--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -39,17 +39,6 @@ RSpec.describe Prog::Vm::Nexus do
   }
   let(:prj) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
 
-  before do
-    allow(nx).to receive(:frame).and_return({
-      "storage_volumes" => [{
-        "use_bdev_ubi" => false,
-        "skip_sync" => true,
-        "storage_size_gib" => 11,
-        "boot" => true
-      }]
-    })
-  end
-
   describe ".assemble" do
     let(:ps) {
       PrivateSubnet.create(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
@@ -333,6 +322,14 @@ RSpec.describe Prog::Vm::Nexus do
     before do
       @host_index = 0
       vm.location = "somewhere-normal"
+      allow(nx).to receive(:frame).and_return({
+        "storage_volumes" => [{
+          "use_bdev_ubi" => false,
+          "skip_sync" => true,
+          "size_gib" => 11,
+          "boot" => true
+        }]
+      })
     end
 
     def new_host(**args)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -439,6 +439,18 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nx.allocation_dataset.map { _1[:used_cores] }).to eq([0, 70])
       expect(nx.allocate).to eq idle.id
     end
+
+    it "updates allocated resource columns" do
+      vmh = new_host(location: "hetzner-hel1").save_changes
+      st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{size_gib: 10}, {size_gib: 15}])
+      nx = described_class.new(st)
+
+      initial_vmh = vmh.dup
+      expect(nx.allocate).to eq vmh.reload.id
+      expect(vmh.used_cores).to eq(initial_vmh.used_cores + 1)
+      expect(vmh.used_hugepages_1g).to eq(initial_vmh.used_hugepages_1g + 8)
+      expect(vmh.available_storage_gib).to eq(initial_vmh.available_storage_gib - 25)
+    end
   end
 
   describe "#create_storage_volume_records" do


### PR DESCRIPTION
### Fix storage_volumes value in the stack for testing
`storage_size_gib` should be `size_gib` in the frame. The current usage in the tests is incorrect.
https://github.com/ubicloud/ubicloud/blob/d96815d8fafb12ef369e1c7cc7b0f2cd0c713edb/lib/validation.rb#L64C5-L64C5

We only use `storage_volumes` from the stack at the `start` label, after which we clear it. Other labels should use `VmStorageVolume` records. Consequently, I moved this general 'allow' block to the `.assemble` block only.

### Fix available storage decrease issue when a vm allocated on vm host
I noticed unusually high values for `available_storage_gib` on our VM hosts

Recently, we moved the VmStorageVolume creation from before VM host selection to after, as seen in commit d9b7d58. The `vm.storage_size_gib` relies on these models to compute total used storage. Therefore, the line `available_storage_gib: Sequel[:available_storage_gib] - vm.storage_size_gib` has no effect, as the VM doesn't yet have storage volume records.

To address this issue, I changed it to return the storage size from the strand's stack if the vm doesn't have storage volumes.

We also need to correct these values in production after deploying this fix.