### PR TITLE
Fix nil ip_list issue in globally_blocked_dnsname

### DIFF
--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -111,7 +111,7 @@ TEMPLATE
     globally_blocked_ipv6s = []
 
     GloballyBlockedDnsname.each do |globally_blocked_dnsname|
-      ips = globally_blocked_dnsname.ip_list
+      ips = globally_blocked_dnsname.ip_list || []
       ips.each do |ip|
         globally_blocked_ipv4s << "#{ip}/32" if ip.ipv4?
         globally_blocked_ipv6s << "#{ip}/128" if ip.ipv6?

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -124,6 +124,9 @@ ADD_RULES
     end
 
     it "does not pass elements if there are not fw rules" do
+      # An address to block but not discovered the ip_list, yet.
+      GloballyBlockedDnsname.create_with_id(dns_name: "blockedhost.com", ip_list: nil)
+
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(vm).to receive(:firewalls).and_return([])
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)


### PR DESCRIPTION
The commit 540b34854f6ba13b1e546b5741b4523c50b7bd62 introduced an iteration via .each over the ip_list column of globally_blocked_dnsname. However, when we add a new entry to the table, until the first iteration of the Prog::ResolveGloballyBlockedDnsnames, the ip_list is empty. Therefore, the Prog::UpdateFirewallRules starts to fail with nil ref. This commit fixes that.