### PR TITLE
Download boot image from MinIO cluster with presigned url

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -115,4 +115,10 @@ module Config
 
   # Logging
   optional :database_logger_level, string
+
+  # Ubicloud Images
+  override :ubicloud_images_bucket_name, "ubicloud-images", string
+  optional :ubicloud_images_blob_storage_endpoint, string
+  optional :ubicloud_images_blob_storage_access_key, string, clear: true
+  optional :ubicloud_images_blob_storage_secret_key, string, clear: true
 end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -8,7 +8,15 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   def custom_url
-    @custom_url ||= frame.fetch("custom_url")
+    @custom_url ||= frame["custom_url"]
+  end
+
+  def blob_storage_client
+    @blob_storage_client ||= Minio::Client.new(
+      endpoint: Config.ubicloud_images_blob_storage_endpoint,
+      access_key: Config.ubicloud_images_blob_storage_access_key,
+      secret_key: Config.ubicloud_images_blob_storage_secret_key
+    )
   end
 
   label def start
@@ -30,9 +38,10 @@ class Prog::DownloadBootImage < Prog::Base
       sshable.cmd("common/bin/daemonizer --clean download_#{image_name.shellescape}")
       hop_learn_storage
     when "NotStarted"
-      sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image #{image_name.shellescape} #{custom_url.shellescape}' download_#{image_name.shellescape}")
+      url = custom_url || blob_storage_client.get_presigned_url("GET", Config.ubicloud_images_bucket_name, "#{image_name}-#{vm_host.arch}.raw", 60 * 60).to_s
+      sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image #{image_name.shellescape} #{url.shellescape}' #{("download_" + image_name).shellescape}")
     when "Failed"
-      puts "#{vm_host} Failed to download '#{image_name}' image"
+      fail "Failed to download '#{image_name}' image on #{vm_host}"
     end
 
     nap 15

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -452,12 +452,7 @@ EOS
       # same time.
       temp_path = File.join(vp.image_root, boot_image + image_ext + ".tmp")
       File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
-        if download.match?(/^https:\/\/.+\.blob\.core\.windows\.net/)
-          install_azcopy
-          r "AZCOPY_CONCURRENCY_VALUE=5 azcopy copy #{download.shellescape} #{temp_path.shellescape}"
-        else
-          r "curl -f -L10 -o #{temp_path.shellescape} #{download.shellescape}"
-        end
+        r "curl -f -L10 -o #{temp_path.shellescape} #{download.shellescape}"
       end
 
       if initial_format == "raw"
@@ -470,16 +465,6 @@ EOS
 
       rm_if_exists(temp_path)
     end
-  end
-
-  def install_azcopy
-    r "which azcopy"
-  rescue CommandFail
-    r "curl -L10 -o azcopy_v10.tar.gz 'https://aka.ms/downloadazcopy-v10-linux#{Arch.render(x64: "", arm64: "-arm64")}'"
-    r "tar --strip-components=1 --exclude=*.txt -xzvf azcopy_v10.tar.gz"
-    r "rm azcopy_v10.tar.gz"
-    r "mv azcopy /usr/bin/azcopy"
-    r "chmod +x /usr/bin/azcopy"
   end
 
   # Unnecessary if host has this set before creating the netns, but

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -49,18 +49,17 @@ RSpec.describe VmSetup do
       vs.download_boot_image("ubuntu-jammy")
     end
 
