### PR TITLE
Freeze core classes in production

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,34 +3,3 @@
 require_relative "loader"
 
 run(Config.development? ? Unreloader : Clover.freeze.app)
-
-freeze_core = false
-# freeze_core = !dev # Uncomment to enable refrigerator
-if freeze_core
-  begin
-    require "refrigerator"
-  rescue LoadError
-  else
-    require "tilt/sass" unless File.exist?(File.expand_path("../compiled_assets.json", __FILE__))
-
-    # When enabling refrigerator, you may need to load additional
-    # libraries before freezing the core to work correctly.  You'll
-    # want to uncomment the appropriate lines below if you run into
-    # problems after enabling refrigerator.
-
-    # rackup -s webrick
-    # require 'forwardable'
-    # require 'webrick'
-
-    # rackup -s Puma
-    # require 'yaml'
-    # Gem.ruby
-
-    # Puma (needed for state file)
-    # require 'yaml'
-
-    # Unicorn (no changes needed)
-
-    Refrigerator.freeze_core
-  end
-end

--- a/loader.rb
+++ b/loader.rb
@@ -85,3 +85,8 @@ AUTOLOAD_CONSTANTS.freeze
 if Config.production?
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
 end
+
+if Config.production?
+  require "refrigerator"
+  Refrigerator.freeze_core
+end


### PR DESCRIPTION
Alas, we can't really run this through unit tests, since we use `rspec-mock`, which mutates classes in order to test things.  As a small consolidation, it cleans up the branches seen in roda-sequel-stack.

But even if we could test with freezing of classes...library gems are entitled to do weird core-class modifications that can break.  To some extent, integration testing is the only way for this one.