### PR TITLE
Send email when the invoice processed

### DIFF
--- a/lib/util.rb
+++ b/lib/util.rb
@@ -77,12 +77,13 @@ module Util
     end
   end
 
-  def self.send_email(receiver, subject, greeting: nil, body: nil, button_title: nil, button_link: nil)
+  def self.send_email(receiver, subject, greeting: nil, body: nil, button_title: nil, button_link: nil, cc: nil)
     html = EmailRenderer.new.render "email/layout", locals: {subject: subject, greeting: greeting, body: body, button_title: button_title, button_link: button_link}
     Mail.deliver do
       from Config.mail_from
       to receiver
       subject subject
+      cc cc
 
       text_part do
         body "#{greeting}\n#{Array(body).join("\n")}\n#{button_link}"

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -15,58 +15,66 @@ class Invoice < Sequel::Model
   end
 
   def charge
+    reload # Reload to get the latest status to avoid double charging
     unless (Stripe.api_key = Config.stripe_secret_key)
-      puts "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
-      return
+      Clog.emit("Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing.")
+      return true
     end
 
     if status != "unpaid"
-      puts "Invoice[#{ubid}] already charged: #{status}"
-      return
+      Clog.emit("Invoice already charged.") { {invoice_already_charged: {ubid: ubid, status: status}} }
+      return true
     end
 
-    if content["cost"] < Config.minimum_invoice_charge_threshold
+    amount = content["cost"].to_f.round(2)
+    if amount < Config.minimum_invoice_charge_threshold
       update(status: "below_minimum_threshold")
-      puts "Invoice[#{ubid}] cost is less than minimum charge cost: $#{content["cost"]}"
-      return
+      Clog.emit("Invoice cost is less than minimum charge cost.") { {invoice_below_threshold: {ubid: ubid, cost: amount}} }
+      return true
     end
 
-    unless (billing_info = BillingInfo[content.dig("billing_info", "id")])
-      puts "Invoice[#{ubid}] doesn't have billing info"
-      return
+    if (billing_info = BillingInfo[content.dig("billing_info", "id")]).nil? || billing_info.payment_methods.empty?
+      Clog.emit("Invoice doesn't have billing info.") { {invoice_no_billing: {ubid: ubid}} }
+      return false
     end
 
