### PR TITLE
Storage device support

### DIFF
--- a/migrate/20231207_storage_device.rb
+++ b/migrate/20231207_storage_device.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:storage_device) do
+      column :id, :uuid, primary_key: true
+      column :name, :text, null: false
+      column :total_storage_gib, :Integer, null: false
+      column :available_storage_gib, :Integer, null: false
+      column :enabled, :bool, null: false, default: true
+      foreign_key :vm_host_id, :vm_host, type: :uuid
+      unique [:vm_host_id, :name]
+    end
+
+    alter_table(:vm_storage_volume) do
+      add_foreign_key :storage_device_id, :storage_device, type: :uuid, null: true
+    end
+
+    # Reuse corresponding VmHost's UBID as StorageDevice UBID and create
+    # records for default storage devices on existing hosts.
+    run <<~SQL
+      INSERT INTO storage_device
+        SELECT id, 'DEFAULT', total_storage_gib, available_storage_gib, id
+        FROM vm_host;
+
+      UPDATE vm_storage_volume
+      SET storage_device_id = vm_host_id
+      FROM vm
+      WHERE vm_storage_volume.vm_id = vm.id;
+    SQL
+
+    # Now that every volume has a storage device, we can enforce NOT NULL.
+    alter_table(:vm_storage_volume) do
+      set_column_not_null :storage_device_id
+    end
+  end
+end

--- a/migrate/20231207_storage_device.rb
+++ b/migrate/20231207_storage_device.rb
@@ -20,7 +20,7 @@ Sequel.migration do
     # records for default storage devices on existing hosts.
     run <<~SQL
       INSERT INTO storage_device
-        SELECT id, 'DEFAULT', total_storage_gib, available_storage_gib, id
+        SELECT id, 'DEFAULT', total_storage_gib, available_storage_gib, true, id
         FROM vm_host;
 
       UPDATE vm_storage_volume

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class StorageDevice < Sequel::Model
+  many_to_one :vm_host
+
+  def self.generate_uuid
+    UBID.generate(UBID::TYPE_ETC).to_uuid
+  end
+end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -11,8 +11,9 @@ class VmHost < Sequel::Model
   one_to_one :hetzner_host, key: :id
   one_to_many :assigned_host_addresses, key: :host_id, class: :AssignedHostAddress
   one_to_many :spdk_installations, key: :vm_host_id
+  one_to_many :storage_devices, key: :vm_host_id
 
-  plugin :association_dependencies, assigned_host_addresses: :destroy, assigned_subnets: :destroy, hetzner_host: :destroy, spdk_installations: :destroy
+  plugin :association_dependencies, assigned_host_addresses: :destroy, assigned_subnets: :destroy, hetzner_host: :destroy, spdk_installations: :destroy, storage_devices: :destroy
 
   include ResourceMethods
   include SemaphoreMethods

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -5,6 +5,7 @@ require_relative "../model"
 class VmStorageVolume < Sequel::Model
   many_to_one :vm
   many_to_one :spdk_installation
+  many_to_one :storage_device
   many_to_one :key_encryption_key_1, class: :StorageKeyEncryptionKey
   many_to_one :key_encryption_key_2, class: :StorageKeyEncryptionKey
 

--- a/prog/rotate_storage_kek.rb
+++ b/prog/rotate_storage_kek.rb
@@ -39,7 +39,8 @@ class Prog::RotateStorageKek < Prog::Base
 
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} reencrypt", stdin: data_json)
+    q_device = vm_storage_volume.storage_device.name.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_device} #{disk_index} reencrypt", stdin: data_json)
 
     hop_test_keys_on_server
   end
@@ -52,7 +53,8 @@ class Prog::RotateStorageKek < Prog::Base
 
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} test-keys", stdin: data_json)
+    q_device = vm_storage_volume.storage_device.name.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_device} #{disk_index} test-keys", stdin: data_json)
 
     hop_retire_old_key_on_server
   end
