### PR TITLE
Fix setup-nftables for VmHosts without additional subnets

### DIFF
--- a/rhizome/host/bin/setup-nftables.rb
+++ b/rhizome/host/bin/setup-nftables.rb
@@ -28,7 +28,7 @@ table inet drop_unused_ip_packets {
   set blocked_ipv4_addresses {
     type ipv4_addr;
     flags interval;
-    elements = {#{ip_ranges_to_block.join(",")}}
+#{ip_ranges_to_block.empty? ? "" : "elements = {#{ip_ranges_to_block.join(",")}}"}
   }
 
   chain prerouting {


### PR DESCRIPTION
The empty set intialization in the nftables setup is causing issues when vmhost does not have any additional subnet. With this commit, we are fixing this issue. In case the subnet is added later on, we already create a new strand to repopulate the set, therefore this is safe.