### PR TITLE
Firewall rules with port ranges

### DIFF
--- a/migrate/20231205_add_fw_rule_port.rb
+++ b/migrate/20231205_add_fw_rule_port.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:firewall_rule) do
+      add_column :port_range, :int4range, null: true, default: Sequel.pg_range(0..65535)
+    end
+    run "ALTER TABLE firewall_rule ADD CONSTRAINT port_range_min_max CHECK (lower(port_range) >= 0 AND upper(port_range) <= 65536)"
+  end
+
+  down do
+    alter_table(:firewall_rule) do
+      drop_column :port_range
+    end
+  end
+end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -155,4 +155,14 @@ class Vm < Sequel::Model
   def storage_encrypted?
     vm_storage_volumes.all? { !_1.key_encryption_key_1_id.nil? }
   end
+
+  def add_allow_ssh_fw_rules(ps)
+    ["0.0.0.0/0", "::/0"].each do |ip|
+      FirewallRule.create_with_id(
+        ip: ip,
+        private_subnet_id: ps.id,
+        port_range: Sequel.pg_range(22..22)
+      )
+    end
+  end
 end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -31,6 +31,16 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         enable_ip4: true
       )
 
+      vm_st.subject.private_subnets.each { _1.firewall_rules.each(&:destroy) }
+      vm_st.subject.add_allow_ssh_fw_rules(vm_st.subject.private_subnets.first)
+      ["0.0.0.0/0", "::/0"].each do |ip|
+        FirewallRule.create_with_id(
+          ip: ip,
+          private_subnet_id: vm_st.subject.private_subnets.first.id,
+          port_range: Sequel.pg_range(5432..5432)
+        )
+      end
+
       postgres_server = PostgresServer.create(
         resource_id: resource_id,
         timeline_id: timeline_id,

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -75,6 +75,8 @@ class Prog::Vm::GithubRunner < Prog::Base
     # yet. When NicNexus switches from "wait_vm" to "setup_nic", it will
     # increment the semaphore, already.
     ps.firewall_rules.map(&:destroy)
+    vm_st.subject.add_allow_ssh_fw_rules(ps)
+
     Clog.emit("Pool is empty") { {github_runner: {label: github_runner.label, repository_name: github_runner.repository_name, cores: vm_st.subject.cores}} }
     vm_st.subject
   end

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -46,7 +46,7 @@ class Prog::Vm::VmPool < Prog::Base
     # yet. When NicNexus switches from "wait_vm" to "setup_nic", it will
     # increment the semaphore, already.
     ps.firewall_rules.map(&:destroy)
-
+    st.subject.add_allow_ssh_fw_rules(ps)
     hop_wait
   end
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -22,11 +22,13 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       ps.associate_with_project(project)
       FirewallRule.create_with_id(
         ip: "0.0.0.0/0",
-        private_subnet_id: ps.id
+        private_subnet_id: ps.id,
+        port_range: nil
       )
       FirewallRule.create_with_id(
         ip: "::/0",
-        private_subnet_id: ps.id
+        private_subnet_id: ps.id,
+        port_range: nil
       )
       Strand.create(prog: "Vnet::SubnetNexus", label: "wait") { _1.id = ubid.to_uuid }
     end

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -5,12 +5,17 @@ class Prog::Vnet::UpdateFirewallRules < Prog::Base
 
   label def update_firewall_rules
     rules = vm.private_subnets.map(&:firewall_rules).flatten
-    allowed_ingress_ip4 = rules.select { !_1.ip6? }.map { _1.ip.to_s }
-    allowed_ingress_ip6 = rules.select { _1.ip6? }.map { _1.ip.to_s }
-
+    allowed_ingress_ip4 = rules.select { !_1.ip6? && !_1.port_range }.map { _1.ip.to_s }
+    allowed_ingress_ip6 = rules.select { _1.ip6? && !_1.port_range }.map { _1.ip.to_s }
+    allowed_ingress_ip4_port_set = generate_ip_port_set(rules.select { !_1.ip6? && _1.port_range })
+    allowed_ingress_ip6_port_set = generate_ip_port_set(rules.select { _1.ip6? && _1.port_range })
+    guest_ephemeral = subdivide_network(vm.ephemeral_net6).first.to_s
     vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<TEMPLATE)
