### PR TITLE
Reduce target host utilization

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Scheduling::Allocator
-  def self.allocate(vm, storage_volumes, target_host_utilization: 0.65, distinct_storage_devices: false, allocation_state_filter: ["accepting"], host_filter: [], location_filter: [], location_preference: [])
+  def self.allocate(vm, storage_volumes, target_host_utilization: 0.55, distinct_storage_devices: false, allocation_state_filter: ["accepting"], host_filter: [], location_filter: [], location_preference: [])
     request = Request.new(
       vm.id,
       vm.cores,
@@ -82,7 +82,7 @@ module Scheduling::Allocator
       vm.sshable&.update(host: vm.ephemeral_net4 || vm.ephemeral_net6.nth(2))
     end
 
-    def initialize(candidate_host, request, score_randomization = rand(0..0.2))
+    def initialize(candidate_host, request, score_randomization = rand(0..0.4))
       @candidate_host = candidate_host
       @request = request
       @vm_host_allocations = [VmHostAllocation.new(:used_cores, candidate_host[:total_cores], candidate_host[:used_cores], request.cores),

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Al do
           "2464de61-7501-8374-9ab0-416caebe31da", 1, 8, 33,
           [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
             [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
-          false, true, 0.65, "x64", ["accepting"], [], [], []
+          false, true, 0.55, "x64", ["accepting"], [], [], []
         )).and_return(al)
       expect(al).to receive(:update)
 
@@ -396,7 +396,7 @@ RSpec.describe Al do
       Vm.create_with_id(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: false, created_at: Time.now, unix_user: "", public_key: "", boot_image: "")
     end
 
-    def create_req(vm, storage_volumes, target_host_utilization: 0.65, distinct_storage_devices: false, allocation_state_filter: ["accepting"], host_filter: [], location_filter: [], location_preference: [])
+    def create_req(vm, storage_volumes, target_host_utilization: 0.55, distinct_storage_devices: false, allocation_state_filter: ["accepting"], host_filter: [], location_filter: [], location_preference: [])
       Al::Request.new(
         vm.id,
         vm.cores,


### PR DESCRIPTION
This commit reduces target host utilization to 55% and increases randomness when selecting a host for a vm. That should alleviate some of the pressure on individual hosts and improve vm provisioning times.