### PR TITLE
Only perform wait_sshable check on IPv4

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -379,7 +379,17 @@ SQL
   end
 
   label def wait_sshable
-    addr = vm.ephemeral_net4 || vm.ephemeral_net6.nth(2)
+    addr = vm.ephemeral_net4
+
+    # Alas, our hosting environment, for now, doesn't support IPv6, so
+    # only check SSH availability when IPv4 is available: a
+    # unistacked IPv6 server will not be checked.
+    #
+    # I considered removing wait_sshable altogether, but (very)
+    # occasionally helps us glean interesting information about boot
+    # problems.
+    hop_create_billing_record unless addr
+
     begin
       Socket.tcp(addr.to_s, 22, connect_timeout: 1) {}
     rescue SystemCallError

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -568,12 +568,9 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
 
-    it "uses ipv6 if ipv4 is not enabled" do
-      expect(vm).to receive(:created_at).and_return(Time.now)
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhhqmsyfvzpy2q9gqb5h0mpde2"))
-      expect(vm).to receive(:ephemeral_net6).and_return(NetAddr::IPv6Net.parse("2a01:4f8:10a:128b:3bfa::/79"))
-      expect(Socket).to receive(:tcp).with("2a01:4f8:10a:128b:3bfa::2", 22, connect_timeout: 1)
-      expect(vm).to receive(:update).with(display_state: "running").and_return(true)
+    it "skips a check if ipv4 is not enabled" do
+      expect(vm.ephemeral_net4).to be_nil
+      expect(vm).not_to receive(:ephemeral_net6)
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
   end


### PR DESCRIPTION

As-is, our hosting environment cannot handle IPv6 transit and IPv6
unistacked VMs *never* reach the provisioned state successfully...even
though they are in fact available.

However, someone reading the console doesn't know this: they'd
conclude the system is totally broken.

I thought about removing the `wait_sshable` state entirely, as in the
general case people can set firewalls restrictive enough to not listen
to SSH or boot custom images that may not use SSH or configure it
differently.  This was my objection even when it was introduced.

However... as a pragmatic measure, `wait_sshable` still teaches us
about occasional boot problems, and as we do not yet support custom
images, we can be reasonably assured that failure to open this port is
abnormal.  Getting paged for those provides lessons we still need.

To mostly retain that source of information, I trim our sails to only
do this check when the targer computer has a route via IPv4.