### PR TITLE
Small improvements for preparing PostgreSQL HA

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -37,6 +37,12 @@ loop do
         pulse = r.check_pulse(session: sessions[r.id], previous_pulse: pulse) if sessions[r.id]
         Clog.emit("Got new pulse") { {got_pulse: {ubid: r.ubid, pulse: pulse}} }
         sleep r.monitoring_interval
+      rescue RuntimeError, IOError => ex
+        Clog.emit("Pulse checking is failed") { {pulse_check_failure: {ubid: r.ubid, exception: Util.exception_to_hash(ex)}} }
+        sleep r.monitoring_interval
+      rescue => ex
+        Clog.emit("Pulse checking is failed permanently!") { {pulse_check_failure: {ubid: r.ubid, exception: Util.exception_to_hash(ex)}} }
+        raise
       end
     end
   end

--- a/config.rb
+++ b/config.rb
@@ -110,7 +110,7 @@ module Config
   optional :postgres_service_project_id, string
   override :postgres_service_hostname, "postgres.ubicloud.com", string
   optional :postgres_service_blob_storage_access_key, string
-  optional :postgres_service_blob_storage_secret_key, string
+  optional :postgres_service_blob_storage_secret_key, string, clear: true
   optional :postgres_service_blob_storage_id, string
 
   # Logging

--- a/config.rb
+++ b/config.rb
@@ -108,7 +108,7 @@ module Config
 
   # Postgres
   optional :postgres_service_project_id, string
-  optional :postgres_service_hostname, string
+  override :postgres_service_hostname, "postgres.ubicloud.com", string
   optional :postgres_service_blob_storage_access_key, string
   optional :postgres_service_blob_storage_secret_key, string
   optional :postgres_service_blob_storage_id, string

--- a/model.rb
+++ b/model.rb
@@ -123,12 +123,12 @@ module ResourceMethods
 end
 
 module HealthMonitorMethods
-  def aggregate_readings(previous_pulse:, reading:)
+  def aggregate_readings(previous_pulse:, reading:, data: {})
     {
       reading: reading,
       reading_rpt: (previous_pulse[:reading] == reading) ? previous_pulse[:reading_rpt] + 1 : 1,
       reading_chg: (previous_pulse[:reading] == reading) ? previous_pulse[:reading_chg] : Time.now
-    }
+    }.merge(data)
   end
 
   def monitoring_interval

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -8,11 +8,6 @@ class GithubRunner < Sequel::Model
   one_to_one :vm, key: :id, primary_key: :vm_id
 
   include ResourceMethods
-
-  def self.redacted_columns
-    super + [:workflow_job]
-  end
-
   include SemaphoreMethods
   semaphore :destroy
 
@@ -26,5 +21,9 @@ class GithubRunner < Sequel::Model
 
   def runner_url
     "http://github.com/#{repository_name}/settings/actions/runners/#{runner_id}" if runner_id
+  end
+
+  def self.redacted_columns
+    super + [:workflow_job]
   end
 end

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -13,11 +13,6 @@ class MinioCluster < Sequel::Model
   many_to_one :private_subnet, key: :private_subnet_id
 
   include ResourceMethods
-
-  def self.redacted_columns
-    super + [:root_cert_1, :root_cert_2]
-  end
-
   include SemaphoreMethods
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
@@ -78,5 +73,9 @@ class MinioCluster < Sequel::Model
 
   def root_certs
     root_cert_1.to_s + root_cert_2.to_s
+  end
+
+  def self.redacted_columns
+    super + [:root_cert_1, :root_cert_2]
   end
 end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -14,11 +14,6 @@ class MinioServer < Sequel::Model
   dataset_module Authorization::Dataset
 
   include ResourceMethods
-
-  def self.redacted_columns
-    super + [:cert]
-  end
-
   include SemaphoreMethods
   include HealthMonitorMethods
 
@@ -91,5 +86,9 @@ class MinioServer < Sequel::Model
       socket: socket,
       ssl_ca_file_data: cluster.root_certs
     )
+  end
+
+  def self.redacted_columns
+    super + [:cert]
   end
 end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -43,7 +43,7 @@ class PostgresResource < Sequel::Model
   end
 
   def hostname
-    if Config.postgres_service_hostname
+    if PostgresResource.dns_zone
       "#{name}.#{Config.postgres_service_hostname}"
     else
       server&.vm&.ephemeral_net4&.to_s
@@ -52,6 +52,10 @@ class PostgresResource < Sequel::Model
 
   def connection_string
     URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s if hostname
+  end
+
+  def self.dns_zone
+    @@dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
   end
 
   def self.redacted_columns

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -15,11 +15,6 @@ class PostgresResource < Sequel::Model
   dataset_module Authorization::Dataset
 
   include ResourceMethods
