### PR TITLE
Raise file descriptor limits for hypervisor

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -543,6 +543,8 @@ ExecStop=#{CloudHypervisor::VERSION.ch_remote_bin} --api-socket #{vp.ch_api_sock
 Restart=no
 User=#{@vm_name}
 Group=#{@vm_name}
+
+LimitNOFILE=500000
 SERVICE
     r "systemctl daemon-reload"
   end


### PR DESCRIPTION
For machines with large vcpu counts (e.g. 60), we can run out of file descriptors, presumably from the amplification in their use from multiqueue tap (dc5e7670bb475e2e07a131f8f4f6fc9751cf78af).

Hadi did me a favor and both reproduced the fault and that `LimitNOFILE` setting addresses it.  Perhaps it could be adjusted to be smaller later, though, once we have some time to work out our anticipated file descriptor usage.

The crash looks like this in the journal:

    VMM thread exited with error: Error activating virtio devices: ActivateVirtioDevices(VirtioActivate(CloneExitEventFd(Os { code: 24, kind: Uncategorized, message: "Too many open files" })))