### PR TITLE
Update error response title with PascalCase type

### DIFF
--- a/clover_api.rb
+++ b/clover_api.rb
@@ -16,7 +16,7 @@ class CloverApi < Roda
     {
       error: {
         code: 404,
-        title: "Resource not found",
+        type: "ResourceNotFound",
         message: "Sorry, we couldn’t find the resource you’re looking for."
       }
     }.to_json

--- a/clover_web.rb
+++ b/clover_web.rb
@@ -44,7 +44,7 @@ class CloverWeb < Roda
   plugin :not_found do
     @error = {
       code: 404,
-      title: "Resource not found",
+      type: "ResourceNotFound",
       message: "Sorry, we couldn’t find the resource you’re looking for."
     }
 

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -6,7 +6,7 @@ require "netaddr"
 module Validation
   class ValidationFailed < CloverError
     def initialize(details)
-      super(400, "Invalid request", "Validation failed for following fields: #{details.keys.join(", ")}", details)
+      super(400, "InvalidRequest", "Validation failed for following fields: #{details.keys.join(", ")}", details)
     end
   end
 

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -140,7 +140,7 @@ class CloverApi
       Authorization.authorize(user.id, "Postgres:view", pg.id)
 
       unless pg.representative_server.primary?
-        fail CloverError.new(400, "Invalid Request", "Superuser password cannot be updated during restore!")
+        fail CloverError.new(400, "InvalidRequest", "Superuser password cannot be updated during restore!")
       end
 
       required_parameters = ["password"]

--- a/routes/clover_base.rb
+++ b/routes/clover_base.rb
@@ -24,15 +24,15 @@ module CloverBase
     case e
     when Sequel::ValidationFailed
       code = 400
-      title = "Invalid request"
+      type = "InvalidRequest"
       message = e.to_s
     when Roda::RodaPlugins::RouteCsrf::InvalidToken
       code = 419
-      title = "Invalid Security Token"
+      type = "InvalidSecurityToken"
       message = "An invalid security token was submitted with this request, and this request could not be processed."
     when CloverError
       code = e.code
-      title = e.title
+      type = e.type
       message = e.message
       details = e.details
     else
@@ -40,7 +40,7 @@ module CloverBase
       warn e.backtrace
 
       code = 500
-      title = "Unexcepted Error"
+      type = "UnexceptedError"
       message = "Sorry, we couldn’t process your request because of an unexpected error."
     end
 
@@ -48,7 +48,7 @@ module CloverBase
 
     {
       code: code,
-      title: title,
+      type: type,
       message: message,
       details: details
     }

--- a/routes/clover_error.rb
+++ b/routes/clover_error.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class CloverError < StandardError
-  attr_reader :code, :title, :message, :details
-  def initialize(code, title, message, details = nil)
+  attr_reader :code, :type, :message, :details
+  def initialize(code, type, message, details = nil)
     @code = code
-    @title = title
+    @type = type
     @message = message
     @details = details
 
@@ -16,6 +16,6 @@ end
 # TODO: Remove the comment once another API use it
 class DependencyError < CloverError
   def initialize(message)
-    super(409, "Dependency Error", message)
+    super(409, "DependencyError", message)
   end
 end

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe Clover do
   it "handles unexpected errors" do
     expect(Account).to receive(:[]).and_raise(RuntimeError)
     expect { visit "/create-account" }.to output(/RuntimeError.*/).to_stderr
-    expect(page.title).to eq("Ubicloud - Unexcepted Error")
+    expect(page.title).to eq("Ubicloud - UnexceptedError")
   end
 end

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -147,9 +147,9 @@ RSpec.describe Clover, "private subnet" do
       it "raises not found when private subnet not exists" do
         visit "#{project.path}/location/hetzner-hel1/private-subnet/08s56d4kaj94xsmrnf5v5m3mav"
 
-        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
-        expect(page).to have_content "Resource not found"
+        expect(page).to have_content "ResourceNotFound"
       end
     end
 

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -118,17 +118,17 @@ RSpec.describe Clover, "billing" do
     it "raises not found when payment method not exists" do
       visit "#{project.path}/billing/payment-method/08s56d4kaj94xsmrnf5v5m3mav"
 
