### PR TITLE
Add Contributor License Agreement workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+jobs:
+  CLAAssistant:
+    runs-on: ubicloud
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://docs.google.com/document/d/1ymjqOk6fXhi-VxnV2qZEgI5ibX9gtg7Y/edit?usp=sharing&ouid=105153831332304232521&rtpof=true&sd=true' # e.g. a CLA or a DCO document
+          branch: 'main'
+          allowlist: byucesoy, enescakir, fdr, ozgune, pykello, umurc, velioglu, bot*
+          remote-organization-name: ubicloud
+          remote-repository-name: cla-signers
+          create-file-commit-message: 'Creating file for storing CLA Signatures'
+          signed-commit-message: '$contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          custom-notsigned-prcomment: 'Hello, please sign the CLA to get your pull request merged. Thanks!'
+


### PR DESCRIPTION
With this commit, we are starting to use
https://github.com/contributor-assistant/github-action for our CLA
agreement. This will simply run an additional workflow to make the
contributor sign the CLA. If they signed it, this will add the signer to
ubicloud/cla-signers repository.