### PR TITLE
Add constraints to StorageDevice and not null VmVolume.storage_device_id

### DIFF
--- a/migrate/20240419_add_constratins_for_volume_device.rb
+++ b/migrate/20240419_add_constratins_for_volume_device.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_storage_volume) do
+      set_column_not_null :storage_device_id
+    end
+
+    alter_table(:storage_device) do
+      add_constraint(:available_storage_gib_non_negative) { available_storage_gib >= 0 }
+      add_constraint(:available_storage_gib_less_than_or_equal_to_total) { available_storage_gib <= total_storage_gib }
+    end
+  end
+end

--- a/migrate/20240422_drop_vmh_storage_gib_cols.rb
+++ b/migrate/20240422_drop_vmh_storage_gib_cols.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm_host) do
+      drop_column :available_storage_gib
+      drop_column :total_storage_gib
+    end
+  end
+end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -227,4 +227,12 @@ class VmHost < Sequel::Model
 
     pulse
   end
+
+  def available_storage_gib
+    storage_devices.sum { _1.available_storage_gib }
+  end
+
+  def total_storage_gib
+    storage_devices.sum { _1.total_storage_gib }
+  end
 end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -54,18 +54,7 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   label def wait_learn_storage
-    reap.each do |st|
-      case st.prog
-      when "LearnStorage"
-        kwargs = {
-          total_storage_gib: st.exitval.fetch("total_storage_gib"),
-          available_storage_gib: st.exitval.fetch("available_storage_gib")
-        }
-
-        vm_host.update(**kwargs)
-      end
-    end
-
+    reap
     if leaf?
       pop "#{image_name} downloaded"
     end

--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -47,7 +47,7 @@ class Prog::LearnStorage < Prog::Base
   end
 
   label def start
-    total, avail = make_model_instances.each_with_object([0, 0]) { |sd, accum|
+    make_model_instances.each do |sd|
       sd.skip_auto_validations(:unique) do
         sd.insert_conflict(target: [:vm_host_id, :name],
           update: {
@@ -55,11 +55,8 @@ class Prog::LearnStorage < Prog::Base
             available_storage_gib: Sequel[:excluded][:available_storage_gib]
           }).save_changes
       end
-      accum[0] += sd.total_storage_gib
-      accum[1] += sd.available_storage_gib
-    }
+    end
 
-    pop({"total_storage_gib" => total, "available_storage_gib" => avail,
-         "msg" => "created StorageDevice records"})
+    pop("created StorageDevice records")
   end
 end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -79,14 +79,6 @@ class Prog::Vm::HostNexus < Prog::Base
           total_cores: total_cores,
           total_cpus: total_cpus
         }
-
-        vm_host.update(**kwargs)
-      when "LearnStorage"
-        kwargs = {
-          total_storage_gib: st.exitval.fetch("total_storage_gib"),
-          available_storage_gib: st.exitval.fetch("available_storage_gib")
-        }
-
         vm_host.update(**kwargs)
       end
     end

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -74,19 +74,13 @@ RSpec.describe Prog::DownloadBootImage do
   end
 
   describe "#wait_learn_storage" do
-    it "updates the vm_host record from the finished programs" do
-      expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
+    it "exits if progs run properly" do
       expect(dbi).to receive(:reap).and_return([
-        instance_double(Strand, prog: "LearnStorage", exitval: {"total_storage_gib" => 300, "available_storage_gib" => 500}),
+        instance_double(Strand, prog: "LearnStorage", exitval: {"msg" => "created StorageDevice records"}),
         instance_double(Strand, prog: "ArbitraryOtherProg")
       ])
 
       expect { dbi.wait_learn_storage }.to exit({"msg" => "my-image downloaded"})
-    end
-
-    it "crashes if an expected field is not set for LearnStorage" do
-      expect(dbi).to receive(:reap).and_return([instance_double(Strand, prog: "LearnStorage", exitval: {})])
-      expect { dbi.wait_learn_storage }.to raise_error KeyError, "key not found: \"total_storage_gib\""
     end
 
     it "donates to children if they are not exited yet" do

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -19,7 +19,7 @@ Mounted on                   1B-blocks        Avail
 /var/storage/devices/stor2  3331416064   3331276800
 EOS
 
