### PR TITLE
Enable coredumps on hosts

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -93,8 +93,9 @@ r "sysctl --system"
 r "apt-get -y install qemu-utils mtools"
 
 # We need nvme-cli to inspect installed NVMe cards in prod servers when
-# looking into I/O performance issues.
-r "apt-get -y install nvme-cli" if is_prod_env
+# looking into I/O performance issues. systemd-coredump is useful when
+# debugging crashes.
+r "apt-get -y install nvme-cli systemd-coredump" if is_prod_env
 
 SpdkSetup.prep
 


### PR DESCRIPTION
Coredumps are useful when debugging crashes. This PR installs `systemd-coredump` when prepping a host.

By default, cores will be stored in `/var/lib/systemd/coredump/`. One can list them by doing `coredumpctl list` and start debugging one using `coredumpctl gdb [pid]`.