### PR TITLE
Fix MINIO_SERVER_URL config for clusters without DnsZone

### DIFF
--- a/prog/minio/setup_minio.rb
+++ b/prog/minio/setup_minio.rb
@@ -19,12 +19,13 @@ class Prog::Minio::SetupMinio < Prog::Base
       minio_server.vm.sshable.cmd("common/bin/daemonizer --clean configure_minio")
       pop "minio is configured"
     when "Failed", "NotStarted"
+      server_url_config = minio_server.cluster.dns_zone ? "MINIO_SERVER_URL=\"#{minio_server.server_url}\"" : ""
       minio_config = <<ECHO
 MINIO_VOLUMES="#{minio_server.minio_volumes}"
 MINIO_OPTS="--console-address :9001"
 MINIO_ROOT_USER="#{minio_server.cluster.admin_user}"
 MINIO_ROOT_PASSWORD="#{minio_server.cluster.admin_password}"
-MINIO_SERVER_URL="#{minio_server.server_url}"
+#{server_url_config}
 ECHO
 
       hosts = <<ECHO

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -110,6 +110,15 @@ ECHO
       expect { nx.configure_minio }.to nap(5)
     end
 
+    it "configures minio without server_url if dns is not configures" do
+      expect(nx.minio_server.cluster).to receive(:dns_zone).and_return(false)
+      expect(nx.minio_server.cluster.servers.first).to receive(:private_ipv4_address).and_return("192.168.0.0")
+      expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check configure_minio").and_return("NotStarted")
+      expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo minio/bin/configure-minio' configure_minio", stdin: config.gsub("MINIO_SERVER_URL=\\\"https://minio-cluster-name.minio.ubicloud.com:9000\\\"", ""))
+
+      expect { nx.configure_minio }.to nap(5)
+    end
+
     it "pops if minio is configured" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check configure_minio").and_return("Succeeded")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --clean configure_minio")


### PR DESCRIPTION
When we refactored minio.urls at
https://github.com/ubicloud/ubicloud/pull/1181/files we overlooked the development minio cluster provisioning without dns_zone. MINIO_SERVER_URL configuration is not necessary if we do not have a dns name or a load balancer in front of the cluster. Furthermore, minio requires this configuration to be the same in all of the servers in the cluster, if not, it rejects to spin up. This causes a problem for development environment because we do not have dnszone setup in dev. This PR simply implements a quick fix for that.