### PR TITLE
Refactor MinIO Provisioning Path

### DIFF
--- a/migrate/20231227_add_minio_pool_vm_size.rb
+++ b/migrate/20231227_add_minio_pool_vm_size.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:minio_pool) do
+      add_column :vm_size, :text, collate: '"C"', null: false
+    end
+  end
+end

--- a/migrate/20231227_remove_minio_cluster_red_cols.rb
+++ b/migrate/20231227_remove_minio_cluster_red_cols.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:minio_cluster) do
+      drop_column :target_total_storage_size_gib
+      drop_column :target_total_pool_count
+      drop_column :target_total_server_count
+      drop_column :target_total_drive_count
+      drop_column :target_vm_size
+    end
+  end
+end

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -33,16 +33,16 @@ class MinioCluster < Sequel::Model
     end.join("\n")
   end
 
-  def per_pool_storage_size
-    (target_total_storage_size_gib / target_total_pool_count).to_i
+  def storage_size_gib
+    pools.sum(&:storage_size_gib)
   end
 
-  def per_pool_server_count
-    (target_total_server_count / target_total_pool_count).to_i
+  def server_count
+    pools.sum(&:server_count)
   end
 
-  def per_pool_drive_count
-    (target_total_drive_count / target_total_pool_count).to_i
+  def drive_count
+    pools.sum(&:drive_count)
   end
 
   def connection_strings

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -49,6 +49,14 @@ class MinioCluster < Sequel::Model
     servers.map { "http://#{_1.vm.ephemeral_net4}:9000" }
   end
 
+  def single_instance_single_drive?
+    server_count == 1 && drive_count == 1
+  end
+
+  def single_instance_multi_drive?
+    server_count == 1 && drive_count > 1
+  end
+
   def hostname
     "#{name}.#{Config.minio_host_name}"
   end

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -15,6 +15,8 @@ class MinioPool < Sequel::Model
   semaphore :destroy, :add_additional_pool
 
   def volumes_url
+    return "/minio/dat1" if cluster.single_instance_single_drive?
+    return "/minio/dat{1...#{drive_count}}" if cluster.single_instance_multi_drive?
     servers_arg = "#{cluster.name}{#{start_index}...#{server_count + start_index - 1}}"
     drivers_arg = "/minio/dat{1...#{per_server_drive_count}}"
     "http://#{servers_arg}.#{Config.minio_host_name}:9000#{drivers_arg}"

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -30,8 +30,6 @@ class MinioServer < Sequel::Model
   end
 
   def minio_volumes
-    return "/minio/dat1" if cluster.target_total_server_count == 1 && cluster.target_total_drive_count == 1
-    return "/minio/dat{1...#{cluster.target_total_drive_count}}" if cluster.target_total_server_count == 1
     cluster.pools.map do |pool|
       pool.volumes_url
     end.join(" ")

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -22,7 +22,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
         "minio-user",
         Config.minio_service_project_id,
         location: minio_pool.cluster.location,
-        size: minio_pool.cluster.target_vm_size,
+        size: minio_pool.vm_size,
         storage_volumes: [
           {encrypted: true, size_gib: 30}
         ] + Array.new(minio_pool.per_server_drive_count) { {encrypted: false, size_gib: (minio_pool.per_server_storage_size / minio_pool.per_server_drive_count).floor} },

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -8,16 +8,15 @@ RSpec.describe MinioCluster do
       location: "hetzner-hel1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
-      admin_password: "dummy-password",
-      target_total_storage_size_gib: 100,
-      target_total_pool_count: 1,
-      target_total_server_count: 1,
-      target_total_drive_count: 1,
-      target_vm_size: "standard-2"
+      admin_password: "dummy-password"
     )
     mp = MinioPool.create_with_id(
       cluster_id: mc.id,
-      start_index: 0
+      start_index: 0,
+      server_count: 1,
+      drive_count: 1,
+      storage_size_gib: 100,
+      vm_size: "standard-2"
     )
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
@@ -43,15 +42,15 @@ RSpec.describe MinioCluster do
   end
 
   it "returns per pool storage size properly" do
-    expect(mc.per_pool_storage_size).to eq(100)
+    expect(mc.storage_size_gib).to eq(100)
   end
 
   it "returns per pool server count properly" do
-    expect(mc.per_pool_server_count).to eq(1)
+    expect(mc.server_count).to eq(1)
   end
 
   it "returns per pool driver count properly" do
-    expect(mc.per_pool_drive_count).to eq(1)
+    expect(mc.drive_count).to eq(1)
   end
 
   it "returns connection strings properly" do

