### PR TITLE
Nap randomly when concurrency limit reached

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -140,7 +140,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     unless utilization < 70
       Clog.emit("Waiting for customer concurrency limit, utilization is high") { {github_runner: github_runner.values, utilization: utilization} }
-      nap 5
+      nap rand(5..15)
     end
 
     Clog.emit("Concurrency limit reached but allocation is allowed because of low utilization") { {github_runner: github_runner.values, utilization: utilization} }

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
       expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
 
-      expect { nx.wait_concurrency_limit }.to nap(5)
+      expect { nx.wait_concurrency_limit }.to nap
     end
 
     it "hops to allocate_vm when customer concurrency limit frees up" do


### PR DESCRIPTION
When customer concurrency limit is reached, we run a utilization check. If the utilization is low enough, we allow them to provision the VM, anyway. However, if the utilization is higher than a set value, we used to nap 5 seconds and run the same cycle. The problem with this approach is that when we get a flood of requests in the same time, generally, the utilization check times are almost the same. However, the utilization value only changes when the VM entity is created and allocated. Therefore, we cannot really catch the real utilization. To be more clear, let's say we had a concurrency limit of 100 vcpus and since the global utilization was low, we could get up to 150 vcpu usage. On top of it, we have 10 more runners waiting to get concurrency limit free up or the utilization to get below 70%. The moment 1 VM gets deprovisioned and the utilization gets to (let's say) 69%, those 10 runners almost simultenaously check the utilization and get the permission to provision the VMs. This creates another flooding in the system. We do not want to get strict locks on VmHosts to learn the utilization, hence, I think sleeping the processes with random intervals will help reduce the impact.