### PR TITLE
Update exit message for image download.

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -112,6 +112,6 @@ class Prog::DownloadBootImage < Prog::Base
       name: image_name,
       version: version
     ).update(activated_at: Time.now)
-    pop "image=#{image_name} version=#{version} downloaded"
+    pop({"msg" => "image downloaded", "name" => image_name, "version" => version})
   end
 end

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dataset).to receive(:update) do |args|
         expect(args[:activated_at]).to be <= Time.now
       end
-      expect { dbi.activate_boot_image }.to exit({"msg" => "image=my-image version=20230303 downloaded"})
+      expect { dbi.activate_boot_image }.to exit({"msg" => "image downloaded", "name" => "my-image", "version" => "20230303"})
     end
   end
 end


### PR DESCRIPTION
Previously we embedded name and version in the exit string, but instead we can just use separate fields for them.