--- a/spec/model/minio/minio_pool_spec.rb
+++ b/spec/model/minio/minio_pool_spec.rb
@@ -8,19 +8,15 @@ RSpec.describe MinioPool do
       location: "hetzner-hel1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
-      admin_password: "dummy-password",
-      target_total_storage_size_gib: 100,
-      target_total_pool_count: 1,
-      target_total_server_count: 1,
-      target_total_drive_count: 1,
-      target_vm_size: "standard-2"
+      admin_password: "dummy-password"
     )
     mp = described_class.create_with_id(
       cluster_id: mc.id,
       start_index: 0,
       server_count: 1,
       drive_count: 1,
-      storage_size_gib: 100
+      storage_size_gib: 100,
+      vm_size: "standard-2"
     )
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 

--- a/spec/model/minio/minio_pool_spec.rb
+++ b/spec/model/minio/minio_pool_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe MinioPool do
 
   describe "#volumes_url" do
     it "returns volumes url properly for a single drive single server pool" do
-      expect(mp.volumes_url).to eq("http://minio-cluster-name{0...0}.minio.ubicloud.com:9000/minio/dat{1...1}")
+      expect(mp.volumes_url).to eq("/minio/dat1")
     end
 
     it "returns volumes url properly for a multi drive single server pool" do
       mp.update(drive_count: 4)
-      expect(mp.volumes_url).to eq("http://minio-cluster-name{0...0}.minio.ubicloud.com:9000/minio/dat{1...4}")
+      expect(mp.volumes_url).to eq("/minio/dat{1...4}")
     end
 
     it "returns volumes url properly for a multi drive multi server pool" do

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -8,19 +8,15 @@ RSpec.describe MinioServer do
       location: "hetzner-hel1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
-      admin_password: "dummy-password",
-      target_total_storage_size_gib: 100,
-      target_total_pool_count: 1,
-      target_total_server_count: 1,
-      target_total_drive_count: 1,
-      target_vm_size: "standard-2"
+      admin_password: "dummy-password"
     )
     mp = MinioPool.create_with_id(
       cluster_id: mc.id,
       start_index: 0,
       server_count: 1,
       drive_count: 1,
-      storage_size_gib: 100
+      storage_size_gib: 100,
+      vm_size: "standard-2"
     )
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
@@ -55,13 +51,12 @@ RSpec.describe MinioServer do
     end
 
     it "returns minio volumes properly for a multi drive single server cluster" do
-      ms.cluster.update(target_total_drive_count: 4)
+      ms.pool.update(drive_count: 4)
       expect(ms.minio_volumes).to eq("/minio/dat{1...4}")
     end
 
     it "returns minio volumes properly for a multi drive multi server cluster" do
-      ms.cluster.update(target_total_drive_count: 4, target_total_server_count: 2)
-      ms.pool.update(server_count: 2, drive_count: 4)
+      ms.pool.update(drive_count: 4, server_count: 2)
       expect(ms.minio_volumes).to eq("http://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
     end
   end

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -11,11 +11,6 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",
-      target_total_storage_size_gib: 100,
-      target_total_pool_count: 1,
-      target_total_server_count: 1,
-      target_total_drive_count: 1,
-      target_vm_size: "standard-2",
       private_subnet_id: ps.id
     )
 
@@ -24,7 +19,8 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       cluster_id: mc.id,
       server_count: 1,
       drive_count: 1,
-      storage_size_gib: 100
+      storage_size_gib: 100,
+      vm_size: "standard-2"
     )
   }
   let(:ps) {

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -17,17 +17,15 @@ RSpec.describe Prog::Minio::SetupMinio do
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",
-      target_total_storage_size_gib: 100,
-      target_total_pool_count: 1,
-      target_total_server_count: 1,
-      target_total_drive_count: 1,
-      target_vm_size: "standard-2",
       private_subnet_id: ps.id
     )
 
     mp = MinioPool.create_with_id(
       start_index: 0,
-      cluster_id: mc.id
+      cluster_id: mc.id,
+      vm_size: "standard-2",
+      server_count: 1,
+      drive_count: 1
     )
     vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
     MinioServer.create_with_id(


### PR DESCRIPTION
With this commit we are changing the provisioning path for MinIO
cluster. The main objective is to eliminate the redundant columns from
the MinIO cluster. They were necessary since the pool or server
provisioning was happening in later stages of the state machine. Moving
all of the entity creations into the assemble functions, we eliminate
the need of redundant columns and load those values dynamically.

**Single instance MinIO configuration fix**
The single instance MinIO clusters do not get the host address prefix
before the mount point because there is no need to connect to any other
node. Therefore, the configuration must simply give a local mount point
path. With this commit, we fix that, before this, the provisioning was
failing for single instance configuration.