### PR TITLE
Change the hugepages arithmetic.

### DIFF
--- a/prog/setup_hugepages.rb
+++ b/prog/setup_hugepages.rb
@@ -5,8 +5,11 @@ class Prog::SetupHugepages < Prog::Base
 
   label def start
     hugepage_size = "1G"
-    # put away 1 core of overhead for host, and reserve 2x1G for 2 SPDK installations
-    hugepage_cnt = 2 + (vm_host.total_mem_gib * (vm_host.total_cores - 1)) / vm_host.total_cores
+
+    # Reserve 5G of overhead for the host. SPDK will use 2 of the hugepages +
+    # upto about 1G of the 5G as not all SPDK allocations are from hugepages.
+    hugepage_cnt = vm_host.total_mem_gib - 5
+
     sshable.cmd("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ hugetlb_free_vmemmap=on default_hugepagesz=#{hugepage_size} hugepagesz=#{hugepage_size} hugepages=#{hugepage_cnt}&/' /etc/default/grub")
     sshable.cmd("sudo update-grub")
 

--- a/spec/prog/setup_hugepages_spec.rb
+++ b/spec/prog/setup_hugepages_spec.rb
@@ -10,10 +10,9 @@ RSpec.describe Prog::SetupHugepages do
   describe "#start" do
     it "pops after installing hugepages" do
       vm_host = instance_double(VmHost)
-      expect(vm_host).to receive(:total_mem_gib).and_return(64)
-      expect(vm_host).to receive(:total_cores).and_return(4).at_least(:once)
+      allow(vm_host).to receive(:total_mem_gib).and_return(64)
       sshable = instance_double(Sshable)
-      expect(sshable).to receive(:cmd).with(/sudo sed.*default_hugepagesz=1G.*hugepagesz=1G.*hugepages=50.*grub/)
+      expect(sshable).to receive(:cmd).with(/sudo sed.*default_hugepagesz=1G.*hugepagesz=1G.*hugepages=59.*grub/)
       expect(sshable).to receive(:cmd).with("sudo update-grub")
       expect(sh).to receive(:sshable).and_return(sshable).at_least(:once)
       expect(sh).to receive(:vm_host).and_return(vm_host).at_least(:once)


### PR DESCRIPTION
Previously, at an arm64 host with 128g memory & 80 cores we tried to get 128 hugepages (2 + 128*79/80), which might put the host under pressure.

This PR enforces a static allocation of 5GB of memory for the host across all configurations, enhancing the predictability of memory available for services running on the host.

In current deployments we have allocated either 248 or 249 huepages per 256g host, so this doesn't reduce the capacity of current deployments.