### PR TITLE
Validate FirewallRule port ranges in the UI

### DIFF
--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -27,7 +27,7 @@ class CloverWeb
           port_range = if r.params["port_range"].empty?
             [0, 65535]
           else
-            r.params["port_range"].split("..").map(&:to_i)
+            Validation.validate_port_range(r.params["port_range"])
           end
 
           pg_range = Sequel.pg_range(port_range.first..port_range.last)


### PR DESCRIPTION
The previous implementation left the validation to a database constraint which caused a poor user experience by getting 500 if the port range is invalid. Now, we have the validation function implemented for APIs, we can make use of it the same way in the UI.