### PR TITLE
Harden against monitor db failures

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -20,7 +20,11 @@ end
 
 postgres_monitor_db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "postgres_monitor_db.crt")
 Util.safe_write_to_file(postgres_monitor_db_ca_bundle_filename, Config.postgres_monitor_database_root_certs)
-POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool, pool_timeout: Config.database_timeout) if Config.postgres_monitor_database_url
+begin
+  POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool, pool_timeout: Config.database_timeout) if Config.postgres_monitor_database_url
+rescue Sequel::DatabaseConnectionError => ex
+  Clog.emit("Failed to connect to Postgres Monitor database") { {database_connection_failed: {exception: Util.exception_to_hash(ex)}} }
+end
 
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -193,6 +193,16 @@ RSpec.describe PostgresServer do
     postgres_server.check_pulse(session: session, previous_pulse: pulse)
   end
 
+  it "catches Sequel::Error if updating PostgresLsnMonitor fails" do
+    lsn_monitor = instance_double(PostgresLsnMonitor, last_known_lsn: "1/5")
+    expect(PostgresLsnMonitor).to receive(:new).and_return(lsn_monitor)
+    expect(lsn_monitor).to receive(:insert_conflict).and_return(lsn_monitor)
+    expect(lsn_monitor).to receive(:save_changes).and_raise(Sequel::Error)
+    expect(Clog).to receive(:emit).with("Failed to update PostgresLsnMonitor")
+
+    postgres_server.check_pulse(session: {db_connection: DB}, previous_pulse: {})
+  end
+
   it "runs query on vm" do
     expect(postgres_server.vm.sshable).to receive(:cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv", stdin: "SELECT 1").and_return("1\n")
     expect(postgres_server.run_query("SELECT 1")).to eq("1")


### PR DESCRIPTION
**Do not crash if the monitor database is not available**
While monitoring database is important, it isn't critical for the entire system
to function. Even the monitor itself can continue to work in degraded mode. So,
if the monitoring database is not available, we should not crash the entire
system. This commit catches Sequel::DatabaseConnectionError that can be raised
while trying to connect to the monitoring database and logs an error message.

**Ignore errors while trying to save last_known_lsn**
Even if the last_known_lsn cannot saved (potentially due to unavailability of
the monitoring database), the monitor should still be able to record pulses.
Otherwise, pulse checking would stop for all PostgreSQL databases when the
monitoring database is down. This commit ensures that we properly handle the
exceptions that can be raised when trying to save the last_known_lsn.

Of course, we shouldn't perform failovers if the last_known_lsn is unknown.
That is still the case, because the last_known_lsn is only used to at the
time of failover to determine the failover target.