### PR TITLE
Don't return path while serializing project on api

### DIFF
--- a/serializers/api/project.rb
+++ b/serializers/api/project.rb
@@ -4,7 +4,6 @@ class Serializers::Api::Project < Serializers::Base
   def self.base(p)
     {
       id: p.ubid,
-      path: p.path,
       name: p.name,
       credit: p.credit.to_f,
       discount: p.discount,


### PR DESCRIPTION
Path is used for directing users to resource related pages on the web, so it is a part of serialization of web endpoint. Returning it from the api endpoint is unnecessary.