### PR TITLE
Fix minio_pool vm_size column related migration

### DIFF
--- a/migrate/20231227_add_minio_pool_vm_size.rb
+++ b/migrate/20231227_add_minio_pool_vm_size.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-  change do
+  up do
     alter_table(:minio_pool) do
-      add_column :vm_size, :text, collate: '"C"', null: false
+      add_column :vm_size, :text, collate: '"C"'
+    end
+
+    run <<~SQL
+      UPDATE minio_pool SET vm_size = 'standard-2';
+    SQL
+
+    alter_table(:minio_pool) do
+      set_column_not_null :vm_size
+    end
+  end
+
+  down do
+    alter_table(:minio_pool) do
+      drop_column :vm_size
     end
   end
 end


### PR DESCRIPTION
This caused an issue during deployment since there is an active minio pool entity that does not have the vm_size column, yet. The new column addition did not allow vm_size column to be null without providing a default value. Now, we first create the column, set a value and then set the not_null constraint.