### PR TITLE
Postgres HA

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -42,4 +42,9 @@ module Option
   PostgresSizes = [2, 4, 8, 16].map {
     PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 128)
   }.freeze
+
+  PostgresHaOption = Struct.new(:name)
+  PostgresHaOptions = [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC].map {
+    PostgresHaOption.new(_1)
+  }.freeze
 end

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -57,6 +57,12 @@ module Validation
     vm_size
   end
 
+  def self.validate_postgres_ha_type(ha_type)
+    unless Option::PostgresHaOptions.find { _1.name == ha_type }
+      fail ValidationFailed.new({ha_type: "\"#{ha_type}\" is not a valid PostgreSQL high availability option. Available options: #{Option::PostgresHaOptions.map(&:name)}"})
+    end
+  end
+
   def self.validate_os_user_name(os_user_name)
     msg = "OS user name must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also have max length of 32."
     fail ValidationFailed.new({user: msg}) unless os_user_name&.match(ALLOWED_OS_USER_NAME_PATTERN)

--- a/migrate/20240209_postgres_multiple_servers.rb
+++ b/migrate/20240209_postgres_multiple_servers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  change do
+    alter_table(:postgres_server) do
+      add_column :representative_at, :timestamptz, null: true, default: nil
+      add_index :resource_id, unique: true, where: Sequel.~(representative_at: nil), concurrently: true
+    end
+  end
+end

--- a/migrate/20240210_postgres_ha.rb
+++ b/migrate/20240210_postgres_ha.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_enum(:ha_type, %w[none async sync])
+    create_enum(:synchronization_status, %w[catching_up ready])
+
+    alter_table(:postgres_resource) do
+      add_column :ha_type, :ha_type, null: false, default: "none"
+    end
+
+    alter_table(:postgres_server) do
+      add_column :synchronization_status, :synchronization_status, null: false, default: "ready"
+    end
+  end
+end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -7,7 +7,8 @@ class PostgresResource < Sequel::Model
   many_to_one :project
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
   many_to_one :parent, key: :parent_id, class: self
-  one_to_one :server, class: PostgresServer, key: :resource_id
+  one_to_many :servers, class: PostgresServer, key: :resource_id
+  one_to_one :representative_server, class: PostgresServer, key: :resource_id, conditions: Sequel.~(representative_at: nil)
   one_through_one :timeline, class: PostgresTimeline, join_table: :postgres_server, left_key: :resource_id, right_key: :timeline_id
   one_to_many :firewall_rules, class: PostgresFirewallRule, key: :postgres_resource_id
 
@@ -46,7 +47,7 @@ class PostgresResource < Sequel::Model
     if Prog::Postgres::PostgresResourceNexus.dns_zone
       "#{name}.#{Config.postgres_service_hostname}"
     else
-      server&.vm&.ephemeral_net4&.to_s
+      representative_server&.vm&.ephemeral_net4&.to_s
     end
   end
 

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -20,7 +20,7 @@ class PostgresResource < Sequel::Model
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
 
-  semaphore :destroy, :update_firewall_rules
+  semaphore :update_firewall_rules, :refresh_dns_record, :destroy
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -74,7 +74,7 @@ class PostgresServer < Sequel::Model
         }
       },
       identity: resource.identity,
-      hosts: "#{vm.ephemeral_net4} #{resource.identity}"
+      hosts: "#{resource.representative_server.vm.ephemeral_net4} #{resource.identity}"
     }
   end
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -16,7 +16,7 @@ class PostgresServer < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
 
