### PR TITLE
Add helper method for decoding deleted record

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -7,6 +7,8 @@ require_relative "../loader"
 
 require "pry"
 
+Sequel.extension :pg_json_ops
+
 def dev_project
   return unless Config.development?
   ac = Account[email: "dev@ubicloud.com"] || Account.create_with_id(email: "dev@ubicloud.com")
@@ -15,6 +17,10 @@ end
 
 def udec(*)
   UBID.decode(*)
+end
+
+def udec_deleted(ubid)
+  DeletedRecord.where(Sequel.pg_json(:model_values)["name"] => Sequel.pg_jsonb_wrap(UBID.parse(ubid).to_uuid)).first
 end
 
 opts = Pry::CLI.parse_options


### PR DESCRIPTION
While working on DeletedRecord, we frequently need to find the record from its ubid. This commit adds a helper method for that.