### PR TITLE
Freeze core classes in production redux

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -53,4 +53,6 @@ OptionParser.new do |opts|
   opts.on("--vm-host-id VM_HOST_ID", "Use existing vm host") { |v| options[:vm_host_id] = (v.length == 26) ? VmHost.from_ubid(v).id : v }
 end.parse!
 
+clover_freeze
+
 main(options)

--- a/bin/monitor
+++ b/bin/monitor
@@ -8,6 +8,9 @@ MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer]
 sessions = {}
 ssh_threads = {}
 pulse_threads = {}
+
+clover_freeze
+
 loop do
   resources = MONITORABLE_RESOURCE_TYPES.flat_map { _1.all }
 

--- a/bin/respirate
+++ b/bin/respirate
@@ -16,6 +16,8 @@ if Config.github_app_id
   Strand.dataset.insert_conflict.insert(id: "c39ae087-6ec4-033a-d440-b7a821061caf", schedule: Time.now, prog: "RedeliverGithubFailures", label: "wait", stack: [{last_check_at: Time.now}].to_json)
 end
 
+clover_freeze
+
 loop do
   d.start_cohort
   next if d.wait_cohort > 0

--- a/config.ru
+++ b/config.ru
@@ -2,35 +2,6 @@
 
 require_relative "loader"
 
+clover_freeze
+
 run(Config.development? ? Unreloader : Clover.freeze.app)
-
-freeze_core = false
-# freeze_core = !dev # Uncomment to enable refrigerator
-if freeze_core
-  begin
-    require "refrigerator"
-  rescue LoadError
-  else
-    require "tilt/sass" unless File.exist?(File.expand_path("../compiled_assets.json", __FILE__))
-
-    # When enabling refrigerator, you may need to load additional
-    # libraries before freezing the core to work correctly.  You'll
-    # want to uncomment the appropriate lines below if you run into
-    # problems after enabling refrigerator.
-
-    # rackup -s webrick
-    # require 'forwardable'
-    # require 'webrick'
-
-    # rackup -s Puma
-    # require 'yaml'
-    # Gem.ruby
-
-    # Puma (needed for state file)
-    # require 'yaml'
-
-    # Unicorn (no changes needed)
-
-    Refrigerator.freeze_core
-  end
-end

--- a/loader.rb
+++ b/loader.rb
@@ -19,7 +19,7 @@ Unreloader = Rack::Unreloader.new(reload: Config.development?, autoload: true) {
 Unreloader.autoload("#{__dir__}/db.rb") { "DB" }
 Unreloader.autoload("#{__dir__}/ubid.rb") { "UBID" }
 
-AUTOLOAD_CONSTANTS = []
+AUTOLOAD_CONSTANTS = ["DB", "UBID"]
 
 # Set up autoloads using Unreloader using a style much like Zeitwerk:
 # directories are modules, file names are classes.
@@ -84,4 +84,20 @@ AUTOLOAD_CONSTANTS.freeze
 
 if Config.production?
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
+end
+
+def clover_freeze
+  return unless Config.production?
+  require "refrigerator"
+
+  # Take care of library dependencies that modify core classes.
+
+  # For at least Puma, per
+  # https://github.com/jeremyevans/roda-sequel-stack/blob/931e810a802b2ab14628111cfce596998316b556/config.ru#L41C6-L42C1
+  require "yaml"
+
+  # Also for at least puma, but not itemized by the roda-sequel-stack
+  # project for some reason.
+  require "nio4r"
+  Refrigerator.freeze
 end


### PR DESCRIPTION
I could produce the faults in 5b6cf623a858615487c27af7e306f2011d1467f0
with:

    RACK_ENV=production foreman start

That's what I thought I did before to test this patch, but maybe I
typoed something.

Analyzing them, I saw that there were two problems:

1. The eager loading code for production in loader.rb is incomplete;
   some specially handled symbols need to be in the
   `AUTOLOAD_CONSTANTS` array.

2. Various entry-points (as in being in `bin` or in `config.ru`) had
   varying set-up requirements before freezing.

The second problem is tricky.  The option I elected for here is to
require every entry point (so everything in `bin` plus something that
hooks into `puma`'s invocation) to be cognizent of when to freeze.  In
at least one case, `bin/pry`, I elected not to freeze.

An alternative, which perhaps is feasible but needs more research,
would be to insist that `bin` entry points do not make any
modifications to Object, forcing them to push most of their logic into
autoloaded symbols.  That is a plausible programming rule but should
be tried before we commit to it.  Since I don't have time for that,
I'm opting for the more invasive approach to keep the code more
undisturbed.
