### PR TITLE
Add Vm.update_spdk_version(...) 

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -21,7 +21,7 @@ class Vm < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup
+  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency
 
   include Authorization::HyperTagMethods
 
@@ -182,6 +182,13 @@ class Vm < Sequel::Model
     end
 
     pulse
+  end
+
+  def update_spdk_version(version)
+    spdk_installation = vm_host.spdk_installations_dataset[version: version]
+    fail "SPDK version #{version} not found on host" unless spdk_installation
+    vm_storage_volumes_dataset.update(spdk_installation_id: spdk_installation.id)
+    incr_update_spdk_dependency
   end
 
   def self.redacted_columns

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -67,4 +67,11 @@ when "recreate-unpersisted"
     ndp_needed, storage_volumes, storage_secrets,
     multiqueue: max_vcpus > 1
   )
+when "reinstall-systemd-units"
+  vm_setup.install_systemd_unit(
+    max_vcpus, cpu_topology, mem_gib, storage_volumes, nics
+  )
+else
+  puts "Invalid action #{action}"
+  exit 1
 end


### PR DESCRIPTION
Previously to change SPDK version of a VM we needed to do multiple weird manual steps. This patch automates some of them and what we need to do is:

1. Install the new SPDK version on the host:

```
> Prog::Storage::SetupSpdk.assemble(
     vm_host.id, "some-spdk-version",
     start_service: true, allocation_weight: 100)
```

2. Update all VMs we want to migrate to this SPDK version. Note that this will just update related configs and won't take effect until host reboot:

```
> vm.update_spdk_version("some-spdk-version")
```

3. Reboot host:

```
> vm_host.incr_reboot
```

4. Optionally, remove the old SPDK installation:

```
> Prog::Storage::RemoveSpdk.assemble(old_spdk_installation.id)
```
