### PR TITLE
Track hugepages used for SPDK installations in the database. 

### DIFF
--- a/migrate/20240423_add_spdk_hugepages.rb
+++ b/migrate/20240423_add_spdk_hugepages.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:spdk_installation) do
+      add_column :hugepages, :int, default: 2, null: false
+    end
+  end
+end

--- a/prog/storage/remove_spdk.rb
+++ b/prog/storage/remove_spdk.rb
@@ -38,7 +38,9 @@ class Prog::Storage::RemoveSpdk < Prog::Base
 
   label def update_database
     vm_host = spdk_installation.vm_host
-    VmHost.where(id: vm_host.id).update(used_hugepages_1g: Sequel[:used_hugepages_1g] - 2)
+    VmHost.where(id: vm_host.id).update(
+      used_hugepages_1g: Sequel[:used_hugepages_1g] - spdk_installation.hugepages
+    )
     spdk_installation.destroy
 
     pop "SPDK installation was removed"

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -35,7 +35,8 @@ class Prog::Storage::SetupSpdk < Prog::Base
       version: frame["version"],
       allocation_weight: 0,
       vm_host_id: vm_host.id,
-      cpu_count: spdk_cpu_count(total_host_cpus: vm_host.total_cpus)
+      cpu_count: spdk_cpu_count(total_host_cpus: vm_host.total_cpus),
+      hugepages: 2
     ) { _1.id = SpdkInstallation.generate_uuid }
 
     hop_install_spdk
@@ -68,13 +69,17 @@ class Prog::Storage::SetupSpdk < Prog::Base
   end
 
   label def update_database
-    SpdkInstallation.where(
+    spdk_installation = SpdkInstallation.where(
       version: frame["version"],
       vm_host_id: vm_host.id
-    ).update(allocation_weight: frame["allocation_weight"])
+    ).first
+
+    spdk_installation.update(allocation_weight: frame["allocation_weight"])
 
     if frame["start_service"]
-      VmHost.where(id: vm_host.id).update(used_hugepages_1g: Sequel[:used_hugepages_1g] + 2)
+      VmHost.where(id: vm_host.id).update(
+        used_hugepages_1g: Sequel[:used_hugepages_1g] + spdk_installation.hugepages
+      )
     end
 
     pop "SPDK was setup"

--- a/spec/prog/storage/remove_spdk_spec.rb
+++ b/spec/prog/storage/remove_spdk_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Prog::Storage::RemoveSpdk do
 
   describe "#update_database" do
     it "updates the database and exits" do
+      expect(spdk_installation).to receive(:hugepages).and_return(2)
       expect(spdk_installation).to receive(:destroy)
       expect { remove_spdk.update_database }.to exit({"msg" => "SPDK installation was removed"})
     end


### PR DESCRIPTION
We use number of hugepages used when installing & removing an SPDK installation. Although this is mostly static, but it is possible that we decide to change number of hugepages used when installing a new SPDK in future.

In which case, we should remember what value used for older installations to update VmHost records correctly when removing them.

This mismatch already happened in production last week, so making this change to avoid it in future.
