### PR TITLE
Add presigned url feature to the minio client

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -77,6 +77,10 @@ class Minio::Client
     response.status
   end
 
+  def get_presigned_url(method, bucket_name, object_name, expires)
+    @signer.presign_v4(method, s3_uri("#{bucket_name}/#{object_name}"), REGION, @creds, Time.now.utc, expires)
+  end
+
   def create_bucket(bucket_name)
     response = send_request("PUT", s3_uri(bucket_name))
     response.status

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe Minio::Client do
     end
   end
 
+  describe "get_presigned_url" do
+    it "creates a presigned URL for given object" do
+      client = described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key)
+      uri = client.get_presigned_url("GET", "test", "object", 3600)
+      expect(uri.to_s).to start_with(endpoint)
+      expect(uri.path).to eq("/test/object")
+      expect(uri.query).to match(/X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=#{access_key}%2F\d{8}%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=\d{8}T\d{6}Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=\w+/)
+    end
+  end
+
   describe "delete_bucket" do
     it "sends a DELETE request to /bucket_name" do
       stub_request(:delete, "#{endpoint}/test").to_return(status: 200)


### PR DESCRIPTION
### Refactor Minio::Client to enhance compatibility with Python version
Furkan ported the Ruby version of "Minio::Client" from the Python version https://github.com/minio/minio-py.

I will migrate more endpoints from it. Minor refactoring was done to make the method interfaces more similar.

### Add presigned url feature to the minio client

We will download large boot images from our MinIO cluster, replacing Azure Blob Storage. Currently, we generate download URLs using SAS tokens from Azure.

MinIO offers similar functionality through presigned URLs. These URLs eliminate the need to send MinIO credentials to VM hosts. They expire after a specified period, making them safe for dataplane transmission. We can also download the presigned URL using any client, including "curl"

I ported it from Python method.

https://github.com/minio/minio-py/blob/fbcfca1b96c8919a496f8420dba0be139091364b/minio/api.py#L2216
