### PR TITLE
Remove spaces in new lines

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -260,7 +260,7 @@ class VmSetup
         type nat hook prerouting priority dstnat; policy accept;
         ip daddr #{public_ipv4} dnat to #{private_ipv4}
       }
-    
+
       chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
         ip saddr #{private_ipv4} ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to #{public_ipv4}
@@ -294,7 +294,7 @@ class VmSetup
           # allow dhcp
           udp sport 68 udp dport 67 accept
           udp sport 67 udp dport 68 accept
-  
+
           # avoid ip4 spoofing
           #{generate_ip4_filter_rules(nics)}
         }

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -276,7 +276,7 @@ table ip6 raw {
     type filter hook prerouting priority raw; policy accept;
     # avoid ip6 spoofing
     ether saddr 3e:bd:a5:96:f7:b9 ip6 saddr != {fddf:53d2:4c89:2305:46a0::/80,fd48:666c:a296:ce4b:2cc6::/79,fe80::3cbd:a5ff:fe96:f7b9} drop
-    
+
   }
 }
 # NAT4 rules


### PR DESCRIPTION
VS Code started to remove these spaces upon saving. We also have `trim_trailing_whitespace = true` in the `.editorconfig` file. I'm uncertain as to how these spaces were introduced, but they need to be removed.