### PR TITLE
Add separate DNS record entry for each insert/delete record operation

### DIFF
--- a/migrate/20231202_concurrency_safe_dns_zones.rb
+++ b/migrate/20231202_concurrency_safe_dns_zones.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  up do
+    alter_table(:dns_record) do
+      add_column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+      drop_index [:dns_zone_id, :name, :type, :data], concurrently: true
+      add_index [:dns_zone_id, :name, :type, :data], concurrently: true
+    end
+  end
+
+  down do
+    alter_table(:dns_record) do
+      drop_index [:dns_zone_id, :name, :type, :data], concurrently: true
+      add_index [:dns_zone_id, :name, :type, :data], unique: true, where: Sequel.lit("NOT tombstoned"), concurrently: true
+      drop_column :created_at
+    end
+  end
+end

--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -9,7 +9,7 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
 
   label def wait
     if dns_zone.last_purged_at < Time.now - 60 * 60 * 1 # ~1 hour
-      hop_purge_tombstoned_records
+      hop_purge_dns_records
     end
 
     when_refresh_dns_servers_set? do
@@ -26,7 +26,8 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
     dns_zone.dns_servers.each do |dns_server|
       records_to_rectify = dns_zone.records_dataset
         .left_join(:seen_dns_records_by_dns_servers, dns_record_id: :id, dns_server_id: dns_server.id)
-        .where(Sequel[:seen_dns_records_by_dns_servers][:dns_record_id] => nil).all
+        .where(Sequel[:seen_dns_records_by_dns_servers][:dns_record_id] => nil)
+        .order(Sequel.asc(:created_at)).all
 
       next if records_to_rectify.empty?
 
@@ -48,15 +49,32 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
     hop_wait
   end
 
-  label def purge_tombstoned_records
+  label def purge_dns_records
+    # These are the records that are obsoleted by a another record with the
+    # same fields but newer date. We can delete them even if they are not
+    # seen yet.
+    obsoleted_records = dns_zone.records_dataset
+      .join(
+        dns_zone.records_dataset
+          .select_group(:dns_zone_id, :name, :type, :data)
+          .select_append { max(created_at).as(:latest_created_at) }
+          .as(:latest_dns_record),
+        [:dns_zone_id, :name, :type, :data]
+      )
+      .where { dns_record[:created_at] < latest_dns_record[:latest_created_at] }.all
+
+    # These are the tombstoned records, we can only delete them if they are
+    # seen by all DNS servers. We join with seen_dns_records_by_dns_servers
+    # and count the number of DNS servers to ensure that they are seen by all
+    # DNS servers.
     dns_server_ids = dns_zone.dns_servers.map(&:id)
-    records_to_purge = dns_zone.records_dataset
-      .select(:id)
+    seen_tombstoned_records = dns_zone.records_dataset
+      .select_group(:id)
       .join(:seen_dns_records_by_dns_servers, dns_record_id: :id, dns_server_id: dns_server_ids)
       .where(tombstoned: true)
-      .group(:id)
       .having { count.function.* =~ dns_server_ids.count }.all
 
+    records_to_purge = obsoleted_records + seen_tombstoned_records
     DB[:seen_dns_records_by_dns_servers].where(dns_record_id: records_to_purge.map(&:id)).delete(force: true)
     records_to_purge.map(&:destroy)
 

--- a/spec/model/dns_zone/dns_zone_spec.rb
+++ b/spec/model/dns_zone/dns_zone_spec.rb
@@ -25,23 +25,6 @@ RSpec.describe DnsZone do
 
       expect(dns_zone.records.count).to eq(1)
     end
