### PR TITLE
Add rhizome multi-device storage abstractions

### DIFF
--- a/rhizome/host/bin/storage-key-tool
+++ b/rhizome/host/bin/storage-key-tool
@@ -11,6 +11,11 @@ unless (vm_name = ARGV.shift)
   exit 1
 end
 
+unless (device = ARGV.shift)
+  puts "expect storage device as argument"
+  exit 1
+end
+
 unless (disk_index = ARGV.shift)
   puts "expected disk_index as argument"
   exit 1
@@ -21,7 +26,7 @@ unless (action = ARGV.shift)
   exit 1
 end
 
-storage_key_tool = StorageKeyTool.new(vm_name, disk_index)
+storage_key_tool = StorageKeyTool.new(vm_name, device, disk_index)
 
 case action
 when "reencrypt"

--- a/rhizome/host/lib/storage_key_tool.rb
+++ b/rhizome/host/lib/storage_key_tool.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
-require_relative "vm_path"
+require_relative "storage_path"
 require_relative "../lib/storage_key_encryption"
 
 class StorageKeyTool
-  def initialize(vm_name, disk_index)
-    vp = VmPath.new(vm_name)
-    @key_file = vp.data_encryption_key(disk_index)
+  def initialize(vm_name, storage_device, disk_index)
+    sp = StoragePath.new(vm_name, storage_device, disk_index)
+    @key_file = sp.data_encryption_key
     @new_key_file = "#{@key_file}.new"
   end
 

--- a/rhizome/host/lib/storage_path.rb
+++ b/rhizome/host/lib/storage_path.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+DEFAULT_STORAGE_DEVICE = "DEFAULT"
+
+class StoragePath
+  def initialize(vm_name, device, disk_index)
+    @vm_name = vm_name
+    @device = device
+    @disk_index = disk_index
+  end
+
+  def device_path
+    @device_path ||=
+      (@device == DEFAULT_STORAGE_DEVICE) ?
+          File.join("", "var", "storage") :
+          File.join("", "var", "storage", "devices", @device)
+  end
+
+  def storage_root
+    @storage_root ||= File.join(device_path, @vm_name)
+  end
+
+  def storage_dir
+    @storage_dir ||= File.join(storage_root, @disk_index.to_s)
+  end
+
+  def disk_file
+    @disk_file ||= File.join(storage_dir, "disk.raw")
+  end
+
+  def data_encryption_key
+    @dek_path ||= File.join(storage_dir, "data_encryption_key.json")
+  end
+
+  def vhost_sock
+    @vhost_sock ||= File.join(storage_dir, "vhost.sock")
+  end
+end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -11,6 +11,7 @@ require_relative "spdk_path"
 require_relative "spdk_rpc"
 require_relative "spdk_setup"
 require_relative "storage_key_encryption"
+require_relative "storage_path"
 
 class StorageVolume
   def initialize(vm_name, params)
@@ -22,7 +23,7 @@ class StorageVolume
     @use_bdev_ubi = params["use_bdev_ubi"] || false
     @skip_sync = params["skip_sync"] || false
     @image_path = vp.image_path(params["image"]) if params["image"]
-    @disk_file = vp.disk(@disk_index)
+    @device = params["storage_device"] || DEFAULT_STORAGE_DEVICE
 
     # Old VMs didn't have the spdk_version field. Fill that in with legacy
     # SPDK version for backward compatibility.
@@ -38,7 +39,11 @@ class StorageVolume
   end
 
   def prep(key_wrapping_secrets)
-    FileUtils.mkdir_p vp.storage(@disk_index, "")
+    # Device path is intended to be created by system admin, so fail loudly if
+    # it doesn't exist
+    fail "Storage device directory doesn't exist: #{sp.device_path}" if !File.exist?(sp.device_path)
+
+    FileUtils.mkdir_p storage_dir
     encryption_key = setup_data_encryption_key(key_wrapping_secrets) if @encrypted
 
     if @image_path.nil?
@@ -109,7 +114,7 @@ class StorageVolume
       key2: data_encryption_key[64..]
     }
 
-    key_file = vp.data_encryption_key(@disk_index)
+    key_file = data_encryption_key_path
 
     # save encrypted key
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
@@ -124,14 +129,13 @@ class StorageVolume
   end
 
   def read_data_encryption_key(key_wrapping_secrets)
