### PR TITLE
Add storage space support

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -63,7 +63,7 @@ module Validation
   end
 
   def self.validate_storage_volumes(storage_volumes, boot_disk_index)
-    allowed_keys = [:encrypted, :size_gib, :boot, :use_bdev_ubi, :skip_sync]
+    allowed_keys = [:encrypted, :size_gib, :boot, :use_bdev_ubi, :skip_sync, :storage_space]
     fail ValidationFailed.new({storage_volumes: "At least one storage volume is required."}) if storage_volumes.empty?
     if boot_disk_index < 0 || boot_disk_index >= storage_volumes.length
       fail ValidationFailed.new({boot_disk_index: "Boot disk index must be between 0 and #{storage_volumes.length - 1}"})

--- a/migrate/20231205_storage_space.rb
+++ b/migrate/20231205_storage_space.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_storage_volume) do
+      add_column :storage_space, :text, null: false, default: "DEFAULT"
+    end
+  end
+end

--- a/prog/rotate_storage_kek.rb
+++ b/prog/rotate_storage_kek.rb
@@ -39,7 +39,8 @@ class Prog::RotateStorageKek < Prog::Base
 
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} reencrypt", stdin: data_json)
+    q_space = vm_storage_volume.storage_space.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_space} #{disk_index} reencrypt", stdin: data_json)
 
     hop_test_keys_on_server
   end
@@ -52,7 +53,8 @@ class Prog::RotateStorageKek < Prog::Base
 
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} test-keys", stdin: data_json)
+    q_space = vm_storage_volume.storage_space.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_space} #{disk_index} test-keys", stdin: data_json)
 
     hop_retire_old_key_on_server
   end
@@ -60,7 +62,8 @@ class Prog::RotateStorageKek < Prog::Base
   label def retire_old_key_on_server
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} retire-old-key", stdin: "{}")
+    q_space = vm_storage_volume.storage_space.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_space} #{disk_index} retire-old-key", stdin: "{}")
 
     hop_retire_old_key_in_database
   end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -33,6 +33,7 @@ class Prog::Vm::Nexus < Prog::Base
       volume[:skip_sync] ||= false
       volume[:encrypted] = true if !volume.has_key? :encrypted
       volume[:boot] = disk_index == boot_disk_index
+      volume[:storage_space] ||= "DEFAULT"
     end
 
     Validation.validate_storage_volumes(storage_volumes, boot_disk_index)
@@ -146,7 +147,8 @@ class Prog::Vm::Nexus < Prog::Base
         "encrypted" => !s.key_encryption_key_1.nil?,
         "spdk_version" => s.spdk_version,
         "use_bdev_ubi" => s.use_bdev_ubi,
-        "skip_sync" => s.skip_sync
+        "skip_sync" => s.skip_sync,
+        "storage_space" => s.storage_space
       }
     }
   end
@@ -219,6 +221,7 @@ SQL
         size_gib: volume["size_gib"],
         use_bdev_ubi: volume["use_bdev_ubi"],
         skip_sync: volume["skip_sync"],
+        storage_space: volume["storage_space"],
         disk_index: disk_index,
         key_encryption_key_1_id: key_encryption_key&.id,
         spdk_installation_id: spdk_installation_id

--- a/rhizome/host/bin/storage-key-tool
+++ b/rhizome/host/bin/storage-key-tool
@@ -11,6 +11,11 @@ unless (vm_name = ARGV.shift)
   exit 1
 end
 
+unless (storage_space = ARGV.shift)
+  puts "expect storage space as argument"
+  exit 1
+end
+
 unless (disk_index = ARGV.shift)
   puts "expected disk_index as argument"
   exit 1
@@ -21,7 +26,7 @@ unless (action = ARGV.shift)
   exit 1
 end
 
-storage_key_tool = StorageKeyTool.new(vm_name, disk_index)
+storage_key_tool = StorageKeyTool.new(vm_name, storage_space, disk_index)
 
 case action
 when "reencrypt"

