### PR TITLE
Project Delete API with error handling simplification

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 module Authorization
-  class Unauthorized < StandardError; end
+  class Unauthorized < CloverError
+    def initialize
+      super(403, "Forbidden", "Sorry, you don't have permission to continue with this request.")
+    end
+  end
 
   def self.has_permission?(subject_id, actions, object_id)
     !matched_policies(subject_id, actions, object_id).empty?

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -3,11 +3,9 @@
 require "time"
 
 module Validation
-  class ValidationFailed < StandardError
-    attr_reader :errors
-    def initialize(errors)
-      @errors = errors
-      super("Validation failed for following fields: #{errors.keys.join(", ")}")
+  class ValidationFailed < CloverError
+    def initialize(details)
+      super(400, "Invalid request", "Validation failed for following fields: #{details.keys.join(", ")}", details)
     end
   end
 

--- a/loader.rb
+++ b/loader.rb
@@ -77,7 +77,7 @@ autoload_normal = ->(subdirectory, include_first: false, flat: false) do
 end
 
 autoload_normal.call("model", flat: true)
-%w[lib clover.rb clover_web.rb clover_api.rb routes/clover_base.rb].each { autoload_normal.call(_1) }
+%w[lib clover.rb clover_web.rb clover_api.rb routes/clover_base.rb routes/clover_error.rb].each { autoload_normal.call(_1) }
 %w[scheduling prog serializers serializers/web serializers/api].each { autoload_normal.call(_1, include_first: true) }
 
 AUTOLOAD_CONSTANTS.freeze

--- a/model/project.rb
+++ b/model/project.rb
@@ -41,6 +41,10 @@ class Project < Sequel::Model
     "/project/#{ubid}"
   end
 
+  def has_resources
+    access_tags_dataset.exclude(hyper_tag_table: [Account.table_name.to_s, Project.table_name.to_s, AccessTag.table_name.to_s]).count > 0
+  end
+
   def soft_delete
     DB.transaction do
       access_tags_dataset.destroy

--- a/model/project.rb
+++ b/model/project.rb
@@ -41,6 +41,18 @@ class Project < Sequel::Model
     "/project/#{ubid}"
   end
 
+  def soft_delete
+    DB.transaction do
+      access_tags_dataset.destroy
+      access_policies_dataset.destroy
+
+      # We still keep the project object for billing purposes.
+      # These need to be cleaned up manually once in a while.
+      # Don't forget to clean up billing info and payment methods.
+      update(visible: false)
+    end
+  end
+
   def current_invoice
     begin_time = invoices.first&.end_time || Time.new(Time.now.year, Time.now.month, 1)
     end_time = Time.now

--- a/routes/clover_base.rb
+++ b/routes/clover_base.rb
@@ -50,19 +50,15 @@ module CloverBase
       code = 400
       title = "Invalid request"
       message = e.to_s
-    when Validation::ValidationFailed
-      code = 400
-      title = "Invalid request"
-      message = "Failed validations"
-      details = e.errors
     when Roda::RodaPlugins::RouteCsrf::InvalidToken
       code = 419
       title = "Invalid Security Token"
       message = "An invalid security token was submitted with this request, and this request could not be processed."
-    when Authorization::Unauthorized
-      code = 403
-      title = "Forbidden"
-      message = "Sorry, you don't have permission to continue with this request."
+    when CloverError
+      code = e.code
+      title = e.title
+      message = e.message
+      details = e.details
     else
       $stderr.print "#{e.class}: #{e.message}\n"
       warn e.backtrace

--- a/routes/clover_error.rb
+++ b/routes/clover_error.rb
@@ -11,3 +11,11 @@ class CloverError < StandardError
     super(message)
   end
 end
+
+# Add here instead of routes/project.rb as it will be used by other APIs as well
+# TODO: Remove the comment once another API use it
+class DependencyError < CloverError
+  def initialize(message)
+    super(409, "Dependency Error", message)
+  end
+end

--- a/routes/clover_error.rb
+++ b/routes/clover_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CloverError < StandardError
+  attr_reader :code, :title, :message, :details
+  def initialize(code, title, message, details = nil)
+    @code = code
+    @title = title
+    @message = message
+    @details = details
+
+    super(message)
+  end
+end

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -57,7 +57,7 @@ class CloverWeb
         Authorization.authorize(@current_user.id, "Project:delete", @project.id)
 
         # If it has some resources, do not allow to delete it.
-        if @project.access_tags_dataset.exclude(hyper_tag_table: [Account.table_name.to_s, Project.table_name.to_s, AccessTag.table_name.to_s]).count > 0
+        if @project.has_resources
           flash["error"] = "'#{@project.name}' project has some resources. Delete all related resources first."
           return {message: "'#{@project.name}' project has some resources. Delete all related resources first."}.to_json
         end

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -62,16 +62,7 @@ class CloverWeb
           return {message: "'#{@project.name}' project has some resources. Delete all related resources first."}.to_json
         end
 
-        DB.transaction do
-          @project.access_tags.each { |access_tag| access_tag.applied_tags_dataset.destroy }
-          @project.access_tags_dataset.destroy
-          @project.access_policies_dataset.destroy
-
-          # We still keep the project object for billing purposes.
-          # These need to be cleaned up manually once in a while.
-          # Don't forget to clean up billing info and payment methods.
-          @project.update(visible: false)
-        end
+        @project.soft_delete
 
         flash["notice"] = "'#{@project.name}' project is deleted."
         return {message: "'#{@project.name}' project is deleted."}.to_json

--- a/serializers/api/project.rb
+++ b/serializers/api/project.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-require_relative "../base"
-
 class Serializers::Api::Project < Serializers::Base
   def self.base(p)
     {
-      id: p.ubid,
-      name: p.name
+      ubid: p.ubid,
+      path: p.path,
+      name: p.name,
+      credit: p.credit.to_f,
+      discount: p.discount,
+      provider: p.provider
     }
   end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Clover, "vm" do
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
     end
+
+    it "not delete" do
+      delete "api/project/#{project.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
   end
 
   describe "authenticated" do
@@ -47,6 +54,42 @@ RSpec.describe Clover, "vm" do
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-project")
+      end
+    end
+
+    describe "delete" do
+      it "success" do
+        delete "api/project/#{project.ubid}"
+
+        expect(last_response.status).to eq(204)
+
+        expect(Project[project.id].visible).to be_falsey
+        expect(AccessTag.where(project_id: project.id).count).to eq(0)
+        expect(AccessPolicy.where(project_id: project.id).count).to eq(0)
+      end
+
+      it "success with non-existing project" do
+        delete "api/project/non_existing_id"
+
+        expect(last_response.status).to eq(204)
+      end
+
+      it "can not delete project when it has resources" do
+        Prog::Vm::Nexus.assemble("key", project.id, name: "vm1")
+
+        delete "api/project/#{project.ubid}"
+
+        expect(last_response.status).to eq(409)
+        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("'#{project.name}' project has some resources. Delete all related resources first.")
+      end
+
+      it "not authorized" do
+        u = create_account("test@test.com")
+        p = u.create_project_with_default_policy("project-1")
+        delete "api/project/#{p.ubid}"
+
+        expect(last_response.status).to eq(403)
+        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, you don't have permission to continue with this request.")
       end
     end
 


### PR DESCRIPTION
Add project delete endpoint to api together with simplifying error handling and project model checks.

- Add `has_resources` and `soft_delete` methods to the project model to simplify operations on routing codes. 
- Add base CloverError class for the errors faced within routing code
- Add delete API endpoint for the project