### PR TITLE
Move Firewalls from VM to Subnet

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -121,9 +121,15 @@ module Validation
   end
 
   def self.validate_cidr(cidr)
-    NetAddr::IPv4Net.parse(cidr)
+    if cidr.include?(".")
+      NetAddr::IPv4Net.parse(cidr)
+    elsif cidr.include?(":")
+      NetAddr::IPv6Net.parse(cidr)
+    else
+      fail ValidationFailed.new({cidr: "Invalid CIDR"})
+    end
   rescue NetAddr::ValidationError
-    fail ValidationFailed.new({CIDR: "Invalid CIDR"})
+    fail ValidationFailed.new({cidr: "Invalid CIDR"})
   end
 
   def self.validate_port_range(port_range)

--- a/migrate/20240409_move_firewall_to_subnet.rb
+++ b/migrate/20240409_move_firewall_to_subnet.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:firewall) do
+      add_foreign_key :private_subnet_id, :private_subnet, type: :uuid
+    end
+
+    run <<~SQL
+      UPDATE firewall f
+      SET private_subnet_id = (
+        SELECT n.private_subnet_id
+        FROM nic n
+        WHERE n.vm_id = f.vm_id
+      );
+    SQL
+  end
+
+  down do
+    run <<~SQL
+      UPDATE firewall f
+      SET vm_id = (
+        SELECT n.vm_id
+        FROM nic n
+        WHERE n.private_subnet_id = f.private_subnet_id
+      );
+    SQL
+
+    alter_table(:firewall) do
+      drop_column :private_subnet_id
+    end
+  end
+end

--- a/migrate/20240425_remove_fw_vm_id.rb
+++ b/migrate/20240425_remove_fw_vm_id.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:firewall) do
+      drop_column :vm_id
+    end
+  end
+
+  down do
+    alter_table(:firewall) do
+      add_foreign_key :vm_id, :vm, type: :uuid
+    end
+  end
+end

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -4,7 +4,7 @@ require_relative "../model"
 
 class Firewall < Sequel::Model
   one_to_many :firewall_rules, key: :firewall_id
-  many_to_one :vm, key: :vm_id
+  many_to_one :private_subnet, key: :private_subnet_id
 
   plugin :association_dependencies, firewall_rules: :destroy
 
@@ -17,7 +17,7 @@ class Firewall < Sequel::Model
       port_range: port_range
     )
 
-    vm&.incr_update_firewall_rules
+    private_subnet&.incr_update_firewall_rules
     fwr
   end
 end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -165,7 +165,7 @@ class PostgresServer < Sequel::Model
   end
 
   def create_resource_firewall_rules
-    fw = Firewall.create_with_id(vm_id: vm.id, name: ubid.to_s, description: "Postgres default firewall")
+    fw = Firewall.create_with_id(private_subnet_id: vm.private_subnets.first.id, name: ubid.to_s, description: "Postgres default firewall")
     resource.firewall_rules.each do |pg_fwr|
       fw.insert_firewall_rule(pg_fwr.cidr.to_s, Sequel.pg_range(5432..5432))
     end

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -6,13 +6,15 @@ class PrivateSubnet < Sequel::Model
   many_to_many :vms, join_table: Nic.table_name, left_key: :private_subnet_id, right_key: :vm_id
   one_to_many :nics, key: :private_subnet_id
   one_to_one :strand, key: :id
-  one_to_many :firewall_rules
+  one_to_many :firewalls
 
   PRIVATE_SUBNET_RANGES = [
     "10.0.0.0/8",
     "172.16.0.0/12",
     "192.168.0.0/16"
   ].freeze
+
+  plugin :association_dependencies, firewalls: :destroy
 
   dataset_module Pagination
   dataset_module Authorization::Dataset
@@ -42,7 +44,7 @@ class PrivateSubnet < Sequel::Model
   end
 
   include SemaphoreMethods
-  semaphore :destroy, :refresh_keys, :add_new_nic
+  semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
 
   def self.random_subnet
     PRIVATE_SUBNET_RANGES.sample

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -11,9 +11,8 @@ class Vm < Sequel::Model
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
   one_to_many :vm_storage_volumes, key: :vm_id, order: Sequel.desc(:boot)
   one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
