### PR TITLE
Fix shifted index in test database setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ task :setup_database, [:env, :parallel] do |_, args|
   database_count.times do |i|
     threads << Thread.new do
       puts "Creating database #{i}..."
-      database_name = "clover_#{args[:env]}#{args[:parallel] ? i : ""}"
+      database_name = "clover_#{args[:env]}#{args[:parallel] ? (i + 1) : ""}"
       `dropdb --if-exists -U postgres #{database_name}`
       `createdb -U postgres -O clover #{database_name}`
       `psql -U postgres -c 'CREATE EXTENSION citext; CREATE EXTENSION btree_gist;' #{database_name}`


### PR DESCRIPTION
We initially implemented this for parallel_tests gem, which uses 0-indexed database names, however we then switched to turbo_tests, because its output format is better. turbo_tests uses 1-indexed database names, so we need to fix the database_setup to use 1-indexed names.