### PR TITLE
Run E2E with the respirate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,16 +48,23 @@ jobs:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: bundle exec rake test_up
 
-    - name: Run tests
+    - name: Install foreman
+      run: gem install foreman
+
+    - name: Add e2e script to Procfile
+      run: |
+        echo "e2e: bin/ci" >> Procfile
+
+    - name: Run services
       env:
-        RACK_ENV: test
+        RACK_ENV: development
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
         CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
         CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
         CI_HETZNER_SACRIFICIAL_SERVER_ID: ${{ secrets.CI_HETZNER_SACRIFICIAL_SERVER_ID }}
         HETZNER_USER: ${{ secrets.HETZNER_USER }}
         HETZNER_PASSWORD: ${{ secrets.HETZNER_PASSWORD }}
-      run: bin/ci
+      run: foreman start
 
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}

--- a/bin/ci
+++ b/bin/ci
@@ -23,6 +23,11 @@ end
 
 def wait_until(st, label = nil)
   while (loaded_st = Strand[st.id]) && loaded_st.label != label
+    if loaded_st.label == "failed"
+      log(st.reload, "FAILED: #{loaded_st.exitval.fetch("msg")}")
+      st.destroy
+      exit 1
+    end
     log(st.reload, "waiting #{label ? "for #{label}" : "exit"}")
     sleep 10
   end

--- a/bin/ci
+++ b/bin/ci
@@ -3,9 +3,10 @@
 
 require_relative "../loader"
 require "time"
+require "optparse"
 
-def main
-  hetzner_server_st = Prog::Test::HetznerServer.assemble
+def main(options)
+  hetzner_server_st = Prog::Test::HetznerServer.assemble(vm_host_id: options[:vm_host_id])
   wait_until(hetzner_server_st, "wait")
 
   encrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: true, test_reboot: true)
@@ -42,4 +43,9 @@ def log(st, msg)
   $stdout.write "#{Time.now.utc.iso8601} | #{st.id} | #{st.prog}.#{st.label} | #{msg} | #{resources}\n"
 end
 
-main
+options = {}
+OptionParser.new do |opts|
+  opts.on("--vm-host-id VM_HOST_ID", "Use existing vm host") { |v| options[:vm_host_id] = (v.length == 26) ? VmHost.from_ubid(v).id : v }
+end.parse!
+
+main(options)

--- a/bin/ci
+++ b/bin/ci
@@ -5,12 +5,41 @@ require_relative "../loader"
 require "time"
 
 def main
-  st = Prog::Test::HetznerServer.assemble
+  hetzner_server_st = Prog::Test::HetznerServer.assemble
+  wait_until(hetzner_server_st, "wait")
 
