### PR TITLE
Fix capacity pages

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -208,7 +208,7 @@ class Prog::Vm::Nexus < Prog::Base
         gpu_enabled: gpu_enabled
       )
     rescue RuntimeError => ex
-      raise unless ex.message.include?("no space left on any eligible hosts")
+      raise unless ex.message.include?("no space left on any eligible host")
 
       queued_vms = queued_vms.all
       Prog::PageNexus.assemble("No capacity left at #{vm.location} for #{vm.arch}", queued_vms.first(25).map(&:ubid), "NoCapacity", vm.location, vm.arch)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates a page if no capacity left and naps" do
-      expect(Scheduling::Allocator).to receive(:allocate).and_raise(RuntimeError.new("no space left on any eligible hosts")).twice
+      expect(Scheduling::Allocator).to receive(:allocate).and_raise(RuntimeError.new("no space left on any eligible host")).twice
       expect { nx.start }.to nap(30)
       expect(Page.active.count).to eq(1)
       expect(Page.from_tag_parts("NoCapacity", vm.location, vm.arch)).not_to be_nil
@@ -315,7 +315,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "resolves the page if no VM left in the queue after 15 minutes" do
       # First run creates the page
-      expect(Scheduling::Allocator).to receive(:allocate).and_raise(RuntimeError.new("no space left on any eligible hosts"))
+      expect(Scheduling::Allocator).to receive(:allocate).and_raise(RuntimeError.new("no space left on any eligible host"))
       expect { nx.start }.to nap(30)
       expect(Page.active.count).to eq(1)
 


### PR DESCRIPTION
Consistently use "no space left on any eligible host" for capacity errors.