### PR TITLE
Small fixes for monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -46,7 +46,7 @@ loop do
     pulse_threads[r.id] ||= Thread.new do
       pulse = {}
       loop do
-        pulse = r.check_pulse(session: sessions[r.id], previous_pulse: pulse) if sessions[r.id]
+        pulse = r.check_pulse(session: sessions[r.id], previous_pulse: pulse)
         Clog.emit("Got new pulse") { {got_pulse: {ubid: r.ubid, pulse: pulse}} }
         sleep r.monitoring_interval
       rescue RuntimeError, IOError => ex

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -67,7 +67,7 @@ class MinioServer < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse: previous_pulse, reading: reading)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
       incr_checkup
     end
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -152,7 +152,7 @@ class PostgresServer < Sequel::Model
           ).save_changes
       end
 
-      if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30
+      if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
         incr_checkup
       end
     end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -169,7 +169,7 @@ class Vm < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse: previous_pulse, reading: reading)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
       incr_checkup
     end
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -221,7 +221,7 @@ class VmHost < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse: previous_pulse, reading: reading)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
       incr_checkup
     end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -166,6 +166,7 @@ RSpec.describe PostgresServer do
     }
 
     expect(session[:db_connection]).to receive(:[]).and_raise(Sequel::DatabaseConnectionError)
+    expect(postgres_server).to receive(:reload).and_return(postgres_server)
     expect(postgres_server).to receive(:incr_checkup)
     postgres_server.check_pulse(session: session, previous_pulse: pulse)
   end
@@ -184,6 +185,7 @@ RSpec.describe PostgresServer do
     expect(session[:db_connection]).to receive(:[]).with("SELECT pg_current_wal_lsn() AS lsn").and_raise(Sequel::DatabaseConnectionError)
     expect(postgres_server).to receive(:primary?).and_return(true)
 
+    expect(postgres_server).to receive(:reload).and_return(postgres_server)
     expect(postgres_server).to receive(:incr_checkup)
     postgres_server.check_pulse(session: session, previous_pulse: pulse)
   end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -269,6 +269,7 @@ RSpec.describe VmHost do
     expect(vh.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("up")
 
     expect(session[:ssh_session]).to receive(:exec!).and_raise Sshable::SshError
+    expect(vh).to receive(:reload).and_return(vh)
     expect(vh).to receive(:incr_checkup)
     expect(vh.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("down")
   end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -130,10 +130,12 @@ RSpec.describe Vm do
     expect(vm.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("up")
 
     expect(session[:ssh_session]).to receive(:exec!).and_return("active\ninactive\n")
+    expect(vm).to receive(:reload).and_return(vm)
     expect(vm).to receive(:incr_checkup)
     expect(vm.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("down")
 
     expect(session[:ssh_session]).to receive(:exec!).and_raise Sshable::SshError
+    expect(vm).to receive(:reload).and_return(vm)
     expect(vm).to receive(:incr_checkup)
     expect(vm.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("down")
   end


### PR DESCRIPTION
**Don't increment checkup semaphore if it is already incremented**
We had few resources that stays unavailable for a long time, and the checkup
semaphore was incremented every time the pulse_check was called. This was
causing the semaphore to be incremented to a very high value, and the lookups
to semaphore table were taking a long time to finish.

**Perform pulse checks even if there is no session**
If we wait until the session is created to start the pulse checks, we don't
perform any pulse checks for resources that were already unavailable when the
monitor started.