### PR TITLE
Add firewall and nic vm name to private subnet serialization

### DIFF
--- a/serializers/api/nic.rb
+++ b/serializers/api/nic.rb
@@ -7,7 +7,7 @@ class Serializers::Api::Nic < Serializers::Base
       name: nic.name,
       private_ipv4: nic.private_ipv4.network.to_s,
       private_ipv6: nic.private_ipv6.nth(2).to_s,
-      subnet_name: nic.private_subnet.name
+      vm_name: nic.vm&.name
     }
   end
 

--- a/serializers/api/private_subnet.rb
+++ b/serializers/api/private_subnet.rb
@@ -9,6 +9,7 @@ class Serializers::Api::PrivateSubnet < Serializers::Base
       location: ps.display_location,
       net4: ps.net4.to_s,
       net6: ps.net6.to_s,
+      firewalls: Serializers::Api::Firewall.serialize(ps.firewalls),
       nics: Serializers::Api::Nic.serialize(ps.nics)
     }
   end


### PR DESCRIPTION
Improving private subnet serialization on API by adding firewall details and nic vm name.