### PR TITLE
GitHub workflow job poller

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -95,6 +95,7 @@ module Config
   optional :github_app_webhook_secret, string, clear: true
   optional :vm_pool_project_id, string
   optional :github_runner_service_project_id, string
+  override :enable_github_workflow_poller, true, bool
 
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string

--- a/migrate/20240417_github_repository.rb
+++ b/migrate/20240417_github_repository.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:github_repository) do
+      column :id, :uuid, primary_key: true, default: nil
+      foreign_key :installation_id, :github_installation, type: :uuid
+      column :name, :text, collate: '"C"', null: false
+      column :created_at, :timestamptz, null: false, default: Sequel::CURRENT_TIMESTAMP
+      column :last_job_at, :timestamptz, null: false, default: Sequel::CURRENT_TIMESTAMP
+      column :last_check_at, :timestamptz, null: false, default: Sequel::CURRENT_TIMESTAMP
+      index [:installation_id, :name], unique: true
+    end
+
+    alter_table(:github_runner) do
+      add_foreign_key :repository_id, :github_repository, type: :uuid
+    end
+  end
+end

--- a/model.rb
+++ b/model.rb
@@ -15,6 +15,7 @@ Sequel::Model.plugin :column_encryption do |enc|
   enc.key 0, Config.clover_column_encryption_key
 end
 Sequel::Model.plugin :many_through_many
+Sequel::Model.plugin :insert_conflict
 
 module SemaphoreMethods
   def self.included(base)

--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../../model"
+
+class GithubRepository < Sequel::Model
+  one_to_one :strand, key: :id
+  many_to_one :installation, key: :installation_id, class: :GithubInstallation
+  one_to_many :runners, key: :repository_id, class: :GithubRunner
+
+  include ResourceMethods
+  include SemaphoreMethods
+
+  semaphore :destroy
+end

--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -5,6 +5,7 @@ require_relative "../model"
 class GithubInstallation < Sequel::Model
   many_to_one :project
   one_to_many :runners, key: :installation_id, class: :GithubRunner
+  one_to_many :repositories, key: :installation_id, class: :GithubRepository
 
   include ResourceMethods
 

--- a/model/postgres/postgres_lsn_monitor.rb
+++ b/model/postgres/postgres_lsn_monitor.rb
@@ -3,5 +3,4 @@
 require_relative "../../model"
 
 class PostgresLsnMonitor < Sequel::Model(POSTGRES_MONITOR_DB[:postgres_lsn_monitor])
-  plugin :insert_conflict
 end

--- a/model/project.rb
+++ b/model/project.rb
@@ -53,6 +53,7 @@ class Project < Sequel::Model
 
       github_installations.each do
         Github.app_client.delete_installation(_1.installation_id)
+        _1.repositories.each(&:incr_destroy)
         _1.destroy
       end
 

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -4,7 +4,6 @@ require_relative "../model"
 
 class StorageDevice < Sequel::Model
   include ResourceMethods
-  plugin :insert_conflict
 
   many_to_one :vm_host
 

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -91,7 +91,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     nap 15 * 60 if Time.now - github_repository.last_job_at > 6 * 60 * 60
 
     begin
