### PR TITLE
Firewall rules UI

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -57,7 +57,8 @@ module Authorization
         {subjects: [subject], actions: ["Vm:view", "Vm:create", "Vm:delete"], objects: [object]},
         {subjects: [subject], actions: ["Vm:Firewall:view", "Vm:Firewall:edit"], objects: [object]},
         {subjects: [subject], actions: ["PrivateSubnet:view", "PrivateSubnet:create", "PrivateSubnet:delete", "PrivateSubnet:nic"], objects: [object]},
-        {subjects: [subject], actions: ["Postgres:view", "Postgres:create", "Postgres:delete"], objects: [object]}
+        {subjects: [subject], actions: ["Postgres:view", "Postgres:create", "Postgres:delete"], objects: [object]},
+        {subjects: [subject], actions: ["Postgres:Firewall:view", "Postgres:Firewall:edit"], objects: [object]}
       ]
     }
   end

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -55,6 +55,7 @@ module Authorization
       acls: [
         {subjects: [subject], actions: ["Project:view", "Project:delete", "Project:user", "Project:policy", "Project:billing", "Project:github"], objects: [object]},
         {subjects: [subject], actions: ["Vm:view", "Vm:create", "Vm:delete"], objects: [object]},
+        {subjects: [subject], actions: ["Vm:Firewall:view", "Vm:Firewall:edit"], objects: [object]},
         {subjects: [subject], actions: ["PrivateSubnet:view", "PrivateSubnet:create", "PrivateSubnet:delete", "PrivateSubnet:nic"], objects: [object]},
         {subjects: [subject], actions: ["Postgres:view", "Postgres:create", "Postgres:delete"], objects: [object]}
       ]

--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -4,7 +4,7 @@ class CloverWeb
   hash_branch(:project_location_prefix, "vm") do |r|
     @serializer = Serializers::Web::Vm
 
-    r.is String do |vm_name|
+    r.on String do |vm_name|
       vm = @project.vms_dataset.where(location: @location).where { {Sequel[:vm][:name] => vm_name} }.first
 
       unless vm
@@ -18,6 +18,41 @@ class CloverWeb
         @vm = serialize(vm, :detailed)
 
         view "vm/show"
+      end
+
+      r.on "firewall-rule" do
+        r.post true do
+          Authorization.authorize(@current_user.id, "Vm:Firewall:edit", vm.id)
+
+          port_range = if r.params["port_range"].empty?
+            [0, 65535]
+          else
+            r.params["port_range"].split("..").map(&:to_i)
+          end
+
+          pg_range = Sequel.pg_range(port_range.first..port_range.last)
+
+          vm.firewalls.first.insert_firewall_rule(r.params["cidr"], pg_range)
+          flash["notice"] = "Firewall rule is created"
+
+          r.redirect "#{@project.path}#{vm.path}"
+        end
+
+        r.is String do |firewall_rule_ubid|
+          r.delete true do
+            Authorization.authorize(@current_user.id, "Vm:Firewall:edit", vm.id)
+            fwr = FirewallRule.from_ubid(firewall_rule_ubid)
+            unless fwr
+              response.status = 404
+              r.halt
+            end
+
+            fwr.destroy
+            vm.incr_update_firewall_rules
+
+            return {message: "Firewall rule deleted"}.to_json
+          end
+        end
       end
 
       r.delete true do

--- a/serializers/web/firewall.rb
+++ b/serializers/web/firewall.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Serializers::Web::Firewall < Serializers::Base
+  def self.base(firewall)
+    {
+      id: firewall.id,
+      name: firewall.name,
+      description: firewall.description,
+      firewall_rules: firewall.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Web::FirewallRule.serialize(fw) }
+    }
+  end
+
+  structure(:default) do |firewall|
+    base(firewall)
+  end
+end

