### PR TITLE
Fix incorrect state transition in PostgresResourceNexus

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -21,7 +21,7 @@ class PostgresResource < Sequel::Model
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
 
-  semaphore :update_firewall_rules, :refresh_dns_record, :destroy
+  semaphore :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :destroy
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -153,12 +153,18 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(dns_zone).to receive(:delete_record).with(record_name: "pg-name.postgres.ubicloud.com.")
       expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "A", ttl: 10, data: "1.1.1.1")
       expect(described_class).to receive(:dns_zone).and_return(dns_zone).twice
+      expect(nx).to receive(:when_initial_provisioning_set?).and_yield
       expect { nx.refresh_dns_record }.to hop("initialize_certificates")
     end
 
     it "hops even if dns zone is not configured" do
       expect(described_class).to receive(:dns_zone).and_return(nil).twice
-      expect { nx.refresh_dns_record }.to hop("initialize_certificates")
+      expect { nx.refresh_dns_record }.to hop("wait")
+    end
+
+    it "hops to wait if initial_provisioning is not set" do
+      expect(nx).to receive(:when_initial_provisioning_set?)
+      expect { nx.refresh_dns_record }.to hop("wait")
     end
   end
 


### PR DESCRIPTION
We used to unconditionally transition to the initialize_certificates label from refresh_dns_record label, which further transitions to create_billing_record label. That means every time we refresh the DNS record, we would create a new root certificates and also new billing records. Both needs to be done once at the time of the initial provisioning. This commit fixes the issue by adding a new transition from refresh_dns_record to wait if the initial provisioning is already done.