### PR TITLE
Fix the reusing pooled vm when the runner doesn't wait the vm

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -308,6 +308,7 @@ class Prog::Vm::GithubRunner < Prog::Base
           Clog.emit("Failed to move serial.log or running journalctl") { {github_runner: github_runner.values} }
         end
       end
+      vm.update(display_state: "deleting")
       vm.incr_destroy
     end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -404,6 +404,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).to receive(:vm_host).and_return(vm_host)
       expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
+      expect(vm).to receive(:update).with(display_state: "deleting")
       expect(vm).to receive(:incr_destroy)
       expect(github_runner).to receive(:destroy)
 
@@ -420,6 +421,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).to receive(:vm_host).and_return(vm_host)
       expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
+      expect(vm).to receive(:update).with(display_state: "deleting")
       expect(vm).to receive(:incr_destroy)
       expect(github_runner).to receive(:destroy)
 
@@ -436,6 +438,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).to receive(:vm_host).and_return(vm_host)
       expect(sshable).to receive(:cmd).and_raise Sshable::SshError.new("bogus", "", "", nil, nil)
       expect(Clog).to receive(:emit).with("Failed to move serial.log or running journalctl").and_call_original
+      expect(vm).to receive(:update).with(display_state: "deleting")
       expect(vm).to receive(:incr_destroy)
       expect(github_runner).to receive(:destroy)
 
@@ -450,6 +453,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"}).at_least(:once)
       expect(sshable).not_to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).not_to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
+      expect(vm).to receive(:update).with(display_state: "deleting")
       expect(vm).to receive(:incr_destroy)
       expect(github_runner).to receive(:destroy)
 


### PR DESCRIPTION
The runner started to not waiting its vm destroy at ee8ec26247274964853eacd9435253fa36cbfedc. After deployment, another issue surfaced. I discovered that one of the runners was at `register_runner` label, but its VM had been deleted already. Furkan pointed that the VM pool selects a VM that's running state and doesn't have a GithubRunner model. Therefore, if the runner model doesn't wait for the VM to be destroyed, the pool may select a VM that's already been used because its GithubRunner has been deleted.

This PR simply updates the display state of the vm as `deleting` while destroying the runner, so it will not picked again.