### PR TITLE
Redact GithubRunner.workflow_job column

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -9,6 +9,10 @@ class GithubRunner < Sequel::Model
 
   include ResourceMethods
 
+  def self.redacted_columns
+    super + [:workflow_job]
+  end
+
   include SemaphoreMethods
   semaphore :destroy
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -25,13 +25,6 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.connection_string).to be_nil
   end
 
-  it "hides sensitive and long columns" do
-    inspect_output = postgres_resource.inspect
-    postgres_resource.class.redacted_columns.each do |column_key|
-      expect(inspect_output).not_to include column_key.to_s
-    end
-  end
-
   it "returns running as display state if the database is ready" do
     expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
     expect(postgres_resource.display_state).to eq("running")

--- a/spec/model/resource_methods_spec.rb
+++ b/spec/model/resource_methods_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe ResourceMethods do
+  it "hides sensitive and long columns" do
+    [GithubRunner, PostgresResource, Vm, VmHost].each do |klass|
+      inspect_output = klass.new.inspect
+      klass.redacted_columns.each do |column_key|
+        expect(inspect_output).not_to include column_key.to_s
+      end
+    end
+  end
+end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -107,11 +107,4 @@ RSpec.describe Vm do
       expect(vm.ephemeral_net4).to be_nil
     end
   end
-
-  it "hides sensitive and long columns" do
-    inspect_output = vm.inspect
-    vm.class.redacted_columns.each do |column_key|
-      expect(inspect_output).not_to include column_key.to_s
-    end
-  end
 end


### PR DESCRIPTION
It contains too much data to show in the inspect output and Clog. Additionally, some of the data includes PII.

I also unified redundant tests.