### PR TITLE
Remove Project.provider

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -80,7 +80,6 @@ module Config
   optional :hetzner_user, string, clear: true
   optional :hetzner_password, string, clear: true
   override :ci_hetzner_sacrificial_server_id, string
-  override :providers, "hetzner", array(string)
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -29,11 +29,11 @@ module Option
   PROVIDERS.freeze
   LOCATIONS.freeze
 
-  def self.locations_for_provider(provider, only_visible: true)
-    Option::LOCATIONS.select { (!only_visible || _1.visible) && (provider.nil? || _1.provider.name == provider) }
+  def self.locations(only_visible: true)
+    Option::LOCATIONS.select { !only_visible || _1.visible }
   end
 
-  def self.postgres_locations_for_provider(provider)
+  def self.postgres_locations
     Option::LOCATIONS.select { _1.name == "hetzner-fsn1" }
   end
 

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -44,14 +44,9 @@ module Validation
     fail ValidationFailed.new({username: msg}) unless username&.match(ALLOWED_MINIO_USERNAME_PATTERN)
   end
 
-  def self.validate_provider(provider)
-    msg = "\"#{provider}\" is not a valid provider. Available providers: #{Option::PROVIDERS.keys}"
-    fail ValidationFailed.new({provider: msg}) unless Option::PROVIDERS.key?(provider)
-  end
-
-  def self.validate_location(location, provider = nil)
-    available_locs = Option.locations_for_provider(provider, only_visible: false).map(&:name)
-    msg = "Given location is not a valid location for provider \"#{provider}\". Available locations: #{available_locs.map { LocationNameConverter.to_display_name(_1) }}"
+  def self.validate_location(location)
+    available_locs = Option.locations(only_visible: false).map(&:name)
+    msg = "Given location is not a valid location. Available locations: #{available_locs.map { LocationNameConverter.to_display_name(_1) }}"
     fail ValidationFailed.new({provider: msg}) unless available_locs.include?(location)
   end
 

--- a/migrate/20240424_drop_project_provider.rb
+++ b/migrate/20240424_drop_project_provider.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:project) do
+      drop_column :provider
+    end
+  end
+end

--- a/model/account.rb
+++ b/model/account.rb
@@ -12,9 +12,8 @@ class Account < Sequel::Model(:accounts)
 
   include Authorization::TaggableMethods
 
