### PR TITLE
Update StorageDevice.available_storage_gib at Vm.destroy

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -499,6 +499,11 @@ SQL
         used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib,
         available_storage_gib: Sequel[:available_storage_gib] + vm_storage_size_gib
       )
+
+      StorageDevice.dataset.where(vm_host_id: vm.vm_host_id, name: "DEFAULT").update(
+        available_storage_gib: Sequel[:available_storage_gib] + vm_storage_size_gib
+      )
+
       vm.projects.map { vm.dissociate_with_project(_1) }
       vm.destroy
     end


### PR DESCRIPTION
Looks like we completely forgot to update available_storage_gib of the storage_device at the Vm.destroy. While this is not harmless at the moment, since we do not use this property anywhere, it will be used soon with the changes in https://github.com/ubicloud/ubicloud/pull/1281. Therefore, we must fix this before deploying those changes.