### PR TITLE
Set locale to C for Postgres clusters

### DIFF
--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -9,6 +9,6 @@ r "chown postgres /dat"
 r "rm -rf /dat/16"
 r "rm -rf /etc/postgresql/16"
 
-r "pg_createcluster 16 main --start"
+r "pg_createcluster 16 main --start --locale=C"
 
 r "sudo -u postgres psql -c 'CREATE ROLE ubi_replication WITH REPLICATION LOGIN'"


### PR DESCRIPTION
This is, perhaps, a better choice for a more international era (the entire world is not en_US), with more multi-tenant SaaS applications that, if they handle internationalization at all, will handle it for multiple locales.

By contrast, in the last era, you were somewhat more likely to install a boxed piece of software, and setting the default collation for everything did what you wanted.

Also, collation code is complex, versioning has to be handled precisely when upgrading or performing physical replication between systems.  But, nearly all text columns tend to be symbols or text where sort orders on the text's value are not meaningful.  In addition, collations slow down text comparisons.

There are some downsides: there are situations where I find the capitalization and punctuation sorts are a little annoying when debugging, but I do not think this a compelling reason to introduce collation dependencies on every text column.

See 596c56cae395fa6c1485c3e39665f75becfb5f25