### PR TITLE
Enable vm pool for arm64 runners

### DIFF
--- a/migrate/20240108_add_arch_to_vm_pool.rb
+++ b/migrate/20240108_add_arch_to_vm_pool.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_pool) do
+      add_column :arch, :arch, default: "x64", null: false
+    end
+  end
+end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -47,12 +47,11 @@ class Prog::Vm::GithubRunner < Prog::Base
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
       location: label_data["location"],
-      storage_size_gib: label_data["storage_size_gib"]
+      storage_size_gib: label_data["storage_size_gib"],
+      arch: label_data["arch"]
     ).first
 
-    # Do not use the pool for arm64 runners until we decide to on their positioning.
-    # Our current use of labels with the `-arm` suffix is a temporary solution.
-    if label_data["arch"] == "x64" && (picked_vm = pool&.pick_vm)
+    if (picked_vm = pool&.pick_vm)
       Clog.emit("Pool is used") { {github_runner: {label: github_runner.label, repository_name: github_runner.repository_name, cores: picked_vm.cores}} }
       return picked_vm
     end

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -7,14 +7,15 @@ class Prog::Vm::VmPool < Prog::Base
 
   semaphore :destroy
 
-  def self.assemble(size:, vm_size:, boot_image:, location:, storage_size_gib:)
+  def self.assemble(size:, vm_size:, boot_image:, location:, storage_size_gib:, arch:)
     DB.transaction do
       vm_pool = VmPool.create_with_id(
         size: size,
         vm_size: vm_size,
         boot_image: boot_image,
         location: location,
-        storage_size_gib: storage_size_gib
+        storage_size_gib: storage_size_gib,
+        arch: arch
       )
       Strand.create(prog: "Vm::VmPool", label: "create_new_vm") { _1.id = vm_pool.id }
     end
@@ -37,7 +38,8 @@ class Prog::Vm::VmPool < Prog::Base
       boot_image: vm_pool.boot_image,
       storage_volumes: [{size_gib: vm_pool.storage_size_gib, encrypted: false}],
       enable_ip4: true,
-      pool_id: vm_pool.id
+      pool_id: vm_pool.id,
+      arch: vm_pool.arch
     )
 
     ps = st.subject.private_subnets.first

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe ".assemble" do
     it "creates the entity and strand properly" do
-      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
+      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86, arch: "x64")
       pool = VmPool[st.id]
       expect(pool).not_to be_nil
       expect(pool.size).to eq(3)
@@ -27,7 +27,7 @@ RSpec.describe Prog::Vm::VmPool do
 
     it "creates a new vm and hops to wait" do
       expect(Config).to receive(:vm_pool_project_id).and_return(prj.id)
-      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
+      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86, arch: "arm64")
       st.update(label: "create_new_vm")
       expect(SshKey).to receive(:generate).and_call_original
       expect(nx).to receive(:vm_pool).and_return(VmPool[st.id]).at_least(:once)
@@ -40,7 +40,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#wait" do
     let(:pool) {
-      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
+      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86, arch: "x64")
     }
 
     it "waits if nothing to do" do


### PR DESCRIPTION
We have not yet enabled the VM pooling feature for arm64 runners in preview.

We are nearing the launch of arm64 runners.  An arm64 runner pool will make provisioning faster.