### PR TITLE
Resource type level (sku based) concessions

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -29,47 +29,62 @@ class InvoiceGenerator
           postal_code: "94127"
         }
 
+        # To keep invoice as it is, keep the resources on the project level. It can be moved to
+        # resource type level once the invoice structure is updated.
         project_content[:resources] = []
         project_content[:subtotal] = 0
-        project_records.group_by { |pr| [pr[:resource_id], pr[:resource_name]] }.each do |(resource_id, resource_name), line_items|
-          resource_content = {}
-          resource_content[:resource_id] = resource_id
-          resource_content[:resource_name] = resource_name
+        existing_resource_types = []
+        project_records.group_by { |pr| pr[:resource_type] }.each do |resource_type, resource_type_records|
+          existing_resource_types.push(resource_type)
+          resource_type_content = {}
+          resource_type_content[:subtotal] = 0
+          resource_type_content[:discount] = 0
+          resource_type_content[:credit] = 0
+          resource_type_content[:concessions] = project.concessions.find_all { |concession| concession.resource_type == resource_type }
 
-          resource_content[:line_items] = []
-          resource_content[:cost] = 0
-          line_items.each do |li|
-            line_item_content = {}
-            line_item_content[:location] = li[:location]
-            line_item_content[:resource_type] = li[:resource_type]
-            line_item_content[:resource_family] = li[:resource_family]
-            line_item_content[:description] = BillingRate.line_item_description(li[:resource_type], li[:resource_family], li[:amount])
-            line_item_content[:amount] = li[:amount].to_f
-            line_item_content[:duration] = li[:duration]
-            line_item_content[:cost] = li[:cost].to_f
+          resource_type_records.group_by { |rtr| [rtr[:resource_id], rtr[:resource_name]] }.each do |(resource_id, resource_name), line_items|
+            resource_content = {}
+            resource_content[:resource_id] = resource_id
+            resource_content[:resource_name] = resource_name
 
-            resource_content[:line_items].push(line_item_content)
-            resource_content[:cost] += line_item_content[:cost]
+            resource_content[:line_items] = []
+            resource_content[:cost] = 0
+            line_items.each do |li|
+              line_item_content = {}
+              line_item_content[:location] = li[:location]
+              line_item_content[:resource_type] = resource_type
+              line_item_content[:resource_family] = li[:resource_family]
+              line_item_content[:description] = BillingRate.line_item_description(resource_type, li[:resource_family], li[:amount])
+              line_item_content[:amount] = li[:amount].to_f
+              line_item_content[:duration] = li[:duration]
+              line_item_content[:cost] = li[:cost].to_f
+
+              resource_content[:line_items].push(line_item_content)
+              resource_content[:cost] += line_item_content[:cost]
+            end
+
+            project_content[:resources].push(resource_content)
+            resource_type_content[:subtotal] += resource_content[:cost]
           end
 
-          project_content[:resources].push(resource_content)
-          project_content[:subtotal] += resource_content[:cost]
+          resource_type_content[:cost] = resource_type_content[:subtotal]
+          project_content[:subtotal] += resource_type_content[:subtotal]
+          project_content[resource_type] = resource_type_content
         end
 
-        # We first apply discounts then credits, this is more beneficial for users as it
-        # would be possible to cover total cost with fewer credits.
         project_content[:cost] = project_content[:subtotal]
         project_content[:discount] = 0
-        if project.discount > 0
-          project_content[:discount] = project_content[:cost] * (project.discount / 100.0)
-          project_content[:cost] -= project_content[:discount]
+        project_content[:credit] = 0
+        # Apply resource level concessions first, then project level ones
+        existing_resource_types.each do |resource_type|
+          apply_concessions(project_content, project_content[resource_type][:concessions], resource_type)
+
+          # Removing the resource type level keys to keep invoice as it is
+          # TODO: Remove it once invoice structure will be updated
+          project_content.delete(resource_type)
         end
 
-        project_content[:credit] = 0
-        if project.credit > 0
-          project_content[:credit] = [project_content[:cost], project.credit.to_f].min
-          project_content[:cost] -= project_content[:credit]
-        end
+        apply_concessions(project_content, project.concessions.find_all { |concession| concession.resource_type.nil? }, nil)
 
         if @save_result
           invoice_month = @begin_time.strftime("%y%m")
@@ -78,22 +93,6 @@ class InvoiceGenerator
           invoice_number = "#{invoice_month}-#{invoice_customer}-#{invoice_order}"
 
           invoice = Invoice.create_with_id(project_id: project.id, invoice_number: invoice_number, content: project_content, begin_time: @begin_time, end_time: @end_time)
