### PR TITLE
Refactor minio URLs

### DIFF
--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -45,8 +45,8 @@ class MinioCluster < Sequel::Model
     pools.sum(&:drive_count)
   end
 
-  def connection_strings
-    servers.map(&:connection_string)
+  def ip4_urls
+    servers.map(&:ip4_url)
   end
 
   def single_instance_single_drive?
@@ -59,5 +59,13 @@ class MinioCluster < Sequel::Model
 
   def hostname
     "#{name}.#{Config.minio_host_name}"
+  end
+
+  def url
+    dns_zone ? "http://#{hostname}:9000" : nil
+  end
+
+  def dns_zone
+    @dns_zone ||= DnsZone.where(project_id: Config.minio_service_project_id, name: Config.minio_host_name).first
   end
 end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -89,7 +89,7 @@ PGHOST=/var/run/postgresql
   end
 
   def blob_storage_endpoint
-    @blob_storage_endpoint ||= blob_storage.connection_strings.first
+    @blob_storage_endpoint ||= blob_storage.url || blob_storage.ip4_urls.sample
   end
 
   def blob_storage_client

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -56,7 +56,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     nap 5 unless vm.strand.label == "wait"
     register_deadline(:wait, 10 * 60)
 
-    minio_server.dns_zone&.insert_record(record_name: cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
+    minio_server.cluster.dns_zone&.insert_record(record_name: cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
     bud Prog::BootstrapRhizome, {"target_folder" => "minio", "subject_id" => vm.id, "user" => "minio-user"}
 
     hop_wait_bootstrap_rhizome
@@ -140,7 +140,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     register_deadline(nil, 10 * 60)
     DB.transaction do
       decr_destroy
-      minio_server.dns_zone&.delete_record(record_name: cluster.hostname)
+      minio_server.cluster.dns_zone&.delete_record(record_name: cluster.hostname)
       minio_server.vm.sshable.destroy
       minio_server.vm.nics.each { _1.incr_destroy }
       minio_server.vm.incr_destroy
@@ -152,7 +152,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
 
   def available?
     client = Minio::Client.new(
-      endpoint: minio_server.connection_string,
+      endpoint: minio_server.ip4_url,
       access_key: minio_server.cluster.admin_user,
       secret_key: minio_server.cluster.admin_password
     )

--- a/prog/minio/setup_minio.rb
+++ b/prog/minio/setup_minio.rb
@@ -24,7 +24,7 @@ MINIO_VOLUMES="#{minio_server.minio_volumes}"
 MINIO_OPTS="--console-address :9001"
 MINIO_ROOT_USER="#{minio_server.cluster.admin_user}"
 MINIO_ROOT_PASSWORD="#{minio_server.cluster.admin_password}"
-MINIO_SERVER_URL="#{minio_server.url}"
+MINIO_SERVER_URL="#{minio_server.server_url}"
 ECHO
 
       hosts = <<ECHO

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe MinioCluster do
 
   it "returns connection strings properly" do
     expect(mc.servers.first.vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
-    expect(mc.connection_strings).to eq(["http://1.1.1.1:9000"])
+    expect(mc.ip4_urls).to eq(["http://1.1.1.1:9000"])
   end
 
   it "returns hyper tag name properly" do

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe MinioServer do
     expect(ms.private_ipv4_address).to eq("192.168.0.0")
   end
 
-  it "returns name properly" do
-    expect(ms.name).to eq("minio-cluster-name-0-0")
-  end
-
   it "returns minio cluster properly" do
     expect(ms.cluster.name).to eq("minio-cluster-name")
   end
@@ -109,20 +105,8 @@ RSpec.describe MinioServer do
     expect(ms.vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
     expect(ms.endpoint).to eq("1.1.1.1:9000")
 
-    expect(ms).to receive(:dns_zone).and_return("something")
+    expect(ms.cluster).to receive(:dns_zone).and_return("something")
     expect(ms.endpoint).to eq("minio-cluster-name0.minio.ubicloud.com:9000")
-  end
-
-  describe "#dns_zone" do
-    before do
-      minio_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
-      allow(Config).to receive(:minio_service_project_id).and_return(minio_project.id)
-    end
-
-    it "returns dns zone properly" do
-      DnsZone.create_with_id(project_id: Config.minio_service_project_id, name: Config.minio_host_name)
-      expect(ms.dns_zone.name).to eq("minio.ubicloud.com")
-    end
   end
 
   describe "#url" do
@@ -133,12 +117,12 @@ RSpec.describe MinioServer do
 
     it "returns url properly" do
       DnsZone.create_with_id(project_id: Config.minio_service_project_id, name: Config.minio_host_name)
-      expect(ms.url).to eq("http://minio-cluster-name.minio.ubicloud.com:9000")
+      expect(ms.server_url).to eq("http://minio-cluster-name.minio.ubicloud.com:9000")
     end
 
     it "returns ip address when dns zone is not found" do
       expect(ms.vm).to receive(:ephemeral_net4).and_return("10.10.10.10")
-      expect(ms.url).to eq("http://10.10.10.10:9000")
+      expect(ms.server_url).to eq("http://10.10.10.10:9000")
     end
   end
 end

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PostgresTimeline do
   end
 
   it "returns walg config" do
-    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"]))
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
 
     walg_config = <<-WALG_CONF
 WALG_S3_PREFIX=s3://#{postgres_timeline.ubid}
@@ -123,7 +123,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns empty array if user is not created yet" do
-    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"])).twice
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint")).at_least(:once)
     minio_client = instance_double(Minio::Client)
     expect(minio_client).to receive(:list_objects).and_raise(RuntimeError.new("The Access Key Id you provided does not exist in our records."))
     expect(Minio::Client).to receive(:new).and_return(minio_client)
@@ -131,7 +131,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "re-raises exceptions other than missin access key" do
-    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"])).twice
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint")).at_least(:once)
     minio_client = instance_double(Minio::Client)
     expect(minio_client).to receive(:list_objects).and_raise(RuntimeError.new("some error"))
     expect(Minio::Client).to receive(:new).and_return(minio_client)
@@ -140,7 +140,7 @@ PGHOST=/var/run/postgresql
 
   it "returns list of backups" do
     stub_const("Backup", Struct.new(:key))
-    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"])).twice
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint")).at_least(:once)
 
     minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key")
     expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/").and_return([instance_double(Backup, key: "backup_stop_sentinel.json"), instance_double(Backup, key: "unrelated_file.txt")])
@@ -150,7 +150,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns blob storage endpoint" do
-    expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, connection_strings: ["https://blob-endpoint"]))
+    expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
     expect(postgres_timeline.blob_storage_endpoint).to eq("https://blob-endpoint")
   end
 

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -74,10 +74,11 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     end
 
     it "updates sshable, inserts dns record and hops to bootstrap_rhizome if dnszone exists" do
-      DnsZone.create_with_id(project_id: minio_project.id, name: Config.minio_host_name)
+      dz = DnsZone.create_with_id(project_id: minio_project.id, name: Config.minio_host_name)
+      expect(nx.minio_server.cluster).to receive(:dns_zone).and_return(dz).at_least(:once)
       vm = nx.minio_server.vm
       vm.strand.update(label: "wait")
-      expect(nx.minio_server.dns_zone).to receive(:insert_record).with(record_name: nx.cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
+      expect(nx.minio_server.cluster.dns_zone).to receive(:insert_record).with(record_name: nx.cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
       expect(nx).to receive(:register_deadline)
       expect(nx).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "minio", "subject_id" => vm.id, "user" => "minio-user"})
       expect { nx.start }.to hop("wait_bootstrap_rhizome")
@@ -232,7 +233,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(nx.minio_server.vm.nics.first).to receive(:incr_destroy)
       expect(nx.minio_server.vm).to receive(:incr_destroy)
       expect(nx.minio_server).to receive(:destroy)
-      expect(nx.minio_server.dns_zone).to receive(:delete_record).with(record_name: nx.cluster.hostname)
+      expect(nx.minio_server.cluster.dns_zone).to receive(:delete_record).with(record_name: nx.cluster.hostname)
       expect { nx.destroy }.to exit({"msg" => "minio server destroyed"})
     end
   end


### PR DESCRIPTION
We have bunc of functions that return connection strings depending on
multiple factors like DnsZone availability, usage of direct ip4 or
hostname, server specific hostname or cluster connection string, etc.
This started to get out of hand. So, this pr tries to simplify this
situation.