### PR TITLE
Use Ubicloud managed PostgreSQL for lsn recording

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -47,6 +47,7 @@ module Config
   optional :stripe_public_key, string, clear: true
   optional :stripe_secret_key, string, clear: true
   optional :heartbeat_url, string
+  optional :clover_database_root_certs, string
 
   # :nocov:
   override :mail_driver, (production? ? :smtp : :logger), symbol
@@ -113,6 +114,7 @@ module Config
   optional :postgres_service_blob_storage_secret_key, string, clear: true
   optional :postgres_service_blob_storage_id, string
   override :postgres_monitor_database_url, Config.clover_database_url, string
+  optional :postgres_monitor_database_root_certs, string
 
   # Logging
   optional :database_logger_level, string

--- a/config.rb
+++ b/config.rb
@@ -112,6 +112,7 @@ module Config
   optional :postgres_service_blob_storage_access_key, string
   optional :postgres_service_blob_storage_secret_key, string, clear: true
   optional :postgres_service_blob_storage_id, string
+  override :postgres_monitor_database_url, Config.clover_database_url, string
 
   # Logging
   optional :database_logger_level, string

--- a/db.rb
+++ b/db.rb
@@ -15,6 +15,8 @@ DB = Sequel.connect(Config.clover_database_url, max_connections: Config.db_pool 
   db.add_conversion_proc(869, NetAddr.method(:parse_ip))
 end
 
+POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool, pool_timeout: Config.database_timeout) if Config.postgres_monitor_database_url
+
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic
 DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range, :pg_array

--- a/db.rb
+++ b/db.rb
@@ -3,7 +3,10 @@
 require "netaddr"
 require "sequel/core"
 require_relative "config"
+require_relative "lib/util"
 
+db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "db_ca_bundle.crt")
+Util.safe_write_to_file(db_ca_bundle_filename, Config.clover_database_root_certs)
 DB = Sequel.connect(Config.clover_database_url, max_connections: Config.db_pool - 1, pool_timeout: Config.database_timeout).tap do |db|
   # Replace dangerous (for cidrs) Ruby IPAddr type that is otherwise
   # used by sequel_pg.  Has come up more than once in the bug tracker:
@@ -15,6 +18,8 @@ DB = Sequel.connect(Config.clover_database_url, max_connections: Config.db_pool 
   db.add_conversion_proc(869, NetAddr.method(:parse_ip))
 end
 
+postgres_monitor_db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "postgres_monitor_db.crt")
+Util.safe_write_to_file(postgres_monitor_db_ca_bundle_filename, Config.postgres_monitor_database_root_certs)
 POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool, pool_timeout: Config.database_timeout) if Config.postgres_monitor_database_url
 
 # Load Sequel Database/Global extensions here

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -64,4 +64,14 @@ module Util
   def self.exception_to_hash(ex)
     {exception: {message: ex.message, class: ex.class.to_s, backtrace: ex.backtrace, cause: ex.cause.inspect}}
   end
+
+  def self.safe_write_to_file(filename, content)
+    FileUtils.mkdir_p(File.dirname(filename))
+    temp_filename = filename + ".tmp"
+    File.open("#{temp_filename}.lock", File::RDWR | File::CREAT) do |lock_file|
+      lock_file.flock(File::LOCK_EX)
+      File.write(temp_filename, content)
+      File.rename(temp_filename, filename)
+    end
+  end
 end

--- a/migrate/postgres_monitor_db.sql
+++ b/migrate/postgres_monitor_db.sql
@@ -1,0 +1,7 @@
+CREATE UNLOGGED TABLE public.postgres_lsn_monitor (
+    postgres_server_id uuid NOT NULL,
+    last_known_lsn pg_lsn
+);
+
+ALTER TABLE ONLY public.postgres_lsn_monitor
+    ADD CONSTRAINT postgres_lsn_monitor_pkey PRIMARY KEY (postgres_server_id);

--- a/model/postgres/postgres_lsn_monitor.rb
+++ b/model/postgres/postgres_lsn_monitor.rb
@@ -2,6 +2,6 @@
 
 require_relative "../../model"
 
-class PostgresLsnMonitor < Sequel::Model
+class PostgresLsnMonitor < Sequel::Model(POSTGRES_MONITOR_DB[:postgres_lsn_monitor])
   plugin :insert_conflict
 end

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -9,12 +9,10 @@ RSpec.describe Minio::Client do
     expect(File).to receive(:exist?).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")).and_return(false)
     expect(FileUtils).to receive(:mkdir_p).with(File.dirname(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")))
     lock_file = instance_double(File, flock: true)
-    expect(File).to receive(:open).with("#{File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".tmp")}.lock", File::RDWR | File::CREAT).and_yield(lock_file)
+    expect(File).to receive(:open).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt.tmp.lock"), File::RDWR | File::CREAT).and_yield(lock_file)
     expect(lock_file).to receive(:flock).with(File::LOCK_EX)
-    temp_file = instance_double(File, puts: true)
-    expect(File).to receive(:open).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".tmp").to_s, File::RDWR | File::CREAT).and_yield(temp_file)
-    expect(temp_file).to receive(:puts).with("data")
-    expect(File).to receive(:rename).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".tmp").to_s, File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt"))
+    expect(File).to receive(:write)
+    expect(File).to receive(:rename).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt.tmp").to_s, File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt"))
 
     minio_client
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,9 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
+    # Since we have 2 active sequel databases, we need to manually
+    # specify which one to clean.
+    DatabaseCleaner[:sequel].db = DB
     DatabaseCleaner.clean_with(:truncation,
       # Skip tables that are filled with migrations.
       except: %w[

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,7 +61,6 @@ RSpec.configure do |config|
       except: %w[
         schema_migrations_password
         account_statuses
-        billing_rate
       ])
   end
 


### PR DESCRIPTION
This data is not very critical because it is refreshed every few seconds. Also
it is already stored an unlogged table. All in al, this looks like a great
opportunity for dogfooding.

To keep development and test simple (i.e. not require another database setup),
I made default value for the new config as Config.clover_database_url. I'm also
not adding a migration to drop existing postgres_lsn_monitor table. In this way
we can continue to use existing database without doing any extra setup in the
development environment.

Also isn't it cool that Sequel is able to use models stored in different
databases and even use associations with them?