### PR TITLE
Add test_cases parameter to the E2E script

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,13 @@ name: E2E CI
 
 on:
   workflow_dispatch:
+    inputs:
+      test_cases:
+        description: 'Comma-separated list of test cases (vm)'
+        required: true
+        default: 'vm'
+        type: string
+
   schedule:
     - cron:  '0 */1 * * *'
 
@@ -53,7 +60,7 @@ jobs:
 
     - name: Add e2e script to Procfile
       run: |
-        echo "e2e: bin/ci" >> Procfile
+        echo "e2e: bin/ci --test-cases=${{ inputs.test_cases }}" >> Procfile
 
     - name: Run services
       env:

--- a/bin/ci
+++ b/bin/ci
@@ -9,13 +9,15 @@ def main(options)
   hetzner_server_st = Prog::Test::HetznerServer.assemble(vm_host_id: options[:vm_host_id])
   wait_until(hetzner_server_st, "wait")
 
-  encrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: true, test_reboot: true)
-  log(encrypted_vms_st, "storage_encrypted: true")
-  wait_until(encrypted_vms_st)
+  if options[:test_cases].include?("vm")
+    encrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: true, test_reboot: true)
+    log(encrypted_vms_st, "storage_encrypted: true")
+    wait_until(encrypted_vms_st)
 
-  unencrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: false, test_reboot: false)
-  log(unencrypted_vms_st, "storage_encrypted: false")
-  wait_until(unencrypted_vms_st)
+    unencrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: false, test_reboot: false)
+    log(unencrypted_vms_st, "storage_encrypted: false")
+    wait_until(unencrypted_vms_st)
+  end
 
   Semaphore.incr(hetzner_server_st.id, "destroy")
   wait_until(hetzner_server_st)
@@ -48,9 +50,10 @@ def log(st, msg)
   $stdout.write "#{Time.now.utc.iso8601} | #{st.id} | #{st.prog}.#{st.label} | #{msg} | #{resources}\n"
 end
 
-options = {}
+options = {test_cases: ["vm"]}
 OptionParser.new do |opts|
   opts.on("--vm-host-id VM_HOST_ID", "Use existing vm host") { |v| options[:vm_host_id] = (v.length == 26) ? VmHost.from_ubid(v).id : v }
+  opts.on("--test-cases TEST_CASES", Array, "List of test cases to run separated by comma") { |v| options[:test_cases] = v }
 end.parse!
 
 clover_freeze


### PR DESCRIPTION
We plan to introduce various E2E test cases such as github and postgres. However, running all these tests can be time-consuming. This parameter will allow us to run only selected test cases.

For our scheduled CI/CD pipeline runs, we can keep the `vm` test cases as the default. We may consider running all test cases by default in the future, depending on the test duration.