### PR TITLE
Increase nap time from 0 to 1 in donate

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -175,7 +175,7 @@ end
 
   def donate
     strand.children.map(&:run)
-    nap 0
+    nap 1
   end
 
   def reap

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe Prog::Base do
   it "keeps children array state in sync even in consecutive-run mode" do
     parent = Strand.create_with_id(prog: "Test", label: "reap_exit_no_children")
     Strand.create_with_id(parent_id: parent.id, prog: "Test", label: "popper")
+    prg = parent.load
+    expect(prg).to receive(:nap).and_raise(Prog::Base::Nap.new(0))
+    expect(parent).to receive(:load).twice.and_return(prg)
     expect(parent).to receive(:unsynchronized_run).twice.and_call_original
     parent.run(10)
   end

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dbi).to receive(:reap).and_return([])
       expect(dbi).to receive(:leaf?).and_return(false)
       expect(dbi).to receive(:donate).and_call_original
-      expect { dbi.wait_learn_storage }.to nap(0)
+      expect { dbi.wait_learn_storage }.to nap(1)
     end
   end
 end

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Prog::InstallDnsmasq do
     it "donates if any sub-progs are still running" do
       expect(idm).to receive(:donate).and_call_original
       expect(idm).to receive(:leaf?).and_return false
-      expect { idm.wait_downloads }.to nap(0)
+      expect { idm.wait_downloads }.to nap(1)
     end
 
     it "hops to compile_and_install when the downloads are done" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     it "donates if bootstrap rhizome continues" do
       expect(nx).to receive(:leaf?).and_return(false)
       expect(nx).to receive(:donate).and_call_original
-      expect { nx.wait_bootstrap_rhizome }.to nap(0)
+      expect { nx.wait_bootstrap_rhizome }.to nap(1)
     end
 
     it "hops to setup if bootstrap rhizome is done" do
@@ -196,7 +196,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     it "donates if setup continues" do
       expect(nx).to receive(:leaf?).and_return(false)
       expect(nx).to receive(:donate).and_call_original
-      expect { nx.wait_setup }.to nap(0)
+      expect { nx.wait_setup }.to nap(1)
     end
 
     it "hops to wait if setup is done" do
@@ -312,7 +312,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     it "donates if reconfigure continues" do
       expect(nx).to receive(:leaf?).and_return(false)
       expect(nx).to receive(:donate).and_call_original
-      expect { nx.wait_reconfigure }.to nap(0)
+      expect { nx.wait_reconfigure }.to nap(1)
     end
 
     it "hops to wait if reconfigure is done" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:leaf?).and_return false
       expect(nx).to receive(:donate).and_call_original
 
-      expect { nx.wait_bootstrap_rhizome }.to nap(0)
+      expect { nx.wait_bootstrap_rhizome }.to nap(1)
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return false
       expect(nx).to receive(:donate).and_call_original
 
-      expect { nx.wait_bootstrap_rhizome }.to nap(0)
+      expect { nx.wait_bootstrap_rhizome }.to nap(1)
     end
   end
 
@@ -162,7 +162,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:reap).and_return([])
       expect(nx).to receive(:leaf?).and_return(false)
       expect(nx).to receive(:donate).and_call_original
-      expect { nx.wait_prep }.to nap(0)
+      expect { nx.wait_prep }.to nap(1)
     end
   end
 
@@ -188,7 +188,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return false
       expect(nx).to receive(:donate).and_call_original
 
-      expect { nx.wait_setup_hugepages }.to nap(0)
+      expect { nx.wait_setup_hugepages }.to nap(1)
     end
   end
 
@@ -226,7 +226,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:leaf?).and_return false
       expect(nx).to receive(:donate).and_call_original
 
-      expect { nx.wait_setup_spdk }.to nap(0)
+      expect { nx.wait_setup_spdk }.to nap(1)
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -664,7 +664,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "donates if firewall rules are not updated" do
       expect(nx).to receive(:leaf?).and_return(false)
-      expect { nx.wait_firewall_rules_before_run }.to nap(0)
+      expect { nx.wait_firewall_rules_before_run }.to nap(1)
     end
 
     it "hops to run if firewall rules are updated" do
@@ -819,7 +819,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "naps when nothing to do" do
       expect(nx).to receive(:leaf?).and_return(false)
-      expect { nx.wait_firewall_rules }.to nap(0)
+      expect { nx.wait_firewall_rules }.to nap(1)
     end
 
     it "hops to run if firewall rules are updated" do


### PR DESCRIPTION
With a nap time of 0 in `donate`, a parent strand executes its children in a loop until they exit, without taking a nap. This supports children making progress to unblock the parent.

However, an issue with this is that children are not always able to immediately make progress and nap 0 becomes wasteful. In production, we see instances where child strands are executed in a tight loop, hogging resources and starving other strands.

This change increases nap time in donate to 1. That way, a parent needs to take a short nap after running its children and cannot immediately re-execute them.