### PR TITLE
Increase max page limit for fetching failed GitHub deliveries

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -34,7 +34,7 @@ module Github
     @@runner_labels ||= YAML.load_file("config/github_runner_labels.yml").to_h { [_1["name"], _1] }
   end
 
-  def self.failed_deliveries(since, max_page = 20)
+  def self.failed_deliveries(since, max_page = 50)
     client = Github.app_client
     all_deliveries = client.get("/app/hook/deliveries?per_page=100")
     page = 1


### PR DESCRIPTION
GitHub's app delivery API lacks adequate filtering features and only permits a maximum of 100 items per page. I've introduced a 'max_page' safety measure to prevent endless pagination.

As the count of delivered webhook events has risen, it appears we need to raise the 'max_page' limit to retrieve all failed deliveries within the specified time range.