### PR TITLE
Logout of all sessions after changing email or password

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -173,10 +173,16 @@ class CloverWeb < Roda
         button_title: "Reset Password",
         button_link: reset_password_email_link)
     end
+    after_reset_password do
+      remove_all_active_sessions_except_current
+    end
 
     change_password_redirect "/account/change-password"
     change_password_route "account/change-password"
     change_password_view { view "account/change_password", "My Account" }
+    after_change_password do
+      remove_all_active_sessions_except_current
+    end
 
     change_login_redirect "/account/change-login"
     change_login_route "account/change-login"
@@ -192,6 +198,9 @@ class CloverWeb < Roda
           "For any questions or assistance, reach out to our team at support@ubicloud.com."],
         button_title: "Verify Email",
         button_link: verify_login_change_email_link)
+    end
+    after_verify_login_change do
+      remove_all_active_sessions_except_current
     end
 
     close_account_redirect "/login"

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe Clover, "auth" do
 
     visit reset_link
     expect(page.title).to eq("Ubicloud - Reset Password")
+
+    fill_in "Password", with: "#{TEST_USER_PASSWORD}_new"
+    fill_in "Password Confirmation", with: "#{TEST_USER_PASSWORD}_new"
+
+    click_button "Reset Password"
+
+    expect(page.title).to eq("Ubicloud - Login")
+
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Password", with: "#{TEST_USER_PASSWORD}_new"
+
+    click_button "Sign in"
   end
 
   it "can login to an account without projects" do
@@ -189,6 +201,39 @@ RSpec.describe Clover, "auth" do
 
       visit verify_link
       expect(page.title).to eq("Ubicloud - Verify New Email")
+
+      click_button "Click to Verify New Email"
+
+      expect(page.title).to eq("Ubicloud - Default Dashboard")
+
+      click_button "Log out"
+
+      expect(page.title).to eq("Ubicloud - Login")
+
+      fill_in "Email Address", with: new_email
+      fill_in "Password", with: TEST_USER_PASSWORD
+
+      click_button "Sign in"
+    end
+
+    it "can change password" do
+      visit "/account/change-password"
+
+      fill_in "New Password", with: "#{TEST_USER_PASSWORD}_new"
+      fill_in "New Password Confirmation", with: "#{TEST_USER_PASSWORD}_new"
+
+      click_button "Change Password"
+
+      expect(page.title).to eq("Ubicloud - Change Password")
+
+      click_button "Log out"
+
+      expect(page.title).to eq("Ubicloud - Login")
+
+      fill_in "Email Address", with: TEST_USER_EMAIL
+      fill_in "Password", with: "#{TEST_USER_PASSWORD}_new"
+
+      click_button "Sign in"
     end
   end
 end


### PR DESCRIPTION
It's advisable to sign out of all active sessions for the current account after changing the email or password.

Let's say the user's password has been somehow compromised and an attacker has accessed the user account. Even if the user resets the password, the attacker's session remains active on their system.