### PR TITLE
Multi-drive first phase

### DIFF
--- a/migrate/20231207_storage_device.rb
+++ b/migrate/20231207_storage_device.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:storage_device) do
+      column :id, :uuid, primary_key: true
+      column :name, :text, null: false
+      column :total_storage_gib, :Integer, null: false
+      column :available_storage_gib, :Integer, null: false
+      column :enabled, :bool, null: false, default: true
+      foreign_key :vm_host_id, :vm_host, type: :uuid
+      unique [:vm_host_id, :name]
+    end
+
+    alter_table(:vm_storage_volume) do
+      add_foreign_key :storage_device_id, :storage_device, type: :uuid, null: true
+    end
+
+    # Reuse corresponding VmHost's UBID as StorageDevice UBID and create
+    # records for default storage devices on existing hosts.
+    run <<~SQL
+      INSERT INTO storage_device
+        SELECT id, 'DEFAULT', total_storage_gib, available_storage_gib, true, id
+        FROM vm_host;
+
+      UPDATE vm_storage_volume
+      SET storage_device_id = vm_host_id
+      FROM vm
+      WHERE vm_storage_volume.vm_id = vm.id;
+    SQL
+  end
+end

--- a/model.rb
+++ b/model.rb
@@ -108,6 +108,10 @@ module ResourceMethods
       generate_ubid.to_uuid
     end
 
+    def new_with_id(*, **)
+      new(*, **) { _1.id = generate_uuid }
+    end
+
     def create_with_id(*, **)
       create(*, **) { _1.id = generate_uuid }
     end

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class StorageDevice < Sequel::Model
+  include ResourceMethods
+
+  many_to_one :vm_host
+
+  def self.ubid_type
+    UBID::TYPE_ETC
+  end
+end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -11,8 +11,9 @@ class VmHost < Sequel::Model
   one_to_one :hetzner_host, key: :id
   one_to_many :assigned_host_addresses, key: :host_id, class: :AssignedHostAddress
   one_to_many :spdk_installations, key: :vm_host_id
+  one_to_many :storage_devices, key: :vm_host_id
 
-  plugin :association_dependencies, assigned_host_addresses: :destroy, assigned_subnets: :destroy, hetzner_host: :destroy, spdk_installations: :destroy
+  plugin :association_dependencies, assigned_host_addresses: :destroy, assigned_subnets: :destroy, hetzner_host: :destroy, spdk_installations: :destroy, storage_devices: :destroy
 
   include ResourceMethods
   include SemaphoreMethods

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -5,6 +5,7 @@ require_relative "../model"
 class VmStorageVolume < Sequel::Model
   many_to_one :vm
   many_to_one :spdk_installation
+  many_to_one :storage_device
   many_to_one :key_encryption_key_1, class: :StorageKeyEncryptionKey
   many_to_one :key_encryption_key_2, class: :StorageKeyEncryptionKey
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -201,6 +201,10 @@ SQL
         available_storage_gib: Sequel[:available_storage_gib] - vm_storage_size_gib
       ).zero?
 
+    StorageDevice.where(vm_host_id: vm_host_id, name: "DEFAULT").update(
+      available_storage_gib: Sequel[:available_storage_gib] - vm_storage_size_gib
+    )
+
     vm_host_id
   end
 

--- a/rhizome/host/bin/storage-key-tool
+++ b/rhizome/host/bin/storage-key-tool
@@ -11,6 +11,11 @@ unless (vm_name = ARGV.shift)
   exit 1
 end
 
+unless (device = ARGV.shift)
+  puts "expect storage device as argument"
+  exit 1
+end
+
 unless (disk_index = ARGV.shift)
   puts "expected disk_index as argument"
   exit 1
@@ -21,7 +26,7 @@ unless (action = ARGV.shift)
   exit 1
 end
 
-storage_key_tool = StorageKeyTool.new(vm_name, disk_index)
+storage_key_tool = StorageKeyTool.new(vm_name, device, disk_index)
 
 case action
 when "reencrypt"

--- a/rhizome/host/lib/storage_key_tool.rb
+++ b/rhizome/host/lib/storage_key_tool.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
-require_relative "vm_path"
+require_relative "storage_path"
 require_relative "../lib/storage_key_encryption"
 
 class StorageKeyTool