-  one_to_many :firewalls, key: :vm_id
 
-  plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy, firewalls: :destroy
+  plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy
 
   dataset_module Pagination
   dataset_module Authorization::Dataset
@@ -30,6 +29,10 @@ class Vm < Sequel::Model
   end
 
   include Authorization::TaggableMethods
+
+  def firewalls
+    private_subnets.flat_map(&:firewalls)
+  end
 
   def display_location
     LocationNameConverter.to_display_name(location)

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -291,7 +291,6 @@ SQL
 
     # create a new set of firewall rules
     postgres_server.create_resource_firewall_rules
-    vm.incr_update_firewall_rules
 
     hop_wait
   end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -2,9 +2,9 @@
 
 class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
-  semaphore :destroy, :refresh_keys, :add_new_nic
+  semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
 
-  def self.assemble(project_id, name: nil, location: "hetzner-hel1", ipv6_range: nil, ipv4_range: nil)
+  def self.assemble(project_id, name: nil, location: "hetzner-hel1", ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false)
     unless (project = Project[project_id])
       fail "No existing project"
     end
@@ -20,6 +20,10 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     DB.transaction do
       ps = PrivateSubnet.create(name: name, location: location, net6: ipv6_range, net4: ipv4_range, state: "waiting") { _1.id = ubid.to_uuid }
       ps.associate_with_project(project)
+      port_range = allow_only_ssh ? 22..22 : 0..65535
+      fw = Firewall.create_with_id(private_subnet_id: ubid.to_uuid, name: "#{name}-default")
+      ["0.0.0.0/0", "::/0"].each { |cidr| FirewallRule.create_with_id(firewall_id: fw.id, cidr: cidr, port_range: Sequel.pg_range(port_range)) }
+
       Strand.create(prog: "Vnet::SubnetNexus", label: "wait") { _1.id = ubid.to_uuid }
     end
   end
@@ -42,6 +46,11 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     when_add_new_nic_set? do
       private_subnet.update(state: "adding_new_nic")
       hop_add_new_nic
+    end
+
+    when_update_firewall_rules_set? do
+      private_subnet.vms.map(&:incr_update_firewall_rules)
+      decr_update_firewall_rules
     end
 
     if private_subnet.last_rekey_at < Time.now - 60 * 60 * 24

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -95,7 +95,7 @@ class CloverApi
 
         request_body_params = Validation.validate_request_body(request.body.read, required_parameters, allowed_optional_parameters)
 
-        Validation.validate_cidr(request_body_params["cidr"])
+        parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
         port_range = if request_body_params["port_range"].nil?
           [0, 65535]
         else
@@ -104,7 +104,7 @@ class CloverApi
 
         pg_range = Sequel.pg_range(port_range.first..port_range.last)
 
-        vm.firewalls.first.insert_firewall_rule(request_body_params["cidr"], pg_range)
+        vm.firewalls.first.insert_firewall_rule(parsed_cidr.to_s, pg_range)
 
         serialize(vm, :detailed)
       end

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -27,11 +27,12 @@ class CloverWeb
       r.on "firewall-rule" do
         r.post true do
           Authorization.authorize(@current_user.id, "Postgres:Firewall:edit", pg.id)
+          parsed_cidr = Validation.validate_cidr(r.params["cidr"])
 
           DB.transaction do
             PostgresFirewallRule.create_with_id(
               postgres_resource_id: pg.id,
-              cidr: r.params["cidr"]
+              cidr: parsed_cidr.to_s
             )
             pg.incr_update_firewall_rules
           end

--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -30,9 +30,10 @@ class CloverWeb
             Validation.validate_port_range(r.params["port_range"])
           end
 
+          parsed_cidr = Validation.validate_cidr(r.params["cidr"])
           pg_range = Sequel.pg_range(port_range.first..port_range.last)
 
