### PR TITLE
Delete pages on resolution

### DIFF
--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -22,6 +22,7 @@ class Prog::PageNexus < Prog::Base
   label def wait
     when_resolve_set? do
       page.resolve
+      page.destroy
       pop "page is resolved"
     end
 

--- a/spec/prog/page_nexus_spec.rb
+++ b/spec/prog/page_nexus_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Prog::PageNexus do
     it "exits when resolved" do
       expect(pn).to receive(:when_resolve_set?).and_yield
       expect(pg).to receive(:resolve)
+      expect(pg).to receive(:destroy)
       expect { pn.wait }.to exit({"msg" => "page is resolved"})
     end
 


### PR DESCRIPTION
We delete(actually destroy) almost all resources when we are done with them. At some point we considered soft-deleting. As a result of that we didn't deleted pages on resolution and instead marked them as resolved. However, since then we also introduced the DeletedRecords concept for historical bookkeeping. I think keeping the pages around is not worth much anymore. We can always look at the DeletedRecords if we need to know what was resolved. We also have old pages in Pagerduty and Slack for easy search. Hence, I'm changing page resolution logic to delete the page instead of just marking it as resolved.