### PR TITLE
Use private network for communication of PostgreSQL primary and standby

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -88,7 +88,7 @@ class PostgresServer < Sequel::Model
         }
       },
       identity: resource.identity,
-      hosts: "#{resource.representative_server.vm.ephemeral_net4} #{resource.identity}"
+      hosts: "#{resource.representative_server.vm.nics.first.private_ipv4.network} #{resource.identity}"
     }
   end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
   semaphore :restart, :configure, :update_firewall_rules, :take_over, :destroy
 
-  def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil)
+  def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil, private_subnet_id: nil)
     DB.transaction do
       ubid = PostgresServer.generate_ubid
 
@@ -29,6 +29,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
           {encrypted: true, size_gib: postgres_resource.target_storage_size_gib}
         ],
         boot_image: "postgres-ubuntu-2204",
+        private_subnet_id: private_subnet_id,
         enable_ip4: true,
         allow_only_ssh: true
       )

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe PostgresServer do
           net4: NetAddr::IPv4Net.parse("172.0.0.0/26"),
           net6: NetAddr::IPv6Net.parse("fdfa:b5aa:14a3:4a3d::/64")
         )
+      ],
+      nics: [
+        instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.70.205.205/32"))
       ]
     )
   }


### PR DESCRIPTION
**Provision standbys in the primary's private subnet**

Previously, we created separate subnets for the primary and standby and used
public network for all communication between them. This change provisions the
standby node in the primary's private subnet, which is more secure. It also
enables the standby to use the primary's private IP address for replication,
thus circumventing the user firewalls.

**Use private IPs in /etc/hosts file of PostgresSQL servers**
We use /etc/hosts for domain name resolution for the internal communication
between the primary and standby servers. This change ensures that the domain
name resolved to the private IP address, so that the all communication between
the primary and standby servers happens over the private network.