### PR TITLE
Allocator improvements

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+module Scheduling::Allocator
+  def self.allocate(vm, storage_volumes, target_host_utilization: 0.65, distinct_storage_devices: false, allocation_state_filter: ["accepting"], host_filter: [], location_filter: [], location_preference: [])
+    request = Request.new(
+      vm.id,
+      vm.cores,
+      vm.mem_gib,
+      storage_volumes.map { _1["size_gib"] }.sum,
+      storage_volumes.size.times.zip(storage_volumes).to_h.sort_by { |k, v| v["size_gib"] * -1 },
+      distinct_storage_devices,
+      vm.ip4_enabled,
+      target_host_utilization,
+      vm.arch,
+      allocation_state_filter,
+      host_filter,
+      location_filter,
+      location_preference
+    )
+    allocation = Allocation.best_allocation(request)
+    fail "#{vm} no space left on any eligible host" unless allocation
+
+    allocation.update(vm)
+    Clog.emit("vm allocated") { {allocation: allocation.to_s, duration: Time.now - vm.created_at} }
+  end
+
+  Request = Struct.new(:vm_id, :cores, :mem_gib, :storage_gib, :storage_volumes, :distinct_storage_devices, :ip4_enabled, :target_host_utilization,
+    :arch_filter, :allocation_state_filter, :host_filter, :location_filter, :location_preference)
+
+  class Allocation
+    attr_reader :score
+
+    def self.best_allocation(request)
+      candidate_hosts(request).map { Allocation.new(_1, request) }
+        .select { _1.is_valid }
+        .min_by { _1.score }
+    end
+
+    def self.candidate_hosts(request)
+      ds = DB[:vm_host]
+        .join(:storage_devices, vm_host_id: Sequel[:vm_host][:id])
+        .join(:total_ipv4, routed_to_host_id: Sequel[:vm_host][:id])
+        .join(:used_ipv4, routed_to_host_id: Sequel[:vm_host][:id])
+        .select(:vm_host_id, :total_cores, :used_cores, :total_hugepages_1g, :used_hugepages_1g, :location, :num_storage_devices, :available_storage_gib, :total_storage_gib, :storage_devices, :total_ipv4, :used_ipv4)
+        .where(allocation_state: request.allocation_state_filter)
+        .where(arch: request.arch_filter)
+        .where { (total_hugepages_1g - used_hugepages_1g >= request.mem_gib) }
+        .where { (total_cores - used_cores >= request.cores) }
+        .with(:total_ipv4, DB[:address]
+          .select_group(:routed_to_host_id)
+          .select_append { round(sum(power(2, 32 - masklen(cidr)))).cast(:integer).as(total_ipv4) }
+          .where { (family(cidr) =~ 4) })
+        .with(:used_ipv4, DB[:address].left_join(:assigned_vm_address, address_id: :id)
+          .select_group(:routed_to_host_id)
+          .select_append { (count(Sequel[:assigned_vm_address][:id]) + 1).as(used_ipv4) })
+        .with(:storage_devices, DB[:storage_device]
+          .select_group(:vm_host_id)
+          .select_append { count.function.*.as(num_storage_devices) }
+          .select_append { sum(available_storage_gib).as(available_storage_gib) }
+          .select_append { sum(total_storage_gib).as(total_storage_gib) }
+          .select_append { json_agg(json_build_object(Sequel.lit("'id'"), Sequel[:storage_device][:id], Sequel.lit("'total_storage_gib'"), total_storage_gib, Sequel.lit("'available_storage_gib'"), available_storage_gib)).order(available_storage_gib).as(storage_devices) }
+          .where(enabled: true)
+          .having { sum(available_storage_gib) >= request.storage_gib }
+          .having { count.function.* >= (request.distinct_storage_devices ? request.storage_volumes.count : 1) })
+
+      ds = ds.where { used_ipv4 < total_ipv4 } if request.ip4_enabled
+      ds = ds.where(vm_host_id: request.host_filter) unless request.host_filter.empty?
+      ds = ds.where(location: request.location_filter) unless request.location_filter.empty?
+      ds.all
+    end
+
+    def self.update_vm(vm_host, vm)
+      ip4, address = vm_host.ip4_random_vm_network if vm.ip4_enabled
+      fail "no ip4 addresses left" if vm.ip4_enabled && !ip4
+      vm.update(
+        vm_host_id: vm_host.id,
+        ephemeral_net6: vm_host.ip6_random_vm_network.to_s,
+        local_vetho_ip: vm_host.veth_pair_random_ip4_addr.to_s,
+        allocated_at: Time.now
+      )
+      AssignedVmAddress.create_with_id(dst_vm_id: vm.id, ip: ip4.to_s, address_id: address.id) if ip4
+      vm.sshable&.update(host: vm.ephemeral_net4 || vm.ephemeral_net6.nth(2))
+    end
+
+    def initialize(candidate_host, request)
+      @candidate_host = candidate_host
+      @request = request
+      @vm_host_allocations = [VmHostAllocation.new(:used_cores, candidate_host[:total_cores], candidate_host[:used_cores], request.cores),
+        VmHostAllocation.new(:used_hugepages_1g, candidate_host[:total_hugepages_1g], candidate_host[:used_hugepages_1g], request.mem_gib)]
+      @storage_allocation = StorageAllocation.new(candidate_host, request)
+      @allocations = @vm_host_allocations + [@storage_allocation]
+      @score = calculate_score
+    end
+
+    def is_valid
+      @allocations.all? { _1.is_valid }
+    end
+
+    def update(vm)
+      vm_host = VmHost[@candidate_host[:vm_host_id]]
+      DB.transaction do
+        Allocation.update_vm(vm_host, vm)
+        VmHost.dataset.where(id: @candidate_host[:vm_host_id]).update(@vm_host_allocations.map { _1.get_vm_host_update }.reduce(&:merge))
+        @storage_allocation.update(vm, vm_host)
+      end
+    end
+
+    def to_s
+      "#{UBID.from_uuidish(@request.vm_id)} (arch=#{@request.arch_filter}, cpu=#{@request.cores}, mem=#{@request.mem_gib}, storage=#{@request.storage_gib}) -> #{UBID.from_uuidish(@candidate_host[:vm_host_id])} (cpu=#{@candidate_host[:used_cores]}/#{@candidate_host[:total_cores]}, mem=#{@candidate_host[:used_hugepages_1g]}/#{@candidate_host[:total_hugepages_1g]}, storage=#{@candidate_host[:total_storage_gib] - @candidate_host[:available_storage_gib]}/#{@candidate_host[:total_storage_gib]}), score=#{@score}"
+    end
+
+    private
+
+    def calculate_score
+      util = @allocations.map { _1.utilization }
+
+      # utilization score, in range [0, 2]
+      avg_util = util.sum.fdiv(util.size)
+      utilization_score = @request.target_host_utilization - avg_util
+      utilization_score = utilization_score.abs + 1 if utilization_score < 0
+
+      # imbalance score, in range [0, 1]
+      imbalance_score = util.max - util.min
+
+      # location preference. 0 if preference is honored, 10 otherwise
+      location_preference_score = (@request.location_preference.empty? || @request.location_preference.include?(@candidate_host[:location])) ? 0 : 10
+
+      utilization_score + imbalance_score + location_preference_score
+    end
+  end
+
+  class VmHostAllocation
+    attr_reader :total, :used, :requested
+    def initialize(column, total, used, requested)
+      fail "resource '#{column}' uses more than is available: #{used} > #{total}" if used > total
+      @column = column
+      @total = total
+      @used = used
+      @requested = requested
+    end
+
+    def is_valid
+      @requested + @used <= @total
+    end
+
+    def utilization
+      (@used + @requested).fdiv(@total)
+    end
+
+    def get_vm_host_update
+      {@column => Sequel[@column] + @requested}
+    end
+  end
+
+  class StorageAllocation
+    attr_reader :is_valid, :total, :used, :requested, :volume_to_device_map
+    def initialize(candidate_host, request)
+      @candidate_host = candidate_host
+      @request = request
+      @is_valid = map_volumes_to_devices
+    end
+
+    def update(vm, vm_host)
+      @storage_device_allocations.each { _1.update }
+      create_storage_volumes(vm, vm_host)
+    end
+
+    def utilization
+      1 - (@candidate_host[:available_storage_gib] - @request.storage_gib).fdiv(@candidate_host[:total_storage_gib])
+    end
+
+    def self.allocate_spdk_installation(spdk_installations)
+      total_weight = spdk_installations.sum(&:allocation_weight)
+      fail "Total weight of all eligible spdk_installations shouldn't be zero." if total_weight == 0
+
+      rand_point = rand(0..total_weight - 1)
+      weight_sum = 0
+      rand_choice = spdk_installations.each { |si|
+        weight_sum += si.allocation_weight
+        break si if weight_sum > rand_point
+      }
+      rand_choice.id
+    end
+
+    private
+
+    def map_volumes_to_devices
+      return false if @candidate_host[:available_storage_gib] < @request.storage_gib
+      @storage_device_allocations = @candidate_host[:storage_devices].map { StorageDeviceAllocation.new(_1["id"], _1["available_storage_gib"]) }
+
+      @volume_to_device_map = {}
+      @request.storage_volumes.each do |vol_id, vol|
+        dev = @storage_device_allocations.detect { |dev| dev.available_storage_gib >= vol["size_gib"] && !(@request.distinct_storage_devices && dev.allocated_storage_gib > 0) }
+        return false if dev.nil?
+        @volume_to_device_map[vol_id] = dev.id
+        dev.allocate(vol["size_gib"])
+      end
+      true
+    end
+
+    def create_storage_volumes(vm, vm_host)
+      @request.storage_volumes.each do |disk_index, volume|
+        spdk_installation_id = StorageAllocation.allocate_spdk_installation(vm_host.spdk_installations)
+
+        key_encryption_key = if volume["encrypted"]
+          key_wrapping_algorithm = "aes-256-gcm"
+          cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
+          key_wrapping_key = cipher.random_key
+          key_wrapping_iv = cipher.random_iv
+
+          StorageKeyEncryptionKey.create_with_id(
+            algorithm: key_wrapping_algorithm,
+            key: Base64.encode64(key_wrapping_key),
+            init_vector: Base64.encode64(key_wrapping_iv),
+            auth_data: "#{vm.inhost_name}_#{disk_index}"
+          )
+        end
+
+        VmStorageVolume.create_with_id(
+          vm_id: vm.id,
+          boot: volume["boot"],
+          size_gib: volume["size_gib"],
+          use_bdev_ubi: SpdkInstallation[spdk_installation_id].supports_bdev_ubi? && volume["boot"],
+          skip_sync: volume["skip_sync"],
+          disk_index: disk_index,
+          key_encryption_key_1_id: key_encryption_key&.id,
+          spdk_installation_id: spdk_installation_id,
+          storage_device_id: @volume_to_device_map[disk_index]
+        )
+      end
+    end
+
+    class StorageDeviceAllocation
+      attr_reader :id, :available_storage_gib, :allocated_storage_gib
+
+      def initialize(id, available_storage_gib)
+        @id = id
+        @available_storage_gib = available_storage_gib
+        @allocated_storage_gib = 0
+      end
+
+      def allocate(size_gib)
+        @available_storage_gib -= size_gib
+        @allocated_storage_gib += size_gib
+      end
+
+      def update
+        StorageDevice.dataset.where(id: id).update(available_storage_gib: Sequel[:available_storage_gib] - @allocated_storage_gib) if @allocated_storage_gib > 0
+      end
+    end
+  end
+end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -1,0 +1,546 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+require "netaddr"
+
+Al = Scheduling::Allocator
+TestAllocation = Struct.new(:score, :is_valid)
+TestResourceAllocation = Struct.new(:utilization, :is_valid)
+RSpec.describe Al do
+  let(:vm) {
+    Vm.new(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: "true", created_at: Time.now, unix_user: "", public_key: "", boot_image: "").tap {
+      _1.id = "2464de61-7501-8374-9ab0-416caebe31da"
+    }
+  }
+
+  describe "allocation_request" do
+    let(:storage_volumes) {
+      [{
+        "use_bdev_ubi" => false,
+        "skip_sync" => true,
+        "size_gib" => 11,
+        "boot" => true
+      }, {
+        "use_bdev_ubi" => true,
+        "skip_sync" => false,
+        "size_gib" => 22,
+        "boot" => false
+      }]
+    }
+
+    it "fails if no valid allocation is found" do
+      expect(Al::Allocation).to receive(:best_allocation).and_return(nil)
+      expect { described_class.allocate(vm, storage_volumes) }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible host"
+    end
+
+    it "persists valid allocation" do
+      al = instance_double(Al::Allocation)
+      expect(Al::Allocation).to receive(:best_allocation)
+        .with(Al::Request.new(
+          "2464de61-7501-8374-9ab0-416caebe31da", 1, 8, 33,
+          [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
+            [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
+          false, true, 0.65, "x64", ["accepting"], [], [], []
+        )).and_return(al)
+      expect(al).to receive(:update)
+
+      described_class.allocate(vm, storage_volumes)
+    end
+  end
+
+  describe "candidate_selection" do
+    let(:req) {
+      Al::Request.new(
+        "2464de61-7501-8374-9ab0-416caebe31da", 2, 8, 33,
+        [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
+          [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
+        false, true, 0.65, "x64", ["accepting"], [], [], []
+      )
+    }
+
+    it "selects the best allocation candidate" do
+      candidates = [[0.1, false], [5, true], [0.9, true], [99, true]]
+      candidates.each { expect(Al::Allocation).to receive(:new).once.ordered.with(_1, req).and_return TestAllocation.new(_1[0], _1[1]) }
+      expect(Al::Allocation).to receive(:candidate_hosts).with(req).and_return(candidates)
+
+      expect(Al::Allocation.best_allocation(req)).to eq(TestAllocation.new(0.9, true))
+    end
+
+    it "disqualifies invalid candidates" do
+      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 6, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh2 = VmHost.create(allocation_state: "draining", arch: "x64", location: "loc1", total_cores: 8, used_cores: 1, total_hugepages_1g: 8, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh3 = VmHost.create(allocation_state: "accepting", arch: "arm64", location: "loc1", total_cores: 8, used_cores: 0, total_hugepages_1g: 8, used_hugepages_1g: 0) { _1.id = Sshable.create_with_id.id }
+      vmh4 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 8, used_cores: 6, total_hugepages_1g: 8, used_hugepages_1g: 5) { _1.id = Sshable.create_with_id.id }
+      vmh5 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "github-runners", total_cores: 8, used_cores: 6, total_hugepages_1g: 80, used_hugepages_1g: 5) { _1.id = Sshable.create_with_id.id }
+
+      StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh3.id, name: "stor1", available_storage_gib: 20, total_storage_gib: 30)
+      StorageDevice.create_with_id(vm_host_id: vmh3.id, name: "stor2", available_storage_gib: 20, total_storage_gib: 30)
+      StorageDevice.create_with_id(vm_host_id: vmh4.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh5.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100, enabled: false)
+
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create_with_id(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create_with_id(cidr: "3.1.1.0/30", routed_to_host_id: vmh3.id)
+      Address.create_with_id(cidr: "4.1.1.0/30", routed_to_host_id: vmh4.id)
+      Address.create_with_id(cidr: "5.1.1.0/30", routed_to_host_id: vmh5.id)
+
+      expect(Al::Allocation.candidate_hosts(req)).to eq([])
+    end
+
+    it "retrieves correct values" do
+      vmh = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      sd1 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
+      sd2 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 12, total_storage_gib: 99)
+
+      expect(Al::Allocation.candidate_hosts(req))
+        .to eq([{location: vmh.location,
+                 num_storage_devices: 2,
+                 storage_devices: [{"available_storage_gib" => sd2.available_storage_gib, "id" => sd2.id, "total_storage_gib" => sd2.total_storage_gib},
+                   {"available_storage_gib" => sd1.available_storage_gib, "id" => sd1.id, "total_storage_gib" => sd1.total_storage_gib}],
+                 total_cores: vmh.total_cores,
+                 total_hugepages_1g: vmh.total_hugepages_1g,
+                 total_storage_gib: sd1.total_storage_gib + sd2.total_storage_gib,
+                 available_storage_gib: sd1.available_storage_gib + sd2.available_storage_gib,
+                 used_cores: vmh.used_cores,
+                 used_hugepages_1g: vmh.used_hugepages_1g,
+                 vm_host_id: vmh.id,
+                 total_ipv4: 4,
+                 used_ipv4: 1}])
+    end
+
+    it "applies host filter" do
+      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create_with_id(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+
+      req.host_filter = [vmh2.id]
+      cand = Al::Allocation.candidate_hosts(req)
+
+      expect(cand.size).to eq(1)
+      expect(cand.first[:vm_host_id]).to eq(vmh2.id)
+    end
+
+    it "applies location filter" do
+      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc2", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create_with_id(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+
+      req.location_filter = ["loc1"]
+      cand = Al::Allocation.candidate_hosts(req)
+
+      expect(cand.size).to eq(1)
+      expect(cand.first[:vm_host_id]).to eq(vmh1.id)
+    end
+
+    it "retrieves candidates with enough storage devices" do
+      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor2", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create_with_id(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+
+      req.distinct_storage_devices = true
+      cand = Al::Allocation.candidate_hosts(req)
+      expect(cand.size).to eq(1)
+      expect(cand.first[:vm_host_id]).to eq(vmh2.id)
+    end
+
+    it "retrieves candidates with available ipv4 addresses if ip4_enabled" do
+      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create_with_id(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id)
+
+      cand = Al::Allocation.candidate_hosts(req)
+      expect(cand.size).to eq(1)
+      expect(cand.first[:vm_host_id]).to eq(vmh1.id)
+    end
+
+    it "retrieves candidates without available ipv4 addresses if not ip4_enabled" do
+      req.ip4_enabled = false
+      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create_with_id(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id)
+
+      cand = Al::Allocation.candidate_hosts(req)
+      expect(cand.size).to eq(2)
+    end
+  end
+
+  describe "Allocation" do
+    let(:req) {
+      Al::Request.new(
+        "2464de61-7501-8374-9ab0-416caebe31da", 2, 8, 33,
+        [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
+          [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
+        false, true, 0.65, "x64", ["accepting"], [], [], []
+      )
+    }
+    let(:vmhds) {
+      {location: "loc1",
+       num_storage_devices: 2,
+       storage_devices: [{"available_storage_gib" => 10, "id" => "sd1id", "total_storage_gib" => 10},
+         {"available_storage_gib" => 101, "id" => "sd2id", "total_storage_gib" => 91}],
+       total_storage_gib: 111,
+       available_storage_gib: 101,
+       total_cores: 8,
+       used_cores: 3,
+       total_hugepages_1g: 22,
+       used_hugepages_1g: 9,
+       vm_host_id: "the_id"}
+    }
+
+    it "initializes individual resource allocations" do
+      expect(Al::VmHostAllocation).to receive(:new).with(:used_cores, vmhds[:total_cores], vmhds[:used_cores], req.cores).and_return(instance_double(Al::VmHostAllocation, utilization: req.target_host_utilization, is_valid: true))
+      expect(Al::VmHostAllocation).to receive(:new).with(:used_hugepages_1g, vmhds[:total_hugepages_1g], vmhds[:used_hugepages_1g], req.mem_gib).and_return(instance_double(Al::VmHostAllocation, utilization: req.target_host_utilization, is_valid: true))
+      expect(Al::StorageAllocation).to receive(:new).with(vmhds, req).and_return(instance_double(Al::StorageAllocation, utilization: req.target_host_utilization, is_valid: true))
+
+      allocation = Al::Allocation.new(vmhds, req)
+      expect(allocation.score).to eq 0
+      expect(allocation.is_valid).to be_truthy
+    end
+
+    it "is valid only if all resource allocations are valid" do
+      expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+      expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, false))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+
+      allocation = Al::Allocation.new(vmhds, req)
+      expect(allocation.score).to eq 0
+      expect(allocation.is_valid).to be_falsy
+    end
+
+    it "has score of 0 if all resources are at target utilization" do
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+
+      expect(Al::Allocation.new(vmhds, req).score).to eq 0
+    end
+
+    it "is penalized if utilization is below target" do
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization * 0.9, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization * 0.9, true))
+      expect(Al::Allocation.new(vmhds, req).score).to be > 0
+    end
+
+    it "penalizes over-utilization more than under-utilization" do
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(0, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0, true))
+      score_low_utilization = Al::Allocation.new(vmhds, req).score
+
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization * 1.01, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization * 1.01, true))
+      score_over_target = Al::Allocation.new(vmhds, req).score
+
+      expect(score_over_target).to be > score_low_utilization
+    end
+
+    it "penalizes imbalance" do
+      expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
+      expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
+      score_balance = Al::Allocation.new(vmhds, req).score
+
+      expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.4, true))
+      expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.6, true))
+      score_imbalance = Al::Allocation.new(vmhds, req).score
+
+      expect(score_imbalance).to be > score_balance
+    end
+
+    it "respects location preferences" do
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(0, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0, true))
+      score_no_preference = Al::Allocation.new(vmhds, req).score
+
+      req.location_preference = ["loc1"]
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(0, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0, true))
+      score_preference_met = Al::Allocation.new(vmhds, req).score
+
+      req.location_preference = ["loc2"]
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+      score_preference_not_met = Al::Allocation.new(vmhds, req).score
+
+      expect(score_no_preference).to be_within(0.0001).of(score_preference_met)
+      expect(score_preference_not_met).to be > score_preference_met
+    end
+  end
+
+  describe "VmHostAllocation" do
+    it "is valid if requested is less than or equal to used" do
+      expect(Al::VmHostAllocation.new(:used_res, 100, 50, 25).is_valid).to be_truthy
+      expect(Al::VmHostAllocation.new(:used_res, 100, 50, 50).is_valid).to be_truthy
+    end
+
+    it "is invalid if requested is less than used" do
+      expect(Al::VmHostAllocation.new(:used_res, 100, 50, 51).is_valid).to be_falsy
+    end
+
+    it "raises an error if used is greater than total" do
+      expect { Al::VmHostAllocation.new(:used_res, 100, 101, 25) }.to raise_error RuntimeError, "resource 'used_res' uses more than is available: 101 > 100"
+    end
+
+    it "returns correct update value on update" do
+      expect(Al::VmHostAllocation.new(:used_res, 100, 50, 25).get_vm_host_update).to eq({used_res: Sequel[:used_res] + 25})
+    end
+  end
+
+  describe "StorageAllocation" do
+    let(:req) {
+      Al::Request.new(
+        "2464de61-7501-8374-9ab0-416caebe31da", 2, 8, 33,
+        [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
+          [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
+        false, 0.65, "x64", ["accepting"], [], [], []
+      )
+    }
+    let(:vmhds) {
+      {location: "loc1",
+       num_storage_devices: 2,
+       storage_devices: [{"available_storage_gib" => 10, "id" => "sd1id", "total_storage_gib" => 10},
+         {"available_storage_gib" => 91, "id" => "sd2id", "total_storage_gib" => 101}],
+       total_storage_gib: 111,
+       available_storage_gib: 101,
+       total_cores: 8,
+       used_cores: 3,
+       total_hugepages_1g: 22,
+       used_hugepages_1g: 9,
+       vm_host_id: "the_id"}
+    }
+
+    it "can allocate storage on the same device" do
+      req.distinct_storage_devices = false
+      req.storage_volumes = [[1, {"size_gib" => 12}], [0, {"size_gib" => 12}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_truthy
+      expect(storage_allocation.volume_to_device_map).to eq({1 => "sd2id", 0 => "sd2id"})
+    end
+
+    it "can allocate storage on distinct devices" do
+      req.distinct_storage_devices = true
+      req.storage_volumes = [[1, {"size_gib" => 50}], [0, {"size_gib" => 10}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_truthy
+      expect(storage_allocation.volume_to_device_map).to eq({1 => "sd2id", 0 => "sd1id"})
+    end
+
+    it "fails if there is not enough space available" do
+      req.storage_gib = 10000
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_falsey
+    end
+
+    it "fails if distinct devices are requested but not available" do
+      req.distinct_storage_devices = true
+      req.storage_volumes = [[1, {"size_gib" => 1}], [0, {"size_gib" => 1}], [2, {"size_gib" => 1}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_falsey
+    end
+
+    it "can calculate utilization" do
+      req.storage_gib = 101
+      req.storage_volumes = [[0, {"size_gib" => 91}], [1, {"size_gib" => 10}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_truthy
+      expect(storage_allocation.utilization).to be_within(0.0001).of(1)
+
+      req.storage_gib = 2
+      req.storage_volumes = [[0, {"size_gib" => 1}], [1, {"size_gib" => 1}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_truthy
+      expect(storage_allocation.utilization).to be_within(0.01).of(0.1)
+    end
+  end
+
+  describe "update" do
+    let(:vol) {
+      [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => false, "boot" => false}]
+    }
+
+    before do
+      vmh = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", net6: "fd10:9b0b:6b4b:8fbb::/64", total_cores: 7, used_cores: 5, total_hugepages_1g: 18, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
+      SpdkInstallation.create(vm_host_id: vmh.id, version: "v1", allocation_weight: 100) { _1.id = vmh.id }
+      Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+    end
+
+    def create_vm
+      Vm.create_with_id(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: false, created_at: Time.now, unix_user: "", public_key: "", boot_image: "")
+    end
+
+    def create_req(vm, storage_volumes, target_host_utilization: 0.65, distinct_storage_devices: false, allocation_state_filter: ["accepting"], host_filter: [], location_filter: [], location_preference: [])
+      Al::Request.new(
+        vm.id,
+        vm.cores,
+        vm.mem_gib,
+        storage_volumes.map { _1["size_gib"] }.sum,
+        storage_volumes.size.times.zip(storage_volumes).to_h.sort_by { |k, v| v["size_gib"] * -1 },
+        distinct_storage_devices,
+        true,
+        target_host_utilization,
+        vm.arch,
+        allocation_state_filter,
+        host_filter,
+        location_filter,
+        location_preference
+      )
+    end
+
+    it "updates resources" do
+      vm = create_vm
+      vmh = VmHost.first
+      used_cores = vmh.used_cores
+      used_hugepages_1g = vmh.used_hugepages_1g
+      available_storage = vmh.storage_devices.sum { _1.available_storage_gib }
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      vmh.reload
+      expect(vm.vm_storage_volumes.detect { _1.disk_index == 0 }.size_gib).to eq(85)
+      expect(vm.vm_storage_volumes.detect { _1.disk_index == 1 }.size_gib).to eq(95)
+      expect(StorageDevice[vm.vm_storage_volumes.detect { _1.disk_index == 0 }.storage_device_id].name).to eq("stor2")
+      expect(StorageDevice[vm.vm_storage_volumes.detect { _1.disk_index == 1 }.storage_device_id].name).to eq("stor1")
+      expect(used_cores + vm.cores).to eq(vmh.used_cores)
+      expect(used_hugepages_1g + vm.mem_gib).to eq(vmh.used_hugepages_1g)
+      expect(available_storage - 180).to eq(vmh.storage_devices.sum { _1.available_storage_gib })
+    end
+
+    it "allows concurrent allocations" do
+      vmh = VmHost.first
+      used_cores = vmh.used_cores
+      used_hugepages_1g = vmh.used_hugepages_1g
+      available_storage = vmh.storage_devices.sum { _1.available_storage_gib }
+      vm1 = create_vm
+      vm2 = create_vm
+      al1 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al2 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al1.update(vm1)
+      al2.update(vm2)
+      vmh.reload
+      expect(used_cores + vm1.cores + vm2.cores).to eq(vmh.used_cores)
+      expect(used_hugepages_1g + vm1.mem_gib + vm2.mem_gib).to eq(vmh.used_hugepages_1g)
+      expect(available_storage - 10).to eq(vmh.storage_devices.sum { _1.available_storage_gib })
+    end
+
+    it "fails concurrent allocations if core constraints are violated" do
+      vmh = VmHost.first
+      vmh.update(used_cores: vmh.used_cores + 1)
+      vm1 = create_vm
+      vm2 = create_vm
+      al1 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al2 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al1.update(vm1)
+      expect { al2.update(vm2) }.to raise_error(Sequel::CheckConstraintViolation, /core_allocation_limit/)
+    end
+
+    it "fails concurrent allocations if memory constraints are violated" do
+      vmh = VmHost.first
+      vmh.update(used_hugepages_1g: vmh.used_hugepages_1g + 1)
+      vm1 = create_vm
+      vm2 = create_vm
+      al1 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al2 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al1.update(vm1)
+      expect { al2.update(vm2) }.to raise_error(Sequel::CheckConstraintViolation, /hugepages_allocation_limit/)
+    end
+
+    it "fails concurrent allocations if storage constraints are violated" do
+      vm1 = create_vm
+      vm2 = create_vm
+      vol = [{"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}]
+      al1 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al2 = Al::Allocation.best_allocation(create_req(vm, vol))
+      al1.update(vm1)
+      expect { al2.update(vm2) }.to raise_error(Sequel::CheckConstraintViolation, /available_storage_gib_non_negative/)
+    end
+
+    it "creates volume without encryption key if storage is not encrypted" do
+      vm = create_vm
+      described_class.allocate(vm, vol)
+      expect(StorageKeyEncryptionKey.count).to eq(0)
+      expect(vm.reload.vm_storage_volumes.first.key_encryption_key_1_id).to be_nil
+      nx = Prog::Vm::Nexus.new(Strand.new).tap {
+        _1.instance_variable_set(:@vm, vm)
+      }
+      expect(nx.storage_secrets.count).to eq(0)
+    end
+
+    it "creates volume with encryption key if storage is encrypted" do
+      vm = create_vm
+      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      expect(StorageKeyEncryptionKey.count).to eq(1)
+      expect(vm.vm_storage_volumes.first.key_encryption_key_1_id).not_to be_nil
+      nx = Prog::Vm::Nexus.new(Strand.new).tap {
+        _1.instance_variable_set(:@vm, vm)
+      }
+      expect(nx.storage_secrets.count).to eq(1)
+    end
+
+    it "calls update_vm" do
+      vm = create_vm
+      expect(Al::Allocation).to receive(:update_vm).with(VmHost.first, vm)
+      described_class.allocate(vm, vol)
+    end
+
+    it "allocates the vm to a host with IPv4 address" do
+      vm = create_vm
+      vmh = VmHost.first
+      address = Address.new(cidr: "0.0.0.0/30", routed_to_host_id: vmh.id)
+      assigned_address = AssignedVmAddress.new(ip: NetAddr::IPv4Net.parse("10.0.0.1"))
+      expect(vmh).to receive(:ip4_random_vm_network).and_return(["0.0.0.0", address])
+      expect(vm).to receive(:ip4_enabled).and_return(true).twice
+      expect(AssignedVmAddress).to receive(:create_with_id).and_return(assigned_address)
+      expect(vm).to receive(:assigned_vm_address).and_return(assigned_address)
+      expect(vm).to receive(:sshable).and_return(instance_double(Sshable)).at_least(:once)
+      expect(vm.sshable).to receive(:update).with(host: assigned_address.ip.network)
+      Al::Allocation.update_vm(vmh, vm)
+    end
+
+    it "fails if there is no ip address available but the vm is ip4 enabled" do
+      vm = create_vm
+      vmh = VmHost.first
+      expect(vmh).to receive(:ip4_random_vm_network).and_return([nil, nil])
+      expect(vm).to receive(:ip4_enabled).and_return(true).at_least(:once)
+      expect { Al::Allocation.update_vm(vmh, vm) }.to raise_error(RuntimeError, /no ip4 addresses left/)
+    end
+  end
+
+  describe "#allocate_spdk_installation" do
+    it "fails if total weight is zero" do
+      si_1 = SpdkInstallation.new(allocation_weight: 0)
+      si_2 = SpdkInstallation.new(allocation_weight: 0)
+
+      expect { Al::StorageAllocation.allocate_spdk_installation([si_1, si_2]) }.to raise_error "Total weight of all eligible spdk_installations shouldn't be zero."
+    end
+
+    it "chooses the only one if one provided" do
+      si_1 = SpdkInstallation.new(allocation_weight: 100) { _1.id = SpdkInstallation.generate_uuid }
+      expect(Al::StorageAllocation.allocate_spdk_installation([si_1])).to eq(si_1.id)
+    end
+
+    it "doesn't return the one with zero weight" do
+      si_1 = SpdkInstallation.new(allocation_weight: 0) { _1.id = SpdkInstallation.generate_uuid }
+      si_2 = SpdkInstallation.new(allocation_weight: 100) { _1.id = SpdkInstallation.generate_uuid }
+      expect(Al::StorageAllocation.allocate_spdk_installation([si_1, si_2])).to eq(si_2.id)
+    end
+  end
+end


### PR DESCRIPTION
The allocator is the component that assigns a VM to a host, as part of VM provisioning. This commit brings the following main changes:

* Carve allocation logic out of Vm::Nexus into a separate file.
* Assign a VM to the most suitable host, instead of a random valid host. Suitability is defined by a score. An allocation score is a relative measure that allows to rank allocation candidates. An allocation with a low score is "more suitable" than an allocation with a high score.
* Allow concurrent allocations if their result is valid. Validity is enforced by DB constraints.