### PR TITLE
Distinct storage device support

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -9,7 +9,7 @@ class Vm < Sequel::Model
   many_to_many :private_subnets, join_table: Nic.table_name, left_key: :vm_id, right_key: :private_subnet_id
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
-  one_to_many :vm_storage_volumes, key: :vm_id
+  one_to_many :vm_storage_volumes, key: :vm_id, order: Sequel.desc(:boot)
   one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
   one_to_many :firewalls, key: :vm_id
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -13,7 +13,8 @@ class Prog::Vm::Nexus < Prog::Base
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
-    enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil)
+    enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil,
+    distinct_storage_devices: false)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -98,7 +99,11 @@ class Prog::Vm::Nexus < Prog::Base
       Strand.create(
         prog: "Vm::Nexus",
         label: "start",
-        stack: [{"storage_volumes" => storage_volumes.map { |v| v.transform_keys(&:to_s) }, "swap_size_bytes" => swap_size_bytes}]
+        stack: [{
+          "storage_volumes" => storage_volumes.map { |v| v.transform_keys(&:to_s) },
+          "swap_size_bytes" => swap_size_bytes,
+          "distinct_storage_devices" => distinct_storage_devices
+        }]
       ) { _1.id = vm.id }
     end
   end
@@ -137,13 +142,6 @@ class Prog::Vm::Nexus < Prog::Base
     @params_path ||= File.join(vm_home, "prep.json")
   end
 
-  def vm_storage_size_gib
-    if (storage_volumes = frame["storage_volumes"])
-      return storage_volumes.map { _1["size_gib"] }.sum
-    end
-    vm.storage_size_gib
-  end
-
   def storage_volumes
     @storage_volumes ||= vm.vm_storage_volumes.map { |s|
       {
@@ -155,7 +153,8 @@ class Prog::Vm::Nexus < Prog::Base
         "encrypted" => !s.key_encryption_key_1.nil?,
         "spdk_version" => s.spdk_version,
         "use_bdev_ubi" => s.use_bdev_ubi,
-        "skip_sync" => s.skip_sync
+        "skip_sync" => s.skip_sync,
+        "storage_device" => s.storage_device.name
       }
     }
   end
@@ -169,17 +168,42 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   def allocation_dataset
-    DB[<<SQL, vm.cores, vm.mem_gib_ratio, vm.mem_gib, vm_storage_size_gib, vm.location, vm.arch]
+    total_storage_gib = frame["storage_volumes"].sum { |v| v["size_gib"] }
+
+    device_allocation_query = if frame["distinct_storage_devices"]
+      <<-SQL
+WITH RankedGroupedAndFilteredStorageDevices AS(
+  SELECT sd.vm_host_id
+  FROM storage_device sd
+    INNER JOIN (VALUES #{frame["storage_volumes"].sort_by { _1["size_gib"] }.reverse.map.with_index(1) { |el, i| "(#{el["size_gib"]},#{i})" }.join(", ")}) AS va(size_gib, volume_rank)
+    ON sd.available_storage_gib >= va.size_gib AND sd.enabled
+  GROUP BY (sd.vm_host_id, va.volume_rank) HAVING count(*) >= va.volume_rank
+),
+EligibleVmHosts AS(
+   SELECT vm_host_id FROM RankedGroupedAndFilteredStorageDevices GROUP BY vm_host_id HAVING count(*) >= #{frame["storage_volumes"].length}
+)
+SELECT *
+FROM vm_host INNER JOIN EligibleVmHosts ON vm_host.id = EligibleVmHosts.vm_host_id
+WHERE
+      SQL
+    else
+      <<-SQL
 SELECT *
 FROM vm_host
-WHERE vm_host.used_cores + ? <= least(vm_host.total_cores, vm_host.total_mem_gib / ?)
-AND vm_host.used_hugepages_1g + ? <= vm_host.total_hugepages_1g
-AND vm_host.available_storage_gib > ?
-AND vm_host.allocation_state = 'accepting'
-AND vm_host.location = ?
-AND vm_host.arch = ?
-ORDER BY random()
-SQL
+WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_device.enabled AND storage_device.vm_host_id = vm_host.id) >= #{total_storage_gib} AND
+      SQL
+    end
+
+    device_allocation_query += <<-SQL
+        vm_host.used_cores + ? <= least(vm_host.total_cores, vm_host.total_mem_gib / ?)
+        AND vm_host.used_hugepages_1g + ? <= vm_host.total_hugepages_1g
+        AND vm_host.allocation_state = 'accepting'
+        AND vm_host.location = ?
+        AND vm_host.arch = ?
+      ORDER BY random()
+    SQL
+
+    DB[device_allocation_query, vm.cores, vm.mem_gib_ratio, vm.mem_gib, vm.location, vm.arch]
   end
 
   def allocate
@@ -190,19 +214,42 @@ SQL
       .where(id: vm_host_id, allocation_state: "accepting")
       .update(
         used_cores: Sequel[:used_cores] + vm.cores,
-        used_hugepages_1g: Sequel[:used_hugepages_1g] + vm.mem_gib,
-        available_storage_gib: Sequel[:available_storage_gib] - vm_storage_size_gib
+        used_hugepages_1g: Sequel[:used_hugepages_1g] + vm.mem_gib
       ).zero?
-
-    StorageDevice.where(vm_host_id: vm_host_id, name: "DEFAULT").update(
-      available_storage_gib: Sequel[:available_storage_gib] - vm_storage_size_gib
-    )
 
     vm_host_id
   end
 
