### PR TITLE
Bump jwt gem from 2.7.1 to 2.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,8 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    jwt (2.7.1)
+    jwt (2.8.0)
+      base64
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     loofah (2.22.0)

--- a/spec/lib/github_spec.rb
+++ b/spec/lib/github_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Github do
   it "creates app client" do
     expect(Config).to receive(:github_app_id).and_return("123456")
     private_key = instance_double(OpenSSL::PKey::RSA)
+    expect(private_key).to receive(:is_a?).with(OpenSSL::PKey::RSA).and_return(true)
     expect(private_key).to receive(:sign).and_return("signed")
     expect(OpenSSL::PKey::RSA).to receive(:new).and_return(private_key)
     expect(Octokit::Client).to receive(:new).with(bearer_token: anything)


### PR DESCRIPTION
Dependabot recommended this update earlier. However, a recent change in the `jwt` library broke one of our tests.

They began explicitly checking the key's class [^1], causing the mocked class to fail with the following error:

    The given key is a RSpec::Mocks::InstanceVerifyingDouble. It has to
    be an OpenSSL::PKey::RSA instance

[^1]: https://github.com/jwt/ruby-jwt/blob/bd3f80bf3d432759101b8edeef073cde73a7434c/lib/jwt/jwa/rsa.rb#L11