### PR TITLE
Add accounts association to the project model

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -9,6 +9,7 @@ class Project < Sequel::Model
   one_to_many :usage_alerts
   one_to_many :github_installations
 
+  many_to_many :accounts, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :vms, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :minio_clusters, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :private_subnets, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
@@ -30,10 +31,6 @@ class Project < Sequel::Model
   end
 
   include Authorization::TaggableMethods
-
-  def user_ids
-    access_tags_dataset.where(hyper_tag_table: Account.table_name.to_s).select_map(:hyper_tag_id)
-  end
 
   def has_valid_payment_method?
     return true unless Config.stripe_secret_key

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -36,7 +36,7 @@ class CloverApi
         r.halt
       end
 
-      unless @project.user_ids.include?(@current_user.id)
+      unless @project.accounts.any? { _1.id == @current_user.id }
         fail Authorization::Unauthorized
       end
 

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -31,7 +31,7 @@ class CloverWeb
         r.halt
       end
 
-      unless @project.user_ids.include?(@current_user.id)
+      unless @project.accounts.any? { _1.id == @current_user.id }
         fail Authorization::Unauthorized
       end
 

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -6,8 +6,7 @@ class CloverWeb
     @serializer = Serializers::Web::Account
 
     r.get true do
-      users_with_hyper_tag = @project.user_ids
-      @users = serialize(Account.where(id: users_with_hyper_tag).all)
+      @users = serialize(@project.accounts)
 
       view "project/user"
     end
@@ -41,7 +40,7 @@ class CloverWeb
       end
 
       r.delete true do
-        unless @project.user_ids.count > 1
+        unless @project.accounts.count > 1
           response.status = 400
           return {message: "You can't remove the last user from '#{@project.name}' project. Delete project instead."}.to_json
         end


### PR DESCRIPTION
Earlier, I implemented `user_ids` method to retrieve the list of user ids associated with a project. This was during my early days. Now, we can use the Sequel method to obtain project users, which is more practical.

This method is also beneficial for operational processes. I often found myself using `Account[project.user_ids.first]` to access the users.