### PR TITLE
Minio SSL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 coverage
 spec/examples.txt
 demo/.env
+var/*
 
 # rhizome/Gemfile is combination of all Gemfiles in subdirectories, so does rhizome/Gemfile.lock
 rhizome/*/Gemfile.lock

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -20,6 +20,14 @@ module Util
     end
   end
 
+  def self.create_root_certificate(common_name:, duration:)
+    create_certificate(
+      subject: "/C=US/O=Ubicloud/CN=#{common_name}",
+      extensions: ["basicConstraints=CA:TRUE", "keyUsage=cRLSign,keyCertSign", "subjectKeyIdentifier=hash"],
+      duration: duration
+    ).map(&:to_pem)
+  end
+
   def self.create_certificate(subject:, duration:, extensions: [], issuer_cert: nil, issuer_key: nil)
     cert = OpenSSL::X509::Certificate.new
     key = OpenSSL::PKey::EC.generate("prime256v1")

--- a/migrate/20240125_add_minio_certs.rb
+++ b/migrate/20240125_add_minio_certs.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:minio_cluster) do
+      add_column :root_cert_1, :text, collate: '"C"'
+      add_column :root_cert_key_1, :text, collate: '"C"'
+      add_column :root_cert_2, :text, collate: '"C"'
+      add_column :root_cert_key_2, :text, collate: '"C"'
+      add_column :certificate_last_checked_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+
+    alter_table(:minio_server) do
+      add_column :cert, :text, collate: '"C"'
+      add_column :cert_key, :text, collate: '"C"'
+      add_column :certificate_last_checked_at, :timestamptz, null: false, default: Sequel.lit("now()")
+    end
+  end
+end

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -19,7 +19,7 @@ class MinioPool < Sequel::Model
     return "/minio/dat{1...#{drive_count}}" if cluster.single_instance_multi_drive?
     servers_arg = "#{cluster.name}{#{start_index}...#{server_count + start_index - 1}}"
     drivers_arg = "/minio/dat{1...#{per_server_drive_count}}"
-    "http://#{servers_arg}.#{Config.minio_host_name}:9000#{drivers_arg}"
+    "https://#{servers_arg}.#{Config.minio_host_name}:9000#{drivers_arg}"
   end
 
   def name

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -63,7 +63,8 @@ class MinioServer < Sequel::Model
         endpoint: ip4_url,
         access_key: cluster.admin_user,
         secret_key: cluster.admin_password,
-        socket: File.join(socket_path, "health_monitor_socket")
+        socket: File.join(socket_path, "health_monitor_socket"),
+        ssl_ca_file_data: cluster.root_certs
       )
     }
   end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -14,10 +14,19 @@ class MinioServer < Sequel::Model
   dataset_module Authorization::Dataset
 
   include ResourceMethods
+
+  def self.redacted_columns
+    super + [:cert]
+  end
+
   include SemaphoreMethods
   include HealthMonitorMethods
 
-  semaphore :checkup, :destroy, :restart, :reconfigure
+  semaphore :checkup, :destroy, :restart, :reconfigure, :refresh_certificates
+
+  plugin :column_encryption do |enc|
+    enc.column :cert_key
+  end
 
   def hostname
     "#{cluster.name}#{index}.#{Config.minio_host_name}"
@@ -34,7 +43,7 @@ class MinioServer < Sequel::Model
   end
 
   def ip4_url
-    "http://#{vm.ephemeral_net4}:9000"
+    "https://#{vm.ephemeral_net4}:9000"
   end
 
   def endpoint

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -96,7 +96,8 @@ PGHOST=/var/run/postgresql
     @blob_storage_client ||= Minio::Client.new(
       endpoint: blob_storage_endpoint,
       access_key: access_key,
-      secret_key: secret_key
+      secret_key: secret_key,
+      ssl_ca_file_data: blob_storage.root_certs
     )
   end
 

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -174,7 +174,8 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     client = Minio::Client.new(
       endpoint: minio_server.ip4_url,
       access_key: minio_server.cluster.admin_user,
-      secret_key: minio_server.cluster.admin_password
+      secret_key: minio_server.cluster.admin_password,
+      ssl_ca_file_data: minio_server.cluster.root_certs
     )
 
     server_data = JSON.parse(client.admin_info.body)["servers"].find { _1["endpoint"] == minio_server.endpoint }

