### PR TITLE
Add GithubRunner to monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -3,7 +3,7 @@
 
 require_relative "../loader"
 
-MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer]
+MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer, GithubRunner]
 
 sessions = {}
 ssh_threads = {}

--- a/bin/monitor
+++ b/bin/monitor
@@ -27,6 +27,16 @@ loop do
         end
       rescue => ex
         Clog.emit("Establishing the SSH session is failed") { {health_monitor_reestablish_ssh_failure: {ubid: r.ubid, exception: Util.exception_to_hash(ex)}} }
+
+        begin
+          r.reload
+        rescue Sequel::NoExistingObject
+          Clog.emit("Resource is deleted") { {health_monitor_resource_deleted: {ubid: r.ubid}} }
+          sessions.delete(r.id)
+          ssh_threads.delete(r.id)
+          break
+        end
+
         sleep 5
       end
     end

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "net/ssh"
 require_relative "../model"
 
 class GithubRunner < Sequel::Model
@@ -9,6 +10,7 @@ class GithubRunner < Sequel::Model
 
   include ResourceMethods
   include SemaphoreMethods
+  include HealthMonitorMethods
   semaphore :destroy
 
   def run_url
@@ -21,6 +23,22 @@ class GithubRunner < Sequel::Model
 
   def runner_url
     "http://github.com/#{repository_name}/settings/actions/runners/#{runner_id}" if runner_id
+  end
+
+  def init_health_monitor_session
+    {
+      ssh_session: vm.sshable.start_fresh_session
+    }
+  end
+
+  def check_pulse(session:, previous_pulse:)
+    reading = begin
+      available_memory = session[:ssh_session].exec!("free | awk 'NR==2 {print $4}'").chomp
+      "up"
+    rescue
+      "down"
+    end
+    aggregate_readings(previous_pulse: previous_pulse, reading: reading, data: {available_memory: available_memory})
   end
 
   def self.redacted_columns

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe GithubRunner do
+  subject(:github_runner) { described_class.new }
+
+  let(:vm) { instance_double(Vm, sshable: instance_double(Sshable)) }
+
+  before do
+    allow(github_runner).to receive_messages(vm: vm)
+  end
+
+  it "initiates a new health monitor session" do
+    expect(github_runner.vm.sshable).to receive(:start_fresh_session)
+    github_runner.init_health_monitor_session
+  end
+
+  it "checks pulse" do
+    session = {
+      ssh_session: instance_double(Net::SSH::Connection::Session)
+    }
+    pulse = {
+      reading: "up",
+      reading_rpt: 5,
+      reading_chg: Time.now - 30
+    }
+
+    expect(session[:ssh_session]).to receive(:exec!).and_return("123\n")
+    github_runner.check_pulse(session: session, previous_pulse: pulse)
+
+    expect(session[:ssh_session]).to receive(:exec!).and_raise Sshable::SshError
+    github_runner.check_pulse(session: session, previous_pulse: pulse)
+  end
+end


### PR DESCRIPTION
**Add GithubRunner's to monitor**
Previously we only monitored PostgresServer and MinioServer entities. It would
be beneficial to monitor GithubRunner entities as well, so that we can get an
early alert if something goes unexpected. As a small bonus, we are collecting
free memory amount as well, although we don't record it anywhere. It will be
only written to logs.

Currently, we do not try to self-heal or page. Primary purpose is logging and
manual debugging.

**Stop monitoring if the target resource is deleted**
When the resource is deleted, the monitor prints unnecessary error messages
until its next cache refresh, which conflicts a bit with short lived nature of
Github runners. With this commit, we now stop monitoring for deleted resources.