### PR TITLE
Refactor image download in rhizome side & add optional image version.

### DIFF
--- a/rhizome/host/bin/download-boot-image
+++ b/rhizome/host/bin/download-boot-image
@@ -9,9 +9,10 @@ end
 custom_url = ARGV.shift
 
 require_relative "../../common/lib/util"
-require_relative "../lib/vm_setup"
+require_relative "../lib/boot_image"
 
 certs = $stdin.read
 ca_path = "/usr/lib/ssl/certs/ubicloud_images_blob_storage_certs.crt"
 safe_write_to_file(ca_path, certs)
-VmSetup.new("").download_boot_image(boot_image, custom_url: custom_url, ca_path: ca_path)
+
+BootImage.new(boot_image, nil).download(url: custom_url, ca_path: ca_path)

--- a/rhizome/host/lib/boot_image.rb
+++ b/rhizome/host/lib/boot_image.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "uri"
+require_relative "../../common/lib/arch"
+
+class BootImage
+  def initialize(name, version)
+    @name = name
+    @version = version
+  end
+
+  def image_path
+    @image_path ||= if @version.nil?
+      "#{image_root}/#{@name}.raw"
+    else
+      "#{image_root}/#{@name}-#{@version}.raw"
+    end
+  end
+
+  def image_root
+    "/var/storage/images"
+  end
+
+  def download(url: nil, ca_path: nil, sha256sum: nil)
+    return if File.exist?(image_path)
+
+    url ||= get_download_url
+
+    fail "Must provide url for #{@name} image" if url.nil?
+    FileUtils.mkdir_p image_root
+
+    # If image URL has query parameter such as SAS token, File.extname returns
+    # it too. We need to remove them and only get extension.
+    ext = image_ext(url)
+    init_format = initial_format(ext)
+
+    # Use of File::EXCL provokes a crash rather than a race
+    # condition if two VMs are lazily getting their images at the
+    # same time.
+    temp_file_name = @version.nil? ? @name : "#{@name}-#{@version}"
+    temp_path = File.join(image_root, "#{temp_file_name}#{ext}.tmp")
+    curl_image(url, temp_path, ca_path)
+    verify_sha256sum(temp_path, sha256sum)
+    convert_image(temp_path, init_format)
+
+    rm_if_exists(temp_path)
+  end
+
+  def image_ext(url)
+    File.extname(URI.parse(url).path)
+  end
+
+  def initial_format(ext)
+    case ext
+    when ".qcow2", ".img"
+      "qcow2"
+    when ".vhd"
+      "vpc"
+    when ".raw"
+      "raw"
+    else
+      fail "Unsupported boot_image format: #{ext}"
+    end
+  end
+
+  def curl_image(url, temp_path, ca_path)
+    ca_arg = ca_path ? " --cacert #{ca_path.shellescape}" : ""
+    File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
+      r "curl -f -L10 -o #{temp_path.shellescape} #{url.shellescape}#{ca_arg}"
+    end
+  end
+
+  def verify_sha256sum(temp_path, sha256sum)
+    if !sha256sum.nil? && sha256sum != Digest::SHA256.file(temp_path).hexdigest
+      fail "Invalid SHA256 sum."
+    end
+  end
+
+  def convert_image(temp_path, initial_format)
+    if initial_format == "raw"
+      File.rename(temp_path, image_path)
+    else
+      # Images are presumed to be atomically renamed into the path,
+      # i.e. no partial images will be passed to qemu-image.
+      r "qemu-img convert -p -f #{initial_format.shellescape} -O raw #{temp_path.shellescape} #{image_path.shellescape}"
+    end
+  end
+
+  # YYY: In future all images will have explicit versions and nil won't be
+  # allowed, so this method will be removed.
+  def version_to_fetch
+    @version || case @name
+                when "ubuntu-jammy"
+                  "20240319"
+                when "almalinux-9.3"
+                  "20231113"
+                end
+  end
+
+  def get_download_url
+    version = version_to_fetch
+    urls = {
+      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-#{version}/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
+      "almalinux-9.3" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-9.3-#{version}.#{_1}.qcow2" }
+    }
+    urls.fetch(@name)
+  end
+end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -6,6 +6,7 @@ require "fileutils"
 require "json"
 require "openssl"
 require "base64"
