### PR TITLE
Add lsn tracking for Postgres monitoring

### DIFF
--- a/migrate/20240208_add_postgres_lsn_monitor.rb
+++ b/migrate/20240208_add_postgres_lsn_monitor.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:postgres_lsn_monitor, unlogged: true) do
+      column :postgres_server_id, :uuid, primary_key: true, null: false
+      column :last_known_lsn, :pg_lsn
+    end
+  end
+end

--- a/model/postgres/postgres_lsn_monitor.rb
+++ b/model/postgres/postgres_lsn_monitor.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "../../model"
+
+class PostgresLsnMonitor < Sequel::Model
+  plugin :insert_conflict
+end


### PR DESCRIPTION
With high availability using async replication, we can trigger failover only
up to a certain threshold of data loss (e.g. we would be OK to lose 100MB of
data but not 1GB). Measuring how much standby is behind compared to primary is
difficult, because we don't have access to the primary at the time of the
failover, thus we need to record the LSNs periodically. Currently, we don't
have a system that periodically collects metrics such as LSN. With this change
monitoring system helps collecting LSN periodically, so that it can be used
while making failover decision.

There are few caveats with collecting metrics such as LSN via monitor;
1. We don't want to add lots of responsibility to monitor to keep it simple and
faster.
2. By design, monitor does not record what it reads because it tries to avoid
accessing to the database as much as possible. It keeps its data in memory.
3. Apart from the database access, writing small data frequently would generate
lots of WAL traffic, which makes backups/restore more difficult.

However for this use case I think these caveats can be mitigated;
- On 1, tracking LSN seems to fit the purpose on health monitor itself. It can
potentially suspect something is wrong based on LSN progress.
- 2 can be mitigated by doing infrequent checkpoints to the database, which is
what we do in this commit. We update the in-memory copy of last_known_lsn in
each health check loop, but save the changes only once a minute.
- For 3, we use unlogged table, which would lose the data if database crashes
or restarts, but that is OK because missing data would be quickly repopulated
by the monitor. If control plane database, monitor and customer database crashes
at the same time, we would not be able to make failover decisions automatically
but that is rare enough and can be resolved by operator intervention.