### PR TITLE
Log the workflow_job webhook events

### DIFF
--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -16,7 +16,31 @@ class CloverWeb
       when "installation"
         return handle_installation(data)
       when "workflow_job"
-        return handle_workflow_job(data)
+        response = handle_workflow_job(data)
+        Clog.emit("workflow_job webhook event") {
+          job = data.fetch("workflow_job")
+          {
+            webhook: {
+              action: data["action"],
+              response: response,
+              payload: {
+                installation_id: data["installation"]["id"],
+                repository_name: data["repository"]["full_name"],
+                workflow_job: {
+                  id: job["id"],
+                  run_id: job["run_id"],
+                  status: job["status"],
+                  conclusion: job["conclusion"],
+                  labels: job["labels"],
+                  created_at: job["created_at"],
+                  started_at: job["started_at"],
+                  completed_at: job["completed_at"]
+                }
+              }
+            }
+          }
+        }
+        return response
       end
 
       return error("Unhandled event")


### PR DESCRIPTION
Recently, I had to investigate an issue concerning the webhook events delivered to us by GitHub, specifically, I was trying to identify missing webhook events.

GitHub offers an endpoint to list the deliveries for an app webhook. However, it lacks a filter and limits the maximum value per page to 100. We must paginate until we reach the issue time. Additionally, the listing endpoint does not return delivery payloads. We are required to fetch the payload for each delivery individually. This process demands considerable manual effort and numerous API requests.

By logging details about delivered webhook events, we could examine our logs for them, thus reducing the need for extensive API requests.