### PR TITLE
Increase the amount of freezing

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -6,16 +6,6 @@ require "mail"
 require "roda"
 
 class Clover < Roda
-  def self.freeze
-    # :nocov:
-    unless Config.test?
-      Sequel::Model.freeze_descendents
-      DB.freeze
-    end
-    # :nocov:
-    super
-  end
-
   route do |r|
     r.on "api" do
       r.run CloverApi

--- a/clover_web.rb
+++ b/clover_web.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "mail"
+require "roda"
 require "tilt"
 require "tilt/erubi"
 

--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -3,6 +3,8 @@
 require "yaml"
 
 class BillingRate
+  @@rates = nil
+
   def self.rates
     @@rates ||= YAML.load_file("config/billing_rates.yml")
   end

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -30,6 +30,8 @@ module Github
     client
   end
 
+  @@runner_labels = nil
+
   def self.runner_labels
     @@runner_labels ||= YAML.load_file("config/github_runner_labels.yml").to_h { [_1["name"], _1] }
   end

--- a/loader.rb
+++ b/loader.rb
@@ -83,7 +83,7 @@ autoload_normal.call("model", flat: true)
 AUTOLOAD_CONSTANTS.freeze
 
 if Config.production?
-  AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
+  AUTOLOAD_CONSTANTS.map { Object.const_get(_1) }.each(&:freeze)
 end
 
 def clover_freeze

--- a/loader.rb
+++ b/loader.rb
@@ -19,7 +19,7 @@ Unreloader = Rack::Unreloader.new(reload: Config.development?, autoload: true) {
 Unreloader.autoload("#{__dir__}/db.rb") { "DB" }
 Unreloader.autoload("#{__dir__}/ubid.rb") { "UBID" }
 
-AUTOLOAD_CONSTANTS = ["DB", "UBID"]
+AUTOLOAD_CONSTANTS = ["DB", "UBID", "Clover"]
 
 # Set up autoloads using Unreloader using a style much like Zeitwerk:
 # directories are modules, file names are classes.

--- a/model/page.rb
+++ b/model/page.rb
@@ -16,6 +16,8 @@ class Page < Sequel::Model
   include ResourceMethods
   semaphore :resolve
 
+  @@pagerduty_client = nil
+
   def pagerduty_client
     @@pagerduty_client ||= Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2)
   end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -210,6 +210,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     ).map(&:to_pem)
   end
 
+  @@dns_zone = nil
+
   def self.dns_zone
     @@dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
   end


### PR DESCRIPTION
    Clover isn't intended to depend on class modifications after an
    initial load phase.  There's no reason to restrict freezing to core
    classes or models, and using `loader.rb`'s existing complications to
    itemize classes under our control to freeze is broad and economical.
