### PR TITLE
Change the location for temporary image downloads

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -448,7 +448,7 @@ EOS
       # Use of File::EXCL provokes a crash rather than a race
       # condition if two VMs are lazily getting their images at the
       # same time.
-      temp_path = "/tmp/" + boot_image + image_ext + ".tmp"
+      temp_path = File.join(vp.image_root, boot_image + image_ext + ".tmp")
       File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
         if download.match?(/^https:\/\/.+\.blob\.core\.windows\.net/)
           install_azcopy

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe VmSetup do
     it "can download an image" do
       expect(File).to receive(:exist?).with("/var/storage/images/ubuntu-jammy.raw").and_return(false)
       expect(File).to receive(:open) do |path, *_args|
-        expect(path).to eq("/tmp/ubuntu-jammy.img.tmp")
+        expect(path).to eq("/var/storage/images/ubuntu-jammy.img.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
       expect(Arch).to receive(:render).and_return("amd64").at_least(:once)
-      expect(vs).to receive(:r).with("curl -f -L10 -o /tmp/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-amd64.img")
-      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /tmp/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw")
-      expect(FileUtils).to receive(:rm_r).with("/tmp/ubuntu-jammy.img.tmp")
+      expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw")
+      expect(FileUtils).to receive(:rm_r).with("/var/storage/images/ubuntu-jammy.img.tmp")
 
       vs.download_boot_image("ubuntu-jammy")
     end
@@ -52,13 +52,13 @@ RSpec.describe VmSetup do
     it "can download image with custom URL that has query params using azcopy" do
       expect(File).to receive(:exist?).with("/var/storage/images/github-ubuntu-2204.raw").and_return(false)
       expect(File).to receive(:open) do |path, *_args|
-        expect(path).to eq("/tmp/github-ubuntu-2204.vhd.tmp")
+        expect(path).to eq("/var/storage/images/github-ubuntu-2204.vhd.tmp")
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
       expect(vs).to receive(:r).with("which azcopy")
-      expect(vs).to receive(:r).with("AZCOPY_CONCURRENCY_VALUE=5 azcopy copy https://images.blob.core.windows.net/images/ubuntu2204.vhd\\?sp\\=r\\&st\\=2023-09-05T22:44:05Z\\&se\\=2023-10-07T06:44:05 /tmp/github-ubuntu-2204.vhd.tmp")
-      expect(vs).to receive(:r).with("qemu-img convert -p -f vpc -O raw /tmp/github-ubuntu-2204.vhd.tmp /var/storage/images/github-ubuntu-2204.raw")
-      expect(FileUtils).to receive(:rm_r).with("/tmp/github-ubuntu-2204.vhd.tmp")
+      expect(vs).to receive(:r).with("AZCOPY_CONCURRENCY_VALUE=5 azcopy copy https://images.blob.core.windows.net/images/ubuntu2204.vhd\\?sp\\=r\\&st\\=2023-09-05T22:44:05Z\\&se\\=2023-10-07T06:44:05 /var/storage/images/github-ubuntu-2204.vhd.tmp")
+      expect(vs).to receive(:r).with("qemu-img convert -p -f vpc -O raw /var/storage/images/github-ubuntu-2204.vhd.tmp /var/storage/images/github-ubuntu-2204.raw")
+      expect(FileUtils).to receive(:rm_r).with("/var/storage/images/github-ubuntu-2204.vhd.tmp")
 
       vs.download_boot_image("github-ubuntu-2204", custom_url: "https://images.blob.core.windows.net/images/ubuntu2204.vhd?sp=r&st=2023-09-05T22:44:05Z&se=2023-10-07T06:44:05")
     end


### PR DESCRIPTION
We initially download the boot images to a temporary location before relocating them to their final destination. The current temporary location is "/tmp/", while the final location is "/var/storage/images". Our GitHub runner VM hosts mount the "/var/storage" directory as a btrfs partition. Downloading a GitHub image requires moving 86GB file between devices, an action we aim to avoid. Furthermore, when the directories are on the same partition, we can use "File.rename" instead of "mv", which achieves the task with fewer system calls.