### PR TITLE
Update pagination to use polymorphic start_with instead of ubid cursor to fix broken pagination in case of concurrent delete

### DIFF
--- a/lib/pagination.rb
+++ b/lib/pagination.rb
@@ -1,25 +1,39 @@
 # frozen_string_literal: true
 
 module Pagination
-  def paginated_result(cursor: nil, page_size: nil, order_column: nil)
+  def paginated_result(start_with: nil, page_size: nil, order_column: nil)
     model = @opts[:model]
     page_size = (page_size&.to_i || 10).clamp(1, 100)
     order_column_sym = (order_column || "id").to_sym
 
-    fail Validation::ValidationFailed.new({cursor: "No resource exist with the given id #{cursor}"}) if cursor && !model.from_ubid(cursor)
-    fail Validation::ValidationFailed.new({order_column: "Given order column does not exist for the resource"}) unless model.columns.include?(order_column_sym)
+    if start_with && order_column_sym == :id
+      begin
+        start_with = UBID.parse(start_with).to_uuid
+      rescue
+        fail Validation::ValidationFailed.new(start_with: "#{start_with} is not a valid ID")
+      end
+    end
+
+    # For now, ordering by ubid is supported for all resource types, as ubid is always unique.
+    # Ordering by name is supported for location-based resources having a name column.
+    # Since the project is the only global resource for now, explicit check is added.
+    supported_order_columns = [:id]
+    if model.table_name != :project && model.columns.include?(:name)
+      supported_order_columns << :name
+    end
+
+    unless supported_order_columns.include?(order_column_sym)
+      fail Validation::ValidationFailed.new(order_column: "Supported ordering columns: #{supported_order_columns.join(", ")}")
+    end
 
     # Get page_size + 1 records to return the last element as the next_cursor
     # by popping it from the records
-    if cursor
-      cursor_order_column_value = model.from_ubid(cursor).send(order_column_sym)
-      page_records = where(Sequel[model.table_name][order_column_sym] >= cursor_order_column_value).order(order_column_sym).limit(page_size + 1).all
-    else
-      page_records = order(order_column_sym).limit(page_size + 1).all
-    end
+    query = model.order(order_column_sym).limit(page_size + 1)
+    query = query.where(Sequel[model.table_name][order_column_sym] >= start_with) if start_with
+    page_records = query.all
 
     if page_records.length > page_size
-      next_cursor = page_records.pop.ubid
+      next_cursor = page_records.pop.send(order_column_sym)
     end
 
     {records: page_records, next_cursor: next_cursor, count: count}

--- a/lib/pagination.rb
+++ b/lib/pagination.rb
@@ -26,16 +26,16 @@ module Pagination
       fail Validation::ValidationFailed.new(order_column: "Supported ordering columns: #{supported_order_columns.join(", ")}")
     end
 
-    # Get page_size + 1 records to return the last element as the next_cursor
+    # Get page_size + 1 records to return the last element as the next_value
     # by popping it from the records
     query = model.order(order_column_sym).limit(page_size + 1)
     query = query.where(Sequel[model.table_name][order_column_sym] >= start_with) if start_with
     page_records = query.all
 
     if page_records.length > page_size
-      next_cursor = page_records.pop.send(order_column_sym)
+      next_value = page_records.pop.send(order_column_sym)
     end
 
