### PR TITLE
Overwrite postgresql base image

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -96,4 +96,6 @@ class Project < Sequel::Model
       end
     end
   end
+
+  feature_flag :postgresql_base_image
 end

--- a/model/project.rb
+++ b/model/project.rb
@@ -87,11 +87,11 @@ class Project < Sequel::Model
 
   def self.feature_flag(*flags)
     flags.map(&:to_s).each do |flag|
-      define_method :"set_#{flag}" do |value|
+      define_method :"set_ff_#{flag}" do |value|
         update(feature_flags: feature_flags.merge({flag => value}))
       end
 
-      define_method :"get_#{flag}" do
+      define_method :"get_ff_#{flag}" do
         feature_flags[flag]
       end
     end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -28,7 +28,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
           {encrypted: true, size_gib: 30},
           {encrypted: true, size_gib: postgres_resource.target_storage_size_gib}
         ],
-        boot_image: "postgres-ubuntu-2204",
+        boot_image: postgres_resource.project.get_ff_postgresql_base_image || "postgres-ubuntu-2204",
         private_subnet_id: private_subnet_id,
         enable_ip4: true,
         allow_only_ssh: true

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Project do
       described_class.feature_flag(:dummy_flag)
       project = described_class.create_with_id(name: "dummy-name")
 
-      expect(project.get_dummy_flag).to be_nil
-      project.set_dummy_flag("new-value")
-      expect(project.get_dummy_flag).to eq "new-value"
+      expect(project.get_ff_dummy_flag).to be_nil
+      project.set_ff_dummy_flag("new-value")
+      expect(project.get_ff_dummy_flag).to eq "new-value"
     end
   end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -46,8 +46,9 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe ".assemble" do
     it "creates postgres server and vm with sshable" do
+      user_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       postgres_resource = PostgresResource.create_with_id(
-        project_id: "e3e333dd-bd9a-82d2-acc1-1c7c1ee9781f",
+        project_id: user_project.id,
         location: "hetzner-hel1",
         name: "pg-name",
         target_vm_size: "standard-2",


### PR DESCRIPTION
**Add ff_ prefix for getting and setting project feature flags**
get/set is popular keywords and has potential to create conflicts. To prevent
that possibility, we are adding ff_ prefix to the methods that are related to
the feature flags.

**Add feature flag for overwriting PostgreSQL base image**
When this flag is set, we would use non-default base image for PostgreSQL
servers. It would enable partners to create and use their own PosgreSQL base
images.