### PR TITLE
Go to start_after_host_reboot label from unavailable label if necessary

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -522,6 +522,13 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
   end
 
   label def unavailable
+    # If the VM become unavailable due to host unavailability, it first needs to
+    # go through start_after_host_reboot state to be able to recover.
+    when_start_after_host_reboot_set? do
+      incr_checkup
+      hop_start_after_host_reboot
+    end
+
     begin
       if available?
         Page.from_tag_parts("VmUnavailable", vm.ubid)&.incr_resolve

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -826,6 +826,12 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#unavailable" do
+    it "hops to start_after_host_reboot when needed" do
+      expect(nx).to receive(:when_start_after_host_reboot_set?).and_yield
+      expect(nx).to receive(:incr_checkup)
+      expect { nx.unavailable }.to hop("start_after_host_reboot")
+    end
+
     it "creates a page if vm is unavailable" do
       expect(Prog::PageNexus).to receive(:assemble)
       expect(nx).to receive(:available?).and_return(false)


### PR DESCRIPTION
If the VM become unavailable due to host unavailability, it first needs to go through start_after_host_reboot state to be able to recover. This commit adds a transition from unavailable to start_after_host_reboot state if the related semaphore is set.