### PR TITLE
For PG health checks catch exceptions thrown while opening connection

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -95,9 +95,8 @@ class PostgresServer < Sequel::Model
   end
 
   def check_pulse(session:, previous_pulse:)
-    session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, user: "postgres")
-
     reading = begin
+      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, user: "postgres")
       lsn_function = primary? ? "pg_current_wal_lsn()" : "pg_last_wal_receive_lsn()"
       last_known_lsn = session[:db_connection]["SELECT #{lsn_function} AS lsn"].first[:lsn]
       "up"


### PR DESCRIPTION
When Sequel.connect is out of the block, raised exceptions leak to the monitor level and evaluated as permanent failure. With this change we start to count those as down events instead of permanent failures. This is achieved by moving
the Sequel.open statement inside the block that already has rescue section.