### PR TITLE
Adding missing validators for VM creation api endpoint

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -58,6 +58,12 @@ module Validation
     vm_size
   end
 
+  def self.validate_boot_image(image_name)
+    unless Option::BootImages.find { _1.name == image_name }
+      fail ValidationFailed.new({boot_image: "\"#{image_name}\" is not a valid boot image name. Available boot image names are: #{Option::BootImages.map(&:name)}"})
+    end
+  end
+
   def self.validate_postgres_ha_type(ha_type)
     unless Option::PostgresHaOptions.find { _1.name == ha_type }
       fail ValidationFailed.new({ha_type: "\"#{ha_type}\" is not a valid PostgreSQL high availability option. Available options: #{Option::PostgresHaOptions.map(&:name)}"})

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -35,6 +35,14 @@ class CloverApi
 
         request_body_params = Validation.validate_request_body(r.body.read, required_parameters, allowed_optional_parameters)
 
+        # Generally parameter validation is handled in progs while creating resources.
+        # Since Vm::Nexus both handles VM creation requests from user and also Postgres
+        # service, moved the boot_image validation here to not allow users to pass
+        # postgres image as boot image while creating a VM.
+        if request_body_params["boot_image"]
+          Validation.validate_boot_image(request_body_params["boot_image"])
+        end
+
         if request_body_params["private_subnet_id"]
           ps_id = UBID.parse(request_body_params["private_subnet_id"]).to_uuid
           Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps_id)

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -44,9 +44,12 @@ class CloverApi
         end
 
         if request_body_params["private_subnet_id"]
-          ps_id = UBID.parse(request_body_params["private_subnet_id"]).to_uuid
-          Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps_id)
-          request_body_params["private_subnet_id"] = ps_id
+          ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"])
+          unless ps
+            fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{request_body_params["private_subnet_id"]}\" is not found"})
+          end
+          Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps.id)
+          request_body_params["private_subnet_id"] = ps.id
         end
 
         st = Prog::Vm::Nexus.assemble(

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -231,5 +231,17 @@ RSpec.describe Validation do
         expect { described_class.validate_cidr("not_a_cidr") }.to raise_error described_class::ValidationFailed
       end
     end
+
+    describe "#validate_boot_image" do
+      it "valid boot image" do
+        expect { described_class.validate_boot_image("ubuntu-jammy") }.not_to raise_error
+        expect { described_class.validate_boot_image("almalinux-9.1") }.not_to raise_error
+      end
+
+      it "invalid boot image" do
+        expect { described_class.validate_boot_image("invalid-boot-image") }.to raise_error described_class::ValidationFailed
+        expect { described_class.validate_boot_image("postgres-ubuntu-2204") }.to raise_error described_class::ValidationFailed
+      end
+    end
   end
 end

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -163,6 +163,30 @@ RSpec.describe Clover, "vm" do
         expect(Vm.first.ip4_enabled).to be true
       end
 
+      it "boot image doesn't passed" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          size: "standard-2",
+          enable_ip4: true
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it "invalid boot image" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          size: "standard-2",
+          boot_image: "invalid-boot-image",
+          enable_ip4: true
+        }.to_json
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\", \"almalinux-9.1\"]")
+      end
+
       it "invalid name" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/invalid_name", {
           public_key: "ssh key",

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -187,6 +187,20 @@ RSpec.describe Clover, "vm" do
         expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\", \"almalinux-9.1\"]")
       end
 
+      it "invalid ps id" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          size: "standard-2",
+          boot_image: "ubuntu-jammy",
+          private_subnet_id: "invalid-ubid",
+          enable_ip4: true
+        }.to_json
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body)["error"]["details"]["private_subnet_id"]).to eq("Private subnet with the given id \"invalid-ubid\" is not found")
+      end
+
       it "invalid name" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/invalid_name", {
           public_key: "ssh key",


### PR DESCRIPTION
**Add boot image validation for vm creation api endpoint**
Validating whether passed boot image is a valid one. Validation
is handled on the router instead of prog (which is the way generally
used for other validations) since the Vm::Nexus handles VM creation
request from both users and Postgres Service.

**Check whether given private subnet id exist for vm creation api endpoint**
Users can pass private subnet id to the VM creation api endpoint, so
the VM will be created under that subnet. Checking whethet a private subnet
with the given id exists to return proper error message.