### PR TITLE
Revert "Encrypt VMs on hosts with bdev_ubi by 50% chance for performance test"

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -203,11 +203,7 @@ SQL
 
   def create_storage_volume_records(vm_host)
     frame["storage_volumes"].each_with_index do |volume, disk_index|
-      spdk_installation_id = allocate_spdk_installation(vm_host.spdk_installations)
-
-      # To test the effect of encryption on the performance, encrypt for bdev_ubi
-      # hosts in a hacky way by 50%. It will be removed once the test is completed.
-      key_encryption_key = if volume["encrypted"] || (SpdkInstallation[spdk_installation_id].supports_bdev_ubi? && rand < 0.5)
+      key_encryption_key = if volume["encrypted"]
         key_wrapping_algorithm = "aes-256-gcm"
         cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
         key_wrapping_key = cipher.random_key
@@ -220,6 +216,8 @@ SQL
           auth_data: "#{vm.inhost_name}_#{disk_index}"
         )
       end
+
+      spdk_installation_id = allocate_spdk_installation(vm_host.spdk_installations)
 
       VmStorageVolume.create_with_id(
         vm_id: vm.id,


### PR DESCRIPTION
Reverts ubicloud/ubicloud#1242

Got this error in production which might have been caused by creating 2 extra artifacts per VM: a key, and a crypto bdev

```
*ERROR*: Failed to populate iobuf large buffer cache. You may need to increase spdk_iobuf_opts.large_pool_count (1024)
iobuf.c: 296:spdk_iobuf_channel_init: *ERROR*: See scripts/calc-iobuf.py for guidance on how to calculate this value.
```