### PR TITLE
Fix pagination by appending clauses to the given query

### DIFF
--- a/lib/pagination.rb
+++ b/lib/pagination.rb
@@ -32,7 +32,7 @@ module Pagination
       fail Validation::ValidationFailed.new(order_column: "Supported ordering columns: #{supported_order_columns.join(", ")}")
     end
 
-    query = model.order(order_column_sym).limit(page_size)
+    query = order(order_column_sym).limit(page_size)
     query = query.where(Sequel[model.table_name][order_column_sym] > start_after) if start_after
     page_records = query.all
 

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -106,6 +106,22 @@ RSpec.describe Clover, "vm" do
         expect(parsed_body["count"]).to eq(2)
       end
 
+      it "success multiple location with pagination" do
+        Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-2")
+        Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-3")
+        Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-4", location: "hetzner-fsn1")
+
+        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm", {
+          order_column: "name",
+          start_after: "dummy-vm-1"
+        }
+
+        expect(last_response.status).to eq(200)
+        parsed_body = JSON.parse(last_response.body)
+        expect(parsed_body["items"].length).to eq(2)
+        expect(parsed_body["count"]).to eq(3)
+      end
+
       it "ubid not exist" do
         get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/foo_ubid"
 


### PR DESCRIPTION
While updating the pagination code, clauses used in the pagination were added to the model directly instead of passed query, fixing that. Also added a test to catch it.