### PR TITLE
Parallelize unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ coverage
 spec/examples.txt
 demo/.env
 var/*
+tmp/*
 
 # rhizome/Gemfile is combination of all Gemfiles in subdirectories, so does rhizome/Gemfile.lock
 rhizome/*/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development do
   gem "rubocop-sequel"
   gem "standard", ">= 1.24.3"
   gem "simplecov"
+  gem "turbo_tests"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
       openssl (> 2.0)
     pagerduty (4.0.1)
     parallel (1.24.0)
+    parallel_tests (4.5.1)
+      parallel
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
@@ -274,6 +276,9 @@ GEM
       bindata (~> 2.4)
       openssl (> 2.0)
       openssl-signature_algorithm (~> 1.0)
+    turbo_tests (2.2.0)
+      parallel_tests (>= 3.3.0, < 5)
+      rspec (>= 3.10)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
@@ -349,6 +354,7 @@ DEPENDENCIES
   standard (>= 1.24.3)
   stripe
   tilt (>= 2.2)
+  turbo_tests
   warning
   webauthn (~> 3.1)
   webmock

--- a/migrate/20230807_update_billing.rb
+++ b/migrate/20230807_update_billing.rb
@@ -2,7 +2,7 @@
 
 Sequel.migration do
   up do
-    DB[:billing_rate].truncate(cascade: true)
+    run "TRUNCATE billing_rate CASCADE"
     copy_into :billing_rate, data: <<COPY
 139d9a67-8182-8578-a303-235cabd5161c	VmCores	standard	hetzner-fsn1	0.000171296
 08c502f7-df5d-8978-9896-feafa0ec5c40	VmCores	standard	hetzner-hel1	0.000154167

--- a/migrate/20230808_add_ipv4_billing.rb
+++ b/migrate/20230808_add_ipv4_billing.rb
@@ -2,7 +2,7 @@
 
 Sequel.migration do
   up do
-    DB[:billing_rate].truncate(cascade: true)
+    run "TRUNCATE billing_rate CASCADE"
     copy_into :billing_rate, data: <<COPY
 139d9a67-8182-8578-a303-235cabd5161c	VmCores	standard	hetzner-fsn1	0.000171296
 08c502f7-df5d-8978-9896-feafa0ec5c40	VmCores	standard	hetzner-hel1	0.000154167

--- a/migrate/20230809_drop_billing_rate.rb
+++ b/migrate/20230809_drop_billing_rate.rb
@@ -20,7 +20,7 @@ Sequel.migration do
       index [:resource_type, :resource_family, :location], unique: true
     end
 
-    DB[:billing_rate].truncate(cascade: true)
+    run "TRUNCATE billing_rate CASCADE"
     copy_into :billing_rate, data: <<COPY
 139d9a67-8182-8578-a303-235cabd5161c	VmCores	standard	hetzner-fsn1	0.000171296
 08c502f7-df5d-8978-9896-feafa0ec5c40	VmCores	standard	hetzner-hel1	0.000154167

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -8,7 +8,7 @@ if (suite = ENV.delete("COVERAGE"))
     minimum_coverage line: 100, branch: 100
     minimum_coverage_by_file line: 100, branch: 100
 
-    command_name suite
+    command_name "#{suite}#{ENV["TEST_ENV_NUMBER"]}"
 
     # rhizome (dataplane) and controlplane should have separate coverage reports.
     # They will have different coverage suites in future.

--- a/spec/model/spec_helper.rb
+++ b/spec/model/spec_helper.rb
@@ -2,7 +2,7 @@
 
 ENV["RACK_ENV"] = "test"
 require_relative "../../model"
-raise "test database doesn't end with test" if DB.opts[:database] && !DB.opts[:database].end_with?("test")
+raise "test database doesn't end with test" if DB.opts[:database] && !/test\d*\z/.match?(DB.opts[:database])
 
 require_relative "../spec_helper"
 

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../spec_helper"
-raise "test database doesn't end with test" if DB.opts[:database] && !DB.opts[:database].end_with?("test")
+raise "test database doesn't end with test" if DB.opts[:database] && !/test\d*\z/.match?(DB.opts[:database])
 
 TEST_USER_EMAIL = "user@example.com"
 TEST_USER_PASSWORD = "Secret@Password123"


### PR DESCRIPTION
**Parallelize unit tests**

**Quick Start**
Run below commands for running unit tests in parallel:

Edit your .env.rb and modify CLOVER_DATABASE_URL for test environment:
```ruby
ENV["CLOVER_DATABASE_URL"] ||= "postgres:///clover_test#{ENV["TEST_ENV_NUMBER"]}?user=clover"
```

Run below commands for running unit tests in parallel:
```bash
rake setup_database[test,1]
bundle exec turbo_tests
```

As the number of tests increase, I started to become uncomfortable with the
unit test duration. Admittedly, our unit tests are pretty quick; they complete
in ~30 seconds on my machine. However this duration is enough to break one's
fast iteration cycle.

If you are OK with the current unit test duration, good for you, you don't need
to do anything. Everything works as before. Though you might find newly added
rake task, setup_database, useful. Run it as `rake setup_database[test]` or
`rake setup_database[development]` and it sets up the database from scratch.

If you want to parallelize the unit test, `setup_database` has an additional
parameter called `parallel`. When executed as `rake setup_database[test,1]`,
the new task would create multiple databases, so that tests can be split into
groups and each group can run on their own different database in parallel.

Then you can run `bundle exec turbo_tests` to run all the unit tests in
parallel. As a nice side note, code coverage also works, which is usually a
weak link on parallel tests.

Unit tests used to take ~30 seconds on my machine (`nproc`: 12), Now with the
`turbo_tests`, they took ~6 seconds.

**Don't use DB variable in migration scripts**
Changing old migration scripts is usually frowned upon, but in this case the
change does not affect the state of the database. The change is using the run
function instead of accessing the tables using DB[:billing_rate], because DB
is a global variable and when multiple threads with different DB values run
at the same time, they break each other.

One might ask, when there can be multiple threads with different DB values. The
answer is when we parallelize unit tests using tests processes, each with their
own databases. The next commit introduces parallel unit tests.