### PR TITLE
Core classes freezing, try three

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -99,5 +99,14 @@ def clover_freeze
   # Also for at least puma, but not itemized by the roda-sequel-stack
   # project for some reason.
   require "nio4r"
-  Refrigerator.freeze
+
+  # this Ruby standard library method patches core classes.
+  "".unicode_normalize(:nfc)
+
+  # A standard library method that edits/creates a module variable as
+  # a side effect.  We encountered it when using rubygems for its tar
+  # file writing.
+  Gem.source_date_epoch
+
+  Refrigerator.freeze_core
 end

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
+require "rubygems/package"
+require "stringio"
+
 class Prog::InstallRhizome < Prog::Base
   subject_is :sshable
 
   label def start
-    require "rubygems/package"
-    require "stringio"
-
     tar = StringIO.new
     Gem::Package::TarWriter.new(tar) do |writer|
       base = Config.root + "/rhizome"


### PR DESCRIPTION
After 4cfcceb22c85d914cd88e6e20af3d20ef01382e8, another run-time code modification was found, yielding a revert in
d6e5d9dd696df35bac53d8a8c55bb05256ea2f0c.  This time, the break was in `InstallRhizome` and in the rubygems code that we use for tar stream generation.

You can produce the crash like this:

    [1] clover-development(main)> require 'rubygems'; require 'refrigerator'; Refrigerator.freeze_core; Gem.source_date_epoch

    FrozenError: can't modify frozen #<Class:Gem>: Gem
    from /home/fdr/.asdf/installs/ruby/3.2.3/lib/ruby/3.2.0/rubygems.rb:1139:in `source_date_epoch_string'

With a backtrace like:

    ruby/3.2.0/rubygems.rb:1139:in `source_date_epoch_string'
    ruby/3.2.0/rubygems.rb:1157:in `source_date_epoch'
    (pry):1:in `__pry__'

In addition, unless rubygems is required before freezing, there is another reopening of the `Gem` module, to define some OpenSSL related constants:

    ruby/3.2.0/rubygems/openssl.rb:6:in `<module:Gem>'
    ruby/3.2.0/rubygems/openssl.rb:5:in `<top (required)>'
    ruby/3.2.0/rubygems/security.rb:10:in `require_relative'
    ruby/3.2.0/rubygems/security.rb:10:in `<top (required)>'
    ruby/3.2.0/rubygems/package.rb:9:in `require_relative'
    ruby/3.2.0/rubygems/package.rb:9:in `<top (required)>'

To fix that, I move the `require` of `rubygems` to the customary place for `require`, at the top of the file, rather than making it so lazy as to wait for a method call to do so.