--- a/rhizome/host/lib/storage_key_tool.rb
+++ b/rhizome/host/lib/storage_key_tool.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
-require_relative "vm_path"
+require_relative "storage_path"
 require_relative "../lib/storage_key_encryption"
 
 class StorageKeyTool
-  def initialize(vm_name, disk_index)
-    vp = VmPath.new(vm_name)
-    @key_file = vp.data_encryption_key(disk_index)
+  def initialize(vm_name, storage_space, disk_index)
+    sp = StoragePath.new(vm_name, storage_space, disk_index)
+    @key_file = sp.data_encryption_key
     @new_key_file = "#{@key_file}.new"
   end
 

--- a/rhizome/host/lib/storage_path.rb
+++ b/rhizome/host/lib/storage_path.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+DEFAULT_STORAGE_SPACE = "DEFAULT"
+
+class StoragePath
+  def initialize(vm_name, storage_space, disk_index)
+    @vm_name = vm_name
+    @storage_space = storage_space
+    @disk_index = disk_index
+  end
+
+  def storage_root
+    @storage_root ||=
+      (@storage_space == DEFAULT_STORAGE_SPACE) ?
+        File.join("", "var", "storage", @vm_name) :
+        File.join("", "var", "storage", "spaces", @storage_space, @vm_name)
+  end
+
+  def storage_dir
+    @storage_dir ||= File.join(storage_root, @disk_index.to_s)
+  end
+
+  def disk_file
+    @disk_file ||= File.join(storage_dir, "disk.raw")
+  end
+
+  def data_encryption_key
+    @dek_path ||= File.join(storage_dir, "data_encryption_key.json")
+  end
+
+  def vhost_sock
+    @vhost_sock ||= File.join(storage_dir, "vhost.sock")
+  end
+end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -11,6 +11,7 @@ require_relative "spdk_path"
 require_relative "spdk_rpc"
 require_relative "spdk_setup"
 require_relative "storage_key_encryption"
+require_relative "storage_path"
 
 class StorageVolume
   def initialize(vm_name, params)
@@ -22,7 +23,7 @@ class StorageVolume
     @use_bdev_ubi = (params["use_bdev_ubi"] || false)
     @skip_sync = (params["skip_sync"] || false)
     @image_path = vp.image_path(params["image"]) if params["image"]
-    @disk_file = vp.disk(@disk_index)
+    @storage_space = (params["storage_space"] || DEFAULT_STORAGE_SPACE)
 
     # Old VMs didn't have the spdk_version field. Fill that in with legacy
     # SPDK version for backward compatibility.
@@ -38,7 +39,7 @@ class StorageVolume
   end
 
   def prep(key_wrapping_secrets)
-    FileUtils.mkdir_p vp.storage(@disk_index, "")
+    FileUtils.mkdir_p storage_dir
     encryption_key = setup_data_encryption_key(key_wrapping_secrets) if @encrypted
 
     if @image_path.nil?
@@ -109,7 +110,7 @@ class StorageVolume
       key2: data_encryption_key[64..]
     }
 
-    key_file = vp.data_encryption_key(@disk_index)
+    key_file = data_encryption_key_path
 
     # save encrypted key
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
@@ -124,14 +125,13 @@ class StorageVolume
   end
 
   def read_data_encryption_key(key_wrapping_secrets)
-    key_file = vp.data_encryption_key(@disk_index)
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
-    sek.read_encrypted_dek(key_file)
+    sek.read_encrypted_dek(data_encryption_key_path)
   end
 
   def unencrypted_image_copy
     q_image_path = @image_path.shellescape
-    q_disk_file = @disk_file.shellescape
+    q_disk_file = disk_file.shellescape
 
     r "cp --reflink=auto #{q_image_path} #{q_disk_file}"
     r "truncate -s #{@disk_size_gib}G #{q_disk_file}"
@@ -157,7 +157,7 @@ class StorageVolume
       params: {
         name: "aio0",
         block_size: 512,
-        filename: @disk_file,
+        filename: disk_file,
         readonly: false
       }
     },
@@ -219,20 +219,20 @@ class StorageVolume
   end
 
   def create_empty_disk_file(disk_size_mib: @disk_size_gib * 1024)
