### PR TITLE
Take longer naps at PostgresTimeline

### DIFF
--- a/migrate/20231203_drop_last_ineffective_check_at.rb
+++ b/migrate/20231203_drop_last_ineffective_check_at.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:postgres_timeline) do
+      drop_column :last_ineffective_check_at
+    end
+  end
+
+  down do
+    alter_table(:postgres_timeline) do
+      add_column :last_ineffective_check_at, :timestamptz
+    end
+  end
+end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -34,14 +34,11 @@ PGHOST=/var/run/postgresql
 
   def need_backup?
     return false if blob_storage_endpoint.nil?
-    return false if last_ineffective_check_at && last_ineffective_check_at > Time.now - 60 * 20
 
     status = leader.vm.sshable.cmd("common/bin/daemonizer --check take_postgres_backup")
     return true if ["Failed", "NotStarted"].include?(status)
     return true if status == "Succeeded" && (last_backup_started_at.nil? || last_backup_started_at < Time.now - 60 * 60 * 24)
 
-    self.last_ineffective_check_at = Time.now
-    save_changes
     false
   end
 

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -44,7 +44,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       hop_take_backup
     end
 
-    nap 30
+    nap 20 * 60
   end
 
   label def take_backup

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -45,25 +45,15 @@ PGHOST=/var/run/postgresql
       expect(postgres_timeline.need_backup?).to be(false)
     end
 
-    it "returns false as backup needed if there is recent backup status check" do
-      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
-      expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now).twice
-      expect(postgres_timeline.need_backup?).to be(false)
-    end
-
     it "returns true as backup needed if there is no backup process or the last backup failed" do
       expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint").twice
-      expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).exactly(4).times
-      expect(sshable).to receive(:cmd).and_return("NotStarted")
+      expect(sshable).to receive(:cmd).and_return("NotStarted", "Failed")
       expect(postgres_timeline.need_backup?).to be(true)
-
-      expect(sshable).to receive(:cmd).and_return("Failed")
       expect(postgres_timeline.need_backup?).to be(true)
     end
 
     it "returns true as backup needed if previous backup started more than a day ago and is succeeded" do
       expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
-      expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).twice
       expect(postgres_timeline).to receive(:last_backup_started_at).and_return(Time.now - 60 * 60 * 25).twice
       expect(sshable).to receive(:cmd).and_return("Succeeded")
       expect(postgres_timeline.need_backup?).to be(true)
@@ -71,7 +61,6 @@ PGHOST=/var/run/postgresql
 
     it "returns false as backup needed if previous backup started less than a day ago" do
       expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
-      expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).twice
       expect(postgres_timeline).to receive(:last_backup_started_at).and_return(Time.now - 60 * 60 * 23).twice
       expect(sshable).to receive(:cmd).and_return("Succeeded")
       expect(postgres_timeline.need_backup?).to be(false)
@@ -79,7 +68,6 @@ PGHOST=/var/run/postgresql
 
     it "returns false as backup needed if previous backup started is in progress" do
       expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
-      expect(postgres_timeline).to receive(:last_ineffective_check_at).and_return(Time.now - 60 * 60).twice
       expect(sshable).to receive(:cmd).and_return("InProgress")
       expect(postgres_timeline.need_backup?).to be(false)
     end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
 
     it "naps if there is nothing to do" do
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(20 * 60)
     end
   end
 


### PR DESCRIPTION
In PostgresTimeline's wait label we make expensive external calls. To reduce
the frequency of those, we used to store the time we make those calls and not
make another call for 20 minutes. Instead of storing that, just napping longer
is much simpler and does not require a database column.