@@ -60,7 +62,8 @@ class Prog::RotateStorageKek < Prog::Base
   label def retire_old_key_on_server
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} retire-old-key", stdin: "{}")
+    q_device = vm_storage_volume.storage_device.name.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_device} #{disk_index} retire-old-key", stdin: "{}")
 
     hop_retire_old_key_in_database
   end

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -136,8 +136,18 @@ class Prog::Test::HetznerServer < Prog::Base
 
   label def wait_install_bdev_ubid
     reap
-    hop_test_host_encrypted if children_idle
+    hop_create_storage_devices if children_idle
     donate
+  end
+
+  label def create_storage_devices
+    sshable.cmd("sudo mkdir -p /var/storage/devices/disk02")
+    StorageDevice.create(
+      vm_host_id: vm_host.id, name: "disk02", available_storage_gib: 100,
+      total_storage_gib: 100
+    ) { _1.id = StorageDevice.generate_uuid }
+
+    hop_test_host_encrypted
   end
 
   label def test_host_encrypted

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -79,12 +79,12 @@ class Prog::Vm::HostNexus < Prog::Base
 
         vm_host.update(**kwargs)
       when "LearnStorage"
-        kwargs = {
+        StorageDevice.create(
+          name: "DEFAULT",
           total_storage_gib: st.exitval.fetch("total_storage_gib"),
-          available_storage_gib: st.exitval.fetch("available_storage_gib")
-        }
-
-        vm_host.update(**kwargs)
+          available_storage_gib: st.exitval.fetch("available_storage_gib"),
+          vm_host_id: vm_host.id
+        ) { _1.id = vm_host.id }
       end
     end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -13,7 +13,7 @@ class Prog::Vm::Nexus < Prog::Base
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
-    enable_ip4: false, pool_id: nil, arch: "x64")
+    enable_ip4: false, pool_id: nil, arch: "x64", distinct_storage_devices: false)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -89,7 +89,10 @@ class Prog::Vm::Nexus < Prog::Base
       Strand.create(
         prog: "Vm::Nexus",
         label: "start",
-        stack: [{"storage_volumes" => storage_volumes.map { |v| v.transform_keys(&:to_s) }}]
+        stack: [{
+          "storage_volumes" => storage_volumes.map { |v| v.transform_keys(&:to_s) },
+          "distinct_storage_devices" => distinct_storage_devices
+        }]
       ) { _1.id = vm.id }
     end
   end
@@ -128,13 +131,6 @@ class Prog::Vm::Nexus < Prog::Base
     @params_path ||= File.join(vm_home, "prep.json")
   end
 
-  def vm_storage_size_gib
-    if (storage_volumes = frame["storage_volumes"])
-      return storage_volumes.map { _1["size_gib"] }.sum
-    end
-    vm.storage_size_gib
-  end
-
   def storage_volumes
     @storage_volumes ||= vm.vm_storage_volumes.map { |s|
       {
@@ -146,7 +142,8 @@ class Prog::Vm::Nexus < Prog::Base
         "encrypted" => !s.key_encryption_key_1.nil?,
         "spdk_version" => s.spdk_version,
         "use_bdev_ubi" => s.use_bdev_ubi,
-        "skip_sync" => s.skip_sync
+        "skip_sync" => s.skip_sync,
+        "storage_device" => s.storage_device.name
       }
     }
   end
@@ -162,16 +159,35 @@ class Prog::Vm::Nexus < Prog::Base
   def allocation_dataset
     requires_bdev_ubi = frame["storage_volumes"].any? { |v| v["use_bdev_ubi"] }
     spdk_where_clause = requires_bdev_ubi ? "AND id in (select vm_host_id from spdk_installation where version like '%ubi%' and allocation_weight > 0)" : ""
