### PR TITLE
Ensure that the runner can log duration even without a vm

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -35,9 +35,12 @@ class GithubRunner < Sequel::Model
   end
 
   def log_duration(message, duration)
-    values = {ubid: ubid, label: label, repository_name: repository_name, duration: duration, vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores}
-    values[:vm_host_ubid] = vm.vm_host.ubid if vm.vm_host
-    values[:vm_pool_ubid] = VmPool[vm.pool_id].ubid if vm.pool_id
+    values = {ubid: ubid, label: label, repository_name: repository_name, duration: duration}
+    if vm
+      values.merge!(vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores)
+      values[:vm_host_ubid] = vm.vm_host.ubid if vm.vm_host
+      values[:vm_pool_ubid] = VmPool[vm.pool_id].ubid if vm.pool_id
+    end
     Clog.emit(message) { {message => values} }
   end
 

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe GithubRunner do
     github_runner.log_duration("runner_tested", 10)
   end
 
+  it "can log duration without a vm" do
+    expect(github_runner).to receive(:vm).and_return(nil)
+    expect(Clog).to receive(:emit).with("runner_tested").and_call_original
+    github_runner.log_duration("runner_tested", 10)
+  end
+
   it "provisions a spare runner" do
     expect(Prog::Vm::GithubRunner).to receive(:assemble).with(github_runner.installation, repository_name: github_runner.repository_name, label: github_runner.label)
       .and_return(instance_double(Strand, subject: instance_double(described_class)))


### PR DESCRIPTION
We expect having a VM where we log duration in the runner, but this doesn't seem to always be the case. I've noticed several crashes in the web logs.

If a webhook is delivered while the runner is being destroyed, the runner's VM may have already been deleted.