-  def create_storage_volume_records(vm_host)
-    frame["storage_volumes"].each_with_index do |volume, disk_index|
+  def allocate_storage_devices(vm_host, storage_volumes)
+    DB.transaction do
+      devices = vm_host.storage_devices_dataset.for_update.order_by(&:available_storage_gib).all
+      device_index = 0
+
+      storage_volumes.sort_by { _1["size_gib"] }.map do |volume|
+        while device_index < devices.length &&
+            (!devices[device_index].enabled ||
+            devices[device_index].available_storage_gib < volume["size_gib"])
+          device_index += 1
+        end
+
+        fail "Storage device allocation failed" unless device_index < devices.length
+
+        # Allocate!
+        allocated_device = devices[device_index]
+        allocated_device.update(available_storage_gib: allocated_device.available_storage_gib - volume["size_gib"])
+        volume.update({"storage_device_id" => allocated_device.id})
+
+        # If we require distinct storage devices, then the next volume can't use
+        # this device. Therefore, skip it.
+        device_index += 1 if frame["distinct_storage_devices"]
+
+        volume
+      end
+    end
+  end
+
+  def create_storage_volume_records(vm_host, storage_volumes)
+    storage_volumes.each_with_index do |volume, disk_index|
       spdk_installation_id = allocate_spdk_installation(vm_host.spdk_installations)
 
       # To test the effect of encryption on the performance, encrypt for bdev_ubi
@@ -229,7 +276,8 @@ SQL
         skip_sync: volume["skip_sync"],
         disk_index: disk_index,
         key_encryption_key_1_id: key_encryption_key&.id,
-        spdk_installation_id: spdk_installation_id
+        spdk_installation_id: spdk_installation_id,
+        storage_device_id: volume["storage_device_id"]
       )
     end
   end
@@ -287,7 +335,10 @@ SQL
     vm_host = VmHost[vm_host_id]
     ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled
 
-    create_storage_volume_records(vm_host)
+    DB.transaction do
+      storage_volumes = allocate_storage_devices(vm_host, frame["storage_volumes"])
+      create_storage_volume_records(vm_host, storage_volumes)
+    end
 
     Clog.emit("vm allocated") do
       {allocation: {vm_host_ubid: vm_host.ubid, ip4: ip4, address: address&.cidr&.to_s,
@@ -494,14 +545,15 @@ SQL
         nic.incr_destroy
       end
 
+      vm.vm_storage_volumes.each do |vol|
+        dev = vol.storage_device
+        dev ||= StorageDevice.dataset.where(vm_host_id: vm.vm_host_id, name: "DEFAULT").first
+        dev.update(available_storage_gib: dev.available_storage_gib + vol.size_gib)
+      end
+
       VmHost.dataset.where(id: vm.vm_host_id).update(
         used_cores: Sequel[:used_cores] - vm.cores,
-        used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib,
-        available_storage_gib: Sequel[:available_storage_gib] + vm_storage_size_gib
-      )
-
-      StorageDevice.dataset.where(vm_host_id: vm.vm_host_id, name: "DEFAULT").update(
-        available_storage_gib: Sequel[:available_storage_gib] + vm_storage_size_gib
+        used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib
       )
 
       vm.projects.map { vm.dissociate_with_project(_1) }


### PR DESCRIPTION
This commit introduces a more intelligent allocator. Now, a host may
have multiple storage devices (not RAID0), and we can allocate a VM's
disks from each of those storage devices distinctively. Most of the
parts in this commit comes from
https://github.com/ubicloud/ubicloud/commit/9cf65be16ea3e9b632fab16503f5aa92c39a2b53 while changing the main
allocation query to handle an edge case. For example, the previous
commit does simply check for the the vm_storage_device with the highest
size and checks if there is a host that has x numbers of disk that can
host the vm_storage_device. This is not very accurate since a VM might
have 2 disks such as;
1. disk1: 30GB
2. disk2: 2TB

The previous commit would check if there is a host with 2 disks, each
has at least 2 TB capacity. With this commit, we try to check storage
devices per host and see if there is a mapping of vm_storage_devices to
storage_devices. The new commit would be able to allocate if there is a
host with, for example;
1. storage_device1.available_storage_gib: 100GB
2. storage_device2.available_storage_gib: 3TB

The previous commit would fail to do so.

Now, in this commit, there is something we need to address, what good
does it have to place vm disks in distinct storage devices? This is
mainly implemented for MinIO, so that it can survive, and self heal in
case a specific drive fails. There is also the question of, what about
the OS disk? Previously, I have considered putting OS disk of a VM into
the hosts OS disk. This is a good idea because, in any case, if the host
OS disk fails, all of the VMs in that host will already fail. The data
disks, on the other hand, will be just fine. However, making the
distinction of OS disk for VM, and allocating storage from other drives
will make this commit much more complicated, especially considering we
will have to dive into allocator in short term, anyway. Here, in this
PR, I made the decision to leave the placement of VM's OS disk or data
disk to fate. OS disk will be seen as any other disk, and we will
(probably) randomly choose any disk (e.g. host's OS disk, or any other
data disk) to place them in according to the available space. This way,
if one of the data disks fail, it is possible that some of the VMs in
that host will be unavailable, and some will lose the data disks.
However, for now, this is not an issue we need to tackle, because there
is exactly 1 minIO VM running on a Minio host. In addition, our
configuration of the host will have a smaller OS disk size and larger
data disk sizes. At the allocation phase, we can enforce the OS disk of
a VM to be placed in the host's os disk. To make it more clear, let's
assume this is our host configuration;
1. 1TB NVMe OS disk
2. 2x4TB NVMe extra disks

When, I provision a minio vm on that host, I will ask this to have;
1. 30GB of OS disk
2. 2x4TB of data disks.

In this configuration, allocator will be forced to place the OS disk
into the host's OS disk space.