### PR TITLE
Tag related payment methods while suspending an account

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -27,5 +27,7 @@ class Account < Sequel::Model(:accounts)
   def suspend
     update(suspended_at: Time.now)
     DB[:account_active_session_keys].where(account_id: id).delete(force: true)
+
+    projects.each { _1.billing_info&.payment_methods_dataset&.update(fraud: true) }
   end
 end

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Clover, "billing" do
     expect(page).to have_content "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
   end
 
+  it "tag payment method fraud after account suspension" do
+    expect(payment_method.reload.fraud).to be(false)
+    user.suspend
+    expect(payment_method.reload.fraud).to be(true)
+  end
+
   context "when Stripe enabled" do
     before do
       allow(Config).to receive(:stripe_secret_key).and_return("secret_key")


### PR DESCRIPTION
We are suspending an account if we think it is a fraud. With this commit we are getting all projects of which the account is member of, then tag all payment methods of those projects as fraud.