### PR TITLE
Use lifecycle policy to automatically purge PostgreSQL backup objects

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -114,6 +114,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
 
       # Create bucket for the timeline
       blob_storage_client.create_bucket(postgres_timeline.ubid)
+      blob_storage_client.set_lifecycle_policy(postgres_timeline.ubid, postgres_timeline.ubid, 8)
     end
   end
 end

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -206,4 +206,20 @@ RSpec.describe Minio::Client do
       expect(minio_client.list_objects("test", "folder_path", max_keys: 1)).to eq([])
     end
   end
+
+  describe "set_lifecycle_policy" do
+    it "raises exception on faulty input" do
+      expect { minio_client.set_lifecycle_policy("test", "shrt", 8) }.to raise_error RuntimeError
+      expect { minio_client.set_lifecycle_policy("test", "loooooooooooooooooooooooooooooooooooooooooooong", 8) }.to raise_error RuntimeError
+      expect { minio_client.set_lifecycle_policy("test", "non-alphanumeric-character", 8) }.to raise_error RuntimeError
+      expect { minio_client.set_lifecycle_policy("test", "testid", "non integer") }.to raise_error RuntimeError
+      expect { minio_client.set_lifecycle_policy("test", "testid", -1) }.to raise_error RuntimeError
+      expect { minio_client.set_lifecycle_policy("test", "testid", 1000) }.to raise_error RuntimeError
+    end
+
+    it "sends a PUT request to /bucket_name?lifecycle" do
+      stub_request(:put, "#{endpoint}/test?lifecycle").to_return(status: 200)
+      expect(minio_client.set_lifecycle_policy("test", "testid", 8)).to eq(200)
+    end
+  end
 end

--- a/spec/lib/minio/header_signer_spec.rb
+++ b/spec/lib/minio/header_signer_spec.rb
@@ -14,12 +14,13 @@ RSpec.describe Minio::HeaderSigner do
   }
 
   describe "build_headers" do
-    it "can build headers and sign" do
+    it "can build headers and sign with and without Content-Md5" do
       method = "PUT"
       uri = URI.parse("http://localhost:9000/test")
       body = "test"
-      allow(Time).to receive(:now).and_return(Time.new("2023-11-30 15:43:58.612009 +0100"))
+      expect(Time).to receive(:now).and_return(Time.new("2023-11-30 15:43:58.612009 +0100")).at_least(:once)
       expect(described_class.new.build_headers(method, uri, body, {access_key: "access_key", secret_key: "secret_key"}, "us-east-1")).to eq(headers)
+      expect(described_class.new.build_headers(method, uri, body, {access_key: "access_key", secret_key: "secret_key"}, "us-east-1", true)).to include("Content-Md5" => "CY9rzUYh03PK3k6DJie09g==")
     end
   end
 end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -58,11 +58,12 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     it "creates bucket and hops" do
       expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs"))
       expect(Minio::Client).to receive(:new).with(endpoint: "https://blob-endpoint", access_key: nil, secret_key: nil, ssl_ca_file_data: "certs").and_return(admin_blob_storage_client)
-      expect(postgres_timeline).to receive(:blob_storage_client).and_return(blob_storage_client)
+      expect(postgres_timeline).to receive(:blob_storage_client).and_return(blob_storage_client).twice
       expect(admin_blob_storage_client).to receive(:admin_add_user).with(postgres_timeline.access_key, postgres_timeline.secret_key).and_return(200)
       expect(admin_blob_storage_client).to receive(:admin_policy_add).with(postgres_timeline.ubid, postgres_timeline.blob_storage_policy).and_return(200)
       expect(admin_blob_storage_client).to receive(:admin_policy_set).with(postgres_timeline.ubid, postgres_timeline.access_key).and_return(200)
       expect(blob_storage_client).to receive(:create_bucket).with(postgres_timeline.ubid).and_return(200)
+      expect(blob_storage_client).to receive(:set_lifecycle_policy).with(postgres_timeline.ubid, postgres_timeline.ubid, 8).and_return(200)
       expect { nx.start }.to hop("wait_leader")
     end
 


### PR DESCRIPTION
**Add set_lifecycle_policy method for Minio client**
MinIO allows setting lifecycle policies for automatic expiration of objects in
it, which is quite useful because it saves us from implementing the logic for
tracking object expirations and purging. Lifecyles can be used with filters and
tiering, but we don't need those right now, only expiration is enough. Thus, I
did not add code for specifying filters or setting up tiering.

**Set lifecycle policy for PostgresTimeline entities**
We need to keep backup files for 7 days, hence we are setting up an expiration
lifecycle policy for 8 days. This only ensures the objects are deleted from the
blob storage, but it does not delete the bucket. Still it is a big improvement
from status quo because it saves lots of space.