### PR TITLE
Backport XSS headers from roda-sequel-stack

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -12,11 +12,10 @@ class CloverWeb < Roda
   plugin :default_headers, {
     "Content-Type" => "text/html",
     "X-Frame-Options" => "deny",
-    "X-Content-Type-Options" => "nosniff",
-    "X-XSS-Protection" => "1; mode=block"
+    "X-Content-Type-Options" => "nosniff"
   }.merge(
     # :nocov:
-    Config.production? ? {"Strict-Transport-Security" => "max-age=15;"} : {}
+    Config.production? ? {"Strict-Transport-Security" => "max-age=15; includeSubDomains"} : {}
     # :nocov:
   )
 


### PR DESCRIPTION
https://github.com/jeremyevans/roda-sequel-stack/commit/3d258dd621e15bea6f04cc0b0ea5aaf427fb9e96

This change is a bit complex, it includes multiple small adjustments:

* Removal of the X-XSS-Protection header, per MDN counter-recommendation, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

* Adds the includeSubDomains policy to HSTS / `Strict-Transport-Security`

* Changes the time-out of the policy (`max-age`).

On the latter-most, we still want to observe for problems, so I'm leaving it at 15, but can boost to a customary length it soon.