+require_relative "boot_image"
 require_relative "vm_path"
 require_relative "spdk_path"
 require_relative "spdk_rpc"
@@ -22,7 +23,7 @@ class StorageVolume
     @disk_size_gib = params["size_gib"]
     @use_bdev_ubi = params["use_bdev_ubi"] || false
     @skip_sync = params["skip_sync"] || false
-    @image_path = vp.image_path(params["image"]) if params["image"]
+    @image_path = BootImage.new(params["image"], params["image_version"]).image_path if params["image"]
     @device = params["storage_device"] || DEFAULT_STORAGE_DEVICE
     @spdk_version = params["spdk_version"]
   end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -87,12 +87,4 @@ class VmPath
       write(home(file_name), s)
     end
   end
-
-  def image_root
-    "/var/storage/images/"
-  end
-
-  def image_path(name)
-    File.join(image_root, name + ".raw")
-  end
 end

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -11,6 +11,7 @@ require "uri"
 require_relative "vm_path"
 require_relative "cloud_hypervisor"
 require_relative "storage_volume"
+require_relative "boot_image"
 
 class VmSetup
   Nic = Struct.new(:net6, :net4, :tap, :mac)
@@ -480,54 +481,8 @@ EOS
     }
   end
 
-  def download_boot_image(boot_image, custom_url: nil, ca_path: nil)
-    urls = {
-      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-20240319/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
-      "almalinux-9.1" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-latest.#{_1}.qcow2" },
-      "github-ubuntu-2204" => nil,
-      "github-ubuntu-2004" => nil,
-      "postgres-ubuntu-2204" => nil
-    }
-
-    download = urls.fetch(boot_image) || custom_url
-    image_path = vp.image_path(boot_image)
-    unless File.exist?(image_path)
-      fail "Must provide custom_url for #{boot_image} image" if download.nil?
-      FileUtils.mkdir_p vp.image_root
-
-      # If image URL has query parameter such as SAS token, File.extname returns
-      # it too. We need to remove them and only get extension.
-      image_ext = File.extname(URI.parse(download).path)
-      initial_format = case image_ext
-      when ".qcow2", ".img"
-        "qcow2"
-      when ".vhd"
-        "vpc"
-      when ".raw"
-        "raw"
-      else
-        fail "Unsupported boot_image format: #{image_ext}"
-      end
-
-      # Use of File::EXCL provokes a crash rather than a race
-      # condition if two VMs are lazily getting their images at the
-      # same time.
-      temp_path = File.join(vp.image_root, boot_image + image_ext + ".tmp")
-      ca_arg = ca_path ? " --cacert #{ca_path.shellescape}" : ""
-      File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
-        r "curl -f -L10 -o #{temp_path.shellescape} #{download.shellescape}#{ca_arg}"
-      end
-
-      if initial_format == "raw"
-        File.rename(temp_path, image_path)
-      else
-        # Images are presumed to be atomically renamed into the path,
-        # i.e. no partial images will be passed to qemu-image.
-        r "qemu-img convert -p -f #{initial_format.shellescape} -O raw #{temp_path.shellescape} #{image_path.shellescape}"
-      end
-
-      rm_if_exists(temp_path)
-    end
+  def download_boot_image(boot_image)
+    BootImage.new(boot_image, nil).download
   end
 
   # Unnecessary if host has this set before creating the netns, but