-  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup, :configure, :update_firewall_rules, :destroy
+  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup, :configure, :update_firewall_rules, :take_over, :destroy
 
   def configure_hash
     configs = {
@@ -103,6 +103,20 @@ class PostgresServer < Sequel::Model
     !resource.representative_server.primary?
   end
 
+  def failover_target
+    target = resource.servers
+      .select { _1.standby? && _1.strand.label == "wait" }
+      .map { {server: _1, lsn: _1.vm.sshable.cmd("sudo -u postgres psql -At -c 'SELECT pg_last_wal_receive_lsn()'").chomp} }
+      .max_by { lsn2int(_1[:lsn]) }
+
+    if resource.ha_type == PostgresResource::HaType::ASYNC
+      return nil if lsn_monitor.last_known_lsn.nil?
+      return nil if lsn_diff(lsn_monitor.last_known_lsn, target[:lsn]) > 80 * 1024 * 1024 # 80 MB or ~5 WAL files
+    end
+
+    target[:server]
+  end
+
   def init_health_monitor_session
     FileUtils.rm_rf(health_monitor_socket_path)
     FileUtils.mkdir_p(health_monitor_socket_path)
@@ -153,5 +167,13 @@ class PostgresServer < Sequel::Model
     resource.firewall_rules.each do |pg_fwr|
       fw.insert_firewall_rule(pg_fwr.cidr.to_s, Sequel.pg_range(5432..5432))
     end
+  end
+
+  def lsn2int(lsn)
+    lsn.split("/").map { _1.rjust(8, "0") }.join.hex
+  end
+
+  def lsn_diff(lsn1, lsn2)
+    lsn2int(lsn1) - lsn2int(lsn2)
   end
 end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -58,7 +58,8 @@ PGHOST=/var/run/postgresql
 
   def latest_backup_label_before_target(target:)
     backup = backups.sort_by(&:last_modified).reverse.find { _1.last_modified < target }
-    backup.key.delete_prefix("basebackups_005/").delete_suffix("_backup_stop_sentinel.json") if backup
+    fail "BUG: no backup found" unless backup
+    backup.key.delete_prefix("basebackups_005/").delete_suffix("_backup_stop_sentinel.json")
   end
 
   def refresh_earliest_backup_completion_time

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -154,6 +154,11 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def wait
+    # Create missing standbys
+    (postgres_resource.required_standby_count + 1 - postgres_resource.servers.count).times do
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: postgres_resource.id, timeline_id: postgres_resource.timeline.id, timeline_access: "fetch")
+    end
+
     when_refresh_dns_record_set? do
       hop_refresh_dns_record
     end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -12,7 +12,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup, :configure, :update_firewall_rules, :destroy
 
-  def self.assemble(resource_id:, timeline_id:, timeline_access:)
+  def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil)
     DB.transaction do
       ubid = PostgresServer.generate_ubid
 
@@ -36,6 +36,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         resource_id: resource_id,
         timeline_id: timeline_id,
         timeline_access: timeline_access,
+        representative_at: representative_at,
         vm_id: vm_st.id
       ) { _1.id = ubid.to_uuid }
 

--- a/rhizome/postgres/bin/initialize-database-from-backup
+++ b/rhizome/postgres/bin/initialize-database-from-backup
@@ -25,6 +25,12 @@ r "sudo -u postgres touch /dat/16/data/pg_ident.conf"
 r "sudo -u postgres touch /dat/16/data/pg_hba.conf"
 r "sudo -u postgres touch /dat/16/data/postgresql.conf"
 
-r "sudo -u postgres touch /dat/16/data/recovery.signal"
-
+# Technically LATEST label can be used for PITR as well, but we use the label
+# name from backups in PITR case. So backup_label can be used to decide on
+# which signal file to use.
+if backup_label == "LATEST"
+  r "sudo -u postgres touch /dat/16/data/standby.signal"
+else
+  r "sudo -u postgres touch /dat/16/data/recovery.signal"
+end
 r "pg_createcluster 16 main"

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -83,7 +83,7 @@ class CloverWeb
         Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
         Authorization.authorize(@current_user.id, "Postgres:view", pg.id)
 
-        unless pg.server.primary?
+        unless pg.representative_server.primary?
           flash["error"] = "Superuser password cannot be updated during restore!"
           return redirect_back_with_inputs
         end
