### PR TITLE
Exclude docker default bridge address from private ip list

### DIFF
--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -279,8 +279,8 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "finds a new subnet if the one it found is taken" do
       expect(PrivateSubnet).to receive(:random_subnet).and_return("172.16.0.0/12").twice
       expect(SecureRandom).to receive(:random_number).with(16383).and_return(1, 2)
-      expect(PrivateSubnet).to receive(:where).with(net4: "172.16.0.128/26", location: "hetzner-hel1").and_return([true])
-      expect(PrivateSubnet).to receive(:where).with(net4: "172.16.0.192/26", location: "hetzner-hel1").and_return([])
+      expect(PrivateSubnet).to receive(:[]).with(net4: "172.16.0.128/26", location: "hetzner-hel1").and_return([true])
+      expect(PrivateSubnet).to receive(:[]).with(net4: "172.16.0.192/26", location: "hetzner-hel1").and_return(nil)
       expect(described_class.random_private_ipv4("hetzner-hel1").to_s).to eq("172.16.0.192/26")
     end
   end


### PR DESCRIPTION
We're excluding the 172.17.0.0 subnet to avoid conflicts with Docker, which uses this range by default. Docker, pre-installed on runners, automatically sets up a bridge network using 172.17.0.0/16 and subsequent subnets (e.g., 172.18.0.0/16). If a subnet is in use, Docker moves to the next available one. However, since dnsmasq assigns private IP addresses post-VM initialization, there's a race condition: Docker can assign its address before the VM is necessarily aware of its virtual networking address information, leading to routing clashes that render IPv4 internet access inoperable in some interleavings.
