### PR TITLE
Query used cores directly from provisioned Vm and Spdks. (alternative approach)

### DIFF
--- a/migrate/20240111_core_count.rb
+++ b/migrate/20240111_core_count.rb
@@ -7,8 +7,8 @@ Sequel.migration do
     end
 
     alter_table(:spdk_installation) do
-        add_column :core_count, Integer, null: false, default: 1
-        add_column :core_offset, Integer, null: false, default: 0
+      add_column :core_count, Integer, null: false, default: 1
+      add_column :core_offset, Integer, null: false, default: 0
     end
 
     create_view(:vm_host_with_stats, <<~SQL

--- a/migrate/20240111_core_count.rb
+++ b/migrate/20240111_core_count.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      drop_constraint :core_allocation_limit
+    end
+
+    alter_table(:spdk_installation) do
+        add_column :core_count, Integer, null: false, default: 1
+        add_column :core_offset, Integer, null: false, default: 0
+    end
+
+    create_view(:vm_host_with_stats, <<~SQL
+      WITH vm_stats AS (
+        -- CTE to get vm stats per host. Has exactly one row per host.
+        SELECT
+          vm_host.id host_id,
+          COALESCE(sum(cores),0) AS vm_cores,
+          count(*) AS vm_count
+        FROM
+          vm_host LEFT OUTER JOIN vm
+        ON vm_host.id=vm.vm_host_id
+        GROUP BY vm_host.id
+      ), spdk_stats AS (
+        -- CTE to get spdk stats per host. Has exactly one row per host.
+        SELECT
+          vm_host.id host_id,
+          COALESCE(sum(core_count),0) AS spdk_cores,
+          count(*) AS spdk_count
+        FROM
+          vm_host LEFT OUTER JOIN spdk_installation s
+        ON vm_host.id=s.vm_host_id
+        GROUP BY vm_host.id
+      )
+      SELECT
+        vm_host.*,
+        vm_host.total_mem_gib / vm_host.total_cores AS mem_ratio,
+        vm_count, spdk_count,
+        vm_cores, spdk_cores
+      FROM vm_host, vm_stats, spdk_stats
+      WHERE
+        vm_host.id=vm_stats.host_id AND vm_host.id=spdk_stats.host_id;
+    SQL
+    )
+  end
+end


### PR DESCRIPTION
An alternative to #1099, which uses views instead of complicating the code in Nexus::allocate.

**First Commit**

== Schema changes ==

We made couple of recent observations:
- We need to use more than 1 core for SPDK to saturate NVMe cards
- Allocating 2 SPDK services on same cores reduces performance.

For this reason, we are adding core_count and core_offset fields to SpdkInstallation. We will use these fields for SPDK service provisioning in a future PR. In this PR, we are just using them to take into account SPDK cores when doing vm allocation.

Note that having 2 SPDK installations on the same host (which reduces a host's capacity) will only happen when doing migration and will be a temporary situation.

Also, we are dropping the core_allocation_limit, (1) we don't want to do have core reservation logic scattered in both code & db constraints, (2) we won't use VmHost.used_cores anymore.

We will drop use_cores in a future PR.

== vm_host_with_stats view ==

This is a new view which has live unmaterialized values of vm count & cores + spdk count & cores. This view will be used in the next commit to get live used cores instead of using a materialized used_cores.

**Second Commit**

Previously we updated VmHost::used_cores to keep track of used cores. Keeping this value adds complexity to the code, e.g. we need to think about concurrency when updating it, and we might forget to update it in some situations when making changes (as we did when installing spdk).

This PR switches to a new method which gets this value directly from Vm and SpdkInstallation records created on the host.

This method can also be applied to used hugepages, which we can do in a follow-up PR.

Also, we need to update SPDK core assignment in a follow-up PR.