@@ -91,7 +91,7 @@ class CloverWeb
         Validation.validate_postgres_superuser_password(r.params["original_password"], r.params["repeat_password"])
 
         pg.update(superuser_password: r.params["original_password"])
-        pg.server.incr_update_superuser_password
+        pg.representative_server.incr_update_superuser_password
 
         flash["notice"] = "The superuser password will be updated in a few seconds"
 

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -5,7 +5,7 @@ class CloverWeb
     @serializer = Serializers::Web::Postgres
 
     r.get true do
-      @postgres_databases = serialize(@project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand, :server, :timeline).all)
+      @postgres_databases = serialize(@project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand, :representative_server, :timeline).all)
 
       view "postgres/index"
     end

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -21,9 +21,9 @@ class Serializers::Web::Postgres < Serializers::Base
   structure(:detailed) do |pg|
     base(pg).merge({
       connection_string: pg.connection_string,
-      primary?: pg.server&.primary?,
+      primary?: pg.representative_server&.primary?,
       firewall_rules: pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Web::PostgresFirewallRule.serialize(fw) }
-    }).merge((pg.timeline && pg.server && pg.server.primary?) ? {
+    }).merge((pg.timeline && pg.representative_server && pg.representative_server.primary?) ? {
       earliest_restore_time: pg.timeline.earliest_restore_time&.utc&.iso8601,
       latest_restore_time: pg.timeline.latest_restore_time&.utc&.iso8601
     } : {})

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -162,6 +162,16 @@ RSpec.describe Validation do
       end
     end
 
+    describe "#validate_postgres_ha_type" do
+      it "valid postgres ha_type" do
+        [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC].each { |ha_type| expect { described_class.validate_postgres_ha_type(ha_type) }.not_to raise_error }
+      end
+
+      it "invalid postgres ha_type" do
+        ["quorum", "on", "off"].each { |ha_type| expect { described_class.validate_postgres_ha_type(ha_type) }.to raise_error described_class::ValidationFailed }
+      end
+    end
+
     describe "#validate_date" do
       it "valid date" do
         expect(described_class.validate_date("2023-11-30 11:41")).to eq(Time.new(2023, 11, 30, 11, 41, 0, "UTC"))

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PostgresResource do
     described_class.new(
       name: "pg-name",
       superuser_password: "dummy-password"
-    )
+    ) { _1.id = "6181ddb3-0002-8ad0-9aeb-084832c9273b" }
   }
 
   it "returns connection string" do
@@ -23,6 +23,11 @@ RSpec.describe PostgresResource do
   it "returns connection string as nil if there is no server" do
     expect(postgres_resource).to receive(:representative_server).and_return(nil).at_least(:once)
     expect(postgres_resource.connection_string).to be_nil
+  end
+
+  it "returns replication_connection_string" do
+    s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
+    expect(s).to include("ubi_replication@pgc60xvcr00a5kbnggj1js4kkq.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/dat/16/data/server.crt")
   end
 
   it "returns running as display state if the database is ready" do

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe PostgresResource do
   end
 
   it "returns connection string with ip address if config is not set" do
-    expect(postgres_resource).to receive(:server).and_return(instance_double(PostgresServer, vm: instance_double(Vm, ephemeral_net4: "1.2.3.4"))).at_least(:once)
+    expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, vm: instance_double(Vm, ephemeral_net4: "1.2.3.4"))).at_least(:once)
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@1.2.3.4")
   end
 
   it "returns connection string as nil if there is no server" do
-    expect(postgres_resource).to receive(:server).and_return(nil).at_least(:once)
+    expect(postgres_resource).to receive(:representative_server).and_return(nil).at_least(:once)
     expect(postgres_resource.connection_string).to be_nil
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -7,7 +7,13 @@ RSpec.describe PostgresServer do
     described_class.new { _1.id = "c068cac7-ed45-82db-bf38-a003582b36ee" }
   }
 
