### PR TITLE
Fix flock flag combine operator in daemonizer

### DIFF
--- a/rhizome/common/bin/daemonizer
+++ b/rhizome/common/bin/daemonizer
@@ -48,7 +48,7 @@ else
   FileUtils.mkdir_p("var/proc")
 
   File.open("var/proc/#{name}.lock", File::RDWR | File::CREAT) do |f|
-    break unless f.flock(File::LOCK_EX || File::LOCK_NB)
+    break unless f.flock(File::LOCK_EX | File::LOCK_NB)
 
     state = get_state(name)
     case state


### PR DESCRIPTION
`File::LOCK_EX` is the option for an exclusive lock, and `File::LOCK_NB` is for non-blocking mode. The `||` operator should actually be a bitwise OR operator `|` to combine these flags correctly.

    clover-development(main)> File::LOCK_EX
    => 2
    clover-development(main)> File::LOCK_EX || File::LOCK_NB
    => 2
    clover-development(main)> File::LOCK_EX | File::LOCK_NB
    => 6