--- a/prog/minio/setup_minio.rb
+++ b/prog/minio/setup_minio.rb
@@ -38,7 +38,10 @@ ff02::3 ip6-allhosts
 ECHO
       config_json = JSON.generate({
         minio_config: minio_config,
-        hosts: hosts
+        hosts: hosts,
+        cert: minio_server.cert,
+        cert_key: minio_server.cert_key,
+        ca_bundle: minio_server.cluster.root_certs
       })
 
       minio_server.vm.sshable.cmd("common/bin/daemonizer 'sudo minio/bin/configure-minio' configure_minio", stdin: config_json)

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -90,7 +90,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     admin_client = Minio::Client.new(
       endpoint: postgres_timeline.blob_storage_endpoint,
       access_key: Config.postgres_service_blob_storage_access_key,
-      secret_key: Config.postgres_service_blob_storage_secret_key
+      secret_key: Config.postgres_service_blob_storage_secret_key,
+      ssl_ca_file_data: postgres_timeline.blob_storage.root_certs
     )
 
     admin_client.admin_remove_user(postgres_timeline.access_key)
@@ -102,7 +103,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       admin_client = Minio::Client.new(
         endpoint: postgres_timeline.blob_storage_endpoint,
         access_key: Config.postgres_service_blob_storage_access_key,
-        secret_key: Config.postgres_service_blob_storage_secret_key
+        secret_key: Config.postgres_service_blob_storage_secret_key,
+        ssl_ca_file_data: postgres_timeline.blob_storage.root_certs
       )
 
       # Setup user keys and policy for the timeline

--- a/rhizome/minio/bin/configure-minio
+++ b/rhizome/minio/bin/configure-minio
@@ -14,8 +14,20 @@ unless (hosts = config_json["hosts"])
   exit 1
 end
 
+cert = config_json["cert"]
+cert_key = config_json["cert_key"]
+ca_bundle = config_json["ca_bundle"]
+
 require_relative "../../common/lib/util"
 
 safe_write_to_file("/etc/default/minio", minio_config)
 safe_write_to_file("/etc/hosts", hosts)
 r "sudo chown -R minio-user:minio-user /etc/default/minio"
+
+if cert && cert_key && ca_bundle
+  r "sudo mkdir -p /home/minio-user/.minio/certs/CAs"
+  safe_write_to_file(".minio/certs/public.crt", cert)
+  safe_write_to_file(".minio/certs/private.key", cert_key)
+  safe_write_to_file(".minio/certs/CAs/public.crt", ca_bundle)
+  r "sudo chown -R minio-user:minio-user /home/minio-user/.minio/certs"
+end

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Minio::Client do
-  let(:endpoint) { "http://localhost:9000" }
+  let(:endpoint) { "https://localhost:9000" }
   let(:access_key) { "minioadmin" }
   let(:secret_key) { "minioadmin" }
 
   it "can use sockets" do
-    expect(Excon).to receive(:new).with("unix:///", socket: "/tmp/socket")
+    expect(Excon).to receive(:new).with("unix:///", socket: "/tmp/socket", ssl_ca_file: File.join(Dir.pwd, "var", "ca_bundles", access_key + ".crt"))
     described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key, socket: "/tmp/socket")
   end
 

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe MinioCluster do
       location: "hetzner-hel1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
