### PR TITLE
Return empty array as backup list if bucket is not created yet

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -46,9 +46,14 @@ PGHOST=/var/run/postgresql
   def backups
     return [] if blob_storage.nil?
 
-    blob_storage_client
-      .list_objects(ubid, "basebackups_005/")
-      .select { _1.key.end_with?("backup_stop_sentinel.json") }
+    begin
+      blob_storage_client
+        .list_objects(ubid, "basebackups_005/")
+        .select { _1.key.end_with?("backup_stop_sentinel.json") }
+    rescue RuntimeError => ex
+      return [] if ex.message.include?("The Access Key Id you provided does not exist in our records.")
+      raise
+    end
   end
 
   def latest_backup_label_before_target(target:)


### PR DESCRIPTION
We try to access backups in serializer, but it is possible that the bucket is not created yet at that time. Simply returning empty array is enough to handle that case.