### PR TITLE
Update runner user with runneradmin and add new runner user

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -43,7 +43,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     end
 
     vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-      "runner",
+      "runneradmin",
       Config.github_runner_service_project_id,
       name: github_runner.ubid.to_s,
       size: label_data["vm_size"],
@@ -135,6 +135,23 @@ class Prog::Vm::GithubRunner < Prog::Base
   label def wait_vm
     nap 5 unless vm.strand.label == "wait"
     register_deadline(:wait, 10 * 60)
+    hop_create_runner_user
+  end
+
+  label def create_runner_user
+    # Sending addgroup and adduser separately, as there is no way
+    # to force group and user has specific names and ids with a
+    # single command
+    command = <<~COMMAND
+      set -ueo pipefail
+      sudo userdel -rf runner || true
+      sudo addgroup --gid 1001 runner
+      sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
+      echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner
+    COMMAND
+
+    vm.sshable.cmd(command.gsub(/^(# .*)?\n/, ""))
+
     hop_setup_environment
   end
 
@@ -177,16 +194,23 @@ class Prog::Vm::GithubRunner < Prog::Base
 
       # We placed the script in the "/usr/local/share/" directory while generating
       # the golden image. However, it needs to be moved to the home directory because
-      # the runner creates some configuration files at the script location. The "runner"
-      # user doesn't have write permission for the "/usr/local/share/" directory.
+      # the runner creates some configuration files at the script location. Since the
+      # github runner vm is created with the runneradmin user, directory is first moved
+      # to runneradmin user's home directory. At the end of this script, it will be moved
+      # to runner user's home folder. We move actions-runner separately below for idempotency
+      # purposes, as the first one guarantees to continue in case the script fails after that
+      # line, and the latter guarateens to continue if the script fails after moving
+      # actions-runner from ./ to /home/runner
       sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./
-      sudo chown -R runner:runner actions-runner
+      sudo [ ! -d /home/runner/actions-runner ] || sudo mv /home/runner/actions-runner ./
+      sudo chown -R runneradmin:runneradmin actions-runner
 
       # ./env.sh sets some variables for runner to run properly
       ./actions-runner/env.sh
 
-      # Include /etc/environment in the runner environment, it's
-      # otherwise ignored, and this omission has caused problems.
+      # Include /etc/environment in the runneradmin environment to move it to the
+      # runner enviornment at the end of this script, it's otherwise ignored, and
+      # this omission has caused problems.
       # See https://github.com/actions/runner/issues/1703
       cat <<EOT > ./actions-runner/run-withenv.sh
       #!/bin/bash
@@ -204,7 +228,10 @@ class Prog::Vm::GithubRunner < Prog::Base
       # The `imagedata.json` file contains information about the generated image.
       # I enrich it with details about the Ubicloud environment and placed it in the runner's home directory.
       # GitHub-hosted runners also use this file as setup_info to show on the GitHub UI.
-      cat /imagegeneration/imagedata.json | jq '. += [#{setup_info.to_json}]' > /home/runner/actions-runner/.setup_info
+      cat /imagegeneration/imagedata.json | jq '. += [#{setup_info.to_json}]' > ./actions-runner/.setup_info
+
+      sudo mv ./actions-runner /home/runner/
+      sudo chown -R runner:runner /home/runner/actions-runner
     COMMAND
 
     # Remove comments and empty lines before sending them to the machine
@@ -225,7 +252,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # having to store the encoded_jit_config.
     vm.sshable.cmd("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner " \
                    "--working-directory '/home/runner' --unit #{SERVICE_NAME} --remain-after-exit -- " \
-                   "./actions-runner/run-withenv.sh {}",
+                   "/home/runner/actions-runner/run-withenv.sh {}",
       stdin: response[:encoded_jit_config])
 
     hop_wait

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -39,7 +39,7 @@ class Prog::Vm::VmPool < Prog::Base
       skip_sync: vm_pool.storage_skip_sync
     }
     Prog::Vm::Nexus.assemble_with_sshable(
-      "runner",
+      "runneradmin",
       Config.vm_pool_project_id,
       size: vm_pool.vm_size,
       location: vm_pool.location,

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
       vm = nx.pick_vm
       expect(vm).not_to be_nil
-      expect(vm.sshable.unix_user).to eq("runner")
+      expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
       expect(vm.cores).to eq(2)
       expect(vm.projects.map(&:id)).to include(Config.github_runner_service_project_id)
@@ -96,7 +96,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
       vm = nx.pick_vm
       expect(vm).not_to be_nil
-      expect(vm.sshable.unix_user).to eq("runner")
+      expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
       expect(vm.cores).to eq(2)
     end
@@ -261,7 +261,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops if vm is ready" do
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(vm).to receive(:strand).and_return(Strand.new(label: "wait"))
-      expect { nx.wait_vm }.to hop("setup_environment")
+      expect { nx.wait_vm }.to hop("create_runner_user")
     end
   end
 
@@ -275,6 +275,20 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
   end
 
+  describe "#create_runner_user" do
+    it "hops to setup environment" do
+      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+        set -ueo pipefail
+        sudo userdel -rf runner || true
+        sudo addgroup --gid 1001 runner
+        sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
+        echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner
+      COMMAND
+
+      expect { nx.create_runner_user }.to hop("setup_environment")
+    end
+  end
+
   describe "#setup_environment" do
     it "hops to register_runner" do
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
@@ -284,7 +298,8 @@ RSpec.describe Prog::Vm::GithubRunner do
         sudo su -c "find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} ';'"
         source /etc/environment
         sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./
-        sudo chown -R runner:runner actions-runner
+        sudo [ ! -d /home/runner/actions-runner ] || sudo mv /home/runner/actions-runner ./
+        sudo chown -R runneradmin:runneradmin actions-runner
         ./actions-runner/env.sh
         cat <<EOT > ./actions-runner/run-withenv.sh
         #!/bin/bash
@@ -293,7 +308,9 @@ RSpec.describe Prog::Vm::GithubRunner do
         EOT
         chmod +x ./actions-runner/run-withenv.sh
         echo "PATH=$PATH" >> ./actions-runner/.env
-        cat /imagegeneration/imagedata.json | jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: https://console.ubicloud.com/project/pjwnadpt27b21p81d7334f11rx/github"}]' > /home/runner/actions-runner/.setup_info
+        cat /imagegeneration/imagedata.json | jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: https://console.ubicloud.com/project/pjwnadpt27b21p81d7334f11rx/github"}]' > ./actions-runner/.setup_info
+        sudo mv ./actions-runner /home/runner/
+        sudo chown -R runner:runner /home/runner/actions-runner
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")
@@ -303,7 +320,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#register_runner" do
     it "registers runner hops" do
       expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: github_runner.ubid.to_s, labels: [github_runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC"})
-      expect(sshable).to receive(:cmd).with("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- ./actions-runner/run-withenv.sh {}",
+      expect(sshable).to receive(:cmd).with("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh {}",
         stdin: "AABBCC")
       expect(github_runner).to receive(:update).with(runner_id: 123, ready_at: anything)
 


### PR DESCRIPTION
Renaming the unix user name of github runner vms from runner to runneradmin then adding a new user with the name runner. Since the runneradmin will be the first user created on vm, it's uid will be 1000 and as the runner user will be the next one, it's uid will be 1001.

Having both runneradmin and runner users with uid 1000 and 1001 will make the users on the Ubicloud same with what Github has on standard runners.

Please note, those uids won't be same with the Github's larger runners as Github has discrepancy between standard and larger runners. Check the issue https://github.com/actions/runner-images/issues/6930 for details.
