### PR TITLE
Add mapping from display location name to internal location name

### DIFF
--- a/config/providers.yml
+++ b/config/providers.yml
@@ -1,0 +1,11 @@
+[
+  {
+    provider_display_name: Hetzner,
+    provider_internal_name: hetzner,
+    locations: [
+      {display_name: eu-central-h1, internal_name: hetzner-fsn1, visible: true },
+      {display_name: eu-north-h1, internal_name: hetzner-hel1, visible: true },
+      {display_name: github-runners, internal_name: github-runners, visible: false }
+    ]
+  }
+]

--- a/demo/cloudify_server
+++ b/demo/cloudify_server
@@ -6,7 +6,7 @@ REPL = true
 require_relative "../loader"
 require "timeout"
 
-LOCATIONS = Option::Locations.map { |l| [l.name, "#{l.provider.display_name} #{l.display_name}"] }.to_h
+LOCATIONS = Option::LOCATIONS.map { |l| [l.name, "#{l.provider.display_name} #{l.display_name}"] }.to_h
 
 def get_input(msg, default = nil)
   prompt = "#{msg}#{default.nil? ? "" : " [default: #{default}]"}: "

--- a/lib/location_name_converter.rb
+++ b/lib/location_name_converter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module LocationNameConverter
+  def self.to_internal_name(display_name)
+    Option::LOCATIONS.find { _1.display_name == display_name }&.name
+  end
+
+  def self.to_display_name(internal_name)
+    Option::LOCATIONS.find { _1.name == internal_name }&.display_name
+  end
+end

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -45,8 +45,8 @@ module Validation
   end
 
   def self.validate_provider(provider)
-    msg = "\"#{provider}\" is not a valid provider. Available providers: #{Option::Providers.keys}"
-    fail ValidationFailed.new({provider: msg}) unless Option::Providers.key?(provider)
+    msg = "\"#{provider}\" is not a valid provider. Available providers: #{Option::PROVIDERS.keys}"
+    fail ValidationFailed.new({provider: msg}) unless Option::PROVIDERS.key?(provider)
   end
 
   def self.validate_location(location, provider = nil)

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -51,7 +51,7 @@ module Validation
 
   def self.validate_location(location, provider = nil)
     available_locs = Option.locations_for_provider(provider, only_visible: false).map(&:name)
-    msg = "\"#{location}\" is not a valid location for provider \"#{provider}\". Available locations: #{available_locs}"
+    msg = "Given location is not a valid location for provider \"#{provider}\". Available locations: #{available_locs.map { LocationNameConverter.to_display_name(_1) }}"
     fail ValidationFailed.new({provider: msg}) unless available_locs.include?(location)
   end
 

--- a/migrate/20240417_rename_tag_location_names.rb
+++ b/migrate/20240417_rename_tag_location_names.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    run <<~SQL
+      UPDATE access_policy
+      SET body = (regexp_replace(body::text, 'hetzner-hel1', 'eu-north-h1', 'g'))::jsonb;
+
+      UPDATE access_policy
+      SET body = (regexp_replace(body::text, 'hetzner-fsn1', 'eu-central-h1', 'g'))::jsonb;
+
+      UPDATE access_tag
+      SET name = (regexp_replace(name, 'hetzner-hel1', 'eu-north-h1'));
+
+      UPDATE access_tag
+      SET name = (regexp_replace(name, 'hetzner-fsn1', 'eu-central-h1'));
+    SQL
+  end
+
+  down do
+    run <<~SQL
+      UPDATE access_policy
+      SET body = (regexp_replace(body::text, 'eu-north-h1', 'hetzner-hel1', 'g'))::jsonb;
+
+      UPDATE access_policy
+      SET body = (regexp_replace(body::text, 'eu-central-h1', 'hetzner-fsn1', 'g'))::jsonb;
+
+      UPDATE access_tag
+      SET name = (regexp_replace(name, 'eu-north-h1', 'hetzner-hel1'));
+
+      UPDATE access_tag
+      SET name = (regexp_replace(name, 'eu-central-h1', 'hetzner-fsn1'));
+    SQL
+  end
+end

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -26,7 +26,11 @@ class MinioCluster < Sequel::Model
   end
 
   def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{location}/minio-cluster/#{name}"
+    "project/#{project.ubid}/location/#{display_location}/minio-cluster/#{name}"
+  end
+
+  def display_location
+    LocationNameConverter.to_display_name(location)
   end
 
   def generate_etc_hosts_entry

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -30,12 +30,16 @@ class PostgresResource < Sequel::Model
     enc.column :server_cert_key
   end
 
+  def display_location
+    LocationNameConverter.to_display_name(location)
+  end
+
   def path
-    "/location/#{location}/postgres/#{name}"
+    "/location/#{display_location}/postgres/#{name}"
   end
 
   def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{location}/postgres/#{name}"
+    "project/#{project.ubid}/location/#{display_location}/postgres/#{name}"
   end
 
   def display_state

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -18,13 +18,17 @@ class PrivateSubnet < Sequel::Model
   dataset_module Authorization::Dataset
   include Authorization::HyperTagMethods
   def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{location}/private-subnet/#{name}"
+    "project/#{project.ubid}/location/#{display_location}/private-subnet/#{name}"
   end
 
   include Authorization::TaggableMethods
 
+  def display_location
+    LocationNameConverter.to_display_name(location)
+  end
+
   def path
-    "/location/#{location}/private-subnet/#{name}"
+    "/location/#{display_location}/private-subnet/#{name}"
   end
 
   include ResourceMethods

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -26,13 +26,17 @@ class Vm < Sequel::Model
   include Authorization::HyperTagMethods
 
   def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{location}/vm/#{name}"
+    "project/#{project.ubid}/location/#{display_location}/vm/#{name}"
   end
 
   include Authorization::TaggableMethods
 
+  def display_location
+    LocationNameConverter.to_display_name(location)
+  end
+
   def path
-    "/location/#{location}/vm/#{name}"
+    "/location/#{display_location}/vm/#{name}"
   end
 
   def ephemeral_net4

--- a/routes/api/project/location.rb
+++ b/routes/api/project/location.rb
@@ -2,8 +2,8 @@
 
 class CloverApi
   hash_branch(:project_prefix, "location") do |r|
-    r.on String do |location_name|
-      @location = location_name
+    r.on String do |location_display_name|
+      @location = LocationNameConverter.to_internal_name(location_display_name)
 
       r.hash_branches(:project_location_prefix)
     end

--- a/routes/web/project/location.rb
+++ b/routes/web/project/location.rb
@@ -2,8 +2,8 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "location") do |r|
-    r.on String do |location_name|
-      @location = location_name
+    r.on String do |location_display_name|
+      @location = LocationNameConverter.to_internal_name(location_display_name)
 
       r.hash_branches(:project_location_prefix)
     end

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -15,9 +15,10 @@ class CloverWeb
       fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
       parsed_size = Validation.validate_postgres_size(r.params["size"])
