### PR TITLE
Fix PG Server certificate refresh infinite loop

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -130,6 +130,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   end
 
   label def refresh_certificates
+    decr_refresh_certificates
     vm.sshable.cmd("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: postgres_server.resource.server_cert)
     vm.sshable.cmd("sudo -u postgres tee /dat/16/data/server.key > /dev/null", stdin: postgres_server.resource.server_cert_key)
     vm.sshable.cmd("sudo -u postgres chmod 600 /dat/16/data/server.key")

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#refresh_certificates" do
     it "pushes certificates to vm and hops to configure during initial provisioning" do
+      expect(nx).to receive(:decr_refresh_certificates)
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: "server_cert")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.key > /dev/null", stdin: "server_cert_key")
       expect(sshable).to receive(:cmd).with("sudo -u postgres chmod 600 /dat/16/data/server.key")
@@ -222,6 +223,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "hops to wait at times other than the initial provisioning" do
+      expect(nx).to receive(:decr_refresh_certificates)
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: "server_cert")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.key > /dev/null", stdin: "server_cert_key")
       expect(sshable).to receive(:cmd).with("sudo -u postgres chmod 600 /dat/16/data/server.key")


### PR DESCRIPTION
Looks like we forgot to decr_refresh_certificates in PostgresServerNexus.refresh_certificates. This causes the server to get into an infinite certificate refresh loop once incremented. This fixes that.