### PR TITLE
Remove DnsZone record for MinioServer with data and type

### DIFF
--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -174,7 +174,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     register_deadline(nil, 10 * 60)
     DB.transaction do
       decr_destroy
-      minio_server.cluster.dns_zone&.delete_record(record_name: cluster.hostname)
+      minio_server.cluster.dns_zone&.delete_record(record_name: cluster.hostname, type: "A", data: vm.ephemeral_net4&.to_s)
       minio_server.vm.sshable.destroy
       minio_server.vm.nics.each { _1.incr_destroy }
       minio_server.vm.incr_destroy


### PR DESCRIPTION
Before this commit we were simply removing any DnsRecord at the MinioServerNexus.destroy. Now, we are removing the record that belongs to that specific server.