### PR TITLE
Make rodauth errors' scheme consistent with API's common error scheme

### DIFF
--- a/spec/routes/api/auth_spec.rb
+++ b/spec/routes/api/auth_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "auth" do
+  let(:user) { create_account }
+
+  it "wrong email" do
+    post "/api/login?login=wrong_mail&password=#{TEST_USER_PASSWORD}", nil, {"CONTENT_TYPE" => "application/json"}
+    expect(last_response.status).to eq(401)
+    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("There was an error logging in")
+    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidCredentials")
+  end
+
+  it "wrong password" do
+    post "/api/login?login=#{TEST_USER_EMAIL}&password=wrongpassword", nil, {"CONTENT_TYPE" => "application/json"}
+    expect(last_response.status).to eq(401)
+    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("There was an error logging in")
+    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidCredentials")
+  end
+
+  it "wrong jwt" do
+    header "Authorization", "Bearer wrongjwt"
+    get "/api/project"
+
+    expect(last_response.status).to eq(400)
+    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("invalid JWT format or claim in Authorization header")
+    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+  end
+
+  it "no login" do
+    get "/api/project"
+
+    expect(last_response.status).to eq(401)
+    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("LoginRequired")
+  end
+end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -39,84 +39,84 @@ RSpec.describe Clover, "postgres" do
       get "/api/project/#{project.ubid}/location/#{pg.location}/postgres"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create" do
       post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/postgres_name"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete ubid" do
       delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get ubid" do
       get "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create firewall rule" do
       post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete firewall rule" do
       delete "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not restore" do
       post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/restore"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not restore ubid" do
       post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/restore"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not reset super user password" do
       post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/#{pg.name}/reset-superuser-password"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not reset super user password ubid" do
       post "/api/project/#{project.ubid}/location/#{pg.location}/postgres/id/#{pg.ubid}/reset-superuser-password"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
   end
 

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -18,42 +18,42 @@ RSpec.describe Clover, "private_subnet" do
       get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create" do
       post "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/foo_name"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete ubid" do
       delete "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/#{ps.name}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get ubid" do
       get "/api/project/#{project.ubid}/location/#{ps.location}/private-subnet/id/#{ps.ubid}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
   end
 

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -18,56 +18,56 @@ RSpec.describe Clover, "vm" do
       get "/api/project/#{project.ubid}/location/#{vm.location}/vm"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create" do
       post "/api/project/#{project.ubid}/location/#{vm.location}/vm/foo_name"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete ubid" do
       delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not get ubid" do
       get "/api/project/#{project.ubid}/location/#{vm.location}/vm/id/#{vm.ubid}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create firewall rule" do
       post "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete firewall rule" do
       delete "/api/project/#{project.ubid}/location/#{vm.location}/vm/#{vm.name}/firewall-rule/foo_ubid"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
   end
 

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Clover, "vm" do
       get "/api/project/#{project.ubid}/pg"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
   end
 

--- a/spec/routes/api/project/private_subnet_spec.rb
+++ b/spec/routes/api/project/private_subnet_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Clover, "private_subnet" do
       get "/api/project/#{project.ubid}/private-subnet"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
   end
 

--- a/spec/routes/api/project/vm_spec.rb
+++ b/spec/routes/api/project/vm_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Clover, "vm" do
       get "/api/project/#{project.ubid}/vm"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
   end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -12,21 +12,21 @@ RSpec.describe Clover, "vm" do
       get "/api/project"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not create" do
       post "/api/project"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
 
     it "not delete" do
       delete "api/project/#{project.ubid}"
 
       expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]).to eq("Please login to continue")
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
   end
 


### PR DESCRIPTION
When requests fail at the authentication step, rodauth was generating it's own error messages in its own format. Converting those errors to the common scheme for the sake of consistency of the API errors.