-    payment_methods = billing_info.payment_methods_dataset.order(:order).all
-
-    payment_methods.each do |payment_method|
-      amount = content["cost"].to_f.round(2)
-      payment_intent = Stripe::PaymentIntent.create({
-        amount: (amount * 100).to_i, # 100 cents to charge $1.00
-        currency: "usd",
-        confirm: true,
-        off_session: true,
-        customer: billing_info.stripe_id,
-        payment_method: payment_method.stripe_id
-      })
-
-      if payment_intent.status == "succeeded"
-        puts "Invoice[#{ubid}] charged with PaymentMethod[#{payment_method.ubid}] for $#{amount}"
-        self.status = "paid"
-        content.merge!({
-          "payment_method" => {
-            "id" => payment_method.id,
-            "stripe_id" => payment_method.stripe_id
-          },
-          "payment_intent" => payment_intent.id
+    errors = []
+    billing_info.payment_methods_dataset.order(:order).each do |pm|
+      begin
+        payment_intent = Stripe::PaymentIntent.create({
+          amount: (amount * 100).to_i, # 100 cents to charge $1.00
+          currency: "usd",
+          confirm: true,
+          off_session: true,
+          customer: billing_info.stripe_id,
+          payment_method: pm.stripe_id
         })
-        save(columns: [:status, :content])
-        return payment_intent.id
+      rescue Stripe::CardError => e
+        Clog.emit("Invoice couldn't charged.") { {invoice_not_charged: {ubid: ubid, payment_method: pm.ubid, error: e.message}} }
+        errors << e.message
+        next
       end
 
-      puts "Invoice[#{ubid}] couldn't charge with PaymentMethod[#{payment_method.ubid}]: #{payment_intent.status}"
+      unless payment_intent.status == "succeeded"
+        Clog.emit("BUG: payment intent should succeed here") { {invoice_not_charged: {ubid: ubid, payment_method: pm.ubid, intent_id: payment_intent.id, error: payment_intent.status}} }
+        next
+      end
+
+      Clog.emit("Invoice charged.") { {invoice_charged: {ubid: ubid, payment_method: pm.ubid, cost: amount}} }
+      self.status = "paid"
+      content.merge!({
+        "payment_method" => {
+          "id" => pm.id,
+          "stripe_id" => pm.stripe_id
+        },
+        "payment_intent" => payment_intent.id
+      })
+      save(columns: [:status, :content])
+      return true
     end
 
-    puts "Invoice[#{ubid}] couldn't charge with any payment method"
+    Clog.emit("Invoice couldn't charged with any payment method.") { {invoice_not_charged: {ubid: ubid}} }
+    false
   end
 end
 

--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -31,6 +31,7 @@ class Serializers::Web::Invoice < Serializers::Base
     base(inv).merge(
       {
         billing_name: inv.content.dig("billing_info", "name"),
+        billing_email: inv.content.dig("billing_info", "email"),
         billing_address: inv.content.dig("billing_info", "address"),
         billing_country: ISO3166::Country.new(inv.content.dig("billing_info", "country"))&.common_name,
         billing_city: inv.content.dig("billing_info", "city"),

--- a/serializers/web/invoice.rb
+++ b/serializers/web/invoice.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "countries"
+
 class Serializers::Web::Invoice < Serializers::Base
   def self.base(inv)
     {

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -6,77 +6,90 @@ RSpec.describe Invoice do
   subject(:invoice) { described_class.new(id: "50d5aae4-311c-843b-b500-77fbc7778050", content: {"cost" => 10}, status: "unpaid") }
 
   let(:billing_info) { BillingInfo.create_with_id(stripe_id: "cs_1234567890") }
-  let(:payment_method) { PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_1234567890") }
+
+  before do
+    allow(invoice).to receive(:reload)
+    allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+  end
 
   describe ".charge" do
     it "not charge if Stripe not enabled" do
       allow(Config).to receive(:stripe_secret_key).and_return(nil)
-      expect do
-        expect(invoice.charge).to be_nil
-      end.to output("Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing.\n").to_stdout
+      expect(Clog).to receive(:emit).with("Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing.").and_call_original
+      expect(invoice.charge).to be true
     end
 
     it "not charge if already charged" do
-      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      expect(Clog).to receive(:emit).with("Invoice already charged.").and_call_original
       invoice.status = "paid"
-      expect do
-        expect(invoice.charge).to be_nil
-      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] already charged: paid\n").to_stdout
+      expect(invoice.charge).to be true
     end
 
     it "not charge if less than minimum charge threshold" do
-      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
       invoice.content["cost"] = 0.4
       expect(invoice).to receive(:update).with(status: "below_minimum_threshold")
-      expect do
-        expect(invoice.charge).to be_nil
-      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] cost is less than minimum charge cost: $0.4\n").to_stdout
+      expect(Clog).to receive(:emit).with("Invoice cost is less than minimum charge cost.").and_call_original
+      expect(invoice.charge).to be true
     end
 
     it "not charge if doesn't have billing info" do
-      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
-      expect do
-        expect(invoice.charge).to be_nil
-      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] doesn't have billing info\n").to_stdout
+      expect(Clog).to receive(:emit).with("Invoice doesn't have billing info.").and_call_original
+      expect(invoice.charge).to be false
     end
 
     it "not charge if no payment methods" do
-      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
       invoice.content["billing_info"] = {"id" => billing_info.id}
-      expect do
-        expect(invoice.charge).to be_nil
-      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] couldn't charge with any payment method\n").to_stdout
+      expect(Clog).to receive(:emit).with("Invoice doesn't have billing info.").and_call_original
+      expect(invoice.charge).to be false
     end
 
-    it "not charge if payment method fails" do
-      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+    it "not charge if all payment methods fails" do
       invoice.content["billing_info"] = {"id" => billing_info.id}
+      payment_method1 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_1", order: 1)
+      payment_method2 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_2", order: 2)
+
       # rubocop:disable RSpec/VerifiedDoubles
-      expect(Stripe::PaymentIntent).to receive(:create).and_return(double(Stripe::PaymentIntent, status: "failed")).at_least(:once)
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method1.stripe_id))
+        .and_raise(Stripe::CardError.new("Unsufficient funds", {}))
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method2.stripe_id))
+        .and_raise(Stripe::CardError.new("Card declined", {}))
       # rubocop:enable RSpec/VerifiedDoubles
