### PR TITLE
Monitoring

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -3,7 +3,7 @@
 
 require_relative "../loader"
 
-MONITORABLE_RESOURCE_TYPES = [PostgresServer]
+MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer]
 
 sessions = {}
 ssh_threads = {}

--- a/bin/monitor
+++ b/bin/monitor
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../loader"
+
+MONITORABLE_RESOURCE_TYPES = []
+
+sessions = {}
+ssh_threads = {}
+pulse_threads = {}
+loop do
+  resources = MONITORABLE_RESOURCE_TYPES.flat_map { _1.all }
+
+  resources.each do |r|
+    ssh_threads[r.id] ||= Thread.new do
+      loop do
+        sessions[r.id] = r.init_health_monitor_session
+
+        loop do
+          sessions[r.id][:ssh_session].process
+        rescue => ex
+          Clog.emit("Processing SSH session is failed. Trying to reestablish the connection") { {health_monitor_ssh_failure: {ubid: r.ubid, exception: Util.exception_to_hash(ex)}} }
+          break
+        end
+      rescue => ex
+        Clog.emit("Establishing the SSH session is failed") { {health_monitor_reestablish_ssh_failure: {ubid: r.ubid, exception: Util.exception_to_hash(ex)}} }
+        sleep 5
+      end
+    end
+
+    pulse_threads[r.id] ||= Thread.new do
+      pulse = {}
+      loop do
+        pulse = r.check_pulse(session: sessions[r.id], previous_pulse: pulse) if sessions[r.id]
+        sleep r.monitoring_interval
+      end
+    end
+  end
+
+  sleep 5 * 60
+end

--- a/bin/monitor
+++ b/bin/monitor
@@ -3,7 +3,7 @@
 
 require_relative "../loader"
 
-MONITORABLE_RESOURCE_TYPES = []
+MONITORABLE_RESOURCE_TYPES = [PostgresServer]
 
 sessions = {}
 ssh_threads = {}

--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -9,10 +9,10 @@ REGION = "us-east-1"
 ADMIN_URI_PATH = "/minio/admin/v3"
 
 class Minio::Client
-  def initialize(endpoint:, access_key:, secret_key:)
+  def initialize(endpoint:, access_key:, secret_key:, socket: nil)
     @creds = {access_key: access_key, secret_key: secret_key}
     @endpoint = endpoint
-    @client = Excon.new(endpoint)
+    @client = socket.nil? ? Excon.new(endpoint) : Excon.new("unix:///", socket: socket)
     @signer = Minio::HeaderSigner.new
     @crypto = Minio::Crypto.new
   end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -52,4 +52,8 @@ module Util
 
     [cert, key]
   end
+
+  def self.exception_to_hash(ex)
+    {exception: {message: ex.message, class: ex.class.to_s, backtrace: ex.backtrace, cause: ex.cause.inspect}}
+  end
 end

--- a/model.rb
+++ b/model.rb
@@ -118,6 +118,20 @@ module ResourceMethods
   end
 end
 
+module HealthMonitorMethods
+  def aggregate_readings(previous_pulse:, reading:)
+    {
+      reading: reading,
+      reading_rpt: (previous_pulse[:reading] == reading) ? previous_pulse[:reading_rpt] + 1 : 1,
+      reading_chg: (previous_pulse[:reading] == reading) ? previous_pulse[:reading_chg] : Time.now
+    }
+  end
+
+  def monitoring_interval
+    5
+  end
+end
+
 if (level = Config.database_logger_level)
   require "logger"
   DB.loggers << Logger.new($stdout, level: level)

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -46,7 +46,7 @@ class MinioCluster < Sequel::Model
   end
 
   def connection_strings
-    servers.map { "http://#{_1.vm.ephemeral_net4}:9000" }
+    servers.map(&:connection_string)
   end
 
   def single_instance_single_drive?

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -34,4 +34,8 @@ class MinioServer < Sequel::Model
       pool.volumes_url
     end.join(" ")
   end
+
+  def connection_string
+    "http://#{vm.ephemeral_net4}:9000"
+  end
 end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -40,7 +40,7 @@ class PostgresServer < Sequel::Model
       ssl_key_file: "'/dat/16/data/server.key'",
       log_timezone: "'UTC'",
       log_directory: "'pg_log'",
-      log_filename: "'postgresql-%A.log'",
+      log_filename: "'postgresql.log'",
       log_truncate_on_rotation: "true",
       logging_collector: "on",
       timezone: "'UTC'",

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -112,9 +112,13 @@ class Sshable < Sequel::Model
     end
 
     # Cache miss.
-    sess = Net::SSH.start(host, unix_user, **COMMON_SSH_ARGS.merge(key_data: keys.map(&:private_key)))
+    sess = start_fresh_session
     Thread.current[:clover_ssh_cache][[host, unix_user]] = sess
     sess
+  end
+
+  def start_fresh_session
+    Net::SSH.start(host, unix_user, **COMMON_SSH_ARGS.merge(key_data: keys.map(&:private_key)))
   end
 
   def invalidate_cache_entry

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -27,7 +27,7 @@ pg_hba_entries = <<-PG_HBA
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 # Database administrative login by Unix domain socket
-local   all             postgres                                peer
+local   all             postgres                                peer map=system2postgres
 
 # "local" is for Unix domain socket connections only
 local   all             all                                     peer
@@ -49,6 +49,18 @@ host    replication     all             ::1/128                 scram-sha-256
 host    all             all             all                     scram-sha-256
 PG_HBA
 safe_write_to_file("/etc/postgresql/16/main/pg_hba.conf", pg_hba_entries)
