### PR TITLE
Add a program to remove an spdk installation

### DIFF
--- a/model/spdk_installation.rb
+++ b/model/spdk_installation.rb
@@ -7,6 +7,7 @@ LEGACY_SPDK_VERSION = "LEGACY_SPDK_VERSION"
 
 class SpdkInstallation < Sequel::Model
   many_to_one :vm_host
+  one_to_many :vm_storage_volumes
 
   def self.generate_uuid
     UBID.generate(UBID::TYPE_ETC).to_uuid

--- a/prog/storage/remove_spdk.rb
+++ b/prog/storage/remove_spdk.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Prog::Storage::RemoveSpdk < Prog::Base
+  subject_is :spdk_installation
+
+  def self.assemble(spdk_installation_id)
+    Strand.create_with_id(
+      prog: "Storage::RemoveSpdk",
+      label: "start",
+      stack: [{
+        "subject_id" => spdk_installation_id
+      }]
+    )
+  end
+
+  label def start
+    vm_host = spdk_installation.vm_host
+
+    fail "Can't remove SPDK from hosts with less than 2 SPDK installations" if vm_host.spdk_installations.length < 2
+
+    spdk_installation.update(allocation_weight: 0)
+
+    hop_wait_volumes
+  end
+
+  label def wait_volumes
+    nap 30 if spdk_installation.vm_storage_volumes.length > 0
+    hop_remove_spdk
+  end
+
+  label def remove_spdk
+    version = spdk_installation.version
+    sshable = spdk_installation.vm_host.sshable
+    sshable.cmd("sudo host/bin/setup-spdk remove #{version.shellescape}")
+
+    hop_update_database
+  end
+
+  label def update_database
+    vm_host = spdk_installation.vm_host
+    VmHost.where(id: vm_host.id).update(used_hugepages_1g: Sequel[:used_hugepages_1g] - 2)
+    spdk_installation.destroy
+
+    pop "SPDK installation was removed"
+  end
+end

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -29,7 +29,7 @@ class Prog::Storage::SetupSpdk < Prog::Base
 
     fail "Can't install more than 2 SPDKs on a host" if vm_host.spdk_installations.length > 1
 
-    fail "No available hugepages" if frame["start_service"] && vm_host.used_hugepages_1g == vm_host.total_hugepages_1g
+    fail "No available hugepages" if frame["start_service"] && vm_host.used_hugepages_1g > vm_host.total_hugepages_1g - 2
 
     SpdkInstallation.create(
       version: frame["version"],
@@ -64,7 +64,7 @@ class Prog::Storage::SetupSpdk < Prog::Base
     ).update(allocation_weight: frame["allocation_weight"])
 
     if frame["start_service"]
-      VmHost.where(id: vm_host.id).update(used_hugepages_1g: Sequel[:used_hugepages_1g] + 1)
+      VmHost.where(id: vm_host.id).update(used_hugepages_1g: Sequel[:used_hugepages_1g] + 2)
     end
 
     pop "SPDK was setup"

--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -29,4 +29,7 @@ when "start"
   spdk_setup.start_services
 when "verify"
   spdk_setup.verify_spdk
+when "remove"
+  spdk_setup.stop_and_remove_services
+  spdk_setup.remove_paths
 end

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -217,6 +217,21 @@ SPDK_HUGEPAGES_MOUNT
     r "systemctl start #{spdk_service}"
   end
 
+  def stop_and_remove_services
+    r "systemctl stop #{spdk_service}"
+    r "systemctl stop #{hugepages_mount_service}"
+    r "systemctl disable #{spdk_service}"
+    r "systemctl disable #{hugepages_mount_service}"
+    FileUtils.rm_f("/lib/systemd/system/#{spdk_service}")
+    FileUtils.rm_f("/lib/systemd/system/#{hugepages_mount_service}")
+  end
+
+  def remove_paths
+    FileUtils.rm_f(conf_path)
+    FileUtils.rm_rf(hugepages_dir)
+    FileUtils.rm_rf(install_path)
+  end
+
   def verify_spdk
     status = (r "systemctl is-active #{spdk_service}").strip
     fail "SPDK failed to start" unless status == "active"

