### PR TITLE
Redirect the invited users to the project's dashboard

### DIFF
--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -24,7 +24,7 @@ class CloverWeb
           "To join project, click the button below.",
           "For any questions or assistance, reach out to our team at support@ubicloud.com."],
         button_title: "Join Project",
-        button_link: base_url + @project.path)
+        button_link: "#{base_url}#{@project.path}/dashboard")
 
       flash["notice"] = "Invitation sent successfully to '#{email}'. You need to add some policies to allow new user to operate in the project.
                         If this user doesn't have account, they will need to create an account and you'll need to add them again."


### PR DESCRIPTION
When a user is invited to a project, the admin also needs to grant them permission. The only page accessible without permission is the project's dashboard page. However, we currently redirect invited users to the project settings page, which results in a 403 error. It's a better user experience to redirect them to the dashboard page.