### PR TITLE
Fix IPv6 provisioning, display state edition

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -398,12 +398,12 @@ SQL
       nap 1
     end
 
-    vm.update(display_state: "running")
-    Clog.emit("vm provisioned") { {vm: vm.values, provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.created_at}} }
     hop_create_billing_record
   end
 
   label def create_billing_record
+    vm.update(display_state: "running")
+    Clog.emit("vm provisioned") { {vm: vm.values, provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.created_at}} }
     project = vm.projects.first
     hop_wait unless project.billable
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -564,13 +564,9 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "hops to wait if sshable" do
-      expect(vm).to receive(:created_at).and_return(Time.now)
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhhqmsyfvzpy2q9gqb5h0mpde2"))
       vm_addr = instance_double(AssignedVmAddress, id: "46ca6ded-b056-4723-bd91-612959f52f6f", ip: NetAddr::IPv4Net.parse("10.0.0.1"))
       expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
-      expect(vm).to receive(:update).with(display_state: "running").and_return(true)
-      expect(Clog).to receive(:emit).with("vm provisioned").and_call_original
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
 
@@ -582,6 +578,11 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#create_billing_record" do
+    before do
+      expect(vm).to receive(:update).with(display_state: "running").and_return(true)
+      expect(Clog).to receive(:emit).with("vm provisioned")
+    end
+
     it "creates billing records when ip4 is enabled" do
       vm_addr = instance_double(AssignedVmAddress, id: "46ca6ded-b056-4723-bd91-612959f52f6f", ip: NetAddr::IPv4Net.parse("10.0.0.1"))
       expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)


### PR DESCRIPTION
As of 4733735c3523747ddb99931261d52f9b7f4c4d34, clover no longer gets stuck in wait_ssh, but if you look carefully, the short-circuit skips key side effects we want like updating the display state and emitting some telemetry.

By re-coupling those side effects to `create_billing_record` rather than `wait_sshable`, I think we get the desired effect without noteworthy downside.