-      admin_password: "dummy-password"
+      admin_password: "dummy-password",
+      root_cert_1: "root_cert_1",
+      root_cert_2: "root_cert_2"
     )
     mp = MinioPool.create_with_id(
       cluster_id: mc.id,
@@ -55,7 +57,7 @@ RSpec.describe MinioCluster do
 
   it "returns connection strings properly" do
     expect(mc.servers.first.vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
-    expect(mc.ip4_urls).to eq(["http://1.1.1.1:9000"])
+    expect(mc.ip4_urls).to eq(["https://1.1.1.1:9000"])
   end
 
   it "returns hyper tag name properly" do

--- a/spec/model/minio/minio_pool_spec.rb
+++ b/spec/model/minio/minio_pool_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe MinioPool do
       location: "hetzner-hel1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
-      admin_password: "dummy-password"
+      admin_password: "dummy-password",
+      root_cert_1: "dummy-root-cert-1",
+      root_cert_2: "dummy-root-cert-2"
     )
     mp = described_class.create_with_id(
       cluster_id: mc.id,
@@ -40,7 +42,7 @@ RSpec.describe MinioPool do
 
     it "returns volumes url properly for a multi drive multi server pool" do
       mp.update(drive_count: 4, server_count: 2)
-      expect(mp.volumes_url).to eq("http://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
+      expect(mp.volumes_url).to eq("https://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
     end
   end
 

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe MinioServer do
       location: "hetzner-hel1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
-      admin_password: "dummy-password"
+      admin_password: "dummy-password",
+      root_cert_1: "dummy-root-cert-1",
+      root_cert_2: "dummy-root-cert-2"
     )
     mp = MinioPool.create_with_id(
       cluster_id: mc.id,
@@ -53,7 +55,7 @@ RSpec.describe MinioServer do
 
     it "returns minio volumes properly for a multi drive multi server cluster" do
       ms.pool.update(drive_count: 4, server_count: 2)
-      expect(ms.minio_volumes).to eq("http://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
+      expect(ms.minio_volumes).to eq("https://minio-cluster-name{0...1}.minio.ubicloud.com:9000/minio/dat{1...2}")
     end
   end
 
@@ -117,12 +119,12 @@ RSpec.describe MinioServer do
 
     it "returns url properly" do
       DnsZone.create_with_id(project_id: Config.minio_service_project_id, name: Config.minio_host_name)
-      expect(ms.server_url).to eq("http://minio-cluster-name.minio.ubicloud.com:9000")
+      expect(ms.server_url).to eq("https://minio-cluster-name.minio.ubicloud.com:9000")
     end
 
     it "returns ip address when dns zone is not found" do
       expect(ms.vm).to receive(:ephemeral_net4).and_return("10.10.10.10")
-      expect(ms.server_url).to eq("http://10.10.10.10:9000")
+      expect(ms.server_url).to eq("https://10.10.10.10:9000")
     end
   end
 end

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -76,19 +76,19 @@ RSpec.describe MinioServer do
   it "checks pulse" do
     session = {
       ssh_session: instance_double(Net::SSH::Connection::Session),
-      minio_client: Minio::Client.new(endpoint: "http://1.2.3.4:9000", access_key: "dummy-key", secret_key: "dummy-secret")
+      minio_client: Minio::Client.new(endpoint: "https://1.2.3.4:9000", access_key: "dummy-key", secret_key: "dummy-secret")
     }
 
     expect(ms.vm).to receive(:ephemeral_net4).and_return("1.2.3.4").at_least(:once)
     expect(ms).not_to receive(:incr_checkup)
 
-    stub_request(:get, "http://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "online", endpoint: "1.2.3.4:9000", drives: [{state: "ok"}]}]}))
+    stub_request(:get, "https://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "online", endpoint: "1.2.3.4:9000", drives: [{state: "ok"}]}]}))
     ms.check_pulse(session: session, previous_pulse: {reading: "down", reading_rpt: 5, reading_chg: Time.now - 30})
 
-    stub_request(:get, "http://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "online", endpoint: "1.2.3.4:9000", drives: [{state: "faulty"}]}]}))
+    stub_request(:get, "https://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "online", endpoint: "1.2.3.4:9000", drives: [{state: "faulty"}]}]}))
     ms.check_pulse(session: session, previous_pulse: {})
 
-    stub_request(:get, "http://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "offline", endpoint: "1.2.3.4:9000"}]}))
+    stub_request(:get, "https://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "offline", endpoint: "1.2.3.4:9000"}]}))
     ms.check_pulse(session: session, previous_pulse: {})
   end
 

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -123,7 +123,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns empty array if user is not created yet" do
-    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint")).at_least(:once)
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
     minio_client = instance_double(Minio::Client)
     expect(minio_client).to receive(:list_objects).and_raise(RuntimeError.new("The Access Key Id you provided does not exist in our records."))
     expect(Minio::Client).to receive(:new).and_return(minio_client)
@@ -131,7 +131,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "re-raises exceptions other than missin access key" do
-    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint")).at_least(:once)
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
     minio_client = instance_double(Minio::Client)
     expect(minio_client).to receive(:list_objects).and_raise(RuntimeError.new("some error"))
     expect(Minio::Client).to receive(:new).and_return(minio_client)
@@ -140,7 +140,7 @@ PGHOST=/var/run/postgresql
 
   it "returns list of backups" do
     stub_const("Backup", Struct.new(:key))
-    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint")).at_least(:once)
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
 
     minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key")
     expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/").and_return([instance_double(Backup, key: "backup_stop_sentinel.json"), instance_double(Backup, key: "unrelated_file.txt")])
@@ -156,6 +156,7 @@ PGHOST=/var/run/postgresql
 
   it "returns blob storage client from cache" do
     expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, root_certs: "certs")).once
     expect(Minio::Client).to receive(:new).and_return("dummy-client").once
     expect(postgres_timeline.blob_storage_client).to eq("dummy-client")
     expect(postgres_timeline.blob_storage_client).to eq("dummy-client")

--- a/spec/model/resource_methods_spec.rb
+++ b/spec/model/resource_methods_spec.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper"
 
 RSpec.describe ResourceMethods do
   it "hides sensitive and long columns" do
-    [GithubRunner, PostgresResource, Vm, VmHost].each do |klass|
+    [GithubRunner, PostgresResource, Vm, VmHost, MinioCluster, MinioServer].each do |klass|
       inspect_output = klass.new.inspect
       klass.redacted_columns.each do |column_key|
         expect(inspect_output).not_to include column_key.to_s

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -6,12 +6,19 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   subject(:nx) { described_class.new(described_class.assemble(minio_pool.id, 0)) }
 
   let(:minio_pool) {
+    ps = Prog::Vnet::SubnetNexus.assemble(
+      minio_project.id, name: "minio-cluster-name"
+    )
     mc = MinioCluster.create_with_id(
       location: "hetzner-hel1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",
-      private_subnet_id: ps.id
+      private_subnet_id: ps.id,
+      root_cert_1: "root_cert_1",
+      root_cert_key_1: "root_cert_key_1",
+      root_cert_2: "root_cert_2",
+      root_cert_key_2: "root_cert_key_2"
     )
 
     MinioPool.create_with_id(
@@ -23,10 +30,19 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       vm_size: "standard-2"
     )
   }
-  let(:ps) {
-    Prog::Vnet::SubnetNexus.assemble(
-      minio_project.id, name: "minio-cluster-name"
-    )
+
+  let(:cert_1) {
+    instance_double(OpenSSL::X509::Certificate, not_after: Time.now + 60 * 60 * 24 * 365 * 5)
+  }
+  let(:key_1) { instance_double(OpenSSL::PKey::EC) }
+  let(:create_certificate_payload) {
+    {
+      subject: "/C=US/O=Ubicloud/CN=#{nx.minio_server.cluster.ubid} Server Certificate",
+      extensions: ["subjectAltName=DNS:minio-cluster-name.minio.ubicloud.com,DNS:minio-cluster-name0.minio.ubicloud.com", "keyUsage=digitalSignature,keyEncipherment", "subjectKeyIdentifier=hash", "extendedKeyUsage=serverAuth"],
+      duration: 60 * 60 * 24 * 30 * 6,
+      issuer_cert: cert_1,
+      issuer_key: key_1
+    }
   }
 
   let(:minio_project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
@@ -50,7 +66,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(Vm.count).to eq 1
       expect(Vm.first.unix_user).to eq "minio-user"
       expect(Vm.first.sshable.host).to eq "temp_#{Vm.first.id}"
-      expect(Vm.first.private_subnets.first.id).to eq ps.id
+      expect(Vm.first.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
     end
 
     it "fails if pool is not valid" do
@@ -65,23 +81,67 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect { nx.start }.to nap(5)
     end
 
-    it "updates sshable and hops to bootstrap_rhizome if dnszone doesn't exist" do
+    it "creates server certificate and hops to bootstrap_rhizome if dnszone doesn't exist" do
       vm = nx.minio_server.vm
       vm.strand.update(label: "wait")
+      expect(nx).to receive(:vm).and_return(vm)
       expect(nx).to receive(:register_deadline)
-      expect(nx).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "minio", "subject_id" => vm.id, "user" => "minio-user"})
-      expect { nx.start }.to hop("wait_bootstrap_rhizome")
+      expect(OpenSSL::X509::Certificate).to receive(:new).with("root_cert_1").and_return(cert_1)
+      expect(OpenSSL::PKey::EC).to receive(:new).with("root_cert_key_1").and_return(key_1)
+      expect(Util).to receive(:create_certificate).with(create_certificate_payload).and_return([instance_double(OpenSSL::X509::Certificate, to_pem: "cert"), instance_double(OpenSSL::PKey::EC, to_pem: "cert_key")])
+      expect(nx.minio_server).to receive(:update).and_call_original
+
+      expect { nx.start }.to hop("bootstrap_rhizome")
+
+      expect(nx.minio_server.cert).to eq "cert"
+      expect(nx.minio_server.cert_key).to eq "cert_key"
     end
 
-    it "updates sshable, inserts dns record and hops to bootstrap_rhizome if dnszone exists" do
+    it "creates server certificate with ip_san and hops to bootstrap_rhizome if dnszone doesn't exist" do
+      vm = nx.minio_server.vm
+      vm.strand.update(label: "wait")
+      expect(nx).to receive(:vm).and_return(vm)
+      expect(nx).to receive(:register_deadline)
+      expect(OpenSSL::X509::Certificate).to receive(:new).with("root_cert_1").and_return(cert_1)
+      expect(OpenSSL::PKey::EC).to receive(:new).with("root_cert_key_1").and_return(key_1)
+
+      expect(Config).to receive(:development?).and_return(true)
+      expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
+      create_certificate_payload[:extensions] = ["subjectAltName=DNS:minio-cluster-name.minio.ubicloud.com,DNS:minio-cluster-name0.minio.ubicloud.com,IP:1.1.1.1", "keyUsage=digitalSignature,keyEncipherment", "subjectKeyIdentifier=hash", "extendedKeyUsage=serverAuth"]
+      expect(Util).to receive(:create_certificate).with(create_certificate_payload).and_return([instance_double(OpenSSL::X509::Certificate, to_pem: "cert"), instance_double(OpenSSL::PKey::EC, to_pem: "cert_key")])
+
+      expect(nx.minio_server).to receive(:update).and_call_original
+
+      expect { nx.start }.to hop("bootstrap_rhizome")
+
+      expect(nx.minio_server.cert).to eq "cert"
+      expect(nx.minio_server.cert_key).to eq "cert_key"
+    end
+
+    it "inserts dns record and hops to bootstrap_rhizome if dnszone exists" do
       dz = DnsZone.create_with_id(project_id: minio_project.id, name: Config.minio_host_name)
       expect(nx.minio_server.cluster).to receive(:dns_zone).and_return(dz).at_least(:once)
       vm = nx.minio_server.vm
       vm.strand.update(label: "wait")
+      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(nx.minio_server.cluster.dns_zone).to receive(:insert_record).with(record_name: nx.cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
       expect(nx).to receive(:register_deadline)
+      expect(OpenSSL::X509::Certificate).to receive(:new).with("root_cert_1").and_return(cert_1)
+      expect(OpenSSL::PKey::EC).to receive(:new).with("root_cert_key_1").and_return(key_1)
+      expect(Util).to receive(:create_certificate).with(create_certificate_payload).and_return([instance_double(OpenSSL::X509::Certificate, to_pem: "cert"), instance_double(OpenSSL::PKey::EC, to_pem: "cert_key")])
+      expect(nx.minio_server).to receive(:update).and_call_original
+
+      expect { nx.start }.to hop("bootstrap_rhizome")
+      expect(nx.minio_server.cert).to eq "cert"
+      expect(nx.minio_server.cert_key).to eq "cert_key"
+    end
+  end
+
+  describe "#bootstrap_rhizome" do
+    it "buds bootstrap rhizome and hops to wait_bootstrap_rhizome" do
+      vm = nx.minio_server.vm
       expect(nx).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "minio", "subject_id" => vm.id, "user" => "minio-user"})
-      expect { nx.start }.to hop("wait_bootstrap_rhizome")
+      expect { nx.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
     end
   end
 
@@ -264,13 +324,13 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   describe "#available?" do
     it "returns true if health check is successful" do
       expect(nx.minio_server.vm).to receive(:ephemeral_net4).and_return("1.2.3.4").twice
-      stub_request(:get, "http://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "online", endpoint: "1.2.3.4:9000", drives: [{state: "ok"}]}]}))
+      stub_request(:get, "https://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "online", endpoint: "1.2.3.4:9000", drives: [{state: "ok"}]}]}))
       expect(nx.available?).to be(true)
     end
 
     it "returns false if health check is unsuccessful" do
       expect(nx.minio_server.vm).to receive(:ephemeral_net4).and_return("1.2.3.4").twice
-      stub_request(:get, "http://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "offline", endpoint: "1.2.3.4:9000"}]}))
+      stub_request(:get, "https://1.2.3.4:9000/minio/admin/v3/info").to_return(status: 200, body: JSON.generate({servers: [{state: "offline", endpoint: "1.2.3.4:9000"}]}))
       expect(nx.available?).to be(false)
     end
 

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe Prog::Minio::SetupMinio do
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",
-      private_subnet_id: ps.id
+      private_subnet_id: ps.id,
+      root_cert_1: "root_cert_1",
+      root_cert_key_1: "root_cert_key_1",
+      root_cert_2: "root_cert_2",
+      root_cert_key_2: "root_cert_key_2"
     )
 
     mp = MinioPool.create_with_id(
@@ -31,7 +35,9 @@ RSpec.describe Prog::Minio::SetupMinio do
     MinioServer.create_with_id(
       minio_pool_id: mp.id,
       vm_id: vm.id,
-      index: 0
+      index: 0,
+      cert: "cert",
+      cert_key: "key"
     )
   }
 
@@ -72,7 +78,7 @@ MINIO_VOLUMES="/minio/dat1"
 MINIO_OPTS="--console-address :9001"
 MINIO_ROOT_USER="minio-admin"
 MINIO_ROOT_PASSWORD="dummy-password"
-MINIO_SERVER_URL="http://minio-cluster-name.minio.ubicloud.com:9000"
+MINIO_SERVER_URL="https://minio-cluster-name.minio.ubicloud.com:9000"
 ECHO
       minio_hosts = <<ECHO
 ::1 ip6-localhost ip6-loopback
@@ -85,7 +91,10 @@ ff02::3 ip6-allhosts
 ECHO
       JSON.generate({
         minio_config: minio_config,
-        hosts: minio_hosts
+        hosts: minio_hosts,
+        cert: "cert",
+        cert_key: "key",
+        ca_bundle: "root_cert_1" + "root_cert_2"
       }).chomp
     }
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -170,15 +170,15 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(nx).to receive(:postgres_resource).and_return(postgres_resource).at_least(:once)
       expect(Config).to receive(:postgres_service_hostname).and_return("postgres.ubicloud.com").at_least(:once)
 
-      expect(nx).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 5).and_call_original
-      expect(nx).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 10).and_call_original
+      expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 5, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
+      expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 10, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
       expect(nx).to receive(:create_server_certificate).and_call_original
 
       expect { nx.initialize_certificates }.to hop("wait_server")
     end
 
     it "naps if there are children" do
-      expect(nx).to receive(:create_root_certificate).twice
+      expect(Util).to receive(:create_root_certificate).twice
       expect(nx).to receive(:create_server_certificate)
       expect(nx).to receive(:leaf?).and_return(false)
       expect { nx.initialize_certificates }.to nap(5)
@@ -190,7 +190,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(OpenSSL::X509::Certificate).to receive(:new).with("root cert 1").and_return(instance_double(OpenSSL::X509::Certificate, not_after: Time.now + 60 * 60 * 24 * 30 * 4))
       expect(OpenSSL::X509::Certificate).to receive(:new).with("server cert").and_return(instance_double(OpenSSL::X509::Certificate, not_after: Time.now + 60 * 60 * 24 * 30 * 4))
 
-      expect(nx).to receive(:create_root_certificate).with(hash_including(duration: 60 * 60 * 24 * 365 * 10))
+      expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 10, common_name: "#{postgres_resource.ubid} Root Certificate Authority")
       expect(postgres_resource.server).to receive(:incr_refresh_certificates)
 
       expect { nx.refresh_certificates }.to hop("wait")


### PR DESCRIPTION
**MinIO Certs DB migration**
We add new columns to both minio_cluster and minio_server tables to
start using SSL certificates.

**Move create_root_certificates to Util** 
We move the create_root_certificate of PostgresResourceNexus Prog to
Util to be able to reuse it in both MinioClusterNexus and
PostgresResourceNexus.

**MinIO ssl certificate provisioning and configurations** 
This commit modifies the MinIO cluster provisioning flow to create root
and server certificates. We also start pushing the root certs as part of
the ca_bundle to the minio servers at the time of configuration.

**Minio Cluster certificate refresh**
We start refreshing certificates for Minio cluster and servers.

**Refactor Minio dependencies with the SSL support** 
We start using ssl certificates for MinIO which requires all the clients
to be accepting the ca bundle we used to create these certificates.
Therefore, here, in this PR, we are updating the dependencies in the
code that are;
1. Any code path that use Minio::Client
2. Postgres wal-g configuration.