### PR TITLE
Specify node and npm versions in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",
         "tailwindcss": "^3.4.1"
+      },
+      "engines": {
+        "node": "21.6.1",
+        "npm": "10.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -8,5 +8,9 @@
     "dev": "npx tailwindcss -o assets/css/app.css",
     "prod": "npx tailwindcss -o assets/css/app.css --minify",
     "watch": "npx tailwindcss -o assets/css/app.css --watch"
+  },
+  "engines": {
+    "node": "21.6.1",
+    "npm": "10.2.4"
   }
 }


### PR DESCRIPTION
This is what the Heroku build pack reads to determine what version to use, as-is we have spurious difference between development and production.

Clover only uses node for compiling css, so, it was not of major concern, but reading build pack output closely showed Heroku was warning us about a few things that it seemed like a good idea to get around to.