-    FileUtils.touch(@disk_file)
-    File.truncate(@disk_file, disk_size_mib * 1024 * 1024)
+    FileUtils.touch(disk_file)
+    File.truncate(disk_file, disk_size_mib * 1024 * 1024)
 
     set_disk_file_permissions
   end
 
   def set_disk_file_permissions
-    FileUtils.chown @vm_name, @vm_name, @disk_file
+    FileUtils.chown @vm_name, @vm_name, disk_file
 
     # don't allow others to read user's disk
-    FileUtils.chmod "u=rw,g=r,o=", @disk_file
+    FileUtils.chmod "u=rw,g=r,o=", disk_file
 
     # allow spdk to access the image
-    r "setfacl -m u:spdk:rw #{@disk_file.shellescape}"
+    r "setfacl -m u:spdk:rw #{disk_file.shellescape}"
   end
 
   def setup_spdk_bdev(encryption_key)
@@ -247,10 +247,10 @@ class StorageVolume
         encryption_key[:key],
         encryption_key[:key2]
       )
-      rpc_client.bdev_aio_create(aio_bdev, @disk_file, 512)
+      rpc_client.bdev_aio_create(aio_bdev, disk_file, 512)
       rpc_client.bdev_crypto_create(non_ubi_bdev, aio_bdev, key_name)
     else
-      rpc_client.bdev_aio_create(non_ubi_bdev, @disk_file, 512)
+      rpc_client.bdev_aio_create(non_ubi_bdev, disk_file, 512)
     end
 
     if @use_bdev_ubi
@@ -271,22 +271,42 @@ class StorageVolume
     r "setfacl -m u:#{@vm_name}:rw #{spdk_vhost_sock.shellescape}"
 
     # create a symlink to the socket in the per vm storage dir
-    rm_if_exists(vp.vhost_sock(@disk_index))
-    FileUtils.ln_s spdk_vhost_sock, vp.vhost_sock(@disk_index)
+    rm_if_exists(vhost_sock)
+    FileUtils.ln_s spdk_vhost_sock, vhost_sock
 
     # Change ownership of the symlink. FileUtils.chown uses File.lchown for
     # symlinks and doesn't follow links. We don't use File.lchown directly
     # because it expects numeric uid & gid, which is less convenient.
-    FileUtils.chown @vm_name, @vm_name, vp.vhost_sock(@disk_index)
+    FileUtils.chown @vm_name, @vm_name, vhost_sock
 
-    vp.vhost_sock(@disk_index)
-  end
-
-  def vhost_sock
-    @vhost_sock ||= vp.vhost_sock(@disk_index)
+    vhost_sock
   end
 
   def spdk_service
     @spdk_service ||= SpdkSetup.new(@spdk_version).spdk_service
+  end
+
+  def sp
+    @sp ||= StoragePath.new(@vm_name, @storage_space, @disk_index)
+  end
+
+  def storage_root
+    @storage_root ||= sp.storage_root
+  end
+
+  def storage_dir
+    @storage_dir ||= sp.storage_dir
+  end
+
+  def disk_file
+    @disk_file ||= sp.disk_file
+  end
+
+  def data_encryption_key_path
+    @dek_path ||= sp.data_encryption_key
+  end
+
+  def vhost_sock
+    @vhost_sock ||= sp.vhost_sock
   end
 end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -39,14 +39,6 @@ class VmPath
     File.join("", "vm", @vm_name, n)
   end
 
-  def storage_root
-    File.join("", "var", "storage", @vm_name)
-  end
-
-  def storage(disk_index, n)
-    File.join(storage_root, disk_index.to_s, n)
-  end
-
   # Define path, q_path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
@@ -94,18 +86,6 @@ class VmPath
     define_method write_method_name do |s|
       write(home(file_name), s)
     end
