### PR TITLE
Improve LearnStorage prog to allow rerunning

### DIFF
--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -24,13 +24,16 @@ class Prog::LearnStorage < Prog::Base
 
   def df_command(path = "") = "df -B1 --output=target,size,avail #{path}"
 
+  def storage_device(name)
+    vm_host.storage_devices.find { _1.name == name } || StorageDevice.new_with_id(vm_host_id: vm_host.id, name: name)
+  end
+
   def make_model_instances
     devices = DfRecord.parse_all(sshable.cmd(df_command))
     if devices.none? { _1.optional_name }
       rec = DfRecord.parse_all(sshable.cmd(df_command("/var/storage"))).first
       [
-        StorageDevice.new_with_id(
-          vm_host_id: vm_host.id, name: "DEFAULT",
+        storage_device("DEFAULT").set(
           # reserve 5G the host.
           available_storage_gib: [rec.avail_gib - 5, 0].max,
           total_storage_gib: rec.size_gib
@@ -39,8 +42,7 @@ class Prog::LearnStorage < Prog::Base
     else
       devices.filter_map do |rec|
         next unless (name = rec.optional_name)
-        StorageDevice.new_with_id(
-          vm_host_id: vm_host.id, name: name,
+        storage_device(name).set(
           available_storage_gib: rec.avail_gib,
           total_storage_gib: rec.size_gib
         )


### PR DESCRIPTION
When we run the `LearnStorage` prog on an existing VM host that already run it, it fails due to a 'duplicate storage device' error. If the storage device already exists, we should avoid creating a new record.

Fixes #1147