### PR TITLE
MinIO Scale-out support by adding new pool

### DIFF
--- a/migrate/20231218_minio_drive_rename.rb
+++ b/migrate/20231218_minio_drive_rename.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:minio_cluster) do
+      rename_column :target_total_driver_count, :target_total_drive_count
+    end
+  end
+end

--- a/migrate/20231222_minio_scale_out.rb
+++ b/migrate/20231222_minio_scale_out.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:minio_pool) do
+      add_column :server_count, :integer, null: true
+      add_column :drive_count, :integer, null: true
+      add_column :storage_size_gib, :bigint, null: true
+    end
+  end
+end

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -17,7 +17,7 @@ class MinioCluster < Sequel::Model
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
 
-  semaphore :destroy
+  semaphore :destroy, :reconfigure
 
   plugin :column_encryption do |enc|
     enc.column :admin_password

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -41,8 +41,8 @@ class MinioCluster < Sequel::Model
     (target_total_server_count / target_total_pool_count).to_i
   end
 
-  def per_pool_driver_count
-    (target_total_driver_count / target_total_pool_count).to_i
+  def per_pool_drive_count
+    (target_total_drive_count / target_total_pool_count).to_i
   end
 
   def connection_strings

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -16,7 +16,7 @@ class MinioPool < Sequel::Model
 
   def volumes_url
     servers_arg = "#{cluster.name}{#{start_index}...#{cluster.per_pool_server_count + start_index - 1}}"
-    drivers_arg = "/minio/dat{1...#{per_server_driver_count}}"
+    drivers_arg = "/minio/dat{1...#{per_server_drive_count}}"
     "http://#{servers_arg}.#{Config.minio_host_name}:9000#{drivers_arg}"
   end
 
@@ -24,8 +24,8 @@ class MinioPool < Sequel::Model
     "#{cluster.name}-#{start_index}"
   end
 
-  def per_server_driver_count
-    (cluster.per_pool_driver_count / cluster.per_pool_server_count).to_i
+  def per_server_drive_count
+    (cluster.per_pool_drive_count / cluster.per_pool_server_count).to_i
   end
 
   def per_server_storage_size

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -12,10 +12,10 @@ class MinioPool < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
 
-  semaphore :destroy
+  semaphore :destroy, :add_additional_pool
 
   def volumes_url
-    servers_arg = "#{cluster.name}{#{start_index}...#{cluster.per_pool_server_count + start_index - 1}}"
+    servers_arg = "#{cluster.name}{#{start_index}...#{server_count + start_index - 1}}"
     drivers_arg = "/minio/dat{1...#{per_server_drive_count}}"
     "http://#{servers_arg}.#{Config.minio_host_name}:9000#{drivers_arg}"
   end
@@ -25,10 +25,10 @@ class MinioPool < Sequel::Model
   end
 
   def per_server_drive_count
-    (cluster.per_pool_drive_count / cluster.per_pool_server_count).to_i
+    (drive_count / server_count).to_i
   end
 
   def per_server_storage_size
-    (cluster.per_pool_storage_size / cluster.per_pool_server_count).to_i
+    (storage_size_gib / server_count).to_i
   end
 end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -15,7 +15,7 @@ class MinioServer < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
 
-  semaphore :destroy
+  semaphore :destroy, :restart, :reconfigure
 
   def hostname
     "#{cluster.name}#{index}.#{Config.minio_host_name}"

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -30,8 +30,8 @@ class MinioServer < Sequel::Model
   end
 
   def minio_volumes
-    return "/minio/dat1" if cluster.target_total_server_count == 1 && cluster.target_total_driver_count == 1
-    return "/minio/dat{1...#{cluster.target_total_driver_count}}" if cluster.target_total_server_count == 1
+    return "/minio/dat1" if cluster.target_total_server_count == 1 && cluster.target_total_drive_count == 1
+    return "/minio/dat{1...#{cluster.target_total_drive_count}}" if cluster.target_total_server_count == 1
     cluster.pools.map do |pool|
       pool.volumes_url
     end.join(" ")

--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -9,6 +9,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
 
   def self.assemble(project_id, cluster_name, location, admin_user,
     storage_size_gib, pool_count, server_count, driver_count, vm_size)
+    storage_size_gib, pool_count, server_count, drive_count, vm_size)
     unless (project = Project[project_id])
       fail "No existing project"
     end
@@ -27,7 +28,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
         target_total_storage_size_gib: storage_size_gib,
         target_total_pool_count: pool_count,
         target_total_server_count: server_count,
