### PR TITLE
Pre-authorize card before adding as payment method

### DIFF
--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -49,11 +49,13 @@ RSpec.describe Clover, "billing" do
     it "can create billing info" do
       # rubocop:disable RSpec/VerifiedDoubles
       expect(Stripe::Checkout::Session).to receive(:create).and_return(double(Stripe::Checkout::Session, url: "#{project.path}/billing/success?session_id=session_123"))
+      expect(Stripe::PaymentIntent).to receive(:create).and_return(double(Stripe::PaymentIntent, status: "requires_capture", id: "pi_1234567890"))
       # rubocop:enable RSpec/VerifiedDoubles
       expect(Stripe::Checkout::Session).to receive(:retrieve).with("session_123").and_return({"setup_intent" => "st_123456790"})
       expect(Stripe::SetupIntent).to receive(:retrieve).with("st_123456790").and_return({"customer" => "cs_1234567890", "payment_method" => "pm_1234567890"})
       expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}, "metadata" => {"company_name" => "Foo Companye Name"}})
       expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return({"card" => {"brand" => "visa"}}).twice
+      expect(Stripe::PaymentIntent).to receive(:cancel).with("pi_1234567890").once
 
       visit project.path
 
@@ -70,6 +72,29 @@ RSpec.describe Clover, "billing" do
       expect(page).to have_field("Billing Name", with: "ACME Inc.")
       expect(billing_info.payment_methods.first.stripe_id).to eq("pm_1234567890")
       expect(page).to have_content "Visa"
+    end
+
+    it "can not create billing info with unauthorized payment" do
+      # rubocop:disable RSpec/VerifiedDoubles
+      expect(Stripe::Checkout::Session).to receive(:create).and_return(double(Stripe::Checkout::Session, url: "#{project.path}/billing/success?session_id=session_123"))
+      expect(Stripe::PaymentIntent).to receive(:create).and_return(double(Stripe::PaymentIntent, status: "canceled", id: "pi_1234567890"))
+      # rubocop:enable RSpec/VerifiedDoubles
+      expect(Stripe::Checkout::Session).to receive(:retrieve).with("session_123").and_return({"setup_intent" => "st_123456790"})
+      expect(Stripe::SetupIntent).to receive(:retrieve).with("st_123456790").and_return({"customer" => "cs_1234567890", "payment_method" => "pm_1234567890"})
+      expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return({"card" => {"brand" => "visa"}}).once
+      expect(Clog).to receive(:emit)
+
+      visit project.path
+
+      within "#desktop-menu" do
+        click_link "Billing"
+      end
+
+      expect(page.title).to eq("Ubicloud - Project Billing")
+      click_button "Add new billing information"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("We couldn't pre-authorize $1 from your card for verification. Please try again or contact our support team at support@ubicloud.com.")
     end
 
     it "can update billing info" do
@@ -100,9 +125,11 @@ RSpec.describe Clover, "billing" do
       expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_222222222").and_return({"card" => {"brand" => "mastercard"}}).twice
       # rubocop:disable RSpec/VerifiedDoubles
       expect(Stripe::Checkout::Session).to receive(:create).and_return(double(Stripe::Checkout::Session, url: "#{project.path}/billing/success?session_id=session_123"))
+      expect(Stripe::PaymentIntent).to receive(:create).and_return(double(Stripe::PaymentIntent, status: "requires_capture", id: "pi_1234567890"))
       # rubocop:enable RSpec/VerifiedDoubles
       expect(Stripe::Checkout::Session).to receive(:retrieve).with("session_123").and_return({"setup_intent" => "st_123456790"})
       expect(Stripe::SetupIntent).to receive(:retrieve).with("st_123456790").and_return({"payment_method" => "pm_222222222"})
+      expect(Stripe::PaymentIntent).to receive(:cancel).with("pi_1234567890").once
 
       visit "#{project.path}/billing"
 


### PR DESCRIPTION
While adding a new card payment method, authorizing 1$ to make sure that the card is valid and that amount can be authorized. If successful, authorization amount will be refunded immediately and card will be added as payment method.