-  def initialize(vm_name, disk_index)
-    vp = VmPath.new(vm_name)
-    @key_file = vp.data_encryption_key(disk_index)
+  def initialize(vm_name, storage_device, disk_index)
+    sp = StoragePath.new(vm_name, storage_device, disk_index)
+    @key_file = sp.data_encryption_key
     @new_key_file = "#{@key_file}.new"
   end
 

--- a/rhizome/host/lib/storage_path.rb
+++ b/rhizome/host/lib/storage_path.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+DEFAULT_STORAGE_DEVICE = "DEFAULT"
+
+class StoragePath
+  def initialize(vm_name, device, disk_index)
+    @vm_name = vm_name
+    @device = device
+    @disk_index = disk_index
+  end
+
+  def device_path
+    @device_path ||=
+      (@device == DEFAULT_STORAGE_DEVICE) ?
+          File.join("", "var", "storage") :
+          File.join("", "var", "storage", "devices", @device)
+  end
+
+  def storage_root
+    @storage_root ||= File.join(device_path, @vm_name)
+  end
+
+  def storage_dir
+    @storage_dir ||= File.join(storage_root, @disk_index.to_s)
+  end
+
+  def disk_file
+    @disk_file ||= File.join(storage_dir, "disk.raw")
+  end
+
+  def data_encryption_key
+    @dek_path ||= File.join(storage_dir, "data_encryption_key.json")
+  end
+
+  def vhost_sock
+    @vhost_sock ||= File.join(storage_dir, "vhost.sock")
+  end
+end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -11,6 +11,7 @@ require_relative "spdk_path"
 require_relative "spdk_rpc"
 require_relative "spdk_setup"
 require_relative "storage_key_encryption"
+require_relative "storage_path"
 
 class StorageVolume
   def initialize(vm_name, params)
@@ -22,7 +23,7 @@ class StorageVolume
     @use_bdev_ubi = params["use_bdev_ubi"] || false
     @skip_sync = params["skip_sync"] || false
     @image_path = vp.image_path(params["image"]) if params["image"]
-    @disk_file = vp.disk(@disk_index)
+    @device = params["storage_device"] || DEFAULT_STORAGE_DEVICE
 
     # Old VMs didn't have the spdk_version field. Fill that in with legacy
     # SPDK version for backward compatibility.
@@ -38,7 +39,11 @@ class StorageVolume
   end
 
   def prep(key_wrapping_secrets)
-    FileUtils.mkdir_p vp.storage(@disk_index, "")
+    # Device path is intended to be created by system admin, so fail loudly if
+    # it doesn't exist
+    fail "Storage device directory doesn't exist: #{sp.device_path}" if !File.exist?(sp.device_path)
+
+    FileUtils.mkdir_p storage_dir
     encryption_key = setup_data_encryption_key(key_wrapping_secrets) if @encrypted
 
     if @image_path.nil?
@@ -109,7 +114,7 @@ class StorageVolume
       key2: data_encryption_key[64..]
     }
 
-    key_file = vp.data_encryption_key(@disk_index)
+    key_file = data_encryption_key_path
 
     # save encrypted key
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
@@ -124,14 +129,13 @@ class StorageVolume
   end
 
   def read_data_encryption_key(key_wrapping_secrets)
-    key_file = vp.data_encryption_key(@disk_index)
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
-    sek.read_encrypted_dek(key_file)
+    sek.read_encrypted_dek(data_encryption_key_path)
   end
 
   def unencrypted_image_copy
     q_image_path = @image_path.shellescape
-    q_disk_file = @disk_file.shellescape
+    q_disk_file = disk_file.shellescape
 
     r "cp --reflink=auto #{q_image_path} #{q_disk_file}"
     r "truncate -s #{@disk_size_gib}G #{q_disk_file}"
@@ -157,7 +161,7 @@ class StorageVolume
       params: {
         name: "aio0",
         block_size: 512,
-        filename: @disk_file,
+        filename: disk_file,
         readonly: false
       }
     },
@@ -219,20 +223,20 @@ class StorageVolume
   end
 
   def create_empty_disk_file(disk_size_mib: @disk_size_gib * 1024)
-    FileUtils.touch(@disk_file)
-    File.truncate(@disk_file, disk_size_mib * 1024 * 1024)
+    FileUtils.touch(disk_file)
+    File.truncate(disk_file, disk_size_mib * 1024 * 1024)
 
     set_disk_file_permissions
   end
 
   def set_disk_file_permissions
