### PR TITLE
Fix Nexus.destroy volume asynchronous update issue

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -581,9 +581,7 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
       end
 
       vm.vm_storage_volumes.each do |vol|
-        dev = vol.storage_device
-        dev ||= StorageDevice.dataset.where(vm_host_id: vm.vm_host_id, name: "DEFAULT").first
-        dev.update(available_storage_gib: dev.available_storage_gib + vol.size_gib)
+        vol.storage_device_dataset.update(available_storage_gib: Sequel[:available_storage_gib] + vol.size_gib)
       end
 
       VmHost.dataset.where(id: vm.vm_host_id).update(


### PR DESCRIPTION
We were using the available_storage_gib value we had in memory in the process when updating the storage device available_storage_gib. This caused async updates to overwrite each other's updates. This commit fixes the issue by using the valus in the database when updating.