### PR TITLE
Move monitorable_resource_types to local scope of resource scanner

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -4,14 +4,15 @@
 require_relative "../loader"
 clover_freeze
 
-MONITORABLE_RESOURCE_TYPES = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner]
 resources = {}
 mutex = Mutex.new
 
 resource_scanner = Thread.new do
+  monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner]
+
   loop do
     mutex.synchronize do
-      Enumerator::Chain.new(*MONITORABLE_RESOURCE_TYPES).each do |r|
+      Enumerator::Chain.new(*monitorable_resource_types).each do |r|
         resources[r.id] ||= MonitorableResource.new(r)
       end
     end


### PR DESCRIPTION
clover_freeze does not allow creating a new constant in global scope as it counts as changing the global state. We don't need monitorable_resource_types to be in the global scope anyway. So I'm moving it to the local scope of the resource scanner.