### PR TITLE
Fix the email button alignment

### DIFF
--- a/views/email/style.erb
+++ b/views/email/style.erb
@@ -196,6 +196,7 @@
       text-decoration: none;
       text-align: center;
       width: 100%;
+      box-sizing: border-box;
   }
 
   .button-primary {


### PR DESCRIPTION
The button in the email template doesn't align correctly due to its borders. When 'box-sizing: border-box' is set, it takes the border into account while calculating the size of the box, thus ensuring correct placement.

Fixes #1166