### PR TITLE
Add wildcard permission support to authorization

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -294,6 +294,10 @@ class CloverWeb < Roda
     request.redirect env["HTTP_REFERER"]
   end
 
+  def has_project_permission(actions)
+    @project_permissions.intersection(Authorization.expand_actions(actions)).any?
+  end
+
   hash_branch("dashboard") do |r|
     view "/dashboard"
   end

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -63,12 +63,7 @@ module Authorization
   def self.generate_default_acls(subject, object)
     {
       acls: [
-        {subjects: [subject], actions: ["Project:view", "Project:edit", "Project:delete", "Project:user", "Project:policy", "Project:billing", "Project:github"], objects: [object]},
-        {subjects: [subject], actions: ["Vm:view", "Vm:create", "Vm:delete"], objects: [object]},
-        {subjects: [subject], actions: ["Vm:Firewall:view", "Vm:Firewall:edit"], objects: [object]},
-        {subjects: [subject], actions: ["PrivateSubnet:view", "PrivateSubnet:create", "PrivateSubnet:delete", "PrivateSubnet:nic"], objects: [object]},
-        {subjects: [subject], actions: ["Postgres:view", "Postgres:create", "Postgres:delete"], objects: [object]},
-        {subjects: [subject], actions: ["Postgres:Firewall:view", "Postgres:Firewall:edit"], objects: [object]}
+        {subjects: [subject], actions: ["*"], objects: [object]}
       ]
     }
   end

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -326,16 +326,6 @@ RSpec.describe Clover, "project" do
         expect(page.status_code).to eq(404)
         expect(page).to have_content "Resource not found"
       end
-
-      it "shows all default actions at documentation" do
-        visit "#{project.path}/policy"
-
-        default_actions = Authorization.generate_default_acls(nil, nil)[:acls].flat_map { _1[:actions] }
-
-        within "table" do
-          default_actions.each { expect(page).to have_content(_1) }
-        end
-      end
     end
 
     describe "delete" do

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -74,7 +74,7 @@
           <% end %>
         </ul>
       </li>
-      <% if @project_data && (@project_permissions & ["Project:user", "Project:policy", "Project:billing", "Project:view"]).any? %>
+      <% if @project_data && has_project_permission(["Project:user", "Project:policy", "Project:billing", "Project:view"]) %>
         <li>
           <div class="text-xs font-semibold leading-6 text-orange-200">Project Details</div>
           <ul role="list" class="-mx-2 mt-2 space-y-1">
@@ -85,7 +85,7 @@
                 url: "#{@project_data[:path]}/user",
                 is_active: request.path.start_with?("#{@project_data[:path]}/user"),
                 icon: "hero-users",
-                has_permission: @project_permissions.include?("Project:user")
+                has_permission: has_project_permission("Project:user")
               }
             ) %>
             <%== render(
@@ -95,7 +95,7 @@
                 url: "#{@project_data[:path]}/policy",
                 is_active: request.path.start_with?("#{@project_data[:path]}/policy"),
                 icon: "hero-key",
-                has_permission: @project_permissions.include?("Project:policy")
+                has_permission: has_project_permission("Project:policy")
               }
             ) %>
             <% if Config.stripe_secret_key %>
@@ -106,7 +106,7 @@
                   url: "#{@project_data[:path]}/billing",
                   is_active: request.path.start_with?("#{@project_data[:path]}/billing"),
                   icon: "hero-banknotes",
-                  has_permission: @project_permissions.include?("Project:billing")
+                  has_permission: has_project_permission("Project:billing")
                 }
               ) %>
             <% end %>
@@ -117,13 +117,13 @@
                 url: @project_data[:path],
                 is_active: request.path == @project_data[:path],
                 icon: "hero-cog-6-tooth",
-                has_permission: @project_permissions.include?("Project:view")
+                has_permission: has_project_permission("Project:view")
               }
             ) %>
           </ul>
         </li>
       <% end %>
-      <% if @project_data && (@project_permissions & ["Project:github"]).any? %>
+      <% if @project_data && has_project_permission("Project:github") %>
               <li>
           <div class="text-xs font-semibold leading-6 text-orange-200">Integrations</div>
           <ul role="list" class="-mx-2 mt-2 space-y-1">
