### PR TITLE
Improve the responsiveness of my account pages

### DIFF
--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -16,11 +16,11 @@
               <%== rodauth.change_login_additional_form_tags %>
               <%== rodauth.csrf_tag("/" + rodauth.change_login_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
-                <div class="col-span-6 sm:col-span-2">
+                <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== render("components/rodauth/login_field", locals: {label: "New Email Address"}) %>
                 </div>
                 <% if rodauth.change_login_requires_password? %>
-                  <div class="col-span-6 sm:col-span-2">
+                  <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>

--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Change Email Address</h2>
             <form action="/<%= rodauth.change_login_route %>" role="form" method="POST">

--- a/views/account/change_password.erb
+++ b/views/account/change_password.erb
@@ -17,15 +17,15 @@
               <%== rodauth.csrf_tag("/" + rodauth.change_password_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.change_password_requires_password? %>
-                  <div class="col-span-6 sm:col-span-2">
+                  <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field", locals: {label: "Current Password"}) %>
                   </div>
                 <% end %>
-                <div class="col-span-6 sm:col-span-2">
+                <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== render("components/rodauth/password_field", locals: {label: "#{rodauth.new_password_label}#{rodauth.input_field_label_suffix}", name: rodauth.new_password_param, autocomplete: "new-password"}) %>
                 </div>
                 <% if rodauth.require_password_confirmation? %>
-                  <div class="col-span-6 sm:col-span-2">
+                  <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field", locals: {label: "New Password Confirmation", confirm: true}) %>
                   </div>
                 <% end %>

--- a/views/account/change_password.erb
+++ b/views/account/change_password.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Change Password</h2>
             <form action="/<%= rodauth.change_password_route %>" role="form" method="POST">

--- a/views/account/close_account.erb
+++ b/views/account/close_account.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Close Account</h2>
             <p class="mt-1 text-sm text-gray-500">This action will permanently delete this account. Deleted data cannot be recovered. Use it carefully.</p>

--- a/views/account/close_account.erb
+++ b/views/account/close_account.erb
@@ -18,7 +18,7 @@
               <%== rodauth.csrf_tag("/" + rodauth.close_account_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.close_account_requires_password? %>
-                  <div class="col-span-6 sm:col-span-2">
+                  <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>

--- a/views/account/multifactor/otp_disable.erb
+++ b/views/account/multifactor/otp_disable.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Disable One-Time Password Authentication</h2>
             <form action="/<%= rodauth.otp_disable_route %>" role="form" method="POST">

--- a/views/account/multifactor/otp_disable.erb
+++ b/views/account/multifactor/otp_disable.erb
@@ -17,7 +17,7 @@
               <%== rodauth.csrf_tag("/" + rodauth.otp_disable_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.two_factor_modifications_require_password? %>
-                  <div class="col-span-6 sm:col-span-2">
+                  <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>

--- a/views/account/multifactor/otp_setup.erb
+++ b/views/account/multifactor/otp_setup.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Setup One-Time Password Authentication</h2>
             <form action="/<%= rodauth.otp_setup_route %>" role="form" method="POST">

--- a/views/account/multifactor/otp_setup.erb
+++ b/views/account/multifactor/otp_setup.erb
@@ -20,14 +20,14 @@
               <% end %>
               <%== rodauth.csrf_tag("/" + rodauth.otp_setup_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
-                <div class="col-span-6 sm:col-span-3">
+                <div class="col-span-6 md:col-span-3">
                   <%== rodauth.otp_qr_code %>
                   <p class="mt-2 text-sm text-gray-500 text-center">
                     If you can't scan the QR code, please enter the following secret in your authenticator app manually: </br>
-                    <span class="font-bold"><%= rodauth.otp_user_key %></span>
+                    <span class="font-bold break-words"><%= rodauth.otp_user_key %></span>
                   </p>
                 </div>
-                <div class="col-span-6 sm:col-span-3 space-y-4">
+                <div class="col-span-6 md:col-span-3 space-y-4">
                   <%== render("components/rodauth/otp_auth_code_field") %>
                   <% if rodauth.two_factor_modifications_require_password? %>
                     <%== render("components/rodauth/password_field") %>

--- a/views/account/multifactor/recovery_codes.erb
+++ b/views/account/multifactor/recovery_codes.erb
@@ -39,7 +39,7 @@
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-6">
                   <% if rodauth.recovery_codes.any? %>
-                    <div class="border p-3 grid grid-cols-1 xl:grid-cols-2 gap-x-3 gap-y-2 bg-slate-100 text-rose-500 font-mono rounded">
+                    <div class="w-fit text-sm xl:text-base whitespace-nowrap border p-3 bg-slate-100 text-rose-500 font-mono rounded">
                       <% rodauth.recovery_codes.each do |code| %>
                         <div><%= code %></div>
                       <% end %>

--- a/views/account/multifactor/recovery_codes.erb
+++ b/views/account/multifactor/recovery_codes.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-10 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <% if rodauth.two_factor_modifications_require_password? %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <h2 class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</h2>

--- a/views/account/multifactor/webauthn_remove.erb
+++ b/views/account/multifactor/webauthn_remove.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Remove Security Key</h2>
             <form action="/<%= rodauth.webauthn_remove_route %>" role="form" method="POST" id="webauthn-remove-form">

--- a/views/account/multifactor/webauthn_remove.erb
+++ b/views/account/multifactor/webauthn_remove.erb
@@ -17,7 +17,7 @@
               <%== rodauth.csrf_tag("/" + rodauth.webauthn_remove_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.two_factor_modifications_require_password? %>
-                  <div class="col-span-6 sm:col-span-2">
+                  <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -31,11 +31,11 @@
               ) %>
               <input id="webauthn-setup" class="hidden" type="text" name="<%= rodauth.webauthn_setup_param %>" value="" hidden/>
               <div class="mt-6 grid grid-cols-6 gap-6">
-                <div class="col-span-6 sm:col-span-2">
+                <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== render("components/form/text", locals: { name: "name", label: "Key Name", attributes: { required: true } }) %>
                 </div>
                 <% if rodauth.two_factor_modifications_require_password? %>
-                  <div class="col-span-6 sm:col-span-2">
+                  <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Setup Security Key</h2>
             <form

--- a/views/account/submenu.erb
+++ b/views/account/submenu.erb
@@ -1,4 +1,4 @@
-<aside class="py-6 lg:col-span-2">
+<aside class="py-6 lg:col-span-4 xl:col-span-3 2xl:col-span-2">
   <nav class="space-y-1">
     <% [
         ["Change Password", "/account/change-password", "hero-key"],

--- a/views/account/two_factor_manage.erb
+++ b/views/account/two_factor_manage.erb
@@ -16,7 +16,7 @@
                 <div class="text-lg font-medium leading-6 text-gray-900">One-Time Password Generator</div>
                 <p class="mt-1 text-sm text-gray-500">Connect an authenticator app that generates verification codes.</p>
               </div>
-              <div class="col-span-6 sm:col-span-2 text-right">
+              <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                 <% if rodauth.otp_exists? %>
                   <%== render(
                     "components/button",
@@ -38,7 +38,7 @@
                 <div class="text-lg font-medium leading-6 text-gray-900">Security Keys</div>
                 <p class="mt-1 text-sm text-gray-500">Connect a security key to your account.</p>
               </div>
-              <div class="col-span-6 sm:col-span-2 text-right">
+              <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                 <%== render("components/button", locals: { text: rodauth.webauthn_setup_link_text, link: rodauth.webauthn_setup_path }) %>
                 <% if rodauth.webauthn_setup? %>
                   <%== render(

--- a/views/account/two_factor_manage.erb
+++ b/views/account/two_factor_manage.erb
@@ -9,7 +9,7 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-10 pb-10">
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <div class="mt-6 grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-4">

--- a/views/auth/verify_login_change.erb
+++ b/views/auth/verify_login_change.erb
@@ -10,7 +10,7 @@
       <div class="overflow-hidden rounded-lg bg-white shadow">
         <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
           <%== render("account/submenu") %>
-          <div class="divide-y divide-gray-200 lg:col-span-9 pb-10">
+          <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <h2 class="text-lg font-medium leading-6 text-gray-900">Verify New Email</h2>
               <form role="form" method="POST">


### PR DESCRIPTION
### Make recovery codes single column

When there are two columns, they aren't very responsive. At certain
widths, the two columns overlap. Instead of attempting to make it
responsive, a single column is more robust in terms of responsiveness.

| Before | After |
| ------------- | ------------- |
| ![recovery_before](https://github.com/ubicloud/ubicloud/assets/993199/c603dccd-7d1d-4a17-9569-3ee721c39e0b) | ![recovery_after](https://github.com/ubicloud/ubicloud/assets/993199/05aee611-c59f-4177-8f5e-48baf7740d15) |


### Make account page submenu more responsive

| Before | After |
| ------------- | ------------- |
| ![sidebar_before](https://github.com/ubicloud/ubicloud/assets/993199/765e33bb-23b0-4be4-92fe-3af179c79088) | ![sidebar_after](https://github.com/ubicloud/ubicloud/assets/993199/c4d80137-18af-4ee6-baf5-67997c5e5c9f) |


### Improve the responsiveness of fields on my account pages

| Before | After |
| ------------- | ------------- |
|  ![fields_before](https://github.com/ubicloud/ubicloud/assets/993199/0ceb249d-3b2c-45a4-b717-137f441f8a6a) | ![fields_after](https://github.com/ubicloud/ubicloud/assets/993199/f5e8a5c4-a72b-4fe7-b130-4b0074fda76d) |
