### PR TITLE
Refactor IPv6 generator to support hosts with smaller than prefix 64

### DIFF
--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -34,7 +34,7 @@ class Prog::LearnNetwork < Prog::Base
     case JSON.parse(s)
     in [iface]
       case iface.fetch("addr_info").filter_map { |info|
-             if (local = info["local"]) && (prefixlen = info["prefixlen"]) && prefixlen <= 64
+             if (local = info["local"]) && (prefixlen = info["prefixlen"]) && prefixlen <= 68
                Ip6.new(local, prefixlen)
              end
            }

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe VmHost do
   end
 
   it "tries to get another random network if the proposal matches the reserved nework" do
-    expect(SecureRandom).to receive(:bytes).and_return("\0\0")
-    expect(SecureRandom).to receive(:bytes).and_call_original
+    expect(SecureRandom).to receive(:random_number).and_return(0)
+    expect(SecureRandom).to receive(:random_number).and_call_original
     expect(vh.ip6_random_vm_network.to_s).not_to eq(vh.ip6_reserved_network)
   end
 


### PR DESCRIPTION
Some providers place multiple hosts behind the same /64. Therefore, the
gateway is the same for both servers. We then try to use this whole /64
in Ubicloud and carve out /80 addresses to assign to VMs. However, when
a single server claims the full /64, we cannot add the second host. Here
in this PR we solve this problem by supporting subnets that are smaller
than /64. This way, when there are 2 servers behind the same subnet, we
can selectively assign a (let's say) /68 subnet to one and another /68
to another. After that, we can still carve out /80 addresses from those.

One important change we are making is in the ip6_random_vm_network. That
is needed because, the rounding up causes the `fail` line to be
triggered. Here is a scenario;
- The host_prefix is 68.
- The prefix is 79
With the rounding up, we produce a lower_bit that is 2 bytes. These 2
bytes before the /79, doesn't fit together with /68 prefix, we may reach
an address that is not directly a child address of the host_prefix.
Therefore, we keep that at minimum 1 and produce a number that is a
single byte which easily fits under the /68 prefix.