### PR TITLE
Update dnsmasq to v2.89

### DIFF
--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -30,7 +30,7 @@ class Prog::InstallDnsmasq < Prog::Base
   end
 
   label def git_clone_dnsmasq
-    q_commit = "aaba66efbd3b4e7283993ca3718df47706a8549b".shellescape
+    q_commit = "5dc14b6e05f39a5ab0dc02e376b1d7da2fda5bc1".shellescape
     sshable.cmd("git init dnsmasq && " \
                 "(cd dnsmasq && " \
                 "  git fetch https://github.com/fdr/dnsmasq.git #{q_commit} --depth=1 &&" \

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Prog::InstallDnsmasq do
     it "fetches a version and pops" do
       sshable = instance_double(Sshable)
       expect(sshable).to receive(:cmd).with <<CMD.rstrip
-git init dnsmasq && (cd dnsmasq &&   git fetch https://github.com/fdr/dnsmasq.git aaba66efbd3b4e7283993ca3718df47706a8549b --depth=1 &&  git checkout aaba66efbd3b4e7283993ca3718df47706a8549b &&  git fsck --full)
+git init dnsmasq && (cd dnsmasq &&   git fetch https://github.com/fdr/dnsmasq.git 5dc14b6e05f39a5ab0dc02e376b1d7da2fda5bc1 --depth=1 &&  git checkout 5dc14b6e05f39a5ab0dc02e376b1d7da2fda5bc1 &&  git fsck --full)
 CMD
       expect(idm).to receive(:sshable).and_return(sshable)
 


### PR DESCRIPTION
I previously used a semi-arbitrary commit to pick up some recent IPv6 related changes.  I am not sure it was relevant: it was a long time ago, with the service in a more primitive state.

But it's a reasonable time to use a dnsmasq release, now that one is newer than the hash I previously recorded.

You can verify this at hash and tag at:

https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=5dc14b6e05f39a5ab0dc02e376b1d7da2fda5bc1