### PR TITLE
Send E2E failed notification for timed out runs too

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,7 +64,7 @@ jobs:
         CI_HETZNER_SACRIFICIAL_SERVER_ID: ${{ secrets.CI_HETZNER_SACRIFICIAL_SERVER_ID }}
         HETZNER_USER: ${{ secrets.HETZNER_USER }}
         HETZNER_PASSWORD: ${{ secrets.HETZNER_PASSWORD }}
-      run: foreman start
+      run: timeout 40m foreman start
 
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}


### PR DESCRIPTION
GitHub displays `canceled` instead of `failed` for workflows that time out.  We don't receive a notification for timed out workflow since `failure()` is false for them. `!success()` returns true for canceled runs too. However, it has a drawback. If we manually cancel a run on the main branch, it will still send a notification.

We decided to failed our job if it times out. We start the foreman script with simple `timeout` command. If the script doesn't finish in time, the `timeout` command will kill it and return non-zero exit code. We catch this exit code and fail the job.