### PR TITLE
Make number of SPDK cpus a function of host cpu count.

### DIFF
--- a/migrate/20240326_add_spdk_cpu_count.rb
+++ b/migrate/20240326_add_spdk_cpu_count.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:spdk_installation) do
+      add_column :cpu_count, :int, default: 2, null: false
+    end
+  end
+end

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -34,17 +34,27 @@ class Prog::Storage::SetupSpdk < Prog::Base
     SpdkInstallation.create(
       version: frame["version"],
       allocation_weight: 0,
-      vm_host_id: vm_host.id
+      vm_host_id: vm_host.id,
+      cpu_count: spdk_cpu_count(total_host_cpus: vm_host.total_cpus)
     ) { _1.id = SpdkInstallation.generate_uuid }
 
     hop_install_spdk
   end
 
   label def install_spdk
-    version = frame["version"]
-    sshable.cmd("sudo host/bin/setup-spdk install #{version.shellescape}")
+    q_version = frame["version"].shellescape
+    cpu_count = spdk_cpu_count(total_host_cpus: vm_host.total_cpus)
+    sshable.cmd("sudo host/bin/setup-spdk install #{q_version} #{cpu_count}")
 
     hop_start_service
+  end
+
+  def spdk_cpu_count(total_host_cpus:)
+    if total_host_cpus <= 64
+      2
+    else
+      4
+    end
   end
 
   label def start_service

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -73,14 +73,11 @@ class Prog::Vm::HostNexus < Prog::Base
       when "LearnCores"
         total_cores = st.exitval.fetch("total_cores")
         total_cpus = st.exitval.fetch("total_cpus")
-        # Currently all SPDK installations share vcpus 0 and 1.
-        spdk_cores = (2 * total_cores) / total_cpus
         kwargs = {
           total_sockets: st.exitval.fetch("total_sockets"),
           total_dies: st.exitval.fetch("total_dies"),
           total_cores: total_cores,
-          total_cpus: total_cpus,
-          used_cores: spdk_cores
+          total_cpus: total_cpus
         }
 
         vm_host.update(**kwargs)
@@ -124,6 +121,9 @@ class Prog::Vm::HostNexus < Prog::Base
   label def wait_setup_spdk
     reap
     if leaf?
+      spdk_installation = vm_host.spdk_installations.first
+      spdk_cores = (spdk_installation.cpu_count * vm_host.total_cores) / vm_host.total_cpus
+      vm_host.update(used_cores: spdk_cores)
       hop_prep_reboot
     end
     donate

--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -20,10 +20,12 @@ spdk_setup = SpdkSetup.new(version)
 
 case verb
 when "install"
+  # use a default of 2 for backward compatibility
+  cpu_count = ARGV.shift || 2
   spdk_setup.install_package
   spdk_setup.create_hugepages_mount
   spdk_setup.create_conf
-  spdk_setup.create_service
+  spdk_setup.create_service(cpu_count: cpu_count.to_i)
   spdk_setup.enable_services
 when "start"
   spdk_setup.start_services

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -85,9 +85,10 @@ class SpdkSetup
     end
   end
 
-  def create_service
+  def create_service(cpu_count:)
     user = SpdkPath.user
     vhost_binary = SpdkPath.bin(@spdk_version, vhost_target)
+    cpumask = (0..cpu_count - 1).to_a.join(",")
     File.write("/lib/systemd/system/#{spdk_service}", <<SPDK_SERVICE
 [Unit]
 Description=Block Storage Service #{@spdk_version}
@@ -99,7 +100,7 @@ ExecStart=#{vhost_binary} -S #{SpdkPath.vhost_dir.shellescape} \
 --huge-dir #{hugepages_dir.shellescape} \
 --iova-mode va \
 --rpc-socket #{rpc_sock.shellescape} \
---cpumask [0,1] \
+--cpumask [#{cpumask}] \
 --disable-cpumask-locks \
 --config #{conf_path.shellescape}
 ExecReload=/bin/kill -HUP $MAINPID

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SpdkSetup do
   describe "#create_service" do
     it "creates the service file" do
       expect(File).to receive(:write).with("/lib/systemd/system/spdk-#{spdk_version}.service", /.*/)
-      expect { spdk_setup.create_service }.not_to raise_error
+      expect { spdk_setup.create_service(cpu_count: 4) }.not_to raise_error
     end
   end
 

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Prog::Storage::SetupSpdk do
       location: "xyz",
       arch: "x64",
       used_hugepages_1g: 0,
-      total_hugepages_1g: 2
+      total_hugepages_1g: 2,
+      total_cpus: 96
     ) { _1.id = "adec2977-74a9-8b71-8473-cf3940a45ac5" }
   }
 
@@ -54,7 +55,7 @@ RSpec.describe Prog::Storage::SetupSpdk do
 
   describe "#install_spdk" do
     it "installs and hops to start_service" do
-      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-spdk install #{spdk_version}")
+      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-spdk install #{spdk_version} 4")
       expect { setup_spdk.install_spdk }.to hop("start_service")
     end
   end
@@ -82,6 +83,20 @@ RSpec.describe Prog::Storage::SetupSpdk do
       allow(setup_spdk).to receive(:frame).and_return({"version" => spdk_version, "start_service" => false})
       expect { setup_spdk.update_database }.to exit({"msg" => "SPDK was setup"})
       expect(vm_host.reload.used_hugepages_1g).to eq(0)
+    end
+  end
+
+  describe "#spdk_cpu_count" do
+    it "uses 2 cpus for AX161" do
+      expect(setup_spdk.spdk_cpu_count(total_host_cpus: 64)).to eq(2)
+    end
+
+    it "uses 4 cpus for RX220" do
+      expect(setup_spdk.spdk_cpu_count(total_host_cpus: 80)).to eq(4)
+    end
+
+    it "uses 4 cpus for AX162" do
+      expect(setup_spdk.spdk_cpu_count(total_host_cpus: 96)).to eq(4)
     end
   end
 end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
       expect(vm_host).to receive(:update).with(arch: "arm64")
-      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2, used_cores: 1)
+      expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2)
       expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),
@@ -209,7 +209,14 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:reap).and_return([])
       expect(nx).to receive(:leaf?).and_return true
       vmh = instance_double(VmHost)
-      nx.instance_variable_set(:@vm_host, vmh)
+      spdk_installation = SpdkInstallation.new(cpu_count: 4)
+      allow(vmh).to receive_messages(
+        spdk_installations: [spdk_installation],
+        total_cores: 48,
+        total_cpus: 96
+      )
+      allow(nx).to receive(:vm_host).and_return(vmh)
+      expect(vmh).to receive(:update).with({used_cores: 2})
 
       expect { nx.wait_setup_spdk }.to hop("prep_reboot")
     end


### PR DESCRIPTION
Previously we always used 2 cpus for SPDK. But this is not ideal since in larger hosts we can fit more VMs, which meant less I/O capacity. To address this, we make SPDK cpu count a function of host cpu count and allocate 4 SPDK cpus when host cpus are more than 64, and 2 otherwise.

This means we'll have 2 SPDK cpus in AX161 which has 64 cpus, but 4 SPDK cpus in AX162 which has 96 cpus. Number of SPDK cpus will also be 4 in RX220, which has 80 host cpus.

Also note that this doesn't further decrease the VM capacity in AX162, since in practice we could reserve 374 out of 384 hugepages which already reduced VM capacity to 46.