### PR TITLE
Change memory ratio and core count for ARM runners

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -51,11 +51,12 @@ class Vm < Sequel::Model
   end
 
   def mem_gib_ratio
+    return 3.2 if arch == "arm64"
     8
   end
 
   def mem_gib
-    cores * mem_gib_ratio
+    (cores * mem_gib_ratio).to_i
   end
 
   # cloud-hypervisor takes topology information in this format:

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -79,8 +79,14 @@ class Prog::Vm::Nexus < Prog::Base
         nic = Nic[nic_s.id]
       end
 
+      cores = if arch == "arm64"
+        vm_size.vcpu
+      else
+        vm_size.vcpu / 2
+      end
+
       vm = Vm.create(public_key: public_key, unix_user: unix_user,
-        name: name, family: vm_size.family, cores: vm_size.vcpu / 2, location: location,
+        name: name, family: vm_size.family, cores: cores, location: location,
         boot_image: boot_image, ip4_enabled: enable_ip4, pool_id: pool_id, arch: arch) { _1.id = ubid.to_uuid }
       nic.update(vm_id: vm.id)
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -157,6 +157,13 @@ RSpec.describe Prog::Vm::Nexus do
         described_class.assemble("some_ssh_key", prj.id, private_subnet_id: ps.id)
       }.to raise_error RuntimeError, "Given subnet is not available in the given project"
     end
+
+    it "creates arm64 vm with double core count and 3.2GB memory per core" do
+      st = described_class.assemble("some_ssh_key", prj.id, size: "standard-4", arch: "arm64")
+      expect(st.subject.cores).to eq(4)
+      expect(st.subject.mem_gib_ratio).to eq(3.2)
+      expect(st.subject.mem_gib).to eq(12)
+    end
   end
 
   describe ".assemble_with_sshable" do


### PR DESCRIPTION
We reserve one physical core for standard-2 virtual machines, which equates to 2 vCPUs for x64 machines. However, arm64 machines do not implement SMT, thereby corresponding to 1 vCPU. The GitHub Actions integration is closely tied to the actions of GitHub product numbering, which allocates 2 cores for standard-2 arm64 runners. We have chosen to adopt the same numbering scheme.

In addition, arm64 bare metal servers have a max memory limitation. At present, we are using RX220 machines from Hetzner, which has 80 cores and 256GB memory. This allocation translates to 3.2GB per core. Our "standard" family virtual machines offer 8GB memory per core for x64. However, this is not feasible for arm64 servers, and we have therefore decided to allocate 3.2GB per core for arm64 runners.

These decisions apply exclusively to GitHub Actions runners. We have yet to make any decisions for standard virtual machines. To avoid unnecessary complexity in the code at this stage, this PR applies to all virtual machines. We can refactor these parts when we decide on the direction for standard ARM virtual machines.

Initially, we considered unifying standard VMs and runner VMs, but the unique nature of the GitHub universe suggests potential divergence when we decide on the product lines for standard VMs.