### PR TITLE
Fix resource deletion from monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -34,6 +34,7 @@ loop do
           Clog.emit("Resource is deleted") { {health_monitor_resource_deleted: {ubid: r.ubid}} }
           sessions.delete(r.id)
           ssh_threads.delete(r.id)
+          pulse_threads.delete(r.id)&.kill
           break
         end
 


### PR DESCRIPTION
Previously, we correctly removed the thread responsible for SSH processing but didn't removed the thread responsible for the health checks. With this commit we also delete and kill the health check thread.