### PR TITLE
Do not fail if the runner does not have a strand in serializer

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -25,6 +25,15 @@ class GithubRunner < Sequel::Model
     "http://github.com/#{repository_name}/settings/actions/runners/#{runner_id}" if runner_id
   end
 
+  def display_state
+    return vm.display_state if vm
+    case strand&.label
+    when "wait_vm_destroy" then "deleted"
+    when "wait_concurrency_limit" then "reached_concurrency_limit"
+    else "not_created"
+    end
+  end
+
   def init_health_monitor_session
     {
       ssh_session: vm.sshable.start_fresh_session

--- a/serializers/web/github_runner.rb
+++ b/serializers/web/github_runner.rb
@@ -18,15 +18,7 @@ class Serializers::Web::GithubRunner < Serializers::Base
         workflow_name: runner.workflow_job["workflow_name"],
         head_branch: runner.workflow_job["head_branch"]
       } : nil,
-      vm_state: if runner.vm
-                  runner.vm.display_state
-                elsif runner.strand.label == "wait_vm_destroy"
-                  "deleted"
-                elsif runner.strand.label == "wait_concurrency_limit"
-                  "reached_concurrency_limit"
-                else
-                  "not_created"
-                end
+      state: runner.display_state
     }
   end
 

--- a/views/project/github.erb
+++ b/views/project/github.erb
@@ -32,7 +32,7 @@
               <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Runner</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Repository</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Label</th>
-              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Vm</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Branch</th>
               <th scope="col" class="relative py-3.5 pl-3 pr-4 text-left text-sm font-semibold text-gray-900 sm:pr-6">Workflow Job</th>
             </tr>
@@ -55,7 +55,7 @@
                     <%= runner[:label] %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <%== render("components/vm_state_label", locals: { state: runner[:vm_state] }) %>
+                    <%== render("components/vm_state_label", locals: { state: runner[:state] }) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= runner.dig(:workflow_job, :head_branch) || "-" %>


### PR DESCRIPTION
Usually, we don't expect that the runner model will lack a strand. However, due to eager loading sending multiple queries, there may be brief periods when the runner doesn't have a strand in the loaded list. This PR ensures that the serializer doesn't fail if the runner is without a strand.

With recent changes, this state isn't only the state of virtual machine. So I moved to the runner model as "display_state" similar to the other models.

I also rename variables to make the test more readable.