### PR TITLE
Setup postgres timeline user keys and bucket on Minio

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -41,6 +41,12 @@ class Minio::Client
     response.status
   end
 
+  def admin_remove_user(access_key)
+    query = URI.encode_www_form({"accessKey" => access_key})
+    response = send_request("DELETE", admin_uri("remove-user?#{query}"))
+    response.status
+  end
+
   def admin_policy_list
     send_request("GET", admin_uri("list-canned-policies"))
   end
@@ -53,6 +59,22 @@ class Minio::Client
 
   def admin_policy_info(policy_name)
     send_request("GET", admin_uri("info-canned-policy?name=#{policy_name}"))
+  end
+
+  def admin_policy_set(policy_name, user_name)
+    query = URI.encode_www_form({
+      "userOrGroup" => user_name,
+      "isGroup" => "false",
+      "policyName" => policy_name
+    })
+    response = send_request("PUT", admin_uri("set-user-or-group-policy?#{query}"))
+    response.data
+  end
+
+  def admin_policy_remove(policy_name)
+    query = URI.encode_www_form({"name" => policy_name})
+    response = send_request("DELETE", admin_uri("remove-canned-policy?#{query}"))
+    response.status
   end
 
   def create_bucket(bucket_name)

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -90,8 +90,12 @@ PGHOST=/var/run/postgresql
   def blob_storage_client
     @blob_storage_client ||= Minio::Client.new(
       endpoint: blob_storage_endpoint,
-      access_key: Config.postgres_service_blob_storage_access_key,
-      secret_key: Config.postgres_service_blob_storage_secret_key
+      access_key: access_key,
+      secret_key: secret_key
     )
+  end
+
+  def blob_storage_policy
+    {Version: "2012-10-17", Statement: [{Effect: "Allow", Action: ["s3:*"], Resource: ["arn:aws:s3:::#{ubid}*"]}]}
   end
 end

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Minio::Client do
     end
   end
 
+  describe "admin_remove_user" do
+    it "sends a DELETE request to /minio/admin/v3/remove-user" do
+      stub_request(:delete, "#{endpoint}/minio/admin/v3/remove-user?accessKey=test").to_return(status: 200)
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_remove_user("test")).to eq(200)
+    end
+  end
+
   describe "admin_policy_list" do
     it "sends a GET request to /minio/admin/v3/list-canned-policies" do
       stub_request(:get, "#{endpoint}/minio/admin/v3/list-canned-policies").to_return(status: 200, body: "test")
@@ -67,6 +75,22 @@ RSpec.describe Minio::Client do
       stub_request(:get, "#{endpoint}/minio/admin/v3/info-canned-policy?name=test").to_return(status: 200, body: "test")
 
       expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_policy_info("test").data[:body]).to eq("test")
+    end
+  end
+
+  describe "admin_policy_set" do
+    it "sends a PUT request to /minio/admin/v3/set-user-or-group-policy" do
+      stub_request(:put, "#{endpoint}/minio/admin/v3/set-user-or-group-policy?userOrGroup=test&isGroup=false&policyName=test").to_return(status: 200)
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_policy_set("test", "test")).to eq({body: "", headers: {}, reason_phrase: "", remote_ip: "127.0.0.1", status: 200})
+    end
+  end
+
+  describe "admin_policy_remove" do
+    it "sends a DELETE request to /minio/admin/v3/remove-canned-policy" do
+      stub_request(:delete, "#{endpoint}/minio/admin/v3/remove-canned-policy?name=test").to_return(status: 200)
+
+      expect(described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key).admin_policy_remove("test")).to eq(200)
     end
   end
 

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -144,4 +144,10 @@ PGHOST=/var/run/postgresql
     expect(postgres_timeline.blob_storage_client).to eq("dummy-client")
     expect(postgres_timeline.blob_storage_client).to eq("dummy-client")
   end
+
+  it "returns blob storage policy" do
+    policy = {Version: "2012-10-17", Statement: [{Effect: "Allow", Action: ["s3:*"], Resource: ["arn:aws:s3:::dummy-ubid*"]}]}
+    expect(postgres_timeline).to receive(:ubid).and_return("dummy-ubid")
+    expect(postgres_timeline.blob_storage_policy).to eq(policy)
+  end
 end


### PR DESCRIPTION
### Adds remove_user, policy_set, policy_remove functionality for Minio 
With this commit, we introduce 3 new APIs to the MinIO Client to support
the PostgreSQL timeline related user, policy and bucket operations.

### Setup postgres timeline user keys and bucket on Minio
With this commit, we start using setting up custom users per postgres
timeline to have individual access to the buckets that are entity
specific.
We also start destroying credentials and buckets when the timeline is
destroyed.