### PR TITLE
Add Private Subnet APIs

### DIFF
--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -14,6 +14,7 @@ class PrivateSubnet < Sequel::Model
     "192.168.0.0/16"
   ].freeze
 
+  dataset_module Pagination
   dataset_module Authorization::Dataset
   include Authorization::HyperTagMethods
   def hyper_tag_name(project)

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class CloverApi
+  hash_branch(:project_location_prefix, "private-subnet") do |r|
+    @serializer = Serializers::Api::PrivateSubnet
+
+    r.get true do
+      result = @project.private_subnets_dataset.where(location: @location).authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
+        cursor: r.params["cursor"],
+        page_size: r.params["page_size"],
+        order_column: r.params["order_column"]
+      )
+
+      {
+        items: serialize(result[:records]),
+        next_cursor: result[:next_cursor],
+        count: result[:count]
+      }
+    end
+
+    r.on "ubid" do
+      r.is String do |ps_id|
+        ps = PrivateSubnet.from_ubid(ps_id)
+        handle_ps_requests(@current_user, ps)
+      end
+    end
+
+    r.is String do |ps_name|
+      r.post true do
+        Authorization.authorize(@current_user.id, "PrivateSubnet:create", @project.id)
+
+        st = Prog::Vnet::SubnetNexus.assemble(
+          @project.id,
+          name: ps_name,
+          location: @location
+        )
+
+        serialize(st.subject)
+      end
+
+      ps = @project.private_subnets_dataset.where(location: @location).where { {Sequel[:private_subnet][:name] => ps_name} }.first
+      handle_ps_requests(@current_user, ps)
+    end
+  end
+
+  def handle_ps_requests(user, ps)
+    unless ps
+      response.status = request.delete? ? 204 : 404
+      request.halt
+    end
+
+    request.get true do
+      Authorization.authorize(user.id, "PrivateSubnet:view", ps.id)
+      serialize(ps)
+    end
+
+    request.delete true do
+      Authorization.authorize(user.id, "PrivateSubnet:delete", ps.id)
+
+      if ps.vms_dataset.count > 0
+        fail DependencyError.new("Private subnet '#{ps.name}' has VMs attached, first, delete them.")
+      end
+
+      ps.incr_destroy
+      response.status = 204
+      request.halt
+    end
+  end
+end

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CloverApi
+  hash_branch(:project_prefix, "private-subnet") do |r|
+    @serializer = Serializers::Api::PrivateSubnet
+
+    r.get true do
+      result = @project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
+        cursor: r.params["cursor"],
+        page_size: r.params["page_size"],
+        order_column: r.params["order_column"]
+      )
+
+      {
+        items: serialize(result[:records]),
+        next_cursor: result[:next_cursor],
+        count: result[:count]
+      }
+    end
+  end
+end

