### PR TITLE
Load UnicodeNormalize before freezing core

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -99,5 +99,9 @@ def clover_freeze
   # Also for at least puma, but not itemized by the roda-sequel-stack
   # project for some reason.
   require "nio4r"
-  Refrigerator.freeze
+
+  # this Ruby standard library method patches core classes.
+  "".unicode_normalize(:nfc)
+
+  Refrigerator.freeze_core
 end


### PR DESCRIPTION
be7acd8a32bf8144392fc1eb7fb74f4cccb5d1b5 broke use of the
`addressable` gem as used by Octokit because it worked with Unicode in
an fairly inoffensive way.  This is because the
`String#unicode_normalize` method lazily patches core modules that are
frozen by refrigerator.  This patch eagerly incurs those core
modifications before freezing.

The defect stack trace can be seen in the revert,
2d7da4d1a9f098419c49f8c030346e6eaf0d7164.

    [1] clover-development(main)> require "refrigerator"
    => true
    [2] clover-development(main)> Refrigerator.freeze_core
    => nil
    [3] clover-development(main)> "".unicode_normalize(:nfc)
    FrozenError: can't modify frozen Module: UnicodeNormalize
    from /home/fdr/.asdf/installs/ruby/3.2.3/lib/ruby/3.2.0/unicode_normalize/tables.rb:222:in `<module:UnicodeNormalize>'

In does not occur if one calls the `unicode_normalize` method before
freezing:

    [1] clover-development(main)> "".unicode_normalize(:nfc)
    => ""
    [2] clover-development(main)> require "refrigerator"
    => true
    [3] clover-development(main)> Refrigerator.freeze_core
    => nil
    [4] clover-development(main)> "".unicode_normalize(:nfc)
    => ""
