### PR TITLE
Encrypt all github runner VMs

### DIFF
--- a/migrate/20240314_encrypt_vm_pool_tuples.rb
+++ b/migrate/20240314_encrypt_vm_pool_tuples.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_pool) do
+      set_column_default(:storage_encrypted, true)
+    end
+
+    run "UPDATE vm_pool SET storage_encrypted = true"
+  end
+end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -32,7 +32,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       boot_image: label_data["boot_image"],
       location: label_data["location"],
       storage_size_gib: label_data["storage_size_gib"],
-      storage_encrypted: false,
+      storage_encrypted: true,
       storage_skip_sync: skip_sync,
       arch: label_data["arch"]
     ).first
@@ -49,7 +49,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       size: label_data["vm_size"],
       location: label_data["location"],
       boot_image: label_data["boot_image"],
-      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: false, skip_sync: skip_sync}],
+      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true, skip_sync: skip_sync}],
       enable_ip4: true,
       arch: label_data["arch"],
       allow_only_ssh: true,

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -205,9 +205,7 @@ SQL
     frame["storage_volumes"].each_with_index do |volume, disk_index|
       spdk_installation_id = allocate_spdk_installation(vm_host.spdk_installations)
 
-      # To test the effect of encryption on the performance, encrypt for bdev_ubi
-      # hosts in a hacky way by 50%. It will be removed once the test is completed.
-      key_encryption_key = if volume["encrypted"] || (SpdkInstallation[spdk_installation_id].supports_bdev_ubi? && rand < 0.5)
+      key_encryption_key = if volume["encrypted"]
         key_wrapping_algorithm = "aes-256-gcm"
         cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
         key_wrapping_key = cipher.random_key

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150, arch: "x64")
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
-        storage_size_gib: 150, storage_encrypted: false,
+        storage_size_gib: 150, storage_encrypted: true,
         storage_skip_sync: true, arch: "x64"
       ).and_return([git_runner_pool])
       expect(git_runner_pool).to receive(:pick_vm).and_return(nil)
@@ -105,7 +105,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150, arch: "arm64")
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
-        storage_size_gib: 150, storage_encrypted: false,
+        storage_size_gib: 150, storage_encrypted: true,
         storage_skip_sync: true, arch: "arm64"
       ).and_return([git_runner_pool])
       expect(git_runner_pool).to receive(:pick_vm).and_return(vm)


### PR DESCRIPTION
As testing encryption for github runner VMs completed successfully, encrypting all github runner VMs now. Both the VMs from the vm pools and VMs created from scratch are encrypted.