### PR TITLE
Remove firewall-rule endpoints from vm and postgres resources

### DIFF
--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -75,48 +75,5 @@ class CloverApi
       response.status = 204
       request.halt
     end
-
-    request.on "firewall-rule" do
-      request.post true do
-        Authorization.authorize(user.id, "Vm:Firewall:edit", vm.id)
-
-        required_parameters = ["cidr"]
-        allowed_optional_parameters = ["port_range"]
-
-        request_body_params = Validation.validate_request_body(request.body.read, required_parameters, allowed_optional_parameters)
-
-        Validation.validate_cidr(request_body_params["cidr"])
-        port_range = if request_body_params["port_range"].nil?
-          [0, 65535]
-        else
-          request_body_params["port_range"] = Validation.validate_port_range(request_body_params["port_range"])
-        end
-
-        pg_range = Sequel.pg_range(port_range.first..port_range.last)
-
-        vm.firewalls.first.insert_firewall_rule(request_body_params["cidr"], pg_range)
-
-        serialize(vm, :detailed)
-      end
-
-      request.get true do
-        Authorization.authorize(user.id, "Vm:Firewall:view", vm.id)
-        Serializers::Api::Firewall.serialize(vm.firewalls.first)
-      end
-
-      request.is String do |firewall_rule_ubid|
-        request.delete true do
-          Authorization.authorize(user.id, "Vm:Firewall:edit", vm.id)
-
-          if (fwr = FirewallRule.from_ubid(firewall_rule_ubid))
-            fwr.destroy
-            vm.incr_update_firewall_rules
-          end
-
-          response.status = 204
-          request.halt
-        end
-      end
-    end
   end
 end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -77,20 +77,6 @@ RSpec.describe Clover, "postgres" do
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
     end
 
-    it "not create firewall rule" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule"
-
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
-    end
-
-    it "not delete firewall rule" do
-      delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
-
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
-    end
-
     it "not restore" do
       post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/restore"
 
@@ -205,31 +191,6 @@ RSpec.describe Clover, "postgres" do
         expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: size, ha_type")
       end
 
-      it "firewall-rule" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule", {
-          cidr: "0.0.0.0/24"
-        }.to_json
-
-        expect(last_response.status).to eq(200)
-      end
-
-      it "firewall-rule pg ubid" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/firewall-rule", {
-          cidr: "0.0.0.0/24"
-        }.to_json
-
-        expect(last_response.status).to eq(200)
-      end
-
-      it "firewall-rule invalid cidr" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule", {
-          cidr: "0.0.0"
-        }.to_json
-
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["CIDR"]).to eq("Invalid CIDR")
-      end
-
       it "restore" do
         stub_const("Backup", Struct.new(:last_modified))
         restore_target = Time.now.utc
@@ -324,13 +285,6 @@ RSpec.describe Clover, "postgres" do
         expect(last_response.status).to eq(404)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
       end
-
-      it "show firewall" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/firewall-rule"
-
-        expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)[0]["cidr"]).to eq("0.0.0.0/0")
-      end
     end
 
     describe "delete" do
@@ -360,24 +314,6 @@ RSpec.describe Clover, "postgres" do
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
-      end
-
-      it "firewall-rule" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}"
-
-        expect(last_response.status).to eq(204)
-      end
-
-      it "firewall-rule ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
-
-        expect(last_response.status).to eq(204)
-      end
-
-      it "firewall-rule not exist" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
-
-        expect(last_response.status).to eq(204)
       end
     end
   end

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -55,20 +55,6 @@ RSpec.describe Clover, "vm" do
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
     end
-
-    it "not create firewall rule" do
-      post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule"
-
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
-    end
-
-    it "not delete firewall rule" do
-      delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule/foo_ubid"
-
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
-    end
   end
 
   describe "authenticated" do
@@ -215,41 +201,6 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(400)
         expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: public_key, size, unix_user, boot_image, enable_ip4, private_subnet_id")
       end
-
-      it "firewall-rule" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule", {
-          cidr: "0.0.0.0/0",
-          port_range: "100..101"
-        }.to_json
-
-        expect(last_response.status).to eq(200)
-      end
-
-      it "firewall-rule vm ubid" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}/firewall-rule", {
-          cidr: "0.0.0.0/0",
-          port_range: "100..1012"
-        }.to_json
-
-        expect(last_response.status).to eq(200)
-      end
-
-      it "firewall-rule no port range" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule", {
-          cidr: "0.0.0.0/1"
-        }.to_json
-
-        expect(last_response.status).to eq(200)
-      end
-
-      it "firewall-rule single port" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule", {
-          cidr: "0.0.0.0/1",
-          port_range: "11111"
-        }.to_json
-
-        expect(last_response.status).to eq(200)
-      end
     end
 
     describe "show" do
@@ -272,13 +223,6 @@ RSpec.describe Clover, "vm" do
 
         expect(last_response.status).to eq(404)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
-      end
-
-      it "firewall" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule"
-
-        expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)["description"]).to eq("Default firewall")
       end
     end
 
@@ -309,24 +253,6 @@ RSpec.describe Clover, "vm" do
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
-      end
-
-      it "firewall-rule" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
-
-        expect(last_response.status).to eq(204)
-      end
-
-      it "firewall-rule ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
-
-        expect(last_response.status).to eq(204)
-      end
-
-      it "firewall-rule not exist" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule/foo_ubid"
-
-        expect(last_response.status).to eq(204)
       end
     end
   end


### PR DESCRIPTION
Since we are planning to associate firewalls with resources instead of managing firewall rules separately for each resource, removing the firewall rule related endpoints from vm and postgres resources.

Once backend implementation of associating firewalls with resources will be implemented, vm and postgres APIs will be updated accordingly.