### PR TITLE
Add nftables to block unused ip addresses in the host

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -169,6 +169,8 @@ class VmHost < Sequel::Model
         end
       end
     end
+
+    Strand.create_with_id(schedule: Time.now, prog: "SetupNftables", label: "start", stack: [{subject_id: id}])
   end
 
   # Operational Functions

--- a/prog/setup_nftables.rb
+++ b/prog/setup_nftables.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Prog::SetupNftables < Prog::Base
+  subject_is :sshable, :vm_host
+
+  label def start
+    additional_subnets = vm_host.assigned_subnets.select { |a| a.cidr.version == 4 && a.cidr.network.to_s != vm_host.sshable.host }
+    sshable.cmd("sudo host/bin/setup-nftables.rb #{additional_subnets.map { _1.cidr.to_s }.to_json.shellescape}")
+
+    pop "nftables was setup"
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -58,6 +58,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnStorage
     bud Prog::InstallDnsmasq
     bud Prog::SetupSysstat
+    bud Prog::SetupNftables
     hop_wait_prep
   end
 

--- a/rhizome/host/bin/setup-nftables.rb
+++ b/rhizome/host/bin/setup-nftables.rb
@@ -1,0 +1,46 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+require "json"
+
+unless (additional_ip_addresses = ARGV.shift)
+  puts "additional IP addresses didn't get passed"
+  additional_ip_addresses = "[]"
+end
+
+# setup blocking unused ip addresses
+NFTABLES_PATH = "/etc/nftables.d/0.conf"
+FileUtils.mkdir_p("/etc/nftables.d")
+FileUtils.touch(NFTABLES_PATH)
+ip_ranges_to_block = JSON.parse(additional_ip_addresses)
+
+safe_write_to_file(NFTABLES_PATH, <<SETUP_ADDITIONAL_IP_BLOCKING)
+#!/usr/sbin/nft -f
+table inet drop_unused_ip_packets;
+delete table inet drop_unused_ip_packets;
+table inet drop_unused_ip_packets {
+  set allowed_ipv4_addresses {
+    type ipv4_addr;
+  }
+
+  set blocked_ipv4_addresses {
+    type ipv4_addr;
+    flags interval;
+    elements = {#{ip_ranges_to_block.join(",")}}
+  }
+
+  chain prerouting {
+    type filter hook prerouting priority 0; policy accept;
+    ip daddr @allowed_ipv4_addresses accept
+    ip daddr @blocked_ipv4_addresses drop
+  }
+}
+SETUP_ADDITIONAL_IP_BLOCKING
+
+File.open("/etc/nftables.conf", File::APPEND | File::RDWR) do |f|
+  # Necessary to keep this idempotent
+  break if f.each_line.any? { |line| line.include?("include \"/etc/nftables.d/*.conf") }
+  f.write("include \"/etc/nftables.d/*.conf\"\n")
+end

--- a/rhizome/host/bin/setup-nftables.rb
+++ b/rhizome/host/bin/setup-nftables.rb
@@ -44,3 +44,6 @@ File.open("/etc/nftables.conf", File::APPEND | File::RDWR) do |f|
   break if f.each_line.any? { |line| line.include?("include \"/etc/nftables.d/*.conf") }
   f.write("include \"/etc/nftables.d/*.conf\"\n")
 end
+
+r "systemctl enable nftables"
+r "systemctl start nftables"

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -97,10 +97,18 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       File.rename(temp_filename, filename)
     end
 
+    reload_nftables
   end
+
   def block_ip4
     FileUtils.rm_f("/etc/nftables.d/#{q_vm}.conf")
+    reload_nftables
   end
+
+  def reload_nftables
+    r "systemctl reload nftables"
+  end
+
   # Delete all traces of the VM.
   def purge
     block_ip4 if vp.read_public_ipv4

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -366,6 +366,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { 1.1.1.1 }
 NFTABLES_CONF
       expect(File).to receive(:rename).with("/etc/nftables.d/test.conf.tmp", "/etc/nftables.d/test.conf")
 
+      expect(vs).to receive(:r).with("systemctl reload nftables")
 
       vs.unblock_ip4("1.1.1.1/32")
     end
@@ -374,6 +375,7 @@ NFTABLES_CONF
   describe "#block_ip4" do
     it "can block ip4" do
       expect(FileUtils).to receive(:rm_f).with("/etc/nftables.d/test.conf")
+      expect(vs).to receive(:r).with("systemctl reload nftables")
 
       vs.block_ip4
     end

--- a/spec/prog/setup_nftables_spec.rb
+++ b/spec/prog/setup_nftables_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::SetupNftables do
+  subject(:sn) {
+    described_class.new(Strand.new(prog: "SetupNftables"))
+  }
+
+  describe "#start" do
+    it "Sets it up and pops" do
+      sshable = instance_double(Sshable, host: "1.1.1.1")
+      vm_host = instance_double(VmHost, ubid: "vmhostubid", assigned_subnets: [
+        instance_double(Address, cidr: instance_double(NetAddr::IPv4Net, version: 4, network: "1.1.1.1", to_s: "1.1.1.1")),
+        instance_double(Address, cidr: instance_double(NetAddr::IPv4Net, version: 6, network: "::", to_s: "::")),
+        instance_double(Address, cidr: instance_double(NetAddr::IPv4Net, version: 4, network: "123.123.123.0/24", to_s: "123.123.123.0/24"))
+      ], sshable: sshable)
+      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-nftables.rb \\[\\\"123.123.123.0/24\\\"\\]")
+      expect(sn).to receive(:sshable).and_return(sshable)
+      expect(sn).to receive(:vm_host).and_return(vm_host).at_least(:once)
+
+      expect { sn.start }.to exit({"msg" => "nftables was setup"})
+    end
+  end
+end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -107,7 +107,8 @@ RSpec.describe Prog::Vm::HostNexus do
         Prog::LearnCores,
         Prog::LearnStorage,
         Prog::InstallDnsmasq,
-        Prog::SetupSysstat
+        Prog::SetupSysstat,
+        Prog::SetupNftables
       ])
     end
 


