### PR TITLE
Add the current time to every clog output

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -19,6 +19,7 @@ class Clog
 
     return if Config.test?
     out[:message] = message
+    out[:time] = Time.now
 
     if (thread_name = Thread.current.name)
       out[:thread] = thread_name

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -1,25 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe Clog do
+  let(:now) { Time.parse("2023-01-17 12:10:54 -0800") }
+
   before do
     allow(Config).to receive(:test?).and_return(false)
+    allow(Time).to receive(:now).and_return(now)
   end
 
   it "will add the thread name to the structure data, if defined" do
     Thread.new do
       Thread.current.name = "test thread name"
-      expect($stdout).to receive(:write).with('{"message":"hello","thread":"test thread name"}' + "\n")
+      expect($stdout).to receive(:write).with('{"message":"hello","time":"' + now.to_s + '","thread":"test thread name"}' + "\n")
       described_class.emit "hello"
     end.join
   end
 
   it "doesn't include a thread name if it is not set" do
-    expect($stdout).to receive(:write).with('{"message":"hello"}' + "\n")
+    expect($stdout).to receive(:write).with('{"message":"hello","time":"' + now.to_s + '"}' + "\n")
     described_class.emit "hello"
   end
 
   it "writes an error when an invalid type is yield from the block" do
-    expect($stdout).to receive(:write).with('{"invalid_type":"Integer","message":"ngmi"}' + "\n")
+    expect($stdout).to receive(:write).with('{"invalid_type":"Integer","message":"ngmi","time":"' + now.to_s + '"}' + "\n")
     described_class.emit("ngmi") { 1 }
   end
 end


### PR DESCRIPTION
Mezmo displays ingestion time, and the timestamps on the logs are not always reliable. The log's print time is sometimes really required.