### PR TITLE
Move health monitor sockets to var directory

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -46,7 +46,7 @@ class MinioServer < Sequel::Model
   end
 
   def init_health_monitor_session
-    socket_path = File.join(Dir.pwd, "health_monitor_sockets", "ms_#{vm.ephemeral_net6.nth(2)}")
+    socket_path = File.join(Dir.pwd, "var", "health_monitor_sockets", "ms_#{vm.ephemeral_net6.nth(2)}")
     FileUtils.rm_rf(socket_path)
     FileUtils.mkdir_p(socket_path)
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -158,7 +158,7 @@ class PostgresServer < Sequel::Model
   end
 
   def health_monitor_socket_path
-    @health_monitor_socket_path ||= File.join(Dir.pwd, "health_monitor_sockets", "pg_#{vm.ephemeral_net6.nth(2)}")
+    @health_monitor_socket_path ||= File.join(Dir.pwd, "var", "health_monitor_sockets", "pg_#{vm.ephemeral_net6.nth(2)}")
   end
 
   def create_resource_firewall_rules


### PR DESCRIPTION
Previously they were at the health_monitor_sockets directory immediatelly under the running directory. Since then we started to use var directory for temporary files such as MinIO root CA files. It is more suitable to keep health monitor sockets there as well.