### PR TITLE
Revert "Load UnicodeNormalize before freezing core"

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -99,9 +99,5 @@ def clover_freeze
   # Also for at least puma, but not itemized by the roda-sequel-stack
   # project for some reason.
   require "nio4r"
-
-  # this Ruby standard library method patches core classes.
-  "".unicode_normalize(:nfc)
-
-  Refrigerator.freeze_core
+  Refrigerator.freeze
 end


### PR DESCRIPTION
This reverts commit 4cfcceb22c85d914cd88e6e20af3d20ef01382e8.

Something in "rubygems/package", which is required by InstallRhizome, modifies core classes. Freezing them breaks Postgres, MinIO and VmHost provisionings.