-    DB[<<SQL, vm.cores, vm.mem_gib_ratio, vm.mem_gib, vm_storage_size_gib, vm.location, vm.arch]
+
+    # YYY: Although when the following WHERE clauses return true then disks can
+    # be allocated, but there are edge cases where disks can be allocated, but
+    # the following WHERE clauses return false. Improve them.
+    max_storage_gib = frame["storage_volumes"].map { |v| v["size_gib"] }.max
+    total_storage_gib = frame["storage_volumes"].sum { |v| v["size_gib"] }
+    n_volumes = frame["storage_volumes"].length
+
+    disks_can_fit_on_distinct_devices = "(SELECT count(*) FROM storage_device WHERE " \
+          "storage_device.enabled AND storage_device.vm_host_id = vm_host.id AND " \
+          "storage_device.available_storage_gib >= #{max_storage_gib}) >= #{n_volumes}"
+
+    all_disks_can_fit_a_single_device = "(SELECT max(available_storage_gib) FROM storage_device WHERE " \
+    "storage_device.enabled AND storage_device.vm_host_id = vm_host.id) >= #{total_storage_gib}"
+
+    device_where_clause = frame["distinct_storage_devices"] ?
+        "AND #{disks_can_fit_on_distinct_devices}" :
+        "AND (#{disks_can_fit_on_distinct_devices} OR #{all_disks_can_fit_a_single_device})"
+
+    DB[<<SQL, vm.cores, vm.mem_gib_ratio, vm.mem_gib, vm.location, vm.arch]
 SELECT *, vm_host.total_mem_gib / vm_host.total_cores AS mem_ratio
 FROM vm_host
 WHERE vm_host.used_cores + ? < least(vm_host.total_cores, vm_host.total_mem_gib / ?)
 AND vm_host.used_hugepages_1g + ? < vm_host.total_hugepages_1g
-AND vm_host.available_storage_gib > ?
 AND vm_host.allocation_state = 'accepting'
 AND vm_host.location = ?
 AND vm_host.arch = ?
 #{spdk_where_clause}
+#{device_where_clause}
 ORDER BY mem_ratio, used_cores
 SQL
   end
@@ -184,15 +200,41 @@ SQL
       .where(id: vm_host_id, allocation_state: "accepting")
       .update(
         used_cores: Sequel[:used_cores] + vm.cores,
-        used_hugepages_1g: Sequel[:used_hugepages_1g] + vm.mem_gib,
-        available_storage_gib: Sequel[:available_storage_gib] - vm_storage_size_gib
+        used_hugepages_1g: Sequel[:used_hugepages_1g] + vm.mem_gib
       ).zero?
 
     vm_host_id
   end
 
-  def create_storage_volume_records(vm_host)
-    frame["storage_volumes"].each_with_index do |volume, disk_index|
+  def allocate_storage_devices(vm_host, storage_volumes)
+    devices = vm_host.storage_devices
+    device_index = 0
+
+    storage_volumes.map do |volume|
+      while device_index < devices.length &&
+          (!devices[device_index].enabled ||
+          devices[device_index].available_storage_gib < volume["size_gib"])
+        device_index += 1
+      end
+
+      fail "Storage device allocation failed" unless device_index < devices.length
+
+      # Allocate!
+      # YYY: handle concurrency
+      allocated_device = devices[device_index]
+      volume.update({"storage_device_id" => allocated_device.id})
+      allocated_device.update(available_storage_gib: allocated_device.available_storage_gib - volume["size_gib"])
+
+      # If we require distinct storage devices, then the next volume can't use
+      # this device. Therfore, skip it.
+      device_index += 1 if frame["distinct_storage_devices"]
+
+      volume
+    end
+  end
+
+  def create_storage_volume_records(vm_host, storage_volumes)
+    storage_volumes.each_with_index do |volume, disk_index|
       key_encryption_key = if volume["encrypted"]
         key_wrapping_algorithm = "aes-256-gcm"
         cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
@@ -219,6 +261,7 @@ SQL
         size_gib: volume["size_gib"],
         use_bdev_ubi: volume["use_bdev_ubi"],
         skip_sync: volume["skip_sync"],
+        storage_device_id: volume["storage_device_id"],
         disk_index: disk_index,
         key_encryption_key_1_id: key_encryption_key&.id,
         spdk_installation_id: spdk_installation_id
@@ -279,7 +322,10 @@ SQL
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled
 