-    FileUtils.chown @vm_name, @vm_name, @disk_file
+    FileUtils.chown @vm_name, @vm_name, disk_file
 
     # don't allow others to read user's disk
-    FileUtils.chmod "u=rw,g=r,o=", @disk_file
+    FileUtils.chmod "u=rw,g=r,o=", disk_file
 
     # allow spdk to access the image
-    r "setfacl -m u:spdk:rw #{@disk_file.shellescape}"
+    r "setfacl -m u:spdk:rw #{disk_file.shellescape}"
   end
 
   def setup_spdk_bdev(encryption_key)
@@ -247,10 +251,10 @@ class StorageVolume
         encryption_key[:key],
         encryption_key[:key2]
       )
-      rpc_client.bdev_aio_create(aio_bdev, @disk_file, 512)
+      rpc_client.bdev_aio_create(aio_bdev, disk_file, 512)
       rpc_client.bdev_crypto_create(non_ubi_bdev, aio_bdev, key_name)
     else
-      rpc_client.bdev_aio_create(non_ubi_bdev, @disk_file, 512)
+      rpc_client.bdev_aio_create(non_ubi_bdev, disk_file, 512)
     end
 
     if @use_bdev_ubi
@@ -271,22 +275,42 @@ class StorageVolume
     r "setfacl -m u:#{@vm_name}:rw #{spdk_vhost_sock.shellescape}"
 
     # create a symlink to the socket in the per vm storage dir
-    rm_if_exists(vp.vhost_sock(@disk_index))
-    FileUtils.ln_s spdk_vhost_sock, vp.vhost_sock(@disk_index)
+    rm_if_exists(vhost_sock)
+    FileUtils.ln_s spdk_vhost_sock, vhost_sock
 
     # Change ownership of the symlink. FileUtils.chown uses File.lchown for
     # symlinks and doesn't follow links. We don't use File.lchown directly
     # because it expects numeric uid & gid, which is less convenient.
-    FileUtils.chown @vm_name, @vm_name, vp.vhost_sock(@disk_index)
+    FileUtils.chown @vm_name, @vm_name, vhost_sock
 
-    vp.vhost_sock(@disk_index)
-  end
-
-  def vhost_sock
-    @vhost_sock ||= vp.vhost_sock(@disk_index)
+    vhost_sock
   end
 
   def spdk_service
     @spdk_service ||= SpdkSetup.new(@spdk_version).spdk_service
+  end
+
+  def sp
+    @sp ||= StoragePath.new(@vm_name, @device, @disk_index)
+  end
+
+  def storage_root
+    @storage_root ||= sp.storage_root
+  end
+
+  def storage_dir
+    @storage_dir ||= sp.storage_dir
+  end
+
+  def disk_file
+    @disk_file ||= sp.disk_file
+  end
+
+  def data_encryption_key_path
+    @dek_path ||= sp.data_encryption_key
+  end
+
+  def vhost_sock
+    @vhost_sock ||= sp.vhost_sock
   end
 end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -39,14 +39,6 @@ class VmPath
     File.join("", "vm", @vm_name, n)
   end
 
-  def storage_root
-    File.join("", "var", "storage", @vm_name)
-  end
-
-  def storage(disk_index, n)
-    File.join(storage_root, disk_index.to_s, n)
-  end
-
   # Define path, q_path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
@@ -94,18 +86,6 @@ class VmPath
     define_method write_method_name do |s|
       write(home(file_name), s)
     end
-  end
-
-  def vhost_sock(disk_index)
-    storage(disk_index, "vhost.sock")
-  end
-
-  def disk(disk_index)
-    storage(disk_index, "disk.raw")
-  end
-
-  def data_encryption_key(disk_index)
-    storage(disk_index, "data_encryption_key.json")
   end
 
   def image_root

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -106,16 +106,21 @@ class VmSetup
   end
 
   def purge_storage
-    # Storage hasn't been created yet, so nothing to purge.
-    return if !File.exist?(vp.storage_root)
+    # prep.json doesn't exist, nothing more to do
+    return if !File.exist?(vp.prep_json)
+
+    storage_roots = []
 
     params = JSON.parse(File.read(vp.prep_json))
     params["storage_volumes"].each { |params|
       volume = StorageVolume.new(@vm_name, params)
       volume.purge_spdk_artifacts
+      storage_roots.append(volume.storage_root)
     }
 
-    rm_if_exists(vp.storage_root)
+    storage_roots.each { |path|
+      rm_if_exists(path)
+    }
   end
 
   def unmount_hugepages