-    it "can download image with custom URL that has query params using azcopy" do
+    it "can download vhd image with custom URL that has query params using curl" do
       expect(File).to receive(:exist?).with("/var/storage/images/github-ubuntu-2204.raw").and_return(false)
       expect(File).to receive(:open) do |path, *_args|
         expect(path).to eq("/var/storage/images/github-ubuntu-2204.vhd.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
-      expect(vs).to receive(:r).with("which azcopy")
-      expect(vs).to receive(:r).with("AZCOPY_CONCURRENCY_VALUE=5 azcopy copy https://images.blob.core.windows.net/images/ubuntu2204.vhd\\?sp\\=r\\&st\\=2023-09-05T22:44:05Z\\&se\\=2023-10-07T06:44:05 /var/storage/images/github-ubuntu-2204.vhd.tmp")
+      expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/github-ubuntu-2204.vhd.tmp http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.vhd\\?X-Amz-Algorithm\\=AWS4-HMAC-SHA256\\&X-Amz-Credential\\=user\\%2F20240112\\%2Fus-east-1\\%2Fs3\\%2Faws4_request\\&X-Amz-Date\\=20240112T132931Z\\&X-Amz-Expires\\=3600\\&X-Amz-SignedHeaders\\=host\\&X-Amz-Signature\\=aabbcc")
       expect(vs).to receive(:r).with("qemu-img convert -p -f vpc -O raw /var/storage/images/github-ubuntu-2204.vhd.tmp /var/storage/images/github-ubuntu-2204.raw")
       expect(FileUtils).to receive(:rm_r).with("/var/storage/images/github-ubuntu-2204.vhd.tmp")
 
-      vs.download_boot_image("github-ubuntu-2204", custom_url: "https://images.blob.core.windows.net/images/ubuntu2204.vhd?sp=r&st=2023-09-05T22:44:05Z&se=2023-10-07T06:44:05")
+      vs.download_boot_image("github-ubuntu-2204", custom_url: "http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.vhd?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240112T132931Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=aabbcc")
     end
 
     it "does not convert image if it's in raw format already" do
@@ -69,12 +68,11 @@ RSpec.describe VmSetup do
         expect(path).to eq("/var/storage/images/github-ubuntu-2204.raw.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
-      expect(vs).to receive(:r).with("which azcopy")
-      expect(vs).to receive(:r).with("AZCOPY_CONCURRENCY_VALUE=5 azcopy copy https://images.blob.core.windows.net/images/ubuntu2204.raw\\?sp\\=r\\&st\\=2023-09-05T22:44:05Z\\&se\\=2023-10-07T06:44:05 /var/storage/images/github-ubuntu-2204.raw.tmp")
+      expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/github-ubuntu-2204.raw.tmp http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.raw\\?X-Amz-Algorithm\\=AWS4-HMAC-SHA256\\&X-Amz-Credential\\=user\\%2F20240112\\%2Fus-east-1\\%2Fs3\\%2Faws4_request\\&X-Amz-Date\\=20240112T132931Z\\&X-Amz-Expires\\=3600\\&X-Amz-SignedHeaders\\=host\\&X-Amz-Signature\\=aabbcc")
       expect(File).to receive(:rename).with("/var/storage/images/github-ubuntu-2204.raw.tmp", "/var/storage/images/github-ubuntu-2204.raw")
       expect(FileUtils).to receive(:rm_r).with("/var/storage/images/github-ubuntu-2204.raw.tmp")
 
-      vs.download_boot_image("github-ubuntu-2204", custom_url: "https://images.blob.core.windows.net/images/ubuntu2204.raw?sp=r&st=2023-09-05T22:44:05Z&se=2023-10-07T06:44:05")
+      vs.download_boot_image("github-ubuntu-2204", custom_url: "http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.raw?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240112T132931Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=aabbcc")
     end
 
     it "can use an image that's already downloaded" do

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -40,11 +40,17 @@ RSpec.describe Prog::DownloadBootImage do
       expect { dbi.download }.to nap(15)
     end
 
+    it "generates presigned URL if a custom_url not provided" do
+      expect(dbi).to receive(:frame).and_return({"image_name" => "my-image"}).at_least(:once)
+      expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, get_presigned_url: "https://minio.example.com/my-image.raw"))
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("NotStarted")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image my-image https://minio.example.com/my-image.raw' download_my-image")
+      expect { dbi.download }.to nap(15)
+    end
+
     it "waits manual intervation if it's failed" do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("Failed")
-      expect {
-        expect { dbi.download }.to nap(15)
-      }.to output("VmHost[#{vm_host.ubid}] Failed to download 'my-image' image\n").to_stdout
+      expect { dbi.download }.to raise_error RuntimeError, "Failed to download 'my-image' image on VmHost[#{vm_host.ubid}]"
     end
 
     it "waits for the download to complete" do


### PR DESCRIPTION
### Download boot image from MinIO cluster with presigned url

We decided to distribute our custom image through our internal MinIO cluster instead of Azure Blob Storage, with this commit marking the latest step in that process.

Presigned URLs are a convenient solution as they eliminate the need to send MinIO credentials to VM hosts. They expire after a specified period, enhancing their security for dataplane transmission.

If a custom URL isn't provided to the "download_boot_image" prog, it generates a presigned URL and uses it to download the image.

This approach also simplifies the process for developers to download images for GitHub runners. They only need to set the relevant configurations and initiate the download with the command `vm_host.download_boot_image("github-ubuntu-2204")`.

Initially, I considered using the `mc` client to download images from the MinIO cluster. However, it seems that the `mc` client only supports downloads using the access key and secret key, and does not support downloads with presigned URLs. I attempted to use `curl` for the download, which performed similarly to the `mc` client. Therefore, I opted for the simpler option and decided to proceed with `curl` for now.

### Remove azcopy support for downloading boot images

We don't need it any more. We download images from internal MinIO cluster.
