### PR TITLE
Limit monitor threads

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -15,6 +15,7 @@ loop do
   resources = MONITORABLE_RESOURCE_TYPES.flat_map { _1.all }
 
   resources.each do |r|
+    break if Thread.list.count + 2 > Config.max_monitor_threads
     ssh_threads[r.id] ||= Thread.new do
       loop do
         sessions[r.id] = r.init_health_monitor_session

--- a/config.rb
+++ b/config.rb
@@ -48,6 +48,7 @@ module Config
   optional :stripe_secret_key, string, clear: true
   optional :heartbeat_url, string
   optional :clover_database_root_certs, string
+  override :max_monitor_threads, 32, int
 
   # :nocov:
   override :mail_driver, (production? ? :smtp : :logger), symbol


### PR DESCRIPTION
We create 2 threads per resource. If the number of resources is high, it is possible to hit max thread limits. In medium term, we should either start to use threads more efficiently (by using something like fiber) or implement support for multiple monitors.

Until then, we are adding this limit, so that the monitor process wouldn't crash due to lack of resources.