### PR TITLE
Round project credit before persisting to database

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -103,7 +103,7 @@ class InvoiceGenerator
             # BigDecimal, it fails the check.
             # Finally, we use save_changes instead of update because it is not possible to
             # pass validate: false to update.
-            project.credit = Sequel[:credit] - project_content[:credit]
+            project.credit = Sequel[:credit] - project_content[:credit].round(3)
             project.save_changes(validate: false)
           end
         else


### PR DESCRIPTION
While generating invoices, I hit the below exception a few times:

    Sequel::CheckConstraintViolation: PG::CheckViolation: ERROR:  new row for relation "project" violates check constraint "min_credit_amount"
    DETAIL:  Failing row contains (UUID, Default, hetzner, t, UUID, -0.0000000000000001, 0, 2024-01-31 22:08:01.346461+00, {}, t, 300).

This is because of the floating point arithmetic. The credit ends up being `-0.0000000000000001` which is less than the minimum credit amount of `0`. To fix this, I will round the credit to 3 decimal places before persisting it to the database.