### PR TITLE
Use randomized file name for MinIO CA

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -9,11 +9,12 @@ REGION = "us-east-1"
 ADMIN_URI_PATH = "/minio/admin/v3"
 
 class Minio::Client
-  def initialize(endpoint:, access_key:, secret_key:, socket: nil, ssl_ca_file_data: nil)
-    ssl_ca_file = File.join(Dir.pwd, "var", "ca_bundles", access_key + ".crt")
-    if ssl_ca_file_data && !File.exist?(ssl_ca_file)
+  def initialize(endpoint:, access_key:, secret_key:, ssl_ca_file_data:, socket: nil)
+    ssl_ca_file_name = Digest::SHA256.hexdigest(ssl_ca_file_data)
+    ssl_ca_file = File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")
+    if !File.exist?(ssl_ca_file)
       FileUtils.mkdir_p(File.dirname(ssl_ca_file))
-      temp_filename = File.join(Dir.pwd, "var", "ca_bundles", access_key + ".tmp")
+      temp_filename = File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".tmp")
       File.open("#{temp_filename}.lock", File::RDWR | File::CREAT) do |lock|
         lock.flock(File::LOCK_EX)
         File.open(temp_filename, File::RDWR | File::CREAT) do |f|

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -83,8 +83,8 @@ class MinioServer < Sequel::Model
       endpoint: server_url,
       access_key: cluster.admin_user,
       secret_key: cluster.admin_password,
-      socket: socket,
-      ssl_ca_file_data: cluster.root_certs
+      ssl_ca_file_data: cluster.root_certs,
+      socket: socket
     )
   end
 

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -15,7 +15,8 @@ class Prog::DownloadBootImage < Prog::Base
     @blob_storage_client ||= Minio::Client.new(
       endpoint: Config.ubicloud_images_blob_storage_endpoint,
       access_key: Config.ubicloud_images_blob_storage_access_key,
-      secret_key: Config.ubicloud_images_blob_storage_secret_key
+      secret_key: Config.ubicloud_images_blob_storage_secret_key,
+      ssl_ca_file_data: Config.ubicloud_images_blob_storage_certs
     )
   end
 

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe MinioServer do
   it "checks pulse" do
     session = {
       ssh_session: instance_double(Net::SSH::Connection::Session),
-      minio_client: Minio::Client.new(endpoint: "https://1.2.3.4:9000", access_key: "dummy-key", secret_key: "dummy-secret")
+      minio_client: Minio::Client.new(endpoint: "https://1.2.3.4:9000", access_key: "dummy-key", secret_key: "dummy-secret", ssl_ca_file_data: "data")
     }
 
     expect(ms.vm).to receive(:ephemeral_net4).and_return("1.2.3.4").at_least(:once)

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -142,7 +142,7 @@ PGHOST=/var/run/postgresql
     stub_const("Backup", Struct.new(:key))
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
 
-    minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key")
+    minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key", ssl_ca_file_data: "data")
     expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/").and_return([instance_double(Backup, key: "backup_stop_sentinel.json"), instance_double(Backup, key: "unrelated_file.txt")])
     expect(Minio::Client).to receive(:new).and_return(minio_client)
 

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Prog::DownloadBootImage do
     it "generates presigned URL if a custom_url not provided" do
       expect(dbi).to receive(:frame).and_return({"image_name" => "my-image"}).at_least(:once)
       expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, get_presigned_url: "https://minio.example.com/my-image.raw"))
-      expect(Config).to receive(:ubicloud_images_blob_storage_certs).and_return("certs")
+      expect(Config).to receive(:ubicloud_images_blob_storage_certs).and_return("certs").at_least(:once)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image").and_return("NotStarted")
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image my-image https://minio.example.com/my-image.raw' download_my-image", stdin: "certs")
       expect { dbi.download }.to nap(15)


### PR DESCRIPTION
We place MinIO root certificates under var/ca_bundles. We used to use the access_key as name for CA bundle, but access_key can be reused accross clusters. With this commit, we start to hash the file content and use that as the name. It both avoids conflicts and ensures that files would be rewritten when the content changes (i.e. when we rotate the root certs).