### PR TITLE
Increase utilization limit to 70% for soft concurrency limit

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -138,7 +138,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       sum(:used_cores) * 100.0 / sum(:total_cores)
     }.first.to_f
 
-    unless utilization < 60
+    unless utilization < 70
       Clog.emit("Waiting for customer concurrency limit, utilization is high") { {github_runner: github_runner.values, utilization: utilization} }
       nap 5
     end


### PR DESCRIPTION
Looking into the pages received, looks like 60% is doing a good job keeping the utilization low and allowing customers to go ahead in not so busy times. I would like to test the utilization limit at 70%. This will allow higher limits for customers and possible less wait time for big players.