--- a/rhizome/host/spec/boot_image_spec.rb
+++ b/rhizome/host/spec/boot_image_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "../lib/boot_image"
+require "openssl"
+require "base64"
+
+RSpec.describe BootImage do
+  subject(:bi) { described_class.new("ubuntu-jammy", "20240110") }
+
+  describe "#download_boot_image" do
+    it "can use an image that's already downloaded" do
+      expect(File).to receive(:exist?).with("/var/storage/images/ubuntu-jammy-20240110.raw").and_return(true)
+      expect(bi).not_to receive(:curl_image)
+      bi.download(url: "url", ca_path: "ca_path", sha256sum: "sha256sum")
+    end
+
+    it "can download an image" do
+      expect(File).to receive(:exist?).with("/var/storage/images/ubuntu-jammy-20240110.raw").and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images")
+      expect(bi).to receive(:image_ext).with("url").and_return(".img")
+      tmp_path = "/var/storage/images/ubuntu-jammy-20240110.img.tmp"
+      expect(bi).to receive(:curl_image).with("url", tmp_path, "ca_path")
+      expect(bi).to receive(:verify_sha256sum).with(tmp_path, "sha256sum")
+      expect(bi).to receive(:convert_image).with(tmp_path, "qcow2")
+      expect(FileUtils).to receive(:rm_r).with(tmp_path)
+
+      bi.download(url: "url", ca_path: "ca_path", sha256sum: "sha256sum")
+    end
+  end
+
+  describe "#image_ext" do
+    it "can handle image without query params" do
+      url = "http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.vhd"
+      expect(bi.image_ext(url)).to eq(".vhd")
+    end
+
+    it "can handle image with query params" do
+      url = "http://minio.ubicloud.com:9000/ubicloud-images/ubuntu-22.04-x64.vhd?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240112T132931Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=aabbcc"
+      expect(bi.image_ext(url)).to eq(".vhd")
+    end
+  end
+
+  describe "#initial_format" do
+    it "fails if initial image has unsupported format" do
+      expect { bi.initial_format(".iso") }.to raise_error RuntimeError, "Unsupported boot_image format: .iso"
+    end
+  end
+
+  describe "#curl_image" do
+    it "can curl image without ca_path" do
+      expect(File).to receive(:open) do |path, *_args|
+        expect(path).to eq("/var/storage/images/ubuntu-jammy-20240110.img.tmp")
+      end.and_yield
+      expect(bi).to receive(:r).with("curl -f -L10 -o /var/storage/images/ubuntu-jammy-20240110.img.tmp url")
+      bi.curl_image("url", "/var/storage/images/ubuntu-jammy-20240110.img.tmp", nil)
+    end
+
+    it "can curl image with ca_path" do
+      expect(File).to receive(:open) do |path, *_args|
+        expect(path).to eq("/var/storage/images/ubuntu-jammy-20240110.img.tmp")
+      end.and_yield
+      expect(bi).to receive(:r).with("curl -f -L10 -o /var/storage/images/ubuntu-jammy-20240110.img.tmp url --cacert ca_path")
+      bi.curl_image("url", "/var/storage/images/ubuntu-jammy-20240110.img.tmp", "ca_path")
+    end
+  end
+
+  describe "#verify_sha256sum" do
+    it "can verify sha256sum" do
+      # Prefer using verifying doubles over normal doubles.
+      expect(Digest::SHA256).to receive(:file).with("/var/storage/images/ubuntu-jammy-20240110.img.tmp").and_return(instance_double(Digest::SHA256, hexdigest: "sha256sum"))
+      bi.verify_sha256sum("/var/storage/images/ubuntu-jammy-20240110.img.tmp", "sha256sum")
+    end
+
+    it "skips verification if sha256sum is empty" do
+      expect(Digest::SHA256).not_to receive(:file)
+      bi.verify_sha256sum("/var/storage/images/ubuntu-jammy-20240110.img.tmp", nil)
+    end
+  end
+
+  describe "#convert_image" do
+    it "can convert image" do
+      expect(bi).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy-20240110.img.tmp /var/storage/images/ubuntu-jammy-20240110.raw")
+      bi.convert_image("/var/storage/images/ubuntu-jammy-20240110.img.tmp", "qcow2")
+    end
+
+    it "does not convert image if it's in raw format already" do
+      expect(File).to receive(:rename).with("/var/storage/images/ubuntu-jammy-20240110.img.tmp", "/var/storage/images/ubuntu-jammy-20240110.raw")
+      bi.convert_image("/var/storage/images/ubuntu-jammy-20240110.img.tmp", "raw")
+    end
+  end
+end


### PR DESCRIPTION
This is in preparation to make boot images versioned. Some of the reasons to do this includes:

* Allow installing a newer version of an image without breaking existing VMs which have references to the older versions.
* Make storage snapshots easier: we know exactly which base image is being used, and we can just snapshot the diff.
* Making correlation of failures to bad OS images easier.

Current patch:
* Moves almost all of the image download logic to the standalone class BootImage.
* Adds optional version and sha256sum parameters to images. If these are null or empty, the behaviour is exactly same as before.
* Uses BootImage in VmSetup and `download-boot-image`.

If an image is versioned, it'll be stored as `/var/storage/images/$name-$version.raw`. Legacy unversioned images are still supported and are stored at `/var/storage/images/$name.raw`.