### PR TITLE
Add --fail flag to curl  for 404 not found errors

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -483,7 +483,7 @@ EOS
           install_azcopy
           r "AZCOPY_CONCURRENCY_VALUE=5 azcopy copy #{download.shellescape} #{temp_path.shellescape}"
         else
-          r "curl -L10 -o #{temp_path.shellescape} #{download.shellescape}"
+          r "curl -f -L10 -o #{temp_path.shellescape} #{download.shellescape}"
         end
       end
 

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe VmSetup do
         expect(path).to eq("/tmp/ubuntu-jammy.img.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
-      expect(vs).to receive(:r).with("curl -L10 -o /tmp/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("curl -f -L10 -o /tmp/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-amd64.img")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /tmp/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw")
       expect(FileUtils).to receive(:rm_r).with("/tmp/ubuntu-jammy.img.tmp")
 


### PR DESCRIPTION
Recently, our hourly E2E tests began failing due to "Image is not in qcow2 format" exception. The image url was returning a 404 Not Found error. By default, curl does not exit with failure codes for 4xx status codes; instead, it downloads the error message as a file. Subsequently, qemu-convert attempts to convert this error message.

I added `-f` flag to curl, forcing it to exit with a non-zero code for 4xx errors.

From curl man:

    -f, --fail

        (HTTP) Fail fast with no output at all on server errors. This is
        useful to enable scripts and users to better deal with failed
        attempts. In normal cases when an HTTP server fails to deliver a
        document, it returns an HTML document stating so (which often
        also describes why and more). This flag will prevent curl from
        outputting that and return error 22.

        This method is not fail-safe and there are occasions where
        non-successful response codes will slip through, especially when
        authentication is involved (response codes 401 and 407).