-    {records: page_records, next_cursor: next_cursor, count: count}
+    {records: page_records, next_value: next_value, count: count}
   end
 end

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -13,7 +13,7 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
+        next_value: result[:next_value],
         count: result[:count]
       }
     end

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = Project.authorized(@current_user.id, "Project:view").where(visible: true).paginated_result(
-        cursor: r.params["cursor"],
+        start_with: r.params["start_with"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -13,7 +13,7 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
+        next_value: result[:next_value],
         count: result[:count]
       }
     end

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.postgres_resources_dataset.where(location: @location).authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
-        cursor: r.params["cursor"],
+        start_with: r.params["start_with"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.private_subnets_dataset.where(location: @location).authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
-        cursor: r.params["cursor"],
+        start_with: r.params["start_with"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -13,7 +13,7 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
+        next_value: result[:next_value],
         count: result[:count]
       }
     end

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.vms_dataset.where(location: @location).authorized(@current_user.id, "Vm:view").paginated_result(
-        cursor: r.params["cursor"],
+        start_with: r.params["start_with"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -13,7 +13,7 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
+        next_value: result[:next_value],
         count: result[:count]
       }
     end

--- a/routes/api/project/postgres.rb
+++ b/routes/api/project/postgres.rb
@@ -13,7 +13,7 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
+        next_value: result[:next_value],
         count: result[:count]
       }
     end

--- a/routes/api/project/postgres.rb
+++ b/routes/api/project/postgres.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
-        cursor: r.params["cursor"],
+        start_with: r.params["start_with"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
-        cursor: r.params["cursor"],
+        start_with: r.params["start_with"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -13,7 +13,7 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
+        next_value: result[:next_value],
         count: result[:count]
       }
     end

--- a/routes/api/project/vm.rb
+++ b/routes/api/project/vm.rb
@@ -13,7 +13,7 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
+        next_value: result[:next_value],
         count: result[:count]
       }
     end

--- a/routes/api/project/vm.rb
+++ b/routes/api/project/vm.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.vms_dataset.authorized(@current_user.id, "Vm:view").paginated_result(
-        cursor: r.params["cursor"],
+        start_with: r.params["start_with"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Pagination do
         expect(result[:count]).to eq(2)
       end
 
-      it "next cursor" do
+      it "next value" do
         result = project.vms_dataset.paginated_result(page_size: 1, order_column: "name")
-        expect(result[:next_cursor]).to eq(second_vm.name)
+        expect(result[:next_value]).to eq(second_vm.name)
       end
 
       it "negative page size" do
@@ -57,7 +57,7 @@ RSpec.describe Pagination do
         expect(result[:records].length).to eq(1)
       end
 
-      it "cursor" do
+      it "start with resource" do
         result = project.vms_dataset.paginated_result(start_with: second_vm.ubid)
         expect(result[:records][0].ubid).to eq(second_vm.ubid)
       end

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Pagination do
 
       it "next cursor" do
         result = project.vms_dataset.paginated_result(page_size: 1, order_column: "name")
-        expect(result[:next_cursor]).to eq(second_vm.ubid)
+        expect(result[:next_cursor]).to eq(second_vm.name)
       end
 
       it "negative page size" do
@@ -58,14 +58,19 @@ RSpec.describe Pagination do
       end
 
       it "cursor" do
-        result = project.vms_dataset.paginated_result(cursor: second_vm.ubid)
+        result = project.vms_dataset.paginated_result(start_with: second_vm.ubid)
         expect(result[:records][0].ubid).to eq(second_vm.ubid)
+      end
+
+      it "non-existing name" do
+        result = project.vms_dataset.paginated_result(start_with: "dum", order_column: "name")
+        expect(result[:records][0].name).to eq(first_vm.name)
       end
     end
 
     describe "unsuccesful" do
-      it "invalid cursor" do
-        expect { project.vms_dataset.paginated_result(cursor: "invalidubid") }.to raise_error(Validation::ValidationFailed)
+      it "invalid start_with" do
+        expect { project.vms_dataset.paginated_result(start_with: "invalidubid") }.to raise_error(Validation::ValidationFailed)
       end
 
       it "invalid order column" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["items"]).to eq([])
-        expect(parsed_body["next_cursor"]).to be_nil
+        expect(parsed_body["next_value"]).to be_nil
         expect(parsed_body["count"]).to eq(0)
       end
 
@@ -93,7 +93,7 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["items"].length).to eq(1)
-        expect(parsed_body["next_cursor"]).to be_nil
+        expect(parsed_body["next_value"]).to be_nil
         expect(parsed_body["count"]).to eq(1)
       end
 
@@ -105,7 +105,7 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["items"].length).to eq(2)
-        expect(parsed_body["next_cursor"]).to be_nil
+        expect(parsed_body["next_value"]).to be_nil
         expect(parsed_body["count"]).to eq(2)
       end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["count"]).to eq(2)
-        expect(parsed_body["next_cursor"]).to be_nil
+        expect(parsed_body["next_value"]).to be_nil
       end
 
       it "invalid order column" do

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe Clover, "vm" do
         expect(parsed_body["count"]).to eq(2)
         expect(parsed_body["next_cursor"]).to be_nil
       end
+
+      it "invalid order column" do
+        project
+        get "/api/project?order_column=name"
+
+        expect(last_response.status).to eq(400)
+      end
     end
 
     describe "create" do


### PR DESCRIPTION
**Replace ubid cursor with polymorphic start_with in pagination request**
Client was passing ubid of next page's first resource as cursor to the
paginated list endpoint. Value to be compared was obtained by accessing the
resource with given ubid and getting the value of order column. Concurrent
deletions were broking that pagination as such resources could not be accessed.

In order to fix that issue, cursor, which was expected to be in the ubid
format, has been substituted with polymorphic start_with. Since the start_with will
be directly compared instead of being a pointer to a resource, concurrent deletion
won't cause any issue.

Value of the start_with is passed as a string though the format of it depends on
the order column. If the order column is id, format of start_with will be ubid,
if it is name it will be free text.

For now only id and name (whenever the resource has unique name) columns can
be used as order column, as using non-unique columns doesn't guarantee right
ordering and having disjoint pages.

Similar to start_with, response's next_cursor also became polymorphic which was
always ubid before. Client will be passing the value of next_cursor as the value
start_with to get the next page.


**Replace next_cursor with next_value in the pagination response**
Before updating ubid based cursors to polymorphic start_with values, next_cursor
was always in the ubid format. Though naming it as `cursor` feels like it will
be used as a pointer to a resource. So, updating it with next_value to specify
that value will be directly compared while finding the next page's resources.
