### PR TITLE
PCI device pass through

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -434,7 +434,8 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
       "mem_gib" => vm.mem_gib,
       "ndp_needed" => host.ndp_needed,
       "storage_volumes" => storage_volumes,
-      "swap_size_bytes" => frame["swap_size_bytes"]
+      "swap_size_bytes" => frame["swap_size_bytes"],
+      "pci_devices" => vm.pci_devices.map { [_1.slot, _1.iommu_group] }
     })
 
     host.sshable.cmd("sudo -u #{q_vm} tee #{params_path.shellescape}", stdin: params_json)

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -606,6 +606,8 @@ WHERE (SELECT max(available_storage_gib) FROM storage_device WHERE storage_devic
         used_hugepages_1g: Sequel[:used_hugepages_1g] - vm.mem_gib
       )
 
+      vm.pci_devices_dataset.update(vm_id: nil)
+
       vm.projects.map { vm.dissociate_with_project(_1) }
       vm.destroy
     end

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -39,6 +39,7 @@ begin
   ndp_needed = params.fetch("ndp_needed", false)
   storage_volumes = params.fetch("storage_volumes")
   swap_size_bytes = params["swap_size_bytes"]
+  pci_devices = params.fetch("pci_devices", [])
 rescue KeyError => e
   puts "Needed #{e.key} in parameters json"
   exit 1
@@ -54,7 +55,7 @@ when "prep"
 
   vm_setup.prep(unix_user, ssh_public_key, nics, gua, ip4,
     local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib,
-    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes)
+    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 when "recreate-unpersisted"
   secrets = JSON.parse($stdin.read)
   unless (storage_secrets = secrets["storage"])

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -231,9 +231,11 @@ RSpec.describe Prog::Vm::Nexus do
       vm.public_key = "test_ssh_key"
       vm.local_vetho_ip = "169.254.0.0"
       nic = Nic.new(private_ipv6: "fd10:9b0b:6b4b:8fbb::/64", private_ipv4: "10.0.0.3/32", mac: "5a:0f:75:80:c3:64")
+      pci = PciDevice.new(slot: "01:00.0", iommu_group: 23)
       expect(nic).to receive(:ubid_to_tap_name).and_return("tap4ncdd56m")
       expect(vm).to receive(:nics).and_return([nic]).at_least(:once)
       expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(1, 1, 1, 1))
+      expect(vm).to receive(:pci_devices).and_return([pci]).at_least(:once)
 
       sshable = instance_spy(Sshable)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
@@ -253,7 +255,8 @@ RSpec.describe Prog::Vm::Nexus do
           "mem_gib" => 8,
           "local_ipv4" => "169.254.0.0",
           "nics" => [["fd10:9b0b:6b4b:8fbb::/64", "10.0.0.3/32", "tap4ncdd56m", "5a:0f:75:80:c3:64"]],
-          "swap_size_bytes" => nil
+          "swap_size_bytes" => nil,
+          "pci_devices" => [["01:00.0", 23]]
         })
       end
       expect(sshable).to receive(:cmd).with(/sudo host\/bin\/setup-vm prep #{nx.vm_name}/, {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/})

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -956,6 +956,17 @@ RSpec.describe Prog::Vm::Nexus do
 
       expect { nx.destroy }.to exit({"msg" => "vm deleted"})
     end
+
+    it "detaches from pci devices" do
+      ds = instance_double(Sequel::Dataset)
+      expect(vm).to receive(:pci_devices_dataset).and_return(ds)
+      expect(ds).to receive(:update).with(vm_id: nil)
+      expect(vm).to receive(:update).with(display_state: "deleting")
+      expect(vm).to receive(:destroy)
+      allow(vm).to receive(:vm_storage_volumes).and_return([])
+
+      expect { nx.destroy }.to exit({"msg" => "vm deleted"})
+    end
   end
 
   describe "#start_after_host_reboot" do


### PR DESCRIPTION
Detach PCI devices during VM destruction:
In `destroy`, VM::Nexus disassociates all PCI devices from the VM.

Add assigned PCI devices to VM:
Pass PCI devices that are assigned to a VM model to the VM on the host as part of VM preparation.