### PR TITLE
DownloadBootImage support of Minio with SSL

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -121,4 +121,5 @@ module Config
   optional :ubicloud_images_blob_storage_endpoint, string
   optional :ubicloud_images_blob_storage_access_key, string, clear: true
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
+  optional :ubicloud_images_blob_storage_certs, string
 end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -39,7 +39,7 @@ class Prog::DownloadBootImage < Prog::Base
       hop_learn_storage
     when "NotStarted"
       url = custom_url || blob_storage_client.get_presigned_url("GET", Config.ubicloud_images_bucket_name, "#{image_name}-#{vm_host.arch}.raw", 60 * 60).to_s
-      sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image #{image_name.shellescape} #{url.shellescape}' #{("download_" + image_name).shellescape}")
+      sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image #{image_name.shellescape} #{url.shellescape}' #{("download_" + image_name).shellescape}", stdin: Config.ubicloud_images_blob_storage_certs)
     when "Failed"
       fail "Failed to download '#{image_name}' image on #{vm_host}"
     end

--- a/rhizome/host/bin/download-boot-image
+++ b/rhizome/host/bin/download-boot-image
@@ -11,4 +11,7 @@ custom_url = ARGV.shift
 require_relative "../../common/lib/util"
 require_relative "../lib/vm_setup"
 
-VmSetup.new("").download_boot_image(boot_image, custom_url: custom_url)
+certs = $stdin.read
+ca_path = "/usr/lib/ssl/certs/ubicloud_images_blob_storage_certs.crt"
+safe_write_to_file(ca_path, certs)
+VmSetup.new("").download_boot_image(boot_image, custom_url: custom_url, ca_path: ca_path)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -418,7 +418,7 @@ EOS
     }
   end
 
-  def download_boot_image(boot_image, custom_url: nil)
+  def download_boot_image(boot_image, custom_url: nil, ca_path: nil)
     urls = {
       "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
       "almalinux-9.1" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-latest.#{_1}.qcow2" },
@@ -451,8 +451,9 @@ EOS
       # condition if two VMs are lazily getting their images at the
       # same time.
       temp_path = File.join(vp.image_root, boot_image + image_ext + ".tmp")
+      ca_arg = ca_path ? " --cacert #{ca_path.shellescape}" : ""
       File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
-        r "curl -f -L10 -o #{temp_path.shellescape} #{download.shellescape}"
+        r "curl -f -L10 -o #{temp_path.shellescape} #{download.shellescape}#{ca_arg}"
       end
 
       if initial_format == "raw"

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -36,15 +36,16 @@ RSpec.describe Prog::DownloadBootImage do
   describe "#download" do
     it "starts to download image if it's not started yet" do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("NotStarted")
-      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image my-image https://example.com/my-image.raw' download_my-image")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image my-image https://example.com/my-image.raw' download_my-image", stdin: nil)
       expect { dbi.download }.to nap(15)
     end
 
     it "generates presigned URL if a custom_url not provided" do
       expect(dbi).to receive(:frame).and_return({"image_name" => "my-image"}).at_least(:once)
       expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, get_presigned_url: "https://minio.example.com/my-image.raw"))
+      expect(Config).to receive(:ubicloud_images_blob_storage_certs).and_return("certs")
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("NotStarted")
-      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image my-image https://minio.example.com/my-image.raw' download_my-image")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image my-image https://minio.example.com/my-image.raw' download_my-image", stdin: "certs")
       expect { dbi.download }.to nap(15)
     end
 


### PR DESCRIPTION
We started using a self signed certificate for the Minio cluster. Therefore, when we download an image from the minio cluster, we must configure curl to accept our root_certs as the ca.