### PR TITLE
Allow to exclude hosts during allocation

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -14,10 +14,13 @@ class Prog::Vm::Nexus < Prog::Base
     unix_user: "ubi", location: "hetzner-hel1", boot_image: Config.default_boot_image_name,
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
     enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil,
-    distinct_storage_devices: false, force_host_id: nil)
+    distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [])
 
     unless (project = Project[project_id])
       fail "No existing project"
+    end
+    if exclude_host_ids.include?(force_host_id)
+      fail "Cannot force and exclude the same host"
     end
     Validation.validate_location(location)
     vm_size = Validation.validate_vm_size(size)
@@ -100,6 +103,7 @@ class Prog::Vm::Nexus < Prog::Base
           "swap_size_bytes" => swap_size_bytes,
           "distinct_storage_devices" => distinct_storage_devices,
           "force_host_id" => force_host_id,
+          "exclude_host_ids" => exclude_host_ids,
           "gpu_enabled" => vm_size.gpu
         }]
       ) { _1.id = vm.id }
@@ -188,6 +192,7 @@ class Prog::Vm::Nexus < Prog::Base
     queued_vms = Vm.join(:strand, id: :id).where(:location => vm.location, :arch => vm.arch, Sequel[:strand][:label] => "start")
     begin
       distinct_storage_devices = frame["distinct_storage_devices"] || false
+      host_exclusion_filter = frame["exclude_host_ids"] || []
       gpu_enabled = frame["gpu_enabled"] || false
       allocation_state_filter, location_filter, location_preference, host_filter =
         if frame["force_host_id"]
@@ -205,6 +210,7 @@ class Prog::Vm::Nexus < Prog::Base
         location_filter: location_filter,
         location_preference: location_preference,
         host_filter: host_filter,
+        host_exclusion_filter: host_exclusion_filter,
         gpu_enabled: gpu_enabled
       )
     rescue RuntimeError => ex

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -5,7 +5,7 @@ module Scheduling::Allocator
     @@target_host_utilization ||= Config.allocator_target_host_utilization
   end
 
-  def self.allocate(vm, storage_volumes, distinct_storage_devices: false, gpu_enabled: false, allocation_state_filter: ["accepting"], host_filter: [], location_filter: [], location_preference: [])
+  def self.allocate(vm, storage_volumes, distinct_storage_devices: false, gpu_enabled: false, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], location_filter: [], location_preference: [])
     request = Request.new(
       vm.id,
       vm.cores,
@@ -20,6 +20,7 @@ module Scheduling::Allocator
       vm.arch,
       allocation_state_filter,
       host_filter,
+      host_exclusion_filter,
       location_filter,
       location_preference
     )
@@ -31,7 +32,7 @@ module Scheduling::Allocator
   end
 
   Request = Struct.new(:vm_id, :cores, :mem_gib, :storage_gib, :storage_volumes, :boot_image, :distinct_storage_devices, :gpu_enabled, :ip4_enabled,
-    :target_host_utilization, :arch_filter, :allocation_state_filter, :host_filter, :location_filter, :location_preference)
+    :target_host_utilization, :arch_filter, :allocation_state_filter, :host_filter, :host_exclusion_filter, :location_filter, :location_preference)
 
   class Allocation
     attr_reader :score
@@ -92,6 +93,7 @@ module Scheduling::Allocator
       ds = ds.where { used_ipv4 < total_ipv4 } if request.ip4_enabled
       ds = ds.where { available_gpus > 0 } if request.gpu_enabled
       ds = ds.where(Sequel[:vm_host][:id] => request.host_filter) unless request.host_filter.empty?
+      ds = ds.exclude(Sequel[:vm_host][:id] => request.host_exclusion_filter) unless request.host_exclusion_filter.empty?
       ds = ds.where(location: request.location_filter) unless request.location_filter.empty?
       ds = ds.where(allocation_state: request.allocation_state_filter) unless request.allocation_state_filter.empty?
       ds.all

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -352,6 +352,7 @@ RSpec.describe Prog::Vm::Nexus do
         allocation_state_filter: ["accepting"],
         distinct_storage_devices: false,
         host_filter: [],
+        host_exclusion_filter: [],
         location_filter: ["hetzner-hel1"],
         location_preference: [],
         gpu_enabled: false
@@ -366,6 +367,7 @@ RSpec.describe Prog::Vm::Nexus do
         allocation_state_filter: ["accepting"],
         distinct_storage_devices: false,
         host_filter: [],
+        host_exclusion_filter: [],
         location_filter: [],
         location_preference: ["github-runners"],
         gpu_enabled: false
@@ -384,11 +386,38 @@ RSpec.describe Prog::Vm::Nexus do
         allocation_state_filter: [],
         distinct_storage_devices: false,
         host_filter: [:vm_host_id],
+        host_exclusion_filter: [],
         location_filter: [],
         location_preference: [],
         gpu_enabled: false
       )
       expect { nx.start }.to hop("create_unix_user")
+    end
+
+    it "can exclude hosts" do
+      allow(nx).to receive(:frame).and_return({
+        "exclude_host_ids" => [:vm_host_id, "another-vm-host-id"],
+        "storage_volumes" => :storage_volumes
+      })
+
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        host_exclusion_filter: [:vm_host_id, "another-vm-host-id"],
+        location_filter: ["hetzner-hel1"],
+        location_preference: [],
+        gpu_enabled: false
+      )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
+    it "fails if same host is forced and excluded" do
+      expect {
+        described_class.assemble("some_ssh_key", prj.id,
+          force_host_id: "some-vm-host-id", exclude_host_ids: ["some-vm-host-id"])
+      }.to raise_error RuntimeError, "Cannot force and exclude the same host"
     end
 
     it "requests distinct storage devices" do
@@ -404,6 +433,7 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: true,
         host_filter: [],
         location_filter: ["hetzner-hel1"],
+        host_exclusion_filter: [],
         location_preference: [],
         gpu_enabled: false
       )
@@ -421,6 +451,7 @@ RSpec.describe Prog::Vm::Nexus do
         allocation_state_filter: ["accepting"],
         distinct_storage_devices: false,
         host_filter: [],
+        host_exclusion_filter: [],
         location_filter: ["hetzner-hel1"],
         location_preference: [],
         gpu_enabled: true


### PR DESCRIPTION
When assembling a VM, a list of hosts can be provided, which the allocator will not consider as valid candidates for that VM. This can be leveraged by Postgres to guarantee that a standby is placed onto a different host than the primary.