### PR TITLE
Log VM host utilization at the wait label

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -206,6 +206,8 @@ class Prog::Vm::HostNexus < Prog::Base
       hop_prep_reboot
     end
 
+    Clog.emit("vm host utilization") { {vm_host_utilization: vm_host.values.slice(:location, :arch, :total_cores, :used_cores, :total_hugepages_1g, :used_hugepages_1g, :total_storage_gib, :available_storage_gib).merge({vms_count: vm_host.vms_dataset.count})} }
+
     nap 30
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -225,6 +225,8 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#wait" do
     it "naps" do
+      expect(vm_host).to receive(:values).and_return({location: "hetzner-hel1", arch: "x64", total_cores: 4})
+      expect(vm_host).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, count: 2))
       expect { nx.wait }.to nap(30)
     end
 


### PR DESCRIPTION
We aim to monitor the utilization of the VM host. As we lack a metric collection service, we log our metrics and oversee them through our logging provider.

The VM host runs the 'wait' label every 30 seconds, which is an optimal time to log the VM host's utilization.

```json
{
    "vm_host_utilization": {
        "location": "github-runners",
        "arch": "x64",
        "total_cores": 4,
        "used_cores": 1,
        "total_hugepages_1g": 50,
        "used_hugepages_1g": 1,
        "total_storage_gib": 845,
        "available_storage_gib": 642
    },
    "message": "vm host utilization",
    "time": "2024-03-08 23:30:31 +0300"
}
```