-  while Strand[st.id]
-    puts "Strand #{st.id} is still running, sleeping for 15 seconds ..."
-    sleep 15
+  encrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: true, test_reboot: true)
+  log(encrypted_vms_st, "storage_encrypted: true")
+  wait_until(encrypted_vms_st)
+
+  unencrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: false, test_reboot: false)
+  log(unencrypted_vms_st, "storage_encrypted: false")
+  wait_until(unencrypted_vms_st)
+
+  Semaphore.incr(hetzner_server_st.id, "destroy")
+  wait_until(hetzner_server_st)
+end
+
+def wait_until(st, label = nil)
+  while (loaded_st = Strand[st.id]) && loaded_st.label != label
+    log(st.reload, "waiting #{label ? "for #{label}" : "exit"}")
+    sleep 10
   end
+  log(st, "reached")
+end
+
+def log(st, msg)
+  resources = case st.prog
+  when "Test::HetznerServer"
+    "VmHost.#{Strand[st.stack.first["vm_host_id"]]&.label}"
+  when "Test::VmGroup"
+    st.stack.first["vms"].map { "Vm.#{Strand[_1]&.label}" }.join(", ")
+  when "Test::Vm"
+    "Vm.#{Strand[st.stack.first["subject_id"]]&.label}"
+  else
+    "#{st.prog}.#{st.label}"
+  end
+  $stdout.write "#{Time.now.utc.iso8601} | #{st.id} | #{st.prog}.#{st.label} | #{msg} | #{resources}\n"
 end
 
 main

--- a/bin/ci
+++ b/bin/ci
@@ -7,65 +7,10 @@ require "time"
 def main
   st = Prog::Test::HetznerServer.assemble
 
-  strand_states = update_status({})
-  retries = 0
-
-  loop do
-    begin
-      ret = st.run
-    # rubocop:disable Lint/RescueException
-    rescue Exception => e
-      log "Exception: #{e}"
-
-      if e.is_a?(Sshable::SshError)
-        puts "Stdout: #{e.stdout}"
-        puts "Stderr: #{e.stderr}"
-      end
-
-      # retry 5 times, for total of 7:45 minutes before announcing failure
-      # sometimes there's some transient network failures which will be resolved if retried.
-      if retries < 5
-        sleep_duration = 15 * 2**retries
-        log "Retrying in #{sleep_duration} seconds ..."
-        sleep sleep_duration
-        retries += 1
-        next
-      else
-        raise
-      end
-    end
-    # rubocop:enable Lint/RescueException
-
-    strand_states = update_status(strand_states)
-    retries = 0
-
-    if ret.is_a?(Prog::Base::Nap)
-      sleep ret.seconds
-    elsif ret.is_a?(Prog::Base::Exit)
-      log "Exited with: #{ret}"
-      exit 0
-    end
+  while Strand[st.id]
+    puts "Strand #{st.id} is still running, sleeping for 15 seconds ..."
+    sleep 15
   end
-end
-
-def update_status(previous)
-  current = Strand.all.map { |x| [x[:id], {prog: x[:prog], label: x[:label]}] }.to_h
-  previous.each_pair { |key, value|
-    if !current.has_key? key
-      log "Strand deleted: id=#{key}, prog=#{value[:prog]}, label=#{value[:label]}"
-    elsif current[key] != value
-      log "Strand updated: id=#{key}, prog=#{value[:prog]}, label=#{value[:label]} => #{current[key][:label]}"
-    end
-  }
-  current.each_pair { |key, value|
-    if !previous.has_key? key
-      log "Strand created: id=#{key}, prog=#{value[:prog]}, label=#{value[:label]}"
-    end
-  }
-end
-
-def log(msg)
-  puts "#{Time.now.utc.iso8601} #{msg}"
 end
 
 main

--- a/prog/test/base.rb
+++ b/prog/test/base.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Prog::Test::Base < Prog::Base
+  def fail_test(msg)
+    strand.update(exitval: {msg: msg})
+    hop_failed
+  end
+
+  def update_stack(new_frame)
+    strand.stack.first.merge!(new_frame)
+    strand.modified!(:stack)
+    strand.save_changes
+  end
+end

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../lib/util"
 
-class Prog::Test::HetznerServer < Prog::Base
+class Prog::Test::HetznerServer < Prog::Test::Base
   semaphore :destroy
 
   def self.assemble(vm_host_id: nil)
@@ -99,7 +99,7 @@ class Prog::Test::HetznerServer < Prog::Base
   def verify_specs_installation(installed: true)
     specs_count = vm_host.sshable.cmd("find /home/rhizome -type f -name '*_spec.rb' -not -path \"/home/rhizome/vendor/*\" | wc -l")
     specs_installed = (specs_count.strip != "0")
-    fail "verify_specs_installation(installed: #{installed}) failed" unless specs_installed == installed
+    fail_test "verify_specs_installation(installed: #{installed}) failed" unless specs_installed == installed
   end
 
   label def run_integration_specs
@@ -150,10 +150,8 @@ class Prog::Test::HetznerServer < Prog::Base
     pop "HetznerServer tests finished!"
   end
 
-  def update_stack(new_frame)
-    strand.stack.first.merge!(new_frame)
-    strand.modified!(:stack)
-    strand.save_changes
+  label def failed
+    nap 15
   end
 
   def hetzner_api

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Prog::Test::Vm < Prog::Base
+class Prog::Test::Vm < Prog::Test::Base
   subject_is :vm, :sshable
 
   label def start
@@ -15,7 +15,7 @@ class Prog::Test::Vm < Prog::Base
     size_info = sshable.cmd("ls -s ~/1.txt").split
 
     unless size_info[0].to_i.between?(500000, 500100)
-      fail "unexpected size after dd"
+      fail_test "unexpected size after dd"
     end
 
     hop_install_packages
@@ -95,6 +95,10 @@ class Prog::Test::Vm < Prog::Base
 
   label def finish
     pop "Verified VM!"
+  end
+
+  label def failed
+    nap 15
   end
 
   def vms_in_same_project

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -3,10 +3,6 @@
 class Prog::Test::Vm < Prog::Base
   subject_is :vm, :sshable
 
-  def self.assemble(vm_id)
-    Strand.create_with_id(prog: "Test::Vm", label: "start", stack: [{subject_id: vm_id}])
-  end
-
   label def start
     hop_verify_dd
   end
@@ -102,22 +98,14 @@ class Prog::Test::Vm < Prog::Base
   end
 
   def vms_in_same_project
-    vm.projects.first.vms_dataset.all.filter { |x|
-      x.id != vm.id
-    }
+    vm.projects.first.vms.filter { _1.id != vm.id }
   end
 
   def vms_with_same_subnet
-    my_subnet = vm.private_subnets.first.id
-    vms_in_same_project.filter { |x|
-      x.private_subnets.first.id == my_subnet
-    }
+    vms_in_same_project.filter { _1.private_subnets.first.id == vm.private_subnets.first.id }
   end
 
   def vms_with_different_subnet
-    my_subnet = vm.private_subnets.first.id
-    vms_in_same_project.filter { |x|
-      x.private_subnets.first.id != my_subnet
-    }
+    vms_in_same_project.filter { _1.private_subnets.first.id != vm.private_subnets.first.id }
   end
 end

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -9,7 +9,8 @@ class Prog::Test::VmGroup < Prog::Base
       label: "start",
       stack: [{
         "storage_encrypted" => storage_encrypted,
-        "test_reboot" => test_reboot
+        "test_reboot" => test_reboot,
+        "vms" => []
       }]
     )
   end
