### PR TITLE
Stop grouping ruby and javascript depandabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,20 +6,12 @@ updates:
       interval: 'daily'
     allow:
       - dependency-type: "all"
-    groups:
-      ruby-dependencies:
-        patterns:
-          - "*"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'
     allow:
       - dependency-type: "all"
-    groups:
-      js-dependencies:
-        patterns:
-          - "*"
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:


### PR DESCRIPTION
In group mode, Dependabot does not generate as much useful output of changelogs and relevant links.  I do find this an impediment: during a conference, we didn't upgrade stuff for a week and now the eight-gem upgrade is hard to evaluate as to what's going on or if there's anything important to know about these library updates.

For example, I did learn about the Rodauth rotation feature by clicking through on the dependabot update text.