### PR TITLE
Branch the route with /id instead of /ubid while accessing resources statically

### DIFF
--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -18,7 +18,7 @@ class CloverApi
       }
     end
 
-    r.on "ubid" do
+    r.on "id" do
       r.on String do |pg_ubid|
         pg = PostgresResource.from_ubid(pg_ubid)
         handle_pg_requests(@current_user, pg, @project)

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -18,7 +18,7 @@ class CloverApi
       }
     end
 
-    r.on "ubid" do
+    r.on "id" do
       r.is String do |ps_id|
         ps = PrivateSubnet.from_ubid(ps_id)
         handle_ps_requests(@current_user, ps)

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -18,7 +18,7 @@ class CloverApi
       }
     end
 
-    r.on "ubid" do
+    r.on "id" do
       r.on String do |vm_ubid|
         vm = Vm.from_ubid(vm_ubid)
         handle_vm_requests(@current_user, vm)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Clover, "postgres" do
     end
 
     it "not delete ubid" do
-      delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}"
+      delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -71,7 +71,7 @@ RSpec.describe Clover, "postgres" do
     end
 
     it "not get ubid" do
-      get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}"
+      get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -99,7 +99,7 @@ RSpec.describe Clover, "postgres" do
     end
 
     it "not restore ubid" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/restore"
+      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/restore"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -113,7 +113,7 @@ RSpec.describe Clover, "postgres" do
     end
 
     it "not reset super user password ubid" do
-      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/reset-superuser-password"
+      post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/reset-superuser-password"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -214,7 +214,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule pg ubid" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/firewall-rule", {
           cidr: "0.0.0.0/24"
         }.to_json
 
@@ -283,7 +283,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "reset password ubid" do
-        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/reset-superuser-password", {
+        post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -312,7 +312,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "success ubid" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}"
+        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(pg.name)
@@ -326,7 +326,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "show firewall" do
-        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/firewall-rule"
+        get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/firewall-rule"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)[0]["cidr"]).to eq("0.0.0.0/0")
@@ -342,7 +342,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "success ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
@@ -356,7 +356,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "not exist ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/foo_ubid"
+        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/foo_ubid"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
@@ -369,7 +369,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/ubid/#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Clover, "private_subnet" do
     end
 
     it "not delete ubid" do
-      delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+      delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -50,7 +50,7 @@ RSpec.describe Clover, "private_subnet" do
     end
 
     it "not get ubid" do
-      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+      get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -139,8 +139,8 @@ RSpec.describe Clover, "private_subnet" do
         expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
       end
 
-      it "success ubid" do
-        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+      it "success id" do
+        get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
@@ -168,8 +168,8 @@ RSpec.describe Clover, "private_subnet" do
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
       end
 
-      it "success ubid" do
-        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/ubid/#{ps.ubid}"
+      it "success id" do
+        delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be true

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Clover, "vm" do
     end
 
     it "not delete ubid" do
-      delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}"
+      delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -50,7 +50,7 @@ RSpec.describe Clover, "vm" do
     end
 
     it "not get ubid" do
-      get "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}"
+      get "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
 
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
@@ -110,7 +110,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "ubid not exist" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/foo_ubid"
+        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/foo_ubid"
 
         expect(last_response.status).to eq(404)
       end
@@ -226,7 +226,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "firewall-rule vm ubid" do
-        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}/firewall-rule", {
+        post "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}/firewall-rule", {
           cidr: "0.0.0.0/0",
           port_range: "100..1012"
         }.to_json
@@ -261,7 +261,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success ubid" do
-        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}"
+        get "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(vm.name)
@@ -291,7 +291,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be true
@@ -305,7 +305,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "not exist ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/foo_ubid"
+        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/foo_ubid"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
@@ -318,7 +318,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "firewall-rule ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/ubid/#{vm.ubid}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
+        delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}/firewall-rule/#{vm.firewalls.map(&:firewall_rules).flatten.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end


### PR DESCRIPTION
While accessing resources statically (by using their ubid instead of name) we where branching the URI with /ubid, though thinking about it further branching with /id looks more correct way to do that.

Users shouldn't care about the format of the unique identifier is in the ubid format. Using /ubid instead of /id adds an unnecessary confusion and also doesn't align with the resource scheme we are returning back from the API.