### PR TITLE
Allow to generate invoices for specific projects

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -4,11 +4,11 @@ require "time"
 require "stripe"
 
 class InvoiceGenerator
-  def initialize(begin_time, end_time, save_result: false, project_id: nil)
+  def initialize(begin_time, end_time, save_result: false, project_ids: [])
     @begin_time = begin_time
     @end_time = end_time
     @save_result = save_result
-    @project_id = project_id
+    @project_ids = project_ids
   end
 
   def run
@@ -120,7 +120,7 @@ class InvoiceGenerator
   def active_billing_records
     active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices])
       .where { |br| Sequel.pg_range(br.span).overlaps(Sequel.pg_range(@begin_time...@end_time)) }
-    active_billing_records = active_billing_records.where(project_id: @project_id) if @project_id
+    active_billing_records = active_billing_records.where(project_id: @project_ids) unless @project_ids.empty?
     active_billing_records.all.map do |br|
       # We cap the billable duration at 672 hours. In this way, we can
       # charge the users same each month no matter the number of days

--- a/model/project.rb
+++ b/model/project.rb
@@ -66,7 +66,7 @@ class Project < Sequel::Model
     begin_time = invoices.first&.end_time || Time.new(Time.now.year, Time.now.month, 1)
     end_time = Time.now
 
-    if (invoice = InvoiceGenerator.new(begin_time, end_time, project_id: id).run.first)
+    if (invoice = InvoiceGenerator.new(begin_time, end_time, project_ids: [id]).run.first)
       return invoice
     end
 

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe InvoiceGenerator do
     generate_billing_record(p1, vm1, Sequel::Postgres::PGRange.new(begin_time, end_time))
     generate_billing_record(p2, vm2, Sequel::Postgres::PGRange.new(begin_time, end_time))
 
-    invoices = described_class.new(begin_time, end_time, project_id: p1.id).run
+    invoices = described_class.new(begin_time, end_time, project_ids: [p1.id]).run
     expect(invoices.count).to eq(1)
   end
 

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Clover, "billing" do
         br_previous = billing_record(Time.parse("2023-06-01"), Time.parse("2023-07-01"))
         br_current = billing_record(Time.parse("2023-07-01"), Time.parse("2023-07-15"))
         invoice_previous = InvoiceGenerator.new(br_previous.span.begin, br_previous.span.end, save_result: true).run.first
-        invoice_current = InvoiceGenerator.new(br_current.span.begin, br_current.span.end, project_id: project.id).run.first
+        invoice_current = InvoiceGenerator.new(br_current.span.begin, br_current.span.end, project_ids: [project.id]).run.first
 
         visit "#{project.path}/billing"
 


### PR DESCRIPTION
We use InvoiceGenerator to display the project's current usage to the customer. We use the 'project_id' argument to filter the project. If it's not provided, we generate invoices for all projects.

Occasionally, we need to generate invoices for specific projects. To accommodate this, I've replaced the 'project_id' argument with 'project_ids', enabling us to filter multiple projects.

Currently, there is a workaround for this issue. But it's inefficient, since it needs to fetch billing records for each project separately. We also need to wrap it with a DB transaction if any of them crash while generating invoice.

    DB.transaction do
        invoices = project_ids.filter_map do |project_id|
            InvoiceGenerator.new(begin_date, end_date, project_id: project_id).run.first
        end
    end

The new way:

    invoices = InvoiceGenerator.new(begin_date, end_date, project_ids: project_ids).run