### PR TITLE
Adds blob_storage selection by id from config to pg_timeline

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -111,6 +111,7 @@ module Config
   optional :postgres_service_hostname, string
   optional :postgres_service_blob_storage_access_key, string
   optional :postgres_service_blob_storage_secret_key, string
+  optional :postgres_service_blob_storage_id, string
 
   # Logging
   optional :database_logger_level, string

--- a/migrate/20231207_add_pg_blob_str_id.rb
+++ b/migrate/20231207_add_pg_blob_str_id.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:postgres_timeline) do
+      add_column :blob_storage_id, :uuid, null: true
+    end
+  end
+end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -85,7 +85,7 @@ PGHOST=/var/run/postgresql
   end
 
   def blob_storage
-    @blob_storage ||= Project[Config.postgres_service_project_id].minio_clusters.first
+    @blob_storage ||= MinioCluster[blob_storage_id]
   end
 
   def blob_storage_endpoint

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -15,7 +15,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       postgres_timeline = PostgresTimeline.create_with_id(
         parent_id: parent_id,
         access_key: SecureRandom.hex(16),
-        secret_key: SecureRandom.hex(32)
+        secret_key: SecureRandom.hex(32),
+        blob_storage_id: Config.postgres_service_blob_storage_id
       )
       Strand.create(prog: "Postgres::PostgresTimelineNexus", label: "start") { _1.id = postgres_timeline.id }
     end

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -150,7 +150,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns blob storage endpoint" do
-    expect(Project).to receive(:[]).and_return(instance_double(Project, minio_clusters: [instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"])]))
+    expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"]))
     expect(postgres_timeline.blob_storage_endpoint).to eq("https://blob-endpoint")
   end
 


### PR DESCRIPTION
We need to add this because we'll need to have multiple MinIO clusters
temporarily. We are pinning the backing blob storage to the postgres
service so that it persistantly uses the same system even when there are
multiple of them in the project.