### PR TITLE
Rename PostgresResource's server_name

### DIFF
--- a/migrate/20240112_rename_server_name.rb
+++ b/migrate/20240112_rename_server_name.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:postgres_resource) do
+      rename_column :server_name, :name
+    end
+  end
+end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -32,11 +32,11 @@ class PostgresResource < Sequel::Model
   end
 
   def path
-    "/location/#{location}/postgres/#{server_name}"
+    "/location/#{location}/postgres/#{name}"
   end
 
   def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{location}/postgres/#{server_name}"
+    "project/#{project.ubid}/location/#{location}/postgres/#{name}"
   end
 
   def display_state
@@ -47,7 +47,7 @@ class PostgresResource < Sequel::Model
 
   def hostname
     if Config.postgres_service_hostname
-      "#{server_name}.#{Config.postgres_service_hostname}"
+      "#{name}.#{Config.postgres_service_hostname}"
     else
       server&.vm&.ephemeral_net4&.to_s
     end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -12,13 +12,13 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
   semaphore :destroy
 
-  def self.assemble(project_id:, location:, server_name:, target_vm_size:, target_storage_size_gib:, parent_id: nil, restore_target: nil)
+  def self.assemble(project_id:, location:, name:, target_vm_size:, target_storage_size_gib:, parent_id: nil, restore_target: nil)
     unless (project = Project[project_id])
       fail "No existing project"
     end
 
     Validation.validate_vm_size(target_vm_size)
-    Validation.validate_name(server_name)
+    Validation.validate_name(name)
     Validation.validate_location(location, project.provider)
 
     DB.transaction do
