### PR TITLE
Fix filtering in MinIO monitoring

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -38,7 +38,7 @@ class MinioServer < Sequel::Model
   end
 
   def connection_string
-    dns_zone ? "http://#{hostname}:9000" : "http://#{vm.ephemeral_net4}:9000"
+    "http://#{vm.ephemeral_net4}:9000"
   end
 
   def init_health_monitor_session
@@ -61,7 +61,7 @@ class MinioServer < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      server_data = JSON.parse(session[:minio_client].admin_info.body)["servers"].find { "http://#{_1["endpoint"]}" == connection_string }
+      server_data = JSON.parse(session[:minio_client].admin_info.body)["servers"].find { _1["endpoint"] == "#{vm.ephemeral_net4}:9000" }
       (server_data["state"] == "online" && server_data["drives"].all? { _1["state"] == "ok" }) ? "up" : "down"
     rescue
       "down"

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -153,7 +153,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       secret_key: minio_server.cluster.admin_password
     )
 
-    server_data = JSON.parse(client.admin_info.body)["servers"].find { _1["endpoint"] == "#{minio_server.vm.ephemeral_net4}:9000" }
+    server_data = JSON.parse(client.admin_info.body)["servers"].find { _1["endpoint"] == minio_server.endpoint }
     server_data["state"] == "online" && server_data["drives"].all? { _1["state"] == "ok" }
   rescue
     false

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -153,7 +153,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       secret_key: minio_server.cluster.admin_password
     )
 
-    server_data = JSON.parse(client.admin_info.body)["servers"].find { "http://#{_1["endpoint"]}" == minio_server.connection_string }
+    server_data = JSON.parse(client.admin_info.body)["servers"].find { _1["endpoint"] == "#{minio_server.vm.ephemeral_net4}:9000" }
     server_data["state"] == "online" && server_data["drives"].all? { _1["state"] == "ok" }
   rescue
     false

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -56,9 +56,6 @@ RSpec.describe MinioCluster do
   it "returns connection strings properly" do
     expect(mc.servers.first.vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
     expect(mc.connection_strings).to eq(["http://1.1.1.1:9000"])
-
-    expect(mc.servers.first).to receive(:dns_zone).and_return("something")
-    expect(mc.connection_strings).to eq(["http://minio-cluster-name0.minio.ubicloud.com:9000"])
   end
 
   it "returns hyper tag name properly" do

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe MinioServer do
     ms.check_pulse(session: session, previous_pulse: {reading: "down", reading_rpt: 5, reading_chg: Time.now - 30})
   end
 
+  it "returns endpoint properly" do
+    expect(ms.vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
+    expect(ms.endpoint).to eq("1.1.1.1:9000")
+
+    expect(ms).to receive(:dns_zone).and_return("something")
+    expect(ms.endpoint).to eq("minio-cluster-name0.minio.ubicloud.com:9000")
+  end
+
   describe "#dns_zone" do
     before do
       minio_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }


### PR DESCRIPTION
Previous fix broke other pieces that depends on cluster's DNS name. This time
we are adding a new method to limit the impact on other places.