### PR TITLE
Fail more gracefully if the validated value is nil

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -31,12 +31,12 @@ module Validation
 
   def self.validate_name(name)
     msg = "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."
-    fail ValidationFailed.new({name: msg}) unless name.match(ALLOWED_NAME_PATTERN)
+    fail ValidationFailed.new({name: msg}) unless name&.match(ALLOWED_NAME_PATTERN)
   end
 
   def self.validate_minio_username(username)
     msg = "Minio user must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also have max length of 32, min length of 3."
-    fail ValidationFailed.new({username: msg}) unless username.match(ALLOWED_MINIO_USERNAME_PATTERN)
+    fail ValidationFailed.new({username: msg}) unless username&.match(ALLOWED_MINIO_USERNAME_PATTERN)
   end
 
   def self.validate_provider(provider)
@@ -59,7 +59,7 @@ module Validation
 
   def self.validate_os_user_name(os_user_name)
     msg = "OS user name must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also have max length of 32."
-    fail ValidationFailed.new({user: msg}) unless os_user_name.match(ALLOWED_OS_USER_NAME_PATTERN)
+    fail ValidationFailed.new({user: msg}) unless os_user_name&.match(ALLOWED_OS_USER_NAME_PATTERN)
   end
 
   def self.validate_storage_volumes(storage_volumes, boot_disk_index)

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Validation do
 
     it "invalid names" do
       [
+        nil,
         "-abc",
         "abc-",
         "-abc-",
@@ -89,6 +90,7 @@ RSpec.describe Validation do
 
       it "invalid os user names" do
         [
+          nil,
           "-abc",
           "ABC",
           "123abc",
@@ -135,8 +137,9 @@ RSpec.describe Validation do
         end
       end
 
-      it "invalid os user names" do
+      it "invalid minio user names" do
         [
+          nil,
           "ab",
           "-abc",
           "ABC",


### PR DESCRIPTION
I saw multiple web requests failing with the following error message:

    Jan 4 11:11:57  app[web]  NoMethodError: undefined method `match' for nil:NilClass
    Jan 4 11:11:57  app[web]  /app/lib/validation.rb:62:in `validate_os_user_name'

It's more appropriate to return a validation error rather than an HTTP 500 if these values are nil.