### PR TITLE
Introduce new ARM runner labels

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -11,6 +11,20 @@
 - { name: ubicloud-standard-4-ubuntu-2004,      vm_size: standard-4,  arch: x64,    storage_size_gib: 150, boot_image: github-ubuntu-2004, location: github-runners }
 - { name: ubicloud-standard-8-ubuntu-2004,      vm_size: standard-8,  arch: x64,    storage_size_gib: 200, boot_image: github-ubuntu-2004, location: github-runners }
 - { name: ubicloud-standard-16-ubuntu-2004,     vm_size: standard-16, arch: x64,    storage_size_gib: 300, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-arm,                         vm_size: standard-2,  arch: arm64,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2-arm,              vm_size: standard-2,  arch: arm64,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-4-arm,              vm_size: standard-4,  arch: arm64,  storage_size_gib: 150, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-8-arm,              vm_size: standard-8,  arch: arm64,  storage_size_gib: 200, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-16-arm,             vm_size: standard-16, arch: arm64,  storage_size_gib: 300, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2-arm-ubuntu-2204,  vm_size: standard-2,  arch: arm64,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-4-arm-ubuntu-2204,  vm_size: standard-4,  arch: arm64,  storage_size_gib: 150, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-8-arm-ubuntu-2204,  vm_size: standard-8,  arch: arm64,  storage_size_gib: 200, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-16-arm-ubuntu-2204, vm_size: standard-16, arch: arm64,  storage_size_gib: 300, boot_image: github-ubuntu-2204, location: github-runners }
+- { name: ubicloud-standard-2-arm-ubuntu-2004,  vm_size: standard-2,  arch: arm64,  storage_size_gib: 86,  boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-4-arm-ubuntu-2004,  vm_size: standard-4,  arch: arm64,  storage_size_gib: 150, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-8-arm-ubuntu-2004,  vm_size: standard-8,  arch: arm64,  storage_size_gib: 200, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-standard-16-arm-ubuntu-2004, vm_size: standard-16, arch: arm64,  storage_size_gib: 300, boot_image: github-ubuntu-2004, location: github-runners }
+# Deprecated: Remove old arm64 labels once all customers have migrated to new labels.
 - { name: ubicloud-standard-2-ubuntu-2204-arm,  vm_size: standard-2,  arch: arm64,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-4-ubuntu-2204-arm,  vm_size: standard-4,  arch: arm64,  storage_size_gib: 150, boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-8-ubuntu-2204-arm,  vm_size: standard-8,  arch: arm64,  storage_size_gib: 200, boot_image: github-ubuntu-2204, location: github-runners }


### PR DESCRIPTION
While arm64 runners were in preview, I appended the "-arm" prefix to the current labels.

I believe the "arm" identifier should be closer to the product line. This pattern feels more intuitive. A few colleagues attempted to use arm64 runners with the "ubicloud-standard-2-arm-ubuntu-2204" label instead of appending it to the entire label. I decided to adopt this pattern. It also makes shorthand labels more convenient, such as "ubicloud-arm" and "ubicloud-standard-2-arm".

At present, our virtual machines only have the "standard" product line. We haven't yet decided on naming for our other product lines or ARM virtual machines. Initially, we considered unifying standard VMs and runner VMs, but the unique nature of the GitHub universe suggests potential divergence. We can revisit our labels when we decide on the naming for our virtual machines.

We should remove old arm64 labels once all customers have migrated to new labels.