### PR TITLE
Remove AlmaLinux 9.1 from boot image options

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -39,8 +39,7 @@ module Option
 
   BootImage = Struct.new(:name, :display_name)
   BootImages = [
-    ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"],
-    ["almalinux-9.1", "AlmaLinux 9.1"]
+    ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"]
   ].map { |args| BootImage.new(*args) }.freeze
 
   VmSize = Struct.new(:name, :family, :vcpu, :memory, :storage_size_gib, :visible, :gpu) do

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -232,7 +232,6 @@ RSpec.describe Validation do
     describe "#validate_boot_image" do
       it "valid boot image" do
         expect { described_class.validate_boot_image("ubuntu-jammy") }.not_to raise_error
-        expect { described_class.validate_boot_image("almalinux-9.1") }.not_to raise_error
       end
 
       it "invalid boot image" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\", \"almalinux-9.1\"]")
+        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\"]")
       end
 
       it "invalid ps id" do


### PR DESCRIPTION
The URL that we had for AlmaLinux 9.1 previously was a general URL without the 9.1 information which pointed to a AlmaLinux 9.3 download when I checked it, so I renamed it to AlmaLinux 9.3 in the rhizome side.

So, currently if a customer requests AlmaLinux 9.1, we'll get paged.

I suggest we remove AlmaLinux from options customers can choose for now, until we properly figure out how we should manage AlmaLinux images.