### PR TITLE
Download custom images with fixed version

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -128,6 +128,10 @@ module Config
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
   optional :ubicloud_images_blob_storage_certs, string
 
+  override :github_ubuntu_2204_version, "20240422.1.0", string
+  override :github_ubuntu_2004_version, "20240422.1.0", string
+  override :postgres_ubuntu_2204_version, "20240226.1.0", string
+
   # Allocator
   override :allocator_target_host_utilization, 0.55, float
   override :allocator_max_random_score, 0.1, float

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -26,7 +26,7 @@ class Prog::DownloadBootImage < Prog::Base
       if frame["custom_url"]
         frame["custom_url"]
       elsif download_from_blob_storage?
-        blob_storage_client.get_presigned_url("GET", Config.ubicloud_images_bucket_name, "#{image_name}-#{vm_host.arch}.raw", 60 * 60).to_s
+        blob_storage_client.get_presigned_url("GET", Config.ubicloud_images_bucket_name, "#{image_name}-#{vm_host.arch}-#{version}.raw", 60 * 60).to_s
       end
   end
 

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -35,7 +35,13 @@ class Prog::DownloadBootImage < Prog::Base
       ["ubuntu-jammy", "x64", "20240319"] => "304983616fcba6ee1452e9f38993d7d3b8a90e1eb65fb0054d672ce23294d812",
       ["ubuntu-jammy", "arm64", "20240319"] => "40ea1181447b9395fa03f6f2c405482fe532a348cc46fbb876effcfbbb35336f",
       ["almalinux-9.3", "x64", "20231113"] => "6bbd060c971fd827a544c7e5e991a7d9e44460a449d2d058a0bb1290dec5a114",
-      ["almalinux-9.3", "arm64", "20231113"] => "a064715bc755346d5a8e1a4c6b1b7abffe4de03f1b0584942d5483ed32aafd67"
+      ["almalinux-9.3", "arm64", "20231113"] => "a064715bc755346d5a8e1a4c6b1b7abffe4de03f1b0584942d5483ed32aafd67",
+      ["github-ubuntu-2204", "x64", "20240422.1.0"] => "8b1b7af6941ce7b8b93d0c20af712e04e8ceedbd673b29fd4fba3406a3ba133c",
+      ["github-ubuntu-2204", "arm64", "20240422.1.0"] => "e14a7176070af022ace0e057a93beaa420602fa331dc67353ea4ce2459344265",
+      ["github-ubuntu-2004", "x64", "20240422.1.0"] => "cf4f3bd4fc43de5804eac32e810101fcfe078aafeb46cb5a34fff8f8f76b360d",
+      ["github-ubuntu-2004", "arm64", "20240422.1.0"] => "3e34cf2cb05ff9ab8c915b556bf31f153e90b20de25551587fadbec81557204b",
+      ["github-gpu-ubuntu-2204", "x64", "20240422.1.0"] => "5bb0577f9aaeae298f5a66403ae55b2092e790eb98ea7ef5812892211a55a548",
+      ["postgres-ubuntu-2204", "x64", "20240226.1.0"] => "f8a2b78189239717355b54ecf62a504a349c96b1ab6a21919984f58c2a367617"
     }
 
     # YYY: In future all images should be checked for sha256 sum, so the nil

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -40,17 +40,17 @@ RSpec.describe Prog::DownloadBootImage do
 
     it "generates presigned URL for github-runners images if a custom_url not provided" do
       params_json = {
-        "image_name" => "github-runners-image",
+        "image_name" => "github-ubuntu-2204",
         "url" => "https://minio.example.com/my-image.raw",
-        "version" => "20230303",
+        "version" => "20240422.1.0",
         "sha256sum" => nil,
         "certs" => "certs"
       }.to_json
-      expect(dbi).to receive(:frame).and_return({"image_name" => "github-runners-image", "version" => "20230303"}).at_least(:once)
+      expect(dbi).to receive(:frame).and_return({"image_name" => "github-ubuntu-2204", "version" => Config.github_ubuntu_2204_version}).at_least(:once)
       expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, get_presigned_url: "https://minio.example.com/my-image.raw"))
       expect(Config).to receive(:ubicloud_images_blob_storage_certs).and_return("certs").at_least(:once)
-      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_github-runners-image_20230303").and_return("NotStarted")
-      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image' download_github-runners-image_20230303", stdin: params_json)
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_github-ubuntu-2204_20240422.1.0").and_return("NotStarted")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-boot-image' download_github-ubuntu-2204_20240422.1.0", stdin: params_json)
       expect { dbi.download }.to nap(15)
     end
 


### PR DESCRIPTION
### Download custom images with fixed version
When we download a custom image without specifying a version, defaults to the latest one, making it difficult to identify which version is in use on the host.

Moreover, when we release a new version of an image, we don't immediately want to download the latest version. Instead, we prefer to test the new version before deploying it on the some hosts first.

Using a fixed version also simplifies the verification of SHA256 checksums.

### Add SHA256 checksums for custom images