### PR TITLE
Add run_query utility for PostgresServer

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -74,7 +74,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def trigger_pg_current_xact_id_on_parent
-    postgres_resource.parent.representative_server.vm.sshable.cmd("sudo -u postgres psql -At -c 'SELECT pg_current_xact_id()'")
+    postgres_resource.parent.representative_server.run_query("SELECT pg_current_xact_id()")
     pop "triggered pg_current_xact_id"
   end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -137,17 +137,9 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
   describe "#trigger_pg_current_xact_id_on_parent" do
     it "triggers pg_current_xact_id and pops" do
-      sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with("sudo -u postgres psql -At -c 'SELECT pg_current_xact_id()'")
-      expect(postgres_resource).to receive(:parent).and_return(
-        instance_double(
-          PostgresResource,
-          representative_server: instance_double(
-            PostgresServer,
-            vm: instance_double(Vm, sshable: sshable)
-          )
-        )
-      )
+      representative_server = instance_double(PostgresServer)
+      expect(representative_server).to receive(:run_query).with("SELECT pg_current_xact_id()")
+      expect(postgres_resource).to receive(:parent).and_return(instance_double(PostgresResource, representative_server: representative_server))
 
       expect { nx.trigger_pg_current_xact_id_on_parent }.to exit({"msg" => "triggered pg_current_xact_id"})
     end


### PR DESCRIPTION
We run SQL queries on the target user database in lots of different places, all in very similar ways. This commit introduces run_query utility to reconcile those calls. As a side benefit it simplifies some of the tests since we don't need to mock sshable anymore.

More subtle, but actually quite important change is that the new utility does not use sudo to run psql as postgres user. It doesn't need to. This is thanks to our earlier change of adding ubi user to pg_ident.conf and allow it to use postgres user while connecting to the database. Does this weaken our security posture? No, because ubi user was always in the sudoers list can can switch to postgres OS user anyway.