+      location = LocationNameConverter.to_internal_name(r.params["location"])
       st = Prog::Postgres::PostgresResourceNexus.assemble(
         project_id: @project.id,
-        location: r.params["location"],
+        location: location,
         name: r.params["name"],
         target_vm_size: parsed_size.vm_size,
         target_storage_size_gib: parsed_size.storage_size_gib,

--- a/routes/web/project/private_subnet.rb
+++ b/routes/web/project/private_subnet.rb
@@ -12,11 +12,12 @@ class CloverWeb
 
     r.post true do
       Authorization.authorize(@current_user.id, "PrivateSubnet:create", @project.id)
+      location = LocationNameConverter.to_internal_name(r.params["location"])
 
       st = Prog::Vnet::SubnetNexus.assemble(
         @project.id,
         name: r.params["name"],
-        location: r.params["location"]
+        location: location
       )
 
       flash["notice"] = "'#{r.params["name"]}' will be ready in a few seconds"

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -17,13 +17,14 @@ class CloverWeb
       ps_id = r.params["private-subnet-id"].empty? ? nil : UBID.parse(r.params["private-subnet-id"]).to_uuid
       Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps_id)
 
+      location = LocationNameConverter.to_internal_name(r.params["location"])
       st = Prog::Vm::Nexus.assemble(
         r.params["public-key"],
         @project.id,
         name: r.params["name"],
         unix_user: r.params["user"],
         size: r.params["size"],
-        location: r.params["location"],
+        location: location,
         boot_image: r.params["boot-image"],
         private_subnet_id: ps_id,
         enable_ip4: r.params.key?("enable-ip4")

--- a/serializers/api/postgres.rb
+++ b/serializers/api/postgres.rb
@@ -6,7 +6,7 @@ class Serializers::Api::Postgres < Serializers::Base
       id: pg.ubid,
       name: pg.name,
       state: pg.display_state,
-      location: pg.location,
+      location: pg.display_location,
       vm_size: pg.target_vm_size,
       storage_size_gib: pg.target_storage_size_gib,
       ha_type: pg.ha_type

--- a/serializers/api/private_subnet.rb
+++ b/serializers/api/private_subnet.rb
@@ -6,7 +6,7 @@ class Serializers::Api::PrivateSubnet < Serializers::Base
       id: ps.ubid,
       name: ps.name,
       state: ps.display_state,
-      location: ps.location,
+      location: ps.display_location,
       net4: ps.net4.to_s,
       net6: ps.net6.to_s,
       nics: Serializers::Api::Nic.serialize(ps.nics)

--- a/serializers/api/vm.rb
+++ b/serializers/api/vm.rb
@@ -8,7 +8,7 @@ class Serializers::Api::Vm < Serializers::Base
       id: vm.ubid,
       name: vm.name,
       state: vm.display_state,
-      location: vm.location,
+      location: vm.display_location,
       size: vm.display_size,
       unix_user: vm.unix_user,
       storage_size_gib: vm.storage_size_gib,

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -8,7 +8,7 @@ class Serializers::Web::Postgres < Serializers::Base
       path: pg.path,
       name: pg.name,
       state: pg.display_state,
-      location: pg.location,
+      location: pg.display_location,
       vm_size: pg.target_vm_size,
       storage_size_gib: pg.target_storage_size_gib,
       ha_type: pg.ha_type

--- a/serializers/web/private_subnet.rb
+++ b/serializers/web/private_subnet.rb
@@ -8,7 +8,7 @@ class Serializers::Web::PrivateSubnet < Serializers::Base
       path: ps.path,
       name: ps.name,
       state: ps.display_state,
-      location: ps.location,
+      location: ps.display_location,
       net4: ps.net4.to_s,
       net6: ps.net6.to_s
     }

