### PR TITLE
Add a IPv4 flag to vm provisioning API

### DIFF
--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -21,7 +21,8 @@ class CloverApi
         unix_user: r.params["unix_user"],
         size: r.params["size"],
         location: @location,
-        boot_image: r.params["boot_image"]
+        boot_image: r.params["boot_image"],
+        enable_ip4: !!r.params["enable_ip4"]
       )
 
       serialize(st.subject)

--- a/serializers/api/vm.rb
+++ b/serializers/api/vm.rb
@@ -12,6 +12,7 @@ class Serializers::Api::Vm < Serializers::Base
       display_size: vm.display_size,
       unix_user: vm.unix_user,
       ip6: vm.ephemeral_net6&.nth(2),
+      ip4: vm.ephemeral_net4,
       projects: Serializers::Api::Project.serialize(vm.projects)
     }
   end

--- a/spec/routes/api/vm_spec.rb
+++ b/spec/routes/api/vm_spec.rb
@@ -66,6 +66,22 @@ RSpec.describe Clover, "vm" do
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-vm")
+        expect(Vm.first.ip4_enabled).to be false
+      end
+
+      it "success with ipv4" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm", {
+          public_key: "ssh key",
+          name: "test-vm",
+          unix_user: "ubi",
+          size: "standard-2",
+          boot_image: "ubuntu-jammy",
+          enable_ip4: true
+        }
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-vm")
+        expect(Vm.first.ip4_enabled).to be true
       end
 
       it "invalid name" do


### PR DESCRIPTION
We developed our APIs in the early days as a PoC but haven't yet added new features.

However, IPv4 is an important one. Several of our customers use our basic APIs, so I added "enable_ip4" flag to unblock them.

Please note that `!!r.params["enable_ip4"]` is only falsy for `nil` and `false`. Other values such as `0` and `"false"` are truthy.