### PR TITLE
Use /etc/hosts for postgres internal DNS resolving

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -70,7 +70,8 @@ class PostgresServer < Sequel::Model
           net6: _1.net6.to_s
         }
       },
-      identity: resource.identity
+      identity: resource.identity,
+      hosts: "#{vm.ephemeral_net4} #{resource.identity}"
     }
   end
 

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -6,6 +6,19 @@ require_relative "../../common/lib/util"
 
 configure_hash = JSON.parse($stdin.read)
 
+# Update /etc/hosts
+hosts = <<-HOSTS
+127.0.0.1 localhost
+::1 ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts
+#{configure_hash["hosts"]}
+HOSTS
+safe_write_to_file("/etc/hosts", hosts)
+
 # Update postgresql.conf
 configs = configure_hash["configs"].map { |k, v| "#{k} = #{v}" }.join("\n")
 safe_write_to_file("/etc/postgresql/16/main/conf.d/001-service.conf", configs)

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe PostgresServer do
       Vm,
       sshable: instance_double(Sshable),
       mem_gib: 8,
+      ephemeral_net4: "1.2.3.4",
       ephemeral_net6: NetAddr::IPv6Net.parse("fdfa:b5aa:14a3:4a3d::/64"),
       private_subnets: [
         instance_double(
@@ -76,7 +77,8 @@ RSpec.describe PostgresServer do
           net6: "fdfa:b5aa:14a3:4a3d::/64"
         }
       ],
-      identity: "pgubid.postgres.ubicloud.com"
+      identity: "pgubid.postgres.ubicloud.com",
+      hosts: "1.2.3.4 pgubid.postgres.ubicloud.com"
     }
 
     expect(postgres_server.configure_hash).to eq(configure_hash)


### PR DESCRIPTION
This has 3 primary benefits;
- It is faster than making DNS queries
- It is faster and swift (no TTL) to update
- It allows setting up standbys that uses fully qualified domain names even when there is no DNS server (i.e. development environments)