### PR TITLE
Fix command order in initialize-database-from-backup

### DIFF
--- a/rhizome/postgres/bin/initialize-database-from-backup
+++ b/rhizome/postgres/bin/initialize-database-from-backup
@@ -9,13 +9,13 @@ end
 
 backup_label = ARGV[0]
 
+r "chown postgres /dat"
 r "sudo -u postgres wal-g backup-fetch /dat/16/data #{backup_label} --config /etc/postgresql/wal-g.env"
 
 # We want to use pg_createcluster, even with an existing database folder because
 # pg_createcluster does additonal things like configuring systemd. However, it
 # also expect to see .conf files in the data directory, so that it can move them
 # to /etc/postgresql/$VERSION/main. Thus we create a bunch of .conf files.
-r "chown postgres /dat"
 r "sudo -u postgres touch /dat/16/data/pg_ident.conf"
 r "sudo -u postgres touch /dat/16/data/pg_hba.conf"
 r "sudo -u postgres touch /dat/16/data/postgresql.conf"


### PR DESCRIPTION
To work properly, wal-g backup-fetch needs /dat directory to be owned by postgres user. We already do that but just after backup-fetch. This commit fixes the order.