### PR DESCRIPTION
***Start using nftables at host to block unused ip addresses***
We recently got an e-mail from Hetzner saying our hosts produce a
routing loop with their gateway when receiving packets for IPs not yet
allocated to a VM.

In this case, the host will forward the packet to the default route,
which is the gateway, which in turn, forwards it back to the host,
until TTL is decremented, with much resource expenditure by both
parties.

To address this, I introduce a new nftables definition at the host
level, with the intention of dropping packets to IP addresses with no
VM allocating them. I add a new table of nftables that has two sets
and two rules:
1. The first rule is to accept packets if the daddr is part of the
   first set.
2. The second rule is to drop packets if the daddr is part of the
   second set.

This commit simply sets up the hosts with necessary path creations and
some changes in the /etc/nftables.conf file to accommodate that.

A small note regarding IPv6: We don't need to implement a similar
mechanism for IPv6, because the behavior is different there. When an
IPv4 packet reaches us and we don't know what to do, we simply send it
back to the network from the default route. In IPv6 on the other hand,
we send a neighbor solicitation message to the local network, if there
is a match, they would respond with a link local address, if there is
not, we don't get that response and send back to the client a
destination unreachable message.
***Start making nftables changes for VM de/provisionings***
Now, we start updating the nftables definitions at the VM creation and
deletion times. Though, these are still not activated since we did not
enable nftables.service. We want to make sure the VMs are creating the
necessary files and removing at the time of deprovisioning properly.
Also, this will give us time to graciously wait for the existing VMs
without introducing a connectivity problem. Once all of the VMs are
rotated and the files are created manually for the long running VMs, we
may proceed to the next commit.

***Enable nftables changes***
With this commit, we start reloading nftables. This means, from now on,
any change happenning in the system will be reflected to the nftables.
We will need to "enable" and "start" commands per host before deploying
this commit, though.