### PR TITLE
Update Firewall Rules after host reboot

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -573,6 +573,6 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
 
     decr_start_after_host_reboot
 
-    hop_wait
+    hop_update_firewall_rules
   end
 end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -886,7 +886,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:update).with(display_state: "starting")
       expect(vm).to receive(:update).with(display_state: "running")
 
-      expect { nx.start_after_host_reboot }.to hop("wait")
+      expect { nx.start_after_host_reboot }.to hop("update_firewall_rules")
     end
   end
 end


### PR DESCRIPTION
When host is rebooted and the network namespace is recreated, the firewall rules are also cleaned up. Nftables needs to be repopulated to have a functioning IPv4 stack.