--- a/serializers/api/private_subnet.rb
+++ b/serializers/api/private_subnet.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Serializers::Api::PrivateSubnet < Serializers::Base
+  def self.base(ps)
+    {
+      id: ps.ubid,
+      name: ps.name,
+      state: ps.display_state,
+      location: ps.location,
+      net4: ps.net4.to_s,
+      net6: ps.net6.to_s,
+      nics: Serializers::Api::Nic.serialize(ps.nics)
+    }
+  end
+
+  structure(:default) do |ps|
+    base(ps)
+  end
+end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe Clover, "private_subnet" do
+  let(:user) { create_account }
+
+  let(:project) { user.create_project_with_default_policy("project-1") }
+
+  let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", policy_body: []) }
+
+  let(:ps) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1").subject }
+
+  let(:ps_wo_permission) { Prog::Vnet::SubnetNexus.assemble(project_wo_permissions.id, name: "dummy-ps-2").subject }
+
+  describe "unauthenticated" do
+    it "not location list" do
+      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
+
+    it "not create" do
+      post "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/foo_name"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
+
+    it "not delete" do
+      delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
+
+    it "not delete ubid" do
+      delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
+
+    it "not get" do
+      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
+
+    it "not get ubid" do
+      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
+  end
+
+  describe "authenticated" do
+    before do
+      login_api(user.email)
+    end
+
+    describe "list" do
+      it "empty" do
+        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["items"]).to eq([])
+      end
+
+      it "success single" do
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["items"].length).to eq(1)
+      end
+
+      it "success multiple" do
+        Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2")
+
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["items"].length).to eq(2)
+      end
+
+      it "with vm nic" do
+        nic = Prog::Vnet::NicNexus.assemble(ps.id, name: "dummy-nic",
+          ipv6_addr: "fd38:5c12:20bf:67d4:919e::/79",
+          ipv4_addr: "172.17.226.186/32")
+
+        Prog::Vm::Nexus.assemble("dummy-public-key", project.id, private_subnet_id: ps.id, nic_id: nic.id, name: "dummy-vm-2")
+
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it "with nic without vm" do
+        Prog::Vnet::NicNexus.assemble(ps.id, name: "dummy-nic",
+          ipv6_addr: "fd38:5c12:20bf:67d4:919e::/79",
+          ipv4_addr: "172.17.226.186/32")
+
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+
+        expect(last_response.status).to eq(200)
+      end
+    end
+
+    describe "create" do
+      it "success" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-ps")
+      end
+
+      it "invalid name" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/invalid_name"
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body)["error"]["details"]["name"]).to eq("Name must only contain lowercase letters, numbers, and hyphens and have max length 63.")
+      end
+
+      it "not authorized" do
+        post "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/foo_subnet"
+
+        expect(last_response.status).to eq(403)
+      end
+    end
+
+    describe "show" do
+      it "success" do
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
+      end
+
+      it "success ubid" do
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
+      end
+
+      it "not found" do
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/not-exists-ps"
+
+        expect(last_response.status).to eq(404)
+        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
+      end
+
+      it "not authorized" do
+        get "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/#{ps_wo_permission.name}"
+
+        expect(last_response.status).to eq(403)
+      end
+    end
+
+    describe "delete" do
+      it "success" do
+        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+
+        expect(last_response.status).to eq(204)
+        expect(SemSnap.new(ps.id).set?("destroy")).to be true
+      end
+
+      it "success ubid" do
+        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+
+        expect(last_response.status).to eq(204)
+        expect(SemSnap.new(ps.id).set?("destroy")).to be true
+      end
+
+      it "dependent vm failure" do
+        Prog::Vm::Nexus.assemble("dummy-public-key", project.id, private_subnet_id: ps.id, name: "dummy-vm-2")
+
+        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+
+        expect(last_response.status).to eq(409)
+      end
+
+      it "not exist" do
+        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/foo_name"
+
+        expect(last_response.status).to eq(204)
+        expect(SemSnap.new(ps.id).set?("destroy")).to be false
+      end
+
+      it "not authorized" do
+        delete "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/#{ps_wo_permission.name}"
+
+        expect(last_response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/routes/api/project/private_subnet_spec.rb
+++ b/spec/routes/api/project/private_subnet_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "private_subnet" do
+  let(:user) { create_account }
+
+  let(:project) { user.create_project_with_default_policy("project-1") }
+
+  describe "unauthenticated" do
+    it "not list" do
+      get "/api/project/#{project.ubid}/private-subnet"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+    end
+  end
+
+  describe "authenticated" do
+    before do
+      login_api(user.email)
+    end
+
+    it "success all pss" do
+      Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-fsn1")
+      Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-hel1")
+
+      get "/api/project/#{project.ubid}/private-subnet"
+
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)["items"].length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Add Private Subnet API endpoints to

- Get, list (on project and location level), create and delete.
- Get and delete will be supported by both ../vm/name and ../vm/ubid/vm_ubid
- Unit tests are also added