### PR TITLE
Adds initial flowtable into nftables definition

### DIFF
--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -55,8 +55,15 @@ table inet fw_table {
     elements = { #{generate_private_ip6_list} }
   }
 
+  flowtable ubi_flowtable {
+    hook ingress priority filter
+    devices = { #{vm.nics.map(&:ubid_to_tap_name).join(",")}, vethi#{vm.inhost_name} }
+  }
+
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
+    ip protocol tcp counter flow offload @ubi_flowtable
+    ip protocol udp counter flow offload @ubi_flowtable
     ip saddr @private_ipv4_ips ct state established,related,new counter accept
     ip daddr @private_ipv4_ips ct state established,related counter accept
     ip6 saddr @private_ipv6_ips ct state established,related,new counter accept


### PR DESCRIPTION
We add the first ever flowtable implementation. flowtables are important
to reduce cpu cycles spent on each packet and possibly help with
latency. The main objective is to cache the tracked packets and create a
cache for the decisions as well.  This way we skip multiple nodes in the
netplan route. Main source of implementation for this commit was;
https://thermalcircle.de/doku.php?id=blog:linux:flowtables_1_a_netfilter_nftables_fastpath

The way flowtables work is that each packet traverses through netfilter
nodes in the host to find the right action to perform. For example, if
it's to be routed, or delivered into the system, packet goes through
different steps of the netfilter and decisions are made along the way.
By adding flowtable entry into the forward hook, we say to add a
flowtable entry for this packet to the system. The entry consists of a
key and value pair. The key part is assembled via hashing the different
parts of the header of the packet and the value is the last form of the
packet after the processing. This hash data is hooked into the netfilter
stack at the ingress node. Therefore, when the next time a packet
arrives with the same hash, we already know what to do to the packet and
simply skip internal nodes, deliver it directly to the neigh node.
Unfortunately, there is not a way to list these tuples active in the
system. However, conntrack is helpful to identify which connections are
offloaded.
Here is an example. I have created a postgres server and started pgbench
with 5 clients, so, I expect to have 5 tcp connections to be initially
established and then offloaded to flowtable. If we start using the
flowtable, here is the output we get in conntrack;
```
root@vhd1jpcnf5ej7kj0wz7h9y7mta ~ # conntrack -L
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [OFFLOAD] mark=0 use=2
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [OFFLOAD] mark=0 use=2
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [OFFLOAD] mark=0 use=2
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [OFFLOAD] mark=0 use=2
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [OFFLOAD] mark=0 use=2
conntrack v1.4.6 (conntrack-tools): 6 flow entries have been shown.
```
Above data is reducted to fit into 80 chars length row. The important
thing is the [OFFLOAD] bit in the results. If I remove the flowtable,
here is how it looks like;
```
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [ASSURED] mark=0 use=1
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [ASSURED] mark=0 use=1
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [ASSURED] mark=0 use=1
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [ASSURED] mark=0 use=1
tcp 6 src=X dst=Y sport=Z dport=T src=Y dst=X sport=T dport=Z [ASSURED] mark=0 use=1
```
Of course the values of Z is different in each line since as a client
running pgbench, we use a different port for each connection but T
(dport), X(src ip), Y(dst ip) is the same 5432. One more thing aboiut
this output is that, you will realize the src and dst ip address and
port numbers flip in the first part of the row and the second part.
That's because conntrack keeps information about both direction of a
connection. Therefore, these tuples are usable in both directions.
Another usefull note is that OFFLOAD flag shouldn't be mixed with
hardware offloading. If that was the case, the flag would be HW_OFFLOAD.

*Benchmarking the changes*
I have also performed a very simple, non-scientific benchmark to see the
impact of this change. I have created a postgres VM on my development
host, I have installed postgres to the host itself to get access to
pgbench library and I have initialized pg_bench with the following
command;
```shell
pgbench -i -s 100 <hostname>
```
After that, I have started running this command;
```
pgbench -c 1 -j 1 -T 60 -P 1 -S <hostname>
```

I kept client and thread counts at 1 to simply see the impact of this
change in 1 connection. I ran this command directly from the host
against the postgres VM to eliminate any remote connection related
latency from the picture. I have run pgbench command 7 times for;
1. With flowtable implementation
2. Without flowtable implementation

Against the same postgres instance, same vm, so, same network stack with
only flowtable change. The result is this;
1. With flowtable, our average latency is 0.118ms
2. Without flowtable, our average latency is 0.127ms

For the correctness' sake, I have removed best and worst results from
both datasets.
This means around 7.5% performance gain can be made with this simple
addition.