### PR TITLE
Add more logging to monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -28,6 +28,8 @@ end
 pulse_checker = Thread.new do
   loop do
     mutex.synchronize do
+      # Deduct 3 for the threads that are always running: main, resource_scanner, pulse_checker
+      Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - 3} }
       resources.each do |r_id, r|
         sleep 1 while Thread.list.count + 2 > Config.max_monitor_threads
 

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -70,8 +70,8 @@ class MonitorableResource
     if @mutex.locked?
       if @pulse_check_started_at + PULSE_TIMEOUT < Time.now
         Clog.emit("Pulse check has stuck.") { {pulse_check_stuck: {ubid: @resource.ubid}} }
-        ThreadPrinter.run
-        Kernel.exit!
+        # ThreadPrinter.run
+        # Kernel.exit!
       end
     end
   end

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -68,10 +68,9 @@ class MonitorableResource
 
   def force_stop_if_stuck
     if @mutex.locked?
+      Clog.emit("Resource is locked.") { {resource_locked: {ubid: @resource.ubid}} }
       if @pulse_check_started_at + PULSE_TIMEOUT < Time.now
         Clog.emit("Pulse check has stuck.") { {pulse_check_stuck: {ubid: @resource.ubid}} }
-        # ThreadPrinter.run
-        # Kernel.exit!
       end
     end
   end

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -127,15 +127,15 @@ RSpec.describe MonitorableResource do
       r_w_event_loop.instance_variable_get(:@mutex).unlock
     end
 
-    it "triggers Kernel.exit if pulse check is stuck" do
-      expect(ThreadPrinter).to receive(:run)
-      expect(Kernel).to receive(:exit!)
+    # it "triggers Kernel.exit if pulse check is stuck" do
+    #   expect(ThreadPrinter).to receive(:run)
+    #   expect(Kernel).to receive(:exit!)
 
-      r_w_event_loop.instance_variable_get(:@mutex).lock
-      r_w_event_loop.instance_variable_set(:@pulse_check_started_at, Time.now - 200)
-      r_w_event_loop.force_stop_if_stuck
-      r_w_event_loop.instance_variable_get(:@mutex).unlock
-    end
+    #   r_w_event_loop.instance_variable_get(:@mutex).lock
+    #   r_w_event_loop.instance_variable_set(:@pulse_check_started_at, Time.now - 200)
+    #   r_w_event_loop.force_stop_if_stuck
+    #   r_w_event_loop.instance_variable_get(:@mutex).unlock
+    # end
   end
 
   describe "#lock_no_wait" do

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -127,15 +127,13 @@ RSpec.describe MonitorableResource do
       r_w_event_loop.instance_variable_get(:@mutex).unlock
     end
 
-    # it "triggers Kernel.exit if pulse check is stuck" do
-    #   expect(ThreadPrinter).to receive(:run)
-    #   expect(Kernel).to receive(:exit!)
-
-    #   r_w_event_loop.instance_variable_get(:@mutex).lock
-    #   r_w_event_loop.instance_variable_set(:@pulse_check_started_at, Time.now - 200)
-    #   r_w_event_loop.force_stop_if_stuck
-    #   r_w_event_loop.instance_variable_get(:@mutex).unlock
-    # end
+    it "triggers Kernel.exit if pulse check is stuck" do
+      r_w_event_loop.instance_variable_get(:@mutex).lock
+      r_w_event_loop.instance_variable_set(:@pulse_check_started_at, Time.now - 200)
+      expect(Clog).to receive(:emit).at_least(:once)
+      r_w_event_loop.force_stop_if_stuck
+      r_w_event_loop.instance_variable_get(:@mutex).unlock
+    end
   end
 
   describe "#lock_no_wait" do


### PR DESCRIPTION
**Don't exit if the pulse check is stuck**
Normally, if the pulse check is stuck, the monitor will exit. This is to ensure
that the pulse checking is not stuck indefinitely. It is similar to apoptosis
logic in respirate. However, it happens more frequently than expected and thus
causing stability problems. While investigating the issue, it would be better
to not exit the monitor if the pulse check is stuck. Instead, we will just log
a message and manually cleanup stuck processes for a while.

**Add more logging to monitor**
We are investigating frequent stuck pulse checks problem. This commit will help
us to understand what is going on at the time of the stuck pulse checks.