@@ -135,7 +135,7 @@
                   url: "#{@project_data[:path]}/github",
                   is_active: request.path.start_with?("#{@project_data[:path]}/github"),
                   icon: "github",
-                  has_permission: @project_permissions.include?("Project:github")
+                  has_permission: has_project_permission("Project:github")
                 }
               ) %>
             <% end %>

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -14,7 +14,7 @@
       "components/page_header",
       locals: {
         title: "PostgreSQL Databases",
-        right_items: @project_permissions.include?("Postgres:create") ? [
+        right_items: has_project_permission("Postgres:create") ? [
           render("components/button", locals: { text: "Create PostgreSQL Database", link: "postgres/create" })
         ] : []
       }
@@ -58,7 +58,7 @@
       icon: "hero-circle-stack",
       title: "No PostgreSQL databases",
       description: "You don't have permission to create PostgreSQL database."
-    }.merge(@project_permissions.include?("Postgres:create") ? {
+    }.merge(has_project_permission("Postgres:create") ? {
       description: "Get started by creating a new PostgreSQL database.",
       button_link: "#{@project_data[:path]}/postgres/create",
       button_title: "New PostgreSQL Database"

--- a/views/private_subnet/index.erb
+++ b/views/private_subnet/index.erb
@@ -14,7 +14,7 @@
       "components/page_header",
       locals: {
         title: "Private Subnets",
-        right_items: @project_permissions.include?("PrivateSubnet:create") ? [
+        right_items: has_project_permission("PrivateSubnet:create") ? [
           render("components/button", locals: { text: "Create Private Subnet", link: "private-subnet/create" })
         ] : []
       }
@@ -58,7 +58,7 @@
       icon: "hero-globe-alt",
       title: "No private subnets",
       description: "You don't have permission to create private subnet."
-    }.merge(@project_permissions.include?("PrivateSubnet:create") ? {
+    }.merge(has_project_permission("PrivateSubnet:create") ? {
       description: "Get started by creating a new private subnet.",
       button_link: "#{@project_data[:path]}/private-subnet/create",
       button_title: "New Private Subnet"

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -15,7 +15,7 @@
       "components/page_header",
       locals: {
         title: "Virtual Machines",
-        right_items: @project_permissions.include?("Vm:create") ? [
+        right_items: has_project_permission("Vm:create") ? [
           render("components/button", locals: { text: "Create Virtual Machine", link: "vm/create" })
         ] : []
       }
@@ -73,7 +73,7 @@
       icon: "hero-server-stack",
       title: "No virtual machines",
       description: "You don't have permission to create virtual machines."
-    }.merge(@project_permissions.include?("Vm:create") ? {
+    }.merge(has_project_permission("Vm:create") ? {
       description: "Get started by creating a new virtual machine.",
       button_link: "#{@project_data[:path]}/vm/create",
       button_title: "New Virtual Machine"


### PR DESCRIPTION
### Add wildcard permission support to authorization

We need to individually specify all available permissions in our access policies. As our feature set expands, our policies become more extensive. When we introduce a new service, we must add permissions for it to existing access policies, as they do not automatically include it. Modifying customer access policies is not a best practice. However, without such modifications, customers won't have access to new features. We could alter our default policy to `"*"`, enabling customers to access all current and future services by default.

The implementation was simpler than I expected. It's sufficient to expand actions before running the authorization query.

### Change cached project permissions to work with wildcard

We have an anti-pattern usage in our authorization workflow. When we load a web page, we cache all permissions for a project and check project permission from there. In other words, without this cache, we would need to send 7 authorization queries to render the sidebar


### Replace default access policy with wildcard

My primary motivation for adding wildcard support was to modify the default access policy using a wildcard. Whenever we introduce a new service, it is necessary to add permissions to existing access policies because they do not automatically incorporate it. This poses a maintenance challenge.

A fine-grained default policy provides more information to new users than one with a wildcard. However, we can educate users about our policy languages through documentation.
