### PR TITLE
Bump addressable from 2.8.5 to 2.8.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     android_key_attestation (0.3.0)
     argon2 (2.3.0)


### PR DESCRIPTION
It appears that when dependabot cannot generate a PR description for a dependency in the group, it prevents dependabot from generating PR descriptions for all packages.

Dependabot can't generate the PR description for addressable gem.

I upgraded `addressable` gem to unblock
https://github.com/ubicloud/ubicloud/pull/1024

# Changelog

### Addressable 2.8.6 <a name="v2.8.6">
- Memoize regexps for common character classes ([#524])

[#524]: https://github.com/sporkmonger/addressable/pull/524
