### PR TITLE
Fix display state of PostgreSQL resources

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -43,7 +43,8 @@ class PostgresResource < Sequel::Model
   end
 
   def display_state
-    return "running" if ["wait", "refresh_certificates"].include?(strand.label)
+    return "unavailable" if representative_server&.strand&.label == "unavailable"
+    return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
     return "deleting" if destroy_set? || strand.label == "destroy"
     "creating"
   end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -36,18 +36,18 @@ RSpec.describe PostgresResource do
     expect(s).to include("ubi_replication@pgc60xvcr00a5kbnggj1js4kkq.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/dat/16/data/server.crt")
   end
 
-  it "returns running as display state if the database is ready" do
+  it "returns display state correctly" do
+    expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "unavailable")))
+    expect(postgres_resource.display_state).to eq("unavailable")
+
+    expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait"))).at_least(:once)
     expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
     expect(postgres_resource.display_state).to eq("running")
-  end
 
-  it "returns deleting as display state if the database is being destroyed" do
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy")).twice
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy")).exactly(3).times
     expect(postgres_resource.display_state).to eq("deleting")
-  end
 
-  it "returns creating as display state for other cases" do
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server")).twice
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server"))
     expect(postgres_resource.display_state).to eq("creating")
   end
 end

--- a/spec/serializers/api/postgres_spec.rb
+++ b/spec/serializers/api/postgres_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Serializers::Api::Postgres do
   let(:pg) { PostgresResource.new(name: "pg-name").tap { _1.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
 
   it "can serialize when no earliest/latest restore times" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)
-    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
@@ -16,25 +16,25 @@ RSpec.describe Serializers::Api::Postgres do
 
   it "can serialize when have earliest/latest restore times" do
     time = Time.now
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).exactly(3)
-    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to eq(time.iso8601)
     expect(data[:latest_restore_time]).to eq(time.iso8601)
   end
 
   it "can serialize when not primary" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil)).exactly(2)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil, strand: nil)).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
   end
 
   it "can serialize when there is no server" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:representative_server).and_return(nil).exactly(2)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:representative_server).and_return(nil).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:primary?]).to be_nil
     expect(data[:earliest_restore_time]).to be_nil

--- a/spec/serializers/web/postgres_spec.rb
+++ b/spec/serializers/web/postgres_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Serializers::Web::Postgres do
   let(:pg) { PostgresResource.new(name: "pg-name").tap { _1.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
 
   it "can serialize when no earliest/latest restore times" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)
-    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
@@ -16,25 +16,25 @@ RSpec.describe Serializers::Web::Postgres do
 
   it "can serialize when have earliest/latest restore times" do
     time = Time.now
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).exactly(3)
-    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil)).exactly(4)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to eq(time.iso8601)
     expect(data[:latest_restore_time]).to eq(time.iso8601)
   end
 
   it "can serialize when not primary" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil)).exactly(2)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil, strand: nil)).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
   end
 
   it "can serialize when there is no server" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).twice
-    expect(pg).to receive(:representative_server).and_return(nil).exactly(2)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:representative_server).and_return(nil).at_least(:once)
     data = described_class.new(:detailed).serialize(pg)
     expect(data[:primary?]).to be_nil
     expect(data[:earliest_restore_time]).to be_nil


### PR DESCRIPTION
We used to just check the label of PostgresResource's own strand. However, the state of representative server is also important, especially at the time of it being unavailable. This commit fixes the display state of PostgreSQL resources by checking the state of the representative server as well.

While doing so, I found another case of wrong display state, while refreshing the dns records, which is also fixed in this commit.