### PR TITLE
Fix CLA link in contributor-assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,5 +28,4 @@ jobs:
           remote-repository-name: cla-signers
           create-file-commit-message: 'Creating file for storing CLA Signatures'
           signed-commit-message: '$contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          custom-notsigned-prcomment: 'Hello, please sign the CLA to get your pull request merged. Thanks!'
 


### PR DESCRIPTION
It looks like using custom messages fails the link usage to the CLA. The issue can be found here
https://github.com/contributor-assistant/github-action/issues/113.