### PR TITLE
Add default dns server to dnsmasq.conf for ip4

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -343,6 +343,7 @@ dhcp-authoritative
 dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
 #{private_ip_dhcp}
 dhcp-option=option6:dns-server,2620:fe::fe,2620:fe::9
+dhcp-option=option:dns-server,149.112.112.112,9.9.9.9
 dhcp-option=26,1400
 DNSMASQ_CONF
 


### PR DESCRIPTION
We need to add the default dns server setting to dnsmasq.conf to make alma linux name resolution work. Looks like the DHCP packets from dnsmasq contains a DNS field which is filled with the VM facing interface's ip address when the option is not specified. That is not picked up by the ubuntu VMs but almalinux does. That results in name resolution failures which causes overall network failure. Here, we set it to quad9 servers which fixes the issue.

fixes #927 