### PR TITLE
Change the runner working directory

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -201,7 +201,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # We use generate-jitconfig instead of registration-token because it's
     # recommended by GitHub for security reasons.
     # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-just-in-time-runners
-    data = {name: github_runner.ubid.to_s, labels: [github_runner.label], runner_group_id: 1}
+    data = {name: github_runner.ubid.to_s, labels: [github_runner.label], runner_group_id: 1, work_folder: "/home/runner/work"}
     response = github_client.post("/repos/#{github_runner.repository_name}/actions/runners/generate-jitconfig", data)
     github_runner.update(runner_id: response[:runner][:id], ready_at: Time.now)
 


### PR DESCRIPTION
The default working directory for job execution is `_work`, which is relative to the runner installation directory. [^1]

Currently, our working directory is
`/home/runner/actions-runner/_work/`. However, the default GitHub runner sets it as `/home/runner/work`.

This isn't a significant issue. However, if a customer has hard-coded paths in their workflow files, they will not function correctly.

I have modified this to ensure full compatibility with the default GitHub runners.

Fixes https://github.com/ubicloud/ubicloud/issues/1037

[^1]: https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-a-repository