-    create_storage_volume_records(vm_host)
+    DB.transaction do
+      storage_volumes = allocate_storage_devices(vm_host, frame["storage_volumes"])
+      create_storage_volume_records(vm_host, storage_volumes)
+    end
 
     Clog.emit("vm allocated") do
       {allocation: {vm_host_ubid: vm_host.ubid, ip4: ip4, address: address&.cidr&.to_s,
@@ -451,10 +497,14 @@ SQL
         nic.incr_destroy
       end
 
+      vm.vm_storage_volumes.each do |vol|
+        dev = vol.storage_device
+        dev.update(available_storage_gib: dev.available_storage_gib + vol.size_gib)
+      end
+
       VmHost.dataset.where(id: vm.vm_host_id).update(
         used_cores: Sequel[:used_cores] - vm.cores,
-        used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib,
-        available_storage_gib: Sequel[:available_storage_gib] + vm_storage_size_gib
+        used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib
       )
       vm.projects.map { vm.dissociate_with_project(_1) }
       vm.destroy

--- a/rhizome/host/bin/storage-key-tool
+++ b/rhizome/host/bin/storage-key-tool
@@ -11,6 +11,11 @@ unless (vm_name = ARGV.shift)
   exit 1
 end
 
+unless (device = ARGV.shift)
+  puts "expect storage device as argument"
+  exit 1
+end
+
 unless (disk_index = ARGV.shift)
   puts "expected disk_index as argument"
   exit 1
@@ -21,7 +26,7 @@ unless (action = ARGV.shift)
   exit 1
 end
 
-storage_key_tool = StorageKeyTool.new(vm_name, disk_index)
+storage_key_tool = StorageKeyTool.new(vm_name, device, disk_index)
 
 case action
 when "reencrypt"

--- a/rhizome/host/lib/storage_key_tool.rb
+++ b/rhizome/host/lib/storage_key_tool.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
-require_relative "vm_path"
+require_relative "storage_path"
 require_relative "../lib/storage_key_encryption"
 
 class StorageKeyTool
-  def initialize(vm_name, disk_index)
-    vp = VmPath.new(vm_name)
-    @key_file = vp.data_encryption_key(disk_index)
+  def initialize(vm_name, storage_device, disk_index)
+    sp = StoragePath.new(vm_name, storage_device, disk_index)
+    @key_file = sp.data_encryption_key
     @new_key_file = "#{@key_file}.new"
   end
 

--- a/rhizome/host/lib/storage_path.rb
+++ b/rhizome/host/lib/storage_path.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+DEFAULT_STORAGE_DEVICE = "DEFAULT"
+
+class StoragePath
+  def initialize(vm_name, device, disk_index)
+    @vm_name = vm_name
+    @device = device
+    @disk_index = disk_index
+  end
+
+  def device_path
+    @device_path ||=
+      (@device == DEFAULT_STORAGE_DEVICE) ?
+          File.join("", "var", "storage") :
+          File.join("", "var", "storage", "devices", @device)
+  end
+
+  def storage_root
+    @storage_root ||= File.join(device_path, @vm_name)
+  end
+
+  def storage_dir
+    @storage_dir ||= File.join(storage_root, @disk_index.to_s)
+  end
+
+  def disk_file
+    @disk_file ||= File.join(storage_dir, "disk.raw")
+  end
+
+  def data_encryption_key
+    @dek_path ||= File.join(storage_dir, "data_encryption_key.json")
+  end
+
+  def vhost_sock
+    @vhost_sock ||= File.join(storage_dir, "vhost.sock")
+  end
+end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -39,14 +39,6 @@ class VmPath
     File.join("", "vm", @vm_name, n)
   end
 
-  def storage_root
-    File.join("", "var", "storage", @vm_name)
-  end
-
-  def storage(disk_index, n)
-    File.join(storage_root, disk_index.to_s, n)
-  end
-
   # Define path, q_path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
@@ -94,18 +86,6 @@ class VmPath
     define_method write_method_name do |s|
       write(home(file_name), s)
     end
-  end
-
-  def vhost_sock(disk_index)
-    storage(disk_index, "vhost.sock")
-  end
-
-  def disk(disk_index)
-    storage(disk_index, "disk.raw")
-  end
-
-  def data_encryption_key(disk_index)
-    storage(disk_index, "data_encryption_key.json")
   end
 
   def image_root

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -106,16 +106,21 @@ class VmSetup
   end
 
   def purge_storage
-    # Storage hasn't been created yet, so nothing to purge.
-    return if !File.exist?(vp.storage_root)
+    # prep.json doesn't exist, nothing more to do
+    return if !File.exist?(vp.prep_json)
+
+    storage_roots = []
 
     params = JSON.parse(File.read(vp.prep_json))
     params["storage_volumes"].each { |params|
       volume = StorageVolume.new(@vm_name, params)
       volume.purge_spdk_artifacts
+      storage_roots.append(volume.storage_root)
     }
 
-    rm_if_exists(vp.storage_root)
+    storage_roots.each { |path|
+      rm_if_exists(path)
+    }
   end
 
   def unmount_hugepages

--- a/rhizome/host/spec/storage_key_tool_spec.rb
+++ b/rhizome/host/spec/storage_key_tool_spec.rb
@@ -5,7 +5,7 @@ require "openssl"
 require "base64"
 
 RSpec.describe StorageKeyTool do
-  subject(:skt) { described_class.new("vm12345", 3) }
+  subject(:skt) { described_class.new("vm12345", DEFAULT_STORAGE_DEVICE, 3) }
 
   def generate_kek
     key_wrapping_algorithm = "aes-256-gcm"

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -80,44 +80,52 @@ RSpec.describe VmSetup do
   end
 
   describe "#purge_storage" do
-    it "can purge storage" do
-      vol_1_params = {
+    let(:vol_1_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_0",
         "disk_index" => 0,
         "encrypted" => false,
         "spdk_version" => "some-version"
       }
-      vol_2_params = {
+    }
+    let(:vol_2_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_1",
         "disk_index" => 1,
         "encrypted" => true,
         "spdk_version" => "some-version"
       }
-      params = JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
+    let(:params) {
+      JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
 
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(true)
+    it "can purge storage" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
 
       # delete the unencrypted volume
       sv_1 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
       expect(sv_1).to receive(:purge_spdk_artifacts)
+      expect(sv_1).to receive(:storage_root).and_return("/var/storage/test")
 
       # delete the encrypted volume
       sv_2 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
       expect(sv_2).to receive(:purge_spdk_artifacts)
+      expect(sv_2).to receive(:storage_root).and_return("/var/storage/test")
 
-      expect(FileUtils).to receive(:rm_r).with("/var/storage/test")
+      allow(FileUtils).to receive(:rm_r).with("/var/storage/test")
 
       vs.purge_storage
     end
 
-    it "exits silently if storage hasn't been created yet" do
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(false)
-      vs.purge_storage
+    it "exits silently if vm hasn't been created yet" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
+      expect { vs.purge_storage }.not_to raise_error
     end
   end
 

--- a/spec/prog/rotate_storage_kek_spec.rb
+++ b/spec/prog/rotate_storage_kek_spec.rb
@@ -36,7 +36,12 @@ RSpec.describe Prog::RotateStorageKek do
   }
 
   let(:volume) {
-    disk = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0)
+    dev = StorageDevice.create(
+      name: "nvme0",
+      total_storage_gib: 100,
+      available_storage_gib: 20
+    ) { _1.id = StorageDevice.generate_uuid }
+    disk = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0, storage_device: dev)
     disk.key_encryption_key_1 = current_kek
     disk.key_encryption_key_2 = new_kek
     disk.vm = vm
@@ -64,7 +69,7 @@ RSpec.describe Prog::RotateStorageKek do
 
   describe "#install" do
     it "installs the key & hops" do
-      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* reencrypt/,
+      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* nvme0 0 reencrypt/,
         stdin: "{\"old_key\":{\"key\":\"key_1\",\"init_vector\":\"iv_1\",\"algorithm\":\"aes-256-gcm\",\"auth_data\":\"somedata\"},\"new_key\":{\"key\":\"key_2\",\"init_vector\":\"iv_2\",\"algorithm\":\"aes-256-gcm\",\"auth_data\":\"somedata\"}}")
       expect { rsk.install }.to hop("test_keys_on_server")
     end
@@ -72,14 +77,14 @@ RSpec.describe Prog::RotateStorageKek do
 
   describe "#test_keys_on_server" do
     it "can test keys on server" do
-      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* test-keys/, stdin: /.*/)
+      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* nvme0 0 test-keys/, stdin: /.*/)
       expect { rsk.test_keys_on_server }.to hop("retire_old_key_on_server")
     end
   end
 
   describe "#retire_old_key_on_server" do
     it "can retire old keys on server" do