@@ -29,9 +30,6 @@ class Prog::Test::VmGroup < Prog::Base
     subnet2_s = Prog::Vnet::SubnetNexus.assemble(
       project.id, name: "the-second-subnet", location: "hetzner-hel1"
     )
-
-    strand.add_child(subnet1_s)
-    strand.add_child(subnet2_s)
 
     storage_encrypted = frame.fetch("storage_encrypted", true)
 
@@ -59,106 +57,60 @@ class Prog::Test::VmGroup < Prog::Base
       enable_ip4: true
     )
 
-    strand.add_child(vm1_s)
-    strand.add_child(vm2_s)
-    strand.add_child(vm3_s)
-    strand.add_child(Strand[vm1_s.subject.nics.first.id])
-    strand.add_child(Strand[vm2_s.subject.nics.first.id])
-    strand.add_child(Strand[vm3_s.subject.nics.first.id])
+    update_stack({
+      "vms" => [vm1_s.id, vm2_s.id, vm3_s.id],
+      "subnets" => [subnet1_s.id, subnet2_s.id],
+      "project_id" => project.id
+    })
 
-    current_frame = strand.stack.first
-    current_frame["vms"] = [vm1_s.id, vm2_s.id, vm3_s.id]
-    current_frame["subnets"] = [subnet1_s.id, subnet2_s.id]
-    current_frame["project_id"] = project.id
-    strand.modified!(:stack)
-    strand.save_changes
-
-    hop_wait_children_ready
+    hop_wait_vms
   end
 
-  label def wait_children_ready
-    reap
-
-    hop_children_ready if children_idle
-
-    donate
+  label def wait_vms
+    nap 10 if frame["vms"].any? { Vm[_1].display_state != "running" }
+    hop_verify_vms
   end
 
-  label def children_ready
-    frame["vms"].each { |vm_id|
-      Sshable[vm_id].update(host: Vm[vm_id].ephemeral_net4.to_s)
-    }
-
-    # add sub-tests
-    strand.add_child(Prog::Test::Vm.assemble(frame["vms"].first))
-
-    hop_wait_subtests
-  end
-
-  label def wait_subtests
-    reap
-
-    if children_idle
+  label def verify_vms
+    if retval&.dig("msg") == "Verified VM!"
       if frame["test_reboot"]
         hop_test_reboot
       else
-        hop_destroy_vms
+        hop_destroy_resources
       end
     end
 
-    donate
+    push Prog::Test::Vm, {subject_id: frame["vms"].first}
   end
 
   label def test_reboot
-    host.incr_reboot
+    vm_host.incr_reboot
     hop_wait_reboot
   end
 
   label def wait_reboot
-    st = host.strand
-
-    if st.label == "wait" && st.semaphores.empty?
+    if vm_host.strand.label == "wait" && vm_host.strand.semaphores.empty?
       # Run VM tests again, but avoid rebooting again
