### PR TITLE
Trigger txid_current on parent before starting restore

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -6,6 +6,7 @@ class PostgresResource < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :project
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
+  many_to_one :parent, key: :parent_id, class: self
   one_to_one :server, class: PostgresServer, key: :resource_id
   one_through_one :timeline, class: PostgresTimeline, join_table: :postgres_server, left_key: :resource_id, right_key: :timeline_id
 


### PR DESCRIPTION
We set the archive_timeout to 60 seconds, so that we would generate at least
one WAL file every minute, even if there is low activity. This allows doing
PITR in minute granularity. However, if there is no activity at all, even with
archive_timeout is set to 60, no new WALs are generated. This is mostly fine
from the perspective of PITR, because if there is no activity, there is nothing
to restore anyway. However, to ensure there is no activity, Postgres requires
at least one WAL file after the target time. This means we cannot complete the
restore if there is no activity at all after the target time.

To overcome this, we trigger pg_current_xact_id() on parent, which creates a
commit record with a timestamp, so Postgres happily creates a new WAL file when
the archive_timeout is passed. One drawback of this is that if the parent DB is
not available, we might not be able to complete the restore operation. Impact
of this can be reduced by periodically calling pg_current_xact_id, however this
did not become a problem in previous iterations of managed PostgreSQL services.
It is also possible to manually complete the restore by retroactively changing
the restore target, so overall it is not a big deal.