### PR TITLE
Use upsert for LearnStorage idempotency

### DIFF
--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -4,6 +4,7 @@ require_relative "../model"
 
 class StorageDevice < Sequel::Model
   include ResourceMethods
+  plugin :insert_conflict
 
   many_to_one :vm_host
 


### PR DESCRIPTION
This is an alternative to "find or create" imperative logic that was pushed down to the leaves of the program to offer a consistent interface via the `storage_device(name)` method.

This caused tests that did not require persistence to start writing to the database as a side effect.

Now, model instances can be instantiated with "new" and passed around and only persisted at the last phase with an upsert.

6e56364d17d503d6a31c18a19372dbf100a6a4ab introduced the imperative code to fix an idempotency issue in
89f9dbd7f2b12c08eb993d947e64003c68c90606.  This can be seen as a refinement of that fix.

The test has been enhanced to be stricter, showing the update of records and how the exit value from the prog is a sum.