--- a/serializers/web/project.rb
+++ b/serializers/web/project.rb
@@ -9,7 +9,7 @@ class Serializers::Web::Project < Serializers::Base
       name: p.name,
       credit: p.credit.to_f,
       discount: p.discount,
-      provider: Option::Providers[p.provider]
+      provider: Option::PROVIDERS[p.provider]
     }
   end
 

--- a/serializers/web/vm.rb
+++ b/serializers/web/vm.rb
@@ -8,7 +8,7 @@ class Serializers::Web::Vm < Serializers::Base
       path: vm.path,
       name: vm.name,
       state: vm.display_state,
-      location: vm.location,
+      location: vm.display_location,
       display_size: vm.display_size,
       storage_size_gib: vm.storage_size_gib,
       storage_encryption: vm.storage_encrypted? ? "encrypted" : "not encrypted",

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Authorization do
     it "hyper_tag_name" do
       expect(users[0].hyper_tag_name).to eq("user/auth1@example.com")
       p = vms[0].projects.first
-      expect(vms[0].hyper_tag_name(p)).to eq("project/#{p.ubid}/location/hetzner-hel1/vm/vm0")
+      expect(vms[0].hyper_tag_name(p)).to eq("project/#{p.ubid}/location/eu-north-h1/vm/vm0")
       expect(projects[0].hyper_tag_name).to eq("project/#{projects[0].ubid}")
     end
 

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -62,6 +62,6 @@ RSpec.describe MinioCluster do
 
   it "returns hyper tag name properly" do
     project = instance_double(Project, ubid: "project-ubid")