-
-    it "ignores error if there is a duplicate record" do
-      dns_zone.insert_record(record_name: "test", type: "A", ttl: 10, data: "1.2.3.4")
-      dns_zone.insert_record(record_name: "test", type: "A", ttl: 10, data: "1.2.3.4")
-
-      expect(dns_zone.records.count).to eq(1)
-    end
-
-    it "raises errors other than duplicate record" do
-      expect(DnsRecord).to receive(:create_with_id).and_raise(Sequel::UniqueConstraintViolation.new("other error"))
-
-      expect {
-        dns_zone.insert_record(record_name: "test", type: "A", ttl: 10, data: "1.2.3.4")
-      }.to raise_error Sequel::UniqueConstraintViolation
-
-      expect(dns_zone.records.count).to eq(0)
-    end
   end
 
   context "when deleting a record" do

--- a/spec/prog/dns_zone/dns_zone_nexus_spec.rb
+++ b/spec/prog/dns_zone/dns_zone_nexus_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Prog::DnsZone::DnsZoneNexus do
       expect { nx.wait }.to hop("refresh_dns_servers")
     end
 
-    it "hops to purge_tombstoned_records if if last purge happened more than 1 hour ago" do
+    it "hops to purge_dns_records if if last purge happened more than 1 hour ago" do
       expect(dns_zone).to receive(:last_purged_at).and_return(Time.now - 60 * 60 * 2)
-      expect { nx.wait }.to hop("purge_tombstoned_records")
+      expect { nx.wait }.to hop("purge_dns_records")
     end
 
     it "naps if there is nothing to do" do
@@ -80,7 +80,24 @@ COMMANDS
     end
   end
 
-  describe "#purge_tombstoned_records" do
+  describe "#purge_dns_records" do
+    it "deletes obsoleted records, seen or unseen" do
+      r1 = DnsRecord.create_with_id(created_at: Time.now - 1, name: "test-pg-1", type: "A", ttl: 10, data: "1.2.3.4")
+      r2 = DnsRecord.create_with_id(created_at: Time.now, name: "test-pg-1", type: "A", ttl: 10, data: "1.2.3.4")
+      r3 = DnsRecord.create_with_id(created_at: Time.now + 1, name: "test-pg-1", type: "A", ttl: 10, data: "1.2.3.4")
+
+      dns_zone.add_record(r1)
+      dns_zone.add_record(r2)
+      dns_zone.add_record(r3)
+
+      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r1.id}', '#{dns_server.id}')"].insert
+      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r3.id}', '#{dns_server.id}')"].insert
+
+      expect { nx.purge_dns_records }.to hop("wait")
+      expect(dns_zone.reload.records.count).to eq(1)
+      expect(DB[:seen_dns_records_by_dns_servers].all.count).to eq(1)
+    end
+
     it "deletes seen tombstoned records" do
       r1 = DnsRecord.create_with_id(name: "test-pg-1", type: "A", ttl: 10, data: "1.2.3.4")
       r2 = DnsRecord.create_with_id(name: "test-pg-2", type: "A", ttl: 10, data: "5.6.7.8", tombstoned: true)
@@ -93,7 +110,7 @@ COMMANDS
       DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r1.id}', '#{dns_server.id}')"].insert
       DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r2.id}', '#{dns_server.id}')"].insert
 
-      expect { nx.purge_tombstoned_records }.to hop("wait")
+      expect { nx.purge_dns_records }.to hop("wait")
       expect(dns_zone.reload.records.count).to eq(2)
       expect(DB[:seen_dns_records_by_dns_servers].all.count).to eq(1)
     end


### PR DESCRIPTION
We used to update tombstoned column when a DNS record is deleted. Records with
same name, type and data can be added and removed many times. We also tried to
keep only one copy of active record using a unique constraint. This provides
nice size reduction, but it complicates record processing. Especially when a
deleted record is added back, we don't have a way to know which request came
last (thus whether should we create or remove the record in the DNS server).

We fix this situation by adding separate DNS record entry for each insert and
delete request. We also tag each record with a timestamp. Now we can process
the records in the request order. Adding separate records for each operation
increases the total size. To remove unnecessary bloat, we expand the purge logic
to also purge obsoleted records.