-          vm.firewalls.first.insert_firewall_rule(r.params["cidr"], pg_range)
+          vm.firewalls.first.insert_firewall_rule(parsed_cidr.to_s, pg_range)
           flash["notice"] = "Firewall rule is created"
 
           r.redirect "#{@project.path}#{vm.path}"

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -212,6 +212,10 @@ RSpec.describe Validation do
         expect { described_class.validate_cidr("0.0.0.0/1") }.not_to raise_error
         expect { described_class.validate_cidr("192.168.1.0/24") }.not_to raise_error
         expect { described_class.validate_cidr("255.255.255.255/0") }.not_to raise_error
+
+        expect { described_class.validate_cidr("::/0") }.not_to raise_error
+        expect { described_class.validate_cidr("::1/128") }.not_to raise_error
+        expect { described_class.validate_cidr("2001:db8::/32") }.not_to raise_error
       end
 
       it "invalid cidr" do
@@ -219,6 +223,9 @@ RSpec.describe Validation do
         expect { described_class.validate_cidr("10.256.0.0/8") }.to raise_error described_class::ValidationFailed
         expect { described_class.validate_cidr("172.16.0.0/33") }.to raise_error described_class::ValidationFailed
         expect { described_class.validate_cidr("not_a_cidr") }.to raise_error described_class::ValidationFailed
+
+        expect { described_class.validate_cidr("::1/129") }.to raise_error described_class::ValidationFailed
+        expect { described_class.validate_cidr("::1/::1") }.to raise_error described_class::ValidationFailed
       end
     end
 

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Firewall do
     end
 
     it "increments VMs update_firewall_rules if there is a VM" do
-      vm = instance_double(Vm)
-      expect(fw).to receive(:vm).and_return(vm)
-      expect(vm).to receive(:incr_update_firewall_rules)
+      private_subnet = instance_double(PrivateSubnet)
+      expect(fw).to receive(:private_subnet).and_return(private_subnet)
+      expect(private_subnet).to receive(:incr_update_firewall_rules)
       fw.insert_firewall_rule("0.0.0.0/0", nil)
     end
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         Vm,
         id: "1c7d59ee-8d46-8374-9553-6144490ecec5",
         sshable: sshable,
-        ephemeral_net4: "1.1.1.1"
+        ephemeral_net4: "1.1.1.1",
+        private_subnets: [instance_double(PrivateSubnet)]
       )
     )
   }
@@ -472,7 +473,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(postgres_server.vm).to receive(:firewalls).and_return([fw])
       expect(fw).to receive(:destroy)
       expect(postgres_server).to receive(:create_resource_firewall_rules)
-      expect(postgres_server.vm).to receive(:incr_update_firewall_rules)
 
       expect { nx.update_firewall_rules }.to hop("wait")
     end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Clover, "postgres" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["CIDR"]).to eq("Invalid CIDR")
+        expect(JSON.parse(last_response.body)["error"]["details"]["cidr"]).to eq("Invalid CIDR")
       end
 
       it "restore" do

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content "12.12.12.0/26"
         expect(page).to have_content "443"
 
-        expect(SemSnap.new(vm.id).set?("update_firewall_rules")).to be true
+        expect(SemSnap.new(vm.private_subnets.first.id).set?("update_firewall_rules")).to be true
       end
     end
 


### PR DESCRIPTION
**Move Firewalls from VM to Subnet model migration**
We made the decision to make Firewalls to be added to the whole subnet
instead of individual VMs. This commit implements the migration file.

**Create Firewalls and attach to Subnet instead of VM**
This commit implements the Firewalls move from VMs to Subnets.
Therefore, there are multiple changes regarding model relationships,
Vm::Nexus.assemble, Vnet::SubnetNexus.assemble and finally at the
routes. The changes are not very interesting as they mostly involve
semaphore increments being performed on subnets instead of individual
VMs or entity creations referring to subnets intead of VMs.

One additional small but interesting change is the cidr validation. It
involves 2 changes;
1. Validate IPv6 as well
2. Return the parsed cidr and use its string representation while
creating the record. This is necessary because when NetAddr is able to
parse a cidr like "1.1.1.1/8" without an issue, db insert fails because
the valid form of that cidr is actually "1.0.0.0/8". This used to cause
500 error in console.

**Move Postgres Firewalls from VMs to Subnets**