### PR TITLE
Load pg_array extension explicitly

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -17,5 +17,5 @@ end
 
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic
-DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range
+DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range, :pg_array
 Sequel.extension :pg_range_ops


### PR DESCRIPTION
We use the `pg_array` extension in the Authorization module. Previously, it functioned without explicit loading. Although I'm uncertain about its previous behaviour, my local development setup recently started failing due to a `NoMethodError: undefined method 'pg_array' for Sequel:Module` exception. The correct practice is to load an extension before use. Therefore, to avoid any unforeseen issues, I've added `pg_array` to the list of loaded extensions.