### PR TITLE
Add more log to monitor runner related metrics

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -34,6 +34,13 @@ class GithubRunner < Sequel::Model
     end
   end
 
+  def log_duration(message, duration)
+    values = {ubid: ubid, label: label, repository_name: repository_name, duration: duration, vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores}
+    values[:vm_host_ubid] = vm.vm_host.ubid if vm.vm_host
+    values[:vm_pool_ubid] = VmPool[vm.pool_id].ubid if vm.pool_id
+    Clog.emit(message) { {message => values} }
+  end
+
   def init_health_monitor_session
     {
       ssh_session: vm.sshable.start_fresh_session

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -95,6 +95,7 @@ class CloverWeb
 
     case data["action"]
     when "in_progress"
+      runner.log_duration("runner_started", Time.parse(job["started_at"]) - Time.parse(job["created_at"]))
       success("GithubRunner[#{runner.ubid}] picked job #{job.fetch("id")}")
     when "completed"
       runner.incr_destroy

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -3,12 +3,17 @@
 require_relative "spec_helper"
 
 RSpec.describe GithubRunner do
-  subject(:github_runner) { described_class.new }
-
-  let(:vm) { instance_double(Vm, sshable: instance_double(Sshable), cores: 2) }
+  subject(:github_runner) { described_class.new.tap { _1.id = "ca2eb084-8a36-8618-a16f-7561d7faf3b6" } }
 
   before do
-    allow(github_runner).to receive_messages(vm: vm)
+    allow(github_runner).to receive(:vm).and_return(instance_double(Vm, arch: "x64", cores: 2, ubid: "vm-ubid", pool_id: "pool-id"))
+    allow(github_runner.vm).to receive_messages(sshable: instance_double(Sshable), vm_host: instance_double(VmHost, ubid: "host-ubid"))
+  end
+
+  it "can log duration when it's from a vm pool" do
+    expect(VmPool).to receive(:[]).with("pool-id").and_return(instance_double(VmPool, ubid: "pool-ubid"))
+    expect(Clog).to receive(:emit).with("runner_tested").and_call_original
+    github_runner.log_duration("runner_tested", 10)
   end
 
   it "initiates a new health monitor session" do

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -100,6 +100,9 @@ RSpec.describe Clover, "github" do
     end
 
     it "updates job details of runner when receive in_progress action" do
+      expect(Clog).to receive(:emit).with("runner_started")
+      expect(runner).to receive(:vm).and_return(instance_double(Vm, ubid: "vm-ubid", arch: "x64", cores: 2, vm_host: nil, pool_id: nil)).at_least(:once)
+      expect(GithubRunner).to receive(:first).and_return(runner)
       send_webhook("workflow_job", workflow_job_payload(action: "in_progress", workflow_job: workflow_job_object(runner_id: runner.runner_id)))
 
       expect(page.status_code).to eq(200)
@@ -135,7 +138,9 @@ RSpec.describe Clover, "github" do
       job_name: "test job name",
       run_id: 7777777,
       workflow_name: "test workflow name",
-      head_branch: "test head branch"
+      head_branch: "test head branch",
+      created_at: "2024-04-24T16:02:42Z",
+      started_at: "2024-04-24T16:03:40Z"
     }
   end
 


### PR DESCRIPTION
We strive to actively monitor metrics like runner provisioning duration and job assignment, as they significantly affect our customers' experience. We don't require all properties from the `GithubRunner` and `Vm` model, so I've created a custom hash instead of using `model.values`.  These fields assist us in filtering our runner metrics based on various parameters.

I wrote the `log_duration` function to avoid repeatedly testing same condition branches and I don't want to add `:nocov`., I considered adding this helper function to the prog, but since it's also used in the web route to log the job's starting duration, I decided to include it in the model.