-  let(:resource) { instance_double(PostgresResource, identity: "pgubid.postgres.ubicloud.com") }
+  let(:resource) {
+    instance_double(
+      PostgresResource,
+      representative_server: postgres_server,
+      identity: "pgubid.postgres.ubicloud.com"
+    )
+  }
 
   let(:vm) {
     instance_double(

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe PostgresServer do
     instance_double(
       PostgresResource,
       representative_server: postgres_server,
-      identity: "pgubid.postgres.ubicloud.com"
+      identity: "pgubid.postgres.ubicloud.com",
+      ha_type: PostgresResource::HaType::NONE
     )
   }
 
@@ -36,76 +37,57 @@ RSpec.describe PostgresServer do
     allow(postgres_server).to receive_messages(resource: resource, vm: vm)
   end
 
-  it "generates configure_hash" do
-    expect(postgres_server).to receive(:timeline).and_return(instance_double(PostgresTimeline, blob_storage: "dummy-blob-storage"))
-    postgres_server.timeline_access = "push"
-    configure_hash = {
-      configs: {
-        listen_addresses: "'*'",
-        max_connections: "200",
-        superuser_reserved_connections: "3",
-        shared_buffers: "2048MB",
-        work_mem: "1MB",
-        maintenance_work_mem: "512MB",
-        max_parallel_workers: "4",
-        max_parallel_workers_per_gather: "2",
-        max_parallel_maintenance_workers: "2",
-        min_wal_size: "80MB",
-        max_wal_size: "5GB",
-        random_page_cost: "1.1",
-        effective_cache_size: "6144MB",
-        effective_io_concurrency: "200",
-        tcp_keepalives_count: "4",
-        tcp_keepalives_idle: "2",
-        tcp_keepalives_interval: "2",
-        ssl: "on",
-        ssl_min_protocol_version: "TLSv1.3",
-        ssl_ca_file: "'/dat/16/data/ca.crt'",
-        ssl_cert_file: "'/dat/16/data/server.crt'",
-        ssl_key_file: "'/dat/16/data/server.key'",
-        log_timezone: "'UTC'",
-        log_directory: "'pg_log'",
-        log_filename: "'postgresql.log'",
-        log_truncate_on_rotation: "true",
-        logging_collector: "on",
-        timezone: "'UTC'",
-        lc_messages: "'C.UTF-8'",
-        lc_monetary: "'C.UTF-8'",
-        lc_numeric: "'C.UTF-8'",
-        lc_time: "'C.UTF-8'",
-        archive_mode: "on",
-        archive_command: "'/usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env'",
-        archive_timeout: "60"
-      },
-      private_subnets: [
-        {
-          net4: "172.0.0.0/26",
-          net6: "fdfa:b5aa:14a3:4a3d::/64"
-        }
-      ],
-      identity: "pgubid.postgres.ubicloud.com",
-      hosts: "1.2.3.4 pgubid.postgres.ubicloud.com"
-    }
+  describe "#configure" do
+    before do
+      allow(postgres_server).to receive(:timeline).and_return(instance_double(PostgresTimeline, blob_storage: "dummy-blob-storage"))
+    end
 
-    expect(postgres_server.configure_hash).to eq(configure_hash)
-  end
+    it "does not set archival related configs if blob storage is not configured" do
+      expect(postgres_server).to receive(:timeline).and_return(instance_double(PostgresTimeline, blob_storage: nil))
+      expect(postgres_server.configure_hash[:configs]).not_to include(:archive_mode, :archive_timeout, :archive_command, :synchronous_standby_names, :primary_conninfo, :recovery_target_time, :restore_command)
+    end
 
-  it "generates configure_hash with additonal fields for restoring servers" do
-    expect(postgres_server).to receive(:timeline).and_return(instance_double(PostgresTimeline, blob_storage: "dummy-blob-storage"))
-    postgres_server.timeline_access = "fetch"
-    expect(postgres_server).to receive(:resource).and_return(instance_double(PostgresResource, restore_target: "2023-10-25 00:00"))
-    expect(postgres_server.configure_hash[:configs]).to include(
-      recovery_target_time: "'2023-10-25 00:00'",
-      restore_command: "'/usr/bin/wal-g wal-fetch %f %p --config /etc/postgresql/wal-g.env'"
-    )
-  end
+    it "sets configs that are specific to primary" do
+      postgres_server.timeline_access = "push"
+      expect(postgres_server.configure_hash[:configs]).to include(:archive_mode, :archive_timeout, :archive_command)
+    end
 
-  it "does not set archival related configs if blob storage is not configured" do
-    expect(postgres_server).to receive(:timeline).and_return(instance_double(PostgresTimeline, blob_storage: nil))
-    postgres_server.timeline_access = "push"
-    expect(postgres_server.configure_hash[:configs]).not_to include(
-      archive_mode: "on"
-    )
+    it "sets synchronous_standby_names for sync replication mode" do
+      postgres_server.timeline_access = "push"
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgubidstandby1", standby?: true, synchronization_status: "catching_up"),
+        instance_double(described_class, ubid: "pgubidstandby2", standby?: true, synchronization_status: "ready")
+      ])
+
+      expect(postgres_server.configure_hash[:configs]).to include(synchronous_standby_names: "'ANY 1 (pgubidstandby2)'")
+    end
+
+    it "sets synchronous_standby_names as empty if there is no caught up standby" do
+      postgres_server.timeline_access = "push"
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgubidstandby1", standby?: true, synchronization_status: "catching_up"),
+        instance_double(described_class, ubid: "pgubidstandby2", standby?: true, synchronization_status: "catching_up")
+      ])
+
+      expect(postgres_server.configure_hash[:configs]).not_to include(:synchronous_standby_names)
+    end
+
+    it "sets configs that are specific to standby" do
+      postgres_server.timeline_access = "fetch"
+      expect(postgres_server).to receive(:doing_pitr?).and_return(false).at_least(:once)
+      expect(resource).to receive(:replication_connection_string)
+      expect(postgres_server.configure_hash[:configs]).to include(:primary_conninfo, :restore_command)
+    end
+
+    it "sets configs that are specific to restoring servers" do
+      postgres_server.timeline_access = "fetch"
+      expect(resource).to receive(:restore_target)
+      expect(postgres_server.configure_hash[:configs]).to include(:recovery_target_time, :restore_command)
+    end
   end
 
   it "initiates a new health monitor session" do

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -93,11 +93,11 @@ PGHOST=/var/run/postgresql
       expect(postgres_timeline.latest_backup_label_before_target(target: most_recent_backup_time - 50)).to eq("0002")
     end
 