-      check_queued_jobs
+      check_queued_jobs if Config.enable_github_workflow_poller
     rescue Octokit::NotFound
       Clog.emit("not found repository") { {not_found_repository: {repository_name: github_repository.name}} }
       if github_repository.runners.count == 0

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/util"
+
+class Prog::Github::GithubRepositoryNexus < Prog::Base
+  subject_is :github_repository
+
+  semaphore :destroy
+
+  def self.assemble(installation, name)
+    DB.transaction do
+      repository = GithubRepository.new_with_id(installation_id: installation.id, name: name)
+      repository.skip_auto_validations(:unique) do
+        repository.insert_conflict(target: [:installation_id, :name], update: {last_job_at: Time.now}).save_changes
+      end
+      Strand.new(prog: "Github::GithubRepositoryNexus", label: "wait") { _1.id = repository.id }
+        .insert_conflict(target: :id).save_changes
+    end
+  end
+
+  def client
+    @client ||= Github.installation_client(github_repository.installation.installation_id).tap { _1.auto_paginate = true }
+  end
+
+  def check_queued_jobs
+    queued_runs = client.repository_workflow_runs(github_repository.name, {status: "queued"})[:workflow_runs]
+    Clog.emit("polled queued runs") { {polled_queued_runs: {repository_name: github_repository.name, count: queued_runs.count}} }
+    queued_labels = Hash.new(0)
+    queued_runs.each do |run|
+      jobs = client.workflow_run_attempt_jobs(github_repository.name, run[:id], run[:run_attempt])[:jobs]
+
+      jobs.each do |job|
+        next if job[:status] != "queued"
+        next unless (label = job[:labels].find { Github.runner_labels.key?(_1) })
+        queued_labels[label] += 1
+      end
+    end
+
+    queued_labels.each do |label, count|
+      idle_runner_count = github_repository.runners_dataset.where(label: label, workflow_job: nil).count
+      # The calculation of the required_runner_count isn't atomic because it
+      # requires multiple API calls and database queries. However, it will
+      # eventually settle on the correct value. If we create more runners than
+      # necessary, the excess will be recycled after 5 minutes at no extra cost
+      # to the customer. If fewer runners are created than needed, the system
+      # will generate more in the next cycle.
+      next if (required_runner_count = count - idle_runner_count) && required_runner_count <= 0
+
+      Clog.emit("extra runner needed") { {needed_extra_runner: {repository_name: github_repository.name, label: label, count: required_runner_count}} }
+
+      required_runner_count.times do
+        Prog::Vm::GithubRunner.assemble(
+          github_repository.installation,
+          repository_name: github_repository.name,
+          label: label
+        )
+      end
+    end
+  end
+
+  def before_run
+    when_destroy_set? do
+      if strand.label != "destroy"
+        register_deadline(nil, 5 * 60)
+        hop_destroy
+      end
+    end
+  end
+
+  label def wait
+    nap 15 * 60 if Time.now - github_repository.last_job_at > 6 * 60 * 60
+
+    begin
+      check_queued_jobs
+    rescue Octokit::NotFound
+      Clog.emit("not found repository") { {not_found_repository: {repository_name: github_repository.name}} }
+      if github_repository.runners.count == 0
+        github_repository.incr_destroy
+        nap 0
+      end
+    end
+
+    nap 5 * 60
+  end
+
+  label def destroy
+    decr_destroy
+
+    unless github_repository.runners.empty?
+      Clog.emit("Cannot destroy repository with active runners") { {not_destroyed_repository: {repository_name: github_repository.name}} }
+      nap 5 * 60
+    end
+
+    github_repository.destroy
+
+    pop "github repository destroyed"
+  end
+end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -13,9 +13,11 @@ class Prog::Vm::GithubRunner < Prog::Base
     end
 
     DB.transaction do
+      repository = Prog::Github::GithubRepositoryNexus.assemble(installation, repository_name).subject
       github_runner = GithubRunner.create_with_id(
         installation_id: installation.id,
         repository_name: repository_name,
+        repository_id: repository.id,
         label: label
       )
 

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -46,6 +46,7 @@ class CloverWeb
         return error("Unregistered installation")
       end
       installation.runners.each(&:incr_destroy)
+      installation.repositories.each(&:incr_destroy)
       installation.destroy
       return success("GithubInstallation[#{installation.ubid}] deleted")
     end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Project do
     it "deletes github installations" do
       expect(project).to receive(:access_tags_dataset).and_return(instance_double(AccessTag, destroy: nil))
       expect(project).to receive(:access_policies_dataset).and_return(instance_double(AccessPolicy, destroy: nil))
