### PR TITLE
Firewalls backend

### DIFF
--- a/migrate/20240121_move_fw_rules.rb
+++ b/migrate/20240121_move_fw_rules.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:firewall) do
+      column :id, :uuid, primary_key: true
+      column :name, :text, null: false, default: "Default"
+      column :description, :text, null: false, default: "Default firewall"
+      column :created_at, :timestamp, null: false, default: Sequel::CURRENT_TIMESTAMP
+      foreign_key :vm_id, :vm, type: :uuid, null: true
+    end
+
+    alter_table(:firewall_rule) do
+      add_foreign_key :firewall_id, :firewall, null: true, type: :uuid
+      rename_column :ip, :cidr
+      set_column_allow_null :private_subnet_id
+      add_unique_constraint [:cidr, :port_range, :firewall_id]
+    end
+
+    run <<~SQL
+INSERT INTO firewall (id, name, description, vm_id)
+SELECT id, 'Default', 'Default firewall', id FROM vm;
+    SQL
+
+    # populate firewall rules per vm
+    run <<~SQL
+WITH vm_subnet_mapping AS (
+  SELECT
+      vm.id AS vm_id,
+      nic.private_subnet_id
+  FROM
+      vm
+  INNER JOIN
+      nic ON vm.id = nic.vm_id
+),
+new_firewall_rules AS (
+    SELECT
+        gen_random_uuid() AS id, -- Generate new UUIDs for the id
+        fwr.cidr as cidr,
+        fwr.port_range as port_range,
+        vm_subnet_mapping.vm_id AS firewall_id
+    FROM
+        firewall_rule fwr
+    INNER JOIN
+        vm_subnet_mapping ON vm_subnet_mapping.private_subnet_id = fwr.private_subnet_id
+)
+INSERT INTO firewall_rule (id, cidr, port_range, firewall_id)
+SELECT id, cidr, port_range, firewall_id FROM new_firewall_rules;
+    SQL
+  end
+
+  down do
+    # Populate the private_subnet_id column
+    run <<~SQL
+      UPDATE firewall_rule fr
+      SET private_subnet_id = (
+        SELECT n.private_subnet_id
+        FROM nic n
+        INNER JOIN vm ON vm.id = n.vm_id
+        INNER JOIN firewall f ON f.vm_id = vm.id
+        WHERE f.id = fr.firewall_id
+        LIMIT 1
+      )
+      WHERE fr.firewall_id IS NOT NULL;
+    SQL
+
+    # Remove duplicates, keeping only one rule per subnet
+    run <<~SQL
+      DELETE FROM firewall_rule
+      WHERE ctid NOT IN (
+        SELECT MIN(ctid)
+        FROM firewall_rule
+        GROUP BY private_subnet_id, cidr, port_range
+      );
+    SQL
+
+    # Remove the firewall_id column from firewall_rule
+    alter_table(:firewall_rule) do
+      drop_column :firewall_id
+      set_column_not_null :private_subnet_id
+      add_unique_constraint [:cidr, :port_range, :private_subnet_id]
+    end
+
+    # Drop the firewall table
+    drop_table(:firewall)
+  end
+end

--- a/migrate/20240122_pg_resource_fw_rules.rb
+++ b/migrate/20240122_pg_resource_fw_rules.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:postgres_firewall_rule) do
+      column :id, :uuid, primary_key: true, null: false
+      column :cidr, :cidr, null: false
+      foreign_key :postgres_resource_id, :postgres_resource, null: false, type: :uuid
+      unique [:postgres_resource_id, :cidr]
+    end
+  end
+end

--- a/migrate/20240123_remove_fwrules_ps_rel.rb
+++ b/migrate/20240123_remove_fwrules_ps_rel.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    run <<~SQL
+DELETE FROM firewall_rule
+WHERE private_subnet_id IS NOT NULL;
+    SQL
+
+    alter_table(:firewall_rule) do
+      drop_column :private_subnet_id
+      set_column_not_null :firewall_id
+    end
+  end
+
+  down do
+    alter_table(:firewall_rule) do
+      add_foreign_key :private_subnet_id, :private_subnet, type: :uuid, null: true
+      set_column_allow_null :firewall_id
+    end
+  end
+end

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class Firewall < Sequel::Model
+  one_to_many :firewall_rules, key: :firewall_id
+  many_to_one :vm, key: :vm_id
+
+  plugin :association_dependencies, firewall_rules: :destroy
+
+  include ResourceMethods
+
+  def insert_firewall_rule(cidr, port_range)
+    fwr = FirewallRule.create_with_id(
+      firewall_id: id,
+      cidr: cidr,
+      port_range: port_range
+    )
+
+    vm&.incr_update_firewall_rules
+    fwr
+  end
+end

