### PR TITLE
Only allow HTTPS access in production

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -6,12 +6,16 @@ class CloverWeb < Roda
   opts[:check_dynamic_arity] = false
   opts[:check_arity] = :warn
 
-  plugin :default_headers,
+  plugin :default_headers, {
     "Content-Type" => "text/html",
-    # 'Strict-Transport-Security'=>'max-age=16070400;', # Uncomment if only allowing https:// access
     "X-Frame-Options" => "deny",
     "X-Content-Type-Options" => "nosniff",
     "X-XSS-Protection" => "1; mode=block"
+  }.merge(
+    # :nocov:
+    Config.production? ? {"Strict-Transport-Security" => "max-age=15;"} : {}
+    # :nocov:
+  )
 
   plugin :content_security_policy do |csp|
     csp.default_src :none


### PR DESCRIPTION
This is the only method we support anyway, as
http://console.ubicloud.com redirects.  We can help out the client here in detecting a malicious middlebox.

See https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security