-flush set inet fw_table allowed_ipv4_ips;
-flush set inet fw_table allowed_ipv6_ips;
+# An nftables idiom for idempotent re-create of a named entity: merge
+# in an empty table (a no-op if the table already exists) and then
+# delete, before creating with a new definition.
+table inet fw_table;
+delete table inet fw_table;
 table inet fw_table {
   set allowed_ipv4_ips {
     type ipv4_addr;
@@ -23,8 +28,78 @@ table inet fw_table {
     flags interval;
 #{allowed_ingress_ip6.any? ? "elements = {#{allowed_ingress_ip6.join(",")}}" : ""}
   }
+
+  set allowed_ipv4_port_tuple {
+    type ipv4_addr . inet_service;
+    flags interval;
+#{allowed_ingress_ip4_port_set.empty? ? "" : "elements = {#{allowed_ingress_ip4_port_set}}"}
+  }
+
+  set allowed_ipv6_port_tuple {
+    type ipv6_addr . inet_service;
+    flags interval;
+#{allowed_ingress_ip6_port_set.empty? ? "" : "elements = {#{allowed_ingress_ip6_port_set}}"}
+  }
+
+  set private_ipv4_ips {
+    type ipv4_addr;
+    flags interval;
+    elements = {
+      #{generate_private_ip4_list}
+    }
+  }
+
+  set private_ipv6_ips {
+    type ipv6_addr
+    flags interval
+    elements = { #{generate_private_ip6_list} }
+  }
+
+  chain forward_ingress {
+    type filter hook forward priority filter; policy drop;
+    ip saddr @private_ipv4_ips ct state established,related,new counter accept
+    ip daddr @private_ipv4_ips ct state established,related counter accept
+    ip6 saddr @private_ipv6_ips ct state established,related,new counter accept
+    ip6 daddr @private_ipv6_ips ct state established,related counter accept
+    ip6 saddr #{guest_ephemeral} ct state established,related,new counter accept
+    ip6 daddr #{guest_ephemeral} ct state established,related counter accept
+    ip saddr @allowed_ipv4_ips ip daddr @private_ipv4_ips counter accept
+    ip6 saddr @allowed_ipv6_ips ip6 daddr #{guest_ephemeral} counter accept
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr #{guest_ephemeral} counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr #{guest_ephemeral} counter accept
+  }
 }
 TEMPLATE
     pop "firewall rule is added"
+  end
+
+  def generate_ip_port_set(rules)
+    rules.map do |rule|
+      ip = rule.ip.to_s
+      port_range = rule.port_range
+      port_rule = if port_range.begin == port_range.end - 1
+        port_range.begin.to_s
+      else
+        "#{port_range.begin}-#{port_range.end - 1}"
+      end
+
+      "#{ip} . #{port_rule}"
+    end.join(",")
+  end
+
+  def generate_private_ip4_list
+    vm.nics.map { NetAddr::IPv4Net.parse(_1.private_ipv4.network.to_s + "/26").to_s }.join(",")
+  end
+
+  def generate_private_ip6_list
+    vm.nics.map { NetAddr::IPv6Net.parse(_1.private_ipv6.network.to_s + "/64").to_s }.join(",")
+  end
+
+  def subdivide_network(net)
+    prefix = net.netmask.prefix_len + 1
+    halved = net.resize(prefix)
+    [halved, halved.next_sib]
   end
 end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -291,44 +291,6 @@ table ip nat {
   }
 }
 
-table inet fw_table {
-  set allowed_ipv4_ips {
-    type ipv4_addr;
-    flags interval;
-  }
-
-  set allowed_ipv6_ips {
-    type ipv6_addr;
-    flags interval;
-  }
-
-  set private_ipv4_ips {
-    type ipv4_addr;
-    flags interval;
-    elements = {
-      192.168.5.50/26
-    }
-  }
-
-  set private_ipv6_ips {
-    type ipv6_addr
-    flags interval
-    elements = { fd48:666c:a296:ce4b:2cc6::/64 }
-  }
-
-  chain forward_ingress {
-    type filter hook forward priority filter; policy drop;
-    tcp dport 22 ct state new,established,related accept
-    ip saddr @private_ipv4_ips ct state established,related,new counter accept
-    ip daddr @private_ipv4_ips ct state established,related counter accept
-    ip6 saddr @private_ipv6_ips ct state established,related,new counter accept
-    ip6 daddr @private_ipv6_ips ct state established,related counter accept
-    ip6 saddr fddf:53d2:4c89:2305:46a0::/80 ct state established,related,new counter accept
-    ip6 daddr fddf:53d2:4c89:2305:46a0::/80 ct state established,related counter accept
-    ip saddr @allowed_ipv4_ips ip daddr @private_ipv4_ips counter accept
-    ip6 saddr @allowed_ipv6_ips ip6 daddr fddf:53d2:4c89:2305:46a0::/80 counter accept
-  }
-}
 NFTABLES_CONF
       expect(vs).to receive(:apply_nftables)
       vs.write_nftables_conf(ip4, gua, nics)

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -11,32 +11,79 @@ RSpec.describe Prog::Vnet::UpdateFirewallRules do
   }
   let(:vm) {
     vmh = instance_double(VmHost, sshable: instance_double(Sshable, cmd: nil))
-    instance_double(Vm, private_subnets: [ps], vm_host: vmh, inhost_name: "x")
+    nic = instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.0/32"), private_ipv6: NetAddr::IPv6Net.parse("fd00::1/128"))
+    ephemeral_net6 = NetAddr::IPv6Net.parse("fd00::1/79")
+    instance_double(Vm, private_subnets: [ps], vm_host: vmh, inhost_name: "x", nics: [nic], ephemeral_net6: ephemeral_net6)
   }
 
   describe "update_firewall_rules" do
     it "populates elements if there are fw rules" do
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(ps).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, ip: "0.0.0.0/0"),
-        instance_double(FirewallRule, ip6?: false, ip: "1.1.1.1/32"),
-        instance_double(FirewallRule, ip6?: true, ip: "::/0"),
-        instance_double(FirewallRule, ip6?: true, ip: "fd00::1/128")
+        instance_double(FirewallRule, ip6?: false, ip: "0.0.0.0/0", port_range: nil),
+        instance_double(FirewallRule, ip6?: false, ip: "1.1.1.1/32", port_range: Sequel.pg_range(22..23)),
+        instance_double(FirewallRule, ip6?: true, ip: "::/0", port_range: nil),
+        instance_double(FirewallRule, ip6?: true, ip: "fd00::1/128", port_range: Sequel.pg_range(8080..65536))
       ])
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
-flush set inet fw_table allowed_ipv4_ips;
-flush set inet fw_table allowed_ipv6_ips;
+# An nftables idiom for idempotent re-create of a named entity: merge
+# in an empty table (a no-op if the table already exists) and then
+# delete, before creating with a new definition.
+table inet fw_table;
+delete table inet fw_table;
 table inet fw_table {
   set allowed_ipv4_ips {
     type ipv4_addr;
     flags interval;
-elements = {0.0.0.0/0,1.1.1.1/32}
+elements = {0.0.0.0/0}
   }
 
   set allowed_ipv6_ips {
     type ipv6_addr;
     flags interval;
-elements = {::/0,fd00::1/128}
+elements = {::/0}
+  }
+
+  set allowed_ipv4_port_tuple {
+    type ipv4_addr . inet_service;
+    flags interval;
+elements = {1.1.1.1/32 . 22}
+  }
+
+  set allowed_ipv6_port_tuple {
+    type ipv6_addr . inet_service;
+    flags interval;
+elements = {fd00::1/128 . 8080-65535}
+  }
+
+  set private_ipv4_ips {
+    type ipv4_addr;
+    flags interval;
+    elements = {
+      10.0.0.0/26
+    }
+  }
+
+  set private_ipv6_ips {
+    type ipv6_addr
+    flags interval
+    elements = { fd00::/64 }
+  }
+
+  chain forward_ingress {
+    type filter hook forward priority filter; policy drop;
+    ip saddr @private_ipv4_ips ct state established,related,new counter accept
+    ip daddr @private_ipv4_ips ct state established,related counter accept
+    ip6 saddr @private_ipv6_ips ct state established,related,new counter accept
+    ip6 daddr @private_ipv6_ips ct state established,related counter accept
+    ip6 saddr fd00::/80 ct state established,related,new counter accept
+    ip6 daddr fd00::/80 ct state established,related counter accept
+    ip saddr @allowed_ipv4_ips ip daddr @private_ipv4_ips counter accept
+    ip6 saddr @allowed_ipv6_ips ip6 daddr fd00::/80 counter accept
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
   }
 }
 ADD_RULES
