### PR TITLE
Download the default boot image in host setup

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -105,6 +105,9 @@ module Config
   # Spdk
   override :spdk_version, "v23.09-ubi-0.2"
 
+  # Boot Images
+  override :default_boot_image_name, "ubuntu-jammy", string
+
   # Pagerduty
   optional :pagerduty_key, string, clear: true
   optional :pagerduty_log_link, string
@@ -128,9 +131,11 @@ module Config
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
   optional :ubicloud_images_blob_storage_certs, string
 
+  override :ubuntu_jammy_version, "20240319", string
   override :github_ubuntu_2204_version, "20240422.1.0", string
   override :github_ubuntu_2004_version, "20240422.1.0", string
   override :postgres_ubuntu_2204_version, "20240226.1.0", string
+  override :github_gpu_ubuntu_2204_version, "20240422.1.0", string
 
   # Allocator
   override :allocator_target_host_utilization, 0.55, float

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -95,7 +95,7 @@ class Prog::Vm::HostNexus < Prog::Base
       spdk_installation = vm_host.spdk_installations.first
       spdk_cores = (spdk_installation.cpu_count * vm_host.total_cores) / vm_host.total_cpus
       vm_host.update(used_cores: spdk_cores)
-      hop_prep_reboot
+      hop_download_boot_image
     end
 
     push Prog::Storage::SetupSpdk, {
@@ -103,6 +103,53 @@ class Prog::Vm::HostNexus < Prog::Base
       "start_service" => false,
       "allocation_weight" => 100
     }
+  end
+
+  def default_boot_images
+    return [Config.default_boot_image_name] if Config.development? || !Config.ubicloud_images_blob_storage_endpoint
+
+    images = ["ubuntu-jammy", "github-ubuntu-2204", "github-ubuntu-2004"]
+
+    # Germany hosts should have PG image too
+    images << "postgres-ubuntu-2204" if vm_host.location == "hetzner-fsn1"
+
+    # GPU hosts should have runner image too
+    images << "github-gpu-ubuntu-2204" if vm_host.pci_devices_dataset.count > 0
+
+    images
+  end
+
+  def default_boot_image_version(image_name)
+    case image_name
+    when "ubuntu-jammy"
+      Config.ubuntu_jammy_version
+    when "github-ubuntu-2204"
+      Config.github_ubuntu_2204_version
+    when "github-ubuntu-2004"
+      Config.github_ubuntu_2004_version
+    when "github-gpu-ubuntu-2204"
+      Config.github_gpu_ubuntu_2204_version
+    when "postgres-ubuntu-2204"
+      Config.postgres_ubuntu_2204_version
+    else
+      fail "Unknown boot image: #{image_name}"
+    end
+  end
+
+  label def download_boot_image
+    default_boot_images.each do |image_name|
+      bud Prog::DownloadBootImage, {
+        "image_name" => image_name,
+        "version" => default_boot_image_version(image_name)
+      }
+    end
+    hop_wait_download_boot_images
+  end
+
+  label def wait_download_boot_images
+    reap
+    hop_prep_reboot if leaf?
+    donate
   end
 
   label def prep_reboot

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -11,7 +11,7 @@ class Prog::Vm::Nexus < Prog::Base
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency
 
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
-    unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
+    unix_user: "ubi", location: "hetzner-hel1", boot_image: Config.default_boot_image_name,
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
     enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil,
     distinct_storage_devices: false, force_host_id: nil)

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -32,7 +32,6 @@ begin
   unix_user = params.fetch("unix_user")
   ssh_public_key = params.fetch("ssh_public_key")
   nics = params.fetch("nics").map { |args| VmSetup::Nic.new(*args) }.freeze
-  boot_image = params.fetch("boot_image")
   max_vcpus = params.fetch("max_vcpus")
   cpu_topology = params.fetch("cpu_topology")
   mem_gib = params.fetch("mem_gib")
