### PR TITLE
Disable stdout buffer for foreman at E2E tests

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -55,4 +55,6 @@ end.parse!
 
 clover_freeze
 
+$stdout.sync = true
+
 main(options)


### PR DESCRIPTION
By default, Ruby buffers stdout, which prevents the 'ci' script from printing any logs until the script is exited. As a result, all logs are printed at the end. foreman docs also recommends disabling the buffer to view these logs.
https://github.com/ddollar/foreman/wiki/Missing-Output