-      installation = instance_double(GithubInstallation, installation_id: 123)
+      installation = instance_double(GithubInstallation, installation_id: 123, repositories: [instance_double(GithubRepository, incr_destroy: nil)])
       expect(installation).to receive(:destroy)
       expect(project).to receive(:github_installations).and_return([installation])
       app_client = instance_double(Octokit::Client)

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+require "octokit"
+
+RSpec.describe Prog::Github::GithubRepositoryNexus do
+  subject(:nx) {
+    described_class.new(Strand.new).tap {
+      _1.instance_variable_set(:@github_repository, github_repository)
+    }
+  }
+
+  let(:github_repository) {
+    GithubRepository.new(name: "ubicloud/ubicloud", last_job_at: Time.now).tap {
+      _1.id = "31b9c46a-602a-8616-ae2f-41775cb592dd"
+    }
+  }
+
+  describe ".assemble" do
+    it "creates github repository or updates last_job_at if the repository exists" do
+      project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
+
+      expect {
+        described_class.assemble(installation, "ubicloud/ubicloud")
+      }.to change(GithubRepository, :count).from(0).to(1)
+      now = Time.now.round(6)
+      expect(Time).to receive(:now).and_return(now).at_least(:once)
+      st = described_class.assemble(installation, "ubicloud/ubicloud")
+      expect(GithubRepository.count).to eq(1)
+      expect(Strand.count).to eq(1)
+      expect(st.subject.last_job_at).to eq(now)
+    end
+  end
+
+  describe ".check_queued_jobs" do
+    let(:client) { instance_double(Octokit::Client) }
+
+    before do
+      allow(Github).to receive(:installation_client).and_return(client)
+      expect(client).to receive(:auto_paginate=)
+      expect(github_repository).to receive(:installation).and_return(instance_double(GithubInstallation, installation_id: "123")).at_least(:once)
+    end
+
+    it "creates extra runner if needed" do
+      expect(client).to receive(:repository_workflow_runs).and_return({workflow_runs: [
+        {id: 1, run_attempt: 2, status: "queued"},
+        {id: 2, run_attempt: 1, status: "queued"}
+      ]})
+      expect(client).to receive(:workflow_run_attempt_jobs).with("ubicloud/ubicloud", 1, 2).and_return({jobs: [
+        {status: "queued", labels: ["ubuntu-latest"]},
+        {status: "queued", labels: ["ubicloud"]},
+        {status: "queued", labels: ["ubicloud"]},
+        {status: "queued", labels: ["ubicloud-standard-4"]},
+        {status: "queued", labels: ["ubicloud-standard-8"]},
+        {status: "failed", labels: ["ubicloud"]}
+      ]})
+      expect(client).to receive(:workflow_run_attempt_jobs).with("ubicloud/ubicloud", 2, 1).and_return({jobs: [
+        {status: "queued", labels: ["ubicloud"]}
+      ]})
+      expect(github_repository).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset)).at_least(:once)
+      expect(github_repository.runners_dataset).to receive(:where).with(label: "ubicloud", workflow_job: nil).and_return([instance_double(GithubRunner)])
+      expect(github_repository.runners_dataset).to receive(:where).with(label: "ubicloud-standard-4", workflow_job: nil).and_return([])
+      expect(github_repository.runners_dataset).to receive(:where).with(label: "ubicloud-standard-8", workflow_job: nil).and_return([instance_double(GithubRunner)])
+      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud").twice
+      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-4")
+      expect(Prog::Vm::GithubRunner).not_to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-8")
+      nx.check_queued_jobs
+    end
+  end
+
+  describe "#before_run" do
+    it "hops to destroy when needed" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx).to receive(:register_deadline)
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "does not hop to destroy if already in the destroy state" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect { nx.before_run }.not_to hop("destroy")
+    end
+  end
+
+  describe "#wait" do
+    it "checks queued jobs and naps" do
+      expect(nx).to receive(:check_queued_jobs)
+      expect { nx.wait }.to nap(5 * 60)
+    end
+
+    it "does not check queued jobs if 6 hours passed from the last job" do
+      expect(github_repository).to receive(:last_job_at).and_return(Time.now - 7 * 60 * 60)
+      expect(nx).not_to receive(:check_queued_jobs)
+      expect { nx.wait }.to nap(15 * 60)
+    end
+
+    it "does not destroys repository and if not found but has active runners" do
+      expect(nx).to receive(:check_queued_jobs).and_raise(Octokit::NotFound)
+      expect(github_repository).to receive(:runners).and_return([instance_double(GithubRunner)])
+      expect(github_repository).not_to receive(:incr_destroy)
+      expect { nx.wait }.to nap(5 * 60)
+    end
+
+    it "destroys repository and if not found" do
+      expect(nx).to receive(:check_queued_jobs).and_raise(Octokit::NotFound)
+      expect(github_repository).to receive(:incr_destroy)
+      expect { nx.wait }.to nap(0)
+    end
+  end
+
+  describe "#destroy" do
+    it "does not destroy if has active runner" do
+      expect(github_repository).to receive(:runners).and_return([instance_double(GithubRunner)])
+      expect { nx.destroy }.to nap(5 * 60)
+    end
+
+    it "deletes resource and pops" do
+      expect(nx).to receive(:decr_destroy)
+      expect(github_repository).to receive(:destroy)
+
+      expect { nx.destroy }.to exit({"msg" => "github repository destroyed"})
+    end
+  end
+end

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -125,6 +125,13 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect(github_repository).to receive(:incr_destroy)
       expect { nx.wait }.to nap(0)
     end
+
+    it "does not poll if it is disabled" do
+      expect(Config).to receive(:enable_github_workflow_poller).and_return(false)
+      expect(nx).not_to receive(:check_queued_jobs)
+
+      expect { nx.wait }.to nap(5 * 60)
+    end
   end
 
   describe "#destroy" do

--- a/ubid.rb
+++ b/ubid.rb
@@ -68,6 +68,7 @@ class UBID
   TYPE_FIREWALL_RULE = "fr"
   TYPE_FIREWALL = "fw"
   TYPE_POSTGRES_FIREWALL_RULE = "pf"
+  TYPE_GITHUB_REPOSITORY = "gp"
 
   # Common entropy-based type for everything else
   TYPE_ETC = "et"


