### PR TITLE
Remove explicit license label from docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.licenses=Elastic-2.0
           tags: |
             type=sha,prefix=
             type=ref,event=branch
@@ -102,8 +100,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.licenses=Elastic-2.0
           tags: |
             type=sha,prefix=
             type=ref,event=branch


### PR DESCRIPTION
We recently transitioned our license from `Elastic-2.0` to `AGPL-3.0`. The "docker/metadata-action" uses the license from GitHub metadata. GitHub employs [licensee](https://github.com/licensee/licensee) to identify the license type. I manually added the license label to our docker image since "licensee" couldn't detect the `Elastic-2.0` license. However, since we've updated our license, there's no longer a need to explicitly set it.