### PR TITLE
Add migration to index semaphore.strand_id

### DIFF
--- a/migrate/20240418_add_semaphore_strand_index.rb
+++ b/migrate/20240418_add_semaphore_strand_index.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  change do
+    alter_table(:semaphore) do
+      add_index :strand_id, concurrently: true
+    end
+  end
+end


### PR DESCRIPTION
Looking at our hot queries (i.e. frequency * duration = long), it appears we were seq scanning and disqualifying nearly all `semaphore` records running a query like:

     SELECT * FROM "semaphore" WHERE ("strand_id" = $1)

The result was excessive consumed CPU time.

The use of `CREATE INDEX CONCURRENTLY` is excessive, but it makes one of our inherited RuboCop rules happy.  Maybe I'll disable that rule later.