### PR TITLE
Add firewall and firewall-rule API endpoints

### DIFF
--- a/routes/api/project/firewall.rb
+++ b/routes/api/project/firewall.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class CloverApi
+  hash_branch(:project_prefix, "firewall") do |r|
+    @serializer = Serializers::Api::Firewall
+
+    r.get true do
+      result = @project.firewalls_dataset.authorized(@current_user.id, "Firewall:view").eager(:firewall_rules).paginated_result(
+        start_after: r.params["start_after"],
+        page_size: r.params["page_size"],
+        order_column: r.params["order_column"]
+      )
+
+      {
+        items: serialize(result[:records]),
+        count: result[:count]
+      }
+    end
+
+    r.post true do
+      Authorization.authorize(@current_user.id, "Firewall:create", @project.id)
+
+      required_parameters = ["name"]
+      allowed_optional_parameters = ["description"]
+      request_body_params = Validation.validate_request_body(r.body.read, required_parameters, allowed_optional_parameters)
+      Validation.validate_name(request_body_params["name"])
+
+      firewall = Firewall.create_with_id(name: request_body_params["name"], description: request_body_params["description"] || "")
+      firewall.associate_with_project(@project)
+
+      serialize(firewall)
+    end
+
+    r.on String do |firewall_ubid|
+      @firewall = Firewall.from_ubid(firewall_ubid)
+
+      unless @firewall
+        response.status = r.delete? ? 204 : 404
+        r.halt
+      end
+
+      r.delete true do
+        Authorization.authorize(@current_user.id, "Firewall:delete", @project.id)
+
+        @firewall.dissociate_with_project(@project)
+        @firewall.destroy
+
+        response.status = 204
+        r.halt
+      end
+
+      r.get true do
+        Authorization.authorize(@current_user.id, "Firewall:view", @project.id)
+
+        serialize(@firewall, :detailed)
+      end
+
+      r.post "attach-subnet" do
+        Authorization.authorize(@current_user.id, "PrivateSubnet:edit", @project.id)
+
+        required_parameters = ["private_subnet_id"]
+        request_body_params = Validation.validate_request_body(r.body.read, required_parameters)
+
+        private_subnet = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"])
+        unless private_subnet
+          fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{request_body_params["private_subnet_id"]}\" is not found"})
+        end
+
+        @firewall.associate_with_private_subnet(private_subnet)
+
+        serialize(@firewall, :detailed)
+      end
+
+      r.post "detach-subnet" do
+        Authorization.authorize(@current_user.id, "PrivateSubnet:edit", @project.id)
+
+        required_parameters = ["private_subnet_id"]
+        request_body_params = Validation.validate_request_body(r.body.read, required_parameters)
+
+        private_subnet = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"])
+        unless private_subnet
+          fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{request_body_params["private_subnet_id"]}\" is not found"})
+        end
+
+        @firewall.disassociate_from_private_subnet(private_subnet)
+
+        serialize(@firewall, :detailed)
+      end
+
+      r.hash_branches(:project_firewall_prefix)
+    end
+  end
+end

--- a/routes/api/project/firewall/firewall_rule.rb
+++ b/routes/api/project/firewall/firewall_rule.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class CloverApi
+  hash_branch(:project_firewall_prefix, "firewall-rule") do |r|
+    @serializer = Serializers::Api::FirewallRule
+
+    r.post true do
+      Authorization.authorize(@current_user.id, "Firewall:edit", @firewall.id)
+
+      required_parameters = ["cidr"]
+      allowed_optional_parameters = ["port_range"]
+
+      request_body_params = Validation.validate_request_body(request.body.read, required_parameters, allowed_optional_parameters)
+
+      parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
+      port_range = if request_body_params["port_range"].nil?
+        [0, 65535]
+      else
+        request_body_params["port_range"] = Validation.validate_port_range(request_body_params["port_range"])
+      end
+
+      pg_range = Sequel.pg_range(port_range.first..port_range.last)
+
+      firewall_rule = @firewall.insert_firewall_rule(parsed_cidr.to_s, pg_range)
+
+      serialize(firewall_rule)
+    end
+
+    r.is String do |firewall_rule_ubid|
+      firewall_rule = FirewallRule.from_ubid(firewall_rule_ubid)
+
+      request.delete true do
+        if firewall_rule
+          Authorization.authorize(@current_user.id, "Firewall:edit", @firewall.id)
+          @firewall.remove_firewall_rule(firewall_rule)
+        end
+
+        response.status = 204
+        r.halt
+      end
+    end
+  end
+end

--- a/serializers/api/firewall.rb
+++ b/serializers/api/firewall.rb
@@ -13,4 +13,10 @@ class Serializers::Api::Firewall < Serializers::Base
   structure(:default) do |firewall|
     base(firewall)
   end
