### PR TITLE
Fix firewall rules for PostgreSQL

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -169,7 +169,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     end
 
     when_update_firewall_rules_set? do
-      postgres_resource.representative_server.incr_update_firewall_rules
+      postgres_resource.servers.each(&:incr_update_firewall_rules)
       decr_update_firewall_rules
     end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
     it "increments update_firewall_rules semaphore of postgres server when update_firewall_rules is set" do
       expect(nx).to receive(:when_update_firewall_rules_set?).and_yield
-      expect(postgres_resource.representative_server).to receive(:incr_update_firewall_rules)
+      expect(postgres_resource.servers).to all(receive(:incr_update_firewall_rules))
       expect { nx.wait }.to nap(30)
     end
   end


### PR DESCRIPTION
Previously we were only incrementing update_firewall_rules semaphore only for representative_server. This commit changes logic to increment semaphore for all servers.