-
-  def self.redacted_columns
-    super + [:root_cert_1, :root_cert_2, :server_cert]
-  end
-
   include SemaphoreMethods
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
@@ -57,5 +52,9 @@ class PostgresResource < Sequel::Model
 
   def connection_string
     URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s if hostname
+  end
+
+  def self.redacted_columns
+    super + [:root_cert_1, :root_cert_2, :server_cert]
   end
 end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -13,7 +13,7 @@ class PostgresServer < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
 
-  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup, :destroy, :update_firewall_rules
+  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup, :configure, :update_firewall_rules, :destroy
 
   def configure_hash
     configs = {

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -36,6 +36,7 @@ class PostgresServer < Sequel::Model
       tcp_keepalives_interval: "2",
       ssl: "on",
       ssl_min_protocol_version: "TLSv1.3",
+      ssl_ca_file: "'/dat/16/data/ca.crt'",
       ssl_cert_file: "'/dat/16/data/server.crt'",
       ssl_key_file: "'/dat/16/data/server.key'",
       log_timezone: "'UTC'",

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -18,11 +18,6 @@ class Vm < Sequel::Model
   dataset_module Authorization::Dataset
 
   include ResourceMethods
-
-  def self.redacted_columns
-    super + [:public_key]
-  end
-
   include SemaphoreMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules
 
@@ -156,5 +151,9 @@ class Vm < Sequel::Model
 
   def storage_encrypted?
     vm_storage_volumes.all? { !_1.key_encryption_key_1_id.nil? }
+  end
+
+  def self.redacted_columns
+    super + [:public_key]
   end
 end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -74,7 +74,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def create_dns_record
-    dns_zone&.insert_record(record_name: postgres_resource.hostname, type: "A", ttl: 10, data: server.vm.ephemeral_net4.to_s)
+    PostgresResource.dns_zone&.insert_record(record_name: postgres_resource.hostname, type: "A", ttl: 10, data: server.vm.ephemeral_net4.to_s)
     hop_initialize_certificates
   end
 
@@ -168,15 +168,11 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       nap 5
     end
 
-    dns_zone&.delete_record(record_name: postgres_resource.hostname)
+    PostgresResource.dns_zone&.delete_record(record_name: postgres_resource.hostname)
     postgres_resource.dissociate_with_project(postgres_resource.project)
     postgres_resource.destroy
 
     pop "postgres resource is deleted"
-  end
-
-  def dns_zone
-    @@dns_zone ||= DnsZone.where(project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname).first
   end
 
   def create_server_certificate

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -125,6 +125,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   label def refresh_certificates
     decr_refresh_certificates
 
+    ca_bundle = [postgres_server.resource.root_cert_1, postgres_server.resource.root_cert_2].join("\n")
+    vm.sshable.cmd("sudo -u postgres tee /dat/16/data/ca.crt > /dev/null", stdin: ca_bundle)
     vm.sshable.cmd("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: postgres_server.resource.server_cert)
     vm.sshable.cmd("sudo -u postgres tee /dat/16/data/server.key > /dev/null", stdin: postgres_server.resource.server_cert_key)
     vm.sshable.cmd("sudo -u postgres chmod 600 /dat/16/data/server.key")

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -125,6 +125,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   label def refresh_certificates
     decr_refresh_certificates
 
+    nap 5 if postgres_server.resource.server_cert.nil?
+
     ca_bundle = [postgres_server.resource.root_cert_1, postgres_server.resource.root_cert_2].join("\n")
     vm.sshable.cmd("sudo -u postgres tee /dat/16/data/ca.crt > /dev/null", stdin: ca_bundle)
     vm.sshable.cmd("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: postgres_server.resource.server_cert)

--- a/rhizome/postgres/bin/initialize-database-from-backup
+++ b/rhizome/postgres/bin/initialize-database-from-backup
@@ -10,6 +10,11 @@ end
 backup_label = ARGV[0]
 
 r "chown postgres /dat"
+
+# Below commands are required for idempotency
+r "rm -rf /dat/16"
+r "rm -rf /etc/postgresql/16"
+
 r "sudo -u postgres wal-g backup-fetch /dat/16/data #{backup_label} --config /etc/postgresql/wal-g.env"
 
 # We want to use pg_createcluster, even with an existing database folder because

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -4,4 +4,9 @@
 require_relative "../../common/lib/util"
 
 r "chown postgres /dat"
+
+# Below commands are required for idempotency
+r "rm -rf /dat/16"
+r "rm -rf /etc/postgresql/16"
+
 r "pg_createcluster 16 main"

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PostgresResource do
   }
 
   it "returns connection string" do
-    expect(Config).to receive(:postgres_service_hostname).and_return("postgres.ubicloud.com").at_least(:once)
+    expect(described_class).to receive(:dns_zone).and_return("something").at_least(:once)
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.postgres.ubicloud.com")
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe PostgresServer do
         tcp_keepalives_interval: "2",
         ssl: "on",
         ssl_min_protocol_version: "TLSv1.3",
+        ssl_ca_file: "'/dat/16/data/ca.crt'",
         ssl_cert_file: "'/dat/16/data/server.crt'",
         ssl_key_file: "'/dat/16/data/server.key'",
         log_timezone: "'UTC'",

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -172,14 +172,14 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 5, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 10, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
-      expect(nx).to receive(:create_server_certificate).and_call_original
+      expect(nx).to receive(:create_certificate).and_call_original
 
       expect { nx.initialize_certificates }.to hop("wait_server")
     end
 
     it "naps if there are children" do
       expect(Util).to receive(:create_root_certificate).twice
-      expect(nx).to receive(:create_server_certificate)
+      expect(nx).to receive(:create_certificate)
       expect(nx).to receive(:leaf?).and_return(false)
       expect { nx.initialize_certificates }.to nap(5)
     end
@@ -200,7 +200,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(OpenSSL::X509::Certificate).to receive(:new).with("root cert 1").and_return(instance_double(OpenSSL::X509::Certificate, not_after: Time.now + 60 * 60 * 24 * 365 * 4))
       expect(OpenSSL::X509::Certificate).to receive(:new).with("server cert").and_return(instance_double(OpenSSL::X509::Certificate, not_after: Time.now + 60 * 60 * 24 * 29))
 
-      expect(nx).to receive(:create_server_certificate)
+      expect(nx).to receive(:create_certificate)
       expect(postgres_resource.server).to receive(:incr_refresh_certificates)
 
       expect { nx.refresh_certificates }.to hop("wait")

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -146,12 +146,12 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(postgres_resource).to receive(:hostname).and_return("pg-name.postgres.ubicloud.com.")
       dns_zone = instance_double(DnsZone)
       expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "A", ttl: 10, data: "1.1.1.1")
-      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(PostgresResource).to receive(:dns_zone).and_return(dns_zone)
       expect { nx.create_dns_record }.to hop("initialize_certificates")
     end
 
     it "hops even if dns zone is not configured" do
-      expect(nx).to receive(:dns_zone).and_return(nil)
+      expect(PostgresResource).to receive(:dns_zone).and_return(nil)
       expect { nx.create_dns_record }.to hop("initialize_certificates")
     end
   end
@@ -168,7 +168,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       )
 
       expect(nx).to receive(:postgres_resource).and_return(postgres_resource).at_least(:once)
