### PR TITLE
Add runneradmin user to sudo and adm groups on github runner

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -210,6 +210,11 @@ class Prog::Vm::GithubRunner < Prog::Base
       # Default GitHub hosted runners have additional adm,systemd-journal groups.
       sudo usermod -a -G docker,adm,systemd-journal runner
 
+      # runneradmin user on default Github hosted runners is a member of adm and
+      # sudo groups. Having sudo access also allows us getting journalctl logs in
+      # case of any issue on the destroy state below by runneradmin user.
+      sudo usermod -a -G sudo,adm runneradmin
+
       # Some configuration files such as $PATH related to the user's home directory
       # need to be changed. GitHub recommends to run post-generation scripts after
       # initial boot.

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -377,6 +377,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         sudo adduser --disabled-password --uid 1001 --gid 1001 --gecos '' runner
         echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-runner
         sudo usermod -a -G docker,adm,systemd-journal runner
+        sudo usermod -a -G sudo,adm runneradmin
         sudo su -c "find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} ';'"
         source /etc/environment
         sudo [ ! -d /usr/local/share/actions-runner ] || sudo mv /usr/local/share/actions-runner ./


### PR DESCRIPTION
Runneradmin user on default Github runners is member of sudo and adm groups. Mimicking the same behaviour for our runners. It also allows us to get journalctl logs on the destroy state by runneradmin user.