### PR TITLE
    Swap allocation heuristic from idle host to mostly-used host

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -178,7 +178,7 @@ AND vm_host.available_storage_gib > ?
 AND vm_host.allocation_state = 'accepting'
 AND vm_host.location = ?
 AND vm_host.arch = ?
-ORDER BY mem_ratio, used_cores
+ORDER BY mem_ratio, abs(used_cores - total_cores * 0.75)
 SQL
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -430,11 +430,9 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nx.allocate).to eq snug.id
     end
 
-    it "prefers hosts with fewer used cores" do
-      idle = new_host
-      new_host(used_cores: 70)
-      expect(nx.allocation_dataset.map { _1[:used_cores] }).to eq([0, 70])
-      expect(nx.allocate).to eq idle.id
+    it "prefers hosts with up to 75% used cores" do
+      (0..80).step(10) { new_host(used_cores: _1) }
+      expect(nx.allocation_dataset.map { _1[:used_cores] }).to eq([60, 50, 70, 40, 30, 20, 10, 0])
     end
 
     it "can use all cores" do


### PR DESCRIPTION
    We've had some recent pathological allocation situations -- we need to
    revisit the ancient-era allocation method -- where we cannot allocate
    larger VMs for extended period due to competition from transient small
    VMs in the GitHub Action pool.
    
    At the same time, we know that systems bordering completely full have
    a few sub-optimal behaviors in allocations.  We can abide it from time
    to time, but a simpler "use most busy system" heuristic will encounter
    it more often than necessary, slowing allocation times.
    
    To "mostly" de-fragment the workload, prefer systems with 75% core
    utilization, not preferring ones more allocated then that.
    
    The order of preference is demonstrated in a test.
