### PR TITLE
Remove implicit download in vm_setup, and add the option to download default image in HostNexus

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -105,6 +105,9 @@ module Config
   # Spdk
   override :spdk_version, "v23.09-ubi-0.2"
 
+  # Boot Images
+  override :default_boot_image_name, "ubuntu-jammy", string
+
   # Pagerduty
   optional :pagerduty_key, string, clear: true
   optional :pagerduty_log_link, string
@@ -128,9 +131,11 @@ module Config
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
   optional :ubicloud_images_blob_storage_certs, string
 
+  override :ubuntu_jammy_version, "20240319", string
   override :github_ubuntu_2204_version, "20240422.1.0", string
   override :github_ubuntu_2004_version, "20240422.1.0", string
   override :postgres_ubuntu_2204_version, "20240226.1.0", string
+  override :github_gpu_ubuntu_2204_version, "20240422.1.0", string
 
   # Allocator
   override :allocator_target_host_utilization, 0.55, float

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -68,7 +68,8 @@ class Prog::Test::HetznerServer < Prog::Test::Base
     vm_host = Prog::Vm::HostNexus.assemble(
       frame["hostname"],
       provider: "hetzner",
-      hetzner_server_identifier: frame["server_id"]
+      hetzner_server_identifier: frame["server_id"],
+      default_boot_images: [Config.default_boot_image_name]
     ).subject
     update_stack({"vm_host_id" => vm_host.id})
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -11,7 +11,7 @@ class Prog::Vm::Nexus < Prog::Base
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency
 
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
-    unix_user: "ubi", location: "hetzner-hel1", boot_image: "ubuntu-jammy",
+    unix_user: "ubi", location: "hetzner-hel1", boot_image: Config.default_boot_image_name,
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
     enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil,
     distinct_storage_devices: false, force_host_id: nil)

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -32,7 +32,6 @@ begin
   unix_user = params.fetch("unix_user")
   ssh_public_key = params.fetch("ssh_public_key")
   nics = params.fetch("nics").map { |args| VmSetup::Nic.new(*args) }.freeze
-  boot_image = params.fetch("boot_image")
   max_vcpus = params.fetch("max_vcpus")
   cpu_topology = params.fetch("cpu_topology")
   mem_gib = params.fetch("mem_gib")
@@ -54,7 +53,7 @@ when "prep"
   end
 
   vm_setup.prep(unix_user, ssh_public_key, nics, gua, ip4,
-    local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib,
+    local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 when "recreate-unpersisted"
   secrets = JSON.parse($stdin.read)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -11,7 +11,6 @@ require "uri"
 require_relative "vm_path"
 require_relative "cloud_hypervisor"
 require_relative "storage_volume"
-require_relative "boot_image"
 
 class VmSetup
   Nic = Struct.new(:net6, :net4, :tap, :mac)
@@ -44,10 +43,9 @@ class VmSetup
     @vp ||= VmPath.new(@vm_name)
   end
 
-  def prep(unix_user, public_key, nics, gua, ip4, local_ip4, boot_image, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
+  def prep(unix_user, public_key, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
     cloudinit(unix_user, public_key, nics, swap_size_bytes)
-    download_boot_image(boot_image)
     storage(storage_params, storage_secrets, true)
     hugepages(mem_gib)
     prepare_pci_devices(pci_devices)
@@ -476,10 +474,6 @@ EOS
       storage_volume.prep(key_wrapping_secrets) if prep
       storage_volume.start(key_wrapping_secrets)
     }
-  end
-
-  def download_boot_image(boot_image)
-    BootImage.new(boot_image, nil).download
   end
 
   # Unnecessary if host has this set before creating the netns, but

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -53,16 +53,6 @@ RSpec.describe VmSetup do
     end
   end
 
-  describe "#download_boot_image" do
-    it "can download ubuntu-jammy boot image" do
-      boot_image = instance_double(BootImage)
-      expect(BootImage).to receive(:new).with("ubuntu-jammy", nil).and_return(boot_image)
-      allow(Arch).to receive(:render).and_return("amd64")
-      expect(boot_image).to receive(:download)
-      vs.download_boot_image("ubuntu-jammy")
-    end
-  end
-
   describe "#purge_storage" do
     let(:vol_1_params) {
       {


### PR DESCRIPTION
### Remove image download from vm_setup
DownloadBootImage is now how we manage image downloads, so we can remove implicit image download from here.

See https://github.com/ubicloud/ubicloud/pull/1526

### Add the option to download the default images on host setup
This is mostly a convenience for developers who always provision VMs after setting up a host. Without this, they'll need to manually do an image download after host setup is done. To use this, one needs to do:

```
> HostNexus.assemble(...., default_boot_images: ["ubuntu-jammy", "github-ubuntu-2204"])
```