### PR TITLE
Decrease the minimum invoice charge threshold

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -82,7 +82,7 @@ module Config
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)
   override :hetzner_ssh_key, string
-  override :minimum_invoice_charge_threshold, 1.0, float
+  override :minimum_invoice_charge_threshold, 0.5, float
 
   # GitHub Runner App
   optional :github_app_name, string

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Invoice do
 
     it "not charge if less than minimum charge threshold" do
       allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
-      invoice.content["cost"] = 0.5
+      invoice.content["cost"] = 0.4
       expect(invoice).to receive(:update).with(status: "below_minimum_threshold")
       expect do
         expect(invoice.charge).to be_nil
-      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] cost is less than minimum charge cost: $0.5\n").to_stdout
+      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] cost is less than minimum charge cost: $0.4\n").to_stdout
     end
 
     it "not charge if doesn't have billing info" do


### PR DESCRIPTION
Stripe supports a minimum charge of $0.50. We have decided to lower our threshold to this value.

https://stripe.com/docs/api/charges/object#charge_object-amount