### PR TITLE
Wait for completion of restart during unavailabilities

### DIFF
--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -121,14 +121,15 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   label def unavailable
     register_deadline(:wait, 10 * 60)
 
+    reap
+    nap 5 unless strand.children.select { _1.prog == "Minio::MinioServerNexus" && _1.label == "minio_restart" }.empty?
+
     if available?
       decr_checkup
-      strand.children.select { _1.prog == "Minio::MinioServerNexus" && _1.label == "minio_restart" }.each(&:destroy)
       hop_wait
     end
 
-    reap
-    bud self.class, frame, :minio_restart if leaf?
+    bud self.class, frame, :minio_restart
     nap 5
   end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -232,14 +232,15 @@ SQL
   label def unavailable
     register_deadline(:wait, 10 * 60)
 
+    reap
+    nap 5 unless strand.children.select { _1.prog == "Postgres::PostgresServerNexus" && _1.label == "restart" }.empty?
+
     if available?
       decr_checkup
-      strand.children.select { _1.prog == "Postgres::PostgresServerNexus" && _1.label == "restart" }.each(&:destroy)
       hop_wait
     end
 
-    reap
-    bud self.class, frame, :restart if leaf?
+    bud self.class, frame, :restart
     nap 5
   end
 

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     end
 
     it "does not bud minio_restart if there is already one restart going on" do
-      expect(nx).to receive(:available?).and_return(false).twice
+      expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(5)
       expect(nx).not_to receive(:bud).with(described_class, {}, :minio_restart)
       expect { nx.unavailable }.to nap(5)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "does not bud restart if there is already one restart going on" do
-      expect(nx).to receive(:available?).and_return(false).twice
+      expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(5)
       expect(nx).not_to receive(:bud).with(described_class, {}, :restart)
       expect { nx.unavailable }.to nap(5)


### PR DESCRIPTION
Previous way of canceling the restart was hazardous. Because, after we start
the restart process, there is no guarantee that it can be cancelled safely.
Even if we destroy the child strand, restart could continue depending on at
which point it is at the time of the cancellation. It is more predictable to
wait for restart's completion and then switching to wait state. This approach
does not increase unavailability, in fact it could decrease slightly, but it
can increase the duration that we consider ourselves unavailable.