### PR TITLE
Don't send a certificate for non-blob-storage image downloads

### DIFF
--- a/rhizome/host/bin/download-boot-image
+++ b/rhizome/host/bin/download-boot-image
@@ -5,11 +5,7 @@ require "json"
 require_relative "../../common/lib/util"
 require_relative "../lib/boot_image"
 
-unless (params = ARGV.shift)
-  puts "need params as argument"
-  exit 1
-end
-
+params = $stdin.read
 params_json = JSON.parse(params)
 
 unless (boot_image = params_json["image_name"])
@@ -21,10 +17,15 @@ end
 version = params_json["version"]
 url = params_json["url"]
 sha256sum = params_json["sha256sum"]
+certs = params_json["certs"]
 
-certs = $stdin.read
-ca_path = "/usr/lib/ssl/certs/ubicloud_images_blob_storage_certs.crt"
-safe_write_to_file(ca_path, certs)
+# Not all image downloads require a certificate
+if certs.nil?
+  ca_path = nil
+else
+  ca_path = "/usr/lib/ssl/certs/ubicloud_images_blob_storage_certs.crt"
+  safe_write_to_file(ca_path, certs)
+end
 
 BootImage.new(boot_image, version).download(
   url: url, ca_path: ca_path, sha256sum: sha256sum


### PR DESCRIPTION
Non-blob-storage images don't require a certificate. This caused problems in the E2E tests where `ubicloud_images_blob_storage_certs` wasn't set.