### PR TITLE
Wrap the strand metadata root fields with the appropriate keys

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -79,7 +79,7 @@ SQL
   def unsynchronized_run
     start_time = Time.now
     prog_label = "#{prog}.#{label}"
-    Clog.emit("starting strand") { {strand: values, time: start_time, prog_label: prog_label} }
+    Clog.emit("starting strand") { {strand: values, strand_started: {delay: start_time - schedule, prog_label: prog_label}} }
 
     if label == stack.first["deadline_target"].to_s
       if (pg = Page.from_tag_parts("Deadline", id, prog, stack.first["deadline_target"]))
@@ -141,8 +141,7 @@ SQL
       fail "BUG: Prog #{prog}##{label} did not provide flow control"
     end
   ensure
-    finish_time = Time.now
-    Clog.emit("finished strand") { {strand: values, time: finish_time, duration: finish_time - start_time, prog_label: prog_label} }
+    Clog.emit("finished strand") { {strand: values, strand_finished: {duration: Time.now - start_time, prog_label: prog_label}} }
   end
 
   def run(seconds = 0)


### PR DESCRIPTION
Clog is not merely a logging class; it also provides guidelines for constructing log metadata. According to f2b128f, we should avoid placing fields at the root. The format `{
well_known_metadata_or_representation_name: { ... }, going_concern: { a_field: "data", b_field: "more data" } }` aligns with clog's design.

I wrapped the fields that were in the root.

I also added the time difference between `strand.schedule` and the current time as delay. This allows us to monitor the delay to determine whether the respirate is handling the load effectively.