### PR TITLE
Add check for fraud payment method

### DIFF
--- a/migrate/20240423_add_fraud_columns.rb
+++ b/migrate/20240423_add_fraud_columns.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:payment_method) do
+      add_column :card_fingerprint, :text, null: true
+      add_column :fraud, :boolean, default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
Adding a check whether the added payment method is tagged as fraud, if so user won't be able to add it. Payment methods will be tagged as fraud operationally.