-
-          if project_content[:credit] > 0
-            # We don't use project.credit here, because credit might get updated between
-            # the time we read and write. Referencing credit column here prevents such
-            # race conditions. If credit got increased, then there is no problem. If it
-            # got decreased, CHECK constraint in the DB will prevent credit balance to go
-            # negative.
-            # We also need to disable Sequel validations, because Sequel simplychecks if
-            # the new value is BigDecimal, but "Sequel[:credit] - project_content[:credit]" expression
-            # is Sequel::SQL::NumericExpression, not BigDecimal. Eventhough it resolves to
-            # BigDecimal, it fails the check.
-            # Finally, we use save_changes instead of update because it is not possible to
-            # pass validate: false to update.
-            project.credit = Sequel[:credit] - project_content[:credit]
-            project.save_changes(validate: false)
-          end
         else
           invoice = Invoice.new(project_id: project.id, content: JSON.parse(project_content.to_json), begin_time: @begin_time, end_time: @end_time, created_at: Time.now, status: "current")
         end
@@ -105,8 +104,57 @@ class InvoiceGenerator
     invoices
   end
 
+  def apply_concessions(project_content, concessions, resource_type)
+    # First apply discounts and then credits
+    concessions.each do |concession|
+      if resource_type
+        discount_amount = project_content[resource_type][:cost] * (concession.discount / 100.0)
+        project_content[resource_type][:discount] += discount_amount
+        project_content[resource_type][:cost] -= discount_amount
+      else
+        discount_amount = project_content[:cost] * (concession.discount / 100.0)
+      end
+
+      project_content[:discount] += discount_amount
+      project_content[:cost] -= discount_amount
+    end
+
+    # TODO: Remove this very hacky check once the discount information will be removed from project model
+    if resource_type.nil?
+      discount_amount = project_content[:cost] * (Project[project_content[:project_id]].discount / 100.0)
+      project_content[:discount] += discount_amount
+      project_content[:cost] -= discount_amount
+    end
+
+    concessions.each do |concession|
+      if resource_type
+        credit_amount = [project_content[resource_type][:cost], concession.credit.to_f].min
+        project_content[resource_type][:cost] -= credit_amount
+        project_content[resource_type][:credit] += credit_amount
+      else
+        credit_amount = [project_content[:cost], concession.credit.to_f].min
+      end
+
+      project_content[:cost] -= credit_amount
+      project_content[:credit] += credit_amount
+      concession.credit -= credit_amount
+      concession.update
+    end
+
+    # TODO: Remove this very hacky check once the credit information will be removed from project model
+    if resource_type.nil?
+      project = Project[project_content[:project_id]]
+      project_credit_amount = project.credit.to_f
+      apply_credit_amount = [project_content[:cost], project_credit_amount].min
+      project_content[:credit] += apply_credit_amount
+      project_content[:cost] -= apply_credit_amount
+      project.credit = project_credit_amount - apply_credit_amount
+      project.save_changes
+    end
+  end
+
   def active_billing_records
-    active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices])
+    active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices, :concessions])
       .where { |br| Sequel.pg_range(br.span).overlaps(Sequel.pg_range(@begin_time...@end_time)) }
     active_billing_records = active_billing_records.where(project_id: @project_id) if @project_id
     active_billing_records.all.map do |br|

--- a/migrate/20240218_add_concession.rb
+++ b/migrate/20240218_add_concession.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:concession) do
+      column :id, :uuid, primary_key: true, default: Sequel.lit("gen_random_uuid()")
+      column :project_id, :project, type: :uuid, null: false
+      column :resource_type, :text, collate: '"C"'
+      column :credit, :numeric, null: false, default: 0
+      constraint(:min_credit) { credit >= 0 }
+      column :discount, :Integer, null: false, default: 0
+      constraint(:max_discount) { discount <= 100 }
+    end
+  end
+end

--- a/model/concession.rb
+++ b/model/concession.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class Concession < Sequel::Model
+  many_to_one :project
+
+  include ResourceMethods
+end

--- a/model/project.rb
+++ b/model/project.rb
@@ -14,6 +14,7 @@ class Project < Sequel::Model
   many_to_many :postgres_resources, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
 
   one_to_many :invoices, order: Sequel.desc(:created_at)
+  one_to_many :concessions
 
   dataset_module Authorization::Dataset
 


### PR DESCRIPTION
```
In order to keep concession on the resource type level (sku is also used
interchangeably at some points) adding a new table concession.

Multiple concessions can be added for the same resource type. If the
concession tuple only has project id column but not resource type,
that means the concession will be applicable for all resources
within that project.
```
```
Updating invoice generator code to apply concessions added to
the concession table. Existing invoices and credit/discount
info on the project table are still supported. In other words,
concessions added to concession table will be applied together
with the credit/discount values added to project table. Structure
of the invoice will be updated with a subsequent PR and credit/discount
info on the project table will also be removed with another one.

Concessions will be applied in the order of

1- Apply resource type level concessions
	- Apply discounts (by multiplying if multiple defined for same type)
	- Apply credit

2- Apply project level concessions
	- Apply discounts defined on concession table
	- Apply discount defined on project table
	- Apply credits defined on concession table
	- Apply credit defined on project table

Also note that, to not affect the invoice structure with this PR,
resource type level values are added first for simpler calculations
then removed before creating the invoice object.

```