### PR TITLE
Set initial_provisioning for MinioServers to avoid unhealthy decision

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -17,7 +17,7 @@ class MinioServer < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
 
-  semaphore :checkup, :destroy, :restart, :reconfigure, :refresh_certificates
+  semaphore :checkup, :destroy, :restart, :reconfigure, :refresh_certificates, :initial_provisioning
 
   plugin :column_encryption do |enc|
     enc.column :cert_key


### PR DESCRIPTION
The health monitor starts checking the minio server state the moment strand switches to wait. This is not good for minio servers because the cluster waits for all the pools to be ready to start them simultaneously. Therefore, until the first restartm they are not up and running even if the strand is in wait state. This new semaphore avoids health checks to move the server into unavailable state before the server gets started.