### PR TITLE
Delete active GitHub installations while deleting the project

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -42,7 +42,7 @@ class Project < Sequel::Model
   end
 
   def has_resources
-    access_tags_dataset.exclude(hyper_tag_table: [Account.table_name.to_s, Project.table_name.to_s, AccessTag.table_name.to_s]).count > 0
+    access_tags_dataset.exclude(hyper_tag_table: [Account.table_name.to_s, Project.table_name.to_s, AccessTag.table_name.to_s]).count > 0 || github_installations.flat_map(&:runners).count > 0
   end
 
   def soft_delete

--- a/model/project.rb
+++ b/model/project.rb
@@ -17,7 +17,7 @@ class Project < Sequel::Model
 
   dataset_module Authorization::Dataset
 
-  plugin :association_dependencies, access_tags: :destroy, access_policies: :destroy, billing_info: :destroy
+  plugin :association_dependencies, access_tags: :destroy, access_policies: :destroy, billing_info: :destroy, github_installations: :destroy
 
   include ResourceMethods
   include Authorization::HyperTagMethods
@@ -49,6 +49,11 @@ class Project < Sequel::Model
     DB.transaction do
       access_tags_dataset.destroy
       access_policies_dataset.destroy
+
+      github_installations.each do
+        Github.app_client.delete_installation(_1.installation_id)
+        _1.destroy
+      end
 
       # We still keep the project object for billing purposes.
       # These need to be cleaned up manually once in a while.


### PR DESCRIPTION
### Do not allow to delete the project if there are active GitHub runners

We ensure the project doesn't have any active resources, as identified
by access tags, before deleting it. As individual GitHub runners lack
access tags, customers can still delete a project even if it has active
GitHub runners.

### Delete active GitHub installations while deleting the project

We should destroy associated GitHub installations when we're deleting a
project, whether it's a soft or hard delete. If we don't, it prevents
customers from installing our GitHub app on any other projects.
If the installation is removed from GitHub, it returns false.

https://github.com/octokit/octokit.rb/blob/a787bf47377229688eea4b6c78b26b584f65595b/lib/octokit/client/apps.rb#L218
