### PR TITLE
Keep VM hosts in draining state after reboot

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -196,7 +196,7 @@ class Prog::Vm::HostNexus < Prog::Base
       vm.incr_start_after_host_reboot
     }
 
-    vm_host.update(allocation_state: "accepting")
+    vm_host.update(allocation_state: "accepting") if vm_host.allocation_state == "unprepared"
 
     hop_wait
   end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -307,9 +307,22 @@ RSpec.describe Prog::Vm::HostNexus do
       expect { nx.verify_spdk }.to hop("verify_hugepages")
     end
 
-    it "start_vms starts vms & hops to wait" do
+    it "start_vms starts vms & becomes accepting & hops to wait if unprepared" do
       expect(vms).to all receive(:incr_start_after_host_reboot)
+      expect(vm_host).to receive(:allocation_state).and_return("unprepared")
       expect(vm_host).to receive(:update).with(allocation_state: "accepting")
+      expect { nx.start_vms }.to hop("wait")
+    end
+
+    it "start_vms starts vms & hops to wait if accepting" do
+      expect(vms).to all receive(:incr_start_after_host_reboot)
+      expect(vm_host).to receive(:allocation_state).and_return("accepting")
+      expect { nx.start_vms }.to hop("wait")
+    end
+
+    it "start_vms starts vms & hops to wait if draining" do
+      expect(vms).to all receive(:incr_start_after_host_reboot)
+      expect(vm_host).to receive(:allocation_state).and_return("draining")
       expect { nx.start_vms }.to hop("wait")
     end
 


### PR DESCRIPTION
In `start_vms`, transition host allocation_state to `accepting` only if it is `unprepared`. If it is in `draining` state, no transition is performed. This prevents hosts to transition from `draining` to `accepting` after a reboot.

Fixes #1383