### PR TITLE
Enable swap space for GitHub runners

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -51,7 +51,8 @@ class Prog::Vm::GithubRunner < Prog::Base
       storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: false}],
       enable_ip4: true,
       arch: label_data["arch"],
-      allow_only_ssh: true
+      allow_only_ssh: true,
+      swap_size_bytes: 4294963200 # ~4096MB, the same value with GitHub hosted runners
     )
 
     Clog.emit("Pool is empty") { {github_runner: {label: github_runner.label, repository_name: github_runner.repository_name, cores: vm_st.subject.cores}} }

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -13,7 +13,7 @@ class Prog::Vm::Nexus < Prog::Base
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
-    enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false)
+    enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -98,7 +98,7 @@ class Prog::Vm::Nexus < Prog::Base
       Strand.create(
         prog: "Vm::Nexus",
         label: "start",
-        stack: [{"storage_volumes" => storage_volumes.map { |v| v.transform_keys(&:to_s) }}]
+        stack: [{"storage_volumes" => storage_volumes.map { |v| v.transform_keys(&:to_s) }, "swap_size_bytes" => swap_size_bytes}]
       ) { _1.id = vm.id }
     end
   end
@@ -350,7 +350,8 @@ SQL
         "cpu_topology" => topo.to_s,
         "mem_gib" => vm.mem_gib,
         "ndp_needed" => host.ndp_needed,
-        "storage_volumes" => storage_volumes
+        "storage_volumes" => storage_volumes,
+        "swap_size_bytes" => frame["swap_size_bytes"]
       })
 
       secrets_json = JSON.generate({

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -48,7 +48,8 @@ class Prog::Vm::VmPool < Prog::Base
       enable_ip4: true,
       pool_id: vm_pool.id,
       arch: vm_pool.arch,
-      allow_only_ssh: true
+      allow_only_ssh: true,
+      swap_size_bytes: 4294963200
     )
 
     hop_wait

--- a/rhizome/host/bin/prepvm.rb
+++ b/rhizome/host/bin/prepvm.rb
@@ -82,6 +82,8 @@ unless (storage_volumes = params["storage_volumes"])
   exit 1
 end
 
+swap_size_bytes = params["swap_size_bytes"]
+
 require "fileutils"
 require_relative "../../common/lib/util"
 require_relative "../lib/vm_setup"
@@ -89,4 +91,4 @@ require_relative "../lib/vm_setup"
 nics = nics_arr.map { |args| VmSetup::Nic.new(*args) }.freeze
 VmSetup.new(vm_name).prep(unix_user, ssh_public_key, nics, gua, ip4,
   local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib,
-  ndp_needed, storage_volumes, storage_secrets)
+  ndp_needed, storage_volumes, storage_secrets, swap_size_bytes)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -238,7 +238,8 @@ RSpec.describe Prog::Vm::Nexus do
           "cpu_topology" => "1:1:1:1",
           "mem_gib" => 8,
           "local_ipv4" => "169.254.0.0",
-          "nics" => [["fd10:9b0b:6b4b:8fbb::/64", "10.0.0.3/32", "tap4ncdd56m", "5a:0f:75:80:c3:64"]]
+          "nics" => [["fd10:9b0b:6b4b:8fbb::/64", "10.0.0.3/32", "tap4ncdd56m", "5a:0f:75:80:c3:64"]],
+          "swap_size_bytes" => nil
         })
       end
       expect(sshable).to receive(:cmd).with(/sudo host\/bin\/prepvm/, {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/})


### PR DESCRIPTION
### Add an option to enable swap for a vm

We aim to enable swap space for certain virtual machines, such as GitHub runner ones. cloudinit offers two methods for setting up swap[^1]: the 'mounts' configuration and the 'swap' configuration. I've chosen to use the 'swap' configuration since it's more straightforward.

I save the desired swap size to the Nexus strand's stack and pass it to the virtual machine through 'prep.json'. If no value is provided, we won't setup a swap.

[^1]: https://cloudinit.readthedocs.io/en/latest/reference/examples.html#adjust-mount-points-mounted

### Enable swap space for GitHub runners

Recently, we've noticed some OOM events occurring with our GitHub runners. Sometimes, these events even result in the termination of the ssh-agent or the runner-script. After reviewing the GitHub-hosted runners, we found that they have 4294963200 bytes of swap space enabled. We've decided to implement the same amount of swap space in our system.

Fixes https://github.com/ubicloud/ubicloud/issues/1217