--- a/model/firewall_rule.rb
+++ b/model/firewall_rule.rb
@@ -3,11 +3,11 @@
 require_relative "../model"
 
 class FirewallRule < Sequel::Model
-  many_to_one :private_subnet
+  many_to_one :firewall, key: :firewall_id
 
   include ResourceMethods
 
   def ip6?
-    ip.to_s.include?(":")
+    cidr.to_s.include?(":")
   end
 end

--- a/model/postgres/postgres_firewall_rule.rb
+++ b/model/postgres/postgres_firewall_rule.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "../../model"
+
+class PostgresFirewallRule < Sequel::Model
+  many_to_one :postgres_resource, key: :postgres_resource_id
+  dataset_module Authorization::Dataset
+
+  include ResourceMethods
+end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -9,7 +9,9 @@ class PostgresResource < Sequel::Model
   many_to_one :parent, key: :parent_id, class: self
   one_to_one :server, class: PostgresServer, key: :resource_id
   one_through_one :timeline, class: PostgresTimeline, join_table: :postgres_server, left_key: :resource_id, right_key: :timeline_id
+  one_to_many :firewall_rules, class: PostgresFirewallRule, key: :postgres_resource_id
 
+  plugin :association_dependencies, firewall_rules: :destroy
   dataset_module Authorization::Dataset
 
   include ResourceMethods
@@ -22,7 +24,7 @@ class PostgresResource < Sequel::Model
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
 
-  semaphore :destroy
+  semaphore :destroy, :update_firewall_rules
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -37,7 +37,7 @@ class PrivateSubnet < Sequel::Model
   end
 
   include SemaphoreMethods
-  semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
+  semaphore :destroy, :refresh_keys, :add_new_nic
 
   def self.random_subnet
     PRIVATE_SUBNET_RANGES.sample

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -11,8 +11,9 @@ class Vm < Sequel::Model
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
   one_to_many :vm_storage_volumes, key: :vm_id
   one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
+  one_to_many :firewalls, key: :vm_id
 
-  plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy
+  plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy, firewalls: :destroy
 
   dataset_module Authorization::Dataset
 
@@ -23,7 +24,7 @@ class Vm < Sequel::Model
   end
 
   include SemaphoreMethods
-  semaphore :destroy, :start_after_host_reboot, :prevent_destroy
+  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules
 
   include Authorization::HyperTagMethods
 
@@ -155,15 +156,5 @@ class Vm < Sequel::Model
 
   def storage_encrypted?
     vm_storage_volumes.all? { !_1.key_encryption_key_1_id.nil? }
-  end
-
-  def add_allow_ssh_fw_rules(ps)
-    ["0.0.0.0/0", "::/0"].each do |ip|
-      FirewallRule.create_with_id(
-        ip: ip,
-        private_subnet_id: ps.id,
-        port_range: Sequel.pg_range(22..22)
-      )
-    end
   end
 end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -71,16 +71,9 @@ class Prog::Vm::GithubRunner < Prog::Base
       boot_image: label_data["boot_image"],
       storage_volumes: [vm_storage_params],
       enable_ip4: true,
-      arch: label_data["arch"]
+      arch: label_data["arch"],
+      allow_only_ssh: true
     )
-
-    ps = vm_st.subject.private_subnets.first
-    # We don't need to incr_update_firewall_rules semaphore here because the VM
-    # is just created and the firewall rules are not applied in the SubnetNexus,
-    # yet. When NicNexus switches from "wait_vm" to "setup_nic", it will
-    # increment the semaphore, already.
-    ps.firewall_rules.map(&:destroy)
-    vm_st.subject.add_allow_ssh_fw_rules(ps)
 
     Clog.emit("Pool is empty") { {github_runner: {label: github_runner.label, repository_name: github_runner.repository_name, cores: vm_st.subject.cores}} }
     vm_st.subject

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -8,12 +8,12 @@ require "base64"
 
 class Prog::Vm::Nexus < Prog::Base
   subject_is :vm
-  semaphore :destroy, :start_after_host_reboot, :prevent_destroy
+  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules
 
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
-    enable_ip4: false, pool_id: nil, arch: "x64")
+    enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -89,6 +89,10 @@ class Prog::Vm::Nexus < Prog::Base
         name: name, family: vm_size.family, cores: cores, location: location,
         boot_image: boot_image, ip4_enabled: enable_ip4, pool_id: pool_id, arch: arch) { _1.id = ubid.to_uuid }
       nic.update(vm_id: vm.id)
+
+      port_range = allow_only_ssh ? 22..22 : 0..65535
+      fw = Firewall.create_with_id(vm_id: vm.id, name: "#{name}-default")
+      ["0.0.0.0/0", "::/0"].each { |cidr| FirewallRule.create_with_id(firewall_id: fw.id, cidr: cidr, port_range: Sequel.pg_range(port_range)) }
 
       vm.associate_with_project(project)
 
