### PR TITLE
Prioritize monitoring of non-ephemeral resources

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -3,7 +3,7 @@
 
 require_relative "../loader"
 
-MONITORABLE_RESOURCE_TYPES = [PostgresServer, MinioServer, GithubRunner, VmHost, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists)]
+MONITORABLE_RESOURCE_TYPES = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner]
 
 sessions = {}
 ssh_threads = {}


### PR DESCRIPTION
We have limited number of threads to monitor all resources. We want to use them to monitor non-ephemeral resources first. This PR changes the resources order while adding resources to the monitor queue.