### PR TITLE
Add ubi_replication user for PostgreSQL

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -50,6 +50,10 @@ class PostgresResource < Sequel::Model
     end
   end
 
+  def identity
+    "#{ubid}.#{Config.postgres_service_hostname}"
+  end
+
   def connection_string
     URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s if hostname
   end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -69,7 +69,8 @@ class PostgresServer < Sequel::Model
           net4: _1.net4.to_s,
           net6: _1.net6.to_s
         }
-      }
+      },
+      identity: resource.identity
     }
   end
 

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -184,8 +184,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     end
 
     Util.create_certificate(
-      subject: "/C=US/O=Ubicloud/CN=#{postgres_resource.ubid} Server Certificate",
-      extensions: ["subjectAltName=DNS:#{postgres_resource.hostname}", "keyUsage=digitalSignature,keyEncipherment", "subjectKeyIdentifier=hash", "extendedKeyUsage=serverAuth,clientAuth"],
+      subject: "/C=US/O=Ubicloud/CN=#{postgres_resource.identity}",
+      extensions: ["subjectAltName=DNS:#{postgres_resource.identity},DNS:#{postgres_resource.hostname}", "keyUsage=digitalSignature,keyEncipherment", "subjectKeyIdentifier=hash", "extendedKeyUsage=serverAuth,clientAuth"],
       duration: 60 * 60 * 24 * 30 * 6, # ~6 months
       issuer_cert: root_cert,
       issuer_key: root_cert_key

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -45,20 +45,26 @@ host    replication     all             ::1/128                 scram-sha-256
 # Allow connections from private subnet with SCRAM authentication
 #{private_subnets}
 
+# Allow replication connection using special replication user for
+# HA standbys
+hostssl replication     ubi_replication all                     cert map=standby2replication
+
 # Allow connections from public internet with SCRAM authentication
 host    all             all             all                     scram-sha-256
 PG_HBA
 safe_write_to_file("/etc/postgresql/16/main/pg_hba.conf", pg_hba_entries)
 
+identity = configure_hash["identity"]
 pg_ident_entries = <<-PG_IDENT
 # PostgreSQL User Name Maps
 # =========================
 #
 # Refer to the PostgreSQL documentation, chapter "Client
 # Authentication" for a complete description.
-# MAPNAME          SYSTEM-USERNAME         PG-USERNAME
-system2postgres    postgres                postgres
-system2postgres    ubi                     postgres
+# MAPNAME             SYSTEM-USERNAME         PG-USERNAME
+system2postgres       postgres                postgres
+system2postgres       ubi                     postgres
+standby2replication   #{identity}             ubi_replication
 PG_IDENT
 safe_write_to_file("/etc/postgresql/16/main/pg_ident.conf", pg_ident_entries)
 

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -9,4 +9,6 @@ r "chown postgres /dat"
 r "rm -rf /dat/16"
 r "rm -rf /etc/postgresql/16"
 
-r "pg_createcluster 16 main"
+r "pg_createcluster 16 main --start"
+
+r "sudo -u postgres psql -c 'CREATE ROLE ubi_replication WITH REPLICATION LOGIN'"

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe PostgresServer do
     described_class.new
   }
 
+  let(:resource) { instance_double(PostgresResource, identity: "pgubid.postgres.ubicloud.com") }
+
   let(:vm) {
     instance_double(
       Vm,
@@ -24,7 +26,7 @@ RSpec.describe PostgresServer do
   }
 
   before do
-    allow(postgres_server).to receive(:vm).and_return(vm)
+    allow(postgres_server).to receive_messages(resource: resource, vm: vm)
   end
 
   it "generates configure_hash" do
@@ -73,7 +75,8 @@ RSpec.describe PostgresServer do
           net4: "172.0.0.0/26",
           net6: "fdfa:b5aa:14a3:4a3d::/64"
         }
-      ]
+      ],
+      identity: "pgubid.postgres.ubicloud.com"
     }
 
     expect(postgres_server.configure_hash).to eq(configure_hash)


### PR DESCRIPTION
This user will be used by standby nodes to connect to the primary nodes and pull the changes. It uses certificate authentication, so it does not need a password.