### PR TITLE
Always skip first address of subnet

### DIFF
--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -4,7 +4,7 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
   subject_is :nic
 
   label def add_subnet_addr
-    addr = nic.vm.boot_image.include?("ubuntu-2004") ? (nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s) : nic.private_subnet.net4.to_s
+    addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
     nic.vm.vm_host.sshable.cmd("sudo ip -n #{nic.vm.inhost_name.shellescape} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
     pop "add_subnet_addr is complete"
   end

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
     it "adds the subnet net4 address to the nic" do
       allow(tunnel.src_nic.vm).to receive_messages(ephemeral_net6: NetAddr.parse_net("2a01:4f8:10a:128b:4919::/80"), inhost_name: "hellovm")
       expect(tunnel.src_nic).to receive(:ubid_to_tap_name).and_return("ncname")
-      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm addr replace 1.1.1.0/26 dev ncname")
-      expect { nx.add_subnet_addr }.to exit({"msg" => "add_subnet_addr is complete"})
-    end
-
-    it "adds the subnet net4 address+1 to the nic for ubuntu-2004" do
-      allow(tunnel.src_nic.vm).to receive_messages(ephemeral_net6: NetAddr.parse_net("2a01:4f8:10a:128b:4919::/80"), inhost_name: "hellovm", boot_image: "ubuntu-2004")
-      expect(tunnel.src_nic).to receive(:ubid_to_tap_name).and_return("ncname")
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm addr replace 1.1.1.1/26 dev ncname")
       expect { nx.add_subnet_addr }.to exit({"msg" => "add_subnet_addr is complete"})
     end


### PR DESCRIPTION
9f0fced2c3ad738db83674f214951179bfe4896a was an expedient fix to fix Ubuntu 20.04, because sometime after that, Linux increased the flexibility of the definition of subnets to support using the all-zero suffix for an interface's normal address.

The problem is, in general, we won't know what version of the kernel is booting, and to do things this way is contra-norms.  It also may not work on some other operating systems because it is contra-norms.

We're still early enough where we can probably sneak this in without a huge project, and I don't think using a the lowest common denominator here is practically nor aesthetically offensive.