-    expect(mc.hyper_tag_name(project)).to eq("project/project-ubid/location/hetzner-hel1/minio-cluster/minio-cluster-name")
+    expect(mc.hyper_tag_name(project)).to eq("project/project-ubid/location/eu-north-h1/minio-cluster/minio-cluster-name")
   end
 end

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe PrivateSubnet do
 
   describe "ui utility methods" do
     it "returns path" do
-      expect(private_subnet.path).to eq "/location/hetzner-hel1/private-subnet/ps"
+      expect(private_subnet.path).to eq "/location/eu-north-h1/private-subnet/ps"
     end
 
     it "returns tag name" do
       pr = instance_double(Project, ubid: "prjubid")
-      expect(private_subnet.hyper_tag_name(pr)).to eq "project/prjubid/location/hetzner-hel1/private-subnet/ps"
+      expect(private_subnet.hyper_tag_name(pr)).to eq "project/prjubid/location/eu-north-h1/private-subnet/ps"
     end
   end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -36,84 +36,84 @@ RSpec.describe Clover, "postgres" do
     end
 
     it "not location list" do
-      get "/api/project/#{project.ubid}/location/#{pg.location}/postgres"
+      get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/postgres_name"
+      post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/postgres_name"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete" do
-      delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}"
+      delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete ubid" do
-      delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
+      delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get" do
-      get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}"
+      get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get ubid" do
-      get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
+      get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create firewall rule" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule"
+      post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete firewall rule" do
-      delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
+      delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not restore" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/restore"
+      post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not restore ubid" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/restore"
+      post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/restore"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not reset super user password" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/reset-superuser-password"
+      post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not reset super user password ubid" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/reset-superuser-password"
+      post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/reset-superuser-password"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
@@ -136,7 +136,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "success single" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres"
+        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(1)
@@ -151,7 +151,7 @@ RSpec.describe Clover, "postgres" do
           target_storage_size_gib: 100
         )
 
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres"
+        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(2)
@@ -206,7 +206,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule", {
           cidr: "0.0.0.0/24"
         }.to_json
 
@@ -214,7 +214,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule pg ubid" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/firewall-rule", {
           cidr: "0.0.0.0/24"
         }.to_json
 
@@ -222,7 +222,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule invalid cidr" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule", {
           cidr: "0.0.0"
         }.to_json
 
@@ -237,7 +237,7 @@ RSpec.describe Clover, "postgres" do
         expect(pg.timeline).to receive(:refresh_earliest_backup_completion_time).and_return(restore_target - 10 * 60)
         expect(PostgresResource).to receive(:[]).with(pg.id).and_return(pg)
         expect(PostgresResource).to receive(:[]).and_call_original.at_least(:once)
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/restore", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg",
           restore_target: restore_target
 
@@ -247,7 +247,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "restore invalid target" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/restore", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg",
           restore_target: Time.now.utc
         }.to_json
@@ -256,7 +256,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "reset password" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/reset-superuser-password", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -266,7 +266,7 @@ RSpec.describe Clover, "postgres" do
       it "reset password invalid restore" do
         pg.representative_server.update(timeline_access: "fetch")
 
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/reset-superuser-password", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -275,7 +275,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "invalid password" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/reset-superuser-password", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
           password: "dummy"
         }.to_json
 
