### PR TITLE
Loosen workflow_job requirement for webhook payloads

### DIFF
--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -58,7 +58,10 @@ class CloverWeb
       return error("Unregistered installation")
     end
 
-    job = data.fetch("workflow_job")
+    unless (job = data["workflow_job"])
+      Clog.emit("No workflow_job in the payload") { {workflow_job_missing: {installation_id: installation.id, action: data["action"]}} }
+      return error("No workflow_job in the payload")
+    end
 
     unless (label = job.fetch("labels").find { Github.runner_labels.key?(_1) })
       return error("Unmatched label")


### PR DESCRIPTION
Based on GitHub documentation "workflow_job" value is required for "workflow_job" webhook event payloads [^1].  It has to be required because we need know workflow details to act on "workflow_job.queued" event. It makes sense.

Some delivered payloads have a 'null' value for 'workflow_job.queued' events, which results in an HTTP 500 error and GitHub marking them as failed. Our `RedeliverGithubFailures` prog attempts to redeliver these every 5 minutes, but consistently receives a 500 error. This cycle continues for about 3 days until the delivery expires.

I have created a support ticket for this issue, and here is the latest response:

    It looks like there is an existing active issue with our engineering
    team to help investigate this issue further. While I don't have an
    ETA on when they will have a resolution, please know the issue is
    being looked into.

For now, if the workflow job is missing, it's advisable to print a log and return 200.

[^1]: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=queued#workflow_job