### PR TITLE
Fix IPv6 only destroy

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -111,7 +111,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
   # Delete all traces of the VM.
   def purge
-    block_ip4 if vp.read_public_ipv4
+    block_ip4
 
     begin
       r "ip netns del #{q_vm}"

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -169,8 +169,6 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:unmount_hugepages)
       expect(vs).to receive(:r).with("deluser --remove-home test")
       expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_return("test.service")
-
-      expect(vs.vp).to receive(:read_public_ipv4).and_return("12.12.12.12")
       expect(vs).to receive(:block_ip4)
 
       vs.purge


### PR DESCRIPTION
If the VM is IPv6 only, or the public_ipv4 file is already deleted in the host in a previous call, this read_public_ipv4 call fails. Instead, we can simply remove the read since it's not necessary anyway.