### PR TITLE
Update pagination logic to accept start_after in the request and don't return next_cursor to fix and simplify pagination

### DIFF
--- a/lib/pagination.rb
+++ b/lib/pagination.rb
@@ -26,15 +26,10 @@ module Pagination
       fail Validation::ValidationFailed.new(order_column: "Supported ordering columns: #{supported_order_columns.join(", ")}")
     end
 
-    # Get page_size + 1 records to return the last element as the next_value
-    # by popping it from the records
-    query = model.order(order_column_sym).limit(page_size + 1)
+    query = model.order(order_column_sym).limit(page_size)
     query = query.where(Sequel[model.table_name][order_column_sym] > start_after) if start_after
     page_records = query.all
-    if page_records.length > page_size
-      next_cursor = page_records.pop.ubid
-    end
 
-    {records: page_records, next_cursor: next_cursor, count: count}
+    {records: page_records, count: count}
   end
 end

--- a/lib/pagination.rb
+++ b/lib/pagination.rb
@@ -1,23 +1,36 @@
 # frozen_string_literal: true
 
 module Pagination
-  def paginated_result(cursor: nil, page_size: nil, order_column: nil)
+  def paginated_result(start_after: nil, page_size: nil, order_column: nil)
     model = @opts[:model]
     page_size = (page_size&.to_i || 10).clamp(1, 100)
     order_column_sym = (order_column || "id").to_sym
 
-    fail Validation::ValidationFailed.new({cursor: "No resource exist with the given id #{cursor}"}) if cursor && !model.from_ubid(cursor)
-    fail Validation::ValidationFailed.new({order_column: "Given order column does not exist for the resource"}) unless model.columns.include?(order_column_sym)
-
-    # Get page_size + 1 records to return the last element as the next_cursor
-    # by popping it from the records
-    if cursor
-      cursor_order_column_value = model.from_ubid(cursor).send(order_column_sym)
-      page_records = where(Sequel[model.table_name][order_column_sym] >= cursor_order_column_value).order(order_column_sym).limit(page_size + 1).all
-    else
-      page_records = order(order_column_sym).limit(page_size + 1).all
+    if start_after && order_column_sym == :id
+      begin
+        start_after = UBID.parse(start_after).to_uuid
+      rescue
+        fail Validation::ValidationFailed.new(start_after: "#{start_after} is not a valid ID")
+      end
     end
 
+    # For now, ordering by ubid is supported for all resource types, as ubid is always unique.
+    # Ordering by name is supported for location-based resources having a name column.
+    # Since the project is the only global resource for now, explicit check is added.
+    supported_order_columns = [:id]
+    if model.table_name != :project && model.columns.include?(:name)
+      supported_order_columns << :name
+    end
+
+    unless supported_order_columns.include?(order_column_sym)
+      fail Validation::ValidationFailed.new(order_column: "Supported ordering columns: #{supported_order_columns.join(", ")}")
+    end
+
+    # Get page_size + 1 records to return the last element as the next_value
+    # by popping it from the records
+    query = model.order(order_column_sym).limit(page_size + 1)
+    query = query.where(Sequel[model.table_name][order_column_sym] > start_after) if start_after
+    page_records = query.all
     if page_records.length > page_size
       next_cursor = page_records.pop.ubid
     end

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -6,14 +6,13 @@ class CloverApi
 
     r.get true do
       result = Project.authorized(@current_user.id, "Project:view").where(visible: true).paginated_result(
-        cursor: r.params["cursor"],
+        start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
         count: result[:count]
       }
     end

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -13,7 +13,6 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
         count: result[:count]
       }
     end

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.postgres_resources_dataset.where(location: @location).authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
-        cursor: r.params["cursor"],
+        start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -13,7 +13,6 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
         count: result[:count]
       }
     end

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.private_subnets_dataset.where(location: @location).authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
-        cursor: r.params["cursor"],
+        start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.vms_dataset.where(location: @location).authorized(@current_user.id, "Vm:view").paginated_result(
-        cursor: r.params["cursor"],
+        start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -13,7 +13,6 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
         count: result[:count]
       }
     end

--- a/routes/api/project/postgres.rb
+++ b/routes/api/project/postgres.rb
@@ -13,7 +13,6 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
         count: result[:count]
       }
     end

--- a/routes/api/project/postgres.rb
+++ b/routes/api/project/postgres.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
-        cursor: r.params["cursor"],
+        start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
-        cursor: r.params["cursor"],
+        start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -13,7 +13,6 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
         count: result[:count]
       }
     end

--- a/routes/api/project/vm.rb
+++ b/routes/api/project/vm.rb
@@ -6,7 +6,7 @@ class CloverApi
 
     r.get true do
       result = @project.vms_dataset.authorized(@current_user.id, "Vm:view").paginated_result(
-        cursor: r.params["cursor"],
+        start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
       )

