### PR TITLE
Show the email of the current account on the UI

### DIFF
--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -17,6 +17,9 @@
               <%== rodauth.csrf_tag("/" + rodauth.change_login_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
+                  <%== render("components/form/text", locals: {label: "Current Email", value: @current_user.email, extra_class: "bg-gray-50 text-gray-500 ring-gray-200 ", attributes: {disabled: true}}) %>
+                </div>
+                <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== render("components/rodauth/login_field", locals: {label: "New Email Address"}) %>
                 </div>
                 <% if rodauth.change_login_requires_password? %>

--- a/views/layouts/topbar.erb
+++ b/views/layouts/topbar.erb
@@ -20,7 +20,7 @@
       <div class="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10" aria-hidden="true"></div>
       <!-- Profile dropdown -->
       <div class="relative group dropdown text-sm leading-6 text-gray-900">
-        <button type="button" class="-m-1.5 flex items-center p-1.5">
+        <button type="button" class="-m-1.5 flex items-center p-1.5" title="<%= @current_user.email %>">
           <%== render("components/icon", locals: { name: "hero-user-circle", classes: "h-8 w-8 rounded-full bg-gray-50" }) %>
           <span class="hidden lg:flex lg:items-center">
             <span class="ml-3 font-semibold" aria-hidden="true"><%= @current_user.name %></span>
@@ -28,16 +28,26 @@
           </span>
         </button>
         <div
-          class="hidden group-[.active]:block absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none"
+          class="hidden group-[.active]:block absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-md bg-white pb-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none divide-y divide-gray-100"
           role="menu"
           tabindex="-1"
         >
-          <a href="/account" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">My Account</a>
-          <a href="/project" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">Projects</a>
-          <form action="/logout" method="post">
-            <%== csrf_tag("/logout") %>
-            <button type="submit" class="block px-3 py-1 hover:bg-gray-100 w-full text-left" role="menuitem" tabindex="-1">Log out</button>
-          </form>
+          <div class="px-3 py-2">
+            <p class="text-sm">Signed in as</p>
+            <p class="truncate text-sm font-medium text-gray-900">
+              <%= @current_user.email %></p>
+          </div>
+          <div>
+            <a href="/account" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">My Account</a>
+            <a href="/project" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">Projects</a>
+          </div>
+          <div>
+
+            <form action="/logout" method="post">
+              <%== csrf_tag("/logout") %>
+              <button type="submit" class="block px-3 py-1 hover:bg-gray-100 w-full text-left" role="menuitem" tabindex="-1">Log out</button>
+            </form>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Currently, we don't display the email of the current account on the UI, which can be inconvenient if you have multiple accounts.

Moreover, if you want to change your email address, you can't see your current one.

We've received customer feedback regarding this issue.


**Topbar:**
<img width="732" alt="Screenshot 2024-02-10 at 09 53 51" src="https://github.com/ubicloud/ubicloud/assets/993199/26849fd6-7b5a-43fd-bcdf-2c6142bbb9dd">

**Change Email Page:**
<img width="1512" alt="Screenshot 2024-02-10 at 09 54 17" src="https://github.com/ubicloud/ubicloud/assets/993199/27945bf7-9baf-4350-964d-39d936a9c1da">
