### PR TITLE
Fix double escaping of continuation_token

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -186,9 +186,6 @@ class Minio::Client
     # when we implement new APIs.
     is_truncated = doc.xpath("//xmlns:IsTruncated").text.casecmp("true").zero?
     continuation_token = doc.xpath("//xmlns:NextContinuationToken").text
-    if continuation_token && encoding_type == "url"
-      continuation_token = CGI.escape(continuation_token)
-    end
     [objects, is_truncated, continuation_token]
   end
 


### PR DESCRIPTION
We recently started to get `The continuation token provided is incorrect` error while fetching the list of backups from blob storage. Upon closer inspection, I realized that the continuation_token was being escaped twice, which means if it has `=` sign in it, we first escape it to `%3D` and then to `%253D`, making the continuation_token invalid. This commit removes one of the escape calls. The other escape is done by encode_www_form call. encode_www_form escapes few other parameters as well, so I prefered to keep that and remove CGI.escape call which only escapes the continuation_token.