### PR TITLE
Upgrade to Ruby 3.2.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.2.3
+ruby 3.2.4
 postgres 15.4
 nodejs 21.7.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM ruby:3.2.3-alpine3.19 as bundler
+FROM ruby:3.2.4-alpine3.19 as bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -19,7 +19,7 @@ RUN bundle config set --local without development:test
 RUN bundle install
 
 
-FROM ruby:3.2.3-alpine3.19
+FROM ruby:3.2.4-alpine3.19
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.2.3"
+ruby "3.2.4"
 
 gem "argon2"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.3p157
+   ruby 3.2.4p170
 
 BUNDLED WITH
-   2.4.10
+   2.5.10


### PR DESCRIPTION
When running rubocop, the new version of the parser gem complains about ruby running with an older version of ruby, though it doesn't cause any problem.  But, in general, we try to keep up to date on the point releases anyhow.

Ruby 3.3 also has its first point release 3.3.1, it might be a good time to upgrade.  After this.

The version of bundler I obtained with the new Ruby is likewise newer, and our needs there are not particularly exotic, so, update it as well.