@@ -283,7 +283,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "reset password ubid" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/reset-superuser-password", {
+        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -305,28 +305,28 @@ RSpec.describe Clover, "postgres" do
 
     describe "show" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}"
+        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(pg.name)
       end
 
       it "success ubid" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
+        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(pg.name)
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/not-exists-pg"
+        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/not-exists-pg"
 
         expect(last_response.status).to eq(404)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "show firewall" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/firewall-rule"
+        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/firewall-rule"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)[0]["cidr"]).to eq("0.0.0.0/0")
@@ -335,47 +335,47 @@ RSpec.describe Clover, "postgres" do
 
     describe "delete" do
       it "success" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}"
+        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
       end
 
       it "success ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
       end
 
       it "not exist" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/foo_name"
+        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/foo_name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 
       it "not exist ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/foo_ubid"
+        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/foo_ubid"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 
       it "firewall-rule" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "firewall-rule ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "firewall-rule not exist" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
+        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
 
         expect(last_response.status).to eq(204)
       end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -15,42 +15,42 @@ RSpec.describe Clover, "private_subnet" do
 
   describe "unauthenticated" do
     it "not location list" do
-      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+      get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create" do
-      post "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/foo_name"
+      post "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete" do
-      delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+      delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete ubid" do
-      delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
+      delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get" do
-      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+      get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get ubid" do
-      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
+      get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
@@ -71,7 +71,7 @@ RSpec.describe Clover, "private_subnet" do
       end
 
       it "success single" do
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(1)
@@ -80,7 +80,7 @@ RSpec.describe Clover, "private_subnet" do
       it "success multiple" do
         Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2")
 
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(2)
@@ -93,7 +93,7 @@ RSpec.describe Clover, "private_subnet" do
 
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, private_subnet_id: ps.id, nic_id: nic.id, name: "dummy-vm-2")
 
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
       end
@@ -103,7 +103,7 @@ RSpec.describe Clover, "private_subnet" do
           ipv6_addr: "fd38:5c12:20bf:67d4:919e::/79",
           ipv4_addr: "172.17.226.186/32")
 
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
+        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
       end
@@ -133,28 +133,28 @@ RSpec.describe Clover, "private_subnet" do
 
     describe "show" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
       end
 
       it "success id" do
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
+        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/not-exists-ps"
+        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/not-exists-ps"
 
         expect(last_response.status).to eq(404)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "not authorized" do
-        get "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/#{ps_wo_permission.name}"
+        get "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
 
         expect(last_response.status).to eq(403)
       end
@@ -162,14 +162,14 @@ RSpec.describe Clover, "private_subnet" do
 
     describe "delete" do
       it "success" do
-        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
       end
 
       it "success id" do
-        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
@@ -178,20 +178,20 @@ RSpec.describe Clover, "private_subnet" do
       it "dependent vm failure" do
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, private_subnet_id: ps.id, name: "dummy-vm-2")
 
-        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
+        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
         expect(last_response.status).to eq(409)
       end
 
       it "not exist" do
-        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/foo_name"
+        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be false
       end
 
       it "not authorized" do
-        delete "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/#{ps_wo_permission.name}"
+        delete "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
 
         expect(last_response.status).to eq(403)
       end

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -15,56 +15,56 @@ RSpec.describe Clover, "vm" do
 
   describe "unauthenticated" do
     it "not location list" do
-      get "/api/project/#{project.ubid}/location/#{vm.location}/vm"
+      get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create" do
-      post "/api/project/#{project.ubid}/location/#{vm.location}/vm/foo_name"
+      post "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete" do
-      delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}"
+      delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete ubid" do
-      delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
+      delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get" do
-      get "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}"
+      get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get ubid" do
-      get "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
+      get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create firewall rule" do
-      post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule"
+      post "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete firewall rule" do
-      delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule/foo_ubid"
+      delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule/foo_ubid"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
@@ -87,7 +87,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success single" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm"
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm"
 
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
@@ -98,7 +98,7 @@ RSpec.describe Clover, "vm" do
       it "success multiple" do
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-2")
 
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm"
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm"
 
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
@@ -107,7 +107,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "ubid not exist" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/foo_ubid"
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/foo_ubid"
 
         expect(last_response.status).to eq(404)
       end
