### PR TITLE
Idempotent group creation on setup_environment state of github_runner prog

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -201,7 +201,11 @@ class Prog::Vm::GithubRunner < Prog::Base
       # Since standard Github runners have both runneradmin and runner users
       # VMs of github runners are created with runneradmin user. Adding
       # runner user and group with the same id and gid as the standard.
+      # Although userdel command deletes the group as well, separate groupdel
+      # command is added to make sure that script can run idempotently if failing
+      # after addgroup but before adduser command below.
       sudo userdel -rf runner || true
+      sudo groupdel -f runner || true
       sudo addgroup --gid 1001 runner
       sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
       echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -373,6 +373,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         set -ueo pipefail
         sudo [ ! -d /home/runner/actions-runner ] || sudo mv /home/runner/actions-runner ./
         sudo userdel -rf runner || true
+        sudo groupdel -f runner || true
         sudo addgroup --gid 1001 runner
         sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
         echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner


### PR DESCRIPTION
Making group creation idempotent while setting up the environment for a github runner.

Userdel command deletes the group if the user exists. Though if the script fails after addgroup command but before adduser command there will be a group but no user. So, the group won't be deleted. Adding explicit groupdel command makes sure that group will be deleted anyway and guarantees the next run of the script after failure idempotent.