### PR TITLE
Graceful shutdown of respirate process

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -4,6 +4,7 @@
 require_relative "../loader"
 
 d = Scheduling::Dispatcher.new
+Signal.trap("TERM") { d.shutdown }
 
 if Config.heartbeat_url
   puts "Starting heartbeat prog"


### PR DESCRIPTION
When the Heroku dyno manager restarts a dyno, it sends `SIGTERM`. It then waits for graceful shutdown for 30 seconds before it sends `SIGKILL`.

We now trap `SIGTERM` in the dispatcher to trigger graceful shutdown, during which:
- no new strands are started
- running strands are allowed to finish
- if no more running strands -> exit the process

Without this graceful shutdown, strands running when `SIGTERM` is received aren't given an opportunity to release their lease. These strands are then locked for up to two minutes, until the lease expires.