@@ -252,7 +252,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "firewall-rule" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule", {
           cidr: "0.0.0.0/0",
           port_range: "100..101"
         }.to_json
@@ -261,7 +261,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "firewall-rule vm ubid" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}/firewall-rule", {
           cidr: "0.0.0.0/0",
           port_range: "100..1012"
         }.to_json
@@ -270,7 +270,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "firewall-rule no port range" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule", {
           cidr: "0.0.0.0/1"
         }.to_json
 
@@ -278,7 +278,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "firewall-rule single port" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule", {
           cidr: "0.0.0.0/1",
           port_range: "11111"
         }.to_json
@@ -289,28 +289,28 @@ RSpec.describe Clover, "vm" do
 
     describe "show" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}"
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(vm.name)
       end
 
       it "success ubid" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(vm.name)
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/not-exists-vm"
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/not-exists-vm"
 
         expect(last_response.status).to eq(404)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "firewall" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule"
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["description"]).to eq("Default firewall")
@@ -319,47 +319,47 @@ RSpec.describe Clover, "vm" do
 
     describe "delete" do
       it "success" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}"
+        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be true
       end
 
       it "success ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be true
       end
 
       it "not exist" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/foo_name"
+        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
       end
 
       it "not exist ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/foo_ubid"
+        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/foo_ubid"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
       end
 
       it "firewall-rule" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "firewall-rule ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "firewall-rule not exist" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule/foo_ubid"
+        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/firewall-rule/foo_ubid"
 
         expect(last_response.status).to eq(204)
       end

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -5,7 +5,7 @@ raise "test database doesn't end with test" if DB.opts[:database] && !/test\d*\z
 
 TEST_USER_EMAIL = "user@example.com"
 TEST_USER_PASSWORD = "Secret@Password123"
