### PR TITLE
Fix the hopped label after refreshing certificate

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -115,7 +115,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     postgres_resource.certificate_last_checked_at = Time.now
     postgres_resource.save_changes
 
-    hop_wait_server
+    hop_wait
   end
 
   label def wait_server

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(nx).to receive(:create_root_certificate).with(hash_including(duration: 60 * 60 * 24 * 365 * 10))
       expect(postgres_resource.server).to receive(:incr_refresh_certificates)
 
-      expect { nx.refresh_certificates }.to hop("wait_server")
+      expect { nx.refresh_certificates }.to hop("wait")
     end
 
     it "rotates server certificate if it is close to expiration" do
@@ -203,7 +203,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(nx).to receive(:create_server_certificate)
       expect(postgres_resource.server).to receive(:incr_refresh_certificates)
 
-      expect { nx.refresh_certificates }.to hop("wait_server")
+      expect { nx.refresh_certificates }.to hop("wait")
     end
 
     it "rotates server certificate using root_cert_2 if root_cert_1 is close to expiration" do
@@ -215,7 +215,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(Util).to receive(:create_certificate).with(hash_including(issuer_cert: root_cert_2)).and_return([instance_double(OpenSSL::X509::Certificate, to_pem: "server cert")])
       expect(postgres_resource.server).to receive(:incr_refresh_certificates)
 
-      expect { nx.refresh_certificates }.to hop("wait_server")
+      expect { nx.refresh_certificates }.to hop("wait")
     end
   end
 


### PR DESCRIPTION
We refresh the certificates for postgres resources monthly, hops to the 'refresh_certificates' label from only 'wait' label

Currently, 'refresh_certificates'  hops to the 'wait_server' label. New resources also pass through the 'wait_server' label before hopping to the 'create_billing_record' label. However, we shouldn't create billing records for existing resources during the monthly certificate renewal.

Certificate renewal is an online operation, it doesn't cause degradation. There's no need to wait for the server. We can hop to the 'wait' label after refreshing the certificate.

I noticed this issue when we had our first postgres resource, which was a month old, and attempted to refresh its certificate in production. Creating duplicate billing records action resulted in the following exception:

    PG::ExclusionViolation | ERROR:  conflicting key value violates
    exclusion constraint
    "billing_record_resource_id_billing_rate_id_span_excl"