### PR TITLE
Don't schedule disks on bdev_ubi enabled hosts if not using bdev_ubi.

### DIFF
--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -369,7 +369,13 @@ RSpec.describe Prog::Vm::Nexus do
               arch: "x64"}.merge(args)
       sa = Sshable.create_with_id(host: "127.0.0.#{@host_index}")
       @host_index += 1
-      VmHost.create(**args) { _1.id = sa.id }
+      host = VmHost.create(**args) { _1.id = sa.id }
+      SpdkInstallation.create(
+        version: "v29.01",
+        allocation_weight: 100,
+        vm_host_id: host.id
+      ) { _1.id = SpdkInstallation.generate_uuid }
+      host
     end
 
     it "fails if there was a concurrent modification to allocation_state" do


### PR DESCRIPTION
Currently, github runners require btrfs if not using bdev_ubi. We will use ext4 for hosts with bdev_ubi installation. So, we make sure we don't schedule disks on a bdev_ubi enabled host if bdev_ubi is not used.

Note that this is a temporary measure, and can be removed when either we have a direct way to check for btrfs (e.g. if we add this field for storage devices), or when we migrate away from btrfs completely.