### PR TITLE
Make Github storage policies arch specific.

### DIFF
--- a/lib/github_storage_policy.rb
+++ b/lib/github_storage_policy.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class GithubStoragePolicy
-  def initialize(rules)
-    @rules = rules || {}
+  def initialize(arch, rules)
+    @rules = rules[arch] || {}
   end
 
   def use_bdev_ubi?

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -24,9 +24,10 @@ class Prog::Vm::GithubRunner < Prog::Base
     end
   end
 
-  def storage_params(size_gib)
+  def storage_params(arch, size_gib)
     project = github_runner.installation.project
-    storage_policy = GithubStoragePolicy.new(project.get_github_storage_policy)
+    storage_policy =
+      GithubStoragePolicy.new(arch, project.get_github_storage_policy || {})
 
     # We use unencrypted storage for now, because provisioning 86G encrypted
     # storage takes ~8 minutes. Unencrypted disk uses `cp` command instead
@@ -63,7 +64,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       size: label_data["vm_size"],
       location: label_data["location"],
       boot_image: label_data["boot_image"],
-      storage_volumes: [storage_params(label_data["storage_size_gib"])],
+      storage_volumes: [storage_params(label_data["arch"], label_data["storage_size_gib"])],
       enable_ip4: true,
       arch: label_data["arch"]
     )

--- a/spec/lib/github_storage_policy_spec.rb
+++ b/spec/lib/github_storage_policy_spec.rb
@@ -2,12 +2,20 @@
 
 RSpec.describe GithubStoragePolicy do
   subject(:sp) {
-    described_class.new({
-      "github_installation_name" => "A",
-      "use_bdev_ubi_rate" => 0.2,
-      "skip_sync_rate" => 0.8,
-      "encrypted_rate" => 0.5
-    })
+    described_class.new("x64", rules)
+  }
+
+  let(:rules) {
+    {
+      "x64" => {
+        "use_bdev_ubi_rate" => 0.2,
+        "skip_sync_rate" => 0.8
+      },
+      "arm64" => {
+        "use_bdev_ubi_rate" => 0.3,
+        "skip_sync_rate" => 0.6
+      }
+    }
   }
 
   describe "#use_bdev_ubi?" do
@@ -18,6 +26,17 @@ RSpec.describe GithubStoragePolicy do
 
     it "returns false with the expected rate" do
       expect(sp).to receive(:rand).and_return(0.55)
+      expect(sp.use_bdev_ubi?).to be(false)
+    end
+
+    it "returns false for a not listed arch" do
+      expect(described_class.new("powerpc", rules).use_bdev_ubi?).to be(false)
+    end
+
+    it "works for arm64" do
+      sp = described_class.new("arm64", rules)
+      expect(sp).to receive(:rand).and_return(0.25, 0.35)
+      expect(sp.use_bdev_ubi?).to be(true)
       expect(sp.use_bdev_ubi?).to be(false)
     end
   end
@@ -31,6 +50,17 @@ RSpec.describe GithubStoragePolicy do
     it "returns false with the expected rate" do
       expect(sp).to receive(:rand).and_return(0.9)
       expect(sp.skip_sync?).to be(false)
+    end
+
+    it "returns false for a not listed arch" do
+      expect(described_class.new("powerpc", rules).skip_sync?).to be(false)
+    end
+
+    it "works for arm64" do
+      sp = described_class.new("arm64", rules)
+      expect(sp).to receive(:rand).and_return(0.65, 0.55)
+      expect(sp.skip_sync?).to be(false)
+      expect(sp.skip_sync?).to be(true)
     end
   end
 end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -65,16 +65,18 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe ".storage_params" do
     it "returns the values returned by the storage_policy" do
       storage_policy_params = {
-        "use_bdev_ubi_rate" => 0.1,
-        "skip_sync_rate" => 0.2
+        "arch64" => {
+          "use_bdev_ubi_rate" => 0.1,
+          "skip_sync_rate" => 0.2
+        }
       }
       project = Project.create_with_id(name: "sample project")
       project.set_github_storage_policy(storage_policy_params)
       expect(github_runner.installation).to receive(:project).and_return(project)
       storage_policy = instance_double(GithubStoragePolicy)
-      expect(GithubStoragePolicy).to receive(:new).with(storage_policy_params).and_return(storage_policy)
+      expect(GithubStoragePolicy).to receive(:new).with("x64", storage_policy_params).and_return(storage_policy)
       expect(storage_policy).to receive_messages(use_bdev_ubi?: false, skip_sync?: true)
-      expect(nx.storage_params(5)).to eq({
+      expect(nx.storage_params("x64", 5)).to eq({
         size_gib: 5,
         encrypted: false,
         use_bdev_ubi: false,


### PR DESCRIPTION
We can be in a situation where we have x64 hosts with bdev_ubi enabled, but no arm64 hosts with bdev_ubi. This PR allows enabling bdev_ubi for just one architecture, and using the old path in the other architectures.

For example, you can do this by:
```
gh_installation.project.set_github_storage_policy({
    x64: {
        use_bdev_ubi_rate: 1.0,
        skip_sync_rate: 1.0
    }
})
```