--- a/routes/api/project/vm.rb
+++ b/routes/api/project/vm.rb
@@ -13,7 +13,6 @@ class CloverApi
 
       {
         items: serialize(result[:records]),
-        next_cursor: result[:next_cursor],
         count: result[:count]
       }
     end

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Pagination do
         expect(result[:count]).to eq(2)
       end
 
-      it "next cursor" do
-        result = project.vms_dataset.paginated_result(page_size: 1, order_column: "name")
-        expect(result[:next_cursor]).to eq(second_vm.ubid)
+      it "last resource" do
+        result = project.vms_dataset.paginated_result(page_size: 3, order_column: "name")
+        expect(result[:records][-1].name).to eq(second_vm.name)
       end
 
       it "partial name" do
@@ -62,9 +62,10 @@ RSpec.describe Pagination do
         expect(result[:records].length).to eq(1)
       end
 
-      it "cursor" do
-        result = project.vms_dataset.paginated_result(start_after: first_vm.ubid)
-        expect(result[:records][0].ubid).to eq(second_vm.ubid)
+      it "empty page" do
+        result = project.vms_dataset.paginated_result(start_after: second_vm.name, order_column: "name")
+        expect(result[:records].length).to eq(0)
+        expect(result[:count]).to eq(2)
       end
     end
 

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Pagination do
         expect(result[:next_cursor]).to eq(second_vm.ubid)
       end
 
+      it "partial name" do
+        result = project.vms_dataset.paginated_result(page_size: 1, order_column: "name", start_after: "dummy-vm")
+        expect(result[:records][0].name).to eq(first_vm.name)
+      end
+
       it "negative page size" do
         result = project.vms_dataset.paginated_result(page_size: -1)
         expect(result[:records].length).to eq(1)
@@ -58,14 +63,14 @@ RSpec.describe Pagination do
       end
 
       it "cursor" do
-        result = project.vms_dataset.paginated_result(cursor: second_vm.ubid)
+        result = project.vms_dataset.paginated_result(start_after: first_vm.ubid)
         expect(result[:records][0].ubid).to eq(second_vm.ubid)
       end
     end
 
     describe "unsuccesful" do
-      it "invalid cursor" do
-        expect { project.vms_dataset.paginated_result(cursor: "invalidubid") }.to raise_error(Validation::ValidationFailed)
+      it "invalid start after" do
+        expect { project.vms_dataset.paginated_result(start_after: "invalidubid") }.to raise_error(Validation::ValidationFailed)
       end
 
       it "invalid order column" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["items"]).to eq([])
-        expect(parsed_body["next_cursor"]).to be_nil
         expect(parsed_body["count"]).to eq(0)
       end
 
@@ -93,7 +92,6 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["items"].length).to eq(1)
-        expect(parsed_body["next_cursor"]).to be_nil
         expect(parsed_body["count"]).to eq(1)
       end
 
@@ -105,7 +103,6 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["items"].length).to eq(2)
-        expect(parsed_body["next_cursor"]).to be_nil
         expect(parsed_body["count"]).to eq(2)
       end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe Clover, "vm" do
         expect(parsed_body["count"]).to eq(2)
         expect(parsed_body["next_cursor"]).to be_nil
       end
+
+      it "invalid order column" do
+        project
+        get "/api/project?order_column=name"
+
+        expect(last_response.status).to eq(400)
+      end
+
+      it "invalid id" do
+        project
+        get "/api/project?start_after=invalid_id"
+
+        expect(last_response.status).to eq(400)
+      end
     end
 
     describe "create" do

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["count"]).to eq(2)
-        expect(parsed_body["next_cursor"]).to be_nil
       end
 
       it "invalid order column" do


### PR DESCRIPTION
**Replace ubid cursor with polymorphic start_after in pagination request**
Client was passing ubid of next page's first resource as cursor to the
paginated list endpoint. Value to be compared was obtained by accessing the
resource with given ubid and getting the value of order column. Concurrent
deletions were broking that pagination as such resources could not be accessed.

In order to fix that issue, cursor, which was expected to be in the ubid
format, has been replaced with polymorphic start_after. Since the start_after will
be directly compared instead of being a pointer to a resource, concurrent deletion
won't cause any issue.

Value of the start_after is passed as a string though the format of it depends on
the order column. If the order column is id, format of start_after will be ubid,
if it is name it will be free text.

For now only id and name (whenever the resource has unique name) columns can
be used as order column, as using non-unique columns doesn't guarantee right
ordering and having disjoint pages.


**Remove next_cursor from the pagination response**
Response of the pagination has been simplified by removing the next_cursor
from it. Client can pass the last element of the current page as the start_after
of the subsequent request to get the next page. If the items of the page doesn't
have any element, it means that there is no more page and resource.

That PR is an alternative pagination implementation to https://github.com/ubicloud/ubicloud/pull/1458. We are still discussing which one will have a better experience. One of them will be merged and the other will be deleted.