### PR TITLE
Don't accept non-numeric value for page size

### DIFF
--- a/lib/pagination.rb
+++ b/lib/pagination.rb
@@ -3,8 +3,14 @@
 module Pagination
   def paginated_result(start_after: nil, page_size: nil, order_column: nil)
     model = @opts[:model]
-    page_size = (page_size&.to_i || 10).clamp(1, 100)
+    page_size ||= 10
     order_column_sym = (order_column || "id").to_sym
+
+    begin
+      page_size = Integer(page_size).clamp(1, 100)
+    rescue ArgumentError
+      fail Validation::ValidationFailed.new(page_size: "#{page_size} is not an integer")
+    end
 
     if start_after && order_column_sym == :id
       begin

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -57,11 +57,6 @@ RSpec.describe Pagination do
         expect(result[:records].length).to eq(100)
       end
 
-      it "non numeric page size" do
-        result = project.vms_dataset.paginated_result(page_size: "foo")
-        expect(result[:records].length).to eq(1)
-      end
-
       it "empty page" do
         result = project.vms_dataset.paginated_result(start_after: second_vm.name, order_column: "name")
         expect(result[:records].length).to eq(0)
@@ -76,6 +71,10 @@ RSpec.describe Pagination do
 
       it "invalid order column" do
         expect { project.vms_dataset.paginated_result(order_column: "non-existing-column") }.to raise_error(Validation::ValidationFailed)
+      end
+
+      it "non numeric page size" do
+        expect { project.vms_dataset.paginated_result(page_size: "foo") }.to raise_error(Validation::ValidationFailed)
       end
     end
   end


### PR DESCRIPTION
We've decided to not support non-numeric value for page size, adding a validation for that.