### PR TITLE
Revert "Freeze core classes in production"

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,3 +3,34 @@
 require_relative "loader"
 
 run(Config.development? ? Unreloader : Clover.freeze.app)
+
+freeze_core = false
+# freeze_core = !dev # Uncomment to enable refrigerator
+if freeze_core
+  begin
+    require "refrigerator"
+  rescue LoadError
+  else
+    require "tilt/sass" unless File.exist?(File.expand_path("../compiled_assets.json", __FILE__))
+
+    # When enabling refrigerator, you may need to load additional
+    # libraries before freezing the core to work correctly.  You'll
+    # want to uncomment the appropriate lines below if you run into
+    # problems after enabling refrigerator.
+
+    # rackup -s webrick
+    # require 'forwardable'
+    # require 'webrick'
+
+    # rackup -s Puma
+    # require 'yaml'
+    # Gem.ruby
+
+    # Puma (needed for state file)
+    # require 'yaml'
+
+    # Unicorn (no changes needed)
+
+    Refrigerator.freeze_core
+  end
+end

--- a/loader.rb
+++ b/loader.rb
@@ -85,8 +85,3 @@ AUTOLOAD_CONSTANTS.freeze
 if Config.production?
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
 end
-
-if Config.production?
-  require "refrigerator"
-  Refrigerator.freeze_core
-end


### PR DESCRIPTION
Alas, doesn't work.  My local model of this was inadequate. Here are error messages that one should be able to reproduce before trying again:

Web:

     Listening on http://0.0.0.0:32793
    bundler: failed to load command: puma (/app/vendor/bundle/ruby/3.2.0/bin/puma)
    /app/vendor/bundle/ruby/3.2.0/gems/nio4r-2.7.0/lib/nio/version.rb:8:in `<top (required)>': can't modify frozen #<Class:Object>: Object (FrozenError)
    from <internal:/app/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    from <internal:/app/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    from /app/vendor/bundle/ruby/3.2.0/gems/nio4r-2.7.0/lib/nio.rb:13:in `<top (required)>'
    from <internal:/app/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    from <internal:/app/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    from /app/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/lib/puma/reactor.rb:22:in `initialize'
    from /app/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/lib/puma/server.rb:248:in `new'
    from /app/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/lib/puma/server.rb:248:in `run'
    from /app/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/lib/puma/single.rb:53:in `run'
    from /app/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/lib/puma/launcher.rb:194:in `run'
    from /app/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/lib/puma/cli.rb:75:in `run'
    from /app/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/bin/puma:10:in `<top (required)>'
    from /app/vendor/bundle/ruby/3.2.0/bin/puma:25:in `load'
    from /app/vendor/bundle/ruby/3.2.0/bin/puma:25:in `<top (required)>'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/cli.rb:492:in `exec'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
    from /app/vendor/ruby-3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:45:in `block in <top (required)>'
    from /app/vendor/ruby-3.2.2/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
    from /app/vendor/ruby-3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:33:in `<top (required)>'
    from /app/vendor/bundle/bin/bundle:108:in `load'
    from /app/vendor/bundle/bin/bundle:108:in `<main>'

Respirate:

    /app/ubid.rb:5:in `<top (required)>': can't modify frozen #<Class:Object>: Object (FrozenError)
    from <internal:/app/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    from <internal:/app/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    from /app/model.rb:49:in `ubid'
    from /app/scheduling/dispatcher.rb:26:in `start_strand'
    from /app/scheduling/dispatcher.rb:68:in `block in start_cohort'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/dataset/actions.rb:162:in `block in each'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:651:in `block (2 levels) in fetch_rows'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:651:in `yield_hash_rows'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:651:in `block in fetch_rows'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:161:in `execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:532:in `_execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:348:in `block (2 levels) in execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:555:in `check_database_errors'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:348:in `block in execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/connection_pool/threaded.rb:92:in `hold'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/database/connecting.rb:293:in `synchronize'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:348:in `execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/extensions/pg_auto_parameterize.rb:213:in `execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/dataset/actions.rb:1189:in `execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/adapters/postgres.rb:651:in `fetch_rows'
    from /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.76.0/lib/sequel/dataset/actions.rb:162:in `each'
    from /app/scheduling/dispatcher.rb:67:in `start_cohort'
    from bin/respirate:20:in `block in <main>'
    from bin/respirate:19:in `loop'
    from bin/respirate:19:in `<main>'

This reverts commit bcb9ece13e8c8aee298644eda5ed019cfb72e682.