-      expect(Config).to receive(:postgres_service_hostname).and_return("postgres.ubicloud.com").at_least(:once)
+      expect(PostgresResource).to receive(:dns_zone).and_return("something").at_least(:once)
 
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 5, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 10, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
@@ -276,7 +276,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   describe "#destroy" do
     it "triggers server deletion and waits until it is deleted" do
       dns_zone = instance_double(DnsZone)
-      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(PostgresResource).to receive(:dns_zone).and_return(dns_zone)
 
       expect(postgres_resource.server).to receive(:incr_destroy)
       expect { nx.destroy }.to nap(5)
@@ -291,19 +291,10 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "completes destroy even if dns zone is not configured" do
-      expect(nx).to receive(:dns_zone).and_return(nil)
+      expect(PostgresResource).to receive(:dns_zone).and_return(nil)
       expect(postgres_resource).to receive(:server).and_return(nil)
 
       expect { nx.destroy }.to exit({"msg" => "postgres resource is deleted"})
-    end
-  end
-
-  describe "#dns_zone" do
-    it "fetches dns zone from database only once" do
-      expect(DnsZone).to receive(:where).exactly(:once).and_return([true])
-
-      nx.dns_zone
-      nx.dns_zone
     end
   end
 end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -285,6 +285,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.update_superuser_password }.to hop("restart")
     end
 
+    it "updates password and hops to wait during initial provisioning if restart is already executed" do
+      expect(nx).to receive(:when_initial_provisioning_set?).and_yield
+      expect(sshable).to receive(:cmd).with("sudo -u postgres psql", stdin: /log_statement = 'none'.*\n.*SCRAM-SHA-256/)
+      expect(nx.strand).to receive(:retval).and_return({"msg" => "postgres server is restarted"})
+      expect { nx.update_superuser_password }.to hop("wait")
+    end
+
     it "updates password and hops to wait at times other than the initial provisioning" do
       expect(nx).to receive(:when_initial_provisioning_set?)
       expect(sshable).to receive(:cmd).with("sudo -u postgres psql", stdin: /log_statement = 'none'.*\n.*SCRAM-SHA-256/)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       PostgresServer,
       resource: instance_double(
         PostgresResource,
+        root_cert_1: "root_cert_1",
+        root_cert_2: "root_cert_2",
         server_cert: "server_cert",
         server_cert_key: "server_cert_key",
         superuser_password: "dummy-password"
@@ -215,6 +217,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#refresh_certificates" do
     it "pushes certificates to vm and hops to configure during initial provisioning" do
+      expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/ca.crt > /dev/null", stdin: "root_cert_1\nroot_cert_2")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: "server_cert")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.key > /dev/null", stdin: "server_cert_key")
       expect(sshable).to receive(:cmd).with("sudo -u postgres chmod 600 /dat/16/data/server.key")
