### PR TITLE
CI inspired hetzner api client changes

### DIFF
--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -47,7 +47,7 @@ class Hosting::HetznerApis
       user: @host.user,
       password: @host.password,
       headers: {"Content-Type" => "application/x-www-form-urlencoded"})
-    connection.delete(path: "/key/#{fingerprint}", expects: 200)
+    connection.delete(path: "/key/#{fingerprint}", expects: [200, 404])
 
     nil
   end

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe Hosting::HetznerApis do
       Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 500, body: ""})
       expect { hetzner_apis.delete_key(key_data) }.to raise_error Excon::Error::InternalServerError
     end
+
+    it "regards a missing key as deleted" do
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0"
+      Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 404, body: ""})
+      expect(hetzner_apis.delete_key(key_data)).to be_nil
+    end
   end
 
   describe "get_main_ip4" do

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Hosting::HetznerApis do
       expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 200, body: ""})
       Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 400, body: ""})
-      expect { hetzner_apis.reset(123) }.to raise_error RuntimeError, "unexpected status 400 for reset"
+      expect { hetzner_apis.reset(123) }.to raise_error Excon::Error::BadRequest
     end
 
     it "raises an error if the ssh key is not set" do
@@ -34,7 +34,7 @@ RSpec.describe Hosting::HetznerApis do
     it "raises an error if the boot fails" do
       expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 400, body: ""})
-      expect { hetzner_apis.reset(123) }.to raise_error RuntimeError, "unexpected status 400 for boot"
+      expect { hetzner_apis.reset(123) }.to raise_error Excon::Error::BadRequest
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.describe Hosting::HetznerApis do
     it "raises an error if adding a key fails" do
       key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0"
       Excon.stub({path: "/key", method: :post}, {status: 500, body: ""})
-      expect { hetzner_apis.add_key("test_key_1", key_data) }.to raise_error RuntimeError, "unexpected status 500 for add_key"
+      expect { hetzner_apis.add_key("test_key_1", key_data) }.to raise_error Excon::Error::InternalServerError
     end
   end
 
@@ -62,7 +62,7 @@ RSpec.describe Hosting::HetznerApis do
     it "raises an error if deleting a key fails" do
       key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0"
       Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 500, body: ""})
-      expect { hetzner_apis.delete_key(key_data) }.to raise_error RuntimeError, "unexpected status 500 for delete_key"
+      expect { hetzner_apis.delete_key(key_data) }.to raise_error Excon::Error::InternalServerError
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe Hosting::HetznerApis do
 
     it "raises an error if getting the main ip4 fails" do
       Excon.stub({path: "/server/123", method: :get}, {status: 404, body: ""})
-      expect { hetzner_apis.get_main_ip4 }.to raise_error RuntimeError, "unexpected status 404 for get_main_ip4"
+      expect { hetzner_apis.get_main_ip4 }.to raise_error Excon::Error::NotFound
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe Hosting::HetznerApis do
 
     it "raises an error if getting the dc info fails" do
       Excon.stub({path: "/server/123", method: :get}, {status: 400, body: ""})
-      expect { hetzner_apis.pull_dc(123) }.to raise_error RuntimeError, "unexpected status 400"
+      expect { hetzner_apis.pull_dc(123) }.to raise_error Excon::Error::BadRequest
     end
   end
 
@@ -103,13 +103,13 @@ RSpec.describe Hosting::HetznerApis do
       stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 400, body: JSON.dump([]))
       stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([]))
 
-      expect { hetzner_apis.pull_ips }.to raise_error RuntimeError, "unexpected status 400"
+      expect { hetzner_apis.pull_ips }.to raise_error Excon::Error::BadRequest
     end
 
     it "raises an error if the subnet API returns an unexpected status" do
       stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 400, body: JSON.dump([]))
 
-      expect { hetzner_apis.pull_ips }.to raise_error RuntimeError, "unexpected status 400"
+      expect { hetzner_apis.pull_ips }.to raise_error Excon::Error::BadRequest
     end
 
     it "raises an error if the failover API returns an unexpected status" do
@@ -117,7 +117,7 @@ RSpec.describe Hosting::HetznerApis do
       stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([]))
       stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([]))
 
-      expect { hetzner_apis.pull_ips }.to raise_error RuntimeError, "unexpected status 400"
+      expect { hetzner_apis.pull_ips }.to raise_error Excon::Error::BadRequest
     end
 
     it "can pull data from the API" do

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -53,20 +53,19 @@ RSpec.describe Hosting::HetznerApis do
   end
 
   describe "delete_key" do
+    let(:key_data) { "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0" }
+
     it "can delete a key" do
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0"
       Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 200, body: ""})
       expect(hetzner_apis.delete_key(key_data)).to be_nil
     end
 
     it "raises an error if deleting a key fails" do
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0"
       Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 500, body: ""})
       expect { hetzner_apis.delete_key(key_data) }.to raise_error Excon::Error::InternalServerError
     end
 
     it "regards a missing key as deleted" do
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0"
       Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 404, body: ""})
       expect(hetzner_apis.delete_key(key_data)).to be_nil
     end


### PR DESCRIPTION
commit 6b9d26d1859ce2b16aabcde0136dabca1822410c
Author: Daniel Farina <daniel@ubicloud.com>
Date:   Thu Dec 14 22:10:21 2023 -0800

    Make Hetzner test ssh key fixture re-use more obvious
    
    By writing it this way, it's more apparent that all the tests use a
    particular key text.

commit 3c3dd8ee7edf205927bdbcd2593d5691688299b8
Author: Daniel Farina <daniel@ubicloud.com>
Date:   Thu Dec 14 22:06:34 2023 -0800

    Accept Hetzner API 404 for delete_key as success
    
    If it is gone, there's no need to halt execution.  This can cause CI
    runs to fail, in the case where a key was deleted but, for one reason
    or another, the deletion success was not recorded.
    
    Perhaps our API should not inflict a similar damage on the consumer,
    see
    https://github.com/ubicloud/ubicloud/issues/597#issuecomment-1718348587

commit 41be4d0cefaa2101be66f3b3715ae7adc74598c5
Author: Daniel Farina <daniel@ubicloud.com>
Date:   Thu Dec 14 22:03:01 2023 -0800

    Switch to using excon expects in Hetzner API client
    
    This makes the code more compact.  I found this improvement while
    looking at making delete_key accept 404 also as a valid/success
    return.