-        target_total_driver_count: driver_count,
+        target_total_drive_count: drive_count,
         target_vm_size: vm_size
       )
       minio_cluster.associate_with_project(project)

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -25,7 +25,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
         size: minio_pool.cluster.target_vm_size,
         storage_volumes: [
           {encrypted: true, size_gib: 30}
-        ] + Array.new(minio_pool.per_server_driver_count) { {encrypted: false, size_gib: (minio_pool.per_server_storage_size / minio_pool.per_server_driver_count).floor} },
+        ] + Array.new(minio_pool.per_server_drive_count) { {encrypted: false, size_gib: (minio_pool.per_server_storage_size / minio_pool.per_server_drive_count).floor} },
         boot_image: "ubuntu-jammy",
         enable_ip4: true,
         private_subnet_id: minio_pool.cluster.private_subnet.id

--- a/rhizome/minio/bin/configure-minio
+++ b/rhizome/minio/bin/configure-minio
@@ -1,0 +1,21 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+config_json = JSON.parse($stdin.read)
+
+unless (minio_config = config_json["minio_config"])
+  puts "need minio_config as argument"
+  exit 1
+end
+
+unless (hosts = config_json["hosts"])
+  puts "need hosts as argument"
+  exit 1
+end
+
+require_relative "../../common/lib/util"
+
+safe_write_to_file("/etc/default/minio", minio_config)
+safe_write_to_file("/etc/hosts", hosts)
+r "sudo chown -R minio-user:minio-user /etc/default/minio"

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MinioCluster do
       target_total_storage_size_gib: 100,
       target_total_pool_count: 1,
       target_total_server_count: 1,
