### PR TITLE
Allow only available postgres location while creating it on API

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -50,6 +50,12 @@ module Validation
     fail ValidationFailed.new({provider: msg}) unless available_locs.include?(location)
   end
 
+  def self.validate_postgres_location(location)
+    available_pg_locs = Option.postgres_locations.map(&:name)
+    msg = "Given location is not a valid postgres location. Available locations: #{available_pg_locs.map { LocationNameConverter.to_display_name(_1) }}"
+    fail ValidationFailed.new({location: msg}) unless available_pg_locs.include?(location)
+  end
+
   def self.validate_vm_size(size)
     unless (vm_size = Option::VmSizes.find { _1.name == size })
       fail ValidationFailed.new({size: "\"#{size}\" is not a valid virtual machine size. Available sizes: #{Option::VmSizes.map(&:name)}"})

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -28,6 +28,7 @@ class CloverApi
       r.post true do
         Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
         fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
+        Validation.validate_postgres_location(@location)
 
         required_parameters = ["size"]
         allowed_optional_parameters = ["ha_type"]

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -16,6 +16,7 @@ class CloverWeb
 
       parsed_size = Validation.validate_postgres_size(r.params["size"])
       location = LocationNameConverter.to_internal_name(r.params["location"])
+      Validation.validate_postgres_location(location)
       st = Prog::Postgres::PostgresResourceNexus.assemble(
         project_id: @project.id,
         location: location,

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Clover, "postgres" do
 
     describe "create" do
       it "success" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres/test-postgres", {
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres", {
           size: "standard-2",
           ha_type: "sync"
         }.to_json
@@ -169,8 +169,18 @@ RSpec.describe Clover, "postgres" do
         expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres")
       end
 
+      it "invalid location" do
+        post "/api/project/#{project.ubid}/location/eu-north-h1/postgres/test-postgres", {
+          size: "standard-2",
+          ha_type: "sync"
+        }.to_json
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body)["error"]["details"]["location"]).to eq("Given location is not a valid postgres location. Available locations: [\"eu-central-h1\"]")
+      end
+
       it "invalid name" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres/INVALIDNAME", {
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/INVALIDNAME", {
           size: "standard-2",
           ha_type: "sync"
         }.to_json
@@ -180,14 +190,14 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "invalid body" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres/test-pg", "invalid_body"
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", "invalid_body"
 
         expect(last_response.status).to eq(400)
         expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Request body isn't a valid JSON object.")
       end
 
       it "missing required key" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres/test-pg", {
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
           unix_user: "ha_type"
         }.to_json
 
@@ -196,7 +206,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "non allowed key" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres/test-pg", {
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
           size: "standard-2",
           foo_key: "foo_val"
         }.to_json


### PR DESCRIPTION
Allowing locations available for postgres only while creating a postgres database via API.