### PR TITLE
Initialize rodauth per documentation

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -323,10 +323,11 @@ class CloverWeb < Roda
     end
     check_csrf!
 
-    rodauth.load_memory
-    rodauth.check_active_session
     @current_user = Account[rodauth.session_value]
     r.rodauth
+    rodauth.load_memory
+    rodauth.check_active_session
+
     r.root do
       r.redirect rodauth.login_route
     end


### PR DESCRIPTION
Normally, you are to call `#rodauth` first, before using its features such as `load_memory`.  Now it seems that the way we had it worked as expected, but it was contra-documentation.

To double check, checked the Rodauth test suite, which has code like this in `password_grace_period_spec.rb`, so indeed, we were unusual.

    roda do |r|
      r.rodauth
      rodauth.load_memory
      r.root do