### PR TITLE
Add issuer name to the invoice

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -22,6 +22,7 @@ class InvoiceGenerator
         project_content[:project_name] = project.name
         project_content[:billing_info] = Serializers::Web::BillingInfo.serialize(project.billing_info)
         project_content[:issuer_info] = {
+          name: "Ubicloud Inc.",
           address: "310 Santa Ana Avenue",
           country: "US",
           city: "San Francisco",

--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -38,6 +38,7 @@ class Serializers::Web::Invoice < Serializers::Base
         billing_postal_code: inv.content.dig("billing_info", "postal_code"),
         tax_id: inv.content.dig("billing_info", "tax_id"),
         company_name: inv.content.dig("billing_info", "company_name"),
+        issuer_name: inv.content.dig("issuer_info", "name"),
         issuer_address: inv.content.dig("issuer_info", "address"),
         issuer_country: ISO3166::Country.new(inv.content.dig("issuer_info", "country"))&.common_name,
         issuer_city: inv.content.dig("issuer_info", "city"),

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe InvoiceGenerator do
         "company_name" => nil
       } : nil,
       "issuer_info" => {
+        "name" => "Ubicloud Inc.",
         "address" => "310 Santa Ana Avenue",
         "country" => "US",
         "city" => "San Francisco",

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -46,6 +46,9 @@
           <div>
             <img class="h-8 w-auto" src="/logo-primary.png" alt="Ubicloud">
             <address class="mt-4 not-italic text-gray-800">
+              <% if @invoice_data[:issuer_name] %>
+                <span class="font-semibold"><%= @invoice_data[:issuer_name] %></span><br>
+              <% end %>
               <%= @invoice_data[:issuer_address] %>,<br>
               <%= @invoice_data[:issuer_city] %>,
               <%= @invoice_data[:issuer_state] %>


### PR DESCRIPTION
We have two entities in the US and the Netherlands. Customers were confused about whether to use "Ubicloud Inc." or "Ubicloud B.V." on the invoice. To clarify, we've added the issuer name to the invoice.

Before:

<img width="493" alt="Screenshot 2024-04-03 at 13 29 28" src="https://github.com/ubicloud/ubicloud/assets/993199/9c35e20e-595c-4e9a-b2f3-68fb137cf814">


After:

<img width="543" alt="Screenshot 2024-04-03 at 13 29 36" src="https://github.com/ubicloud/ubicloud/assets/993199/82288981-ad89-493e-a81b-fa948e3a8773">
