### PR TITLE
Fix empty alert box if DELETE returns 404

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -77,6 +77,11 @@ $(".delete-btn").on("click", function (event) {
             window.location.href = redirect;
         },
         error: function (xhr, ajaxOptions, thrownError) {
+          if(xhr.status == 404){
+            window.location.href = redirect;
+            return;
+          }
+
           let message = thrownError;
           try {
             err = JSON.parse(xhr.responseText);


### PR DESCRIPTION
404 is count as error, thus creating an alert box. However for DELETE requests 404 is expected response, so we don't want to handle it as error.