@@ -54,7 +53,7 @@ when "prep"
   end
 
   vm_setup.prep(unix_user, ssh_public_key, nics, gua, ip4,
-    local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib,
+    local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 when "recreate-unpersisted"
   secrets = JSON.parse($stdin.read)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -11,7 +11,6 @@ require "uri"
 require_relative "vm_path"
 require_relative "cloud_hypervisor"
 require_relative "storage_volume"
-require_relative "boot_image"
 
 class VmSetup
   Nic = Struct.new(:net6, :net4, :tap, :mac)
@@ -44,10 +43,9 @@ class VmSetup
     @vp ||= VmPath.new(@vm_name)
   end
 
-  def prep(unix_user, public_key, nics, gua, ip4, local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
+  def prep(unix_user, public_key, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
     cloudinit(unix_user, public_key, nics, swap_size_bytes)
-    download_boot_image(boot_image)
     storage(storage_params, storage_secrets, true)
     hugepages(mem_gib)
     prepare_pci_devices(pci_devices)
@@ -476,10 +474,6 @@ EOS
       storage_volume.prep(key_wrapping_secrets) if prep
       storage_volume.start(key_wrapping_secrets)
     }
-  end
-
-  def download_boot_image(boot_image)
-    BootImage.new(boot_image, nil).download
   end
 
   # Unnecessary if host has this set before creating the netns, but

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -53,16 +53,6 @@ RSpec.describe VmSetup do
     end
   end
 
-  describe "#download_boot_image" do
-    it "can download ubuntu-jammy boot image" do
-      boot_image = instance_double(BootImage)
-      expect(BootImage).to receive(:new).with("ubuntu-jammy", nil).and_return(boot_image)
-      allow(Arch).to receive(:render).and_return("amd64")
-      expect(boot_image).to receive(:download)
-      vs.download_boot_image("ubuntu-jammy")
-    end
-  end
-
   describe "#purge_storage" do
     let(:vol_1_params) {
       {

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -181,7 +181,85 @@ RSpec.describe Prog::Vm::HostNexus do
       )
       allow(nx).to receive(:vm_host).and_return(vmh)
       expect(vmh).to receive(:update).with({used_cores: 2})
-      expect { nx.setup_spdk }.to hop("prep_reboot")
+      expect { nx.setup_spdk }.to hop("download_boot_image")
+    end
+  end
+
+  describe "#default_boot_images" do
+    it "returns the default image in development env" do
+      expect(Config).to receive(:development?).and_return(true)
+      expect(nx.default_boot_images).to eq([Config.default_boot_image_name])
+    end
+
+    it "returns the default image in non-development env without blob storage" do
+      expect(Config).to receive(:development?).and_return(false)
+      expect(Config).to receive(:ubicloud_images_blob_storage_endpoint).and_return(nil)
+      expect(nx.default_boot_images).to eq([Config.default_boot_image_name])
+    end
+
+    it "also includes github-runner images in non-development env with blob storage" do
+      expect(Config).to receive(:development?).and_return(false)
+      expect(Config).to receive(:ubicloud_images_blob_storage_endpoint).and_return("https://some.blob.storage")
+      expect(vm_host).to receive(:location).and_return("some-location")
+      expect(vm_host).to receive(:pci_devices_dataset).and_return([])
+      expect(nx.default_boot_images).to eq(["ubuntu-jammy", "github-ubuntu-2204", "github-ubuntu-2004"])
+    end
+
+    it "also includes postgres image for Germany hosts" do
+      expect(Config).to receive(:development?).and_return(false)
+      expect(Config).to receive(:ubicloud_images_blob_storage_endpoint).and_return("https://some.blob.storage")
+      expect(vm_host).to receive(:location).and_return("hetzner-fsn1")
+      expect(vm_host).to receive(:pci_devices_dataset).and_return([])
+      expect(nx.default_boot_images).to eq(["ubuntu-jammy", "github-ubuntu-2204", "github-ubuntu-2004", "postgres-ubuntu-2204"])
+    end
+
+    it "also includes github-gpu image for GPU hosts" do
+      expect(Config).to receive(:development?).and_return(false)
+      expect(Config).to receive(:ubicloud_images_blob_storage_endpoint).and_return("https://some.blob.storage")
+      expect(vm_host).to receive(:location).and_return("some-location")
+      expect(vm_host).to receive(:pci_devices_dataset).and_return([instance_double(PciDevice)])
+      expect(nx.default_boot_images).to eq(["ubuntu-jammy", "github-ubuntu-2204", "github-ubuntu-2004", "github-gpu-ubuntu-2204"])
+    end
+  end
+
+  describe "#default_boot_image_version" do
+    it "returns the version for the default image" do
+      expect(nx.default_boot_image_version("ubuntu-jammy")).to eq(Config.ubuntu_jammy_version)
+      expect(nx.default_boot_image_version("github-ubuntu-2204")).to eq(Config.github_ubuntu_2204_version)
+      expect(nx.default_boot_image_version("github-ubuntu-2004")).to eq(Config.github_ubuntu_2004_version)
+      expect(nx.default_boot_image_version("github-gpu-ubuntu-2204")).to eq(Config.github_gpu_ubuntu_2204_version)
+      expect(nx.default_boot_image_version("postgres-ubuntu-2204")).to eq(Config.postgres_ubuntu_2204_version)
+    end
+
+    it "fails for unknown images" do
+      expect { nx.default_boot_image_version("unknown-image") }.to raise_error RuntimeError, "Unknown boot image: unknown-image"
+    end
+  end
+
+  describe "#download_boot_image" do
+    it "starts the download process and hops" do
+      default_images = ["ubuntu-jammy", "github-ubuntu-2204"]
+      expect(nx).to receive(:default_boot_images).and_return(default_images)
+      expect(nx).to receive(:bud).with(Prog::DownloadBootImage, {"image_name" => "ubuntu-jammy", "version" => Config.ubuntu_jammy_version})
+      expect(nx).to receive(:bud).with(Prog::DownloadBootImage, {"image_name" => "github-ubuntu-2204", "version" => Config.github_ubuntu_2204_version})
+      expect { nx.download_boot_image }.to hop("wait_download_boot_images")
+    end
+  end
+
+  describe "#wait_download_boot_images" do
+    it "hops to prep_reboot if all tasks are done" do
+      expect(nx).to receive(:reap).and_return([])
+      expect(nx).to receive(:leaf?).and_return true
+
+      expect { nx.wait_download_boot_images }.to hop("prep_reboot")
+    end
+
+    it "donates its time if child strands are still running" do
+      expect(nx).to receive(:reap).and_return([])
+      expect(nx).to receive(:leaf?).and_return false
+      expect(nx).to receive(:donate).and_call_original
+
+      expect { nx.wait_download_boot_images }.to nap(1)
     end
   end
 


### PR DESCRIPTION
**UPDATE**: Alternatively, we can merge https://github.com/ubicloud/ubicloud/pull/1597

Since clover is going to only allocate boot images that have already been downloaded to storage volumes, we need at least one boot image when host setup finishes. This commit downloads the default boot image (configurable, currently ubuntu-jammy) when setting up the host.

In addition, we don't need image download in vm_setup. So, we remove it.