### PR TITLE
Fix thinko in freezing core classes

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -99,5 +99,5 @@ def clover_freeze
   # Also for at least puma, but not itemized by the roda-sequel-stack
   # project for some reason.
   require "nio4r"
-  Refrigerator.freeze
+  Refrigerator.freeze_core
 end


### PR DESCRIPTION
Previously, the Refrigerator class is all that would be frozen: not really useful at all.  Now it will freeze core classes as intended.

Reported-by: Burak Yucesoy <2082070+byucesoy@users.noreply.github.com>