-      current_frame = strand.stack.first
-      current_frame["test_reboot"] = false
-      strand.modified!(:stack)
-      strand.save_changes
-      hop_wait_children_ready
+      update_stack({"test_reboot" => false})
+      hop_verify_vms
     end
 
-    nap 30
+    nap 20
   end
 
-  label def destroy_vms
-    frame["vms"].each { |vm_id|
-      Vm[vm_id].incr_destroy
-    }
+  label def destroy_resources
+    frame["vms"].each { Vm[_1].incr_destroy }
+    frame["subnets"].each { PrivateSubnet[_1].incr_destroy }
 
-    hop_wait_vms_destroyed
+    hop_wait_resources_destroyed
   end
 
-  label def wait_vms_destroyed
-    reap
+  label def wait_resources_destroyed
+    unless frame["vms"].all? { Vm[_1].nil? } && frame["subnets"].all? { PrivateSubnet[_1].nil? }
+      nap 5
+    end
 
-    hop_destroy_subnets if children_idle
-
-    donate
-  end
-
-  label def destroy_subnets
-    frame["subnets"].each { |subnet_id|
-      PrivateSubnet[subnet_id].incr_destroy
-    }
-
-    hop_wait_subnets_destroyed
-  end
-
-  label def wait_subnets_destroyed
-    reap
-
-    hop_finish if children_idle
-
-    donate
+    hop_finish
   end
 
   label def finish
@@ -166,15 +118,13 @@ class Prog::Test::VmGroup < Prog::Base
     pop "VmGroup tests finished!"
   end
 
-  def children_idle
-    active_children = strand.children_dataset.where(Sequel.~(label: "wait"))
-    active_semaphores = strand.children_dataset.join(:semaphore, strand_id: :id)
-
-    active_children.count == 0 and active_semaphores.count == 0
+  def update_stack(new_frame)
+    strand.stack.first.merge!(new_frame)
+    strand.modified!(:stack)
+    strand.save_changes
   end
 
-  def host
-    vm_id = frame["vms"].first
-    Vm[vm_id].vm_host
+  def vm_host
+    @vm_host ||= Vm[frame["vms"].first].vm_host
   end
 end

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -2,7 +2,7 @@
 
 require "net/ssh"
 
