### PR TITLE
Reduce the frequency of failed redeliveries to every 5 minutes

### DIFF
--- a/prog/redeliver_github_failures.rb
+++ b/prog/redeliver_github_failures.rb
@@ -9,6 +9,6 @@ class Prog::RedeliverGithubFailures < Prog::Base
     strand.modified!(:stack)
     strand.save_changes
 
-    nap 10 * 60
+    nap 5 * 60
   end
 end

--- a/spec/prog/redeliver_github_failures_spec.rb
+++ b/spec/prog/redeliver_github_failures_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Prog::RedeliverGithubFailures do
       expect(Github).to receive(:redeliver_failed_deliveries).with(Time.parse("2023-10-19 22:27:47 +0000"))
       expect(rgf.strand).to receive(:save_changes)
       expect {
-        expect { rgf.wait }.to nap(10 * 60)
+        expect { rgf.wait }.to nap(5 * 60)
       }.to change { rgf.strand.stack.first["last_check_at"] }.from("2023-10-19 22:27:47 +0000").to("2023-10-19 23:27:47 +0000")
     end
   end


### PR DESCRIPTION
Currently, we check GitHub app webhook deliveries every 10 minutes and redeliver any that have failed. If a "workflow_job.queued" delivery fails, the customer  waits 10 minutes for a redelivery.

I have decided to reduce this frequency to every 5 minutes to enhance the customer experience.