### PR TITLE
Use channel_binding=require in connection string

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -56,7 +56,13 @@ class PostgresResource < Sequel::Model
   end
 
   def connection_string
-    URI::Generic.build2(scheme: "postgres", userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}", host: hostname).to_s if hostname
+    return nil unless (hn = hostname)
+    URI::Generic.build2(
+      scheme: "postgres",
+      userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}",
+      host: hn,
+      query: "channel_binding=require"
+    ).to_s
   end
 
   def replication_connection_string(application_name:)

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe PostgresResource do
 
   it "returns connection string" do
     expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return("something").at_least(:once)
-    expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.postgres.ubicloud.com")
+    expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.postgres.ubicloud.com?channel_binding=require")
   end
 
   it "returns connection string with ip address if config is not set" do
     expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, vm: instance_double(Vm, ephemeral_net4: "1.2.3.4"))).at_least(:once)
-    expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@1.2.3.4")
+    expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@1.2.3.4?channel_binding=require")
   end
 
   it "returns connection string as nil if there is no server" do


### PR DESCRIPTION
Although there is a CA apparatus set up for databases, it's not exposed in the UI anywhere.  Thus, unless one is unusually Postgres-aware, one is likely to use the database in a manner that will be prone to MITM attack.  Also, even with a trust root available, people tend to connect in a way that is prone to MITM attacks anyway: it's a bit of a hassle to set up.

As it turns out, since Postgres 13's libpq, one can set the `channel_binding` to `require` which will ensure both the server and client have the same view of the communication channel's cryptographic information before connecting, preventing MITM attacks.  Postgres 13 was long enough ago that I think we can inconvenience people with even older libpq.