### PR TITLE
Prioritize "github-runners" location for github runners.

### DIFF
--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -450,6 +450,18 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nx.allocate).to eq vmh.id
     end
 
+    it "prioritizes the github-runners location for runners" do
+      new_host(location: "somewhere-weird")
+      new_host(location: "somewhere-weird")
+      new_host(location: "somewhere-weird")
+      vmh = new_host(location: "github-runners")
+      new_host(location: "somewhere-weird")
+      new_host(location: "somewhere-weird")
+      new_host(location: "somewhere-weird")
+      vm.location = "github-runners"
+      expect(nx.allocate).to eq vmh.id
+    end
+
     it "does not match if there is not enough storage capacity" do
       new_host(available_storage_gib: 10)
       expect(vm.storage_size_gib).to eq(35)


### PR DESCRIPTION
We had several capacity incidents for VM or PG allocations, because github-runners used capacity of all hosts. This patch will make sure that we use non "github-runners" locations for runners only when we have to. Therefore, leaving more capacity for VM and PG.

Note that we might not need special ordering for github-runners location after completing the fleet unification. This is a temporary solution to reduce capacity incidents for VM and PG allocations.