-      expect(page.title).to eq("Ubicloud - Resource not found")
+      expect(page.title).to eq("Ubicloud - ResourceNotFound")
       expect(page.status_code).to eq(404)
-      expect(page).to have_content "Resource not found"
+      expect(page).to have_content "ResourceNotFound"
     end
 
     it "raises not found when add payment method if project not exists" do
       visit "#{project.path}/billing/payment-method/create"
 
-      expect(page.title).to eq("Ubicloud - Resource not found")
+      expect(page.title).to eq("Ubicloud - ResourceNotFound")
       expect(page.status_code).to eq(404)
-      expect(page).to have_content "Resource not found"
+      expect(page).to have_content "ResourceNotFound"
     end
 
     it "can't delete last payment method" do
@@ -270,9 +270,9 @@ RSpec.describe Clover, "billing" do
       it "raises not found when invoice not exists" do
         visit "#{project.path}/billing/invoice/08s56d4kaj94xsmrnf5v5m3mav"
 
-        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
-        expect(page).to have_content "Resource not found"
+        expect(page).to have_content "ResourceNotFound"
       end
     end
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -188,9 +188,9 @@ RSpec.describe Clover, "postgres" do
       it "raises not found when PostgreSQL database not exists" do
         visit "#{project.path}/location/hetzner-fsn1/postgres/08s56d4kaj94xsmrnf5v5m3mav"
 
-        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
-        expect(page).to have_content "Resource not found"
+        expect(page).to have_content "ResourceNotFound"
       end
 
       it "can restore PostgreSQL database" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -138,9 +138,9 @@ RSpec.describe Clover, "project" do
       it "raises not found when project not exists" do
         visit "/project/08s56d4kaj94xsmrnf5v5m3mav"
 
-        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
-        expect(page).to have_content "Resource not found"
+        expect(page).to have_content "ResourceNotFound"
       end
 
       it "can update the project name" do
@@ -247,9 +247,9 @@ RSpec.describe Clover, "project" do
       it "raises not found when user not exists" do
         visit "#{project.path}/user/08s56d4kaj94xsmrnf5v5m3mav"
 
-        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
-        expect(page).to have_content "Resource not found"
+        expect(page).to have_content "ResourceNotFound"
       end
     end
 
@@ -322,9 +322,9 @@ RSpec.describe Clover, "project" do
 
         visit "#{project.path}/policy/pcqv67qwh9t23k4g88xrjya7eb"
 
-        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
-        expect(page).to have_content "Resource not found"
+        expect(page).to have_content "ResourceNotFound"
       end
     end
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -228,9 +228,9 @@ RSpec.describe Clover, "vm" do
       it "raises not found when virtual machine not exists" do
         visit "#{project.path}/location/hetzner-hel1/vm/08s56d4kaj94xsmrnf5v5m3mav"
 
-        expect(page.title).to eq("Ubicloud - Resource not found")
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
-        expect(page).to have_content "Resource not found"
+        expect(page).to have_content "ResourceNotFound"
       end
     end
 

--- a/views/error.erb
+++ b/views/error.erb
@@ -1,9 +1,9 @@
-<% @page_title = @error[:title] %>
+<% @page_title = @error[:type] %>
 
 <main class="grid min-h-full place-items-center px-6 py-24 sm:py-32 lg:px-8">
   <div class="text-center">
     <p class="text-base font-semibold text-orange-600"><%= @error[:code] %></p>
-    <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl"><%= @error[:title] %></h1>
+    <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl"><%= @error[:type] %></h1>
     <p class="mt-6 text-base leading-7 text-gray-600"><%= @error[:message] %></p>
     <div class="mt-10 flex items-center justify-center gap-x-6">
       <button


### PR DESCRIPTION
In the RFC https://datatracker.ietf.org/doc/html/rfc7807, type is
the only key required as a part of the error response. It is used
to decide the kind of the error obtained from the API. Client codes
will be using that type to understand the kind of the error. Note that,
same error code (which is basically the http error code) might have
different error type. To show that it is a constant text returned from an
API, value of the type key converted to the PascalCase.

As a side effect of that change, texts shown as title on UI also became
PascalCase. As it still informs the user on the UI as it was informing
before that commit, it is acceptable.
