### PR TITLE
Allocator: fix for host forcing and test improvement

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -44,7 +44,6 @@ module Scheduling::Allocator
         .join(:used_ipv4, routed_to_host_id: Sequel[:vm_host][:id])
         .left_join(:gpus, vm_host_id: Sequel[:vm_host][:id])
         .select(Sequel[:vm_host][:id].as(:vm_host_id), :total_cores, :used_cores, :total_hugepages_1g, :used_hugepages_1g, :location, :num_storage_devices, :available_storage_gib, :total_storage_gib, :storage_devices, :total_ipv4, :used_ipv4, Sequel.function(:coalesce, :num_gpus, 0).as(:num_gpus), Sequel.function(:coalesce, :available_gpus, 0).as(:available_gpus), :available_iommu_groups)
-        .where(allocation_state: request.allocation_state_filter)
         .where(arch: request.arch_filter)
         .where { (total_hugepages_1g - used_hugepages_1g >= request.mem_gib) }
         .where { (total_cores - used_cores >= request.cores) }
@@ -75,6 +74,7 @@ module Scheduling::Allocator
       ds = ds.where { available_gpus > 0 } if request.gpu_enabled
       ds = ds.where(Sequel[:vm_host][:id] => request.host_filter) unless request.host_filter.empty?
       ds = ds.where(location: request.location_filter) unless request.location_filter.empty?
+      ds = ds.where(allocation_state: request.allocation_state_filter) unless request.allocation_state_filter.empty?
       ds.all
     end
 

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -547,6 +547,13 @@ RSpec.describe Al do
       expect(nx.storage_secrets.count).to eq(0)
     end
 
+    it "can have empty allocation state filter" do
+      vmh = VmHost.first
+      vmh.update(allocation_state: "draining")
+      al = Al::Allocation.best_allocation(create_req(vm, vol, allocation_state_filter: []))
+      expect(al).to be_truthy
+    end
+
     it "creates volume with encryption key if storage is encrypted" do
       vm = create_vm
       described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -267,17 +267,17 @@ RSpec.describe Al do
     it "is penalized if utilization is below target" do
       expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization * 0.9, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization * 0.9, true))
-      expect(Al::Allocation.new(vmhds, req).score).to be > 0
+      expect(Al::Allocation.new(vmhds, req, 0).score).to be > 0
     end
 
     it "penalizes over-utilization more than under-utilization" do
       expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(0, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0, true))
-      score_low_utilization = Al::Allocation.new(vmhds, req).score
+      score_low_utilization = Al::Allocation.new(vmhds, req, 0).score
 
       expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization * 1.01, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization * 1.01, true))
-      score_over_target = Al::Allocation.new(vmhds, req).score
+      score_over_target = Al::Allocation.new(vmhds, req, 0).score
 
       expect(score_over_target).to be > score_low_utilization
     end
@@ -286,12 +286,12 @@ RSpec.describe Al do
       expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
       expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
-      score_balance = Al::Allocation.new(vmhds, req).score
+      score_balance = Al::Allocation.new(vmhds, req, 0).score
 
       expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.4, true))
       expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.5, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0.6, true))
-      score_imbalance = Al::Allocation.new(vmhds, req).score
+      score_imbalance = Al::Allocation.new(vmhds, req, 0).score
 
       expect(score_imbalance).to be > score_balance
     end
@@ -309,7 +309,7 @@ RSpec.describe Al do
       req.location_preference = ["loc2"]
       expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
-      score_preference_not_met = Al::Allocation.new(vmhds, req).score
+      score_preference_not_met = Al::Allocation.new(vmhds, req, 0).score
 
       expect(score_no_preference).to be_within(0.0001).of(score_preference_met)
       expect(score_preference_not_met).to be > score_preference_met


### PR DESCRIPTION
Fix allocator query for empty allocation state (e.g. used when forcing a host) and make allocator tests deterministic.