### PR TITLE
Add provisioning timestamps to virtual machine model

### DIFF
--- a/migrate/20240320_add_vm_provision_timestamps.rb
+++ b/migrate/20240320_add_vm_provision_timestamps.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm) do
+      add_column :allocated_at, :timestamptz
+      add_column :provisioned_at, :timestamptz
+    end
+  end
+end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -350,7 +350,7 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
         allocated_at: Time.now
       )
 
-      Clog.emit("vm allocated") { {vm: vm.values, allocation: {vm_ubid: vm.ubid, vm_host_ubid: vm_host.ubid}} }
+      Clog.emit("vm allocated") { {vm: vm.values, allocation: {vm_ubid: vm.ubid, vm_host_ubid: vm_host.ubid, duration: Time.now - vm.created_at}} }
 
       AssignedVmAddress.create_with_id(dst_vm_id: vm.id, ip: ip4.to_s, address_id: address.id) if ip4
     end
@@ -454,7 +454,7 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
 
   label def create_billing_record
     vm.update(display_state: "running", provisioned_at: Time.now)
-    Clog.emit("vm provisioned") { {vm: vm.values, provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.created_at}} }
+    Clog.emit("vm provisioned") { {vm: vm.values, provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.allocated_at}} }
     project = vm.projects.first
     hop_wait unless project.billable
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -346,7 +346,8 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
       vm.update(
         vm_host_id: vm_host_id,
         ephemeral_net6: vm_host.ip6_random_vm_network.to_s,
-        local_vetho_ip: vm_host.veth_pair_random_ip4_addr.to_s
+        local_vetho_ip: vm_host.veth_pair_random_ip4_addr.to_s,
+        allocated_at: Time.now
       )
 
       Clog.emit("vm allocated") { {vm: vm.values, allocation: {vm_ubid: vm.ubid, vm_host_ubid: vm_host.ubid}} }
@@ -452,7 +453,7 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
   end
 
   label def create_billing_record
-    vm.update(display_state: "running")
+    vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned") { {vm: vm.values, provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.created_at}} }
     project = vm.projects.first
     hop_wait unless project.billable

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Prog::Vm::Nexus do
     disk_2 = VmStorageVolume.new(boot: false, size_gib: 15, disk_index: 1, use_bdev_ubi: true, skip_sync: true)
     disk_2.spdk_installation = si
     disk_2.storage_device = dev2
-    vm = Vm.new(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "hetzner-hel1").tap {
+    vm = Vm.new(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "hetzner-hel1", created_at: Time.now).tap {
       _1.id = "2464de61-7501-8374-9ab0-416caebe31da"
       _1.vm_storage_volumes.append(disk_1)
       _1.vm_storage_volumes.append(disk_2)
@@ -674,7 +674,9 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe "#create_billing_record" do
     before do
-      expect(vm).to receive(:update).with(display_state: "running").and_return(true)
+      now = Time.now
+      expect(Time).to receive(:now).and_return(now).at_least(:once)
+      expect(vm).to receive(:update).with(display_state: "running", provisioned_at: now).and_return(true)
       expect(Clog).to receive(:emit).with("vm provisioned")
     end
 


### PR DESCRIPTION
### Refactor vm allocation log
The IPv4 allocation follows this line. Even if we print this, we may not allocate a VM on this host. It's best to print when the allocation is finalized.

In the past, we encountered concurrency and lease violation problems with respirate, resulting in the same IP being assigned to multiple VMs. We included detailed information in the log to assist with debugging. However, these values have become too verbose and are no longer useful.

### Add migration to add provisioning timestamps to virtual machine

### Add provisioning timestamps to virtual machine model
The virtual machine model only includes a 'created_at' timestamp, which we use to track provisioning times. However, this also covers the waiting time in the queue if there's insufficient capacity. As the virtual machine is a core model for us, I suggest tracking allocation and provisioning times separately. This could enhance our understanding of provisioning times and help us improve them.