--- a/serializers/web/firewall_rule.rb
+++ b/serializers/web/firewall_rule.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Serializers::Web::FirewallRule < Serializers::Base
+  def self.base(firewall_rule)
+    {
+      id: firewall_rule.id,
+      ubid: firewall_rule.ubid,
+      cidr: firewall_rule.cidr,
+      port_range: firewall_rule.port_range&.begin ? "#{firewall_rule.port_range.begin}..#{firewall_rule.port_range.end - 1}" : "0..65535"
+    }
+  end
+
+  structure(:default) do |firewall_rule|
+    base(firewall_rule)
+  end
+end

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -21,7 +21,8 @@ class Serializers::Web::Postgres < Serializers::Base
   structure(:detailed) do |pg|
     base(pg).merge({
       connection_string: pg.connection_string,
-      primary?: pg.server&.primary?
+      primary?: pg.server&.primary?,
+      firewall_rules: pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Web::PostgresFirewallRule.serialize(fw) }
     }).merge((pg.timeline && pg.server && pg.server.primary?) ? {
       earliest_restore_time: pg.timeline.earliest_restore_time&.utc&.iso8601,
       latest_restore_time: pg.timeline.latest_restore_time&.utc&.iso8601

--- a/serializers/web/postgres_firewall_rule.rb
+++ b/serializers/web/postgres_firewall_rule.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Serializers::Web::PostgresFirewallRule < Serializers::Base
+  def self.base(postgres_firewall_rule)
+    {
+      id: postgres_firewall_rule.id,
+      ubid: postgres_firewall_rule.ubid,
+      cidr: postgres_firewall_rule.cidr
+    }
+  end
+
+  structure(:default) do |postgres_firewall_rule|
+    base(postgres_firewall_rule)
+  end
+end

--- a/serializers/web/vm.rb
+++ b/serializers/web/vm.rb
@@ -25,7 +25,8 @@ class Serializers::Web::Vm < Serializers::Base
   structure(:detailed) do |vm|
     base(vm).merge(
       {
-        nics: vm.nics.map { |nic| Serializers::Web::Nic.serialize(nic) }
+        nics: vm.nics.map { |nic| Serializers::Web::Nic.serialize(nic) },
+        firewalls: vm.firewalls.map { |fw| Serializers::Web::Firewall.serialize(fw) }
       }
     )
   end

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Clover, "billing" do
       visit "#{project.path}/billing"
 
       # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
-      # UI tests run without a JavaScript enginer.
+      # UI tests run without a JavaScript engine.
       btn = find "#payment-method-#{payment_method.ubid} .delete-btn"
       page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -121,6 +121,79 @@
       </div>
     </div>
   <% end %>
+  <!-- Firewall Rules Card -->
+  <% if Authorization.has_permission?(@current_user.id, "Postgres:Firewall:view", @pg[:id]) %>
+    <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          Firewall Rules
+        </h3>
+      </div>
+    </div>
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Port Range</th>
+            <% if Authorization.has_permission?(@current_user.id, "Postgres:Firewall:edit", @pg[:id]) %>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @pg[:firewall_rules].each do |fwr| %>
+            <tr>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432</td>
+              <% if Authorization.has_permission?(@current_user.id, "Postgres:Firewall:edit", @pg[:id]) %>
+                <td
+                  id="fwr-delete-<%=fwr[:ubid]%>"
+                  class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+                >
+                  <button
+                    type="button"
+                    data-url="<%= "#{request.path}/firewall-rule/#{fwr[:ubid]}" %>"
+                    data-csrf="<%= csrf_token("#{request.path}/firewall-rule/#{fwr[:ubid]}", "DELETE") %>"
+                    data-redirect="<%= request.path.to_s %>"
+                    class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
+                  >
+                    <%== render("components/icon", locals: { name: "hero-trash", classes: "h-5 w-5" }) %>
+                  </button>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+          <% if Authorization.has_permission?(@current_user.id, "Postgres:Firewall:edit", @pg[:id]) %>
+            <tr>
+              <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST">
+                <%== csrf_tag("#{request.path}/firewall-rule") %>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  <%== render(
+                    "components/form/text",
+                    locals: {
+                      name: "cidr",
+                      type: "cidr",
+                      attributes: {
+                        placeholder: "0.0.0.0/0",
+                        required: true
+                      }
+                    }
+                  ) %>
+                </td>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  5432
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <%== render("components/form/submit_button", locals: { text: "Create" }) %>
+                </td>
+              </form>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
   <!-- Delete Card -->
   <% if Authorization.has_permission?(@current_user.id, "Postgres:delete", @pg[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
@@ -132,7 +205,7 @@
               <p>This action will permanently delete this PostgreSQL database.</p>
             </div>
           </div>
-          <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+          <div id="postgres-delete-<%=@pg[:ubid]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <%== render(
               "components/delete_button",
               locals: {

--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -123,6 +123,14 @@
               <td class="px-2 py-2 border">Postgres:delete</td>
               <td class="px-2 py-2 border">Grants permission to delete PostgreSQL database.</td>
             </tr>
+            <tr>
+              <td class="px-2 py-2 border">Postgres:Firewall:view</td>
+              <td class="px-2 py-2 border">Grants permission to view PostgreSQL database firewall rules.</td>
+            </tr>
+            <tr>
+              <td class="px-2 py-2 border">Postgres:Firewall:edit</td>
+              <td class="px-2 py-2 border">Grants permission to create/delete PostgreSQL database firewall rules.</td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -64,6 +64,14 @@
               <td class="px-2 py-2 border">Grants permission to delete Vm</td>
             </tr>
             <tr>
+              <td class="px-2 py-2 border">Vm:Firewall:view</td>
+              <td class="px-2 py-2 border">Grants permission to view Vm Firewall rules</td>
+            </tr>
+            <tr>
+              <td class="px-2 py-2 border">Vm:Firewall:edit</td>
+              <td class="px-2 py-2 border">Grants permission to create or delete Vm firewall rules</td>
+            </tr>
+            <tr>
               <td class="px-2 py-2 border">Project:view</td>
               <td class="px-2 py-2 border">Grants permission to view Project details</td>
             </tr>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -82,6 +82,81 @@
       </tbody>
     </table>
   </div>
+  <!-- Firewall Rules Card -->
+  <% if Authorization.has_permission?(@current_user.id, "Vm:Firewall:view", @vm[:id]) && @vm[:state] != "creating" %>
+    <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          Firewall Rules
+        </h3>
+      </div>
+    </div>
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Port Range</th>
+            <% if Authorization.has_permission?(@current_user.id, "Vm:Firewall:edit", @vm[:id]) %>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @vm[:firewalls].each do |fw| %>
+            <% fw[:firewall_rules].each do |fwr| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:port_range] %></td>
+                <% if Authorization.has_permission?(@current_user.id, "Vm:Firewall:edit", @vm[:id]) %>
+                  <td
+                    id="fwr-delete-<%=fwr[:ubid]%>"
+                    class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+                  >
+                    <button
+                      type="button"
+                      data-url="<%= "#{request.path}/firewall-rule/#{fwr[:ubid]}" %>"
+                      data-csrf="<%= csrf_token("#{request.path}/firewall-rule/#{fwr[:ubid]}", "DELETE") %>"
+                      data-redirect="<%= request.path.to_s %>"
+                      class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
+                    >
+                      <%== render("components/icon", locals: { name: "hero-trash", classes: "h-5 w-5" }) %>
+                    </button>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+          <% end %>
+          <% if Authorization.has_permission?(@current_user.id, "Vm:Firewall:edit", @vm[:id]) %>
+            <tr>
+              <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST">
+                <%== csrf_tag("#{request.path}/firewall-rule") %>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  <%== render(
+                    "components/form/text",
+                    locals: {
+                      name: "cidr",
+                      type: "cidr",
+                      attributes: {
+                        placeholder: "0.0.0.0/0",
+                        required: true
+                      }
+                    }
+                  ) %>
+                </td>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  <%== render("components/form/text", locals: { name: "port_range", type: "text", attributes: { placeholder: "0..65536" } }) %>
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <%== render("components/form/submit_button", locals: { text: "Create" }) %>
+                </td>
+              </form>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
   <!-- Delete Card -->
   <% if Authorization.has_permission?(@current_user.id, "Vm:delete", @vm[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
@@ -94,7 +169,7 @@
                 carefully.</p>
             </div>
           </div>
-          <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+          <div id="vm-delete-<%=@vm[:ubid]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <button
               type="button"
               data-url="<%= request.path %>"

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -1,5 +1,7 @@
 <% @page_title = @vm[:name] %>
-<div class="auto-refresh hidden" data-interval="10"></div>
+<% if @vm[:state] != "running" %>
+  <div class="auto-refresh hidden" data-interval="10"></div>
+<% end %>
 
 <div class="space-y-1">
   <%== render(


### PR DESCRIPTION
here we go;
<img width="3002" alt="Screenshot 2024-01-23 at 15 10 19" src="https://github.com/ubicloud/ubicloud/assets/6233557/d51679bb-8cae-4593-8446-1aebe5617de2">

<img width="3001" alt="Screenshot 2024-01-23 at 15 09 28" src="https://github.com/ubicloud/ubicloud/assets/6233557/d6612339-1038-4e4a-aec2-99c66dd4314f">


**VM firewall rules view**
This commit implements the UI components of the firewalls for VMs. We
keep it minimal and not make it a part of the provisioning path. The VM
comes with 2 default firewall rules anyway, we simply visualize them in
the detailed VM view and allow customer to add new firewall rules or
delete existing ones.

**Do not auto-refresh if VM is already running** 
We keep auto refreshing the VM page even after the VM is provisioned and
in running state. This was initially introduced to give an update about
the statues of provisitioning at the start. However, keeping it
refreshing even after the provisioning is finished is creating a funny
situation. When we try to write a cidr value to create a new firewall
rule, if we're not fast enough, the page refreshes and the firewall rule
definition that we wanted to create gets lost. This commit simply checks
the VM[:state] and if it is running, we do not refresh.

**PostgreSQL firewall rules UI implementation** 
We introduce the new UI components to support firewall rules for
postgres.