### PR TITLE
Handle missing leader case more gracefully

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -34,6 +34,7 @@ PGHOST=/var/run/postgresql
 
   def need_backup?
     return false if blob_storage_endpoint.nil?
+    return false if leader.nil?
 
     status = leader.vm.sshable.cmd("common/bin/daemonizer --check take_postgres_backup")
     return true if ["Failed", "NotStarted"].include?(status)

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -35,6 +35,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   label def wait_leader
+    hop_destroy if postgres_timeline.leader.nil?
+
     nap 5 if postgres_timeline.leader.strand.label != "wait"
     hop_wait
   end

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -45,6 +45,12 @@ PGHOST=/var/run/postgresql
       expect(postgres_timeline.need_backup?).to be(false)
     end
 
+    it "returns false as backup needed if there is no leader" do
+      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
+      expect(postgres_timeline).to receive(:leader).and_return(nil)
+      expect(postgres_timeline.need_backup?).to be(false)
+    end
+
     it "returns true as backup needed if there is no backup process or the last backup failed" do
       expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint").twice
       expect(sshable).to receive(:cmd).and_return("NotStarted", "Failed")

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -55,13 +55,18 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
   end
 
   describe "#wait_leader" do
+    it "hops to destroy if leader is missing" do
+      expect(postgres_timeline).to receive(:leader).and_return(nil)
+      expect { nx.wait_leader }.to hop("destroy")
+    end
+
     it "naps if leader not ready" do
-      expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "start")))
+      expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "start"))).twice
       expect { nx.wait_leader }.to nap(5)
     end
 
     it "hops if leader is ready" do
-      expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait")))
+      expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait"))).twice
       expect { nx.wait_leader }.to hop("wait")
     end
   end


### PR DESCRIPTION
PostgresTimelines live longer than the PostgresServers because they hold the backups, which might be needed even after user deletes the database. However, previously we didn't handled this case properly, which throws exception in various places when leader is not found.