### PR TITLE
Direct requests coming from api subdomain to api endpoints

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -16,9 +16,19 @@ class Clover < Roda
   end
 
   route do |r|
-    r.on "api" do
+    subdomain = r.host.split(".").first
+    if subdomain == "api"
       r.run CloverApi
     end
+
+    # To make test and development easier
+    # :nocov:
+    unless Config.production?
+      r.on "api" do
+        r.run CloverApi
+      end
+    end
+    # :nocov:
 
     r.run CloverWeb
   end

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe Clover, "vm" do
         project
         get "/api/project"
 
+        puts last_response.body
+
+        expect(last_response.status).to eq(200)
+        parsed_body = JSON.parse(last_response.body)
+        expect(parsed_body["count"]).to eq(2)
+      end
+
+      it "success with api subdomain" do
+        project
+        header "Host", "api.ubicloud.com"
+        get "/project"
+
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
         expect(parsed_body["count"]).to eq(2)


### PR DESCRIPTION
Directing requests coming from api subdomain to api endpoints. So, clients can send api requests to api.ubicloud.com instead of console.ubicloud.com/api as they do now.

Also, continue directing requests coming to /api to api endpoints in test and development environments to make development and test easier.