### PR TITLE
Change index pages to use resource name to show

### DIFF
--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Clover, "private subnet" do
         expect(page.title).to eq("Ubicloud - Private Subnets")
         expect(page).to have_content private_subnet.name
 
-        click_link "Show", href: "#{project.path}#{private_subnet.path}"
+        click_link private_subnet.name, href: "#{project.path}#{private_subnet.path}"
 
         expect(page.title).to eq("Ubicloud - #{private_subnet.name}")
         expect(page).to have_content private_subnet.name

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Clover, "postgres" do
         expect(page.title).to eq("Ubicloud - PostgreSQL Databases")
         expect(page).to have_content pg.name
 
-        click_link "Show", href: "#{project.path}#{pg.path}"
+        click_link pg.name, href: "#{project.path}#{pg.path}"
 
         expect(page.title).to eq("Ubicloud - #{pg.name}")
         expect(page).to have_content pg.name

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Virtual Machines")
         expect(page).to have_content vm.name
 
-        click_link "Show", href: "#{project.path}#{vm.path}"
+        click_link vm.name, href: "#{project.path}#{vm.path}"
 
         expect(page.title).to eq("Ubicloud - #{vm.name}")
         expect(page).to have_content vm.name

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -29,21 +29,19 @@
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Location</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-              <span class="sr-only">Show</span>
-            </th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           <% @postgres_databases.each do |pg| %>
             <tr>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= pg[:name] %></td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium sm:pl-6" scope="row">
+                <a href="<%= @project_data[:path] %><%= pg[:path] %>" class="text-orange-600 hover:text-orange-700">
+                  <%= pg[:name] %>
+                </a>
+              </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= pg[:location] %></td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                 <%== render("components/pg_state_label", locals: { state: pg[:state] }) %>
-              </td>
-              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                <a href="<%= @project_data[:path] %><%= pg[:path] %>" class="text-orange-600 hover:text-orange-700">Show</a>
               </td>
             </tr>
           <% end %>

--- a/views/private_subnet/index.erb
+++ b/views/private_subnet/index.erb
@@ -29,21 +29,19 @@
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Location</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-              <span class="sr-only">Show</span>
-            </th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           <% @pss.each do |ps| %>
             <tr>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= ps[:name] %></td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <a href="<%= @project_data[:path] %><%= ps[:path] %>" class="text-orange-600 hover:text-orange-700">
+                  <%= ps[:name] %>
+                </a>
+              </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= ps[:location] %></td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                 <%== render("components/ps_state_label", locals: { state: ps[:state] }) %>
-              </td>
-              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                <a href="<%= @project_data[:path] %><%= ps[:path] %>" class="text-orange-600 hover:text-orange-700">Show</a>
               </td>
             </tr>
           <% end %>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -33,15 +33,16 @@
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Storage Size</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">IP Address</th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-              <span class="sr-only">Show</span>
-            </th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           <% @vms.each do |vm| %>
             <tr>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= vm[:name] %></td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium sm:pl-6" scope="row">
+                <a href="<%= @project_data[:path] %><%= vm[:path] %>" class="text-orange-600 hover:text-orange-700">
+                  <%= vm[:name] %>
+                </a>
+              </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:location] %></td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:display_size] %></td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:storage_size_gib] %>
@@ -54,11 +55,7 @@
                   <%== render("components/copieble_content", locals: { content: vm[:ip4], message: "Copied IPv4" }) %>
                 <% else %>
                   <%== render("components/copieble_content", locals: { content: vm[:ip6], message: "Copied IPv6" }) %>
-
                 <% end %>
-              </td>
-              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                <a href="<%= @project_data[:path] %><%= vm[:path] %>" class="text-orange-600 hover:text-orange-700">Show</a>
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION
## Change private subnets page to use name to show instead of Show button 
Having a separate Show button is meaningless when customers can click on
the name of the subnet. This is also more consistent with the Firewalls.

## Change compute page to use name to show instead of Show button

## Change PostgreSQL page to use name to show instead of Show button