### PR TITLE
Ensure requested entities exists before accessing in Postgres serializer

### DIFF
--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -21,7 +21,7 @@ class Serializers::Web::Postgres < Serializers::Base
   structure(:detailed) do |pg|
     base(pg).merge({
       connection_string: pg.connection_string
-    }).merge(pg.server.primary? ? {
+    }).merge((pg.timeline && pg.server && pg.server.primary?) ? {
       earliest_restore_time: pg.timeline.earliest_restore_time&.utc&.iso8601,
       latest_restore_time: pg.timeline.latest_restore_time&.utc&.iso8601
     } : {})

--- a/spec/serializers/web/postgres_spec.rb
+++ b/spec/serializers/web/postgres_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Serializers::Web::Postgres do
 
   it "can serialize when no earliest/latest restore times" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).twice
-    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).twice
+    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)
+    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(3)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
@@ -17,8 +17,8 @@ RSpec.describe Serializers::Web::Postgres do
   it "can serialize when have earliest/latest restore times" do
     time = Time.now
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).twice
-    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).twice
+    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).exactly(3)
+    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(3)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to eq(time.iso8601)
     expect(data[:latest_restore_time]).to eq(time.iso8601)
@@ -26,7 +26,7 @@ RSpec.describe Serializers::Web::Postgres do
 
   it "can serialize when not primary" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: false, vm: nil)).twice
+    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: false, vm: nil))
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil


### PR DESCRIPTION
During deprovisioning, entities might be deleted in various orders, in some of them, serializing Postgres results in an exception since the requested entities do not exist anymore. With this commit we are adding checks before trying to access those entities.