-      target_total_driver_count: 1,
+      target_total_drive_count: 1,
       target_vm_size: "standard-2"
     )
     mp = MinioPool.create_with_id(
@@ -51,7 +51,7 @@ RSpec.describe MinioCluster do
   end
 
   it "returns per pool driver count properly" do
-    expect(mc.per_pool_driver_count).to eq(1)
+    expect(mc.per_pool_drive_count).to eq(1)
   end
 
   it "returns connection strings properly" do

--- a/spec/model/minio/minio_pool_spec.rb
+++ b/spec/model/minio/minio_pool_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MinioPool do
       target_total_storage_size_gib: 100,
       target_total_pool_count: 1,
       target_total_server_count: 1,
-      target_total_driver_count: 1,
+      target_total_drive_count: 1,
       target_vm_size: "standard-2"
     )
     mp = described_class.create_with_id(
@@ -35,12 +35,12 @@ RSpec.describe MinioPool do
     end
 
     it "returns volumes url properly for a multi drive single server pool" do
-      mp.cluster.update(target_total_driver_count: 4)
+      mp.cluster.update(target_total_drive_count: 4)
       expect(mp.volumes_url).to eq("http://minio-cluster-name{0...0}.minio.ubicloud.com:9000/minio/dat{1...4}")
     end
 
     it "returns volumes url properly for a multi drive multi server pool" do
-      mp.cluster.update(target_total_driver_count: 4, target_total_server_count: 2)
+      mp.cluster.update(target_total_drive_count: 4, target_total_server_count: 2)
       expect(mp.volumes_url).to eq("http://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
     end
   end
@@ -50,9 +50,9 @@ RSpec.describe MinioPool do
   end
 
   it "returns per server driver count properly" do
-    expect(mp.cluster).to receive(:per_pool_driver_count).and_return(4)
+    expect(mp.cluster).to receive(:per_pool_drive_count).and_return(4)
     expect(mp.cluster).to receive(:per_pool_server_count).and_return(2)
-    expect(mp.per_server_driver_count).to eq(2)
+    expect(mp.per_server_drive_count).to eq(2)
   end
 
   it "returns per server storage size properly" do
@@ -62,7 +62,7 @@ RSpec.describe MinioPool do
   end
 
   it "returns servers in ordered way" do
-    mp.cluster.update(target_total_driver_count: 4, target_total_server_count: 2)
+    mp.cluster.update(target_total_drive_count: 4, target_total_server_count: 2)
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
     MinioServer.create_with_id(

--- a/spec/model/minio/minio_pool_spec.rb
+++ b/spec/model/minio/minio_pool_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe MinioPool do
     )
     mp = described_class.create_with_id(
       cluster_id: mc.id,
-      start_index: 0
+      start_index: 0,
+      server_count: 1,
+      drive_count: 1,
+      storage_size_gib: 100
     )
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
@@ -35,12 +38,12 @@ RSpec.describe MinioPool do
     end
 
     it "returns volumes url properly for a multi drive single server pool" do
-      mp.cluster.update(target_total_drive_count: 4)
+      mp.update(drive_count: 4)
       expect(mp.volumes_url).to eq("http://minio-cluster-name{0...0}.minio.ubicloud.com:9000/minio/dat{1...4}")
     end
 
     it "returns volumes url properly for a multi drive multi server pool" do
-      mp.cluster.update(target_total_drive_count: 4, target_total_server_count: 2)
+      mp.update(drive_count: 4, server_count: 2)
       expect(mp.volumes_url).to eq("http://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
     end
   end
@@ -50,19 +53,19 @@ RSpec.describe MinioPool do
   end
 
   it "returns per server driver count properly" do
-    expect(mp.cluster).to receive(:per_pool_drive_count).and_return(4)
-    expect(mp.cluster).to receive(:per_pool_server_count).and_return(2)
+    expect(mp).to receive(:drive_count).and_return(4)
+    expect(mp).to receive(:server_count).and_return(2)
     expect(mp.per_server_drive_count).to eq(2)
   end
 
   it "returns per server storage size properly" do
-    expect(mp.cluster).to receive(:per_pool_storage_size).and_return(500)
-    expect(mp.cluster).to receive(:per_pool_server_count).and_return(2)
+    expect(mp).to receive(:storage_size_gib).and_return(500)
+    expect(mp).to receive(:server_count).and_return(2)
     expect(mp.per_server_storage_size).to eq(250)
   end
 
   it "returns servers in ordered way" do
-    mp.cluster.update(target_total_drive_count: 4, target_total_server_count: 2)
+    mp.update(drive_count: 4, server_count: 2)
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
     MinioServer.create_with_id(

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe MinioServer do
     )
     mp = MinioPool.create_with_id(
       cluster_id: mc.id,
-      start_index: 0
+      start_index: 0,
+      server_count: 1,
+      drive_count: 1,
+      storage_size_gib: 100
     )
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
@@ -58,6 +61,7 @@ RSpec.describe MinioServer do
 
     it "returns minio volumes properly for a multi drive multi server cluster" do
       ms.cluster.update(target_total_drive_count: 4, target_total_server_count: 2)
+      ms.pool.update(server_count: 2, drive_count: 4)
       expect(ms.minio_volumes).to eq("http://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
     end
   end

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MinioServer do
       target_total_storage_size_gib: 100,
       target_total_pool_count: 1,
       target_total_server_count: 1,
-      target_total_driver_count: 1,
+      target_total_drive_count: 1,
       target_vm_size: "standard-2"
     )
     mp = MinioPool.create_with_id(
@@ -52,12 +52,12 @@ RSpec.describe MinioServer do
     end
 
     it "returns minio volumes properly for a multi drive single server cluster" do
-      ms.cluster.update(target_total_driver_count: 4)
+      ms.cluster.update(target_total_drive_count: 4)
       expect(ms.minio_volumes).to eq("/minio/dat{1...4}")
     end
 
     it "returns minio volumes properly for a multi drive multi server cluster" do
-      ms.cluster.update(target_total_driver_count: 4, target_total_server_count: 2)
+      ms.cluster.update(target_total_drive_count: 4, target_total_server_count: 2)
       expect(ms.minio_volumes).to eq("http://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
     end
   end

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
       expect(MinioCluster.first.target_total_storage_size_gib).to eq 100
       expect(MinioCluster.first.target_total_pool_count).to eq 1
       expect(MinioCluster.first.target_total_server_count).to eq 1
-      expect(MinioCluster.first.target_total_driver_count).to eq 1
+      expect(MinioCluster.first.target_total_drive_count).to eq 1
       expect(MinioCluster.first.target_vm_size).to eq "standard-2"
       expect(MinioCluster.first.projects).to eq [minio_project]
       expect(MinioCluster.first.strand.label).to eq "start"

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
       target_total_storage_size_gib: 100,
       target_total_pool_count: 1,
       target_total_server_count: 1,
-      target_total_driver_count: 1,
+      target_total_drive_count: 1,
       target_vm_size: "standard-2",
       private_subnet_id: ps.id
     )

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       target_total_storage_size_gib: 100,
       target_total_pool_count: 1,
       target_total_server_count: 1,
-      target_total_driver_count: 1,
+      target_total_drive_count: 1,
       target_vm_size: "standard-2",
       private_subnet_id: ps.id
     )

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Prog::Minio::SetupMinio do
       target_total_storage_size_gib: 100,
       target_total_pool_count: 1,
       target_total_server_count: 1,
-      target_total_driver_count: 1,
+      target_total_drive_count: 1,
       target_vm_size: "standard-2",
       private_subnet_id: ps.id
     )


### PR DESCRIPTION
```
    Rename minio_cluster driver column to drive
```
```
    Rename minio driver references to drive
```
```
    Add pool specific configuration to MinioPool
```
```
    MinIO Scale-out support by adding new pool

    With this commit, we are adding support to add new pools to an existing
    MinIO cluster. The documentation is here
    https://min.io/docs/minio/linux/operations/install-deploy-manage/expand-minio-deployment.html
    The idea is to create a new pool with servers, reconfigure the cluster
    by editing /etc/default/minio in all servers and perform a restart.
    Servers detect the new pool automatically and perform the metadata
    exchange.
```