### PR TITLE
Remove support for spdk-v23.09 (without bdev_ubi)

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -101,7 +101,7 @@ module Config
   override :minio_version, "minio_20231007150738.0.0_amd64"
 
   # Spdk
-  override :spdk_version, "v23.09"
+  override :spdk_version, "v23.09-ubi-0.2"
 
   # Pagerduty
   optional :pagerduty_key, string, clear: true

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -4,8 +4,6 @@ class Prog::Storage::SetupSpdk < Prog::Base
   subject_is :sshable, :vm_host
 
   SUPPORTED_SPDK_VERSIONS = [
-    ["v23.09", "arm64"],
-    ["v23.09", "x64"],
     ["v23.09-ubi-0.2", "x64"],
     ["v23.09-ubi-0.2", "arm64"]
   ]

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -108,16 +108,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
     vm_host.sshable.cmd("sudo chmod a+rw #{tmp_dir}")
     vm_host.sshable.cmd("sudo RUN_E2E_TESTS=1 SPDK_TESTS_TMP_DIR=#{tmp_dir} bundle exec rspec host/e2e")
 
-    hop_install_bdev_ubid
-  end
-
-  label def install_bdev_ubid
-    version = "v23.09-ubi-0.2"
-    hop_wait if vm_host.spdk_installations.find { _1.version == version } || retval&.dig("msg") == "SPDK was setup"
-
-    # disable the default installation and install a bdev_ubi enabled spdk
-    vm_host.spdk_installations_dataset.update(allocation_weight: 0)
-    push Prog::Storage::SetupSpdk, {subject_id: vm_host.id, version: version, start_service: true, allocation_weight: 100}
+    hop_wait
   end
 
   label def wait

--- a/rhizome/host/lib/spdk_path.rb
+++ b/rhizome/host/lib/spdk_path.rb
@@ -3,7 +3,7 @@
 # YYY: Remove all checks against this after upgrading all legacy systems
 LEGACY_SPDK_VERSION = "LEGACY_SPDK_VERSION"
 
-DEFAULT_SPDK_VERSION = "v23.09"
+DEFAULT_SPDK_VERSION = "v23.09-ubi-0.2"
 
 module SpdkPath
   def self.user

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -57,8 +57,6 @@ class SpdkSetup
     end
 
     {
-      ["v23.09", :arm64] => "https://github.com/ubicloud/spdk/releases/download/v23.09/spdk-arm64.tar.gz",
-      ["v23.09", :x64] => "https://github.com/ubicloud/spdk/releases/download/v23.09/spdk-23.09-x64.tar.gz",
       ["v23.09-ubi-0.2", :arm64] => "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.2-arm64/ubicloud-spdk-ubuntu-22.04-arm64.tar.gz",
       ["v23.09-ubi-0.2", :x64] => "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.2/ubicloud-spdk-ubuntu-22.04-x64.tar.gz"
     }.fetch([@spdk_version, arch])

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe SpdkSetup do
 
   describe "#create_hugepages_mount" do
     it "creates the hugepages mount" do
-      expect(spdk_setup).to receive(:r).with("sudo --user=spdk mkdir -p /home/spdk/hugepages.#{spdk_version}")
-      expect(File).to receive(:write).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version}.mount", /.*/)
+      expect(spdk_setup).to receive(:r).with("sudo --user=spdk mkdir -p /home/spdk/hugepages.#{spdk_version.tr("-", ".")}")
+      expect(File).to receive(:write).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount", /.*/)
       expect { spdk_setup.create_hugepages_mount }.not_to raise_error
     end
   end
@@ -77,7 +77,7 @@ RSpec.describe SpdkSetup do
   describe "#enable_services" do
     it "enables services" do
       expect(spdk_setup).to receive(:r).with("systemctl enable spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:r).with("systemctl enable home-spdk-hugepages.#{spdk_version}.mount")
+      expect(spdk_setup).to receive(:r).with("systemctl enable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect { spdk_setup.enable_services }.not_to raise_error
     end
   end
@@ -85,7 +85,7 @@ RSpec.describe SpdkSetup do
   describe "#start_services" do
     it "starts services" do
       expect(spdk_setup).to receive(:r).with("systemctl start spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:r).with("systemctl start home-spdk-hugepages.#{spdk_version}.mount")
+      expect(spdk_setup).to receive(:r).with("systemctl start home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect { spdk_setup.start_services }.not_to raise_error
     end
   end

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Storage::SetupSpdk do
     ))
   }
 
-  let(:spdk_version) { "v23.09" }
+  let(:spdk_version) { "v23.09-ubi-0.2" }
   let(:sshable) {
     instance_double(Sshable)
   }

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -121,25 +121,14 @@ RSpec.describe Prog::Test::HetznerServer do
   end
 
   describe "#run_integration_specs" do
-    it "hops to install_bdev_ubid" do
+    it "hops to wait" do
       tmp_dir = "/var/storage/tests"
       expect(hs_test.vm_host.sshable).to receive(:cmd).with("sudo mkdir -p #{tmp_dir}")
       expect(hs_test.vm_host.sshable).to receive(:cmd).with("sudo chmod a+rw #{tmp_dir}")
       expect(hs_test.vm_host.sshable).to receive(:cmd).with(
         "sudo RUN_E2E_TESTS=1 SPDK_TESTS_TMP_DIR=#{tmp_dir} bundle exec rspec host/e2e"
       )
-      expect { hs_test.run_integration_specs }.to hop("install_bdev_ubid")
-    end
-  end
-
-  describe "#install_bdev_ubid" do
-    it "hops to wait if it's installed" do
-      expect(hs_test).to receive(:retval).and_return({"msg" => "SPDK was setup"})
-      expect { hs_test.install_bdev_ubid }.to hop("wait")
-    end
-
-    it "setups spdk with bdev_ubi" do
-      expect { hs_test.install_bdev_ubid }.to hop("start", "Storage::SetupSpdk")
+      expect { hs_test.run_integration_specs }.to hop("wait")
     end
   end
 


### PR DESCRIPTION
spdk-v23.09-ubi-0.2 has same binaries spdk-v23.09 has + `vhost_ubi`, so we don't need spdk-v23.09 anymore.