### PR TITLE
Require more modern ciphers for Postgres

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -33,6 +33,7 @@ class PostgresServer < Sequel::Model
       tcp_keepalives_idle: "2",
       tcp_keepalives_interval: "2",
       ssl: "on",
+      ssl_min_protocol_version: "TLSv1.3",
       ssl_cert_file: "'/dat/16/data/server.crt'",
       ssl_key_file: "'/dat/16/data/server.key'",
       log_timezone: "'UTC'",

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe PostgresServer do
         tcp_keepalives_idle: "2",
         tcp_keepalives_interval: "2",
         ssl: "on",
+        ssl_min_protocol_version: "TLSv1.3",
         ssl_cert_file: "'/dat/16/data/server.crt'",
         ssl_key_file: "'/dat/16/data/server.key'",
         log_timezone: "'UTC'",


### PR DESCRIPTION
Let's get this out of the way before developing more customers.  Each upgrade to cipher suites is something of a production once it can break customers, let's get on the most modern footing we can to delay that as long as possible...and TLS 1.3 is not even that modern anymore (but there's nothing newer yet).

For about a decade, I used the Mozilla wiki
(https://wiki.mozilla.org/Security/Server_Side_TLS) to source preferred ciphers, but look at this handy tool they also have:

https://ssl-config.mozilla.org/#server=postgresql&version=16&config=modern&openssl=3.0.2&guideline=5.7

This tool doesn't have some important recommendations still seen at the wiki, such what certificate cipher to use (prime256v1, which is already satisfied), and how frequently to rotate the certificate (90 days).

So, make sure to reference both resources carefully when changing the ciphers and key management strategy.

There's also a slight disagreement between the two resources, as the wiki only references GCM ciphers for a cipher suite string, thus not supporting CCM AES variants in TLS v1.3, whereas the ssl-config page thinks merely specifying TLS v1.3, with all its ciphers, is good enough.  This isn't explained on the wiki page or in discussion, so it may be an oversight.  I think I will accept the simplicity of supporting TLS v1.3 wholesale rather than micromanaging the cipher suite, since it doesn't have ciphers considered weak yet: other web searching suggests CCM variants are uncontroversial.