### PR TITLE
Block tcp udp port 111

### DIFF
--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -67,6 +67,7 @@ table inet fw_table {
     type filter hook forward priority filter; policy drop;
     ip protocol tcp counter flow offload @ubi_flowtable
     ip protocol udp counter flow offload @ubi_flowtable
+    meta l4proto { tcp, udp } th dport 111 drop
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept
     ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -85,6 +85,7 @@ elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
     type filter hook forward priority filter; policy drop;
     ip protocol tcp counter flow offload @ubi_flowtable
     ip protocol udp counter flow offload @ubi_flowtable
+    meta l4proto { tcp, udp } th dport 111 drop
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept
     ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
@@ -163,6 +164,7 @@ table inet fw_table {
     type filter hook forward priority filter; policy drop;
     ip protocol tcp counter flow offload @ubi_flowtable
     ip protocol udp counter flow offload @ubi_flowtable
+    meta l4proto { tcp, udp } th dport 111 drop
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept
     ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept


### PR DESCRIPTION
We recently got an e-mail from a cyber security agency stating that one of the VMs have port 111 reachable from the public internet. Looks like this port is used by Portmapper (or RPCbind) which are used for various tasks like network attached file system. We are not making use of these services and there is possibly not a good reason why a customer would need. When left reachable, this port poses a security risk that can be exploited for DDoS reflection attacks. Therefore, all things considered, we have decided to block port 111 by default.