### PR TITLE
Pick host for VM randomly

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -170,7 +170,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   def allocation_dataset
     DB[<<SQL, vm.cores, vm.mem_gib_ratio, vm.mem_gib, vm_storage_size_gib, vm.location, vm.arch]
-SELECT *, vm_host.total_mem_gib / vm_host.total_cores AS mem_ratio
+SELECT *
 FROM vm_host
 WHERE vm_host.used_cores + ? <= least(vm_host.total_cores, vm_host.total_mem_gib / ?)
 AND vm_host.used_hugepages_1g + ? <= vm_host.total_hugepages_1g
@@ -178,7 +178,7 @@ AND vm_host.available_storage_gib > ?
 AND vm_host.allocation_state = 'accepting'
 AND vm_host.location = ?
 AND vm_host.arch = ?
-ORDER BY mem_ratio, used_cores
+ORDER BY random()
 SQL
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -423,20 +423,6 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.allocate }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible hosts for somewhere-normal"
     end
 
-    it "prefers the host with a more snugly fitting RAM ratio, even if busy" do
-      snug = new_host(used_cores: 78)
-      new_host(total_mem_gib: snug.total_mem_gib * 2)
-      expect(nx.allocation_dataset.map { _1[:mem_ratio] }).to eq([8, 16])
-      expect(nx.allocate).to eq snug.id
-    end
-
-    it "prefers hosts with fewer used cores" do
-      idle = new_host
-      new_host(used_cores: 70)
-      expect(nx.allocation_dataset.map { _1[:used_cores] }).to eq([0, 70])
-      expect(nx.allocate).to eq idle.id
-    end
-
     it "can use all cores" do
       vmh = new_host(used_cores: 79)
       expect(nx.allocate).to eq vmh.id


### PR DESCRIPTION
We used to pick the host for a VM based on memory/CPU ratio. This causes
predominantly picking the same host(s) if there are some hosts with different
memory/CPU ratios than rest of the fleet.

This is especially easy to analyze at present because we don't have multiple
memory tiers available to the customer just yet, otherwise it'd do something
weird like put a memory heavy provision on something with little memory,
leaving very little room for anything else. Though we have host memory ratio
skew, it nevertheless does not translate into the customer's bought capacity
for anything we sell at present, so we are eating the mismatch for now.

For example a recent pathological case was that we had new hosts with 1GBit
network cards, and the rest of the fleet had 10GBit network cards. The new
hosts were picked for VMs, because they had different memory/CPU ratios.

We are also working on more sophisticated host picking algorithm, but that item
got delayed for the sake of higher priority tasks. I think this change would
improve the situation in the meantime.