### PR TITLE
Remove unnecessary detach logic from Nic

### DIFF
--- a/model/nic.rb
+++ b/model/nic.rb
@@ -8,9 +8,12 @@ class Nic < Sequel::Model
   one_to_many :src_ipsec_tunnels, key: :src_nic_id, class: IpsecTunnel
   one_to_many :dst_ipsec_tunnels, key: :dst_nic_id, class: IpsecTunnel
   one_to_one :strand, key: :id, class: Strand
+  plugin :association_dependencies, src_ipsec_tunnels: :destroy, dst_ipsec_tunnels: :destroy
+
   include ResourceMethods
   include SemaphoreMethods
-  semaphore :destroy, :detach_vm, :start_rekey, :trigger_outbound_update,
+
+  semaphore :destroy, :start_rekey, :trigger_outbound_update,
     :old_state_drop_trigger, :setup_nic, :repopulate
 
   plugin :column_encryption do |enc|


### PR DESCRIPTION
Detach nic from the VM logic is not needed since we do not support
managing nics, yet. There is no need to keep it.

I have also moved the cleanup of tunnels to the
association_dependencies.

Furthermore, since we do not bud any child processes anymore, we do not
need to destroy child progs separately at the time of nic destroy.