### PR TITLE
Don't wait vm deletion while deleting GithubRunner

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -117,7 +117,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "wait_vm_destroy"].include?(strand.label)
+      if strand.label != "destroy"
         register_deadline(nil, 10 * 60)
         update_billing_record
         hop_destroy
@@ -311,13 +311,8 @@ class Prog::Vm::GithubRunner < Prog::Base
       vm.incr_destroy
     end
 
-    hop_wait_vm_destroy
-  end
-
-  label def wait_vm_destroy
-    nap 10 unless vm.nil?
-
     github_runner.destroy
+
     pop "github runner deleted"
   end
 end

--- a/serializers/web/github_runner.rb
+++ b/serializers/web/github_runner.rb
@@ -18,13 +18,7 @@ class Serializers::Web::GithubRunner < Serializers::Base
         workflow_name: runner.workflow_job["workflow_name"],
         head_branch: runner.workflow_job["head_branch"]
       } : nil,
-      vm_state: if runner.vm
-                  runner.vm.display_state
-                elsif runner.strand.label == "wait_vm_destroy"
-                  "deleted"
-                else
-                  "not_created"
-                end
+      vm_state: runner.vm&.display_state || "not_created"
     }
   end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -234,12 +234,6 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(nx.strand).to receive(:label).and_return("destroy")
       expect { nx.before_run }.not_to hop("destroy")
     end
-
-    it "does not hop to destroy if already in the wait_vm_destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("wait_vm_destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
   end
 
   describe "#start" do
@@ -411,8 +405,9 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
       expect(vm).to receive(:incr_destroy)
+      expect(github_runner).to receive(:destroy)
 
-      expect { nx.destroy }.to hop("wait_vm_destroy")
+      expect { nx.destroy }.to exit({"msg" => "github runner deleted"})
     end
 
     it "destroys resources and hops if runner deregistered, also, copies serial log if workflow_job is nil" do
@@ -426,8 +421,9 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
       expect(vm).to receive(:incr_destroy)
+      expect(github_runner).to receive(:destroy)
 
-      expect { nx.destroy }.to hop("wait_vm_destroy")
+      expect { nx.destroy }.to exit({"msg" => "github runner deleted"})
     end
 
     it "destroys resources and hops if runner deregistered, also, emits log if it couldn't move the serial.log" do
@@ -441,8 +437,9 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(sshable).to receive(:cmd).and_raise Sshable::SshError.new("bogus", "", "", nil, nil)
       expect(Clog).to receive(:emit).with("Failed to move serial.log or running journalctl").and_call_original
       expect(vm).to receive(:incr_destroy)
+      expect(github_runner).to receive(:destroy)
 
-      expect { nx.destroy }.to hop("wait_vm_destroy")
+      expect { nx.destroy }.to exit({"msg" => "github runner deleted"})
     end
 
     it "simply destroys the VM if the workflow_job is there and the conclusion is success" do
@@ -454,8 +451,9 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(sshable).not_to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).not_to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
       expect(vm).to receive(:incr_destroy)
+      expect(github_runner).to receive(:destroy)
 
-      expect { nx.destroy }.to hop("wait_vm_destroy")
+      expect { nx.destroy }.to exit({"msg" => "github runner deleted"})
     end
 
     it "does not destroy vm if it's already destroyed" do
@@ -464,21 +462,9 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(client).not_to receive(:delete)
       expect(github_runner).to receive(:vm).and_return(nil)
       expect(vm).not_to receive(:incr_destroy)
-
-      expect { nx.destroy }.to hop("wait_vm_destroy")
-    end
-  end
-
-  describe "#wait_vm_destroy" do
-    it "naps if vm not destroyed yet" do
-      expect { nx.wait_vm_destroy }.to nap(10)
-    end
-
-    it "pops if vm destroyed" do
-      expect(nx).to receive(:vm).and_return(nil)
       expect(github_runner).to receive(:destroy)
 
-      expect { nx.wait_vm_destroy }.to exit({"msg" => "github runner deleted"})
+      expect { nx.destroy }.to exit({"msg" => "github runner deleted"})
     end
   end
 end

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -81,8 +81,6 @@ RSpec.describe Clover, "github" do
     end
 
     it "can list active runners" do
-      runner1_st = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo")
-      runner1_st.update(label: "wait_vm_destroy")
       vm = Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "runner-vm").subject
       runner2 = GithubRunner.create_with_id(
         installation_id: installation.id,
@@ -103,12 +101,10 @@ RSpec.describe Clover, "github" do
 
       expect(page.status_code).to eq(200)
       expect(page.title).to eq("Ubicloud - GitHub Runners")
-      expect(page).to have_content runner1_st.ubid
       expect(page).to have_content "Runner doesn't have a job yet"
       expect(page).to have_content runner2.ubid
       expect(page).to have_content "creating"
       expect(page).to have_content "not_created"
-      expect(page).to have_content "deleted"
       expect(page).to have_link runner2.workflow_job["workflow_name"], href: runner2.run_url
       expect(page).to have_link runner2.workflow_job["name"], href: runner2.job_url
     end


### PR DESCRIPTION
Burak has some valid points at 9f3561eb3e2368e47276bb4214db3ff9da3ce9fb

From a user's perspective, deleting in the background speeds up the process and improves the user experience. Showing the runners while destroying the virtual machines after completing a job doesn't add value for the customer and only makes the active runner list longer. Virtual machine deletion has its own deadline, which we'd be notified about. If we wait for this deletion, we'd end up with two pages. Moreover, removing it simplifies some parts of the code.