### PR TITLE
Increase runner recycle threshold from 2 to 5 minutes

### DIFF
--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -340,8 +340,8 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe "#wait" do
-    it "does not destroy runner if it does not pick a job in two minutes, and busy" do
-      expect(Time).to receive(:now).and_return(github_runner.ready_at + 3 * 60)
+    it "does not destroy runner if it does not pick a job in five minutes, and busy" do
+      expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
       expect(client).to receive(:get).and_return({busy: true})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect(github_runner).not_to receive(:incr_destroy)
@@ -349,13 +349,13 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect { nx.wait }.to nap(15)
     end
 
-    it "destroys runner if it does not pick a job in two minutes and not busy" do
+    it "destroys runner if it does not pick a job in five minutes and not busy" do
       expect(github_runner).to receive(:workflow_job).and_return(nil)
-      expect(Time).to receive(:now).and_return(github_runner.ready_at + 3 * 60)
+      expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
       expect(client).to receive(:get).and_return({busy: false})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect(github_runner).to receive(:incr_destroy)
-      expect(Clog).to receive(:emit).with("Destroying GithubRunner because it does not pick a job in two minutes").and_call_original
+      expect(Clog).to receive(:emit).with("The runner does not pick a job").and_call_original
 
       expect { nx.wait }.to nap(0)
     end


### PR DESCRIPTION
Our runners don't know which task to execute until it's assigned. If a workflow task is cancelled before a runner is assigned, we're unsure which runner to remove. Therefore, if no task is assigned to a runner within two minutes, we presume there's no task pending and proceed to destroy the runner. Recently, we've noticed that GitHub isn't able to assign tasks to runners within two minutes sometimes. As a result, we've decided to extend this threshold to five minutes. The downside is that these idle runners occupy our core capacity for an additional three minutes. However, this situation is relatively rare, and we don't charge customers for idle runners.