### PR TITLE
Revert "Fix thinko in freezing core classes"

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -99,5 +99,5 @@ def clover_freeze
   # Also for at least puma, but not itemized by the roda-sequel-stack
   # project for some reason.
   require "nio4r"
-  Refrigerator.freeze_core
+  Refrigerator.freeze
 end


### PR DESCRIPTION
Alas, another gem does some patching of core classes. It's a recursive dependency of Octokit for the github runners.

Here is the message:

    message
        can't modify frozen Module: UnicodeNormalize
    class
        FrozenError

Here is the stack trace:

    ruby-3.2.3/lib/ruby/3.2.0/unicode_normalize/tables.rb:222:in `<module:UnicodeNormalize>'
    ruby-3.2.3/lib/ruby/3.2.0/unicode_normalize/tables.rb:6:in `<top (required)>'
    ruby-3.2.3/lib/ruby/3.2.0/unicode_normalize/normalize.rb:21:in `require_relative'
    ruby-3.2.3/lib/ruby/3.2.0/unicode_normalize/normalize.rb:21:in `<top (required)>'
    bundle/ruby/3.2.0/gems/addressable-2.8.6/lib/addressable/uri.rb:589:in `unicode_normalize'
    bundle/ruby/3.2.0/gems/addressable-2.8.6/lib/addressable/uri.rb:589:in `normalize_component'
    bundle/ruby/3.2.0/gems/addressable-2.8.6/lib/addressable/uri.rb:1545:in `block in normalized_path'
    bundle/ruby/3.2.0/gems/addressable-2.8.6/lib/addressable/uri.rb:1544:in `map'
    bundle/ruby/3.2.0/gems/addressable-2.8.6/lib/addressable/uri.rb:1544:in `normalized_path'
    bundle/ruby/3.2.0/gems/addressable-2.8.6/lib/addressable/uri.rb:2178:in `normalize'
    bundle/ruby/3.2.0/gems/octokit-8.1.0/lib/octokit/connection.rb:156:in `request'
    bundle/ruby/3.2.0/gems/octokit-8.1.0/lib/octokit/connection.rb:28:in `post'
    bundle/ruby/3.2.0/gems/octokit-8.1.0/lib/octokit/client/apps.rb:73:in `create_app_installation_access_token'
    /app/lib/github.rb:26:in `installation_client'
    /app/prog/vm/github_runner.rb:113:in `github_client'
    /app/prog/vm/github_runner.rb:280:in `destroy'