-    it "returns nil if no backups before given target" do
+    it "raises error if no backups before given target" do
       stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([])
 
-      expect(postgres_timeline.latest_backup_label_before_target(target: Time.now)).to be_nil
+      expect { postgres_timeline.latest_backup_label_before_target(target: Time.now) }.to raise_error RuntimeError, "BUG: no backup found"
     end
   end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -90,6 +90,12 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
       described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 100, parent_id: parent.id, restore_target: restore_target)
     end
+
+    it "creates additional servers for HA" do
+      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_access: "push"))
+      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_access: "fetch")).twice
+      described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 100, ha_type: "sync")
+    end
   end
 
   describe "#before_run" do

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -269,8 +269,13 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   end
 
   describe "#wait" do
-    it "naps" do
-      expect(postgres_resource).to receive(:certificate_last_checked_at).and_return(Time.now)
+    before do
+      allow(postgres_resource).to receive_messages(certificate_last_checked_at: Time.now, required_standby_count: 0)
+    end
+
+    it "creates missing standbys" do
+      expect(postgres_resource).to receive(:required_standby_count).and_return(1)
+      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble)
       expect { nx.wait }.to nap(30)
     end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
 
-      st = described_class.assemble(resource_id: postgres_resource.id, timeline_id: postgres_timeline.id, timeline_access: "push")
+      st = described_class.assemble(resource_id: postgres_resource.id, timeline_id: postgres_timeline.id, timeline_access: "push", representative_at: Time.now)
 
       postgres_server = PostgresServer[st.id]
       expect(postgres_server).not_to be_nil

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "does not show reset superuser password for restoring database" do
-        pg.server.update(timeline_access: "fetch")
+        pg.representative_server.update(timeline_access: "fetch")
 
         visit "#{project.path}#{pg.path}"
         expect(page).to have_no_content "Reset superuser password"
