### PR TITLE
Combine create_runner_user and setup_environment on GithubRunner

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -135,23 +135,6 @@ class Prog::Vm::GithubRunner < Prog::Base
   label def wait_vm
     nap 5 unless vm.strand.label == "wait"
     register_deadline(:wait, 10 * 60)
-    hop_create_runner_user
-  end
-
-  label def create_runner_user
-    # Sending addgroup and adduser separately, as there is no way
-    # to force group and user has specific names and ids with a
-    # single command
-    command = <<~COMMAND
-      set -ueo pipefail
-      sudo userdel -rf runner || true
-      sudo addgroup --gid 1001 runner
-      sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
-      echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner
-    COMMAND
-
-    vm.sshable.cmd(command.gsub(/^(# .*)?\n/, ""))
-
     hop_setup_environment
   end
 
@@ -175,6 +158,17 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   label def setup_environment
     command = <<~COMMAND
+      # To make sure the script errors out if any command fails
+      set -ueo pipefail
+
+      # Since standard Github runners have both runneradmin and runner users
+      # VMs of github runners are created with runneradmin user. Adding
+      # runner user and group with the same id and gid as the standard.
+      sudo userdel -rf runner || true
+      sudo addgroup --gid 1001 runner
+      sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
+      echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner
+
       # runner unix user needed access to manipulate the Docker daemon.
       # Default GitHub hosted runners have additional adm,systemd-journal groups.
       sudo usermod -a -G docker,adm,systemd-journal runner

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops if vm is ready" do
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(vm).to receive(:strand).and_return(Strand.new(label: "wait"))
-      expect { nx.wait_vm }.to hop("create_runner_user")
+      expect { nx.wait_vm }.to hop("setup_environment")
     end
   end
 
@@ -275,25 +275,16 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
   end
 
-  describe "#create_runner_user" do
-    it "hops to setup environment" do
+  describe "#setup_environment" do
+    it "hops to register_runner" do
+      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
+      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         sudo userdel -rf runner || true
         sudo addgroup --gid 1001 runner
         sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
         echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner
-      COMMAND
-
-      expect { nx.create_runner_user }.to hop("setup_environment")
-    end
-  end
-
-  describe "#setup_environment" do
-    it "hops to register_runner" do
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
         sudo usermod -a -G docker,adm,systemd-journal runner
         sudo su -c "find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} ';'"
         source /etc/environment


### PR DESCRIPTION
Since running a command on VM can take from few seconds to ~30 seconds,sending commands separately for create_runner_user and setup_environment can affect the runner provisioning time significantly.

Although combining those two states causes setup_environment to be responsible about two tasks, decreasing provisioning time is more important than that.