### PR TITLE
Fix self connections via public IPv4

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -260,7 +260,7 @@ class VmSetup
         type nat hook prerouting priority dstnat; policy accept;
         ip daddr #{public_ipv4} dnat to #{private_ipv4}
       }
-    
+
       chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
         ip saddr #{private_ipv4} ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to #{public_ipv4}
@@ -294,7 +294,7 @@ class VmSetup
           # allow dhcp
           udp sport 68 udp dport 67 accept
           udp sport 67 udp dport 68 accept
-  
+
           # avoid ip4 spoofing
           #{generate_ip4_filter_rules(nics)}
         }


### PR DESCRIPTION
This was not working before because the public IPv4 implementation
depends on NAT. The VMs do not know anything about the public IPv4
address. So, what was happenning was that, when we send a packet to the
assigned public IPv4 address of the VM;
1. We get the packet in the tap interface of the VM with source address
as the private ipv4 and destination address as the public ipv4.
2. At the prerouting node of the netfilter chain, we dnat the packet
with destination being the private ipv4 address of the VM because, well,
the destination address is equal to the public ip of the VM.
3. At the postrouting node of the netfilter chain, we were not snatting
the packet because the source ip address is part of a private ipv4
class. That was causing the response to not be redelivered via the same
route. Now, I added a second rule to snat when the source and
destination addresses are equal to the private ipv4 address of the VM.
So, we snat via public ipv4, this way, VM knows that it needs to send a
response to the public ip.
4. We send back the packet through tap device.