-      expect do
-        expect(invoice.charge).to be_nil
-      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] couldn't charge with PaymentMethod[#{payment_method.ubid}]: failed
-Invoice[1va3atns1h3j3pm07fyy7ey050] couldn't charge with any payment method\n").to_stdout
+      expect(Clog).to receive(:emit).with("Invoice couldn't charged.").and_call_original.twice
+      expect(Clog).to receive(:emit).with("Invoice couldn't charged with any payment method.").and_call_original
+      expect(invoice.charge).to be false
     end
 
-    it "can charge" do
-      allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+    it "fails if PaymentIntent does not raise an exception in case of failure" do
       invoice.content["billing_info"] = {"id" => billing_info.id}
+      payment_method = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_1", order: 1)
 
       # rubocop:disable RSpec/VerifiedDoubles
-      expect(Stripe::PaymentIntent).to receive(:create).and_return(double(Stripe::PaymentIntent, status: "succeeded", id: "pi_1234567890")).with(hash_including(
-        amount: 1000,
-        customer: billing_info.stripe_id,
-        payment_method: payment_method.stripe_id
-      )).at_least(:once)
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method.stripe_id))
+        .and_return(double(Stripe::PaymentIntent, id: "payment-intent-id", status: "failed"))
+      # rubocop:enable RSpec/VerifiedDoubles
+      expect(Clog).to receive(:emit).with("BUG: payment intent should succeed here").and_call_original
+      expect(Clog).to receive(:emit).with("Invoice couldn't charged with any payment method.").and_call_original
+      expect(invoice.charge).to be false
+    end
+
+    it "can charge from a correct payment method even some of them are not working" do
+      invoice.content["billing_info"] = {"id" => billing_info.id}
+      payment_method1 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_1", order: 1)
+      payment_method2 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_2", order: 2)
+      payment_method3 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_3", order: 3)
+      # rubocop:disable RSpec/VerifiedDoubles
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method1.stripe_id))
+        .and_raise(Stripe::CardError.new("Declined", {}))
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method2.stripe_id))
+        .and_return(double(Stripe::PaymentIntent, status: "succeeded", id: "pi_1234567890"))
+      expect(Stripe::PaymentIntent).not_to receive(:create).with(hash_including(payment_method: payment_method3.stripe_id))
       # rubocop:enable RSpec/VerifiedDoubles
       expect(invoice).to receive(:save).with(columns: [:status, :content])
-      expect do
-        expect(invoice.charge).to eq("pi_1234567890")
-      end.to output("Invoice[1va3atns1h3j3pm07fyy7ey050] charged with PaymentMethod[#{payment_method.ubid}] for $10.0\n").to_stdout
+      expect(Clog).to receive(:emit).with("Invoice couldn't charged.").and_call_original
+      expect(Clog).to receive(:emit).with("Invoice charged.").and_call_original
+      expect(invoice.charge).to be true
       expect(invoice.status).to eq("paid")
-      expect(invoice.content["payment_method"]["id"]).to eq(payment_method.id)
+      expect(invoice.content["payment_method"]["id"]).to eq(payment_method2.id)
       expect(invoice.content["payment_intent"]).to eq("pi_1234567890")
     end
   end

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Invoice do
       expect(Clog).to receive(:emit).with("Invoice couldn't charged.").and_call_original.twice
       expect(Clog).to receive(:emit).with("Invoice couldn't charged with any payment method.").and_call_original
       expect(invoice.charge).to be false
+      expect(Mail::TestMailer.deliveries.length).to eq 1
     end
 
     it "fails if PaymentIntent does not raise an exception in case of failure" do


### PR DESCRIPTION
## Improve invoice charging function

We manually charge invoices. I've resolved some issues we encountered during the charging process.

Firstly, I switched the logging method from 'puts' to 'Clog'.

We attempted to charge each payment method listed in the billing information sequentially. Sometimes, the Stripe Ruby SDK throws an error when a payment fails. In such cases, we need to catch the error and proceed to charge the next payment method.

If we successfully charge an invoice, there's no need to continue trying other payment methods, so we break the loop.

If all payment methods fail, we leave the invoice unpaid.

## Add cc parameter to the email sending function

We need to cc the support email when sending a failed payment email to the customer. This way, the support team can follow up with the customer if necessary.

## Send an email when the invoice is successfully charged

We email the customer once the invoice is successfully processed.

We plan to include the invoice as a PDF attachment in future emails. However, generating a PDF on the backend is complex, so we'll add this feature in the next update.

## Send an email when the invoice is failed to charge

We automate the process of sending emails when an invoice fails to charge, including error details from the Stripe API.

We also add the support email as a CC, allowing the entire team to follow up with the customer if needed.