@@ -225,6 +228,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "hops to wait at times other than the initial provisioning" do
+      expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/ca.crt > /dev/null", stdin: "root_cert_1\nroot_cert_2")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: "server_cert")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.key > /dev/null", stdin: "server_cert_key")
       expect(sshable).to receive(:cmd).with("sudo -u postgres chmod 600 /dat/16/data/server.key")

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -364,6 +364,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:when_update_firewall_rules_set?).and_yield
       expect { nx.wait }.to hop("update_firewall_rules")
     end
+
+    it "hops to configure if configure is set" do
+      expect(nx).to receive(:when_configure_set?).and_yield
+      expect { nx.wait }.to hop("configure")
+    end
   end
 
   describe "#update_firewall_rules" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -216,6 +216,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe "#refresh_certificates" do
+    it "waits for certificate creation by the parent resource" do
+      expect(postgres_server.resource).to receive(:server_cert).and_return(nil)
+      expect { nx.refresh_certificates }.to nap(5)
+    end
+
     it "pushes certificates to vm and hops to configure during initial provisioning" do
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/ca.crt > /dev/null", stdin: "root_cert_1\nroot_cert_2")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: "server_cert")


### PR DESCRIPTION
This PR consist of small improvements and refactors that I did while developing HA for PostgreSQL. I'm introducing them as separate PR for making the already complex HA PR a bit simpler/cleaner.

**Clean up PostgreSQL semaphore updates**
We forgot to decrement some of the semaphores. With this commit we are fixing
that. While doing so I moved the place of some semaphore updates for having a
cleaner prog.

**Move redacted_columns in PostgresResource to end of file**
This is purely estetic. I will add more class methods and wanted to put all of
them to the end of the file because it is OK for them to take less mind and eye
space.

**Set PostgresResource's hostname based on existence of dns_zone**
Previously, hostname was set based on whether Config.postgres_service_hostname
is set or not. However, checking the existence of DnsZone is safer. After all
it is possible to set Config.postgres_service_hostname but not configure the
DnsZone. In fact, Config.postgres_service_hostname is useful in non DnsZone
related contexes (such as certificate generation), thus it is not unusual to
set the config but not the DnsZone.

**Make PostgresServer's configure label triggerable via semaphore**
The label itself is already designed to be runnable after different occassions,
such as during provisioning or at the end of PITR. This commit simply adds a
semaphore to trigger the label when needed.

**Make initializing database from backup idempotent**
Previously, if the initialization fails midway, it might not be repeatable
depending the the failure point. This commit cleans up the data and config
directories before attempting to retry.

**Put root CA bundle to PostgresServer's VMs**
This will be useful when we setup HA standbys. Standbys would want to connect
to the primary nodes with verify-full option. At that time they will need to
know root CAs to be able to complete verification of the certificate chain.

**Add clientAuth capability to Postgres certificates**
This will be useful when we setup HA standbys. Standbys would want to connect
to the primary nodes and they will use this certificate to authenticate. To be
able to use this certificate to authenticate, the certificates needs to have
clientAuth capability.

**Wait for certificate cration by PostgresResource**
In usual case, certificate creation would be completed very quickly as we sign
certificates ourselves. However if certificate creation delays, potentially due
to an error in previous step, and we continue with PostgresServer provisioning,
server can put empty certs, which would prevent Postgres from starting. We add
a check in PostgresServer::refresh_certificates to not progress if the certs
are not ready yet.

**Rescue errors during pulse check**
Pulse check can throw an exception due to various reason. If that happens the
thread responsible for performing pulse check for that particular resource
would exit and we cannot perform any more health checks. We already catch the
exceptions while processing SSH sessions for the same purpose. Adding a similar
exception handling logic for pulse checks prevents thread exits.

**Allow passing and storing extra data in pulses**
Resources might want to store some, intended to be minimal, data in pulses to
be able to make better unavailability decisions. Normally, a way to achieve
this would be overriding the aggregate_readings method, but this seems like a
common need so adding it to the default aggregate_readings method makes sense.

However, it is important to note that the intention here is keeping such data
to be small, so that it would not put extra load on monitor process that is
designed to have high frequency.