### PR TITLE
Make subnets and Github runners aware of prevent_destroy VMs

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -214,8 +214,8 @@ end
   def register_deadline(deadline_target, deadline_in)
     current_frame = strand.stack.first
     if (deadline_at = current_frame["deadline_at"]).nil? ||
-        Time.parse(deadline_at.to_s) > Time.now + deadline_in ||
-        (old_deadline_target = current_frame["deadline_target"]) != deadline_target
+        (old_deadline_target = current_frame["deadline_target"]) != deadline_target ||
+        Time.parse(deadline_at.to_s) > Time.now + deadline_in
 
       if old_deadline_target != deadline_target && (pg = Page.from_tag_parts("Deadline", strand.id, strand.prog, old_deadline_target))
         pg.incr_resolve

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -211,10 +211,11 @@ end
     fail Hop.new(@strand.prog, @strand.label, {label: label, retval: nil})
   end
 
-  def register_deadline(deadline_target, deadline_in)
+  def register_deadline(deadline_target, deadline_in, allow_extension: false)
     current_frame = strand.stack.first
     if (deadline_at = current_frame["deadline_at"]).nil? ||
         (old_deadline_target = current_frame["deadline_target"]) != deadline_target ||
+        allow_extension ||
         Time.parse(deadline_at.to_s) > Time.now + deadline_in
 
       if old_deadline_target != deadline_target && (pg = Page.from_tag_parts("Deadline", strand.id, strand.prog, old_deadline_target))

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -95,6 +95,11 @@ class Prog::Test < Prog::Base
     hop_pusher1
   end
 
+  label def extend_deadline
+    register_deadline(:pusher2, 1, allow_extension: true)
+    hop_pusher1
+  end
+
   label def set_popping_deadline1
     push Prog::Test, {}, :set_popping_deadline2
   end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -372,6 +372,7 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def wait_vm_destroy
+    register_deadline(nil, 10 * 60, allow_extension: true) if vm&.prevent_destroy_set?
     nap 10 unless vm.nil?
 
     github_runner.destroy

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -118,6 +118,8 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
   label def destroy
     if private_subnet.nics.any? { |n| !n.vm_id.nil? }
+      register_deadline(nil, 10 * 60, allow_extension: true) if private_subnet.nics.any? { |n| n.vm&.prevent_destroy_set? }
+
       Clog.emit "Cannot destroy subnet with active nics, first clean up the attached resources" do
         {private_subnet: private_subnet.values}
       end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -175,6 +175,14 @@ RSpec.describe Prog::Base do
       expect {
         st.unsynchronized_run
       }.not_to change { st.stack.first["deadline_at"] }
+
+      # allow to explicitly extend deadline
+      st.label = :extend_deadline
+      st.stack.first["deadline_at"] = Time.now
+      st.stack.first["deadline_target"] = :pusher2
+      expect {
+        st.unsynchronized_run
+      }.to change { st.stack.first["deadline_at"] }
     end
 
     it "triggers a page exactly once when deadline is expired" do

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -572,8 +572,14 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect { nx.wait_vm_destroy }.to nap(10)
     end
 
+    it "extends deadline if vm prevents destroy" do
+      expect(vm).to receive(:prevent_destroy_set?).and_return(true)
+      expect(nx).to receive(:register_deadline).with(nil, 10 * 60, allow_extension: true)
+      expect { nx.wait_vm_destroy }.to nap(10)
+    end
+
     it "pops if vm destroyed" do
-      expect(nx).to receive(:vm).and_return(nil)
+      expect(nx).to receive(:vm).and_return(nil).twice
       expect(github_runner).to receive(:destroy)
 
       expect { nx.wait_vm_destroy }.to exit({"msg" => "github runner deleted"})


### PR DESCRIPTION
VMs whose `prevent_destroy` semaphore is set are protected from destruction. PrivateSubnet and GithubRunner progs are not aware of this and may perceive themselves as stuck waiting for VM destruction, which triggers pages:
`GithubRunner.wait_vm_destroy did not reach  on time`
`SubnetNexus.destroy did not reach  on time`

This PR addresses the issue described above by allowing to extend deadlines. GithubRunner and SubnetNexus leverage that new functionality to extend deadlines while waiting for destruction of a VM whose `prevent_destroy` semaphore is set.

Fixes #1177 