+
+pg_ident_entries = <<-PG_IDENT
+# PostgreSQL User Name Maps
+# =========================
+#
+# Refer to the PostgreSQL documentation, chapter "Client
+# Authentication" for a complete description.
+# MAPNAME          SYSTEM-USERNAME         PG-USERNAME
+system2postgres    postgres                postgres
+system2postgres    ubi                     postgres
+PG_IDENT
+safe_write_to_file("/etc/postgresql/16/main/pg_ident.conf", pg_ident_entries)
 
 # Reload the postmaster to apply changes
 r "pg_ctlcluster 16 main reload || pg_ctlcluster 16 main restart"

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -22,10 +22,6 @@ class Scheduling::Dispatcher
     ).order_by(:schedule).limit(idle_connections)
   end
 
-  def exception_to_hash(ex)
-    {exception: {message: ex.message, class: ex.class.to_s, backtrace: ex.backtrace, cause: ex.cause.inspect}}
-  end
-
   def start_strand(strand)
     strand_ubid = strand.ubid.freeze
     apoptosis_r, apoptosis_w = IO.pipe
@@ -51,12 +47,12 @@ class Scheduling::Dispatcher
     Thread.new do
       strand.run Strand::LEASE_EXPIRATION / 4
     rescue => ex
-      Clog.emit("exception terminates thread") { exception_to_hash(ex) }
+      Clog.emit("exception terminates thread") { Util.exception_to_hash(ex) }
 
       loop do
         ex = ex.cause
         break unless ex
-        Clog.emit("nested exception") { exception_to_hash(ex) }
+        Clog.emit("nested exception") { Util.exception_to_hash(ex) }
       end
     ensure
       # Adequate to unblock IO.select.

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe Minio::Client do
   let(:access_key) { "minioadmin" }
   let(:secret_key) { "minioadmin" }
 
+  it "can use sockets" do
+    expect(Excon).to receive(:new).with("unix:///", socket: "/tmp/socket")
+    described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key, socket: "/tmp/socket")
+  end
+
   describe "admin_info" do
     it "sends a GET request to /minio/admin/v3/info" do
       stub_request(:get, "#{endpoint}/minio/admin/v3/info").to_return(status: 200, body: "test")

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe PostgresServer do
         ssl_key_file: "'/dat/16/data/server.key'",
         log_timezone: "'UTC'",
         log_directory: "'pg_log'",
-        log_filename: "'postgresql-%A.log'",
+        log_filename: "'postgresql.log'",
         log_truncate_on_rotation: "true",
         logging_collector: "on",
         timezone: "'UTC'",


### PR DESCRIPTION
**Move exception_to_hash to Util**
Previously, only dispatcher was using this helper function, but it is useful in
other contexes such as in monitoring. Thus, we are moving it to Util.

**Add monitor process**
We are adding a new executable for health monitor. This process would fetch the
list of resources that needs to be monitored and checks their health in a loop.

Here are the things we specifically cared about while implementing this;
- We are decoupling health checks from the resource's nexus progs. This allows
us to perform very frequent health checks independent from the nexus' schedule.
It also does not cause unnecessary lock holding while doing the health checks.
Finally this allows us to independently scale monitoring process.
- We use persistent SSH sessions for monitoring. This ensures very fast health
check cycles. Moreover, we even use SSH tunnels to communicate with the target
software directly, thus avoiding many expensive system calls and forks, though
example of such communication is not available in this commit. See the next one
for an example.
- Each resource decides how the persistent session must be created and how the
check itself must be performed. It does this by defining two functions called;
init_health_monitor_session and check_pulse. Monitoring process creates the
session using init_health_monitor_session and passes it to check_pulse. Primary
contract between the monitor and the resource is that the session needs to be
based on SSH. In a similar fashion, resource can decide how frequently it needs
to be monitored by defining monitoring_interval function.

**Add helper to sshable to start fresh SSH sessions**
In the context of monitoring, we want a fresh SSH session that is not taken
from the thread's cache, because we are calling session.process ourselves and
doing that interferes with regular command execution. To prevent that, we are
creating a fresh SSH session for the resources we want to monitor.

**Add monitoring for PosgresServer**
For running SELECT 1 queries without forking postmaster and without running
expensive system calls, we are using persistent sessions over SSH tunnel. This
is done by forwarding local UNIX socket to the Postgres socket in the target
server.

This is faster than running `psql -c 'SELECT 1'`, because it doesn't spawn new
process thus doesn't make lots of system calls. In my rough experiments using
sockets is 3-4x faster than running `psql -c 'SELECT 1'`.

This approach is also significantly reduces the memory allocations, which could
cause OOM problems when there is a high load on the system and make us declare
unavailability unnecessarily.

**Try to recover Postgres from unavailability**
Currently we just try to restart PostgreSQL process. In the future, this can be
extended to triggering failover for HA enabled databases or creating a standby
for non-HA databases.

One usual false positive is database not responding to queries during the crash
recovery. In such cases, triggering restart is counter-productive as it would
undo some part of crash recovery. To prevent that, we check the logs and not
trigger restart if the database is in crash recovery.

**Allow using sockets in MinIO client**
This allows us to use sockets for faster and more efficient communication with
the web server.

**Move connection_string to individual MinioServers**
MinioServer itself also needs to know its own connection string. Instead of
duplicating the code, we move connection_string to MinioServer model and the
MinioCluster refers to the connection_string functin in the MinioServer.

**Add monitoring for MinioServer**
We are using admin_info endpoint provided by MinIO, which returns status of
each server and their drives. Similar to PostgresServer, we are using UNIX
sockets for the communication, which avoids doing unnecessary system calls and
memory allocations.

**Try to recover MinIO from unavailability**
Currently only attempt for recovery is restarting the MinIO service, which
seemed to help in few cases. In the future, we might automate VM replacement.