### PR TITLE
Start using distinct disks for Minio

### DIFF
--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -34,7 +34,7 @@ class Prog::LearnStorage < Prog::Base
       total_storage_gib: rec.size_gib
     )]
 
-    devices.filter_map do |rec|
+    devices.each do |rec|
       next unless (name = rec.optional_name)
       sds << StorageDevice.new_with_id(
         vm_host_id: vm_host.id, name: name,

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -31,7 +31,8 @@ class Prog::Minio::MinioServerNexus < Prog::Base
         ] + Array.new(minio_pool.per_server_drive_count) { {encrypted: false, size_gib: (minio_pool.per_server_storage_size / minio_pool.per_server_drive_count).floor} },
         boot_image: "ubuntu-jammy",
         enable_ip4: true,
-        private_subnet_id: minio_pool.cluster.private_subnet.id
+        private_subnet_id: minio_pool.cluster.private_subnet.id,
+        distinct_storage_devices: true
       )
 
       minio_server = MinioServer.create(minio_pool_id: minio_pool_id, vm_id: vm_st.id, index: index) { _1.id = ubid.to_uuid }


### PR DESCRIPTION
This commit changes the minio provisioning to start using distinct host disks per os and data disks.