### PR TITLE
Get optional tax_id and company name on billing page

### DIFF
--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -34,6 +34,10 @@ class CloverWeb
             postal_code: r.params["postal_code"],
             line1: r.params["address"],
             line2: nil
+          },
+          metadata: {
+            tax_id: r.params["tax_id"],
+            company_name: r.params["company_name"]
           }
         })
 

--- a/serializers/web/billing_info.rb
+++ b/serializers/web/billing_info.rb
@@ -14,7 +14,9 @@ class Serializers::Web::BillingInfo < Serializers::Base
       country: bi.stripe_data["address"]["country"],
       city: bi.stripe_data["address"]["city"],
       state: bi.stripe_data["address"]["state"],
-      postal_code: bi.stripe_data["address"]["postal_code"]
+      postal_code: bi.stripe_data["address"]["postal_code"],
+      tax_id: bi.stripe_data["metadata"]["tax_id"],
+      company_name: bi.stripe_data["metadata"]["company_name"]
     } : {})
   end
 

--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -36,6 +36,8 @@ class Serializers::Web::Invoice < Serializers::Base
         billing_city: inv.content.dig("billing_info", "city"),
         billing_state: inv.content.dig("billing_info", "state"),
         billing_postal_code: inv.content.dig("billing_info", "postal_code"),
+        tax_id: inv.content.dig("billing_info", "tax_id"),
+        company_name: inv.content.dig("billing_info", "company_name"),
         issuer_address: inv.content.dig("issuer_info", "address"),
         issuer_country: ISO3166::Country.new(inv.content.dig("issuer_info", "country"))&.common_name,
         issuer_city: inv.content.dig("issuer_info", "city"),

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe InvoiceGenerator do
         "country" => "NL",
         "city" => nil,
         "state" => nil,
-        "postal_code" => nil
+        "postal_code" => nil,
+        "tax_id" => "123456",
+        "company_name" => nil
       } : nil,
       "issuer_info" => {
         "address" => "310 Santa Ana Avenue",
@@ -121,7 +123,7 @@ RSpec.describe InvoiceGenerator do
 
   it "generates invoice for project with billing info" do
     allow(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
-    expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}}).at_least(:once)
+    expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "metadata" => {"tax_id" => "123456"}, "address" => {"country" => "NL"}}).at_least(:once)
 
     generate_vm_billing_record(p1, vm1, Sequel::Postgres::PGRange.new(begin_time - 90 * day, nil))
     bi = BillingInfo.create_with_id(stripe_id: "cs_1234567890")

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -142,6 +142,26 @@
                     }
                   ) %>
                 </div>
+                <div class="sm:col-span-4">
+                  <%== render(
+                    "components/form/text",
+                    locals: {
+                      name: "tax_id",
+                      label: "Tax ID (Optional)",
+                      value: @billing_info_data[:tax_id]
+                    }
+                  ) %>
+                </div>
+                <div class="sm:col-span-4">
+                  <%== render(
+                    "components/form/text",
+                    locals: {
+                      name: "company_name",
+                      label: "Company Name (Optional)",
+                      value: @billing_info_data[:company_name]
+                    }
+                  ) %>
+                </div>
               </div>
             </div>
           </div>

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -63,8 +63,16 @@
         <div class="mt-8 grid grid-cols-2 gap-3">
           <div>
             <h3 class="text-lg font-semibold text-gray-800">Bill to:</h3>
-            <h3 class="text-lg font-semibold text-gray-800"><%= @invoice_data[:billing_name] %></h3>
+            <h3 class="text-lg font-semibold text-gray-800">
+              <%= @invoice_data[:billing_name] %>
+              <% if @invoice_data[:company_name] %>
+                - <%= @invoice_data[:company_name] %>
+              <% end %>
+            </h3>
             <address class="mt-2 not-italic text-gray-500">
+              <% if @invoice_data[:tax_id] %>
+                Tax ID: <%= @invoice_data[:tax_id] %> <br>
+              <% end %>
               <%= @invoice_data[:billing_address] %>,<br>
               <%= @invoice_data[:billing_city] %>,
               <%= @invoice_data[:billing_state] %>


### PR DESCRIPTION
Adding support to get tax_id and company name information from customers on the billing page, so we can show those on invoices.

Note that, we are getting tax id and company name from customer after they add billing info to their project via Stripe. We can not get those informations from customers while creating Stripe Checkout Session as Stripe does not allow getting them with the way we are using it. We are keeping them as metadata on the Stripe, so we don't have them on our database.