### PR TITLE
Do not resolve capacity incident immediately

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -278,7 +278,9 @@ SQL
       nap 30
     end
 
-    Page.from_tag_parts("NoCapacity", vm.location, vm.arch)&.incr_resolve if queued_vms.count <= 1
+    if (page = Page.from_tag_parts("NoCapacity", vm.location, vm.arch)) && page.created_at < Time.now - 15 * 60 && queued_vms.count <= 1
+      page.incr_resolve
+    end
 
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled


### PR DESCRIPTION
When the number of queued virtual machines is not high, the capacity page is resolved but triggered each time the queue is emptied and refilled. To ensure complete resolution, we may keep the capacity incidents at least 15 minutes. At worst, this will generate 4 incidents per hour.