### PR TITLE
Store serial.log to the host for failed GH Runners

### DIFF
--- a/rhizome/host/bin/delete-old-serial-logs
+++ b/rhizome/host/bin/delete-old-serial-logs
@@ -1,0 +1,24 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+
+directory_path = "/var/log/ubicloud/serials"
+
+# Delete files older than 1 day
+Dir.glob(File.join(directory_path, "*")).each do |file|
+  next unless File.file?(file) # Skip directories
+
+  file_age_in_hours = (Time.now - File.mtime(file)) / 3600
+  FileUtils.rm(file) if file_age_in_hours > 24
+end
+
+# Reduce the directory size to less than 1GB
+files_with_sizes = Dir.glob(File.join(directory_path, "*"))
+  .select { File.file?(_1) }
+  .map { {file: _1, size: File.size(_1)} }
+  .sort_by { _1[:size] }
+while files_with_sizes.sum { _1[:size] } > 1 * 1024 * 1024 * 1024 # 1GB in bytes
+  break unless (largest_file = files_with_sizes.pop)
+  FileUtils.rm(largest_file[:file])
+end

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -95,3 +95,9 @@ SpdkSetup.prep
 
 # cron job to store serial.log files
 FileUtils.mkdir_p("/var/log/ubicloud/serials")
+File.write("/etc/cron.d/ubicloud-clean-serial-logs", <<CRON)
+0 * * * * root /home/rhizome/host/bin/delete-old-serial-logs
+CRON
+
+r "systemctl enable cron"
+r "systemctl start cron"

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -92,3 +92,6 @@ r "sysctl --system"
 r "apt-get -y install qemu-utils mtools"
 
 SpdkSetup.prep
+
+# cron job to store serial.log files
+FileUtils.mkdir_p("/var/log/ubicloud/serials")


### PR DESCRIPTION
**Store serial.log to the host for failed GH Runners**
This commit is made for debugging purposes. When a job fails and
customers suspect the platform, we need a way to read the serial.log.
That's why, we spare a directory in the host to move the serial.log file
when a job fails. We also store serial.log and run journalctl against
the runner-script in case workflow_job is nil. This is to understand if
there was something wrong with the runner-script and it caused the job
to not be assigned or simply the job is cancelled.
We also change the nap time from 0 to 15 for exitted runner-scripts. The
main reason is that, we detect the runner is exitted but we don't know
if it's succeeded or failed. This information is only populated when we
get the webhook from github. Therefore, we give github 15 seconds to
update us, otherwise, probably the conclusion field will be "InProgess"
which we will filter out and not store the journal and serial.log

**Add cron job to clean-up serial.log files older than 1hr**
We need to clean the serial.log files. This is both a security measure
and a practice to avoid disk full in the host. We take 2 measures;
1. Delete serial.log files if they are older than 1 hr.
2. If the directory is larger than 1 GB, delete files starting from the
largest one until we get to less than 1 GB.