### PR TITLE
Fix redirect after usage alert deletion

### DIFF
--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -393,7 +393,7 @@
                       text: "Remove",
                       url: "#{@project_data[:path]}/usage-alert/#{alert[:ubid]}",
                       confirmation: alert[:name],
-                      redirect: "#{@project_data[:path]}/usage-alert"
+                      redirect: "#{@project_data[:path]}/billing"
                     }
                   ) %>
                 </td>


### PR DESCRIPTION
We used to redirect project/<ubid>/usage-alert after deleting a usage alert, however, there is no such page. We should redirect to project/<ubid>/billing instead.