### PR TITLE
Add connection and channel initialize durations to sshable log

### DIFF
--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Sshable do
           end
 
           if log_value
+            sa.instance_variable_set(:@connect_duration, 1.1)
             expect(Clog).to receive(:emit).with("ssh cmd execution") do |&blk|
               dat = blk.call
               if repl_value


### PR DESCRIPTION
We record the total time the `sshable.cmd` takes, which includes the time needed to establish a connection and initialize the channel. We also maintain an SSH connection cache, reducing connection times when there is an existing cache. This PR logs the time taken to connect and initialize the channel, allowing us to see the actual time spent on command execution.