### PR TITLE
Run CI on both x64 and arm64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,12 @@ on:
 
 jobs:
   ruby-ci:
-    runs-on: ubicloud
+    strategy:
+      matrix:
+        runs-on: [ubicloud, ubicloud-arm]
+    continue-on-error: true
+    name: Ruby CI - ${{matrix.runs-on}}
+    runs-on: ${{matrix.runs-on}}
 
     env:
       DB_USER: clover
@@ -34,6 +39,25 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v4
+
+    - name: Cache ruby for ARM runners
+      id: cache-ruby
+      if: matrix.runs-on == 'ubicloud-arm'
+      uses: actions/cache@v3
+      with:
+        path: /opt/hostedtoolcache/Ruby
+        key: ${{ matrix.runs-on }}-ruby-${{ hashFiles('.tool-versions') }}
+
+    - name: Install ruby for ARM runners if not cached
+      if: matrix.runs-on == 'ubicloud-arm' && steps.cache-ruby.outputs.cache-hit != 'true'
+      run: |
+        git clone https://github.com/rbenv/ruby-build.git
+        sudo ./ruby-build/install.sh
+        RUBY_VERSION="$(grep -E '^ruby ' .tool-versions | cut -d' ' -f2)"
+        sudo ruby-build "$RUBY_VERSION" /opt/hostedtoolcache/Ruby/$RUBY_VERSION/arm64
+        sudo chown -R runner:runner /opt/hostedtoolcache/Ruby
+        touch /opt/hostedtoolcache/Ruby/$RUBY_VERSION/arm64.complete
+        rm -rf ruby-build
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     net-ssh (7.2.1)
     netaddr (2.0.6)
     nio4r (2.7.0)
+    nokogiri (1.16.0-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-darwin)
@@ -294,6 +296,7 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux

--- a/rhizome/Gemfile.lock
+++ b/rhizome/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     rspec-support (3.12.1)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
The code for our rhizome (dataplane) depends on the architecture of the VM host. It's possible for tests to pass on x64 but fail on arm64 due to incorrect assumptions, such as f58dc74a. I believe it's beneficial to run rhizome tests on both architectures. 

Additionally, testing our arm64 runners is a sound strategy.

The "ruby/ruby-builder" currently lacks an arm64 release for Ubuntu [^1], preventing us from adding Ruby to our golden ARM image using the default scripts [^2]. I prefer not to create custom scripts for our golden image.  However, if multiple customers request Ruby on arm64 images, I'll consider it.
At present, I only install and cache it for arm64 runners.

[^1]: https://github.com/ruby/setup-ruby#supported-platforms
[^2]: https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-ruby.sh
