### PR TITLE
Use bdev_ubi 0.2

### DIFF
--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -6,7 +6,7 @@ class Prog::Storage::SetupSpdk < Prog::Base
   SUPPORTED_SPDK_VERSIONS = [
     ["v23.09", "arm64"],
     ["v23.09", "x64"],
-    ["v23.09-ubi-0.1", "x64"]
+    ["v23.09-ubi-0.2", "x64"]
   ]
 
   def self.assemble(vm_host_id, version, start_service: false, allocation_weight: 0)

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -125,7 +125,7 @@ class Prog::Test::HetznerServer < Prog::Base
     SpdkInstallation.dataset.update(allocation_weight: 0)
     strand.add_child(
       Prog::Storage::SetupSpdk.assemble(
-        vm_host.id, "v23.09-ubi-0.1",
+        vm_host.id, "v23.09-ubi-0.2",
         start_service: true,
         allocation_weight: 100
       )

--- a/rhizome/host/lib/spdk_rpc.rb
+++ b/rhizome/host/lib/spdk_rpc.rb
@@ -40,13 +40,19 @@ class SpdkRpc
     raise e unless if_exists
   end
 
-  def bdev_ubi_create(name, base_bdev_name, image_path, skip_sync = false, stripe_size_mb = 1)
+  def bdev_ubi_create(name, base_bdev_name, image_path,
+    skip_sync = false,
+    stripe_size_kb = 1024,
+    copy_on_read = false,
+    directio = true)
     params = {
       name: name,
       base_bdev: base_bdev_name,
       image_path: image_path,
-      stripe_size_mb: stripe_size_mb,
-      no_sync: skip_sync
+      stripe_size_kb: stripe_size_kb,
+      no_sync: skip_sync,
+      copy_on_read: copy_on_read,
+      directio: directio
     }
     call("bdev_ubi_create", params)
   end

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -56,11 +56,11 @@ class SpdkSetup
       fail "BUG: unexpected architecture"
     end
 
-    # YYY: Support v23.09-ubi-0.1 on arm64
+    # YYY: Support v23.09-ubi-0.2 on arm64
     {
       ["v23.09", :arm64] => "https://github.com/ubicloud/spdk/releases/download/v23.09/spdk-arm64.tar.gz",
       ["v23.09", :x64] => "https://github.com/ubicloud/spdk/releases/download/v23.09/spdk-23.09-x64.tar.gz",
-      ["v23.09-ubi-0.1", :x64] => "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.1/ubicloud-spdk-ubuntu-22.04-x64.tar.gz"
+      ["v23.09-ubi-0.2", :x64] => "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.2/ubicloud-spdk-ubuntu-22.04-x64.tar.gz"
     }.fetch([@spdk_version, arch])
   end
 


### PR DESCRIPTION
We made some performance improvements in bdev_ubi-0.2. This patch drops support for v0.1 (since it's not deployed anywhere), and adds support for v0.2.

bdev_ubi-0.2 makes the following changes:
* stripe_size_mb -> stripe_size_kb, with a minimum of 128kb. This widens the stripe size range, which helps us in experiments for the optimal value.
* copy_on_read: Previously, we always on copied on first read/write access to base image. This flag allows turning off copies for read accesses, which helps us reduce total I/O.
* directio: Previously, we didn't use O_DIRECT for base image access. This added a buffering layer in host OS FS. Now by setting directio to true (which is the default), we can skip the host pagecache buffer.