### PR TITLE
Drop foreign key constraints in PostgresResource and PostgresTimeline

### DIFF
--- a/migrate/20231208_drop_pg_foreign_key_constraints.rb
+++ b/migrate/20231208_drop_pg_foreign_key_constraints.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  # When column names are passed in array form, Sequel only drops or creates
+  # the constraint, without touching to the column itself.
+  up do
+    alter_table(:postgres_resource) do
+      drop_foreign_key [:parent_id]
+    end
+
+    alter_table(:postgres_timeline) do
+      drop_foreign_key [:parent_id]
+    end
+  end
+
+  down do
+    alter_table(:postgres_resource) do
+      add_foreign_key([:parent_id], :postgres_resource)
+    end
+
+    alter_table(:postgres_timeline) do
+      add_foreign_key([:parent_id], :postgres_timeline)
+    end
+  end
+end

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -11,6 +11,10 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   semaphore :destroy
 
   def self.assemble(parent_id: nil)
+    if parent_id && (PostgresResource[parent_id]).nil?
+      fail "No existing parent"
+    end
+
     DB.transaction do
       postgres_timeline = PostgresTimeline.create_with_id(
         parent_id: parent_id,

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
   end
 
   describe ".assemble" do
+    it "throws an exception if parent is not found" do
+      expect {
+        described_class.assemble(parent_id: "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b")
+      }.to raise_error RuntimeError, "No existing parent"
+    end
+
     it "creates postgres timeline" do
       st = described_class.assemble
 


### PR DESCRIPTION
Both of these tables has parent_id column referencing themselves. They are used in forks to refer the parent PostgresResource and PostgresTimeline. Foreign key constraints prevents deletion of the parent entity while the child entity is still around, so we are removing the constraint.