### PR TITLE
Add application type checking to heartbeat

### DIFF
--- a/prog/heartbeat.rb
+++ b/prog/heartbeat.rb
@@ -3,8 +3,14 @@
 require "excon"
 
 class Prog::Heartbeat < Prog::Base
+  CONNECTED_APPLICATION_QUERY = <<SQL
+SELECT count(DISTINCT application_name)
+FROM pg_stat_activity
+WHERE application_name ~ '^(bin/respirate|bin/monitor|.*/puma)$'
+SQL
+
   label def wait
-    DB["SELECT 1"].first
+    nap 10 unless DB.get(CONNECTED_APPLICATION_QUERY) == 3
     Excon.get(Config.heartbeat_url, read_timeout: 2, write_timeout: 2, connect_timeout: 2)
     nap 10
   rescue Excon::Error::Timeout => e

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -11,20 +11,25 @@ RSpec.describe Prog::Heartbeat do
     before { allow(Config).to receive(:heartbeat_url).and_return("http://localhost:3000") }
 
     it "fails if it can't connect to the database" do
-      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_raise(Sequel::DatabaseConnectionError)
+      expect(DB).to receive(:[]).with(described_class::CONNECTED_APPLICATION_QUERY).and_raise(Sequel::DatabaseConnectionError)
 
       expect { hb.wait }.to raise_error Sequel::DatabaseConnectionError
     end
 
     it "naps if it can't send request in expected time" do
-      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_return(3)
+      expect(hb).to receive(:fetch_connected).and_return(described_class::EXPECTED)
       stub_request(:get, "http://localhost:3000").and_raise(Excon::Error::Timeout)
       expect(Clog).to receive(:emit).with("heartbeat request timed out")
       expect { hb.wait }.to nap(10)
     end
 
     it "naps if not all expected application types are connected" do
-      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_return(2)
+      expect(hb).to receive(:fetch_connected).and_return(%w[monitor puma])
+
+      expect(Clog).to receive(:emit).with("some expected connected clover services are missing") do |&blk|
+        expect(blk.call).to eq(heartbeat_missing: {difference: ["respirate"]})
+      end
+
       req = stub_request(:get, "http://localhost:3000").to_return(status: 200)
       expect { hb.wait }.to nap(10)
       expect(req).not_to have_been_requested
@@ -32,7 +37,7 @@ RSpec.describe Prog::Heartbeat do
 
     it "pushes a heartbeat and naps" do
       req = stub_request(:get, "http://localhost:3000").to_return(status: 200)
-      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_return(3)
+      expect(hb).to receive(:fetch_connected).and_return(described_class::EXPECTED)
 
       expect { hb.wait }.to nap(10)
       expect(req).to have_been_requested

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -11,21 +11,31 @@ RSpec.describe Prog::Heartbeat do
     before { allow(Config).to receive(:heartbeat_url).and_return("http://localhost:3000") }
 
     it "fails if it can't connect to the database" do
-      expect(DB).to receive(:[]).with("SELECT 1").and_raise(Sequel::DatabaseConnectionError)
+      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_raise(Sequel::DatabaseConnectionError)
 
       expect { hb.wait }.to raise_error Sequel::DatabaseConnectionError
     end
 
     it "naps if it can't send request in expected time" do
+      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_return(3)
       stub_request(:get, "http://localhost:3000").and_raise(Excon::Error::Timeout)
       expect(Clog).to receive(:emit).with("heartbeat request timed out")
       expect { hb.wait }.to nap(10)
     end
 
+    it "naps if not all expected application types are connected" do
+      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_return(2)
+      req = stub_request(:get, "http://localhost:3000").to_return(status: 200)
+      expect { hb.wait }.to nap(10)
+      expect(req).not_to have_been_requested
+    end
+
     it "pushes a heartbeat and naps" do
-      stub_request(:get, "http://localhost:3000").to_return(status: 200)
+      req = stub_request(:get, "http://localhost:3000").to_return(status: 200)
+      expect(DB).to receive(:get).with(described_class::CONNECTED_APPLICATION_QUERY).and_return(3)
 
       expect { hb.wait }.to nap(10)
+      expect(req).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
A trick for more robust ditch-effort monitoring is to ensure at least one backend for each expected process type is connected to Postgres.

In principle this could be made stricter by checking for the quantity of each backend relative to expectations, but these expectations are quite unstable given changes in pooling and compute acquisition, so it's more suited to a not-yet-designed Prog that would offer something more rich than what "heartbeat" is intended to provide.