### PR TITLE
Adjust SPDK pool sizes.

### DIFF
--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -22,6 +22,7 @@ case verb
 when "install"
   spdk_setup.install_package
   spdk_setup.create_hugepages_mount
+  spdk_setup.create_conf
   spdk_setup.create_service
   spdk_setup.enable_services
 when "start"

--- a/rhizome/host/lib/spdk_path.rb
+++ b/rhizome/host/lib/spdk_path.rb
@@ -41,6 +41,10 @@ module SpdkPath
       File.join(home, "spdk-#{spdk_version}.sock")
   end
 
+  def self.conf_path(spdk_version)
+    File.join(home, "spdk-#{spdk_version}.conf")
+  end
+
   def self.install_prefix
     File.join("", "opt")
   end

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -4,6 +4,7 @@ require_relative "../../common/lib/util"
 require_relative "../../common/lib/arch"
 require_relative "spdk_path"
 require "fileutils"
+require "json"
 
 class SpdkSetup
   def initialize(spdk_version)
@@ -26,6 +27,10 @@ class SpdkSetup
 
   def install_path
     @install_path ||= SpdkPath.install_path(@spdk_version)
+  end
+
+  def conf_path
+    @conf_path ||= SpdkPath.conf_path(@spdk_version)
   end
 
   def spdk_service
@@ -97,7 +102,8 @@ ExecStart=#{vhost_binary} -S #{SpdkPath.vhost_dir.shellescape} \
 --iova-mode va \
 --rpc-socket #{rpc_sock.shellescape} \
 --cpumask [0,1] \
---disable-cpumask-locks
+--disable-cpumask-locks \
+--config #{conf_path.shellescape}
 ExecReload=/bin/kill -HUP $MAINPID
 LimitMEMLOCK=8400113664
 PrivateDevices=yes
@@ -127,12 +133,80 @@ Description=SPDK hugepages mount #{@spdk_version}
 What=hugetlbfs
 Where=#{hugepages_dir}
 Type=hugetlbfs
-Options=uid=#{user},size=1G
+Options=uid=#{user},size=2G
 
 [Install]
 WantedBy=#{spdk_service}
 SPDK_HUGEPAGES_MOUNT
     )
+  end
+
+  def create_conf
+    iobuf_conf = [{
+      method: "iobuf_set_options",
+      params: {
+        # Each bdev iobuf channel requires 128 small pool items & 16 large pool
+        # items. These are hard-coded in v23.09 and aren't configurable. Each
+        # accel iobuf channel requires 128 small pool & 16 large pool items.
+        # These values are configurable using accel_set_options.
+        #
+        # An unencrypted volume requires 1 bdev & 1 accel iobuff channels. An
+        # encrypted volume requires 1 bdev & 2 accel iobuff channels.
+        #
+        # So, small_pool_count must be at least #Volumes-per-host*3*128, and
+        # large_pool_count must be at least #Volumes-per-host*3*16. This config,
+        # which modifies the defaults, is enough for 100 encrypted volumes in a
+        # host.
+        small_pool_count: 38400,
+        large_pool_count: 4800,
+        small_bufsize: 8192,
+        large_bufsize: 135168
+      }
+    }]
+
+    # Leave these same as defaults for now.
+    accel_conf = [{
+      method: "accel_set_options",
+      params: {
+        small_cache_size: 128,
+        large_cache_size: 16,
+        task_count: 2048,
+        sequence_count: 2048,
+        buf_count: 2048
+      }
+    }]
+
+    bdev_conf = [{
+      method: "bdev_set_options",
+      params: {
+        # SPDK pre-populates the bdev_io cache per each io_channel. So,
+        # bdev_io_pool_size should be least #io_channels * bdev_io_cache_size.
+        # Therefore, bdev_io_pool_size must be #Volumes-per-host * 256.
+        #
+        # The default config is enough for 512 volumes in a host, so keeping it
+        # as it is.
+        bdev_io_pool_size: 65536,
+        bdev_io_cache_size: 256,
+        bdev_auto_examine: true
+      }
+    }]
+
+    safe_write_to_file(conf_path, JSON.pretty_generate({
+      subsystems: [
+        {
+          subsystem: "iobuf",
+          config: iobuf_conf
+        },
+        {
+          subsystem: "accel",
+          config: accel_conf
+        },
+        {
+          subsystem: "bdev",
+          config: bdev_conf
+        }
+      ]
+    }))
   end
 
   def enable_services


### PR DESCRIPTION
Default small_pool_count and large_pool_count wasn't enough for our usecases, and we would get errors like `Failed to populate iobuf small buffer cache.`.

Previously, we could only provision 21 encrypted (or 32 unencrypted) volumes per host without getting errors.

The new config is enough for 100 encrypted volumes per host, which is large enough for our current host sizes. We currently can have up to about 39 standard-2 VMs in our 80 core arm64 hosts, and up to about 31 standard-2 VMs in our largest x64 hosts.

Increasing small_pool_count and large_pool_count requires increasing hugepages allocated to SPDK from 1G to 2G, which we also do in this PR.

This patch fixes the issue for new hosts automatically. For older hosts, we need to:
* Put the host in `draining` allocation state & wait for VMs to destroy
* `vmh.sshable.cmd("sudo host/bin/setup-spdk install v23.09-ubi-0.2")`
* `vmh.incr_reboot`
* Put the host in `accepting` allocation state