### PR TITLE
Remove tmp image if the download operation fails

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -26,11 +26,9 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   label def wait_draining
-    unless vm_host.vms.empty?
-      nap 15
-    end
-    sshable.cmd("sudo rm -f /var/storage/images/#{image_name.shellescape}.raw")
-    hop_download
+    hop_download if vm_host.vms.empty?
+
+    nap 15
   end
 
   label def download
@@ -73,6 +71,9 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   label def activate_host
+    # Verify that the image was downloaded
+    sshable.cmd("ls /var/storage/images/#{image_name}.raw")
+
     vm_host.update(allocation_state: "accepting")
 
     pop "#{image_name} downloaded"

--- a/rhizome/host/bin/download-boot-image
+++ b/rhizome/host/bin/download-boot-image
@@ -14,4 +14,4 @@ require_relative "../lib/vm_setup"
 certs = $stdin.read
 ca_path = "/usr/lib/ssl/certs/ubicloud_images_blob_storage_certs.crt"
 safe_write_to_file(ca_path, certs)
-VmSetup.new("").download_boot_image(boot_image, custom_url: custom_url, ca_path: ca_path)
+VmSetup.new("").download_boot_image(boot_image, force: true, custom_url: custom_url, ca_path: ca_path)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -459,7 +459,7 @@ EOS
     }
   end
 
-  def download_boot_image(boot_image, custom_url: nil, ca_path: nil)
+  def download_boot_image(boot_image, force: false, custom_url: nil, ca_path: nil)
     urls = {
       "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
       "almalinux-9.1" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-latest.#{_1}.qcow2" },
@@ -470,7 +470,7 @@ EOS
 
     download = urls.fetch(boot_image) || custom_url
     image_path = vp.image_path(boot_image)
-    return if File.exist?(image_path)
+    return if File.exist?(image_path) && !force
 
     fail "Must provide custom_url for #{boot_image} image" if download.nil?
     FileUtils.mkdir_p vp.image_root

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe VmSetup do
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
       expect(Arch).to receive(:render).and_return("amd64").at_least(:once)
       expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-amd64.img")
-      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw.tmp")
       expect(FileUtils).to receive(:rm_r).with("/var/storage/images/ubuntu-jammy.img.tmp")
+      expect(File).to receive(:rename).with("/var/storage/images/ubuntu-jammy.raw.tmp", "/var/storage/images/ubuntu-jammy.raw")
 
       vs.download_boot_image("ubuntu-jammy")
     end
@@ -75,8 +76,9 @@ RSpec.describe VmSetup do
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
       expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/github-ubuntu-2204.vhd.tmp http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.vhd\\?X-Amz-Algorithm\\=AWS4-HMAC-SHA256\\&X-Amz-Credential\\=user\\%2F20240112\\%2Fus-east-1\\%2Fs3\\%2Faws4_request\\&X-Amz-Date\\=20240112T132931Z\\&X-Amz-Expires\\=3600\\&X-Amz-SignedHeaders\\=host\\&X-Amz-Signature\\=aabbcc")
-      expect(vs).to receive(:r).with("qemu-img convert -p -f vpc -O raw /var/storage/images/github-ubuntu-2204.vhd.tmp /var/storage/images/github-ubuntu-2204.raw")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f vpc -O raw /var/storage/images/github-ubuntu-2204.vhd.tmp /var/storage/images/github-ubuntu-2204.raw.tmp")
       expect(FileUtils).to receive(:rm_r).with("/var/storage/images/github-ubuntu-2204.vhd.tmp")
+      expect(File).to receive(:rename).with("/var/storage/images/github-ubuntu-2204.raw.tmp", "/var/storage/images/github-ubuntu-2204.raw")
 
       vs.download_boot_image("github-ubuntu-2204", custom_url: "http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.vhd?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240112T132931Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=aabbcc")
     end
@@ -89,7 +91,6 @@ RSpec.describe VmSetup do
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
       expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/github-ubuntu-2204.raw.tmp http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.raw\\?X-Amz-Algorithm\\=AWS4-HMAC-SHA256\\&X-Amz-Credential\\=user\\%2F20240112\\%2Fus-east-1\\%2Fs3\\%2Faws4_request\\&X-Amz-Date\\=20240112T132931Z\\&X-Amz-Expires\\=3600\\&X-Amz-SignedHeaders\\=host\\&X-Amz-Signature\\=aabbcc")
       expect(File).to receive(:rename).with("/var/storage/images/github-ubuntu-2204.raw.tmp", "/var/storage/images/github-ubuntu-2204.raw")
-      expect(FileUtils).to receive(:rm_r).with("/var/storage/images/github-ubuntu-2204.raw.tmp")
 
       vs.download_boot_image("github-ubuntu-2204", custom_url: "http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.raw?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240112T132931Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=aabbcc")
     end

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe Prog::DownloadBootImage do
 
     it "hops if it's drained" do
       expect(vm_host).to receive(:vms).and_return([])
-      expect(sshable).to receive(:cmd).with("sudo rm -f /var/storage/images/my-image.raw")
       expect { dbi.wait_draining }.to hop("download")
     end
   end
@@ -99,6 +98,7 @@ RSpec.describe Prog::DownloadBootImage do
 
   describe "#activate_host" do
     it "activates vm host again" do
+      expect(sshable).to receive(:cmd).with("ls /var/storage/images/my-image.raw")
       expect {
         expect { dbi.activate_host }.to exit({"msg" => "my-image downloaded"})
       }.to change { vm_host.reload.allocation_state }.from("unprepared").to("accepting")


### PR DESCRIPTION
### Exit early if the image already exists

It's just a structural refactor. No need extra indentation.

### Finalize the image download with File.rename

At present, we download the image to a temporary path and then move it to the final location using the `qemu-img convert` command. However, this process is not atomic and can be time-consuming.  It would be more efficient to use the `File.rename` command to move the image directly to the final location, as this is an atomic operation.  This method also allows other virtual machines to use the old image right up until the last moment.

### Add force flag to download image even if exists

If the boot image already exists, the virtual machine uses it. However, in certain situations like updating GitHub runner images, we need to download the latest version. If the force flag is set to true, the VM host will download the image regardless of its existence.

### Allow only one concurrent image download with flock

Right now, we use the "File::CREAT | File::EXCL" flags to open a temporary file for image downloads, which should stop multiple downloads happening at once. These flags only let one process create the file, and if the file is already there, it fails. However, if a download gets interrupted, the file sticks around and the next download attempt fails. It's tricky to figure out if the file is incomplete, so we have to delete it manually. Using flock to lock a lock file is a more effective way to stop multiple downloads idempotently at the same time.

### Use force flag in the boot image download prog

The previous version of the `download_boot_image` method fails when the file already exists. I've incorporated a `force` flag into the method to overwrite any pre-existing file.  This way, the program doesn't need to delete the existing file before downloading the boot image.

Fixes #911