### PR TITLE
Use server_url for MinioServer health checks

### DIFF
--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -172,7 +172,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
 
   def available?
     client = Minio::Client.new(
-      endpoint: minio_server.ip4_url,
+      endpoint: minio_server.server_url,
       access_key: minio_server.cluster.admin_user,
       secret_key: minio_server.cluster.admin_password,
       ssl_ca_file_data: minio_server.cluster.root_certs


### PR DESCRIPTION
Commit ee862348fc36af5c94bfc2dc9a07acbc311335cc updated the function we use for health checks. However, further commit to start using SSL certificates forgot to update this with the DNS name of the cluster. Since we do not have IP san in the certificate, health checks started failing.