-  end
-
-  def vhost_sock(disk_index)
-    storage(disk_index, "vhost.sock")
-  end
-
-  def disk(disk_index)
-    storage(disk_index, "disk.raw")
-  end
-
-  def data_encryption_key(disk_index)
-    storage(disk_index, "data_encryption_key.json")
   end
 
   def image_root

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -106,16 +106,21 @@ class VmSetup
   end
 
   def purge_storage
-    # Storage hasn't been created yet, so nothing to purge.
-    return if !File.exist?(vp.storage_root)
+    # prep.json doesn't exist, nothing more to do
+    return if !File.exist?(vp.prep_json)
+
+    storage_roots = []
 
     params = JSON.parse(File.read(vp.prep_json))
     params["storage_volumes"].each { |params|
       volume = StorageVolume.new(@vm_name, params)
       volume.purge_spdk_artifacts
+      storage_roots.append(volume.storage_root)
     }
 
-    rm_if_exists(vp.storage_root)
+    storage_roots.each { |path|
+      rm_if_exists(path)
+    }
   end
 
   def unmount_hugepages

--- a/rhizome/host/spec/storage_key_tool_spec.rb
+++ b/rhizome/host/spec/storage_key_tool_spec.rb
@@ -5,7 +5,7 @@ require "openssl"
 require "base64"
 
 RSpec.describe StorageKeyTool do
-  subject(:skt) { described_class.new("vm12345", 3) }
+  subject(:skt) { described_class.new("vm12345", DEFAULT_STORAGE_SPACE, 3) }
 
   def generate_kek
     key_wrapping_algorithm = "aes-256-gcm"

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -80,44 +80,52 @@ RSpec.describe VmSetup do
   end
 
   describe "#purge_storage" do
-    it "can purge storage" do
-      vol_1_params = {
+    let(:vol_1_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_0",
         "disk_index" => 0,
         "encrypted" => false,
         "spdk_version" => "some-version"
       }
-      vol_2_params = {
+    }
+    let(:vol_2_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_1",
         "disk_index" => 1,
         "encrypted" => true,
         "spdk_version" => "some-version"
       }
-      params = JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
+    let(:params) {
+      JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
 
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(true)
+    it "can purge storage" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
 
       # delete the unencrypted volume
       sv_1 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
       expect(sv_1).to receive(:purge_spdk_artifacts)
+      expect(sv_1).to receive(:storage_root).and_return("/var/storage/test")
 
       # delete the encrypted volume
       sv_2 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
       expect(sv_2).to receive(:purge_spdk_artifacts)
+      expect(sv_2).to receive(:storage_root).and_return("/var/storage/test")
 
-      expect(FileUtils).to receive(:rm_r).with("/var/storage/test")
+      allow(FileUtils).to receive(:rm_r).with("/var/storage/test")
 
       vs.purge_storage
     end
 
-    it "exits silently if storage hasn't been created yet" do
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(false)
-      vs.purge_storage
+    it "exits silently if vm hasn't been created yet" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
+      expect { vs.purge_storage }.not_to raise_error
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -35,8 +35,38 @@ RSpec.describe Prog::Test::VmGroup do
     it "hops to wait_subtests" do
       vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
       Sshable.create { _1.id = vm.id }
+      expect(vg_test).to receive(:verify_storage_volumes)
       allow(vg_test).to receive(:frame).and_return({"vms" => [vm.id]})
       expect { vg_test.children_ready }.to hop("wait_subtests", "Test::VmGroup")
+    end
+  end
+
+  describe "#verify_storage_volumes" do
+    let(:sshable) { Sshable.create_with_id }
+    let(:host) { VmHost.create(location: "x") { _1.id = sshable.id } }
+    let(:vm) {
+      Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x", vm_host_id: host.id)
+    }
+    before do
+      allow(vg_test).to receive(:host).and_return(host)
+      allow(host).to receive(:sshable).and_return(sshable)
+
+      si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
+      [
+        VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: true, spdk_installation_id: si.id),
+        VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 15, disk_index: 1, boot: false, spdk_installation_id: si.id, storage_space: "nvme0")
+      ]
+    end
+
+    it "verifies sizes of all storage volumes" do
+      expect(sshable).to receive(:cmd).with("sudo wc --bytes /var/storage/#{vm.inhost_name}/0/disk.raw").and_return("5368709120 /path\n")
+      expect(sshable).to receive(:cmd).with("sudo wc --bytes /var/storage/spaces/nvme0/#{vm.inhost_name}/1/disk.raw").and_return("16106127360 /path\n")
+      expect { vg_test.verify_storage_volumes(vm) }.not_to raise_error
+    end
+
+    it "fails if file size is too small" do
+      expect(sshable).to receive(:cmd).with("sudo wc --bytes /var/storage/#{vm.inhost_name}/0/disk.raw").and_return("5368709110 /path\n")
+      expect { vg_test.verify_storage_volumes(vm) }.to raise_error RuntimeError
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Prog::Test::VmGroup do
     let(:vm) {
       Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x", vm_host_id: host.id)
     }
