### PR TITLE
Fix GithubRunner setup_environment actions-runner script idempotency

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -190,6 +190,14 @@ class Prog::Vm::GithubRunner < Prog::Base
       # To make sure the script errors out if any command fails
       set -ueo pipefail
 
+      # In case the script is run until we mv to /home/runner but the state
+      # could not progress because of any reason (e.g. deployment, runner
+      # failure), the idempotency is broken. The script needs to be copied back
+      # to the home directory of the runneradmin. More information regarding the
+      # operation can be found in the middle of the script where we chown the
+      # actions-runner.
+      sudo [ ! -d /home/runner/actions-runner ] || sudo mv /home/runner/actions-runner ./
+
       # Since standard Github runners have both runneradmin and runner users
       # VMs of github runners are created with runneradmin user. Adding
       # runner user and group with the same id and gid as the standard.
@@ -225,7 +233,6 @@ class Prog::Vm::GithubRunner < Prog::Base
       # line, and the latter guarateens to continue if the script fails after moving
       # actions-runner from ./ to /home/runner
       sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./
-      sudo [ ! -d /home/runner/actions-runner ] || sudo mv /home/runner/actions-runner ./
       sudo chown -R runneradmin:runneradmin actions-runner
 
       # ./env.sh sets some variables for runner to run properly

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -371,6 +371,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
+        sudo [ ! -d /home/runner/actions-runner ] || sudo mv /home/runner/actions-runner ./
         sudo userdel -rf runner || true
         sudo addgroup --gid 1001 runner
         sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
@@ -379,7 +380,6 @@ RSpec.describe Prog::Vm::GithubRunner do
         sudo su -c "find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} ';'"
         source /etc/environment
         sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./
-        sudo [ ! -d /home/runner/actions-runner ] || sudo mv /home/runner/actions-runner ./
         sudo chown -R runneradmin:runneradmin actions-runner
         ./actions-runner/env.sh
         cat <<EOT > ./actions-runner/run-withenv.sh


### PR DESCRIPTION
In case the script is run until we mv to /home/runner but the state could not progress because of any reason (e.g. deployment, runner failure), the idempotency is broken. The script needs to be copied back to the home directory of the runneradmin. More information regarding the operation can be found in the middle of the script where we chown the actions-runner.