-    key_file = vp.data_encryption_key(@disk_index)
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
-    sek.read_encrypted_dek(key_file)
+    sek.read_encrypted_dek(data_encryption_key_path)
   end
 
   def unencrypted_image_copy
     q_image_path = @image_path.shellescape
-    q_disk_file = @disk_file.shellescape
+    q_disk_file = disk_file.shellescape
 
     r "cp --reflink=auto #{q_image_path} #{q_disk_file}"
     r "truncate -s #{@disk_size_gib}G #{q_disk_file}"
@@ -157,7 +161,7 @@ class StorageVolume
       params: {
         name: "aio0",
         block_size: 512,
-        filename: @disk_file,
+        filename: disk_file,
         readonly: false
       }
     },
@@ -219,20 +223,20 @@ class StorageVolume
   end
 
   def create_empty_disk_file(disk_size_mib: @disk_size_gib * 1024)
-    FileUtils.touch(@disk_file)
-    File.truncate(@disk_file, disk_size_mib * 1024 * 1024)
+    FileUtils.touch(disk_file)
+    File.truncate(disk_file, disk_size_mib * 1024 * 1024)
 
     set_disk_file_permissions
   end
 
   def set_disk_file_permissions
-    FileUtils.chown @vm_name, @vm_name, @disk_file
+    FileUtils.chown @vm_name, @vm_name, disk_file
 
     # don't allow others to read user's disk
-    FileUtils.chmod "u=rw,g=r,o=", @disk_file
+    FileUtils.chmod "u=rw,g=r,o=", disk_file
 
     # allow spdk to access the image
-    r "setfacl -m u:spdk:rw #{@disk_file.shellescape}"
+    r "setfacl -m u:spdk:rw #{disk_file.shellescape}"
   end
 
   def setup_spdk_bdev(encryption_key)
@@ -247,10 +251,10 @@ class StorageVolume
         encryption_key[:key],
         encryption_key[:key2]
       )
-      rpc_client.bdev_aio_create(aio_bdev, @disk_file, 512)
+      rpc_client.bdev_aio_create(aio_bdev, disk_file, 512)
       rpc_client.bdev_crypto_create(non_ubi_bdev, aio_bdev, key_name)
     else
-      rpc_client.bdev_aio_create(non_ubi_bdev, @disk_file, 512)
+      rpc_client.bdev_aio_create(non_ubi_bdev, disk_file, 512)
     end
 
     if @use_bdev_ubi
@@ -271,22 +275,42 @@ class StorageVolume
     r "setfacl -m u:#{@vm_name}:rw #{spdk_vhost_sock.shellescape}"
 
     # create a symlink to the socket in the per vm storage dir
-    rm_if_exists(vp.vhost_sock(@disk_index))
-    FileUtils.ln_s spdk_vhost_sock, vp.vhost_sock(@disk_index)
+    rm_if_exists(vhost_sock)
+    FileUtils.ln_s spdk_vhost_sock, vhost_sock
 
     # Change ownership of the symlink. FileUtils.chown uses File.lchown for
     # symlinks and doesn't follow links. We don't use File.lchown directly
     # because it expects numeric uid & gid, which is less convenient.
-    FileUtils.chown @vm_name, @vm_name, vp.vhost_sock(@disk_index)
+    FileUtils.chown @vm_name, @vm_name, vhost_sock
 
-    vp.vhost_sock(@disk_index)
-  end
-
-  def vhost_sock
-    @vhost_sock ||= vp.vhost_sock(@disk_index)
+    vhost_sock
   end
 
   def spdk_service
     @spdk_service ||= SpdkSetup.new(@spdk_version).spdk_service
+  end
+
+  def sp
+    @sp ||= StoragePath.new(@vm_name, @device, @disk_index)
+  end
+
+  def storage_root
+    @storage_root ||= sp.storage_root
+  end
+
+  def storage_dir
+    @storage_dir ||= sp.storage_dir
+  end
+
+  def disk_file
+    @disk_file ||= sp.disk_file
+  end
+
+  def data_encryption_key_path
+    @dek_path ||= sp.data_encryption_key
+  end
+
+  def vhost_sock
+    @vhost_sock ||= sp.vhost_sock
   end
 end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -39,14 +39,6 @@ class VmPath
     File.join("", "vm", @vm_name, n)
   end
 
