### PR TITLE
Add globally blocked dnsname infrastructure

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -16,6 +16,9 @@ if Config.github_app_id
   Strand.dataset.insert_conflict.insert(id: "c39ae087-6ec4-033a-d440-b7a821061caf", schedule: Time.now, prog: "RedeliverGithubFailures", label: "wait", stack: [{last_check_at: Time.now}].to_json)
 end
 
+# We always insert this strand using the same UBID ("stresolvee4block0dnsnamesz")
+Strand.dataset.insert_conflict.insert(id: "c3b200ed-ce22-c33a-0326-06d735551d9f", schedule: Time.now, prog: "ResolveGloballyBlockedDnsnames", label: "wait")
+
 clover_freeze
 
 loop do

--- a/migrate/20240311_add_globally_blocked_dnsname.rb
+++ b/migrate/20240311_add_globally_blocked_dnsname.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:globally_blocked_dnsname) do
+      column :id, :uuid, primary_key: true
+      column :dns_name, :text, collate: '"C"', null: false, unique: true
+      column :ip_list, "inet[]", null: true
+      column :last_check_at, :timestamp, null: true
+    end
+  end
+end

--- a/model/globally_blocked_dnsname.rb
+++ b/model/globally_blocked_dnsname.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../model"
+
+class GloballyBlockedDnsname < Sequel::Model
+  include ResourceMethods
+
+  def self.ubid_type
+    UBID::TYPE_ETC
+  end
+end

--- a/prog/resolve_globally_blocked_dnsnames.rb
+++ b/prog/resolve_globally_blocked_dnsnames.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "socket"
+require "open-uri"
+require "net/http"
+class Prog::ResolveGloballyBlockedDnsnames < Prog::Base
+  label def wait
+    GloballyBlockedDnsname.each do |globally_blocked_dnsname|
+      dns_name = globally_blocked_dnsname.dns_name
+
+      begin
+        addr_info = Socket.getaddrinfo(dns_name, nil)
+      rescue SocketError
+        Clog.emit("Failed to resolve blocked dns name") { {dns_name: dns_name} }
+        next
+      end
+
+      ip_list = addr_info.map do |info|
+        info[3]
+      end.uniq
+
+      globally_blocked_dnsname.update(ip_list: Sequel.lit("ARRAY[#{ip_list.map { |ip| "'#{ip}'::inet" }.join(",")}]"), last_check_at: Time.now)
+    end
+
+    nap 60 * 60
+  end
+end

--- a/spec/prog/resolve_globally_blocked_dnsnames_spec.rb
+++ b/spec/prog/resolve_globally_blocked_dnsnames_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+require "socket"
+RSpec.describe Prog::ResolveGloballyBlockedDnsnames do
+  subject(:rgbd) {
+    described_class.new(Strand.new(prog: "ResolveGloballyBlockedDnsnames", label: "wait"))
+  }
+
+  let(:globally_blocked_dnsname) { GloballyBlockedDnsname.create_with_id(dns_name: "example.com", last_check_at: "2023-10-19 19:27:47 +0000") }
+
+  describe "#wait" do
+    before do
+      globally_blocked_dnsname
+    end
+
+    it "resolves dnsnames to ip addresses and updates records" do
+      expect(Socket).to receive(:getaddrinfo).with("example.com", nil).and_return([[nil, nil, nil, "1.1.1.1"], [nil, nil, nil, "2a00:1450:400e:811::200e"], [nil, nil, nil, "1.1.1.1"]])
+      expect(Time).to receive(:now).and_return(Time.new("2023-10-19 23:27:47 +0000")).at_least(:once)
+      expect { rgbd.wait }.to nap(60 * 60)
+
+      expect(globally_blocked_dnsname.reload.ip_list.map(&:to_s).sort).to eq(["1.1.1.1", "2a00:1450:400e:811::200e"])
+    end
+
+    it "skips if socket fails" do
+      expect(Socket).to receive(:getaddrinfo).with("example.com", nil).and_raise(SocketError)
+      expect { rgbd.wait }.to nap(60 * 60)
+
+      expect(globally_blocked_dnsname.reload.ip_list).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
**Add globally blocked dnsname infrastructure migration**

**Add globally blocked dnsnames to firewall rules** 
The nftables that is used for firewall rules gets 2 new sets. These are
used to block incoming and outgoing traffic to select IP addresses.

**Add prog to update ip addresses of globally blocked dns names**
This commit introduces a new prog that will periodically check the ip
addresses of globally blocked dnsnames. This way, the list will be kept
fresh and the new VMs will be provisioned with the new list. In future,
we might introduce a system here to trigger a firewall rule update for
existing VMs as well.