### PR TITLE
Use 2 vcpus for SPDK on new hosts.

### DIFF
--- a/migrate/20240118_core_constraint.rb
+++ b/migrate/20240118_core_constraint.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      # Previously, we didn't allocate one core on each host to offset host
+      # memory overheads. Given that we will use 1 core (=2 vcpus) per host for
+      # SPDK using only 1G, we can relax this constraint.
+      drop_constraint :core_allocation_limit
+      add_constraint(:core_allocation_limit) { used_cores <= total_cores }
+    end
+
+    # We had missed to account for SPDK in previous hosts. SPDK uses 1 vcpu in
+    # all previous setups, which is one core.
+    run <<~SQL
+      UPDATE vm_host SET used_cores = used_cores + 1;
+    SQL
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -70,11 +70,16 @@ class Prog::Vm::HostNexus < Prog::Base
         mem_gib = st.exitval.fetch("mem_gib")
         vm_host.update(total_mem_gib: mem_gib)
       when "LearnCores"
+        total_cores = st.exitval.fetch("total_cores")
+        total_cpus = st.exitval.fetch("total_cpus")
+        # Currently all SPDK installations share vcpus 0 and 1.
+        spdk_cores = (2 * total_cores) / total_cpus
         kwargs = {
           total_sockets: st.exitval.fetch("total_sockets"),
           total_dies: st.exitval.fetch("total_dies"),
-          total_cores: st.exitval.fetch("total_cores"),
-          total_cpus: st.exitval.fetch("total_cpus")
+          total_cores: total_cores,
+          total_cpus: total_cpus,
+          used_cores: spdk_cores
         }
 
         vm_host.update(**kwargs)

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -178,8 +178,8 @@ class Prog::Vm::Nexus < Prog::Base
     DB[<<SQL, vm.cores, vm.mem_gib_ratio, vm.mem_gib, vm_storage_size_gib, vm.location, vm.arch]
 SELECT *, vm_host.total_mem_gib / vm_host.total_cores AS mem_ratio
 FROM vm_host
-WHERE vm_host.used_cores + ? < least(vm_host.total_cores, vm_host.total_mem_gib / ?)
-AND vm_host.used_hugepages_1g + ? < vm_host.total_hugepages_1g
+WHERE vm_host.used_cores + ? <= least(vm_host.total_cores, vm_host.total_mem_gib / ?)
+AND vm_host.used_hugepages_1g + ? <= vm_host.total_hugepages_1g
 AND vm_host.available_storage_gib > ?
 AND vm_host.allocation_state = 'accepting'
 AND vm_host.location = ?

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -96,7 +96,7 @@ ExecStart=#{vhost_binary} -S #{SpdkPath.vhost_dir.shellescape} \
 --huge-dir #{hugepages_dir.shellescape} \
 --iova-mode va \
 --rpc-socket #{rpc_sock.shellescape} \
---cpumask [0] \
+--cpumask [0,1] \
 --disable-cpumask-locks
 ExecReload=/bin/kill -HUP $MAINPID
 LimitMEMLOCK=8400113664

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
       expect(vm_host).to receive(:update).with(arch: "arm64")
-      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2)
+      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2, used_cores: 1)
       expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),
@@ -149,7 +149,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
     it "crashes if an expected field is not set for LearnCores" do
       expect(nx).to receive(:reap).and_return([instance_double(Strand, prog: "LearnCores", exitval: {})])
-      expect { nx.wait_prep }.to raise_error KeyError, "key not found: \"total_sockets\""
+      expect { nx.wait_prep }.to raise_error KeyError, "key not found: \"total_cores\""
     end
 
     it "crashes if an expected field is not set for LearnStorage" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -464,6 +464,26 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nx.allocate).to eq idle.id
     end
 
+    it "can use all cores" do
+      vmh = new_host(used_cores: 79)
+      expect(nx.allocate).to eq vmh.id
+    end
+
+    it "fails if all cores have been used" do
+      new_host(used_cores: 80)
+      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
+    end
+
+    it "can use all hugepages" do
+      vmh = new_host(used_hugepages_1g: 632 - vm.mem_gib)
+      expect(nx.allocate).to eq vmh.id
+    end
+
+    it "fails if all hugepages have been used" do
+      new_host(used_hugepages_1g: 632 - vm.mem_gib + 1)
+      expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
+    end
+
     it "updates allocated resource columns" do
       vmh = new_host(location: "hetzner-hel1")
       st = described_class.assemble("some_ssh_key", prj.id, storage_volumes: [{size_gib: 10}, {size_gib: 15}])


### PR DESCRIPTION
Each OS vcpu can only use one NVMe queue, and in our benchmarks we can't saturate a NVMe card using a single queue. This patch changes number of vcpus used for SPDK to 2 to improve the overall I/O performance.

Note that a single VM will be limited to the performance of a single NVMe queue, as SPDK's vhost_user_blk implementation uses a single thread. But running multiple VMs in a host will allow using both vcpus.

In an AX-161 machine:
* 1-vcpu, 1 or more VMs: unencrypted 697 MiB/s, encrypted 540 MiB/s
* 2-vcpu, 2 or more VMs: unencrypted 1360 MiB/s, encrypted 1040 MiB/s

We could get better performance in encrypted case by using 3 vcpus, but then we would decrease VM capacity in a host by 1. Assuming 2-core VMs, in a host with 32 total cores, assigning 1 or 2 vcpus for SPDK allows 31 VMs, but 3 vcpus for SPDK allows 30 VMs. So we're accepting this trade-off for now.