### PR TITLE
Quick and dirty suspend feature

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -22,6 +22,7 @@ class Vm < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup
+  semaphore :suspend, :unsuspend
 
   include Authorization::HyperTagMethods
 


### PR DESCRIPTION
The case of re-allocating if CPU and/or memory resources have since allocated is left unsolved.

Also seen is grotesque copies of bookkeeping of VmHost core and memory counts, as well as some tests I declined to copy and paste for "systemctl stop" idempotency.