### PR TITLE
Fix MinioServer's health checks

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -25,7 +25,7 @@ class Minio::Client
 
     @creds = {access_key: access_key, secret_key: secret_key}
     @endpoint = endpoint
-    @client = socket.nil? ? Excon.new(endpoint, ssl_ca_file: ssl_ca_file) : Excon.new("unix:///", socket: socket, ssl_ca_file: ssl_ca_file)
+    @client = Excon.new(endpoint, socket: socket, ssl_ca_file: ssl_ca_file)
     @signer = Minio::HeaderSigner.new
     @crypto = Minio::Crypto.new
   end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -54,7 +54,7 @@ class MinioServer < Sequel::Model
     ssh_session.forward.local(UNIXServer.new(File.join(socket_path, "health_monitor_socket")), private_ipv4_address, 9000)
     {
       ssh_session: ssh_session,
-      minio_client: client(socket: File.join(socket_path, "health_monitor_socket"))
+      minio_client: client(socket: File.join("unix://", socket_path, "health_monitor_socket"))
     }
   end
 

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -5,11 +5,6 @@ RSpec.describe Minio::Client do
   let(:access_key) { "minioadmin" }
   let(:secret_key) { "minioadmin" }
 
-  it "can use sockets" do
-    expect(Excon).to receive(:new).with("unix:///", socket: "/tmp/socket", ssl_ca_file: File.join(Dir.pwd, "var", "ca_bundles", access_key + ".crt"))
-    described_class.new(endpoint: endpoint, access_key: access_key, secret_key: secret_key, socket: "/tmp/socket")
-  end
-
   it "can use ssl_ca_file_data" do
     expect(File).to receive(:exist?).with(File.join(Dir.pwd, "var", "ca_bundles", access_key + ".crt")).and_return(false)
     expect(FileUtils).to receive(:mkdir_p).with(File.dirname(File.join(Dir.pwd, "var", "ca_bundles", access_key + ".crt")))


### PR DESCRIPTION
Previously, health checks for MinioServer entity were failing because we did not configured the client properly to use HTTPS over UNIX sockets. Excon was trying to use HTTP connections because url was not passed.