### PR TITLE
Add nil check in failover_target

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -110,6 +110,8 @@ class PostgresServer < Sequel::Model
       .map { {server: _1, lsn: _1.run_query("SELECT pg_last_wal_receive_lsn()").chomp} }
       .max_by { lsn2int(_1[:lsn]) }
 
+    return nil if target.nil?
+
     if resource.ha_type == PostgresResource::HaType::ASYNC
       return nil if lsn_monitor.last_known_lsn.nil?
       return nil if lsn_diff(lsn_monitor.last_known_lsn, target[:lsn]) > 80 * 1024 * 1024 # 80 MB or ~5 WAL files

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -93,12 +93,17 @@ RSpec.describe PostgresServer do
   describe "#failover_target" do
     before do
       postgres_server.timeline_access = "push"
-      expect(resource).to receive(:servers).and_return([
+      allow(resource).to receive(:servers).and_return([
         postgres_server,
         instance_double(described_class, ubid: "pgubidstandby1", standby?: true, strand: instance_double(Strand, label: "wait_catch_up")),
         instance_double(described_class, ubid: "pgubidstandby2", standby?: true, run_query: "1/5", strand: instance_double(Strand, label: "wait")),
         instance_double(described_class, ubid: "pgubidstandby3", standby?: true, run_query: "1/10", strand: instance_double(Strand, label: "wait"))
       ])
+    end
+
+    it "returns nil if there is no standby" do
+      expect(resource).to receive(:servers).and_return([postgres_server]).at_least(:once)
+      expect(postgres_server.failover_target).to be_nil
     end
 
     it "returns the standby with highest lsn in sync replication" do


### PR DESCRIPTION
If there is no failover target found, we should exit early and return nil. Next lines in the code tries to access target, which is nil and will raise an error.