@@ -338,7 +342,10 @@ SQL
   label def prep
     case host.sshable.cmd("common/bin/daemonizer --check prep_#{q_vm}")
     when "Succeeded"
-      hop_run
+      host.sshable.cmd("common/bin/daemonizer --clean prep_#{q_vm}")
+      vm.nics.each { _1.incr_setup_nic }
+      bud Prog::Vnet::UpdateFirewallRules, {subject_id: vm.id}, :update_firewall_rules
+      hop_wait_firewall_rules_before_run
     when "NotStarted", "Failed"
       topo = vm.cloud_hypervisor_cpu_topology
 
@@ -376,9 +383,13 @@ SQL
     nap 5
   end
 
+  label def wait_firewall_rules_before_run
+    reap
+    hop_run if leaf?
+    donate
+  end
+
   label def run
-    host.sshable.cmd("common/bin/daemonizer --clean prep_#{q_vm}")
-    vm.nics.each { _1.incr_setup_nic }
     host.sshable.cmd("sudo systemctl start #{q_vm}")
     hop_wait_sshable
   end
@@ -427,7 +438,24 @@ SQL
       hop_start_after_host_reboot
     end
 
+    when_update_firewall_rules_set? do
+      register_deadline(:wait, 5 * 60)
+      hop_update_firewall_rules
+    end
+
     nap 30
+  end
+
+  label def update_firewall_rules
+    decr_update_firewall_rules
+    bud Prog::Vnet::UpdateFirewallRules, {subject_id: vm.id}, :update_firewall_rules
+    hop_wait_firewall_rules
+  end
+
+  label def wait_firewall_rules
+    reap
+    hop_wait if leaf?
+    donate
   end
 
   label def prevent_destroy

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -38,7 +38,7 @@ class Prog::Vm::VmPool < Prog::Base
       encrypted: vm_pool.storage_encrypted,
       skip_sync: vm_pool.storage_skip_sync
     }
-    st = Prog::Vm::Nexus.assemble_with_sshable(
+    Prog::Vm::Nexus.assemble_with_sshable(
       "runner",
       Config.vm_pool_project_id,
       size: vm_pool.vm_size,
@@ -47,16 +47,10 @@ class Prog::Vm::VmPool < Prog::Base
       storage_volumes: [storage_params],
       enable_ip4: true,
       pool_id: vm_pool.id,
-      arch: vm_pool.arch
+      arch: vm_pool.arch,
+      allow_only_ssh: true
     )
 
-    ps = st.subject.private_subnets.first
-    # We don't need to incr_update_firewall_rules semaphore here because the VM
-    # is just created and the firewall rules are not applied in the SubnetNexus,
-    # yet. When NicNexus switches from "wait_vm" to "setup_nic", it will
-    # increment the semaphore, already.
-    ps.firewall_rules.map(&:destroy)
-    st.subject.add_allow_ssh_fw_rules(ps)
     hop_wait
   end
 

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -30,7 +30,6 @@ class Prog::Vnet::NicNexus < Prog::Base
   label def wait_vm
     nap 60 unless nic.vm
     when_setup_nic_set? do
-      nic.private_subnet.incr_update_firewall_rules
       hop_add_subnet_addr
     end
     nap 1
@@ -76,7 +75,6 @@ class Prog::Vnet::NicNexus < Prog::Base
 
   label def repopulate
     bud Prog::Vnet::RekeyNicTunnel, {}, :add_subnet_addr
-    nic.private_subnet.incr_update_firewall_rules
     hop_wait_repopulate
   end
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -2,7 +2,7 @@
 
 class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
-  semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
+  semaphore :destroy, :refresh_keys, :add_new_nic
 
   def self.assemble(project_id, name: nil, location: "hetzner-hel1", ipv6_range: nil, ipv4_range: nil)
     unless (project = Project[project_id])
@@ -20,16 +20,6 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     DB.transaction do
       ps = PrivateSubnet.create(name: name, location: location, net6: ipv6_range, net4: ipv4_range, state: "waiting") { _1.id = ubid.to_uuid }
       ps.associate_with_project(project)
-      FirewallRule.create_with_id(
-        ip: "0.0.0.0/0",
-        private_subnet_id: ps.id,
-        port_range: nil
-      )
-      FirewallRule.create_with_id(
-        ip: "::/0",
-        private_subnet_id: ps.id,
-        port_range: nil
-      )
       Strand.create(prog: "Vnet::SubnetNexus", label: "wait") { _1.id = ubid.to_uuid }
     end
   end
@@ -54,11 +44,6 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       hop_add_new_nic
     end
 
-    when_update_firewall_rules_set? do
-      private_subnet.update(state: "updating_firewall_rules")
-      hop_update_firewall_rules
-    end
-
     if private_subnet.last_rekey_at < Time.now - 60 * 60 * 24
       private_subnet.incr_refresh_keys
     end
@@ -76,25 +61,6 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
   def gen_reqid
     SecureRandom.random_number(100000) + 1
-  end
-
-  label def update_firewall_rules
-    decr_update_firewall_rules
-    private_subnet.vms.each do |vm|
-      bud Prog::Vnet::UpdateFirewallRules, {subject_id: vm.id}, :update_firewall_rules
-    end
-
-    hop_wait_fw_rules
-  end
-
-  label def wait_fw_rules
-    reap
-    if leaf?
-      private_subnet.update(state: "waiting")
-      hop_wait
-    end
-
-    donate
   end
 
   label def add_new_nic
@@ -164,7 +130,6 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
     if private_subnet.nics.empty?
       DB.transaction do
-        private_subnet.firewall_rules.map(&:destroy)
         private_subnet.projects.each { |p| private_subnet.dissociate_with_project(p) }
         private_subnet.destroy
       end

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -3,13 +3,16 @@
 class Prog::Vnet::UpdateFirewallRules < Prog::Base
   subject_is :vm
 
+  FirewallRuleObj = Struct.new(:cidr, :port_range)
+
   label def update_firewall_rules
-    rules = vm.private_subnets.map(&:firewall_rules).flatten
-    allowed_ingress_ip4 = rules.select { !_1.ip6? && !_1.port_range }.map { _1.ip.to_s }
-    allowed_ingress_ip6 = rules.select { _1.ip6? && !_1.port_range }.map { _1.ip.to_s }
-    allowed_ingress_ip4_port_set = generate_ip_port_set(rules.select { !_1.ip6? && _1.port_range })
-    allowed_ingress_ip6_port_set = generate_ip_port_set(rules.select { _1.ip6? && _1.port_range })
+    rules = vm.firewalls.map(&:firewall_rules).flatten
+    allowed_ingress_ip4 = NetAddr.summ_IPv4Net(rules.select { !_1.ip6? && !_1.port_range }.map { _1.cidr }).map(&:to_s)
+    allowed_ingress_ip6 = NetAddr.summ_IPv6Net(rules.select { _1.ip6? && !_1.port_range }.map { _1.cidr }).map(&:to_s)
+    allowed_ingress_ip4_port_set = consolidate_rules(rules.select { !_1.ip6? && _1.port_range })
+    allowed_ingress_ip6_port_set = consolidate_rules(rules.select { _1.ip6? && _1.port_range })
     guest_ephemeral = subdivide_network(vm.ephemeral_net6).first.to_s
+
     vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<TEMPLATE)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
