### PR TITLE
Add extra logging when leases are unexpectedly cleared

### DIFF
--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -55,6 +55,8 @@ SQL
         end
       end.at_least(:once)
 
+      expect(Clog).to receive(:emit).with("lease violated data").and_call_original
+      expect(Clog).to receive(:emit).at_least(:once).and_call_original
       expect { st.run }.to raise_error RuntimeError, "BUG: lease violated"
     end
   end


### PR DESCRIPTION
Unfortunately, this incurs an extra query returning a lot more data (relatively) and transaction block on every freeing of a lease, but it's a cost we can incur.

After increasing parallelism levels, we have still yet another bug rattling around with transient strands, probably still related to `exitval`.  It's rare: for the many, many strand executions, I've seen it once since I made that change.

Adding this information can help us with vital clues, such as the state of the `lease` and `exitval` columns.