### PR TITLE
Self-serve PostgreSQL restart

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -92,6 +92,12 @@ $(".delete-btn").on("click", function (event) {
     });
 });
 
+$(".restart-btn").on("click", function (event) {
+  if (!confirm("Are you sure to restart?")) {
+    event.preventDefault();
+  }
+});
+
 $(".copieble-content").on("click", ".copy-button", function (event) {
   let parent = $(this).parent();
   let content = parent.data("content");

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -16,7 +16,8 @@ class PostgresServer < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
 
-  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup, :configure, :update_firewall_rules, :take_over, :destroy
+  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
+  semaphore :restart, :configure, :update_firewall_rules, :take_over, :destroy
 
   def configure_hash
     configs = {

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -44,6 +44,8 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     when_destroy_set? do
       if strand.label != "destroy"
         hop_destroy
+      elsif strand.stack.count > 1
+        pop "operation is cancelled due to the destruction of the minio server"
       end
     end
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -53,6 +53,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     when_destroy_set? do
       if strand.label != "destroy"
         hop_destroy
+      elsif strand.stack.count > 1
+        pop "operation is cancelled due to the destruction of the postgres server"
       end
     end
   end

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -97,6 +97,15 @@ class CloverWeb
 
         r.redirect "#{@project.path}#{pg.path}"
       end
+
+      r.post "restart" do
+        Authorization.authorize(@current_user.id, "Postgres:edit", pg.id)
+        pg.servers.each do |s|
+          s.incr_restart
+        rescue Sequel::ForeignKeyConstraintViolation
+        end
+        r.redirect "#{@project.path}#{pg.path}"
+      end
     end
   end
 end

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -386,6 +386,13 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(nx.strand).to receive(:label).and_return("destroy")
       expect { nx.before_run }.not_to hop("destroy")
     end
+
+    it "pops additional operations from stack" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(nx.strand.stack).to receive(:count).and_return(2)
+      expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the minio server"})
+    end
   end
 
   describe "#available?" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx.strand).to receive(:label).and_return("destroy")
       expect { nx.before_run }.not_to hop("destroy")
     end
+
+    it "pops additional operations from stack" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(nx.strand.stack).to receive(:count).and_return(2)
+      expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the postgres server"})
+    end
   end
 
   describe "#start" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -450,6 +450,12 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:when_configure_set?).and_yield
       expect { nx.wait }.to hop("configure")
     end
+
+    it "pushes restart if restart is set" do
+      expect(nx).to receive(:when_restart_set?).and_yield
+      expect(nx).to receive(:push).with(described_class, {}, "restart").and_call_original
+      expect { nx.wait }.to hop("restart")
+    end
   end
 
   describe "#update_firewall_rules" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -244,6 +244,14 @@ RSpec.describe Clover, "postgres" do
         expect(page.status_code).to eq(200)
         expect(page).to have_content "Superuser password cannot be updated during restore!"
       end
+
+      it "can restart PostgreSQL database" do
+        visit "#{project.path}#{pg.path}"
+        expect(page).to have_content "Restart"
+        click_button "Restart"
+
+        expect(page.status_code).to eq(200)
+      end
     end
 
     describe "firewall" do

--- a/views/components/form/submit_button.erb
+++ b/views/components/form/submit_button.erb
@@ -1,3 +1,14 @@
 <% name = defined?(name) ? name : nil %>
+<% extra_class = defined?(extra_class) ? extra_class : nil %>
 
-<%== render("components/button", locals: { text: text, attributes: { "type" => "submit", "name" => name } }) %>
+<%== render(
+  "components/button",
+  locals: {
+    text: text,
+    extra_class: extra_class,
+    attributes: {
+      "type" => "submit",
+      "name" => name
+    }
+  }
+) %>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -203,29 +203,53 @@
       </table>
     </div>
   <% end %>
-  <!-- Delete Card -->
-  <% if Authorization.has_permission?(@current_user.id, "Postgres:delete", @pg[:id]) %>
+  <% if Authorization.has_permission?(@current_user.id, ["Postgres:edit", "Postgres:delete"], @pg[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-      <div class="px-4 py-5 sm:p-6">
-        <div class="sm:flex sm:items-center sm:justify-between">
-          <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete PostgreSQL database</h3>
-            <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this PostgreSQL database.</p>
+      <!-- Restart Card -->
+      <% if Authorization.has_permission?(@current_user.id, "Postgres:edit", @pg[:id]) %>
+        <div class="px-4 py-5 sm:p-6">
+          <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restart" %>" role="form" method="POST">
+            <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restart") %>
+            <div class="sm:flex sm:items-center sm:justify-between">
+              <div>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">Restart PostgreSQL database</h3>
+                <div class="mt-2 text-sm text-gray-500">
+                  <p>This action will restart the PostgreSQL database. The database will be offline momentarily, and all
+                    connections will be dropped.</p>
+                </div>
+              </div>
+              <div id="postgres-restart-<%=@pg[:ubid]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                  <%== render("components/form/submit_button", locals: { text: "Restart", extra_class: "restart-btn" }) %>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      <% end %>
+      <!-- Delete Card -->
+      <% if Authorization.has_permission?(@current_user.id, "Postgres:delete", @pg[:id]) %>
+        <div class="px-4 py-5 sm:p-6">
+          <div class="sm:flex sm:items-center sm:justify-between">
+            <div>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">Delete PostgreSQL database</h3>
+              <div class="mt-2 text-sm text-gray-500">
+                <p>This action will permanently delete this PostgreSQL database.</p>
+              </div>
+            </div>
+            <div id="postgres-delete-<%=@pg[:ubid]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <%== render(
+                "components/delete_button",
+                locals: {
+                  url: request.path,
+                  confirmation: @pg[:name],
+                  redirect: "#{@project_data[:path]}/postgres"
+                }
+              ) %>
             </div>
           </div>
-          <div id="postgres-delete-<%=@pg[:ubid]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-            <%== render(
-              "components/delete_button",
-              locals: {
-                url: request.path,
-                confirmation: @pg[:name],
-                redirect: "#{@project_data[:path]}/postgres"
-              }
-            ) %>
-          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/views/project/policy.erb
+++ b/views/project/policy.erb
@@ -124,6 +124,10 @@
               <td class="px-2 py-2 border">Grants permission to create PostgreSQL database.</td>
             </tr>
             <tr>
+              <td class="px-2 py-2 border">Postgres:edit</td>
+              <td class="px-2 py-2 border">Grants permission to edit PostgreSQL database details.</td>
+            </tr>
+            <tr>
               <td class="px-2 py-2 border">Postgres:delete</td>
               <td class="px-2 py-2 border">Grants permission to delete PostgreSQL database.</td>
             </tr>


### PR DESCRIPTION
While being able to restart your own database is useful on its own, it is also
a requirement for being able to modify(and see its effect) of some GUCs. For
example, currently, we are adding new extensions and some of those extensions
require to be loaded via shared_preload_libraries GUC, which requires restart.