--- a/rhizome/host/spec/storage_key_tool_spec.rb
+++ b/rhizome/host/spec/storage_key_tool_spec.rb
@@ -5,7 +5,7 @@ require "openssl"
 require "base64"
 
 RSpec.describe StorageKeyTool do
-  subject(:skt) { described_class.new("vm12345", 3) }
+  subject(:skt) { described_class.new("vm12345", DEFAULT_STORAGE_DEVICE, 3) }
 
   def generate_kek
     key_wrapping_algorithm = "aes-256-gcm"

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -81,44 +81,50 @@ RSpec.describe VmSetup do
   end
 
   describe "#purge_storage" do
-    it "can purge storage" do
-      vol_1_params = {
+    let(:vol_1_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_0",
         "disk_index" => 0,
         "encrypted" => false,
         "spdk_version" => "some-version"
       }
-      vol_2_params = {
+    }
+    let(:vol_2_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_1",
         "disk_index" => 1,
         "encrypted" => true,
         "spdk_version" => "some-version"
       }
-      params = JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
+    let(:params) {
+      JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
 
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(true)
+    it "can purge storage" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
 
       # delete the unencrypted volume
       sv_1 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
       expect(sv_1).to receive(:purge_spdk_artifacts)
+      expect(sv_1).to receive(:storage_root).and_return("/var/storage/test")
 
       # delete the encrypted volume
       sv_2 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
       expect(sv_2).to receive(:purge_spdk_artifacts)
-
-      expect(FileUtils).to receive(:rm_r).with("/var/storage/test")
+      expect(sv_2).to receive(:storage_root).and_return("/var/storage/test")
 
       vs.purge_storage
     end
 
-    it "exits silently if storage hasn't been created yet" do
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(false)
-      vs.purge_storage
+    it "exits silently if vm hasn't been created yet" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
+      expect { vs.purge_storage }.not_to raise_error
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -364,6 +364,12 @@ RSpec.describe Prog::Vm::Nexus do
       sa = Sshable.create_with_id(host: "127.0.0.#{@host_index}")
       @host_index += 1
       host = VmHost.create(**args) { _1.id = sa.id }
+      StorageDevice.create_with_id(
+        name: "DEFAULT",
+        available_storage_gib: args[:available_storage_gib],
+        total_storage_gib: args[:total_storage_gib],
+        vm_host_id: host.id
+      )
       SpdkInstallation.create(
         version: "v29.01",
         allocation_weight: 100,
@@ -474,6 +480,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vmh.used_cores).to eq(initial_vmh.used_cores + 1)
       expect(vmh.used_hugepages_1g).to eq(initial_vmh.used_hugepages_1g + 8)
       expect(vmh.available_storage_gib).to eq(initial_vmh.available_storage_gib - 25)
+      expect(vmh.storage_devices_dataset[name: "DEFAULT"].available_storage_gib).to eq(initial_vmh.available_storage_gib - 25)
     end
   end
 

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -159,7 +159,9 @@ RSpec.describe UBID do
     vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
     expect(vm.ubid).to start_with UBID::TYPE_VM
 
-    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id)
+    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
+
+    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id, storage_device_id: dev.id)
     expect(sv.ubid).to start_with UBID::TYPE_VM_STORAGE_VOLUME
 
     kek = StorageKeyEncryptionKey.create_with_id(algorithm: "x", key: "x", init_vector: "x", auth_data: "x")
@@ -221,7 +223,8 @@ RSpec.describe UBID do
     host = VmHost.create(location: "x") { _1.id = sshable.id }
     si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
     vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
-    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id)
+    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
+    sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id, storage_device_id: dev.id)
     kek = StorageKeyEncryptionKey.create_with_id(algorithm: "x", key: "x", init_vector: "x", auth_data: "x")
     account = Account.create_with_id(email: "x@y.net")
     project = account.create_project_with_default_policy("x")


