### PR TITLE
Change user hyper tag with UBID

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -67,6 +67,7 @@ class CloverWeb < Roda
       flash["error"] = @error[:message]
       return redirect_back_with_inputs
     when Validation::ValidationFailed
+      flash["error"] = "Validation failed for following fields: #{@error[:details].keys.join(", ")}"
       flash["errors"] = (flash["errors"] || {}).merge(@error[:details])
       return redirect_back_with_inputs
     when Roda::RodaPlugins::RouteCsrf::InvalidToken

--- a/model/access_policy.rb
+++ b/model/access_policy.rb
@@ -6,6 +6,36 @@ class AccessPolicy < Sequel::Model
   many_to_one :project
 
   include ResourceMethods
+
+  def transform_to_names
+    tag_to_name = project.accounts.map { [_1.hyper_tag_name, _1.policy_tag_name] }.to_h
+    transform(tag_to_name)
+    self
+  end
+
+  def transform_to_tags
+    name_to_tag = project.accounts.map { [_1.policy_tag_name, _1.hyper_tag_name] }.to_h
+    transform(name_to_tag)
+    self
+  end
+
+  def transform(lookup)
+    body["acls"] = body["acls"].map do
+      _1.tap { |acl|
+        acl["subjects"] = value_from_lookup(lookup, acl["subjects"])
+        acl["objects"] = value_from_lookup(lookup, acl["objects"])
+      }
+    end
+  end
+
+  def value_from_lookup(lookup, key)
+    return key.map { value_from_lookup(lookup, _1) } if key.is_a?(Array)
+    if key.start_with?("user/")
+      lookup.fetch(key) { fail Validation::ValidationFailed.new({body: "'#{key}' doesn't exists in your project."}) }
+    else
+      lookup[key] || key
+    end
+  end
 end
 
 # We need to unrestrict primary key so project.add_access_policy works

--- a/model/account.rb
+++ b/model/account.rb
@@ -7,6 +7,10 @@ class Account < Sequel::Model(:accounts)
   include Authorization::HyperTagMethods
 
   def hyper_tag_name(project = nil)
+    ubid
+  end
+
+  def policy_tag_name
     "user/#{email}"
   end
 

--- a/model/project.rb
+++ b/model/project.rb
@@ -8,6 +8,7 @@ class Project < Sequel::Model
   one_to_one :billing_info, key: :id, primary_key: :billing_info_id
   one_to_many :github_installations
 
+  many_to_many :accounts, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :vms, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :minio_clusters, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :private_subnets, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
@@ -27,10 +28,6 @@ class Project < Sequel::Model
   end
 
   include Authorization::TaggableMethods
-
-  def user_ids
-    access_tags_dataset.where(hyper_tag_table: Account.table_name.to_s).select_map(:hyper_tag_id)
-  end
 
   def has_valid_payment_method?
     return true unless Config.stripe_secret_key

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -25,7 +25,7 @@ class CloverApi
         r.halt
       end
 
-      unless @project.user_ids.include?(@current_user.id)
+      unless @project.accounts.include?(@current_user)
         fail Authorization::Unauthorized
       end
 

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -31,7 +31,7 @@ class CloverWeb
         r.halt
       end
 
-      unless @project.user_ids.include?(@current_user.id)
+      unless @project.accounts.include?(@current_user)
         fail Authorization::Unauthorized
       end
 

--- a/routes/web/project/policy.rb
+++ b/routes/web/project/policy.rb
@@ -30,7 +30,7 @@ class CloverWeb
           return redirect_back_with_inputs
         end
 
-        policy.update(body: body)
+        policy.tap { _1.body = body }.transform_to_tags.save_changes
 
         flash["notice"] = "'#{policy.name}' policy updated for '#{@project.name}'"
 

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -6,8 +6,7 @@ class CloverWeb
     @serializer = Serializers::Web::Account
 
     r.get true do
-      users_with_hyper_tag = @project.user_ids
-      @users = serialize(Account.where(id: users_with_hyper_tag).all)
+      @users = serialize(@project.accounts)
 
       view "project/user"
     end
@@ -41,7 +40,7 @@ class CloverWeb
       end
 
       r.delete true do
-        unless @project.user_ids.count > 1
+        unless @project.accounts.count > 1
           response.status = 400
           return {message: "You can't remove the last user from '#{@project.name}' project. Delete project instead."}.to_json
         end

--- a/serializers/web/access_policy.rb
+++ b/serializers/web/access_policy.rb
@@ -2,6 +2,7 @@
 
 class Serializers::Web::AccessPolicy < Serializers::Base
   def self.base(ap)
+    ap.transform_to_names
     {
       id: ap.id,
       ubid: ap.ubid,

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -104,10 +104,14 @@ RSpec.describe Authorization do
 
   describe "#HyperTagMethods" do
     it "hyper_tag_name" do
-      expect(users[0].hyper_tag_name).to eq("user/auth1@example.com")
+      expect(users[0].hyper_tag_name).to eq(users[0].ubid)
       p = vms[0].projects.first
       expect(vms[0].hyper_tag_name(p)).to eq("project/#{p.ubid}/location/hetzner-hel1/vm/vm0")
       expect(projects[0].hyper_tag_name).to eq("project/#{projects[0].ubid}")
+    end
+
+    it "policy_tag_name" do
+      expect(users[0].policy_tag_name).to eq("user/auth1@example.com")
     end
 
     it "hyper_tag_name error" do

--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -18,6 +18,9 @@
         <%== csrf_tag("#{@project_data[:path]}/policy/#{@policy[:ubid]}") %>
         <div class="grid grid-cols-12 gap-6">
           <div class="col-span-full">
+            <% if (error = flash.dig("errors", "body")) %>
+              <p class="text-sm text-red-600 leading-6"><%= error %></p>
+            <% end %>
             <div class="policy-editor text-sm">
               <pre class="bg-gray-50 rounded-lg p-3 h-[60vh] overflow-scroll" contenteditable="true">
                 <%= flash.dig("old", "body") || @policy[:body] %>


### PR DESCRIPTION
All resources are represented in our authorization system, referred to as a "hyper tag". Each resource has a unique format, for example, users are represented as `user/test@example.com`, projects as `project/pjbw1tcvkew67qcxqsjpbvh19c`, and virtual machines as `project/pjcm807azyxe6ht7ct027tcg83/location/hetzner-fsn1/vm/my-vm`.

We prefer using user-friendly names over UBIDs, making it easier for customers to edit their access policies. However, we identified a problem with this approach. When a resource's hyper tag changes (e.g., a user changes their email), the existing access policies need to be updated accordingly. Without such updates, permissions to resources could be affected.

Automatically updating access policies to apply these changes is not recommended. Instead, I propose keeping the resource's UBID as the hyper tag in the database, which eliminates the need for changes when resources are renamed. This is because UBIDs remain constant throughout a resource's lifetime.

We only need to map the prettified policy name when displaying or saving access policies. The authorization system uses UBIDs in the background.

I have refactored the user's hyper tag for now. I will continue to refactor other resources in subsequent PRs after the deployment of user change.

We need to update user hyper tags in production after deployment.

From a security perspective, we only transform tags/UBIDs for resources associated with this project.