### PR TITLE
Minio non superuser

### DIFF
--- a/rhizome/minio/bin/configure-minio
+++ b/rhizome/minio/bin/configure-minio
@@ -26,8 +26,8 @@ r "sudo chown -R minio-user:minio-user /etc/default/minio"
 
 if cert && cert_key && ca_bundle
   r "sudo mkdir -p /home/minio-user/.minio/certs/CAs"
-  safe_write_to_file(".minio/certs/public.crt", cert)
-  safe_write_to_file(".minio/certs/private.key", cert_key)
-  safe_write_to_file(".minio/certs/CAs/public.crt", ca_bundle)
+  safe_write_to_file("/home/minio-user/.minio/certs/public.crt", cert)
+  safe_write_to_file("/home/minio-user/.minio/certs/private.key", cert_key)
+  safe_write_to_file("/home/minio-user/.minio/certs/CAs/public.crt", ca_bundle)
   r "sudo chown -R minio-user:minio-user /home/minio-user/.minio/certs"
 end

--- a/rhizome/minio/bin/install_minio
+++ b/rhizome/minio/bin/install_minio
@@ -9,3 +9,4 @@ end
 
 r "wget https://dl.min.io/server/minio/release/linux-amd64/archive/#{ver}.deb -O minio.deb"
 r "sudo dpkg -i minio.deb"
+r "systemctl enable minio.service"


### PR DESCRIPTION
**Use non-root user for Minio**
We create a separate user for the minio service and use it instead of
the main unix-user. This is mainly a security related patch and the
commands given by minio in their documentation is used in the
implementation;
https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#create-the-systemd-service-file

**Enable minio.service so that we auto start after a possible reboot**