--- a/spec/prog/storage/remove_spdk_spec.rb
+++ b/spec/prog/storage/remove_spdk_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Storage::RemoveSpdk do
+  subject(:remove_spdk) {
+    described_class.new(described_class.assemble(
+      "2f7071b5-3a0e-85da-9727-8a32fbcbd94b"
+    ))
+  }
+
+  let(:spdk_version) { "v23.09-ubi-0.2" }
+  let(:sshable) {
+    instance_double(Sshable)
+  }
+  let(:vm_host) {
+    vmh = instance_double(VmHost)
+    allow(vmh).to receive_messages(
+      sshable: sshable,
+      spdk_installations: ["spdk_1", "spdk_2"],
+      id: "d05761b4-2cad-8b71-a300-ded6153e02b2"
+    )
+    vmh
+  }
+  let(:spdk_installation) {
+    si = instance_double(SpdkInstallation)
+    allow(si).to receive_messages(vm_host: vm_host, version: spdk_version)
+    si
+  }
+
+  before do
+    allow(remove_spdk).to receive(:spdk_installation).and_return(spdk_installation)
+  end
+
+  describe "#start" do
+    it "hops to wait_volumes" do
+      expect(spdk_installation).to receive(:update).with(allocation_weight: 0)
+      expect { remove_spdk.start }.to hop("wait_volumes")
+    end
+
+    it "fails if already contains 1 installations" do
+      expect(vm_host).to receive(:spdk_installations).and_return(["spdk_1"])
+      expect { remove_spdk.start }.to raise_error RuntimeError, "Can't remove SPDK from hosts with less than 2 SPDK installations"
+    end
+  end
+
+  describe "#wait_volumes" do
+    it "waits until all volumes using the installation are destroyed" do
+      expect(spdk_installation).to receive(:vm_storage_volumes).and_return([:vm])
+      expect { remove_spdk.wait_volumes }.to nap(30)
+    end
+
+    it "hops to remove_spdk if no volumes are using the installation" do
+      expect(spdk_installation).to receive(:vm_storage_volumes).and_return([])
+      expect { remove_spdk.wait_volumes }.to hop("remove_spdk")
+    end
+  end
+
+  describe "#remove_spdk" do
+    it "hops to update_database" do
+      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-spdk remove v23.09-ubi-0.2")
+      expect { remove_spdk.remove_spdk }.to hop("update_database")
+    end
+  end
+
+  describe "#update_database" do
+    it "updates the database and exits" do
+      expect(spdk_installation).to receive(:destroy)
+      expect { remove_spdk.update_database }.to exit({"msg" => "SPDK installation was removed"})
+    end
+  end
+end

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Prog::Storage::SetupSpdk do
       location: "xyz",
       arch: "x64",
       used_hugepages_1g: 0,
-      total_hugepages_1g: 1
+      total_hugepages_1g: 2
     ) { _1.id = "adec2977-74a9-8b71-8473-cf3940a45ac5" }
   }
 
@@ -75,7 +75,7 @@ RSpec.describe Prog::Storage::SetupSpdk do
   describe "#update_database" do
     it "updates the database and exits" do
       expect { setup_spdk.update_database }.to exit({"msg" => "SPDK was setup"})
-      expect(vm_host.reload.used_hugepages_1g).to eq(1)
+      expect(vm_host.reload.used_hugepages_1g).to eq(2)
     end
 
     it "doesn't reserve a hugepage if service didn't start" do


### PR DESCRIPTION
Current spdk upgrade path is to install a new spdk version and then remove the older version. We could install a new version using `Prog::Storage::SetupSpdk.assemble(host_id, version)`, but a program to remove an older version was missing.

This PR adds that. This program disables the installation by setting its allocation_wait to 0, then waits until volumes using that installation has been destroyed, and then removes it.

This is supposed to be invoked manually by an operator. To invoke it, one should do:

```
> Prog::Storage::RemoveSpdk.assemble(spdk_installation_id)
```