### PR TITLE
Use implied re-raising of exceptions

### DIFF
--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -85,7 +85,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       minio_server.vm.sshable.cmd("sudo groupadd -f --system minio-user")
       minio_server.vm.sshable.cmd("sudo useradd --no-create-home --system -g minio-user minio-user")
     rescue => ex
-      raise ex unless ex.message.include?("already exists")
+      raise unless ex.message.include?("already exists")
     end
 
     hop_setup

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -311,7 +311,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     hop_wait
   rescue Octokit::Conflict => e
-    raise e unless e.message.include?("Already exists")
+    raise unless e.message.include?("Already exists")
 
     # If the runner already exists at GitHub side, this suggests that the
     # process terminated prematurely before hop wait. We can't be sure if the

--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -114,7 +114,7 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
           "src #{src} dst #{dst} proto esp spi #{spi} reqid #{@reqid} mode tunnel " \
           "aead 'rfc4106(gcm(aes))' {} 128 #{is_ipv4 ? "sel src 0.0.0.0/0 dst 0.0.0.0/0" : ""}", stdin: key)
       rescue Sshable::SshError => e
-        raise e unless e.message.include?("File exists")
+        raise unless e.message.include?("File exists")
       end
     end
 

--- a/rhizome/host/lib/spdk_rpc.rb
+++ b/rhizome/host/lib/spdk_rpc.rb
@@ -21,8 +21,8 @@ class SpdkRpc
 
   def bdev_aio_delete(name, if_exists = true)
     call("bdev_aio_delete", {name: name})
-  rescue SpdkNotFound => e
-    raise e unless if_exists
+  rescue SpdkNotFound
+    raise unless if_exists
   end
 
   def bdev_crypto_create(name, base_bdev_name, key_name)
@@ -36,8 +36,8 @@ class SpdkRpc
 
   def bdev_crypto_delete(name, if_exists = true)
     call("bdev_crypto_delete", {name: name})
-  rescue SpdkNotFound => e
-    raise e unless if_exists
+  rescue SpdkNotFound
+    raise unless if_exists
   end
 
   def bdev_ubi_create(name, base_bdev_name, image_path,
@@ -59,8 +59,8 @@ class SpdkRpc
 
   def bdev_ubi_delete(name, if_exists = true)
     call("bdev_ubi_delete", {name: name})
-  rescue SpdkNotFound => e
-    raise e unless if_exists
+  rescue SpdkNotFound
+    raise unless if_exists
   end
 
   def vhost_create_blk_controller(name, bdev)
@@ -73,8 +73,8 @@ class SpdkRpc
 
   def vhost_delete_controller(name, if_exists = true)
     call("vhost_delete_controller", {ctrlr: name})
-  rescue SpdkNotFound => e
-    raise e unless if_exists
+  rescue SpdkNotFound
+    raise unless if_exists
   end
 
   def accel_crypto_key_create(name, cipher, key, key2)
@@ -89,8 +89,8 @@ class SpdkRpc
 
   def accel_crypto_key_destroy(name, if_exists = true)
     call("accel_crypto_key_destroy", {key_name: name})
-  rescue SpdkNotFound => e
-    raise e unless if_exists
+  rescue SpdkNotFound
+    raise unless if_exists
   end
 
   def call(method, params = {})

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -69,7 +69,7 @@ class StorageVolume
     begin
       setup_spdk_bdev(encryption_key)
       setup_spdk_vhost
-    rescue SpdkExists => e
+    rescue SpdkExists
       # If some of SPDK artifacts exist, purge and retry. But retry only once
       # to prevent potential retry loops.
       if retries == 0
@@ -77,7 +77,7 @@ class StorageVolume
         purge_spdk_artifacts
         retry
       end
-      raise e
+      raise
     end
   end
 


### PR DESCRIPTION
I think it is more idiomatic to only use `raise` when re-raising an exception.  The use of the `raise expr` form indicates that something more complex is going on (e.g. that a new exception might have been bound to a variable), when in these cases, that is not true.