### PR TITLE
Use minor version instead of patch version for NodeJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21.7.2-alpine3.19 as frontend-builder
+FROM node:21.7-alpine3.19 as frontend-builder
 WORKDIR /app
 COPY tailwind.config.js package.json package-lock.json ./
 COPY views/ ./views/


### PR DESCRIPTION
Every week, a new patch released for NodeJS, then Dependabot creates a PR to update the version.

Since we are not heavily dependent on NodeJS, we can pin the minor version instead of the patch version. So, we can avoid the weekly PRs.

While building image, it will pull the latest patch version of the minor version.