### PR TITLE
Rename last_backup_started_at as latest_backup_started_at

### DIFF
--- a/migrate/20231203_add_latest_backup_started_at_to_timeline.rb
+++ b/migrate/20231203_add_latest_backup_started_at_to_timeline.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:postgres_timeline) do
+      add_column :latest_backup_started_at, :timestamptz
+    end
+
+    run "UPDATE postgres_timeline SET latest_backup_started_at = last_backup_started_at"
+  end
+
+  down do
+    alter_table(:postgres_timeline) do
+      drop_column :latest_backup_started_at
+    end
+  end
+end

--- a/migrate/20231204_drop_last_backup_started_at.rb
+++ b/migrate/20231204_drop_last_backup_started_at.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:postgres_timeline) do
+      drop_column :last_backup_started_at
+    end
+  end
+
+  down do
+    alter_table(:postgres_timeline) do
+      add_column :last_backup_started_at, :timestamptz
+
+      run "UPDATE postgres_timeline SET last_backup_started_at = latest_backup_started_at"
+    end
+  end
+end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -38,7 +38,7 @@ PGHOST=/var/run/postgresql
 
     status = leader.vm.sshable.cmd("common/bin/daemonizer --check take_postgres_backup")
     return true if ["Failed", "NotStarted"].include?(status)
-    return true if status == "Succeeded" && (last_backup_started_at.nil? || last_backup_started_at < Time.now - 60 * 60 * 24)
+    return true if status == "Succeeded" && (latest_backup_started_at.nil? || latest_backup_started_at < Time.now - 60 * 60 * 24)
 
     false
   end
@@ -51,7 +51,7 @@ PGHOST=/var/run/postgresql
       .select { _1.key.end_with?("backup_stop_sentinel.json") }
   end
 
-  def last_backup_label_before_target(target:)
+  def latest_backup_label_before_target(target:)
     backup = backups.sort_by(&:last_modified).reverse.find { _1.last_modified < target }
     backup.key.delete_prefix("basebackups_005/").delete_suffix("_backup_stop_sentinel.json") if backup
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -129,7 +129,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     when "Succeeded"
       hop_refresh_certificates
     when "Failed", "NotStarted"
-      unless (backup_label = postgres_server.timeline.last_backup_label_before_target(target: postgres_server.resource.restore_target))
+      unless (backup_label = postgres_server.timeline.latest_backup_label_before_target(target: postgres_server.resource.restore_target))
         fail "BUG: no backup found"
       end
       vm.sshable.cmd("common/bin/daemonizer 'sudo postgres/bin/initialize-database-from-backup #{backup_label}' initialize_database_from_backup")

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -60,14 +60,14 @@ PGHOST=/var/run/postgresql
 
     it "returns true as backup needed if previous backup started more than a day ago and is succeeded" do
       expect(postgres_timeline).to receive(:blob_storage).and_return("dummy-blob-storage")
-      expect(postgres_timeline).to receive(:last_backup_started_at).and_return(Time.now - 60 * 60 * 25).twice
+      expect(postgres_timeline).to receive(:latest_backup_started_at).and_return(Time.now - 60 * 60 * 25).twice
       expect(sshable).to receive(:cmd).and_return("Succeeded")
       expect(postgres_timeline.need_backup?).to be(true)
     end
 
     it "returns false as backup needed if previous backup started less than a day ago" do
       expect(postgres_timeline).to receive(:blob_storage).and_return("dummy-blob-storage")
-      expect(postgres_timeline).to receive(:last_backup_started_at).and_return(Time.now - 60 * 60 * 23).twice
+      expect(postgres_timeline).to receive(:latest_backup_started_at).and_return(Time.now - 60 * 60 * 23).twice
       expect(sshable).to receive(:cmd).and_return("Succeeded")
       expect(postgres_timeline.need_backup?).to be(false)
     end
@@ -79,7 +79,7 @@ PGHOST=/var/run/postgresql
     end
   end
 
-  describe "#last_backup_label_before_target" do
+  describe "#latest_backup_label_before_target" do
     it "returns most recent backup before given target" do
       stub_const("Backup", Struct.new(:last_modified))
       most_recent_backup_time = Time.now
@@ -91,14 +91,14 @@ PGHOST=/var/run/postgresql
         ]
       )
 
-      expect(postgres_timeline.last_backup_label_before_target(target: most_recent_backup_time - 50)).to eq("0002")
+      expect(postgres_timeline.latest_backup_label_before_target(target: most_recent_backup_time - 50)).to eq("0002")
     end
 
     it "returns nil if no backups before given target" do
       stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([])
 
-      expect(postgres_timeline.last_backup_label_before_target(target: Time.now)).to be_nil
+      expect(postgres_timeline.latest_backup_label_before_target(target: Time.now)).to be_nil
     end
   end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#initialize_database_from_backup" do
     it "triggers initialize_database_from_backup if initialize_database_from_backup command is not sent yet or failed" do
       expect(postgres_server.resource).to receive(:restore_target).and_return(Time.now).twice
-      expect(postgres_server.timeline).to receive(:last_backup_label_before_target).and_return("backup-label").twice
+      expect(postgres_server.timeline).to receive(:latest_backup_label_before_target).and_return("backup-label").twice
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo postgres/bin/initialize-database-from-backup backup-label' initialize_database_from_backup").twice
 
       # NotStarted
@@ -247,7 +247,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "fails if the timeline has no backup" do
       expect(postgres_server.resource).to receive(:restore_target).and_return(Time.now)
-      expect(postgres_server.timeline).to receive(:last_backup_label_before_target).and_return(nil)
+      expect(postgres_server.timeline).to receive(:latest_backup_label_before_target).and_return(nil)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check initialize_database_from_backup").and_return("NotStarted")
       expect { nx.initialize_database_from_backup }.to raise_error RuntimeError, "BUG: no backup found"
     end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -114,10 +114,8 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
   end
 
   describe "#take_backup" do
-    it "updates last_backup_started_at even if backup is not needed" do
+    it "hops to wait if backup is not needed" do
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
-      expect(postgres_timeline).to receive(:last_backup_started_at=)
-      expect(postgres_timeline).to receive(:save_changes)
       expect { nx.take_backup }.to hop("wait")
     end
 
@@ -126,7 +124,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo postgres/bin/take-backup' take_postgres_backup")
       expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, vm: instance_double(Vm, sshable: sshable)))
-      expect(postgres_timeline).to receive(:last_backup_started_at=)
+      expect(postgres_timeline).to receive(:latest_backup_started_at=)
       expect(postgres_timeline).to receive(:save_changes)
       expect { nx.take_backup }.to hop("wait")
     end


### PR DESCRIPTION
Last can be used to describe both oldest and newest. Latest is a more clear
way to communicate newest/most recent.