-TEST_LOCATION = "hetzner-hel1"
+TEST_LOCATION = "eu-north-h1"
 
 def create_account(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD, with_project: true, enable_otp: false, enable_webauthn: false)
   hash = Argon2::Password.new({

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Clover, "private subnet" do
         expect(page.title).to eq("Ubicloud - Create Private Subnet")
         name = "dummy-ps"
         fill_in "Name", with: name
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
 
         click_button "Create"
 
@@ -88,7 +88,7 @@ RSpec.describe Clover, "private subnet" do
         expect(page.title).to eq("Ubicloud - Create Private Subnet")
 
         fill_in "Name", with: "invalid name"
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
 
         click_button "Create"
 
@@ -104,7 +104,7 @@ RSpec.describe Clover, "private subnet" do
         expect(page.title).to eq("Ubicloud - Create Private Subnet")
 
         fill_in "Name", with: private_subnet.name
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
 
         click_button "Create"
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Clover, "postgres" do
         expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
         name = "new-pg-db"
         fill_in "Name", with: name
-        choose option: "hetzner-fsn1"
+        choose option: "eu-central-h1"
         choose option: "standard-2"
         choose option: PostgresResource::HaType::NONE
 
@@ -98,7 +98,7 @@ RSpec.describe Clover, "postgres" do
         expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
 
         fill_in "Name", with: "invalid name"
-        choose option: "hetzner-fsn1"
+        choose option: "eu-central-h1"
         choose option: "standard-2"
         choose option: PostgresResource::HaType::NONE
 
@@ -115,7 +115,7 @@ RSpec.describe Clover, "postgres" do
         expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
 
         fill_in "Name", with: pg.name
-        choose option: "hetzner-fsn1"
+        choose option: "eu-central-h1"
         choose option: "standard-2"
         choose option: PostgresResource::HaType::NONE
 
@@ -135,7 +135,7 @@ RSpec.describe Clover, "postgres" do
         expect(page).to have_content "Project doesn't have valid billing information"
 
         fill_in "Name", with: "new-pg-db"
-        choose option: "hetzner-fsn1"
+        choose option: "eu-central-h1"
         choose option: "standard-2"
         choose option: PostgresResource::HaType::NONE
 
@@ -186,7 +186,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "raises not found when PostgreSQL database not exists" do
-        visit "#{project.path}/location/hetzner-fsn1/postgres/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/eu-central-h1/postgres/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - Resource not found")
         expect(page.status_code).to eq(404)

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
         name = "dummy-vm"
         fill_in "Name", with: name
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
         uncheck "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
@@ -90,7 +90,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
         name = "dummy-vm"
         fill_in "Name", with: name
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
         check "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
@@ -115,7 +115,7 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content "Create new subnet"
         name = "dummy-vm"
         fill_in "Name", with: name
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
         select match: :prefer_exact, text: ps.name
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
@@ -136,7 +136,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
 
         fill_in "Name", with: "invalid name"
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
@@ -154,7 +154,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
 
         fill_in "Name", with: vm.name
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
@@ -174,7 +174,7 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content "Project doesn't have valid billing information"
 
         fill_in "Name", with: "dummy-vm"
-        choose option: "hetzner-hel1"
+        choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
@@ -226,7 +226,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "raises not found when virtual machine not exists" do
-        visit "#{project.path}/location/hetzner-hel1/vm/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/eu-north-h1/vm/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - Resource not found")
         expect(page.status_code).to eq(404)

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -45,7 +45,7 @@
               <div class="col-span-full">
                 <% locations = Option
                     .postgres_locations_for_provider(@project_data.dig(:provider, :name))
-                    .map { |l| [l.name, l.display_name, @prices[l.name].to_json] }
+                    .map { |l| [l.display_name, l.display_name, @prices[l.name].to_json] }
                 %>
                 <%== render(
                   "components/form/radio_small_cards",

--- a/views/private_subnet/create.erb
+++ b/views/private_subnet/create.erb
@@ -46,7 +46,7 @@
                   locals: {
                     name: "location",
                     label: "Location",
-                    options: Option.locations_for_provider(@project_data.dig(:provider, :name)).to_h { |l| [l.name, l.display_name] },
+                    options: Option.locations_for_provider(@project_data.dig(:provider, :name)).to_h { |l| [l.display_name, l.display_name] },
                     attributes: {
                       required: true
                     }

--- a/views/project/create.erb
+++ b/views/project/create.erb
@@ -31,7 +31,7 @@
               locals: {
                 name: "provider",
                 label: "Provider",
-                options: Option::Providers.map { [_1, _2.display_name] }.to_h,
+                options: Option::PROVIDERS.map { [_1, _2.display_name] }.to_h,
                 attributes: {
                   required: true
                 }

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -45,7 +45,7 @@
               <div class="col-span-full">
                 <% locations = Option
                     .locations_for_provider(@project_data.dig(:provider, :name))
-                    .map { |l| [l.name, l.display_name, @prices[l.name].to_json] }
+                    .map { |l| [l.display_name, l.display_name, @prices[l.name].to_json] }
                 %>
                 <%== render(
                   "components/form/radio_small_cards",


### PR DESCRIPTION
In order to show location names on URIs like `eu-central-h1` instead of `hetzner-fsn1`, mapping have been added. So, users will send a request to the display locations but internally we will use internal names on the code.

To make handling provider and location information from a single point and easily, `provider_information.yml` is added. After this commit, provider and location information will be populated dynamically. So, if a new region wants to be added, it will be enough updating that file only.