### PR TITLE
Add deadline for DNS purge

### DIFF
--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -9,6 +9,7 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
 
   label def wait
     if dns_zone.last_purged_at < Time.now - 60 * 60 * 1 # ~1 hour
+      register_deadline(:wait, 5 * 60)
       hop_purge_dns_records
     end
 


### PR DESCRIPTION
We observed a case where DNS purge stuck because some of the rows it tries to delete were already deleted, which is unexpected because the only place that deletes DNS records is purge_dns_records label. While debugging the issue we fixed it thus missed the furter debugging chance to understand root cause. I couldn't reproduce this in my local environment, so I'm adding a deadline in case we hit it again.