### PR TITLE
Do not use the same runner when the script failed

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -41,6 +41,10 @@ class GithubRunner < Sequel::Model
     Clog.emit(message) { {message => values} }
   end
 
+  def provision_spare_runner
+    Prog::Vm::GithubRunner.assemble(installation, repository_name: repository_name, label: label).subject
+  end
+
   def init_health_monitor_session
     {
       ssh_session: vm.sshable.start_fresh_session

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -491,12 +491,11 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect { nx.wait }.to nap(15)
     end
 
-    it "registers the runner again if the runner-script is failed" do
+    it "provisions a spare runner and destroys the current one if the runner-script is failed" do
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("failed")
-      expect(client).to receive(:delete)
-      expect(github_runner).to receive(:update).with(runner_id: nil, ready_at: nil)
-
-      expect { nx.wait }.to hop("register_runner")
+      expect(github_runner).to receive(:provision_spare_runner)
+      expect(github_runner).to receive(:incr_destroy)
+      expect { nx.wait }.to nap(0)
     end
 
     it "naps if the runner-script is running" do


### PR DESCRIPTION
### Add a helper to create spare runner

Our runners are job agnostic, meaning they can run any job with the matched label. This enables us to create a spare runner with the same label if the initial one doesn't function properly.

This helper is also useful for on-call engineers.

### Do not use the same runner when the script failed

Currently, when the script failed, we assume it failed because of an initialization error, and we try to register the same runner again. This is not always true. The script might be "failed" while running the workflow. We should create a new spare runner and destroy the failed one.

I can implement additional checks such as verify if the runner has completed the job, and avoid creating a spare runner if the job is completed. However, runner script failures are uncommon. Even when some errors occur, they exit with a zero exit code, not a non-zero one generally. Therefore, I believe it's currently unnecessary to add more checks. If script failures increase, we can reconsider adding them.