### PR TITLE
Fix RSpec warning "An expectation was set on nil"

### DIFF
--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -249,7 +249,9 @@ RSpec.describe VmHost do
   end
 
   it "initiates a new health monitor session" do
-    expect(vh.sshable).to receive(:start_fresh_session)
+    sshable = instance_double(Sshable)
+    expect(vh).to receive(:sshable).and_return(sshable)
+    expect(sshable).to receive(:start_fresh_session)
     vh.init_health_monitor_session
   end
 


### PR DESCRIPTION
Fix this warning when running control plane tests

```
WARNING: An expectation of `:start_fresh_session` was set on `nil`. To allow expectations on `nil` and suppress this message, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `true`. To disallow expectations on `nil`, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `false`. Called from /home/runner/work/ubicloud/ubicloud/spec/model/vm_host_spec.rb:252:in `block (2 levels) in <top (required)>'.
```

That warning seems to break Ruby CI jobs:
https://github.com/ubicloud/ubicloud/actions/runs/8646970249/job/23707422376?pr=1448