### PR TITLE
Upgrade to Ruby 3.2.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.2.2
+ruby 3.2.3
 postgres 15.4
 nodejs 21.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM ruby:3.2.2-alpine3.17 as bundler
+FROM ruby:3.2.3-alpine3.19 as bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -19,7 +19,7 @@ RUN bundle config set --local without development:test
 RUN bundle install
 
 
-FROM ruby:3.2.2-alpine3.17
+FROM ruby:3.2.3-alpine3.19
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.2.2"
+ruby "3.2.3"
 
 gem "argon2"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-linux
 
@@ -355,7 +356,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 3.2.3p157
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
This was a bug fix release from about three weeks ago.  I didn't upgrade to get around a particular bug, this is mere hygiene.

https://www.ruby-lang.org/en/news/2024/01/18/ruby-3-2-3-released/