### PR TITLE
Add project rename functionality

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -53,7 +53,7 @@ module Authorization
   def self.generate_default_acls(subject, object)
     {
       acls: [
-        {subjects: [subject], actions: ["Project:view", "Project:delete", "Project:user", "Project:policy", "Project:billing", "Project:github"], objects: [object]},
+        {subjects: [subject], actions: ["Project:view", "Project:edit", "Project:delete", "Project:user", "Project:policy", "Project:billing", "Project:github"], objects: [object]},
         {subjects: [subject], actions: ["Vm:view", "Vm:create", "Vm:delete"], objects: [object]},
         {subjects: [subject], actions: ["PrivateSubnet:view", "PrivateSubnet:create", "PrivateSubnet:delete", "PrivateSubnet:nic"], objects: [object]},
         {subjects: [subject], actions: ["Postgres:view", "Postgres:create", "Postgres:delete"], objects: [object]}

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -44,6 +44,15 @@ class CloverWeb
         view "project/show"
       end
 
+      r.post true do
+        Authorization.authorize(@current_user.id, "Project:edit", @project.id)
+        @project.update(name: r.params["name"])
+
+        flash["notice"] = "The project name is updated to '#{@project.name}'."
+
+        r.redirect @project.path
+      end
+
       r.delete true do
         Authorization.authorize(@current_user.id, "Project:delete", @project.id)
 

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -142,6 +142,23 @@ RSpec.describe Clover, "project" do
         expect(page.status_code).to eq(404)
         expect(page).to have_content "Resource not found"
       end
+
+      it "can update the project name" do
+        new_name = "New Project Name"
+        visit project.path
+
+        fill_in "name", with: new_name
+        click_button "Save"
+
+        expect(page).to have_content new_name
+        expect(project.reload.name).to eq(new_name)
+      end
+
+      it "can not update the project name when does not have permissions" do
+        visit project_wo_permissions.path
+
+        expect { click_button "Save" }.to raise_error Capybara::ElementNotFound
+      end
     end
 
     describe "users" do

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -6,23 +6,29 @@
 <% description = (defined?(description) && description) ? description : nil %>
 <% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
 <% extra_class = defined?(extra_class) ? extra_class : nil %>
+<% button_title = defined?(button_title) ? button_title : nil %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>
     <label for="<%= name %>" class="block text-sm font-medium leading-6"><%= label %></label>
   <% end %>
-  <input
-    id="<%= name %>"
-    type="<%= type %>"
-    name="<%= name %>"
-    <% if value %>
-    value="<%= value %>"
+  <div class="flex gap-x-2">
+    <input
+      id="<%= name %>"
+      type="<%= type %>"
+      name="<%= name %>"
+      <% if value %>
+      value="<%= value %>"
+      <% end %>
+      class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%> <%= extra_class %>"
+      <% attributes.each do |atr_key, atr_value| %>
+      <%= atr_key %>="<%= atr_value %>"
+      <% end%>
+    >
+    <% if button_title %>
+      <%== render("components/form/submit_button", locals: { text: button_title }) %>
     <% end %>
-    class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%> <%= extra_class %>"
-    <% attributes.each do |atr_key, atr_value| %>
-    <%= atr_key %>="<%= atr_value %>"
-    <% end%>
-  >
+  </div>
   <% if error %>
     <% if error.is_a?(Array) %>
       <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">

--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -68,6 +68,10 @@
               <td class="px-2 py-2 border">Grants permission to view Project details</td>
             </tr>
             <tr>
+              <td class="px-2 py-2 border">Project:edit</td>
+              <td class="px-2 py-2 border">Grants permission to update Project details</td>
+            </tr>
+            <tr>
               <td class="px-2 py-2 border">Project:delete</td>
               <td class="px-2 py-2 border">Grants permission to delete Project</td>
             </tr>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -13,16 +13,40 @@
 
 <div class="grid gap-6">
   <!-- Detail Card -->
-  <%== render(
-    "components/kv_data_card",
-    locals: {
-      data: [
-        ["ID", @project_data[:ubid]],
-        ["Name", @project_data[:name]],
-        ["Provider", @project_data.dig(:provider, :display_name)]
-      ]
-    }
-  ) %>
+  <form action="<%= (@project_data[:path]) %>" method="POST">
+    <%== csrf_tag((@project_data[:path])) %>
+
+    <%== render(
+      "components/kv_data_card",
+      locals: {
+        data: [
+          ["ID", @project_data[:ubid]],
+          (
+            if Authorization.has_permission?(@current_user.id, "Project:edit", @project_data[:id])
+              [
+                "Name",
+                render(
+                  "components/form/text",
+                  locals: {
+                    name: "name",
+                    value: @project_data[:name],
+                    button_title: "Save",
+                    attributes: {
+                      required: true
+                    }
+                  }
+                ),
+                { escape: false }
+              ]
+            else
+              ["Name", @project_data[:name]]
+            end
+          ),
+          ["Provider", @project_data.dig(:provider, :display_name)]
+        ]
+      }
+    ) %>
+  </form>
   <!-- Delete Card -->
   <% if Authorization.has_permission?(@current_user.id, "Project:delete", @project_data[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">


### PR DESCRIPTION
The default project created with user registration is named "Default". Users can create a project with their own custom name. However, confusion arises when a user invites another user to their default project, as the invited user sees two different projects named "Default". It becomes challenging to distinguish between the original default project and the newly added one.

We plan to enhance the user experience when multiple projects share the same name.

For now, we offer a project renaming functionality, allowing users to rename their default projects.

<img width="1321" alt="Screenshot 2024-02-05 at 17 01 07" src="https://github.com/ubicloud/ubicloud/assets/993199/98cadb66-8448-4f94-b65f-733a9cf38994">

