### PR TITLE
Kill active processes in the namespace when purging

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -573,6 +573,6 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
 
     decr_start_after_host_reboot
 
-    hop_wait
+    hop_update_firewall_rules
   end
 end

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -114,6 +114,13 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     block_ip4
 
     begin
+      pids = r "ip netns pids #{q_vm}"
+      pids.split.each { |pid| r "kill -9 #{pid}" }
+    rescue CommandFail => ex
+      raise unless ex.stderr.include?("Cannot open network namespace: No such file or directory")
+    end
+
+    begin
       r "ip netns del #{q_vm}"
     rescue CommandFail => ex
       raise unless /Cannot remove namespace file ".*": No such file or directory/.match?(ex.stderr)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -164,6 +164,13 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def interfaces(nics, multiqueue)
+    begin
+      pids = r "ip netns pids #{q_vm}"
+      pids.split.each { |pid| r "kill -9 #{pid}" }
+    rescue CommandFail => ex
+      raise unless ex.stderr.include?("Cannot open network namespace: No such file or directory")
+    end
+
     # We first delete the network namespace for idempotency. Instead
     # we could catch various exceptions for each command run, and if
     # the error message matches certain text, we could resume. But

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -886,7 +886,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:update).with(display_state: "starting")
       expect(vm).to receive(:update).with(display_state: "running")
 
-      expect { nx.start_after_host_reboot }.to hop("wait")
+      expect { nx.start_after_host_reboot }.to hop("update_firewall_rules")
     end
   end
 end


### PR DESCRIPTION
Looks like deleting namespace alone is not enough to cleanup all the VM processes from the host. Namespace delete succeeds but residue interfaces may continue existing untill all the processes die. With this commit, we hard kill all the processes before issues namespace delete.