+
+  structure(:detailed) do |firewall|
+    base(firewall).merge({
+      private_subnets: firewall.private_subnets.map { |ps| Serializers::Api::PrivateSubnet.serialize(ps) }
+    })
+  end
 end

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "firewall" do
+  let(:user) { create_account }
+
+  let(:project) { user.create_project_with_default_policy("project-1") }
+
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall").tap { _1.associate_with_project(project) } }
+
+  let(:firewall_rule) { FirewallRule.create_with_id(firewall_id: firewall.id, cidr: "0.0.0.0/0", port_range: Sequel.pg_range(80..5432)) }
+
+  describe "unauthenticated" do
+    it "not post" do
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+
+    it "not delete" do
+      delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+  end
+
+  describe "authenticated" do
+    before do
+      login_api(user.email)
+    end
+
+    it "create firewall rule" do
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule", {
+        cidr: "0.0.0.0/0",
+        port_range: "100..101"
+      }.to_json
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "can not create same firewall rule" do
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule", {
+        cidr: firewall_rule.cidr,
+        port_range: "80..5432"
+      }.to_json
+
+      expect(last_response.status).to eq(400)
+    end
+
+    it "firewall rule no port range" do
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule", {
+        cidr: "0.0.0.0/1"
+      }.to_json
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "firewall rule single port" do
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule", {
+        cidr: "0.0.0.0/1",
+        port_range: "11111"
+      }.to_json
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "firewall rule delete" do
+      delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      expect(last_response.status).to eq(204)
+    end
+
+    it "firewall rule delete does not exist" do
+      delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/fooubid"
+      expect(last_response.status).to eq(204)
+    end
+  end
+end

--- a/spec/routes/api/project/firewall_spec.rb
+++ b/spec/routes/api/project/firewall_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "firewall" do
+  let(:user) { create_account }
+
+  let(:project) { user.create_project_with_default_policy("project-1") }
+
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall").tap { _1.associate_with_project(project) } }
+
+  describe "unauthenticated" do
+    it "not list" do
+      get "/api/project/#{project.ubid}/firewall"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+
+    it "not create" do
+      post "/api/project/#{project.ubid}/firewall"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+
+    it "not delete" do
+      delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+
+    it "not get" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+
+    it "not associate" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/attach-subnet"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+
+    it "not dissociate" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/detach-subnet"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
+  end
+
+  describe "authenticated" do
+    before do
+      login_api(user.email)
+    end
+
+    it "success get all firewalls" do
+      Firewall.create_with_id(name: firewall.name).associate_with_project(project)
+
+      get "/api/project/#{project.ubid}/firewall"
+
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)["items"].length).to eq(2)
+    end
+
+    it "success get firewall" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}"
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "get does not exist" do
+      get "/api/project/#{project.ubid}/firewall/foo_ubid"
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it "success post" do
+      post "/api/project/#{project.ubid}/firewall", {
+        name: "foo-name",
+        description: "Firewall description"
+      }.to_json
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "success delete" do
+      delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}"
+
+      expect(last_response.status).to eq(204)
+    end
+
+    it "delete not exist" do
+      delete "/api/project/#{project.ubid}/firewall/foo_ubid"
+
+      expect(last_response.status).to eq(204)
+    end
+
+    it "attach to subnet" do
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
+      expect(ps).to receive(:incr_update_firewall_rules)
+
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/attach-subnet", {
+        private_subnet_id: ps.ubid
+      }.to_json
+
+      expect(firewall.private_subnets.count).to eq(1)
+      expect(firewall.private_subnets.first.id).to eq(ps.id)
+      expect(last_response.status).to eq(200)
+    end
+
+    it "attach to subnet not exist" do
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/attach-subnet", {
+        private_subnet_id: "fooubid"
+      }.to_json
+
+      expect(last_response.status).to eq(400)
+    end
+
+    it "detach from subnet" do
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
+      expect(ps).to receive(:incr_update_firewall_rules)
+
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/detach-subnet", {
+        private_subnet_id: ps.ubid
+      }.to_json
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "detach from subnet not exist" do
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/detach-subnet", {
+        private_subnet_id: "fooubid"
+      }.to_json
+
+      expect(last_response.status).to eq(400)
+    end
+
+    it "attach and detach" do
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      expect(PrivateSubnet).to receive(:from_ubid).and_return(ps).twice
+      expect(ps).to receive(:incr_update_firewall_rules).twice
+
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/attach-subnet", {
+        private_subnet_id: ps.ubid
+      }.to_json
+
+      expect(firewall.private_subnets.count).to eq(1)
+
+      post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/detach-subnet", {
+        private_subnet_id: ps.ubid
+      }.to_json
+
+      expect(firewall.reload.private_subnets.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
**Add private subnet to detailed firewall api serialization**
As firewalls are started to be associated with private subnets,
adding private subnet information to the detailed firewall api
serialization.


**Add firewall API endpoints**
Adding API endpoints to manage firewalls. Endpoints include
- Adding Firewall
- Deleting Firewall
- Getting/Listing Firewalls
- Associate/Dissociate with subnets

Firewall rule management will be added with the subsequent commit.

**Add firewall rule API endpoints**
Adding API endpoints to manage firewall rules. Endpoints include
- Adding firewall rules
- Deleting firewall rules
