### PR TITLE
Clean the downloaded image daemon after completion

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -27,6 +27,7 @@ class Prog::DownloadBootImage < Prog::Base
   label def download
     case sshable.cmd("common/bin/daemonizer --check download_#{image_name.shellescape}")
     when "Succeeded"
+      sshable.cmd("common/bin/daemonizer --clean download_#{image_name.shellescape}")
       hop_learn_storage
     when "NotStarted"
       sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image #{image_name.shellescape} #{custom_url.shellescape}' download_#{image_name.shellescape}")

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Prog::DownloadBootImage do
 
     it "hops if it's succeeded" do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("Succeeded")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --clean download_my-image")
       expect { dbi.download }.to hop("learn_storage")
     end
   end


### PR DESCRIPTION
I incorrectly used  daemonizer. For repetitive tasks, it appears necessary to clean it after each successful run. Otherwise, new tasks prematurely exit with "Succeeded" at the start, likely due to the influence of the previous run.