### PR TITLE
Increase HSTS max-age to one week

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -15,7 +15,7 @@ class CloverWeb < Roda
     "X-Content-Type-Options" => "nosniff"
   }.merge(
     # :nocov:
-    Config.production? ? {"Strict-Transport-Security" => "max-age=300; includeSubDomains"} : {}
+    Config.production? ? {"Strict-Transport-Security" => "max-age=604800; includeSubDomains"} : {}
     # :nocov:
   )
 


### PR DESCRIPTION
The follow-up to eb040a3275a4b300dd7dfb52d6fc8b9df7b2a0e3, as there have been no problems with the fifteen second and five minute variants.