### PR TITLE
Fix created_at accessor for PostgresTimelineNexus

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -51,7 +51,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     # For the purpose of missing backup pages, we act like the very first backup
     # is taken at the creation, which ensures that we would get a page if and only
     # if no backup is taken for 2 days.
-    latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max || created_at
+    latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max || postgres_timeline.created_at
     if postgres_timeline.leader && latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60 # 2 days
       Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", [postgres_timeline.ubid], "MissingBackup", postgres_timeline.id)
     else


### PR DESCRIPTION
The nexus doesn't have  `created_at`, PostgresTimeline has it. The operation fails until
`postgres_timeline.backups.map(&:last_modified).max` returns a value.