### PR TITLE
Move dns_server class variable to the prog

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -43,7 +43,7 @@ class PostgresResource < Sequel::Model
   end
 
   def hostname
-    if PostgresResource.dns_zone
+    if Prog::Postgres::PostgresResourceNexus.dns_zone
       "#{name}.#{Config.postgres_service_hostname}"
     else
       server&.vm&.ephemeral_net4&.to_s
@@ -52,10 +52,6 @@ class PostgresResource < Sequel::Model
 
   def connection_string
     URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s if hostname
-  end
-
-  def self.dns_zone
-    @@dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
   end
 
   def self.redacted_columns

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -74,7 +74,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def create_dns_record
-    PostgresResource.dns_zone&.insert_record(record_name: postgres_resource.hostname, type: "A", ttl: 10, data: server.vm.ephemeral_net4.to_s)
+    Prog::Postgres::PostgresResourceNexus.dns_zone&.insert_record(record_name: postgres_resource.hostname, type: "A", ttl: 10, data: server.vm.ephemeral_net4.to_s)
     hop_initialize_certificates
   end
 
@@ -168,7 +168,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       nap 5
     end
 
-    PostgresResource.dns_zone&.delete_record(record_name: postgres_resource.hostname)
+    Prog::Postgres::PostgresResourceNexus.dns_zone&.delete_record(record_name: postgres_resource.hostname)
     postgres_resource.dissociate_with_project(postgres_resource.project)
     postgres_resource.destroy
 
@@ -190,5 +190,9 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       issuer_cert: root_cert,
       issuer_key: root_cert_key
     ).map(&:to_pem)
+  end
+
+  def self.dns_zone
+    @@dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
   end
 end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PostgresResource do
   }
 
   it "returns connection string" do
-    expect(described_class).to receive(:dns_zone).and_return("something").at_least(:once)
+    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return("something").at_least(:once)
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.postgres.ubicloud.com")
   end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -146,12 +146,12 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(postgres_resource).to receive(:hostname).and_return("pg-name.postgres.ubicloud.com.")
       dns_zone = instance_double(DnsZone)
       expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "A", ttl: 10, data: "1.1.1.1")
-      expect(PostgresResource).to receive(:dns_zone).and_return(dns_zone)
+      expect(described_class).to receive(:dns_zone).and_return(dns_zone)
       expect { nx.create_dns_record }.to hop("initialize_certificates")
     end
 
     it "hops even if dns zone is not configured" do
-      expect(PostgresResource).to receive(:dns_zone).and_return(nil)
+      expect(described_class).to receive(:dns_zone).and_return(nil)
       expect { nx.create_dns_record }.to hop("initialize_certificates")
     end
   end
@@ -168,7 +168,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       )
 
       expect(nx).to receive(:postgres_resource).and_return(postgres_resource).at_least(:once)
-      expect(PostgresResource).to receive(:dns_zone).and_return("something").at_least(:once)
+      expect(described_class).to receive(:dns_zone).and_return("something").at_least(:once)
 
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 5, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 10, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
@@ -276,7 +276,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   describe "#destroy" do
     it "triggers server deletion and waits until it is deleted" do
       dns_zone = instance_double(DnsZone)
-      expect(PostgresResource).to receive(:dns_zone).and_return(dns_zone)
+      expect(described_class).to receive(:dns_zone).and_return(dns_zone)
 
       expect(postgres_resource.server).to receive(:incr_destroy)
       expect { nx.destroy }.to nap(5)
@@ -291,7 +291,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "completes destroy even if dns zone is not configured" do
-      expect(PostgresResource).to receive(:dns_zone).and_return(nil)
+      expect(described_class).to receive(:dns_zone).and_return(nil)
       expect(postgres_resource).to receive(:server).and_return(nil)
 
       expect { nx.destroy }.to exit({"msg" => "postgres resource is deleted"})


### PR DESCRIPTION
In production, we freeze the models, which raises exception if ||= operator is used together with class variables. We do not freeze the progs, so I'm moving dns_server to the PostgresResourceNexus prog to avoid problems related with freezing.