-  def create_project_with_default_policy(name, provider: Option::Provider::HETZNER, policy_body: nil)
-    Validation.validate_provider(provider)
-    project = Project.create_with_id(name: name, provider: provider)
+  def create_project_with_default_policy(name, policy_body: nil)
+    project = Project.create_with_id(name: name)
     project.associate_with_project(project)
     associate_with_project(project)
     project.add_access_policy(

--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -14,7 +14,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
     end
 
     Validation.validate_vm_size(vm_size)
-    Validation.validate_location(location, project.provider)
+    Validation.validate_location(location)
     Validation.validate_name(cluster_name)
     Validation.validate_minio_username(admin_user)
 

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -17,7 +17,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       fail "No existing project"
     end
 
-    Validation.validate_location(location, project.provider)
+    Validation.validate_location(location)
     Validation.validate_name(name)
     Validation.validate_vm_size(target_vm_size)
     Validation.validate_postgres_ha_type(ha_type)

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -20,7 +20,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def setup_vms
-    project = Project.create_with_id(name: "project 1", provider: "hetzner")
+    project = Project.create_with_id(name: "project 1")
     project.associate_with_project(project)
 
     subnet1_s = Prog::Vnet::SubnetNexus.assemble(

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -19,7 +19,7 @@ class Prog::Vm::Nexus < Prog::Base
     unless (project = Project[project_id])
       fail "No existing project"
     end
-    Validation.validate_location(location, project.provider)
+    Validation.validate_location(location)
     vm_size = Validation.validate_vm_size(size)
 
     storage_volumes ||= [{

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     name ||= PrivateSubnet.ubid_to_name(ubid)
 
     Validation.validate_name(name)
-    Validation.validate_location(location, project.provider)
+    Validation.validate_location(location)
 
     ipv6_range ||= random_private_ipv6(location).to_s
     ipv4_range ||= random_private_ipv4(location).to_s

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -18,11 +18,11 @@ class CloverApi
     end
 
     r.post true do
-      required_parameters = ["name", "provider"]
+      required_parameters = ["name"]
 
       request_body_params = Validation.validate_request_body(r.body.read, required_parameters)
 
-      project = @current_user.create_project_with_default_policy(request_body_params["name"], provider: request_body_params["provider"])
+      project = @current_user.create_project_with_default_policy(request_body_params["name"])
 
       serialize(project)
     end

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -11,7 +11,7 @@ class CloverWeb
     end
 
     r.post true do
-      project = @current_user.create_project_with_default_policy(r.params["name"], provider: r.params["provider"])
+      project = @current_user.create_project_with_default_policy(r.params["name"])
 
       r.redirect project.path
     end

--- a/serializers/api/project.rb
+++ b/serializers/api/project.rb
@@ -6,8 +6,7 @@ class Serializers::Api::Project < Serializers::Base
       id: p.ubid,
       name: p.name,
       credit: p.credit.to_f,
-      discount: p.discount,
-      provider: p.provider
+      discount: p.discount
     }
   end
 

--- a/serializers/web/project.rb
+++ b/serializers/web/project.rb
@@ -8,8 +8,7 @@ class Serializers::Web::Project < Serializers::Base
       path: p.path,
       name: p.name,
       credit: p.credit.to_f,
-      discount: p.discount,
-      provider: Option::PROVIDERS[p.provider]
+      discount: p.discount
     }
   end
 

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe InvoiceGenerator do
 
   let(:p1) {
     Account.create_with_id(email: "auth1@example.com")
-    Project.create_with_id(name: "cool-project", provider: "hetzner")
+    Project.create_with_id(name: "cool-project")
   }
   let(:vm1) { Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", family: "standard", cores: 2, location: "hetzner-hel1", boot_image: "x") }
 
@@ -147,7 +147,7 @@ RSpec.describe InvoiceGenerator do
   end
 
   it "generates invoice for a single project" do
-    p2 = Project.create_with_id(name: "cool-project", provider: "hetzner")
+    p2 = Project.create_with_id(name: "cool-project")
     vm2 = Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", family: "standard", cores: 2, location: "hetzner-hel1", boot_image: "x")
 
     generate_billing_record(p1, vm1, Sequel::Postgres::PGRange.new(begin_time, end_time))

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -31,16 +31,6 @@ RSpec.describe Validation do
       end
     end
 
-    describe "#validate_provider" do
-      it "valid provider" do
-        expect(described_class.validate_provider("hetzner")).to be_nil
-      end
-
-      it "invalid provider" do
-        expect { described_class.validate_provider("hetzner-cloud") }.to raise_error described_class::ValidationFailed
-      end
-    end
-
     describe "#validate_vm_size" do
       it "valid vm size" do
         expect(described_class.validate_vm_size("standard-2").name).to eq("standard-2")
@@ -54,20 +44,20 @@ RSpec.describe Validation do
     describe "#validate_location" do
       it "valid locations" do
         [
-          ["hetzner-hel1", nil],
-          ["hetzner-hel1", "hetzner"],
-          ["github-runners", "hetzner"]
-        ].each do |location, provider|
-          expect(described_class.validate_location(location, provider)).to be_nil
+          "hetzner-hel1",
+          "hetzner-fsn1",
+          "github-runners"
+        ].each do |location|
+          expect(described_class.validate_location(location)).to be_nil
         end
       end
 
       it "invalid locations" do
         [
-          ["hetzner-hel2", nil],
-          ["hetzner-hel2", "hetzner"]
-        ].each do |location, provider|
-          expect { described_class.validate_location(location, provider) }.to raise_error described_class::ValidationFailed
+          "hetzner-hel2",
+          "hetzner-fsn2"
+        ].each do |location|
+          expect { described_class.validate_location(location) }.to raise_error described_class::ValidationFailed
         end
       end
     end

--- a/spec/model/github_installation_spec.rb
+++ b/spec/model/github_installation_spec.rb
@@ -4,7 +4,7 @@ require_relative "spec_helper"
 
 RSpec.describe GithubInstallation do
   subject(:installation) {
-    project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+    project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
 
     described_class.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
   }

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe MinioServer do
 
   describe "#url" do
     before do
-      minio_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      minio_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       allow(Config).to receive(:minio_service_project_id).and_return(minio_project.id)
     end
 

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe VmPool do
 
   describe ".pick_vm" do
     let(:prj) {
-      Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
     }
     let(:vm) {
       vm = Vm.create_with_id(

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
 
   describe ".assemble" do
     it "creates github repository or updates last_job_at if the repository exists" do
-      project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
 
       expect {

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
     )
   }
 
-  let(:minio_project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
+  let(:minio_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
   describe ".assemble" do
     before do

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
     Prog::Vnet::SubnetNexus.assemble(minio_project.id, name: "minio-cluster-name")
   }
 
-  let(:minio_project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
+  let(:minio_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
   before do
     allow(minio_cluster).to receive(:projects).and_return([minio_project])

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     }
   }
 
-  let(:minio_project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
+  let(:minio_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
   before do
     allow(Config).to receive(:minio_service_project_id).and_return(minio_project.id)

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::Minio::SetupMinio do
   subject(:nx) { described_class.new(Strand.new) }
 
   let(:minio_server) {
-    prj = Project.create_with_id(name: "default", provider: "hetzner")
+    prj = Project.create_with_id(name: "default")
     prj.associate_with_project(prj)
     ps = Prog::Vnet::SubnetNexus.assemble(
       prj.id, name: "minio-cluster-name"

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   end
 
   describe ".assemble" do
-    let(:customer_project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
-    let(:postgres_project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
+    let(:customer_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+    let(:postgres_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
     it "validates input" do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
       postgres_timeline = PostgresTimeline.create_with_id
 
-      postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       st = described_class.assemble(resource_id: postgres_resource.id, timeline_id: postgres_timeline.id, timeline_access: "push", representative_at: Time.now)

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#finish" do
     it "exits" do
-      project = Project.create_with_id(name: "project 1", provider: "hetzner")
+      project = Project.create_with_id(name: "project 1")
       allow(vg_test).to receive(:frame).and_return({"project_id" => project.id})
       expect { vg_test.finish }.to exit({"msg" => "VmGroup tests finished!"})
     end

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Prog::Test::Vm do
       ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a3::/64"),
       nics: [nic3])
 
-    project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+    project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
     allow(project).to receive(:vms).and_return([vm1, vm2, vm3])
     allow(vm1).to receive(:projects).and_return [project]
     allow(vm_test).to receive_messages(sshable: sshable, vm: vm1)

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe ".assemble" do
     it "creates github runner and vm with sshable" do
-      project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
 
       st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud")
@@ -45,7 +45,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "creates github runner with custom size" do
-      project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
       st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud-standard-8")
 
@@ -63,10 +63,10 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe ".pick_vm" do
-    let(:project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
+    let(:project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
     before do
-      runner_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      runner_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       allow(Config).to receive(:github_runner_service_project_id).and_return(runner_project.id)
     end
 
@@ -118,7 +118,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe ".update_billing_record" do
-    let(:project) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
+    let(:project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
     before do
       allow(github_runner).to receive(:installation).and_return(instance_double(GithubInstallation, project: project)).at_least(:once)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Prog::Vm::Nexus do
     }
     vm
   }
-  let(:prj) { Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) } }
+  let(:prj) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
   describe ".assemble" do
     let(:ps) {

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#create_new_vm" do
     let(:prj) {
-      Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
     }
 
     it "creates a new vm and hops to wait" do

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Clover, "postgres" do
 
   describe "unauthenticated" do
     before do
-      postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end
 
@@ -123,7 +123,7 @@ RSpec.describe Clover, "postgres" do
   describe "authenticated" do
     before do
       login_api(user.email)
-      postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end
 

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Clover, "vm" do
   describe "authenticated" do
     before do
       login_api(user.email)
-      postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe Clover, "vm" do
     describe "create" do
       it "success" do
         post "/api/project", {
-          name: "test-project",
-          provider: "hetzner"
+          name: "test-project"
         }.to_json
 
         expect(last_response.status).to eq(200)
@@ -72,9 +71,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "missing parameter" do
-        post "/api/project", {
-          name: "test-project"
-        }.to_json
+        post "/api/project", {}.to_json
 
         expect(last_response.status).to eq(400)
       end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Clover, "postgres" do
 
   describe "authenticated" do
     before do
-      postgres_project = Project.create_with_id(name: "default", provider: "hetzner").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
       login(user.email)
 

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe Clover, "project" do
         expect(page.title).to eq("Ubicloud - Create Project")
 
         fill_in "Name", with: name
-        choose option: "hetzner"
 
         click_button "Create"
 

--- a/views/layouts/topbar.erb
+++ b/views/layouts/topbar.erb
@@ -10,14 +10,6 @@
   <img class="h-5 w-auto lg:hidden" src="/logo-primary.png" alt="Ubicloud">
   <div class="flex flex-1 gap-x-4 self-stretch justify-end lg:gap-x-6">
     <div class="flex items-center gap-x-4 lg:gap-x-6">
-      <% if @project_data %>
-        <div class="text-gray-900 text-sm text-right lg:text-base">
-          <span class="font-semibold">Provider:</span>
-          <%= @project_data.dig(:provider, :display_name) %>
-        </div>
-      <% end %>
-      <!-- Separator -->
-      <div class="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10" aria-hidden="true"></div>
       <!-- Profile dropdown -->
       <div class="relative group dropdown text-sm leading-6 text-gray-900">
         <button type="button" class="-m-1.5 flex items-center p-1.5" title="<%= @current_user.email %>">

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -44,7 +44,7 @@
               </div>
               <div class="col-span-full">
                 <% locations = Option
-                    .postgres_locations_for_provider(@project_data.dig(:provider, :name))
+                    .postgres_locations
                     .map { |l| [l.display_name, l.display_name, @prices[l.name].to_json] }
                 %>
                 <%== render(

--- a/views/private_subnet/create.erb
+++ b/views/private_subnet/create.erb
@@ -46,7 +46,7 @@
                   locals: {
                     name: "location",
                     label: "Location",
-                    options: Option.locations_for_provider(@project_data.dig(:provider, :name)).to_h { |l| [l.display_name, l.display_name] },
+                    options: Option.locations.to_h { |l| [l.display_name, l.display_name] },
                     attributes: {
                       required: true
                     }

--- a/views/project/create.erb
+++ b/views/project/create.erb
@@ -25,19 +25,6 @@
               }
             ) %>
           </div>
-          <div class="sm:col-span-full">
-            <%== render(
-              "components/form/radio_small_cards",
-              locals: {
-                name: "provider",
-                label: "Provider",
-                options: Option::PROVIDERS.map { [_1, _2.display_name] }.to_h,
-                attributes: {
-                  required: true
-                }
-              }
-            ) %>
-          </div>
         </div>
 
       </div>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -41,8 +41,7 @@
             else
               ["Name", @project_data[:name]]
             end
-          ),
-          ["Provider", @project_data.dig(:provider, :display_name)]
+          )
         ]
       }
     ) %>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -44,7 +44,7 @@
               </div>
               <div class="col-span-full">
                 <% locations = Option
-                    .locations_for_provider(@project_data.dig(:provider, :name))
+                    .locations
                     .map { |l| [l.display_name, l.display_name, @prices[l.name].to_json] }
                 %>
                 <%== render(


### PR DESCRIPTION
We are removing provider property from project. This way, a given project can have resources in different provider regions. This change makes sense since we are renaming the location names to not include the provider information. It will also be helpful for us to run the github actions workload on hosts from different providers.