### PR TITLE
Don't activate vm host after downloading boot image

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -67,14 +67,8 @@ class Prog::DownloadBootImage < Prog::Base
     end
 
     if leaf?
-      hop_activate_host
+      pop "#{image_name} downloaded"
     end
     donate
-  end
-
-  label def activate_host
-    vm_host.update(allocation_state: "accepting")
-
-    pop "#{image_name} downloaded"
   end
 end

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Prog::DownloadBootImage do
         instance_double(Strand, prog: "ArbitraryOtherProg")
       ])
 
-      expect { dbi.wait_learn_storage }.to hop("activate_host")
+      expect { dbi.wait_learn_storage }.to exit({"msg" => "my-image downloaded"})
     end
 
     it "crashes if an expected field is not set for LearnStorage" do
@@ -94,14 +94,6 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dbi).to receive(:leaf?).and_return(false)
       expect(dbi).to receive(:donate).and_call_original
       expect { dbi.wait_learn_storage }.to nap(0)
-    end
-  end
-
-  describe "#activate_host" do
-    it "activates vm host again" do
-      expect {
-        expect { dbi.activate_host }.to exit({"msg" => "my-image downloaded"})
-      }.to change { vm_host.reload.allocation_state }.from("unprepared").to("accepting")
     end
   end
 end


### PR DESCRIPTION
We were activating host once DownloadBootImage downloads the boot image. It was ok to activate host after downloading the github image as we were preventing host to create runners by setting host's location to something invalid. Though, with fleet unification it became problematic. With the commit, host is not activated after boot image download, which is safer. Also, host activation after boot image download was unintuitive.

Note that, DownloadBootImage prog is used to download github and postgres images only while setting up the vm host, so no effect for VMs.