### PR DESCRIPTION
commit 2e1e6efe8f686490f9c3c9a02825d14f3cea9aac
Author: Daniel Farina <daniel@ubicloud.com>
Date:   Mon Jan 8 12:02:38 2024 -0800

    Fill StorageDevice records upon VmHost prep
    
    Generally, personnel are responsible for initial set-up of a VmHost
    before letting it run its `prep` code as it comes to file systems,
    RAID configuration, LVM, etc.
    
    The first versions of Clover assumed the root file system was all
    system resources, so that this was a responsibility was all but
    invisible, as it was built around Hetzner defaults to streamline
    development.
    
    That there may be prepratory steps became more obvious with GitHub
    Actions, which needed a particular btrfs configuration for
    copy-on-write.
    
    Now, with MinIO, we want to be able to assign particular physical
    devices to particular virtual devices, as the former was designed
    around application-level failure management rather than relying on
    block device abstractions like RAID.
    
    To do that, personnel are responsible for creating and mounting file
    systems in `/var/storage/devices/$NAME`.  This modified LearnStorage
    program will read all of them and create records to represent them.
    
    For backwards compatibility reasons, the simple global disk space
    accounting on VmHost records is kept up to date in duplication.
    
    Experimenting with this patch is a bit tricky, since one needs
    multiple file systems.  The following ruby program, with a tunable
    `N`, can create a series of loopback devices with file systems in each
    that get mounted on reboots, suitable for experimentation without a
    lot of typing or physical devices to back each mount point in
    `/var/storage/devices/$NAME`:
    
        #!/usr/bin/env ruby
        # frozen_string_literal: true
    
        require "fileutils"
    
        N = 3 # Number of loopback devices to create
    
        FileUtils.mkdir_p("/var/storage/devices")
    
        # Get free space in bytes
        free_space_bytes = Integer(`df -B 1 --output=avail /var/storage | tail -n 1`)
    
        # Of the free space, use half of it for multi-device modeling,
        # rounding to the nearest 4K page for device size to suppress annoying
        # warning messages.
        device_size_bytes = (free_space_bytes / (N * 2 * 4096)) * 4096
    
        (1..N).each do |i|
          # Create loopback file
          FileUtils.touch("/var/storage/loopback#{i}")
          `sudo fallocate -l #{device_size_bytes} /var/storage/loopback#{i}`
    
          losetup_unit_name = "loopback#{i}.service"
          # Set up loopback devices now and on boot.
          #
          # https://askubuntu.com/questions/1142417/how-do-i-set-up-a-loop-device-at-startup-with-service
          losetup_unit = <<LOSETUP
        [Unit]
        Description=Mount Loopback Device #{i}
        DefaultDependencies=no
        Conflicts=umount.target
        Before=local-fs.target
        After=systemd-udevd.service home.mount
        Require=systemd-udevd.service
    
        [Service]
        Type=oneshot
        ExecStart=/sbin/losetup /dev/loop#{i} /var/storage/loopback#{i}
        ExecStop=/sbin/losetup -d /dev/loop#{i}
        TimeoutSec=60
        RemainAfterExit=yes
    
        [Install]
        WantedBy=local-fs.target
        Also=systemd-udevd.service
        LOSETUP
    
          File.write("/etc/systemd/system/#{losetup_unit_name}", losetup_unit)
          `sudo systemctl daemon-reload`
          `sudo systemctl enable --now -- #{losetup_unit_name}`
    
          # Format file system
          `sudo mkfs.ext4 /dev/loop#{i}`
    
          where = "/var/storage/devices/stor#{i}"
          mount_unit = <<MOUNT
        [Unit]
        Description=Mount device#{i} on #{where}
    
        [Mount]
        What=/dev/loop#{i}
        Where=#{where}
    
        [Install]
        WantedBy=multi-user.target
        MOUNT
    
          mount_unit_name = where[1..].tr("/", "-") + ".mount"
          File.write("/etc/systemd/system/#{mount_unit_name}", mount_unit)
          `sudo systemctl daemon-reload`
          `sudo systemctl enable --now -- #{mount_unit_name}`
        end
    
        puts "Loopback devices created and mounted!"

commit bdf8a5d1cea933d7ddaf482ae5c4618957b7a1cb
Author: Daniel Farina <daniel@ubicloud.com>
Date:   Mon Jan 8 11:58:41 2024 -0800

    Add new_with_id to model base class
    
    This is a lot like `create_with_id`, except without inserting a
    record, just like Sequel's `new` vs. `create`.  It is useful in
    situations where models are passed around and modified a little before
    saving.

commit 17914a01a18a0c77595468d0c79cb39d5e8a043a
Author: Hadi Moshayedi <hadi@ubicloud.com>
Date:   Wed Dec 6 14:00:50 2023 -0800

    Migrations for storage device support
    
    Represents each physical storage device that can be arranged into
    virtual disks in a virtual machine.
