### PR TITLE
Fix MinioServer health monitor pulse

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -59,13 +59,7 @@ class MinioServer < Sequel::Model
     ssh_session.forward.local(UNIXServer.new(File.join(socket_path, "health_monitor_socket")), private_ipv4_address, 9000)
     {
       ssh_session: ssh_session,
-      minio_client: Minio::Client.new(
-        endpoint: server_url,
-        access_key: cluster.admin_user,
-        secret_key: cluster.admin_password,
-        socket: File.join(socket_path, "health_monitor_socket"),
-        ssl_ca_file_data: cluster.root_certs
-      )
+      minio_client: client(socket: File.join(socket_path, "health_monitor_socket"))
     }
   end
 
@@ -87,5 +81,15 @@ class MinioServer < Sequel::Model
 
   def server_url
     cluster.url || ip4_url
+  end
+
+  def client(socket: nil)
+    Minio::Client.new(
+      endpoint: server_url,
+      access_key: cluster.admin_user,
+      secret_key: cluster.admin_password,
+      socket: socket,
+      ssl_ca_file_data: cluster.root_certs
+    )
   end
 end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -60,7 +60,7 @@ class MinioServer < Sequel::Model
     {
       ssh_session: ssh_session,
       minio_client: Minio::Client.new(
-        endpoint: ip4_url,
+        endpoint: server_url,
         access_key: cluster.admin_user,
         secret_key: cluster.admin_password,
         socket: File.join(socket_path, "health_monitor_socket"),

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -180,7 +180,8 @@ class Prog::Minio::MinioServerNexus < Prog::Base
 
     server_data = JSON.parse(client.admin_info.body)["servers"].find { _1["endpoint"] == minio_server.endpoint }
     server_data["state"] == "online" && server_data["drives"].all? { _1["state"] == "ok" }
-  rescue
+  rescue => ex
+    Clog.emit("Minio server is down") { {minio_server_down: {ubid: minio_server.ubid, exception: Util.exception_to_hash(ex)}} }
     false
   end
 

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -171,14 +171,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   end
 
   def available?
-    client = Minio::Client.new(
-      endpoint: minio_server.server_url,
-      access_key: minio_server.cluster.admin_user,
-      secret_key: minio_server.cluster.admin_password,
-      ssl_ca_file_data: minio_server.cluster.root_certs
-    )
-
-    server_data = JSON.parse(client.admin_info.body)["servers"].find { _1["endpoint"] == minio_server.endpoint }
+    server_data = JSON.parse(minio_server.client.admin_info.body)["servers"].find { _1["endpoint"] == minio_server.endpoint }
     server_data["state"] == "online" && server_data["drives"].all? { _1["state"] == "ok" }
   rescue => ex
     Clog.emit("Minio server is down") { {minio_server_down: {ubid: minio_server.ubid, exception: Util.exception_to_hash(ex)}} }


### PR DESCRIPTION
**Add log message to MinioServer health checks when exception thrown**
At the moment, we blindly return false and assume the server is down for
MinioServer healthchecks when there is an exception. However, this may
not mean the server is down. Especially considering we have made some
changes to the client, enabled SSL on the Minio side recently, there is
not a clear way to understand what is going on if we simply swallow the
error. This commit adds a clog message for that scenario.

**Fix MinioServer pulse check** 
Health monitor pulse check is still using ip4 address of the
MinioServer. With the current ssl related change, this is updated and we
must use the server_url.

**Refactor MinioServer health check client initialization** 
We had almost the same code in two different places. We move it into a
method in the module and make use of that in the nexus.