### PR TITLE
Enable storage_skip_sync for github runners.

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -26,13 +26,14 @@ class Prog::Vm::GithubRunner < Prog::Base
   def pick_vm
     label = github_runner.label
     label_data = Github.runner_labels[label]
+    skip_sync = true
     pool = VmPool.where(
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
       location: label_data["location"],
       storage_size_gib: label_data["storage_size_gib"],
       storage_encrypted: false,
-      storage_skip_sync: false,
+      storage_skip_sync: skip_sync,
       arch: label_data["arch"]
     ).first
 
@@ -48,7 +49,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       size: label_data["vm_size"],
       location: label_data["location"],
       boot_image: label_data["boot_image"],
-      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: false}],
+      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: false, skip_sync: skip_sync}],
       enable_ip4: true,
       arch: label_data["arch"],
       allow_only_ssh: true

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
         storage_size_gib: 150, storage_encrypted: false,
-        storage_skip_sync: false, arch: "x64"
+        storage_skip_sync: true, arch: "x64"
       ).and_return([git_runner_pool])
       expect(git_runner_pool).to receive(:pick_vm).and_return(nil)
       expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
@@ -106,7 +106,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
         storage_size_gib: 150, storage_encrypted: false,
-        storage_skip_sync: false, arch: "arm64"
+        storage_skip_sync: true, arch: "arm64"
       ).and_return([git_runner_pool])
       expect(git_runner_pool).to receive(:pick_vm).and_return(vm)
       expect(Clog).to receive(:emit).with("Pool is used").and_call_original


### PR DESCRIPTION
Github runner VMs are supposed to run only once and don't need to survive on host reboot. Skipping sync can improve their I/O performance.

This only has an effect when using bdev_ubi. It will be just ignored for non bdev_ubi storage bdevs.

Commands like `apt update` or `apt install` issue many sync requests. So, we expect enabling skip_sync to improve some performance of some customer workflows.

After merging this PR, we need to:
* `VmPool.where(location: "github-runners").update(storage_skip_sync: true)`
* Refresh vm pools.

I'm not doing the update command in a migration file, since it is not logically required by this change, and is just a production config.