### PR TITLE
Use id instead of ubid while serializing project resource on api

### DIFF
--- a/serializers/api/project.rb
+++ b/serializers/api/project.rb
@@ -3,7 +3,7 @@
 class Serializers::Api::Project < Serializers::Base
   def self.base(p)
     {
-      ubid: p.ubid,
+      id: p.ubid,
       path: p.path,
       name: p.name,
       credit: p.credit.to_f,


### PR DESCRIPTION
While serializing resources, id is used as a key to return ubid of the resource. Project was not following that, updated it.