### PR TITLE
Update project create endpoint to get parameters from json body

### DIFF
--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -11,7 +11,11 @@ class CloverApi
     end
 
     r.post true do
-      project = @current_user.create_project_with_default_policy(r.params["name"], provider: r.params["provider"])
+      required_parameters = ["name", "provider"]
+
+      request_body_params = Validation.validate_request_body(r.body.read, required_parameters)
+
+      project = @current_user.create_project_with_default_policy(request_body_params["name"], provider: request_body_params["provider"])
 
       serialize(project)
     end

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -50,10 +50,18 @@ RSpec.describe Clover, "vm" do
         post "/api/project", {
           name: "test-project",
           provider: "hetzner"
-        }
+        }.to_json
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-project")
+      end
+
+      it "missing parameter" do
+        post "/api/project", {
+          name: "test-project"
+        }.to_json
+
+        expect(last_response.status).to eq(400)
       end
     end
 


### PR DESCRIPTION
It is expected to pass parameters for a resource to be created on the body as json object. Project create endpoint wasn't following that rule, updated it to follow. Similar to all other create endpoints, parameters of the request are also validated.