### PR DESCRIPTION
### Move Sequel.insert_conflict plugin to base model

Two of our models uses this plugin, also I added two new models that will use it. Since, the number of models that uses this plugin is increasing, I decided to move it to the base model.

It allows to run insert_conflict queries via model instance directly.
https://sequel.jeremyevans.net/rdoc-plugins/classes/Sequel/Plugins/InsertConflict.html

### Add migration for GithubRepository model

GitHub provides an API endpoint to access installation repositories. However, not all customers use Ubicloud runners for all their repositories. While we have information of active repositories in the DeletedRecord, we prefer not to use it for application logic. Therefore, I've introduced the GithubRunner model to maintain a list of active repositories. This model is created when the first job is delivered for the repository. It also includes a 'last_job_at' column to help to clean up inactive repositories. Our job polling mechanism need active repositories.

### Add GithubRepository nexus to poll queued jobs

Our integration with GitHub Actions runner relies on the webhook delivered by GitHub. If GitHub fails to deliver the "workflow_job.queued" event, our control plane remains unaware of the new queued job and cannot provision a runner for it. If GitHub attempts and fails to deliver, we have "Prog::RedeliverGithubFailures" to retry the delivery. However, if GitHub doesn't attempt delivery, we have no way of knowing. We've encountered instances where GitHub failed to deliver the "workflow_job.queued" event, and we currently have an active support ticket for this issue. GitHub engineers are working to resolve this. Furthermore, GitHub has had 6 incidents in the past 7 days. We need to develop a solution to make our service more resilient to GitHub's issues.

We're also addressing an issue related to the "max-parallel" configuration. GitHub Actions workflow syntax allows to limit concurrent jobs in a matrix via the "max-parallel" configuration. Unfortunately, it sends the "workflow_job.queued" event for all jobs in the matrix simultaneously. The job payload lacks an indicator for whether the job is limited by "max-parallel" or not. We don't have this indicator in the API payload either. The poller views all jobs as queued. It provisions a runner for all jobs in the matrix until the workflow run is finished when the initially provisioned runner is recycled. However, the runner will pick jobs from the queue one by one based on the "max-parallel" value. There are several issues about "max-parallel" config design, but GitHub doesn't want to improve it. I think "max-parallel" is misdesigned and has architectural problem, but yeah we need to deal with it. The poller is our best solution to this problem, even if it means keeping idle runners for limited jobs.

The poller design presents its own challenges. Let's first understand GitHub's resources. We have a GitHub app that customers install on their accounts. We keep a GithubInstallation record for each customer. Customers may allow only certain repositories or all repositories while installing our GitHub app. Each repository has workflow runs, and each run has workflow jobs. When we receive a "workflow_job.queued" event, we create a GithubRunner record if the payload contains the "ubicloud" label.

There isn't an endpoint that provides queued jobs for a GitHub installation with the "ubicloud" label. We need to retrieve all repositories for each GitHub installation, get queued workflow runs for each repository, get jobs for each run, and check the job's status and label. This process requires numerous requests. We've decided to poll only active repositories. If no new job is queued for a repository in the last 6 hours, we don't poll it. In other words, at least one job should arrive within a 6-hour timeframe for us to poll the repository.

Furthermore, self-hosted runners are job-agnostic. We can't register a runner for a specific job. We register with the requested label to the repository, and GitHub assigns the job to the appropriate runner. Thus, the poller compares the count of queued jobs and idle runners for the repository.

"Prog::Github::RepositoryNexus" polls the repository's jobs every 5 minutes. The "max-parallel" scenario requires more frequent polling than the "missing webhook" scenario. I chose 5 minutes interval for the poller because our runner recycling threshold is 5 minutes. So for "max-parallel" scenarios, we will keep idle runners for 5 minutes. No need to provision additional runners for 5 minutes. For missing webhook events, 5 minutes is a reasonable interval.

### Do not poll jobs if the remaining rate limit is too low

GitHub imposes different rate limits for each installation, which vary based on account type, member count, and repository count [^1].

Despite our efforts to restrict the number of polled repositories, we might still surpass the rate limit, although our rough calculations suggest we shouldn't.

To avoid exceeding this limit, I've implemented a check, as breaching it also impacts runners, given that we require the API to register runner.

If the remaining limit dips below 10%, we halt polling and pause until the rate limit resets.

If the remaining limit fall under 50%, we adjust our polling frequency to every 15 minutes instead of every 5 minutes.

[^1]: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28


### Add a switch to disable GitHub workflow poller

GithubRepositoryNexus polls queued jobs every 5 minutes. When GitHub has an outage, probably poller will try and try again to get the queued jobs and will fail. When GitHub is down, we can disable poller to avoid unnecessary load.

