### PR TITLE
Enable allocation of GPUs

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -187,6 +187,7 @@ class Prog::Vm::Nexus < Prog::Base
     queued_vms = Vm.join(:strand, id: :id).where(:location => vm.location, :arch => vm.arch, Sequel[:strand][:label] => "start")
     begin
       distinct_storage_devices = frame["distinct_storage_devices"] || false
+      gpu_enabled = frame["gpu_enabled"] || false
       allocation_state_filter, location_filter, location_preference, host_filter =
         if frame["force_host_id"]
           [[], [], [], [frame["force_host_id"]]]
@@ -202,7 +203,8 @@ class Prog::Vm::Nexus < Prog::Base
         allocation_state_filter: allocation_state_filter,
         location_filter: location_filter,
         location_preference: location_preference,
-        host_filter: host_filter
+        host_filter: host_filter,
+        gpu_enabled: gpu_enabled
       )
     rescue RuntimeError => ex
       raise unless ex.message.include?("no space left on any eligible hosts")

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -351,7 +351,8 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [],
         location_filter: ["hetzner-hel1"],
-        location_preference: []
+        location_preference: [],
+        gpu_enabled: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -364,7 +365,8 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [],
         location_filter: [],
-        location_preference: ["github-runners"]
+        location_preference: ["github-runners"],
+        gpu_enabled: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -381,7 +383,8 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [:vm_host_id],
         location_filter: [],
-        location_preference: []
+        location_preference: [],
+        gpu_enabled: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -389,7 +392,8 @@ RSpec.describe Prog::Vm::Nexus do
     it "requests distinct storage devices" do
       allow(nx).to receive(:frame).and_return({
         "distinct_storage_devices" => true,
-        "storage_volumes" => :storage_volumes
+        "storage_volumes" => :storage_volumes,
+        "gpu_enabled" => false
       })
 
       expect(Scheduling::Allocator).to receive(:allocate).with(
@@ -398,7 +402,26 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: true,
         host_filter: [],
         location_filter: ["hetzner-hel1"],
-        location_preference: []
+        location_preference: [],
+        gpu_enabled: false
+      )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
+    it "requests a gpu" do
+      allow(nx).to receive(:frame).and_return({
+        "gpu_enabled" => true,
+        "storage_volumes" => :storage_volumes
+      })
+
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        location_filter: ["hetzner-hel1"],
+        location_preference: [],
+        gpu_enabled: true
       )
       expect { nx.start }.to hop("create_unix_user")
     end


### PR DESCRIPTION
The allocator now checks if a VM requires a GPU. If it does, it schedules it on a host with available GPUs. It randomly selects an available GPU and then assigns that GPU together with other devices in the same IOMMU group to the VM.

The allocator penalizes assigning VMs that do not require a GPU to a host that has GPUs.