### PR TITLE
Adjust storage key tool for multiple devices

### DIFF
--- a/prog/rotate_storage_kek.rb
+++ b/prog/rotate_storage_kek.rb
@@ -39,7 +39,8 @@ class Prog::RotateStorageKek < Prog::Base
 
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} reencrypt", stdin: data_json)
+    q_device = vm_storage_volume.storage_device.name.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_device} #{disk_index} reencrypt", stdin: data_json)
 
     hop_test_keys_on_server
   end
@@ -52,7 +53,8 @@ class Prog::RotateStorageKek < Prog::Base
 
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} test-keys", stdin: data_json)
+    q_device = vm_storage_volume.storage_device.name.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_device} #{disk_index} test-keys", stdin: data_json)
 
     hop_retire_old_key_on_server
   end
@@ -60,7 +62,8 @@ class Prog::RotateStorageKek < Prog::Base
   label def retire_old_key_on_server
     q_vm = vm.inhost_name.shellescape
     disk_index = vm_storage_volume.disk_index
-    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{disk_index} retire-old-key", stdin: "{}")
+    q_device = vm_storage_volume.storage_device.name.shellescape
+    sshable.cmd("sudo host/bin/storage-key-tool #{q_vm} #{q_device} #{disk_index} retire-old-key", stdin: "{}")
 
     hop_retire_old_key_in_database
   end

--- a/spec/prog/rotate_storage_kek_spec.rb
+++ b/spec/prog/rotate_storage_kek_spec.rb
@@ -36,7 +36,12 @@ RSpec.describe Prog::RotateStorageKek do
   }
 
   let(:volume) {
-    disk = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0)
+    dev = StorageDevice.create(
+      name: "nvme0",
+      total_storage_gib: 100,
+      available_storage_gib: 20
+    ) { _1.id = StorageDevice.generate_uuid }
+    disk = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0, storage_device: dev)
     disk.key_encryption_key_1 = current_kek
     disk.key_encryption_key_2 = new_kek
     disk.vm = vm
@@ -64,7 +69,7 @@ RSpec.describe Prog::RotateStorageKek do
 
   describe "#install" do
     it "installs the key & hops" do
-      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* reencrypt/,
+      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* nvme0 0 reencrypt/,
         stdin: "{\"old_key\":{\"key\":\"key_1\",\"init_vector\":\"iv_1\",\"algorithm\":\"aes-256-gcm\",\"auth_data\":\"somedata\"},\"new_key\":{\"key\":\"key_2\",\"init_vector\":\"iv_2\",\"algorithm\":\"aes-256-gcm\",\"auth_data\":\"somedata\"}}")
       expect { rsk.install }.to hop("test_keys_on_server")
     end
@@ -72,14 +77,14 @@ RSpec.describe Prog::RotateStorageKek do
 
   describe "#test_keys_on_server" do
     it "can test keys on server" do
-      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* test-keys/, stdin: /.*/)
+      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* nvme0 0 test-keys/, stdin: /.*/)
       expect { rsk.test_keys_on_server }.to hop("retire_old_key_on_server")
     end
   end
 
   describe "#retire_old_key_on_server" do
     it "can retire old keys on server" do
-      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* retire-old-key/, stdin: "{}")
+      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/storage-key-tool .* nvme0 0 retire-old-key/, stdin: "{}")
       expect { rsk.retire_old_key_on_server }.to hop("retire_old_key_in_database")
     end
   end


### PR DESCRIPTION
A long-delayed follow-up to 46e2647d69f11914214771c2be71bf9900d97b8d, to bring the calling format of `host/bin/storage-key-tool` up to date.