### PR TITLE
Monitor VmHosts and Vm resources

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -3,7 +3,7 @@
 
 require_relative "../loader"
 
-MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer, GithubRunner, VmHost]
+MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer, GithubRunner, VmHost, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists)]
 
 sessions = {}
 ssh_threads = {}

--- a/bin/monitor
+++ b/bin/monitor
@@ -3,7 +3,7 @@
 
 require_relative "../loader"
 
-MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer, GithubRunner]
+MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer, GithubRunner, VmHost]
 
 sessions = {}
 ssh_threads = {}

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -8,7 +8,7 @@ class Prog::PageNexus < Prog::Base
     DB.transaction do
       pg = Page.from_tag_parts(tag_parts)
       unless pg
-        pg = Page.create_with_id(summary: summary, details: {"related_resources" => related_resources}, tag: Page.generate_tag(tag_parts))
+        pg = Page.create_with_id(summary: summary, details: {"related_resources" => Array(related_resources)}, tag: Page.generate_tag(tag_parts))
         Strand.create(prog: "PageNexus", label: "start") { _1.id = pg.id }
       end
     end


### PR DESCRIPTION
This just monitors the VmHost and Vm resources, and creates a page when there is a failure. It does not try to heal it. After using this for a while in prod, we can decide on how the automated healing would look like.

Also fixes #1382 