### PR TITLE
Remove the warning suppression for the webauthn package

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,9 +41,6 @@ DatabaseCleaner.url_allowlist = [
 
 Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser.*/)
 Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations.*/)
-# It's resolved already but the webauthn-ruby hasn't release a new version since Feb 2023.
-# https://github.com/cedarcode/webauthn-ruby/issues/388
-Warning.ignore(/circular require considered harmful/, /.*lib\/webauthn\/relying_party.*/)
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|


### PR DESCRIPTION
The new version has been released and no longer prints warnings.

https://github.com/ubicloud/ubicloud/pull/1051

https://github.com/cedarcode/webauthn-ruby/pull/389