### PR TITLE
Allow to change subject_id while pushing

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -156,7 +156,7 @@ end
   def push(prog, new_frame = {}, label = "start")
     old_prog = strand.prog
     old_label = strand.label
-    new_frame = new_frame.merge("subject_id" => @subject_id, "link" => [strand.prog, old_label])
+    new_frame = {"subject_id" => @subject_id, "link" => [strand.prog, old_label]}.merge(new_frame)
 
     fail Hop.new(old_prog, old_label,
       {prog: Strand.prog_verify(prog), label: label,

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -112,4 +112,8 @@ class Prog::Test < Prog::Base
   label def bad_pop
     pop nil
   end
+
+  label def push_subject_id
+    push Prog::Test, {"subject_id" => "70b633b7-1d24-4526-a47f-d2580597d53f"}
+  end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe Prog::Base do
     expect(post - ante).to be > 121
   end
 
+  it "can push new subject_id" do
+    st = Strand.create_with_id(prog: "Test", label: "push_subject_id")
+    st.run
+    expect(st.stack.first["subject_id"]).not_to eq(st.id)
+  end
+
   it "requires a symbol for hop" do
     expect {
       Strand.new(prog: "Test", label: "invalid_hop").unsynchronized_run


### PR DESCRIPTION
The `merge` operation overwrites the value of the existing key. Even if we set `subject_id` in `new_frame`, it gets overwritten by the current strand's id.

For instance, suppose you wish to install rhizome on a VM host from a strand other than `HostNexus`. You might call `push Prog::InstallRhizome, {"subject_id" => vm_host.id}`. However, this `subject_id` becomes irrelevant, as it's overwritten by the current strand's id.

This PR allows the modification of `subject_id` in the new frame.