### PR TITLE
Program to remove a boot image.

### DIFF
--- a/migrate/20240516_boot_image_size_gib.rb
+++ b/migrate/20240516_boot_image_size_gib.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:boot_image) do
+      add_column :size_gib, Integer, null: true
+    end
+
+    # Update existing boot images
+    run <<-SQL
+    UPDATE boot_image
+    SET size_gib = CASE
+        WHEN boot_image.name = 'ubuntu-jammy' THEN 3
+        WHEN boot_image.name = 'almalinux-9.1' THEN 10
+        WHEN vm_host.arch = 'x64' AND boot_image.name LIKE 'github-ubuntu-%' THEN 75
+        WHEN vm_host.arch = 'arm64' AND boot_image.name LIKE 'github-ubuntu-%' THEN 50
+        WHEN boot_image.name = 'github-gpu-ubuntu-2204' THEN 31
+        WHEN boot_image.name LIKE 'postgres-%' THEN 8
+        ELSE 0
+    END
+    FROM vm_host
+    WHERE boot_image.vm_host_id = vm_host.id;
+    SQL
+
+    alter_table(:boot_image) do
+      set_column_not_null :size_gib
+    end
+  end
+end

--- a/model/boot_image.rb
+++ b/model/boot_image.rb
@@ -11,4 +11,10 @@ class BootImage < Sequel::Model
   def self.ubid_type
     UBID::TYPE_ETC
   end
+
+  def path
+    version ?
+        "/var/storage/images/#{name}-#{version}.raw" :
+        "/var/storage/images/#{name}.raw"
+  end
 end

--- a/model/boot_image.rb
+++ b/model/boot_image.rb
@@ -12,6 +12,11 @@ class BootImage < Sequel::Model
     UBID::TYPE_ETC
   end
 
+  # Introduced for removing a boot image via REPL.
+  def remove_boot_image
+    Strand.create_with_id(schedule: Time.now, prog: "RemoveBootImage", label: "start", stack: [{subject_id: id}])
+  end
+
   def path
     version ?
         "/var/storage/images/#{name}-#{version}.raw" :

--- a/prog/remove_boot_image.rb
+++ b/prog/remove_boot_image.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Prog::RemoveBootImage < Prog::Base
+  subject_is :boot_image
+
+  label def start
+    boot_image.update(activated_at: nil)
+    hop_wait_volumes
+  end
+
+  label def wait_volumes
+    nap 30 if boot_image.vm_storage_volumes.count > 0
+    hop_remove
+  end
+
+  label def remove
+    boot_image.vm_host.sshable.cmd("sudo rm -rf #{boot_image.path.shellescape}")
+
+    hop_update_database
+  end
+
+  label def update_database
+    StorageDevice.where(vm_host_id: boot_image.vm_host.id, name: "DEFAULT").update(
+      available_storage_gib: Sequel[:available_storage_gib] + boot_image.size_gib
+    )
+    boot_image.destroy
+    pop "Boot image was removed."
+  end
+end

--- a/spec/model/boot_image_spec.rb
+++ b/spec/model/boot_image_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe BootImage do
+  subject(:boot_image) { described_class.new }
+
+  describe "#remove_boot_image" do
+    it "creates a strand to delete boot image" do
+      expect(Strand).to receive(:create_with_id) do |args|
+        expect(args[:prog]).to eq("RemoveBootImage")
+        expect(args[:label]).to eq("start")
+        expect(args[:stack]).to eq([{subject_id: 1}])
+      end
+      boot_image.id = 1
+      boot_image.remove_boot_image
+    end
+  end
+end