-  def storage_root
-    File.join("", "var", "storage", @vm_name)
-  end
-
-  def storage(disk_index, n)
-    File.join(storage_root, disk_index.to_s, n)
-  end
-
   # Define path, q_path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
@@ -94,18 +86,6 @@ class VmPath
     define_method write_method_name do |s|
       write(home(file_name), s)
     end
-  end
-
-  def vhost_sock(disk_index)
-    storage(disk_index, "vhost.sock")
-  end
-
-  def disk(disk_index)
-    storage(disk_index, "disk.raw")
-  end
-
-  def data_encryption_key(disk_index)
-    storage(disk_index, "data_encryption_key.json")
   end
 
   def image_root

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -106,16 +106,21 @@ class VmSetup
   end
 
   def purge_storage
-    # Storage hasn't been created yet, so nothing to purge.
-    return if !File.exist?(vp.storage_root)
+    # prep.json doesn't exist, nothing more to do
+    return if !File.exist?(vp.prep_json)
+
+    storage_roots = []
 
     params = JSON.parse(File.read(vp.prep_json))
     params["storage_volumes"].each { |params|
       volume = StorageVolume.new(@vm_name, params)
       volume.purge_spdk_artifacts
+      storage_roots.append(volume.storage_root)
     }
 
-    rm_if_exists(vp.storage_root)
+    storage_roots.each { |path|
+      rm_if_exists(path)
+    }
   end
 
   def unmount_hugepages

--- a/rhizome/host/spec/storage_key_tool_spec.rb
+++ b/rhizome/host/spec/storage_key_tool_spec.rb
@@ -5,7 +5,7 @@ require "openssl"
 require "base64"
 
 RSpec.describe StorageKeyTool do
-  subject(:skt) { described_class.new("vm12345", 3) }
+  subject(:skt) { described_class.new("vm12345", DEFAULT_STORAGE_DEVICE, 3) }
 
   def generate_kek
     key_wrapping_algorithm = "aes-256-gcm"

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -81,44 +81,50 @@ RSpec.describe VmSetup do
   end
 
   describe "#purge_storage" do
-    it "can purge storage" do
-      vol_1_params = {
+    let(:vol_1_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_0",
         "disk_index" => 0,
         "encrypted" => false,
         "spdk_version" => "some-version"
       }
-      vol_2_params = {
+    }
+    let(:vol_2_params) {
+      {
         "size_gib" => 20,
         "device_id" => "test_1",
         "disk_index" => 1,
         "encrypted" => true,
         "spdk_version" => "some-version"
       }
-      params = JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
+    let(:params) {
+      JSON.generate({storage_volumes: [vol_1_params, vol_2_params]})
+    }
 
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(true)
+    it "can purge storage" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
 
       # delete the unencrypted volume
       sv_1 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
       expect(sv_1).to receive(:purge_spdk_artifacts)
+      expect(sv_1).to receive(:storage_root).and_return("/var/storage/test")
 
       # delete the encrypted volume
       sv_2 = instance_double(StorageVolume)
       expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
       expect(sv_2).to receive(:purge_spdk_artifacts)
-
-      expect(FileUtils).to receive(:rm_r).with("/var/storage/test")
+      expect(sv_2).to receive(:storage_root).and_return("/var/storage/test")
 
       vs.purge_storage
     end
 
-    it "exits silently if storage hasn't been created yet" do
-      expect(File).to receive(:exist?).with("/var/storage/test").and_return(false)
-      vs.purge_storage
+    it "exits silently if vm hasn't been created yet" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
+      expect { vs.purge_storage }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
Managing multiple storage devices per VM indicates makes the old one-to-one assumptions of the code in `vm_path.rb` obsolete.  This patch introduces a similar `storage_path.rb` that is capable of computing paths for multiple storage devices.

With the exception of the storage-key-tool interface change -- largely harmless as the key tool is not run automatically -- these rhizome changes are thought to be backwards compatible, and can be deployed first.

Hadi wrote the code, but I am taking responsibility for breaking it up and deploying it.