### PR TITLE
Support bdev_ubi v0.2 on arm64.

### DIFF
--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -6,7 +6,8 @@ class Prog::Storage::SetupSpdk < Prog::Base
   SUPPORTED_SPDK_VERSIONS = [
     ["v23.09", "arm64"],
     ["v23.09", "x64"],
-    ["v23.09-ubi-0.2", "x64"]
+    ["v23.09-ubi-0.2", "x64"],
+    ["v23.09-ubi-0.2", "arm64"]
   ]
 
   def self.assemble(vm_host_id, version, start_service: false, allocation_weight: 0)

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -56,10 +56,10 @@ class SpdkSetup
       fail "BUG: unexpected architecture"
     end
 
-    # YYY: Support v23.09-ubi-0.2 on arm64
     {
       ["v23.09", :arm64] => "https://github.com/ubicloud/spdk/releases/download/v23.09/spdk-arm64.tar.gz",
       ["v23.09", :x64] => "https://github.com/ubicloud/spdk/releases/download/v23.09/spdk-23.09-x64.tar.gz",
+      ["v23.09-ubi-0.2", :arm64] => "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.2-arm64/ubicloud-spdk-ubuntu-22.04-arm64.tar.gz",
       ["v23.09-ubi-0.2", :x64] => "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.2/ubicloud-spdk-ubuntu-22.04-x64.tar.gz"
     }.fetch([@spdk_version, arch])
   end


### PR DESCRIPTION
Now that we have setup the bdev_ubi arm64 release pipeline and have created the package, we can support it in Ubicloud VM hosts too.