### PR TITLE
Use meta l4proto to perform header matching for flow tables

### DIFF
--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -65,8 +65,7 @@ table inet fw_table {
 
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-    ip protocol tcp counter flow offload @ubi_flowtable
-    ip protocol udp counter flow offload @ubi_flowtable
+    meta l4proto { tcp, udp } flow offload @ubi_flowtable
     meta l4proto { tcp, udp } th dport 111 drop
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -83,8 +83,7 @@ elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
 
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-    ip protocol tcp counter flow offload @ubi_flowtable
-    ip protocol udp counter flow offload @ubi_flowtable
+    meta l4proto { tcp, udp } flow offload @ubi_flowtable
     meta l4proto { tcp, udp } th dport 111 drop
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept
@@ -162,8 +161,7 @@ table inet fw_table {
 
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-    ip protocol tcp counter flow offload @ubi_flowtable
-    ip protocol udp counter flow offload @ubi_flowtable
+    meta l4proto { tcp, udp } flow offload @ubi_flowtable
     meta l4proto { tcp, udp } th dport 111 drop
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept


### PR DESCRIPTION
In addition to being shorter, this also applies to IPv6 packets.

https://wiki.nftables.org/wiki-nftables/index.php/Matching_packet_headers

Kudos to https://news.ycombinator.com/user?id=rany_ for noticing this improvement and conveying it to us in
https://news.ycombinator.com/item?id=39594769.