### PR TITLE
Optimize nap times while the runner waiting for a vm

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -158,7 +158,10 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def wait_vm
-    nap 5 unless vm.strand.label == "wait"
+    # If the vm is not allocated yet, we know that the vm provisioning will take
+    # definitely more than 18 seconds.
+    nap 18 unless vm.allocated_at
+    nap 1 unless vm.provisioned_at
     register_deadline(:wait, 10 * 60)
     hop_setup_environment
   end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -341,15 +341,18 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe "#wait_vm" do
-    it "naps if vm not ready" do
-      expect(vm).to receive(:strand).and_return(Strand.new(label: "prep"))
-      expect(nx).not_to receive(:pick_vm)
-      expect { nx.wait_vm }.to nap(5)
+    it "naps 18 seconds if vm is not allocated yet" do
+      expect(vm).to receive(:allocated_at).and_return(nil)
+      expect { nx.wait_vm }.to nap(18)
+    end
+
+    it "naps a second if vm is allocated but not provisioned yet" do
+      expect(vm).to receive(:allocated_at).and_return(Time.now)
+      expect { nx.wait_vm }.to nap(1)
     end
 
     it "hops if vm is ready" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:strand).and_return(Strand.new(label: "wait"))
+      expect(vm).to receive_messages(allocated_at: Time.now, provisioned_at: Time.now)
       expect { nx.wait_vm }.to hop("setup_environment")
     end
   end


### PR DESCRIPTION
Recently, Furkan modified the workflow to update the firewall rule during VM provisioning. Now, it's updated after the VM reaches the `wait` label. Consequently, if the runner doesn't check the vm in the time between the VM reaching the `wait` label and the start of the firewall rule update, it must wait for the firewall rule update to complete.

The VM model has a `provisioned_at` timestamp, which provides a better way to verify whether the VM has been provisioned.

Furthermore, if we nap for 5 seconds at this point, we could potentially wait an extra 5 seconds, even if the VM is already provisioned, until the next schedule. We know that our fastest VM provisioning time is 18 seconds. Therefore, if we run this label for the first time, we can wait for 18 seconds. This PR increases the checking frequency to 1 second after the initial run, allowing the runner to detect a provisioned VM more promptly.