### PR TITLE
Get the URL for ubuntu and almalinux images in Prog::DownloadBootImage

### DIFF
--- a/rhizome/host/bin/download-boot-image
+++ b/rhizome/host/bin/download-boot-image
@@ -13,9 +13,16 @@ unless (boot_image = params_json["image_name"])
   exit 1
 end
 
-# YYY: version will be mandatory in the future
-version = params_json["version"]
-url = params_json["url"]
+unless (version = params_json["version"])
+  puts "need version in params"
+  exit 1
+end
+
+unless (url = params_json["url"])
+  puts "need url in params"
+  exit 1
+end
+
 sha256sum = params_json["sha256sum"]
 certs = params_json["certs"]
 

--- a/rhizome/host/lib/boot_image.rb
+++ b/rhizome/host/lib/boot_image.rb
@@ -12,6 +12,9 @@ class BootImage
   end
 
   def image_path
+    # YYY: Support for unversioned images is still required in StorageVolume
+    # code when we want to recreate storage. We can remove this check once we
+    # have removed all unversioned images from production.
     @image_path ||= if @version.nil?
       "#{image_root}/#{@name}.raw"
     else
@@ -23,12 +26,9 @@ class BootImage
     "/var/storage/images"
   end
 
-  def download(url: nil, ca_path: nil, sha256sum: nil)
+  def download(url:, ca_path: nil, sha256sum: nil)
     return if File.exist?(image_path)
 
-    url ||= get_download_url
-
-    fail "Must provide url for #{@name} image" if url.nil?
     FileUtils.mkdir_p image_root
 
     # If image URL has query parameter such as SAS token, File.extname returns
@@ -86,25 +86,5 @@ class BootImage
       # i.e. no partial images will be passed to qemu-image.
       r "qemu-img convert -p -f #{initial_format.shellescape} -O raw #{temp_path.shellescape} #{image_path.shellescape}"
     end
-  end
-
-  # YYY: In future all images will have explicit versions and nil won't be
-  # allowed, so this method will be removed.
-  def version_to_fetch
-    @version || case @name
-                when "ubuntu-jammy"
-                  "20240319"
-                when "almalinux-9.3"
-                  "20231113"
-                end
-  end
-
-  def get_download_url
-    version = version_to_fetch
-    urls = {
-      "ubuntu-jammy" => "https://cloud-images.ubuntu.com/releases/jammy/release-#{version}/ubuntu-22.04-server-cloudimg-#{Arch.render(x64: "amd64")}.img",
-      "almalinux-9.3" => Arch.render(x64: "x86_64", arm64: "aarch64").yield_self { "https://repo.almalinux.org/almalinux/9/cloud/#{_1}/images/AlmaLinux-9-GenericCloud-9.3-#{version}.#{_1}.qcow2" }
-    }
-    urls.fetch(@name)
   end
 end


### PR DESCRIPTION
### Get the URL for ubuntu and almalinux images in Prog::DownloadBootImage

For all other images we created the URL in the clover side and passed it
as an argument to rhizome. It makes sense if we do the same for ubuntu
and almalinux too, so we have the entire URL logic in one place.

### Enforce URL and Version in download-boot-image.

We now send URL and version for all images, so we can enforce it in the
rhizome side