### PR TITLE
Rescue access errors while fetching backups

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -51,7 +51,8 @@ PGHOST=/var/run/postgresql
         .list_objects(ubid, "basebackups_005/")
         .select { _1.key.end_with?("backup_stop_sentinel.json") }
     rescue RuntimeError => ex
-      return [] if ex.message.include?("The Access Key Id you provided does not exist in our records.")
+      recoverable_errors = ["The Access Key Id you provided does not exist in our records.", "AccessDenied"]
+      return [] if recoverable_errors.any? { ex.message.include?(_1) }
       raise
     end
   end


### PR DESCRIPTION
Sometimes the access configuration is not ready yet when we try to fetch backups from blob storage. In those cases, it is better experience to just return an empty backup list instead of an exception. We already catch one such exception but it seems depending on the process in access configuration, MinIO generates different error messages. With this commit we start to catch another such exception.