### PR TITLE
Fix the bug that waiting workflow jobs steal the runners

### DIFF
--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -75,10 +75,14 @@ class CloverWeb
       return success("GithubRunner[#{runner.ubid}] created")
     end
 
+    unless (runner_id = job.fetch("runner_id"))
+      return error("A workflow_job without runner_id")
+    end
+
     runner = GithubRunner.first(
       installation_id: installation.id,
       repository_name: data["repository"]["full_name"],
-      runner_id: job.fetch("runner_id")
+      runner_id: runner_id
     )
 
     return error("Unregistered runner") unless runner

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -77,6 +77,13 @@ RSpec.describe Clover, "github" do
       expect(page.body).to eq({message: "GithubRunner[#{runner.ubid}] created"}.to_json)
     end
 
+    it "fails if not queued and runner_id is empty" do
+      send_webhook("workflow_job", workflow_job_payload(action: "waiting", runner_id: nil))
+
+      expect(page.status_code).to eq(200)
+      expect(page.body).to eq({error: {message: "A workflow_job without runner_id"}}.to_json)
+    end
+
     it "fails if runner not exists" do
       send_webhook("workflow_job", workflow_job_payload(action: "in_progress", runner_id: 789))
 


### PR DESCRIPTION
Today, I noticed a GithubRunner instance running for ~8 hours. This seemed suspicious to me, as runners are typically ephemeral and CI jobs generally do not last this long. I suspected that the runner might be stuck. I checked and the job status was "waiting". GitHub Actions has a manual approval mechanism. The job remains in the "waiting" state until someone approves it. The job states proceed in the following order: waiting, queued, in_progress, and completed. If a job doesn't require manual approval, it begins in the "queued" state. We provision a new runner when we receive a webhook event for a workflow job in the "queued" state.

GitHubRunner rows have an empty runner_id column until the runner picks up a job. When GitHub sends a workflow_job event in the "waiting" state, `workflow_job["runner_id"]` is also empty. Therefore, even when the job is in the "waiting" state, we assume that the runner_id values match and associate the job with the runner.  Consequently, the runner waits for the job, which remains in the "waiting" state until manual approval.