### PR TITLE
Destroy child strands while deleting PostgresServer

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -237,6 +237,7 @@ SQL
   label def destroy
     decr_destroy
 
+    strand.children.each { _1.destroy }
     vm.private_subnets.each { _1.incr_destroy }
     vm.incr_destroy
     postgres_server.destroy


### PR DESCRIPTION
If destroy request comes during wait_bootstrap_rhizome, existing child strand prevents deletion of the PostgresServer. Also Prog::BootstrapRhizome cannot complete because VM gets deleted. Since we are destroying the resource, we do not care about the completion of Prog::BootstrapRhizome, so we can just destroy it as well.