-      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* retire-old-key/, stdin: "{}")
+      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* nvme0 0 retire-old-key/, stdin: "{}")
       expect { rsk.retire_old_key_on_server }.to hop("retire_old_key_in_database")
     end
   end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -127,10 +127,12 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#wait_prep" do
     it "updates the vm_host record from the finished programs" do
       expect(nx).to receive(:leaf?).and_return(true)
+      sshable = Sshable.create_with_id
+      host = VmHost.create(location: "xyz") { _1.id = sshable.id }
+      allow(vm_host).to receive(:id).and_return(host.id)
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
       expect(vm_host).to receive(:update).with(arch: "arm64")
       expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2)
-      expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),
         instance_double(Strand, prog: "LearnArch", exitval: {"arch" => "arm64"}),
@@ -138,6 +140,13 @@ RSpec.describe Prog::Vm::HostNexus do
         instance_double(Strand, prog: "LearnStorage", exitval: {"total_storage_gib" => 300, "available_storage_gib" => 500}),
         instance_double(Strand, prog: "ArbitraryOtherProg")
       ])
+
+      expect(StorageDevice).to receive(:create).with(
+        name: "DEFAULT",
+        total_storage_gib: 300,
+        available_storage_gib: 500,
+        vm_host_id: host.id
+      ).and_call_original
 
       expect { nx.wait_prep }.to hop("setup_hugepages")
     end

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -159,7 +159,9 @@ RSpec.describe UBID do
     vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
     expect(vm.ubid).to start_with UBID::TYPE_VM
 