-class Prog::Test::VmGroup < Prog::Base
+class Prog::Test::VmGroup < Prog::Test::Base
   def self.assemble(storage_encrypted: true, test_reboot: true)
     Strand.create_with_id(
       prog: "Test::VmGroup",
@@ -118,10 +118,8 @@ class Prog::Test::VmGroup < Prog::Base
     pop "VmGroup tests finished!"
   end
 
-  def update_stack(new_frame)
-    strand.stack.first.merge!(new_frame)
-    strand.modified!(:stack)
-    strand.save_changes
+  label def failed
+    nap 15
   end
 
   def vm_host

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe Prog::Test::HetznerServer do
 
     it "succeeds when installed=false & exists" do
       expect(hs_test.vm_host.sshable).to receive(:cmd).and_return("5\n")
-      expect { hs_test.verify_specs_installation(installed: false) }.to raise_error RuntimeError
+      expect(hs_test).to receive(:fail_test).with("verify_specs_installation(installed: false) failed")
+      hs_test.verify_specs_installation(installed: false)
     end
   end
 
@@ -182,6 +183,12 @@ RSpec.describe Prog::Test::HetznerServer do
   describe "#finish" do
     it "exits" do
       expect { hs_test.finish }.to exit({"msg" => "HetznerServer tests finished!"})
+    end
+  end
+
+  describe "#failed" do
+    it "naps" do
+      expect { hs_test.failed }.to nap(15)
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -3,134 +3,104 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Test::VmGroup do
-  subject(:vg_test) {
-    described_class.new(described_class.assemble)
-  }
+  subject(:vg_test) { described_class.new(described_class.assemble) }
 
   describe "#start" do
     it "hops to setup_vms" do
-      expect { vg_test.start }.to hop("setup_vms", "Test::VmGroup")
+      expect { vg_test.start }.to hop("setup_vms")
     end
   end
 
   describe "#setup_vms" do
     it "hops to wait_children_ready" do
-      expect { vg_test.setup_vms }.to hop("wait_children_ready", "Test::VmGroup")
+      expect(vg_test).to receive(:update_stack).and_call_original
+      expect { vg_test.setup_vms }.to hop("wait_vms")
     end
   end
 
-  describe "#wait_children_ready" do
-    it "hops to children_ready if children idle" do
-      expect(vg_test).to receive(:children_idle).and_return(true)
-      expect { vg_test.wait_children_ready }.to hop("children_ready", "Test::VmGroup")
+  describe "#wait_vms" do
+    it "hops to verify_vms if vms are ready" do
+      expect(vg_test).to receive(:frame).and_return({"vms" => ["111"]})
+      expect(Vm).to receive(:[]).with("111").and_return(instance_double(Vm, display_state: "running"))
+      expect { vg_test.wait_vms }.to hop("verify_vms")
     end
 
-    it "donates if children not idle" do
-      expect(vg_test).to receive(:children_idle).and_return(false)
-      expect { vg_test.wait_children_ready }.to nap(0)
-    end
-  end
-
-  describe "#children_ready" do
-    it "hops to wait_subtests" do
-      vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
-      Sshable.create { _1.id = vm.id }
-      allow(vg_test).to receive(:frame).and_return({"vms" => [vm.id]})
-      expect { vg_test.children_ready }.to hop("wait_subtests", "Test::VmGroup")
+    it "naps if vms are not running" do
+      expect(vg_test).to receive(:frame).and_return({"vms" => ["111"]})
+      expect(Vm).to receive(:[]).with("111").and_return(instance_double(Vm, display_state: "creating"))
+      expect { vg_test.wait_vms }.to nap(10)
     end
   end
 
-  describe "#wait_subtests" do
-    it "hops to destroy_vms if children idle and not test_reboot" do
-      expect(vg_test).to receive(:children_idle).and_return(true)
+  describe "#verify_vms" do
+    it "runs tests for the first vm" do
+      expect(vg_test).to receive(:frame).and_return({"vms" => ["111"]})
+      expect { vg_test.verify_vms }.to hop("start", "Test::Vm")
+    end
+
+    it "hops to destroy_resources if tests are done and not test_reboot" do
+      expect(vg_test.strand).to receive(:retval).and_return({"msg" => "Verified VM!"})
       expect(vg_test).to receive(:frame).and_return({"test_reboot" => false})
-      expect { vg_test.wait_subtests }.to hop("destroy_vms", "Test::VmGroup")
+      expect { vg_test.verify_vms }.to hop("destroy_resources")
     end
 
-    it "hops to test_reboot if children idle and test_reboot" do
-      expect(vg_test).to receive(:children_idle).and_return(true)
+    it "hops to test_reboot if tests are done and test_reboot" do
+      expect(vg_test.strand).to receive(:retval).and_return({"msg" => "Verified VM!"})
       expect(vg_test).to receive(:frame).and_return({"test_reboot" => true})
-      expect { vg_test.wait_subtests }.to hop("test_reboot", "Test::VmGroup")
-    end
-
-    it "donates if children not idle" do
-      expect(vg_test).to receive(:children_idle).and_return(false)
-      expect { vg_test.wait_subtests }.to nap(0)
+      expect { vg_test.verify_vms }.to hop("test_reboot")
     end
   end
 
   describe "#test_reboot" do
     it "hops to wait_reboot" do
-      host = instance_double(VmHost)
-      expect(vg_test).to receive(:host).and_return(host)
-      expect(host).to receive(:incr_reboot).with(no_args)
-      expect { vg_test.test_reboot }.to hop("wait_reboot", "Test::VmGroup")
+      expect(vg_test).to receive(:vm_host).and_return(instance_double(VmHost)).twice
+      expect(vg_test.vm_host).to receive(:incr_reboot).with(no_args)
+      expect { vg_test.test_reboot }.to hop("wait_reboot")
     end
   end
 
   describe "#wait_reboot" do
-    let(:st) {
-      instance_double(Strand)
-    }
+    let(:st) { instance_double(Strand) }
 
     before do
-      host = instance_double(VmHost)
-      allow(vg_test).to receive(:host).and_return(host)
-      allow(host).to receive(:strand).and_return(st)
+      allow(vg_test).to receive(:vm_host).and_return(instance_double(VmHost))
+      allow(vg_test.vm_host).to receive(:strand).and_return(st)
     end
 
     it "naps if strand is busy" do
       expect(st).to receive(:label).and_return("reboot")
-      expect { vg_test.wait_reboot }.to nap(30)
+      expect { vg_test.wait_reboot }.to nap(20)
     end
 
     it "runs vm tests if reboot done" do
       expect(st).to receive(:label).and_return("wait")
       expect(st).to receive(:semaphores).and_return([])
-      expect { vg_test.wait_reboot }.to hop("wait_children_ready", "Test::VmGroup")
+      expect { vg_test.wait_reboot }.to hop("verify_vms")
     end
   end
 
-  describe "#destroy_vms" do
-    it "hops to wait_vms_destroyed" do
-      vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
-      Sshable.create { _1.id = vm.id }
-      Strand.create(prog: "Vm::Nexus", label: "wait") { _1.id = vm.id }
-      allow(vg_test).to receive(:frame).and_return({"vms" => [vm.id]})
-      expect { vg_test.destroy_vms }.to hop("wait_vms_destroyed", "Test::VmGroup")
+  describe "#destroy_resources" do
+    it "hops to wait_resources_destroyed" do
+      allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
+      expect(Vm).to receive(:[]).with("vm_id").and_return(instance_double(Vm, incr_destroy: nil))
+      expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(instance_double(PrivateSubnet, incr_destroy: nil))
+      expect { vg_test.destroy_resources }.to hop("wait_resources_destroyed")
     end
   end
 
-  describe "#wait_vms_destroyed" do
-    it "hops to destroy_subnets if children idle" do
-      expect(vg_test).to receive(:children_idle).and_return(true)
-      expect { vg_test.wait_vms_destroyed }.to hop("destroy_subnets", "Test::VmGroup")
+  describe "#wait_resources_destroyed" do
+    it "hops to finish if all resources are destroyed" do
+      allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
+      expect(Vm).to receive(:[]).with("vm_id").and_return(nil)
+      expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(nil)
+
+      expect { vg_test.wait_resources_destroyed }.to hop("finish")
     end
 
-    it "donates if children not idle" do
-      expect(vg_test).to receive(:children_idle).and_return(false)
-      expect { vg_test.wait_vms_destroyed }.to nap(0)
-    end
-  end
-
-  describe "#destroy_subnets" do
-    it "hops to wait_subnets_destroyed" do
-      subnet = PrivateSubnet.create_with_id(net6: "1::/64", net4: "192.168.1.1", name: "n", location: "l")
-      Strand.create(prog: "Vnet::SubnetNexus", label: "wait") { _1.id = subnet.id }
-      allow(vg_test).to receive(:frame).and_return({"subnets" => [subnet.id]})
-      expect { vg_test.destroy_subnets }.to hop("wait_subnets_destroyed", "Test::VmGroup")
-    end
-  end
-
-  describe "#wait_subnets_destroyed" do
-    it "hops to finish if children idle" do
-      expect(vg_test).to receive(:children_idle).and_return(true)
-      expect { vg_test.wait_subnets_destroyed }.to hop("finish", "Test::VmGroup")
-    end
-
-    it "donates if children not idle" do
-      expect(vg_test).to receive(:children_idle).and_return(false)
-      expect { vg_test.wait_subnets_destroyed }.to nap(0)
+    it "naps if all resources are not destroyed yet" do
+      allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
+      expect(Vm).to receive(:[]).with("vm_id").and_return(instance_double(Vm))
+      expect { vg_test.wait_resources_destroyed }.to nap(5)
     end
   end
 
@@ -142,21 +112,13 @@ RSpec.describe Prog::Test::VmGroup do
     end
   end
 
-  describe "#children_idle" do
-    it "returns true if no children" do
-      st = Strand.create_with_id(prog: "Prog", label: "label")
-      allow(vg_test).to receive(:strand).and_return(st)
-      expect(vg_test.children_idle).to be(true)
-    end
-  end
-
-  describe "#host" do
+  describe "#vm_host" do
     it "returns first VM's host" do
       sshable = Sshable.create_with_id
-      host = VmHost.create(location: "A") { _1.id = sshable.id }
-      vm = Vm.create_with_id(unix_user: "root", public_key: "", name: "xyz", location: "a", boot_image: "b", family: "z", cores: 1, vm_host_id: host.id)
+      vm_host = VmHost.create(location: "A") { _1.id = sshable.id }
+      vm = Vm.create_with_id(unix_user: "root", public_key: "", name: "xyz", location: "a", boot_image: "b", family: "z", cores: 1, vm_host_id: vm_host.id)
       expect(vg_test).to receive(:frame).and_return({"vms" => [vm.id]})
-      expect(vg_test.host).to eq(host)
+      expect(vg_test.vm_host).to eq(vm_host)
     end
   end
 end

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe Prog::Test::VmGroup do
     end
   end
 
+  describe "#failed" do
+    it "naps" do
+      expect { vg_test.failed }.to nap(15)
+    end
+  end
+
   describe "#vm_host" do
     it "returns first VM's host" do
       sshable = Sshable.create_with_id

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe Prog::Test::Vm do
       expect(sshable).to receive(:cmd).with("dd if=/dev/random of=~/1.txt bs=512 count=1000000")
       expect(sshable).to receive(:cmd).with("sync ~/1.txt")
       expect(sshable).to receive(:cmd).with("ls -s ~/1.txt").and_return "300 /home/xyz/1.txt"
-      expect { vm_test.verify_dd }.to raise_error RuntimeError, "unexpected size after dd"
+      expect(vm_test.strand).to receive(:update).with(exitval: {msg: "unexpected size after dd"})
+      expect { vm_test.verify_dd }.to hop("failed")
     end
   end
 
@@ -142,6 +143,12 @@ RSpec.describe Prog::Test::Vm do
   describe "#finish" do
     it "exits" do
       expect { vm_test.finish }.to exit({"msg" => "Verified VM!"})
+    end
+  end
+
+  describe "#failed" do
+    it "naps" do
+      expect { vm_test.failed }.to nap(15)
     end
   end
 end


### PR DESCRIPTION
## Run E2E tests with respirate

We dream of running E2E tests with the respirate. Currently, the `bin/ci` script assembles a `Test::HetznerServer` strand and runs it until termination. This is a primitive version of respirate, assuming all other strands are its children. For GitHub E2E tests, we also need to provision `GithubRunner` strands via a webhook, which are not children of `Test::HetznerServer`. Alongside this, we need to run a web server. I used `foreman` to run multiple services, similar to Heroku's approach. It exists when one of the services exit.

Running tests with the respirate has its advantages and disadvantages.
However, I believe the advantages outweigh the disadvantages.

**Pros:**

- We also test the respirate functionality in E2E tests.
- We don't need to develop custom functionality like parent-child relationships on all strands. This doesn't align with our other progs, and it's unnecessary for the respirate. In the next commit, I removed over 200 lines.
- The primitive runs one strand at a time, while the respirate executes them concurrently.
- While the primitive waits on naps, the respirate runs other strands.
- The primitive has a custom retry mechanism, but the respirate uses its own retry mechanism.

**Cons:**

- The primitive runs strands itself, having direct access to the results of the strand runs. Conversely, the respirate runs strands, which might get stuck at some point, causing the CI script to wait unnecessarily.
- The primitive provides superior logging. However, the new version includes the respirate logs, and I have added some logs to the new CI script.

## Refactor E2E tests to run with respirate

We don't require a parent-child relationship for all strands for the respirate. I removed them.

Additionally, I moved `Test::VmGroup` from `Test::HetznerServer` to the CI script. `HetznerServer` tests the VM host workflows, while `VmGroup` tests VM functionality. I've separated the test cases. The CI script is aware of the test cases currently running.  The GitHub E2E tests can utilize the same VM host. In the future, we also have the option to run a subset of the tests.

## Allow to run E2E on existing vm host

HetznerServer resets the server and assembles a VM host, which also triggers a reboot. This process takes at least 10 minutes.

I have added a feature to run E2E tests on an existing VM host, allowing developers to easily execute E2E tests using the command `./bin/ci --vm-host-id "7b68b5e9-bf1c-8771-8a22-c63d194f3e92"` or with UBID. This command only runs VM tests and does not destroy the existing VM host.

I used `OptionParser` to parse arguments, enabling the addition of extra flags to run a subset of test cases in future. We might add boolean flags like `./bin/ci --vm --github --postgres` or an array list like `./bin/ci --test-cases=vm,github,postgres`.

## Exit the CI script if a test failed

One of the drawbacks of the respirate, compared to the primitive version, is that the primitive one exits when a strand run fails. However, in the new version, the CI script isn't aware if the respirate is failing or not. I've implemented early exits for some failed test cases.


