### PR TITLE
Fix typo in the access policy language explanation

### DIFF
--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -40,8 +40,8 @@
           <span class="text-gray-700 font-medium">"project/&lt;PROJECT_ID&gt;"</span>,
           <span class="text-gray-700 font-medium">"user/&lt;EMAIL&gt;"</span>,
           <span class="text-gray-700 font-medium">"project/&lt;PROJECT_ID&gt;/location/&lt;LOCATION_NAME&gt;/vm/&lt;VM_NAME&gt;"</span>
-          or custom tags can be used for subjects, and objects. To use a tag in policy, it should have to assoaciated
-          with the project. Actions are predefined.
+          or custom tags can be used for subjects, and objects. To use a tag in policy, it has to be associated with
+          the project. Actions are predefined.
         </p>
         <table class="min-w-full divide-y divide-gray-300 text-left">
           <thead class="font-semibold">


### PR DESCRIPTION
Fix typo in the access policy language explanation