@@ -38,7 +38,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       end
 
       postgres_resource = PostgresResource.create_with_id(
-        project_id: project_id, location: location, server_name: server_name,
+        project_id: project_id, location: location, name: name,
         target_vm_size: target_vm_size, target_storage_size_gib: target_storage_size_gib,
         superuser_password: superuser_password, parent_id: parent_id,
         restore_target: restore_target
@@ -127,7 +127,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     BillingRecord.create_with_id(
       project_id: postgres_resource.project_id,
       resource_id: postgres_resource.id,
-      resource_name: postgres_resource.server_name,
+      resource_name: postgres_resource.name,
       billing_rate_id: BillingRate.from_resource_properties("PostgresCores", "standard", postgres_resource.location)["id"],
       amount: server.vm.cores
     )
@@ -135,7 +135,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     BillingRecord.create_with_id(
       project_id: postgres_resource.project_id,
       resource_id: postgres_resource.id,
-      resource_name: postgres_resource.server_name,
+      resource_name: postgres_resource.name,
       billing_rate_id: BillingRate.from_resource_properties("PostgresStorage", "standard", postgres_resource.location)["id"],
       amount: postgres_resource.target_storage_size_gib
     )

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -5,7 +5,7 @@ class CloverWeb
     @serializer = Serializers::Web::Postgres
 
     r.on String do |pg_name|
-      pg = @project.postgres_resources_dataset.where(location: @location).where { {Sequel[:postgres_resource][:server_name] => pg_name} }.first
+      pg = @project.postgres_resources_dataset.where(location: @location).where { {Sequel[:postgres_resource][:name] => pg_name} }.first
 
       unless pg
         response.status = 404
@@ -21,7 +21,7 @@ class CloverWeb
       r.delete true do
         Authorization.authorize(@current_user.id, "Postgres:delete", pg.id)
         pg.incr_destroy
-        return {message: "Deleting #{pg.server_name}"}.to_json
+        return {message: "Deleting #{pg.name}"}.to_json
       end
 
       r.post "restore" do
@@ -31,7 +31,7 @@ class CloverWeb
         st = Prog::Postgres::PostgresResourceNexus.assemble(
           project_id: @project.id,
           location: pg.location,
-          server_name: r.params["name"],
+          name: r.params["name"],
           target_vm_size: pg.target_vm_size,
           target_storage_size_gib: pg.target_storage_size_gib,
           parent_id: pg.id,

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -18,7 +18,7 @@ class CloverWeb
       st = Prog::Postgres::PostgresResourceNexus.assemble(
         project_id: @project.id,
         location: r.params["location"],
-        server_name: r.params["name"],
+        name: r.params["name"],
         target_vm_size: parsed_size.vm_size,
         target_storage_size_gib: parsed_size.storage_size_gib
       )

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -6,7 +6,7 @@ class Serializers::Web::Postgres < Serializers::Base
       id: pg.id,
       ubid: pg.ubid,
       path: pg.path,
-      name: pg.server_name,
+      name: pg.name,
       state: pg.display_state,
       location: pg.location,
       vm_size: pg.target_vm_size,

--- a/spec/model/dns_zone/dns_zone_spec.rb
+++ b/spec/model/dns_zone/dns_zone_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DnsZone do
   end
 
   it "returns record_name with dot" do
-    expect(dns_zone.add_dot_if_missing("pg-server-name.postgres.ubicloud.com")).to eq("pg-server-name.postgres.ubicloud.com.")
-    expect(dns_zone.add_dot_if_missing("pg-server-name.postgres.ubicloud.com.")).to eq("pg-server-name.postgres.ubicloud.com.")
+    expect(dns_zone.add_dot_if_missing("pg-name.postgres.ubicloud.com")).to eq("pg-name.postgres.ubicloud.com.")
+    expect(dns_zone.add_dot_if_missing("pg-name.postgres.ubicloud.com.")).to eq("pg-name.postgres.ubicloud.com.")
   end
 end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -5,14 +5,14 @@ require_relative "../spec_helper"
 RSpec.describe PostgresResource do
   subject(:postgres_resource) {
     described_class.new(
-      server_name: "pg-server-name",
+      name: "pg-name",
       superuser_password: "dummy-password"
     )
   }
 
   it "returns connection string" do
     expect(Config).to receive(:postgres_service_hostname).and_return("postgres.ubicloud.com").at_least(:once)
-    expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-server-name.postgres.ubicloud.com")
+    expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.postgres.ubicloud.com")
   end
 
   it "returns connection string with ip address if config is not set" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       postgres_resource = PostgresResource.create_with_id(
         project_id: "e3e333dd-bd9a-82d2-acc1-1c7c1ee9781f",
         location: "hetzner-hel1",
-        server_name: "pg-server-name",
+        name: "pg-name",
         target_vm_size: "standard-2",
         target_storage_size_gib: 100,
         superuser_password: "dummy-password"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Clover, "postgres" do
     Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: project.id,
       location: "hetzner-fsn1",
-      server_name: "pg-with-permission",
+      name: "pg-with-permission",
       target_vm_size: "standard-2",
       target_storage_size_gib: 100
     ).subject
@@ -21,7 +21,7 @@ RSpec.describe Clover, "postgres" do
     Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: project_wo_permissions.id,
       location: "hetzner-fsn1",
-      server_name: "pg-without-permission",
+      name: "pg-without-permission",
       target_vm_size: "standard-2",
       target_storage_size_gib: 100
     ).subject
@@ -68,8 +68,8 @@ RSpec.describe Clover, "postgres" do
         visit "#{project.path}/postgres"
 
         expect(page.title).to eq("Ubicloud - PostgreSQL Databases")
-        expect(page).to have_content pg.server_name
-        expect(page).to have_no_content pg_wo_permission.server_name
+        expect(page).to have_content pg.name
+        expect(page).to have_no_content pg_wo_permission.name
       end
     end
 
@@ -112,7 +112,7 @@ RSpec.describe Clover, "postgres" do
 
         expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
 
-        fill_in "Name", with: pg.server_name
+        fill_in "Name", with: pg.name
         choose option: "hetzner-fsn1"
         choose option: "standard-2"
 
@@ -165,12 +165,12 @@ RSpec.describe Clover, "postgres" do
         visit "#{project.path}/postgres"
 
         expect(page.title).to eq("Ubicloud - PostgreSQL Databases")
-        expect(page).to have_content pg.server_name
+        expect(page).to have_content pg.name
 
         click_link "Show", href: "#{project.path}#{pg.path}"
 
-        expect(page.title).to eq("Ubicloud - #{pg.server_name}")
-        expect(page).to have_content pg.server_name
+        expect(page.title).to eq("Ubicloud - #{pg.name}")
+        expect(page).to have_content pg.name
       end
 
       it "raises forbidden when does not have permissions" do
@@ -251,7 +251,7 @@ RSpec.describe Clover, "postgres" do
         btn = find ".delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-        expect(page.body).to eq({message: "Deleting #{pg.server_name}"}.to_json)
+        expect(page.body).to eq({message: "Deleting #{pg.name}"}.to_json)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
       end
 

--- a/spec/serializers/web/postgres_spec.rb
+++ b/spec/serializers/web/postgres_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../../spec_helper"
 
 RSpec.describe Serializers::Web::Postgres do
-  let(:pg) { PostgresResource.new(server_name: "pg-server-name").tap { _1.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
+  let(:pg) { PostgresResource.new(name: "pg-name").tap { _1.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
 
   it "can serialize when no earliest/latest restore times" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice


### PR DESCRIPTION
This has potential to be mixed up with PostgresServer's name and we use just
name in other similar resources.