### PR TITLE
Update ubuntu-jammy release to 20240319

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -461,7 +461,7 @@ EOS
 
   def download_boot_image(boot_image, custom_url: nil, ca_path: nil)
     urls = {
-      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
+      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-20240319/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
       "almalinux-9.1" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-latest.#{_1}.qcow2" },
       "github-ubuntu-2204" => nil,
       "github-ubuntu-2004" => nil,

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe VmSetup do
       end.and_yield
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images/")
       expect(Arch).to receive(:render).and_return("amd64").at_least(:once)
-      expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20231010/ubuntu-22.04-server-cloudimg-amd64.img")
+      expect(vs).to receive(:r).with("curl -f -L10 -o /var/storage/images/ubuntu-jammy.img.tmp https://cloud-images.ubuntu.com/releases/jammy/release-20240319/ubuntu-22.04-server-cloudimg-amd64.img")
       expect(vs).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy.img.tmp /var/storage/images/ubuntu-jammy.raw")
       expect(FileUtils).to receive(:rm_r).with("/var/storage/images/ubuntu-jammy.img.tmp")
 


### PR DESCRIPTION
There has been a recent vulnerability discovery that impacts kernel versions linux-5.15.y, linux-6.1.y, and linux-6.6.y. Our version of ubuntu-jammy comes with kernel 5.15.0-86-generic which is vulnerable. There has been patches to the kernel versions to mitigate the issue. Looks like the recently published ubuntu-jammy images come with kernel 5.15.0-101-generic which has the patches applied according to; https://www.ubuntuupdates.org/package/core/jammy/main/updates/linux-tools-5.15.0-101-generic

More information regarding the vulnerability can be found here;
- https://pwning.tech/nftables/
- https://www.cvedetails.com/cve/CVE-2024-1086/
- https://news.ycombinator.com/item?id=39828424

We will also need to upgrade the kernel in our hosts and replace the images in existing hosts to create the new VMs from.