+
     before do
       allow(vg_test).to receive(:host).and_return(host)
       allow(host).to receive(:sshable).and_return(sshable)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Prog::Vm::Nexus do
       init_vector: "iv", auth_data: "somedata"
     ) { _1.id = "04a3fe32-4cf0-48f7-909e-e35822864413" }
     si = SpdkInstallation.new(version: "v1") { _1.id = SpdkInstallation.generate_uuid }
-    disk_1 = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0)
+    disk_1 = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0, storage_space: "nvme0", use_bdev_ubi: false, skip_sync: false)
     disk_1.spdk_installation = si
     disk_1.key_encryption_key_1 = kek
-    disk_2 = VmStorageVolume.new(boot: false, size_gib: 15, disk_index: 1)
+    disk_2 = VmStorageVolume.new(boot: false, size_gib: 15, disk_index: 1, storage_space: "DEFAULT", use_bdev_ubi: true, skip_sync: true)
     disk_2.spdk_installation = si
     vm = Vm.new(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "hetzner-hel1").tap {
       _1.id = "2464de61-7501-8374-9ab0-416caebe31da"
@@ -189,6 +189,17 @@ RSpec.describe Prog::Vm::Nexus do
     end
   end
 
+  describe "#storage_volumes" do
+    it "includes all storage volumes" do
+      expect(nx.storage_volumes).to eq([
+        {"boot" => true, "disk_index" => 0, "image" => nil, "size_gib" => 20, "device_id" => "vm4hjdwr_0", "encrypted" => true,
+         "spdk_version" => "v1", "use_bdev_ubi" => false, "skip_sync" => false, "storage_space" => "nvme0"},
+        {"boot" => false, "disk_index" => 1, "image" => nil, "size_gib" => 15, "device_id" => "vm4hjdwr_1", "encrypted" => false,
+         "spdk_version" => "v1", "use_bdev_ubi" => true, "skip_sync" => true, "storage_space" => "DEFAULT"}
+      ])
+    end
+  end
+
   describe "#prep" do
     it "generates and passes a params json" do
       vm = nx.vm
@@ -327,7 +338,8 @@ RSpec.describe Prog::Vm::Nexus do
           "use_bdev_ubi" => false,
           "skip_sync" => true,
           "size_gib" => 11,
-          "boot" => true
+          "boot" => true,
+          "storage_space" => "nvme0"
         }]
       })
     end


### PR DESCRIPTION
Previously there wasn't an easy way to store each disk of a VM on a separate storage device on the host. This PR enables that by introducing storage spaces.

The steps to use this are:
* System admin mounts a disk on the host to `/var/storage/spaces/nvme0`, and a different disk to `/var/storage/spaces/nvme1`.
* When creating a VM, we specify `storage_space` param of each volume:

```
> Prog::Vm::Nexus.assemble(..., storage_volumes: [{..., storage_space: "nvme0"}, {..., storage_space: "nvme1"}])
```

* Then, the first VM storage volume will be stored on the first physical disk & the second storage volume will be stored on the second physical disk. For example, first disk's data will go to `/var/storage/spaces/nvme0/vm12345/1/`

If the storage_space parameter is omitted, then the default storage space will be used, and storage volumes will be created directly under `/var/storage`, as before.