--- a/spec/prog/remove_boot_image_spec.rb
+++ b/spec/prog/remove_boot_image_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::RemoveBootImage do
+  subject(:rbi) { described_class.new(Strand.new(stack: [{}])) }
+
+  let(:sshable) { Sshable.create_with_id }
+  let(:vm_host) { VmHost.create(location: "hetzner-hel1") { _1.id = sshable.id } }
+  let(:boot_image) { BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vm_host.id, size_gib: 14) }
+
+  before do
+    allow(rbi).to receive(:boot_image).and_return(boot_image)
+    allow(boot_image).to receive(:vm_host).and_return(vm_host)
+    allow(vm_host).to receive(:sshable).and_return(sshable)
+  end
+
+  describe "#start" do
+    it "deactivates and hops to wait_volumes" do
+      expect { rbi.start }.to hop("wait_volumes")
+      expect(boot_image.reload.activated_at).to be_nil
+    end
+  end
+
+  describe "#wait_volumes" do
+    it "hops to remove_volumes if all volumes are removed" do
+      expect { rbi.wait_volumes }.to hop("remove")
+    end
+
+    it "waits for volumes to be removed" do
+      expect(boot_image).to receive(:vm_storage_volumes).and_return([1])
+      expect { rbi.wait_volumes }.to nap(30)
+    end
+  end
+
+  describe "#remove" do
+    it "removes image and pops" do
+      expect(sshable).to receive(:cmd).with("sudo rm -rf /var/storage/images/ubuntu-jammy-20220202.raw")
+      expect { rbi.remove }.to hop("update_database")
+    end
+
+    it "can remove unversioned image" do
+      boot_image.update(version: nil)
+      expect(sshable).to receive(:cmd).with("sudo rm -rf /var/storage/images/ubuntu-jammy.raw")
+      expect { rbi.remove }.to hop("update_database")
+    end
+  end
+
+  describe "#update_database" do
+    it "updates storage and destroys boot image" do
+      boot_image.id
+      storage_device = StorageDevice.create_with_id(vm_host_id: vm_host.id, name: "DEFAULT", available_storage_gib: 100, total_storage_gib: 200)
+      expect { rbi.update_database }.to exit({"msg" => "Boot image was removed."})
+      expect(BootImage[boot_image.id]).to be_nil
+      expect(storage_device.reload.available_storage_gib).to eq(114)
+    end
+  end
+end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Al do
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
       sd1 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
       sd2 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 12, total_storage_gib: 99)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
 
       expect(Al::Allocation.candidate_hosts(req))
         .to eq([{location: vmh.location,
@@ -123,7 +123,7 @@ RSpec.describe Al do
       sd1 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
       Vm.create_with_id(vm_host_id: vmh.id, family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: false, created_at: Time.now, unix_user: "", public_key: "", boot_image: "")
       Vm.create_with_id(vm_host_id: vmh.id, family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: false, created_at: Time.now, unix_user: "", public_key: "", boot_image: "ubuntu-jammy")
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
 
       expect(Al::Allocation.candidate_hosts(req))
         .to eq([{location: vmh.location,
@@ -151,8 +151,8 @@ RSpec.describe Al do
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
       Address.create_with_id(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
       req.host_filter = [vmh2.id]
       cand = Al::Allocation.candidate_hosts(req)
@@ -168,8 +168,8 @@ RSpec.describe Al do
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
       Address.create_with_id(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
       req.location_filter = ["loc1"]
       cand = Al::Allocation.candidate_hosts(req)
@@ -186,8 +186,8 @@ RSpec.describe Al do
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor2", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
       Address.create_with_id(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
       req.distinct_storage_devices = true
       cand = Al::Allocation.candidate_hosts(req)
@@ -202,8 +202,8 @@ RSpec.describe Al do
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
       Address.create_with_id(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
       cand = Al::Allocation.candidate_hosts(req)
       expect(cand.size).to eq(1)
@@ -218,8 +218,8 @@ RSpec.describe Al do
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
       Address.create_with_id(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
       cand = Al::Allocation.candidate_hosts(req)
       expect(cand.size).to eq(2)
@@ -235,8 +235,8 @@ RSpec.describe Al do
       PciDevice.create_with_id(vm_host_id: vmh2.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
       PciDevice.create_with_id(vm_host_id: vmh2.id, slot: "02:00.0", device_class: "0300", vendor: "vd", device: "dv2", numa_node: 0, iommu_group: 9)
       PciDevice.create_with_id(vm_host_id: vmh2.id, slot: "03:00.0", device_class: "1234", vendor: "vd", device: "dv3", numa_node: 0, iommu_group: 11)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now)
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
       req.gpu_enabled = true
       cand = Al::Allocation.candidate_hosts(req)
@@ -460,7 +460,7 @@ RSpec.describe Al do
 
     before do
       vmh = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", net6: "fd10:9b0b:6b4b:8fbb::/64", total_cores: 7, used_cores: 5, total_hugepages_1g: 18, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now)
+      BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create(vm_host_id: vmh.id, version: "v1", allocation_weight: 100) { _1.id = vmh.id }
@@ -621,8 +621,8 @@ RSpec.describe Al do
     it "allocates the latest active boot image for boot volumes" do
       vmh = VmHost.first
       BootImage.where(vm_host_id: vmh.id).update(activated_at: nil)
-      bi = BootImage.create_with_id(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "20230303", activated_at: Time.now)
-      BootImage.create_with_id(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "20240404", activated_at: nil)
+      bi = BootImage.create_with_id(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "20230303", activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "20240404", activated_at: nil, size_gib: 3)
       vm = create_vm
       described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => true}])
       expect(vm.vm_storage_volumes.first.boot_image_id).to eq(bi.id)


### PR DESCRIPTION
Once we install a newer version of an image, we might want to remove the older versions. This program enables that.

To use it, an operator is expect to run the following in the REPL:

```
> boot_image = BootImage[... id ...]
> st = boot_image.remove_boot_image
```

Then it'll wait for storage volumes using that boot image to drain and after that it'll remove the image files and db records.