### PR TITLE
Remove references to SPDK_LEGACY_VERSION.

### DIFF
--- a/model/spdk_installation.rb
+++ b/model/spdk_installation.rb
@@ -2,9 +2,6 @@
 
 require_relative "../model"
 
-# YYY: Remove all checks against this after upgrading all legacy systems
-LEGACY_SPDK_VERSION = "LEGACY_SPDK_VERSION"
-
 class SpdkInstallation < Sequel::Model
   many_to_one :vm_host
   one_to_many :vm_storage_volumes

--- a/rhizome/host/lib/spdk_path.rb
+++ b/rhizome/host/lib/spdk_path.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# YYY: Remove all checks against this after upgrading all legacy systems
-LEGACY_SPDK_VERSION = "LEGACY_SPDK_VERSION"
-
 DEFAULT_SPDK_VERSION = "v23.09-ubi-0.2"
 
 module SpdkPath
@@ -30,15 +27,11 @@ module SpdkPath
     # Hugepages path can't have any "-" characters. This is because mount
     # service name should match the path, and the "-" s in mount service name
     # are regarded as "/" s in the path.
-    (spdk_version == LEGACY_SPDK_VERSION) ?
-      File.join(home, "hugepages") :
-      File.join(home, "hugepages.#{spdk_version.tr("-", ".")}")
+    File.join(home, "hugepages.#{spdk_version.tr("-", ".")}")
   end
 
   def self.rpc_sock(spdk_version)
-    (spdk_version == LEGACY_SPDK_VERSION) ?
-      File.join(home, "spdk.sock") :
-      File.join(home, "spdk-#{spdk_version}.sock")
+    File.join(home, "spdk-#{spdk_version}.sock")
   end
 
   def self.conf_path(spdk_version)
@@ -50,9 +43,7 @@ module SpdkPath
   end
 
   def self.install_path(spdk_version)
-    (spdk_version == LEGACY_SPDK_VERSION) ?
-      File.join(install_prefix, "spdk") :
-      File.join(install_prefix, "spdk-#{spdk_version}")
+    File.join(install_prefix, "spdk-#{spdk_version}")
   end
 
   def self.bin(version, n)

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -34,10 +34,7 @@ class SpdkSetup
   end
 
   def spdk_service
-    @spdk_service ||=
-      (@spdk_version == LEGACY_SPDK_VERSION) ?
-          "spdk.service" :
-          "spdk-#{@spdk_version}.service"
+    @spdk_service ||= "spdk-#{@spdk_version}.service"
   end
 
   def hugepages_mount_service

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -24,10 +24,7 @@ class StorageVolume
     @skip_sync = params["skip_sync"] || false
     @image_path = vp.image_path(params["image"]) if params["image"]
     @device = params["storage_device"] || DEFAULT_STORAGE_DEVICE
-
-    # Old VMs didn't have the spdk_version field. Fill that in with legacy
-    # SPDK version for backward compatibility.
-    @spdk_version = params["spdk_version"] || LEGACY_SPDK_VERSION
+    @spdk_version = params["spdk_version"]
   end
 
   def vp


### PR DESCRIPTION
We don't have any legacy SPDK installations in production anymore, so we can remove these.