### PR TITLE
Add storage flags to vm pools.

### DIFF
--- a/migrate/20240111_add_storage_flags_to_vm_pool.rb
+++ b/migrate/20240111_add_storage_flags_to_vm_pool.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_pool) do
+      add_column :storage_encrypted, :bool, default: false, null: false
+      add_column :storage_use_bdev_ubi, :bool, default: false, null: false
+      add_column :storage_skip_sync, :bool, default: false, null: false
+    end
+  end
+end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -44,11 +44,15 @@ class Prog::Vm::GithubRunner < Prog::Base
   def pick_vm
     label = github_runner.label
     label_data = Github.runner_labels[label]
+    vm_storage_params = storage_params(label_data["arch"], label_data["storage_size_gib"])
     pool = VmPool.where(
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
       location: label_data["location"],
       storage_size_gib: label_data["storage_size_gib"],
+      storage_encrypted: vm_storage_params[:encrypted],
+      storage_use_bdev_ubi: vm_storage_params[:use_bdev_ubi],
+      storage_skip_sync: vm_storage_params[:skip_sync],
       arch: label_data["arch"]
     ).first
 
@@ -64,7 +68,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       size: label_data["vm_size"],
       location: label_data["location"],
       boot_image: label_data["boot_image"],
-      storage_volumes: [storage_params(label_data["arch"], label_data["storage_size_gib"])],
+      storage_volumes: [vm_storage_params],
       enable_ip4: true,
       arch: label_data["arch"]
     )

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -9,13 +9,21 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe ".assemble" do
     it "creates the entity and strand properly" do
-      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86, arch: "x64")
+      st = described_class.assemble(
+        size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1",
+        storage_size_gib: 86, storage_encrypted: true, storage_use_bdev_ubi: true,
+        storage_skip_sync: false, arch: "x64"
+      )
       pool = VmPool[st.id]
       expect(pool).not_to be_nil
       expect(pool.size).to eq(3)
       expect(pool.vm_size).to eq("standard-2")
       expect(pool.boot_image).to eq("img")
       expect(pool.location).to eq("hetzner-fsn1")
+      expect(pool.storage_size_gib).to eq(86)
+      expect(pool.storage_encrypted).to be(true)
+      expect(pool.storage_use_bdev_ubi).to be(true)
+      expect(pool.storage_skip_sync).to be(false)
       expect(st.label).to eq("create_new_vm")
     end
   end
@@ -27,7 +35,11 @@ RSpec.describe Prog::Vm::VmPool do
 
     it "creates a new vm and hops to wait" do
       expect(Config).to receive(:vm_pool_project_id).and_return(prj.id)
-      st = described_class.assemble(size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86, arch: "arm64")
+      st = described_class.assemble(
+        size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1",
+        storage_size_gib: 86, storage_encrypted: true, storage_use_bdev_ubi: true,
+        storage_skip_sync: false, arch: "arm64"
+      )
       st.update(label: "create_new_vm")
       expect(SshKey).to receive(:generate).and_call_original
       expect(nx).to receive(:vm_pool).and_return(VmPool[st.id]).at_least(:once)
@@ -40,7 +52,11 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#wait" do
     let(:pool) {
-      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86, arch: "x64")
+      VmPool.create_with_id(
+        size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1",
+        storage_size_gib: 86, storage_encrypted: true, storage_use_bdev_ubi: true,
+        storage_skip_sync: false, arch: "x64"
+      )
     }
 
     it "waits if nothing to do" do


### PR DESCRIPTION
Previously it was possible that we return a VM with wrong storage flags from a vm pool, because vm pools were not filtered by storage flags.

This PR adds storage flags to vm pools to fix that.