@@ -48,8 +95,11 @@ ADD_RULES
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(ps).to receive(:firewall_rules).and_return([])
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
-flush set inet fw_table allowed_ipv4_ips;
-flush set inet fw_table allowed_ipv6_ips;
+# An nftables idiom for idempotent re-create of a named entity: merge
+# in an empty table (a no-op if the table already exists) and then
+# delete, before creating with a new definition.
+table inet fw_table;
+delete table inet fw_table;
 table inet fw_table {
   set allowed_ipv4_ips {
     type ipv4_addr;
@@ -62,9 +112,50 @@ table inet fw_table {
     flags interval;
 
   }
+
+  set allowed_ipv4_port_tuple {
+    type ipv4_addr . inet_service;
+    flags interval;
+
+  }
+
+  set allowed_ipv6_port_tuple {
+    type ipv6_addr . inet_service;
+    flags interval;
+
+  }
+
+  set private_ipv4_ips {
+    type ipv4_addr;
+    flags interval;
+    elements = {
+      10.0.0.0/26
+    }
+  }
+
+  set private_ipv6_ips {
+    type ipv6_addr
+    flags interval
+    elements = { fd00::/64 }
+  }
+
+  chain forward_ingress {
+    type filter hook forward priority filter; policy drop;
+    ip saddr @private_ipv4_ips ct state established,related,new counter accept
+    ip daddr @private_ipv4_ips ct state established,related counter accept
+    ip6 saddr @private_ipv6_ips ct state established,related,new counter accept
+    ip6 daddr @private_ipv6_ips ct state established,related counter accept
+    ip6 saddr fd00::/80 ct state established,related,new counter accept
+    ip6 daddr fd00::/80 ct state established,related counter accept
+    ip saddr @allowed_ipv4_ips ip daddr @private_ipv4_ips counter accept
+    ip6 saddr @allowed_ipv6_ips ip6 daddr fd00::/80 counter accept
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
+  }
 }
 ADD_RULES
-
       expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rule is added"})
     end
   end


### PR DESCRIPTION
### Adds port ranges to the firewall_rules
### Add firewall rule ip,port_range tuples for nftables
With this commit, we add 2 more sets to the nftables configuration so
that the port ranges are usable for the firewall rules. This will be
specifically used for postgresql service since it's supposed to serve
requests from one and only 5432 port.

Here, there is one more change to make the migration efforts easier.
Instead of flushing individual sets and repopulating, we start to use
delete table command so that we can make change to the whole table
definition without changing the dataplane code. With this change, the
firewall rules related parts in the dataplane script vm_setup is also
obsolete. Therefore, we remove it.

### Add firewall rules for port 5432 for pg servers
### Add GithubRunner and VmPool default firewall rule for dport 22