### PR TITLE
Filter out exited strands from dispatcher scan

### DIFF
--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -18,7 +18,7 @@ class Scheduling::Dispatcher
     end
 
     Strand.dataset.where(
-      Sequel.lit("(lease IS NULL OR lease < now()) AND schedule < now()")
+      Sequel.lit("(lease IS NULL OR lease < now()) AND schedule < now() AND exitval IS NULL")
     ).order_by(:schedule).limit(idle_connections)
   end
 


### PR DESCRIPTION
It's important to know that have not allowed exited strands to self-delete when worked for a while now, it's exclusively something parent strands must do.

However, the query for the dispatcher scan can, by bad luck, return *only* exited strands if unlucky.  Directly working these strands is bound to not change anything.

They are skipped for any meaningful work by `take_lease_and_reload`, which has a `WHERE` clause on `exitval`...and they can be returned another time.  And another time.  Forever.  No more progress.

To fix this, filter those records out of the initial `strand` scan.

It's still necessary to both check (to avoid starvation) and re-check `exitval` in `take_lease_and_reload`, since `exitval` can be set during the period between those two queries.