### PR TITLE
Configurable allocator settings and adjustments for GitHub runners

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -127,4 +127,8 @@ module Config
   optional :ubicloud_images_blob_storage_access_key, string, clear: true
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
   optional :ubicloud_images_blob_storage_certs, string
+
+  # Allocator
+  override :allocator_target_host_utilization, 0.55, float
+  override :allocator_max_random_score, 0.1, float
 end

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -146,9 +146,11 @@ module Scheduling::Allocator
       score += util.max - util.min
 
       if @candidate_host[:location] == "github-runners"
-      # penalty for ongoing vm provisionings on the host
+        # penalty for ongoing vm provisionings on the host
         score += @candidate_host[:vm_provisioning_count] * 0.5
 
+        # penalty for AX161, TODO: remove after migration to AX162
+        score += 0.5 if @candidate_host[:total_cores] == 32
       end
 
       # penalty of 5 if host has a GPU but VM doesn't require a GPU

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -317,11 +317,12 @@ RSpec.describe Al do
       expect(score_imbalance).to be > score_balance
     end
 
-    it "penalizes concurrent provisioning" do
+    it "penalizes concurrent provisioning for github runners" do
       expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+      vmhds[:location] = "github-runners"
       vmhds[:vm_provisioning_count] = 1
-      expect(Al::Allocation.new(vmhds, req, 0).score).to be > 0
+      expect(Al::Allocation.new(vmhds, req).score).to eq(0.5)
     end
 
     it "respects location preferences" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -325,6 +325,14 @@ RSpec.describe Al do
       expect(Al::Allocation.new(vmhds, req).score).to eq(0.5)
     end
 
+    it "penalizes AX161 github runners" do
+      expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+      expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
+      vmhds[:location] = "github-runners"
+      vmhds[:total_cores] = 32
+      expect(Al::Allocation.new(vmhds, req).score).to eq(0.5)
+    end
+
     it "respects location preferences" do
       expect(Al::VmHostAllocation).to receive(:new).twice.and_return(TestResourceAllocation.new(0, true))
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(0, true))


### PR DESCRIPTION
Make key allocator settings configurable
Extract parameters defining target host utilization and score
randomization and make them config settings.

Penalize concurrent provisioning only for GitHub runners
Apply an increased penalty for provisioning a GitHub runner VM on a host
where other VMs are being provisioned. Concurrent provisionings
take noticeably longer. For short-lived VMs (github runners), short
provisioning times are crucial. For long-lived VMs, however, it's more
crucial to find the most suitable host, even if provisioning takes a
few seconds longer.


Penalize AX161 for GitHub runners
Temporary change to discourage AX161 for GitHub runners, to
direct most of the load to AX162 hosts for x64. AX161s hosts are
identified by their core count of 32.