### PR TITLE
Replace wait_sshable with a script in host

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -437,24 +437,21 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
   end
 
   label def wait_sshable
-    addr = vm.ephemeral_net4
+    case host.sshable.cmd("common/bin/daemonizer --check wait_sshable_#{q_vm}")
+    when "Succeeded"
+      host.sshable.cmd("common/bin/daemonizer --clean wait_sshable_#{q_vm}")
 
-    # Alas, our hosting environment, for now, doesn't support IPv6, so
-    # only check SSH availability when IPv4 is available: a
-    # unistacked IPv6 server will not be checked.
-    #
-    # I considered removing wait_sshable altogether, but (very)
-    # occasionally helps us glean interesting information about boot
-    # problems.
-    hop_create_billing_record unless addr
-
-    begin
-      Socket.tcp(addr.to_s, 22, connect_timeout: 1) {}
-    rescue SystemCallError
-      nap 1
+      hop_create_billing_record
+    when "NotStarted", "Failed"
+      # I considered removing wait_sshable altogether, but (very)
+      # occasionally helps us glean interesting information about boot
+      # problems.
+      prefix_len = vm.ephemeral_net6.netmask.prefix_len + 1
+      source_ip = vm.ephemeral_net6.resize(prefix_len).next_sib.nth(3)
+      host.sshable.cmd("common/bin/daemonizer 'sudo host/bin/verify-sshable #{q_vm} #{source_ip} #{vm.ephemeral_net6.nth(2)}' wait_sshable_#{q_vm}")
     end
 
-    hop_create_billing_record
+    nap 1
   end
 
   label def create_billing_record

--- a/rhizome/host/bin/verify-sshable
+++ b/rhizome/host/bin/verify-sshable
@@ -1,0 +1,41 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+unless (vm = ARGV.shift)
+  puts "expected vm.inhost_name as argument"
+  exit 1
+end
+
+unless (source_ip = ARGV.shift)
+  puts "expected source ip as argument"
+  exit 1
+end
+
+unless (target_ip = ARGV.shift)
+  puts "expected target ip as argument"
+  exit 1
+end
+
+# Here in this script we punch a hole in the firewall to allow the source_ip to
+# connect to the target_ip on port 22. This is a safe operation because the
+# source ip belongs to the same host as the target ip. This is used to verify
+# that the target vm is up and running and is reachable via ssh.
+added = false
+begin
+  r "sudo ip netns exec #{vm} nft add element inet fw_table allowed_ipv6_port_tuple { #{source_ip} . 22 }"
+  added = true
+rescue => e
+  raise unless e.message.include?("File exists")
+end
+
+r "sudo ip netns exec #{vm} ip link set dev lo up"
+r "sudo ip netns exec #{vm} ip addr replace #{source_ip}/128 dev lo"
+
+begin
+  r "sudo ip netns exec #{vm} nc -w 1 -s #{source_ip} #{target_ip} 22"
+ensure
+  r "sudo ip netns exec #{vm} ip addr del #{source_ip}/128 dev lo"
+  r "sudo ip netns exec #{vm} nft delete element inet fw_table allowed_ipv6_port_tuple { #{source_ip} . 22 }" if added
+end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -658,22 +658,27 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#wait_sshable" do
-    it "naps if not sshable" do
-      expect(vm).to receive(:ephemeral_net4).and_return("10.0.0.1")
-      expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1).and_raise Errno::ECONNREFUSED
+    let(:vm_host) { instance_double(VmHost, sshable: instance_double(Sshable)) }
+
+    before do
+      allow(vm).to receive(:vm_host).and_return(vm_host).at_least(:once)
+      allow(vm).to receive(:ephemeral_net6).and_return(NetAddr::IPv6Net.parse("2a01:4f8:161:24db:2d4e::/79")).at_least(:once)
+    end
+
+    it "starts a new check and waits if Failed" do
+      expect(vm.vm_host.sshable).to receive(:cmd).with("common/bin/daemonizer --check wait_sshable_#{vm.inhost_name}").and_return("Failed")
+      expect(vm.vm_host.sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo host/bin/verify-sshable #{vm.inhost_name} 2a01:4f8:161:24db:2d4f::3 2a01:4f8:161:24db:2d4e::2' wait_sshable_#{vm.inhost_name}")
       expect { nx.wait_sshable }.to nap(1)
     end
 
-    it "hops to wait if sshable" do
-      vm_addr = instance_double(AssignedVmAddress, id: "46ca6ded-b056-4723-bd91-612959f52f6f", ip: NetAddr::IPv4Net.parse("10.0.0.1"))
-      expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)
-      expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
-      expect { nx.wait_sshable }.to hop("create_billing_record")
+    it "naps if InProgress" do
+      expect(vm.vm_host.sshable).to receive(:cmd).with("common/bin/daemonizer --check wait_sshable_#{vm.inhost_name}").and_return("InProgress")
+      expect { nx.wait_sshable }.to nap(1)
     end
 
-    it "skips a check if ipv4 is not enabled" do
-      expect(vm.ephemeral_net4).to be_nil
-      expect(vm).not_to receive(:ephemeral_net6)
+    it "hops to create_billing_record if sshable" do
+      expect(vm.vm_host.sshable).to receive(:cmd).with("common/bin/daemonizer --check wait_sshable_#{vm.inhost_name}").and_return("Succeeded")
+      expect(vm.vm_host.sshable).to receive(:cmd).with("common/bin/daemonizer --clean wait_sshable_#{vm.inhost_name}")
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
   end


### PR DESCRIPTION
With this commit, we are replacing the logic in wait_sshable in the controlplane with a script that runs in the host. We punch a small hole in the firewall for an ip address that is allocated for our use but specific to the VM. Therefore, this does not create a security issue as well. This way, we verify the VM connectability without depending on the controlplane IP address and heroku's networking which does not support IPv6 (sigh).