@@ -17,13 +20,13 @@ class Prog::Vnet::UpdateFirewallRules < Prog::Base
 table inet fw_table;
 delete table inet fw_table;
 table inet fw_table {
-  set allowed_ipv4_ips {
+  set allowed_ipv4_cidrs {
     type ipv4_addr;
     flags interval;
 #{allowed_ingress_ip4.any? ? "elements = {#{allowed_ingress_ip4.join(",")}}" : ""}
   }
 
-  set allowed_ipv6_ips {
+  set allowed_ipv6_cidrs {
     type ipv6_addr;
     flags interval;
 #{allowed_ingress_ip6.any? ? "elements = {#{allowed_ingress_ip6.join(",")}}" : ""}
@@ -41,7 +44,7 @@ table inet fw_table {
 #{allowed_ingress_ip6_port_set.empty? ? "" : "elements = {#{allowed_ingress_ip6_port_set}}"}
   }
 
-  set private_ipv4_ips {
+  set private_ipv4_cidrs {
     type ipv4_addr;
     flags interval;
     elements = {
@@ -49,7 +52,7 @@ table inet fw_table {
     }
   }
 
-  set private_ipv6_ips {
+  set private_ipv6_cidrs {
     type ipv6_addr
     flags interval
     elements = { #{generate_private_ip6_list} }
@@ -64,36 +67,110 @@ table inet fw_table {
     type filter hook forward priority filter; policy drop;
     ip protocol tcp counter flow offload @ubi_flowtable
     ip protocol udp counter flow offload @ubi_flowtable
-    ip saddr @private_ipv4_ips ct state established,related,new counter accept
-    ip daddr @private_ipv4_ips ct state established,related counter accept
-    ip6 saddr @private_ipv6_ips ct state established,related,new counter accept
-    ip6 daddr @private_ipv6_ips ct state established,related counter accept
+    ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
+    ip daddr @private_ipv4_cidrs ct state established,related counter accept
+    ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
+    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
     ip6 saddr #{guest_ephemeral} ct state established,related,new counter accept
     ip6 daddr #{guest_ephemeral} ct state established,related counter accept
-    ip saddr @allowed_ipv4_ips ip daddr @private_ipv4_ips counter accept
-    ip6 saddr @allowed_ipv6_ips ip6 daddr #{guest_ephemeral} counter accept
-    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip saddr @allowed_ipv4_cidrs ip daddr @private_ipv4_cidrs counter accept
+    ip6 saddr @allowed_ipv6_cidrs ip6 daddr #{guest_ephemeral} counter accept
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr #{guest_ephemeral} counter accept
-    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr #{guest_ephemeral} counter accept
   }
 }
 TEMPLATE
+
     pop "firewall rule is added"
   end
 
-  def generate_ip_port_set(rules)
-    rules.map do |rule|
-      ip = rule.ip.to_s
-      port_range = rule.port_range
-      port_rule = if port_range.begin == port_range.end - 1
-        port_range.begin.to_s
-      else
-        "#{port_range.begin}-#{port_range.end - 1}"
+  # This method is needed to properly consolidate port_ranges + cidrs.
+  # For example, if we have the following rules:
+  # 1. 10.10.10.8/29 . 80-8080
+  # 2. 10.10.10.0/27 . 5432-10000
+  #
+  # We can't just merge the cidrs because the port ranges overlap. We need to
+  # first identify where the overlap is in the port ranges and then merge the
+  # cidrs for the overlapping port ranges. The result should be:
+  # 1. 10.10.10.8/29 . 80-5431
+  # 2. 10.10.10.0/27 . 5432-10000
+  #
+  # In the processing of these 2 rules, we first identify the port segments as;
+  # 1. 80-5431
+  # 2. 5432-8080
+  # 3. 8081-10000
+  #
+  # Then we identify the cidrs for each segment:
+  # 1. 10.10.10.8/29 (This is simply used from the first rule because the first
+  #    rule is the only rule that has a cidr that overlaps with this segment)
+  # 2. 10.10.10.8/29 + 10.10.10.0/27: The combination of these will result in
+  #    10.10.10.0/27
+  # 3. 10.10.10.0/27 (This is simply used from the second rule because the
+  #    second rule is the only rule that has a cidr that overlaps with this
+  #    segment)
+  #
+  # For the combination of the cidrs, we use the summ_IPv4/6Net method from the
+  # netaddr gem. This method will combine the cidrs and remove any duplicates.
+  # If we don't perform this combination, we will end up with an error from
+  # nftables saying file exists.
+  #
+  # Additionally, the customers may have thousands of rules and possibly, they
+  # overlap. We want to minimize the number of rules that we create on the
+  # nftables side to avoid performance issues.
+  def consolidate_rules(rules)
+    port_segments = create_port_segments(rules)
+    consolidated_rules = []
+
+    port_segments.each do |segment|
+      # Find rules that overlap with the current segment
+      overlapping_rules = rules.select do |r|
+        r.port_range.begin <= segment[:end] && r.port_range.end - 1 >= segment[:begin]
       end
 
-      "#{ip} . #{port_rule}"
+      # Merge cidrs for overlapping rules
+      merged_cidrs = if rules.first.cidr.version == 4
+        NetAddr.summ_IPv4Net(overlapping_rules.map(&:cidr))
+      else
+        NetAddr.summ_IPv6Net(overlapping_rules.map(&:cidr))
+      end
+      merged_cidrs.each do |cidr|
+        consolidated_rules << FirewallRuleObj.new(cidr, {begin: segment[:begin], end: segment[:end] + 1})
+      end
+    end
+
+    combined_rules = combine_continuous_ranges_for_same_subnet(consolidated_rules)
+    combined_rules.map do |r|
+      if r.port_range[:begin] != r.port_range[:end] - 1
+        "#{r.cidr} . #{r.port_range[:begin]}-#{r.port_range[:end] - 1}"
+      else
+        "#{r.cidr} . #{r.port_range[:begin]}"
+      end
     end.join(",")
+  end
+
+  def combine_continuous_ranges_for_same_subnet(rules)
+    rules.sort_by { |r| [r.cidr.to_s, r.port_range[:begin]] }.chunk_while { |a, b| a.cidr.to_s == b.cidr.to_s && a.port_range[:end] == b.port_range[:begin] }.map do |chunk|
+      if chunk.size > 1
+        FirewallRuleObj.new(chunk.first.cidr, {begin: chunk.first.port_range[:begin], end: chunk.last.port_range[:end]})
+      else
+        chunk.first
+      end
+    end
+  end
+
+  def create_port_segments(rules)
+    # Extract unique start and end points from port ranges
+    points = rules.flat_map { |r| [r.port_range.begin.to_i, r.port_range.end.to_i] }.uniq.sort
+    segments = []
+
+    # Create segments based on unique points
+    points.each_cons(2) do |start_point, end_point|
+      segments << {begin: start_point, end: end_point - 1}
+    end
+
+    segments
   end
 
   def generate_private_ip4_list

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -79,6 +79,8 @@ table inet fw_table {
     ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr #{guest_ephemeral} counter accept
     ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr #{guest_ephemeral} counter accept
+    ip saddr 0.0.0.0/0 icmp type echo-request counter accept
+    ip6 saddr ::/0 icmpv6 type echo-request counter accept
   }
 }
 TEMPLATE

--- a/spec/model/firewall_rule_spec.rb
+++ b/spec/model/firewall_rule_spec.rb
@@ -4,14 +4,14 @@ require_relative "spec_helper"
 
 RSpec.describe FirewallRule do
   describe "FirewallRule" do
-    let(:ps) {
-      PrivateSubnet.create_with_id(net6: "0::0", net4: "0.0.0.0/0", name: "x", location: "x")
+    let(:fw) {
+      Firewall.create_with_id
     }
 
     it "returns ip6? properly" do
-      fw_rule = described_class.create_with_id(ip: "::/0", private_subnet_id: ps.id)
+      fw_rule = described_class.create_with_id(cidr: "::/0", firewall_id: fw.id)
       expect(fw_rule.ip6?).to be true
-      fw_rule.update(ip: "0.0.0.0/0")
+      fw_rule.update(cidr: "0.0.0.0/0")
       expect(fw_rule.ip6?).to be false
     end
   end

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Firewall do
+  describe "Firewall" do
+    let(:fw) {
+      described_class.create_with_id(name: "test-fw", description: "test fw desc")
+    }
+
+    it "inserts firewall rules" do
+      fw.insert_firewall_rule("10.0.0.16/28", Sequel.pg_range(80..5432))
+      expect(fw.firewall_rules.count).to eq(1)
+      expect(fw.firewall_rules.first.cidr.to_s).to eq("10.0.0.16/28")
+      pr = fw.firewall_rules.first.port_range
+      expect(pr.begin).to eq(80)
+      expect(pr.end).to eq(5433)
+    end
+
+    it "increments VMs update_firewall_rules if there is a VM" do
+      vm = instance_double(Vm)
+      expect(fw).to receive(:vm).and_return(vm)
+      expect(vm).to receive(:incr_update_firewall_rules)
+      fw.insert_firewall_rule("0.0.0.0/0", nil)
+    end
+  end
+end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -263,6 +263,14 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(postgres_resource).to receive(:certificate_last_checked_at).and_return(Time.now - 60 * 60 * 24 * 30 - 1)
       expect { nx.wait }.to hop("refresh_certificates")
     end
+
+    it "increments update_firewall_rules semaphore of postgres server if when_update_firewall_rules_set? is called" do
+      expect(postgres_resource).to receive(:certificate_last_checked_at).and_return(Time.now)
+
+      expect(nx).to receive(:when_update_firewall_rules_set?).and_yield
+      expect(postgres_resource.server).to receive(:incr_update_firewall_rules)
+      expect { nx.wait }.to nap(30)
+    end
   end
 
   describe "#destroy" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -346,6 +346,24 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:available?).and_return(true)
       expect { nx.wait }.to nap(30)
     end
+
+    it "hops to update_firewall_rules if update_firewall_rules is set" do
+      expect(nx).to receive(:when_update_firewall_rules_set?).and_yield
+      expect { nx.wait }.to hop("update_firewall_rules")
+    end
+  end
+
+  describe "#update_firewall_rules" do
+    it "updates firewall rules and hops to wait" do
+      expect(postgres_server).to receive(:ubid).and_return("dummy-ubid")
+      fw = instance_double(Firewall, name: "dummy-ubid")
+      expect(postgres_server.vm).to receive(:firewalls).and_return([fw])
+      expect(fw).to receive(:destroy)
+      expect(postgres_server).to receive(:create_resource_firewall_rules)
+      expect(postgres_server.vm).to receive(:incr_update_firewall_rules)
+
+      expect { nx.update_firewall_rules }.to hop("wait")
+    end
   end
 
   describe "#unavailable" do

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -93,8 +93,6 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "starts setup and pings subnet" do
-      expect(ps).to receive(:incr_update_firewall_rules)
-      expect(nic).to receive(:private_subnet).and_return(ps)
       vm = instance_double(Vm)
       expect(nic).to receive(:vm).and_return(vm)
       expect(nx).to receive(:when_setup_nic_set?).and_yield
@@ -168,10 +166,6 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#repopulate" do
     it "buds RekeyNicTunnel with add_subnet_addr" do
-      ps = instance_double(PrivateSubnet)
-      nic = instance_double(Nic, private_subnet: ps)
-      expect(nx).to receive(:nic).and_return(nic)
-      expect(ps).to receive(:incr_update_firewall_rules)
       expect(nx).to receive(:bud).with(Prog::Vnet::RekeyNicTunnel, {}, :add_subnet_addr)
       expect { nx.repopulate }.to hop("wait_repopulate")
     end

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -97,6 +97,8 @@ elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
     ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
     ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
+    ip saddr 0.0.0.0/0 icmp type echo-request counter accept
+    ip6 saddr ::/0 icmpv6 type echo-request counter accept
   }
 }
 ADD_RULES
@@ -173,6 +175,8 @@ table inet fw_table {
     ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
     ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
+    ip saddr 0.0.0.0/0 icmp type echo-request counter accept
+    ip6 saddr ::/0 icmpv6 type echo-request counter accept
   }
 }
 ADD_RULES

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -19,12 +19,18 @@ RSpec.describe Prog::Vnet::UpdateFirewallRules do
   describe "update_firewall_rules" do
     it "populates elements if there are fw rules" do
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(ps).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, ip: "0.0.0.0/0", port_range: nil),
-        instance_double(FirewallRule, ip6?: false, ip: "1.1.1.1/32", port_range: Sequel.pg_range(22..23)),
-        instance_double(FirewallRule, ip6?: true, ip: "::/0", port_range: nil),
-        instance_double(FirewallRule, ip6?: true, ip: "fd00::1/128", port_range: Sequel.pg_range(8080..65536))
-      ])
+      expect(vm).to receive(:firewalls).and_return([instance_double(Firewall, name: "fw_table", firewall_rules: [
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: nil),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("10.10.10.0/26"), port_range: Sequel.pg_range(80..10000)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("123.123.123.64/27"), port_range: Sequel.pg_range(8080..12000)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("123.123.123.64/26"), port_range: Sequel.pg_range(9000..16000)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("::/0"), port_range: nil),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(8080..65536)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/64"), port_range: Sequel.pg_range(0..8081)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::2/64"), port_range: Sequel.pg_range(80..10000))
+      ])])
+
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
@@ -32,13 +38,13 @@ RSpec.describe Prog::Vnet::UpdateFirewallRules do
 table inet fw_table;
 delete table inet fw_table;
 table inet fw_table {
-  set allowed_ipv4_ips {
+  set allowed_ipv4_cidrs {
     type ipv4_addr;
     flags interval;
 elements = {0.0.0.0/0}
   }
 
-  set allowed_ipv6_ips {
+  set allowed_ipv6_cidrs {
     type ipv6_addr;
     flags interval;
 elements = {::/0}
@@ -47,16 +53,16 @@ elements = {::/0}
   set allowed_ipv4_port_tuple {
     type ipv4_addr . inet_service;
     flags interval;
-elements = {1.1.1.1/32 . 22}
+elements = {1.1.1.1/32 . 22,10.10.10.0/26 . 80-9999,123.123.123.64/26 . 9000-15999,123.123.123.64/27 . 8080-8999}
   }
 
   set allowed_ipv6_port_tuple {
     type ipv6_addr . inet_service;
     flags interval;
-elements = {fd00::1/128 . 8080-65535}
+elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
   }
 
-  set private_ipv4_ips {
+  set private_ipv4_cidrs {
     type ipv4_addr;
     flags interval;
     elements = {
@@ -64,7 +70,7 @@ elements = {fd00::1/128 . 8080-65535}
     }
   }
 
-  set private_ipv6_ips {
+  set private_ipv6_cidrs {
     type ipv6_addr
     flags interval
     elements = { fd00::/64 }
@@ -79,17 +85,17 @@ elements = {fd00::1/128 . 8080-65535}
     type filter hook forward priority filter; policy drop;
     ip protocol tcp counter flow offload @ubi_flowtable
     ip protocol udp counter flow offload @ubi_flowtable
-    ip saddr @private_ipv4_ips ct state established,related,new counter accept
-    ip daddr @private_ipv4_ips ct state established,related counter accept
-    ip6 saddr @private_ipv6_ips ct state established,related,new counter accept
-    ip6 daddr @private_ipv6_ips ct state established,related counter accept
+    ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
+    ip daddr @private_ipv4_cidrs ct state established,related counter accept
+    ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
+    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
     ip6 saddr fd00::/80 ct state established,related,new counter accept
     ip6 daddr fd00::/80 ct state established,related counter accept
-    ip saddr @allowed_ipv4_ips ip daddr @private_ipv4_ips counter accept
-    ip6 saddr @allowed_ipv6_ips ip6 daddr fd00::/80 counter accept
-    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip saddr @allowed_ipv4_cidrs ip daddr @private_ipv4_cidrs counter accept
+    ip6 saddr @allowed_ipv6_cidrs ip6 daddr fd00::/80 counter accept
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
-    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
   }
 }
@@ -100,7 +106,7 @@ ADD_RULES
 
     it "does not pass elements if there are not fw rules" do
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(ps).to receive(:firewall_rules).and_return([])
+      expect(vm).to receive(:firewalls).and_return([])
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
@@ -108,13 +114,13 @@ ADD_RULES
 table inet fw_table;
 delete table inet fw_table;
 table inet fw_table {
-  set allowed_ipv4_ips {
+  set allowed_ipv4_cidrs {
     type ipv4_addr;
     flags interval;
 
   }
 
-  set allowed_ipv6_ips {
+  set allowed_ipv6_cidrs {
     type ipv6_addr;
     flags interval;
 
@@ -132,7 +138,7 @@ table inet fw_table {
 
   }
 
-  set private_ipv4_ips {
+  set private_ipv4_cidrs {
     type ipv4_addr;
     flags interval;
     elements = {
@@ -140,7 +146,7 @@ table inet fw_table {
     }
   }
 
-  set private_ipv6_ips {
+  set private_ipv6_cidrs {
     type ipv6_addr
     flags interval
     elements = { fd00::/64 }
@@ -155,17 +161,17 @@ table inet fw_table {
     type filter hook forward priority filter; policy drop;
     ip protocol tcp counter flow offload @ubi_flowtable
     ip protocol udp counter flow offload @ubi_flowtable
-    ip saddr @private_ipv4_ips ct state established,related,new counter accept
-    ip daddr @private_ipv4_ips ct state established,related counter accept
-    ip6 saddr @private_ipv6_ips ct state established,related,new counter accept
-    ip6 daddr @private_ipv6_ips ct state established,related counter accept
+    ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
+    ip daddr @private_ipv4_cidrs ct state established,related counter accept
+    ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
+    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
     ip6 saddr fd00::/80 ct state established,related,new counter accept
     ip6 daddr fd00::/80 ct state established,related counter accept
-    ip saddr @allowed_ipv4_ips ip daddr @private_ipv4_ips counter accept
-    ip6 saddr @allowed_ipv6_ips ip6 daddr fd00::/80 counter accept
-    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip saddr @allowed_ipv4_cidrs ip daddr @private_ipv4_cidrs counter accept
+    ip6 saddr @allowed_ipv6_cidrs ip6 daddr fd00::/80 counter accept
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . tcp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
-    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_ips counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr . udp dport @allowed_ipv6_port_tuple ip6 daddr fd00::/80 counter accept
   }
 }

--- a/ubid.rb
+++ b/ubid.rb
@@ -67,6 +67,7 @@ class UBID
   TYPE_DNS_SERVER = "ds"
   TYPE_FIREWALL_RULE = "fr"
   TYPE_FIREWALL = "fw"
+  TYPE_POSTGRES_FIREWALL_RULE = "pf"
 
   # Common entropy-based type for everything else
   TYPE_ETC = "et"

--- a/ubid.rb
+++ b/ubid.rb
@@ -66,6 +66,7 @@ class UBID
   TYPE_DNS_RECORD = "dr"
   TYPE_DNS_SERVER = "ds"
   TYPE_FIREWALL_RULE = "fr"
+  TYPE_FIREWALL = "fw"
 
   # Common entropy-based type for everything else
   TYPE_ETC = "et"


### PR DESCRIPTION
**Migrate firewall_rules from ps to firewall entity**
This commit implements the migration of current firewall rules from a
private subnet specific form into a more structured form. First of all,
we create a new entity called `Firewall` which represents the sum of all
of the firewall rules per resource. Secondly, we are breaking the
firewall-private_subnet relationship and make it a part of the vm
resource. This way, we are able to apply different firewalls to
individual resources in the same subnet. Therefore, customers have a
more granular control over the accessibility of the resources. An
advantages use case would be, simply shutting down all of the access
into a database from public internet and allowing application VMs to be
accessible. Migration work consists of 4 individual steps;
1. Create the new `Firewall` entity.
2. Add a new column `firewall_id` to the firewall_rule entity.
3. Create new `firewall` entity for all of the VMs in the system.
4. Repopulate copies of the current firewall_rules per VM since in the
old system, there was only 1 copy for all of the resources in the same
subnet.

**Add PostgresResourceFirewallRule model** 
This commit adds a new table named pg_resource_firewall_rule. This way,
we will be able to manage a pg resource' firewall rules in its own
table. This is mainly required for;
1. Properly visualizing the pg resource firewall rules in the UI in the
next PR.
2. Having a single place that will be used by multiple VMs under the
same postgres resource (e.g. pg HA).

**Add Firewall backend support** 
Now, the firewalls are part of the VM entity and its Vm::Nexus'
responsibility to apply firewall rule related changes. This requires a
couple of state additions, some removal and provisioning path changes.

**Add firewall backend support to PG** 
Pg service starts using the new firewall backend to support firewall
rules.

**GithubRunner and VMPool firewall support**

**Cleanup for migration of firewall_rules under firewall entity** 
Drop and delete operations in the schema. Mainly separated to its own
commit to handle the deployment without a respirate restart.