### PR TITLE
Add ubid to postgres hostname for better namespacing

### DIFF
--- a/migrate/20240220_postgres_hostname_version.rb
+++ b/migrate/20240220_postgres_hostname_version.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_enum(:hostname_version, %w[v1 v2])
+
+    alter_table(:postgres_resource) do
+      add_column :hostname_version, :hostname_version, null: false, default: "v1"
+    end
+  end
+end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -45,7 +45,8 @@ class PostgresResource < Sequel::Model
 
   def hostname
     if Prog::Postgres::PostgresResourceNexus.dns_zone
-      "#{name}.#{Config.postgres_service_hostname}"
+      return "#{name}.#{Config.postgres_service_hostname}" if hostname_version == "v1"
+      "#{name}.#{ubid}.#{Config.postgres_service_hostname}"
     else
       representative_server&.vm&.ephemeral_net4&.to_s
     end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -42,7 +42,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         project_id: project_id, location: location, name: name,
         target_vm_size: target_vm_size, target_storage_size_gib: target_storage_size_gib,
         superuser_password: superuser_password, ha_type: ha_type, parent_id: parent_id,
-        restore_target: restore_target
+        restore_target: restore_target,
+        hostname_version: "v2"
       )
       postgres_resource.associate_with_project(project)
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -10,9 +10,15 @@ RSpec.describe PostgresResource do
     ) { _1.id = "6181ddb3-0002-8ad0-9aeb-084832c9273b" }
   }
 
-  it "returns connection string" do
+  it "returns connection string without ubid qualifier" do
     expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return("something").at_least(:once)
+    expect(postgres_resource).to receive(:hostname_version).and_return("v1")
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.postgres.ubicloud.com?channel_binding=require")
+  end
+
+  it "returns connection string with ubid qualifier" do
+    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return("something").at_least(:once)
+    expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.pgc60xvcr00a5kbnggj1js4kkq.postgres.ubicloud.com?channel_binding=require")
   end
 
   it "returns connection string with ip address if config is not set" do


### PR DESCRIPTION
Currently the conntection string format we use for postgres databases is
`<database-name>.postgres.ubicloud.com`, which means all postgres databases
share the same global subdomain as a suffix; postgres.ubicloud.com.

This has few problems;
- It is not possible to re-use the same database name. It needs to be unique
globally.
- It leaks information regarding the existence of other databases.
- It requires knowing the name at the time of certificate provisioning, which
hinders pre-provisioning, especially if we want to use publicly trusted CAs at
some point.

With this commit, we start to use `<database-name>.<ubid>postgres.ubicloud.com`
as our naming format. This solves all the above problems.

Since we have legacy databases, we cannot simply switch to new format, we need
a way to distinguish old and new databases. For this purpose, I added a new
column; hostname_version. I'm planning to remove it once all legacy databases
are deprovisioned or migrated.