-    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id)
+    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
+
+    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id, storage_device_id: dev.id)
     expect(sv.ubid).to start_with UBID::TYPE_VM_STORAGE_VOLUME
 
     kek = StorageKeyEncryptionKey.create_with_id(algorithm: "x", key: "x", init_vector: "x", auth_data: "x")
@@ -221,7 +223,8 @@ RSpec.describe UBID do
     host = VmHost.create(location: "x") { _1.id = sshable.id }
     si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
     vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
-    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id)
+    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
+    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id, storage_device_id: dev.id)
     kek = StorageKeyEncryptionKey.create_with_id(algorithm: "x", key: "x", init_vector: "x", auth_data: "x")
     account = Account.create_with_id(email: "x@y.net")
     project = account.create_project_with_default_policy("x")


### PR DESCRIPTION
Previously there wasn't an easy way to store each disk of a VM on a separate storage device on the host. This PR enables that by introducing storage devices.

By default, there is a `DEFAULT` storage device created for each host which places data directories directly under `/var/storage`.

To create other storage devices:
* System admin mounts a disk on the host to `/var/storage/devices/01`, and mounts a different disk to `/var/storage/devices/02`.
* Create a storage device record for each of these devices:
```
> StorageDevice.create(
      vm_host_id: vmh.id, name: "01", available_storage_gib: 100,
      total_storage_gib: 100) { _1.id = StorageDevice.generate_uuid }
> StorageDevice.create(
      vm_host_id: vmh.id, name: "02", available_storage_gib: 100,
      total_storage_gib: 100) { _1.id = StorageDevice.generate_uuid }
```
* If you want, disable the default device:
```
> StorageDevice.where(vm_host_id: vmh.id, name: "DEFAULT").update(enabled: false)
```
* Now, when provisioning a VM you can use separate devices for each volume:
```
> Prog::Vm::Nexus.assemble(..., storage_volumes: [{...}, {...}], ..., distinct_storage_devices: true)
```

* Then, the one of the storage volumes will be stored on the first physical disk & the other storage volume will be stored on the second physical disk. For example, one of the disk's data will go to `/var/storage/devices/01/vm12345/1/`
