### PR TITLE
Decrement checkup semaphore if health check succeeds

### DIFF
--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -106,8 +106,8 @@ class Prog::Minio::MinioServerNexus < Prog::Base
 
   label def wait
     when_checkup_set? do
-      decr_checkup
       hop_unavailable if !available?
+      decr_checkup
     end
 
     when_reconfigure_set? do

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -264,6 +264,7 @@ SQL
 
     when_checkup_set? do
       hop_unavailable if !available?
+      decr_checkup
     end
 
     when_update_firewall_rules_set? do

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -208,6 +208,7 @@ class Prog::Vm::HostNexus < Prog::Base
 
     when_checkup_set? do
       hop_unavailable if !available?
+      decr_checkup
     end
 
     Clog.emit("vm host utilization") { {vm_host_utilization: vm_host.values.slice(:location, :arch, :total_cores, :used_cores, :total_hugepages_1g, :used_hugepages_1g, :total_storage_gib, :available_storage_gib).merge({vms_count: vm_host.vms_dataset.count})} }

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -490,6 +490,7 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
 
     when_checkup_set? do
       hop_unavailable if !available?
+      decr_checkup
     rescue Sshable::SshError
       # Host is likely to be down, which will be handled by HostNexus. We still
       # go to the unavailable state for keeping track of the state.


### PR DESCRIPTION
If checkup semaphore is incremented, we perform a detailed health check on the resource and go to unavailable state if the health check fails. If the health check succeeds, we should decrement the checkup semaphore, so that we wouldn't perform more health checks until the next time the resource is marked for a detailed health check.