### PR TITLE
Apply 1$ github runner credit only if there is a cost

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -74,7 +74,7 @@ class InvoiceGenerator
         # Each project have $1 github runner credit every month
         # 1$ github credit won't be shown on the portal billing page for now.
         github_usage = project_content[:resources].flat_map { _1[:line_items] }.select { _1[:resource_type] == "GitHubRunnerMinutes" }.sum { _1[:cost] }
-        github_credit = [1.0, github_usage].min
+        github_credit = [1.0, github_usage, project_content[:cost]].min
         if github_credit > 0
           project_content[:github_credit] = github_credit
           project_content[:credit] += project_content[:github_credit]

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -229,6 +229,17 @@ RSpec.describe InvoiceGenerator do
     expect(after["credit"]).to eq(11)
     expect(p1.reload.credit).to eq(0)
   end
+
+  it "handles full discount and github runner credits together" do
+    github_runner = GithubRunner.create_with_id(label: "ubicloud", repository_name: "my-repo")
+    generate_billing_record(p1, vm1, Sequel::Postgres::PGRange.new(begin_time - 90 * day, end_time + 90 * day))
+    generate_billing_record(p1, github_runner, Sequel::Postgres::PGRange.new(begin_time - 90 * day, end_time + 90 * day))
+
+    p1.update(credit: 0, discount: 100)
+    invoice = described_class.new(begin_time, end_time, save_result: true).run.first.content
+
+    expect(invoice["cost"]).to eq(0)
+  end
 end
 
 # rubocop:enable RSpec/NoExpectationExample


### PR DESCRIPTION
Applying 1$ github runner credit for projects having cost less than 1$ after project level discounts and credits may cause negative total cost. Fixing that.