### PR TITLE
Allow reserving some cores per host for non-runner purposes.

### DIFF
--- a/migrate/20240420_add_github_runner_allocation_core_threshold.rb
+++ b/migrate/20240420_add_github_runner_allocation_core_threshold.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      add_column :github_runner_allocation_core_threshold, :int, default: 0, null: false
+    end
+  end
+end


### PR DESCRIPTION
We currently use the whole available capacity of a host for github-runners. This can cause capacity issues for regular VMs. This PR 
allows reserving some cores for regular VMs by setting a threshold.

E.g. if we do the following:

```
vm_host.update(github_runner_allocation_core_threshold: 4)
```

Then it won't allocate a runner if number of available cores after provisioning the runner is below 4.

(I will add tests if the idea makes sense)