-      expect { ls.start }.to exit({"total_storage_gib" => 3, "available_storage_gib" => 3, "msg" => "created StorageDevice records"}).and change {
+      expect { ls.start }.to exit({"msg" => "created StorageDevice records"}).and change {
         StorageDevice.map(&:name).sort
       }.from([]).to(%w[DEFAULT stor1 stor2])
     end
@@ -39,7 +39,7 @@ Mounted on                   1B-blocks        Avail
 /var/storage/devices/stor2  3331416064   1531276800
 EOS
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      expect { ls.start }.to exit({"total_storage_gib" => 13, "available_storage_gib" => 3, "msg" => "created StorageDevice records"}).and change {
+      expect { ls.start }.to exit({"msg" => "created StorageDevice records"}).and change {
         StorageDevice.map { |sd|
           sd.values.slice(
             :name, :available_storage_gib, :total_storage_gib
@@ -54,6 +54,9 @@ EOS
           {name: "stor2", total_storage_gib: 3, available_storage_gib: 1}
         ]
       )
+
+      expect(vmh.reload.available_storage_gib).to eq(3)
+      expect(vmh.reload.total_storage_gib).to eq(13)
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -131,12 +131,10 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
       expect(vm_host).to receive(:update).with(arch: "arm64")
       expect(vm_host).to receive(:update).with(total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2)
-      expect(vm_host).to receive(:update).with(total_storage_gib: 300, available_storage_gib: 500)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),
         instance_double(Strand, prog: "LearnArch", exitval: {"arch" => "arm64"}),
         instance_double(Strand, prog: "LearnCores", exitval: {"total_sockets" => 2, "total_dies" => 3, "total_cores" => 4, "total_cpus" => 5}),
-        instance_double(Strand, prog: "LearnStorage", exitval: {"total_storage_gib" => 300, "available_storage_gib" => 500}),
         instance_double(Strand, prog: "ArbitraryOtherProg")
       ])
 
@@ -151,11 +149,6 @@ RSpec.describe Prog::Vm::HostNexus do
     it "crashes if an expected field is not set for LearnCores" do
       expect(nx).to receive(:reap).and_return([instance_double(Strand, prog: "LearnCores", exitval: {})])
       expect { nx.wait_prep }.to raise_error KeyError, "key not found: \"total_cores\""
-    end
-
-    it "crashes if an expected field is not set for LearnStorage" do
-      expect(nx).to receive(:reap).and_return([instance_double(Strand, prog: "LearnStorage", exitval: {})])
-      expect { nx.wait_prep }.to raise_error KeyError, "key not found: \"total_storage_gib\""
     end
 
     it "donates to children if they are not exited yet" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -393,7 +393,8 @@ RSpec.describe Prog::Vm::Nexus do
               arch: "x64"}.merge(args)
       sa = Sshable.create_with_id(host: "127.0.0.#{@host_index}")
       @host_index += 1
-      host = VmHost.create(**args) { _1.id = sa.id }
+
+      host = VmHost.create(**args.except(:available_storage_gib, :total_storage_gib)) { _1.id = sa.id }
       StorageDevice.create_with_id(
         name: "DEFAULT",
         available_storage_gib: args[:available_storage_gib],
@@ -521,7 +522,7 @@ RSpec.describe Prog::Vm::Nexus do
       SpdkInstallation.create(vm_host_id: id, version: "v1", allocation_weight: 100) { _1.id = id }
       StorageDevice.create(
         vm_host_id: host.id, name: "nvme0",
-        available_storage_gib: 100, total_storage_gib: 50
+        available_storage_gib: 100, total_storage_gib: 150
       ) { _1.id = StorageDevice.generate_uuid }
       StorageDevice.create(
         vm_host_id: host.id, name: "DEFAULT",


### PR DESCRIPTION
**StorageDevice VmHost and VmStorageVolume schema updates** 
We have 3 main changes here.
1. Drop VmHost.available_storage_gib column;
This is not used anywhere. We solely depend on
StorageDevice.available_storage_gib during allocation. Therefore,
removing this column.

2. Drop VmHost.total_storage_gib column;
Not used anywhere. Removed to not cause confusion and async issues. We
added a wraaper function around storage devices to be safer.

3. Make VmStorageVolume.storage_device_id column not nullable;
We occasionally see a drift of StorageDevice.available_storage_gib vs
vm.vm_storage_volume used sizes. This is happening because of bugs and
not maintaining the relationship in between volume and the device
properly. In result, they cause negative available_storage_gib. This
commit introduces new constraints to block these cases so that we can be
aware of the situation.

4. Introduce non zero and smaller than total_storage_gib constraints to
the StorageDevice.available_storage_gib column.

**Replace VmHost.available_storage_gib column with a function** 
The availablae_storage_gib column in the VmHost comes from old times and
have no use in the codebase. It causes confusion and this is cleaning up
that column. Still for the sake of reaching the available storage size
in the host, I added a new function which is a wrapper around
storage_devices.

**Remove VmHost.total_storage_gib** 
This is not used anywhere, so, we are dropping the column. For the sake
of operator tooling, we add a wrapper function in the host model to find
out the total_storage_gib from the storage devices.