### PR TITLE
Reduce nap time in Vm::Nexus.prep

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -422,7 +422,7 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
       host.sshable.cmd("common/bin/daemonizer 'sudo host/bin/prepvm.rb #{params_path.shellescape}' prep_#{q_vm}", stdin: secrets_json)
     end
 
-    nap 5
+    nap 1
   end
 
   label def wait_firewall_rules_before_run

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Prog::Vm::Nexus do
       end
       expect(sshable).to receive(:cmd).with(/sudo host\/bin\/prepvm/, {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/})
 
-      expect { nx.prep }.to nap(5)
+      expect { nx.prep }.to nap(1)
     end
 
     it "naps if prep command is in progress" do
@@ -267,7 +267,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("InProgress")
       vmh = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vmh)
-      expect { nx.prep }.to nap(5)
+      expect { nx.prep }.to nap(1)
     end
 
     it "generates local_ipv4 if not set" do


### PR DESCRIPTION
This change reduces the nap time in `Vm::Nexus.prep` from 5 sec to 1 sec. At least on an idle host, preparation typically succeeds in less than a second. Reducing nap time by 4 sec has the potential to shave 4 sec off VM provisioning.