### PR TITLE
Validate account names

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -152,6 +152,7 @@ class CloverWeb < Roda
     before_create_account do
       account[:id] = Account.generate_uuid
       account[:name] = param("name")
+      Validation.validate_account_name(account[:name])
     end
     after_create_account do
       Account[account_id].create_project_with_default_policy("Default")

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -34,6 +34,10 @@ module Validation
   # - Alphanumeric, hyphen, underscore, space, parantheses, exclamation, question mark, star
   ALLOWED_SHORT_TEXT_PATTERN = %r{\A[a-zA-Z0-9_\-!?\*\(\) ]{1,63}\z}
 
+  # - Max length 63
+  # - Unicode letters, numbers, hyphen, space
+  ALLOWED_ACCOUNT_NAME = %r{\A\p{L}[\p{L}0-9\- ]{1,62}\z}
+
   def self.validate_name(name)
     msg = "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."
     fail ValidationFailed.new({name: msg}) unless name&.match(ALLOWED_NAME_PATTERN)
@@ -184,5 +188,9 @@ module Validation
 
   def self.validate_short_text(text, field_name)
     fail ValidationFailed.new({field_name: "The #{field_name} must have max length 63 and only contain alphanumeric characters, hyphen, underscore, space, parantheses, exclamation, question mark and star."}) unless text.match(ALLOWED_SHORT_TEXT_PATTERN)
+  end
+
+  def self.validate_account_name(name)
+    fail ValidationFailed.new({name: "Name must only contain letters, numbers, spaces, and hyphens and have max length 63."}) unless name&.match(ALLOWED_ACCOUNT_NAME)
   end
 end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -266,4 +266,36 @@ RSpec.describe Validation do
       end
     end
   end
+
+  describe "#validate_account_name" do
+    it "valid account names" do
+      [
+        "John Doe",
+        "john doe",
+        "John Doe-Smith",
+        "Jøhn Döe",
+        "John2 Doe",
+        "J" * 63
+      ].each do |name|
+        expect(described_class.validate_account_name(name)).to be_nil
+      end
+    end
+
+    it "invalid account names" do
+      [
+        nil,
+        "",
+        " John Doe",
+        "1john Doe",
+        ".john Doe",
+        "https://example.com",
+        "Click this link: http://example.com",
+        "Click this link example.com",
+        "🚀 emojis not allowed",
+        "J" * 64
+      ].each do |name|
+        expect { described_class.validate_account_name(name) }.to raise_error described_class::ValidationFailed
+      end
+    end
+  end
 end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Clover, "auth" do
   it "can not login new account without verification" do
     visit "/create-account"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Full Name", with: "John Doe"
     fill_in "Password", with: TEST_USER_PASSWORD
     fill_in "Password Confirmation", with: TEST_USER_PASSWORD
     click_button "Create Account"
@@ -26,6 +27,19 @@ RSpec.describe Clover, "auth" do
     click_button "Sign in"
 
     expect(page.title).to eq("Ubicloud - Resend Verification")
+  end
+
+  it "can not create new account with invalid name" do
+    visit "/create-account"
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Full Name", with: "Click here http://example.com"
+    fill_in "Password", with: TEST_USER_PASSWORD
+    fill_in "Password Confirmation", with: TEST_USER_PASSWORD
+    click_button "Create Account"
+
+    expect(page.title).to eq("Ubicloud - Create Account")
+    expect(Mail::TestMailer.deliveries.length).to eq 0
+    expect(page).to have_content("Name must only contain letters, numbers, spaces, and hyphens and have max length 63.")
   end
 
   it "can create new account and verify it" do


### PR DESCRIPTION
The account name is used in the email templates such as project invitations. If the account name isn't validated, it can be exploited to insert harmful links into emails.  A user could alter their name to a URL, enabling them to send email invitations with malicious links.

I've decided not to allow "." as well. This invalidates names like 'John Jr. Doe', but services like Gmail make links clickable even without the 'http://' prefix. So, it's better to be safe than sorry.