### PR TITLE
Do not convert the image if it's already in .raw format

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -441,6 +441,8 @@ EOS
         "qcow2"
       when ".vhd"
         "vpc"
+      when ".raw"
+        "raw"
       else
         fail "Unsupported boot_image format: #{image_ext}"
       end
@@ -458,9 +460,13 @@ EOS
         end
       end
 
-      # Images are presumed to be atomically renamed into the path,
-      # i.e. no partial images will be passed to qemu-image.
-      r "qemu-img convert -p -f #{initial_format.shellescape} -O raw #{temp_path.shellescape} #{image_path.shellescape}"
+      if initial_format == "raw"
+        File.rename(temp_path, image_path)
+      else
+        # Images are presumed to be atomically renamed into the path,
+        # i.e. no partial images will be passed to qemu-image.
+        r "qemu-img convert -p -f #{initial_format.shellescape} -O raw #{temp_path.shellescape} #{image_path.shellescape}"
+      end
 
       rm_if_exists(temp_path)
     end


### PR DESCRIPTION
We convert 'qcow2', 'img', and 'vhd' images to 'raw' format to enable their use with Cloud Hypervisor. If the source image is already in 'raw' format, there's no need for conversion; we simply move it.

At present, we don't have any source images in 'raw' format. However, I plan to distribute GitHub runner images via our internal MinIO cluster. Instead of uploading 'vhd' images, I will upload the converted 'raw' images to MinIO. This way, each VM host won't need to convert images, which has two main benefits:

  - Converting 86GB images typically takes 6-7 minutes. Distributing 'raw' images will speed up the image download operation on VM hosts.
  - When each VM host converts the image locally, the resulting raw images are not identical, as their checksums differ. By distributing a 'raw' image, we can ensure that all VM hosts have the exact same image file.