### PR TITLE
Allow to link back to another label for continuation of push

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -153,10 +153,9 @@ end
     strand.retval
   end
 
-  def push(prog, new_frame = {}, label = "start")
-    old_prog = strand.prog
-    old_label = strand.label
-    new_frame = {"subject_id" => @subject_id, "link" => [strand.prog, old_label]}.merge(new_frame)
+  def push(prog, new_frame = {}, label = "start", next_prog: nil, next_label: nil)
+    old_prog, old_label = strand.prog, strand.label
+    new_frame = {"subject_id" => @subject_id, "link" => [next_prog || old_prog, next_label || old_label]}.merge(new_frame)
 
     fail Hop.new(old_prog, old_label,
       {prog: Strand.prog_verify(prog), label: label,

--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -15,8 +15,6 @@ class Prog::BootstrapRhizome < Prog::Base
   end
 
   label def setup
-    pop "rhizome user bootstrapped and source installed" if retval&.dig("msg") == "installed rhizome"
-
     key_data = sshable.keys.map(&:private_key)
     Util.rootish_ssh(sshable.host, user, key_data, <<SH)
 set -ueo pipefail
@@ -29,6 +27,10 @@ sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authoriz
 echo #{sshable.keys.map(&:public_key).join("\n").shellescape} | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 SH
 
-    push Prog::InstallRhizome, {"target_folder" => frame["target_folder"]}
+    push Prog::InstallRhizome, {"target_folder" => frame["target_folder"]}, next_label: "finish"
+  end
+
+  label def finish
+    pop "rhizome user bootstrapped and source installed"
   end
 end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -197,8 +197,7 @@ SQL
     postgres_server.run_query(commands)
 
     when_initial_provisioning_set? do
-      hop_wait if retval&.dig("msg") == "postgres server is restarted"
-      push self.class, frame, "restart"
+      push self.class, frame, "restart", next_label: "wait"
     end
 
     hop_wait

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -75,15 +75,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def verify_vms
-    if retval&.dig("msg") == "Verified VM!"
-      if frame["test_reboot"]
-        hop_test_reboot
-      else
-        hop_destroy_resources
-      end
-    end
-
-    push Prog::Test::Vm, {subject_id: frame["vms"].first}
+    push Prog::Test::Vm, {subject_id: frame["vms"].first}, next_label: frame["test_reboot"] ? "test_reboot" : "destroy_resources"
   end
 
   label def test_reboot

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -336,12 +336,8 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   label def update_firewall_rules
-    if retval&.dig("msg") == "firewall rule is added"
-      hop_wait
-    end
-
     decr_update_firewall_rules
-    push Prog::Vnet::UpdateFirewallRules, {}, :update_firewall_rules
+    push Prog::Vnet::UpdateFirewallRules, {}, :update_firewall_rules, next_label: "wait"
   end
 
   label def update_spdk_dependency

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -160,11 +160,14 @@ RSpec.configure do |config|
   RSpec::Matchers.define :hop do |expected_label, expected_prog|
     supports_block_expectations
 
+    chain(:with_hop) { |&b| @with_hop = b }
+
     match do |block|
       block.call
       false
     rescue Prog::Base::Hop => hop
       @hop = hop
+      @with_hop&.call(hop)
       (expected_label.nil? || hop.new_label == expected_label) &&
         ((expected_prog.nil? && hop.old_prog == hop.new_prog) || hop.new_prog == expected_prog)
     end


### PR DESCRIPTION
### Pass hop exception to the custom rspec matcher

We use a custom rspec matcher to verify hop events. In certain tests,
it's necessary to examine the details of the hop exception. Therefore,
we've made a change to pass the hop exception to the rspec helper,
enabling us to check the exception details within the rspec matcher.

### Allow to link back to another label for continuation of push

Pushing is becoming popular these days. If you're budding a single prog
and don't require concurrency, push is a better option than bud.

At present, its usage pattern is complex. You need to check the retval
of push in the same label you pushed, then move to the next label.

However, we can simplify this by allowing a link back to another label
for the continuation of push. This way, the pushed program returns the
next label instead of the previous one.


Fixes #1187