@@ -232,7 +232,7 @@ RSpec.describe Clover, "postgres" do
         visit "#{project.path}#{pg.path}"
         expect(page).to have_content "Reset superuser password"
 
-        pg.server.update(timeline_access: "fetch")
+        pg.representative_server.update(timeline_access: "fetch")
         fill_in "New password", with: "DummyPassword123"
         fill_in "New password (repeat)", with: "DummyPassword123"
         click_button "Reset"

--- a/spec/serializers/web/postgres_spec.rb
+++ b/spec/serializers/web/postgres_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Serializers::Web::Postgres do
   it "can serialize when no earliest/latest restore times" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)
-    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
@@ -18,7 +18,7 @@ RSpec.describe Serializers::Web::Postgres do
     time = Time.now
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).exactly(3)
-    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to eq(time.iso8601)
     expect(data[:latest_restore_time]).to eq(time.iso8601)
@@ -26,7 +26,7 @@ RSpec.describe Serializers::Web::Postgres do
 
   it "can serialize when not primary" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:server).and_return(instance_double(PostgresServer, primary?: false, vm: nil)).exactly(2)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil)).exactly(2)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
@@ -34,7 +34,7 @@ RSpec.describe Serializers::Web::Postgres do
 
   it "can serialize when there is no server" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:server).and_return(nil).exactly(2)
+    expect(pg).to receive(:representative_server).and_return(nil).exactly(2)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:primary?]).to be_nil
     expect(data[:earliest_restore_time]).to be_nil


### PR DESCRIPTION
**Support multiple PostgresServers per PostgresResource**
So far, we assumed PostgresResource would only have one PostgresServer entity
and we wrote bunch of code with that assumption. However, in the case of high
availability and SKU changes with failovers, a PostgresResource can have more
than one PostgresServer entities. In such cases, it is important to have a way
distinguish the PostgresServer that is the primary contact point of the given
PostgresResource in places like taking backups or configuring the DNS records.
This commits introduced representative_server association for PostgresResource,
which refers to that primary contact point.

representative_server is different than the primary server. Restoring or read
replica PostgresResources would not have a primary server but they would have
a representative_server.

Rest of the commit is some helpers and boring refactors to ensure that we don't
assume only one PostgresServer per PostgresResource.

**PostgreSQL HA standby set up**
We are introducing new parameter for PostgresResource.assemble; ha_status, and
depending on its value we configure sync or async (or no) replication. If sync
replication is specified, we create 2 standbys and require acknowledgement from
at least one of them. If async replication is specified, we create 1 standby.

**Failover of PostgreSQL primary server**
This commits extends the logic in unavailable label. We start to check if there
is an appropriate a failover target, that is sufficently caught up HA standby.
If there is such failover target, we fence the primary node by destroying it
and promote the standby.

There is a special check for async replication; we only trigger failover if the
LSN difference between primary and standby is less than 80MB (~5 WAL files).
This puts a limit on data loss for async replication. We don't need such check
for sync replication, because it should be in same LSN with primary anyway.

**Recreate missing standbys after failover**
After the failover operation is completed, one of the standbys become a primary
node and old primary gets destroyed. As a result of that we are left with one
missing standby. This commit ensures that we are creating a new standby for
replacing the old one.