### PR TITLE
Do not select unversioned image if there is an active versioned image

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -253,7 +253,7 @@ module Scheduling::Allocator
       boot_image = BootImage.where(
         vm_host_id: vm_host.id,
         name: boot_image_name
-      ).exclude(activated_at: nil).order_by(Sequel.desc(:version)).first
+      ).exclude(activated_at: nil).order_by(Sequel.desc(:version, nulls: :last)).first
 
       boot_image.id
     end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -622,6 +622,7 @@ RSpec.describe Al do
       vmh = VmHost.first
       BootImage.where(vm_host_id: vmh.id).update(activated_at: nil)
       bi = BootImage.create_with_id(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "20230303", activated_at: Time.now, size_gib: 3)
+      BootImage.create_with_id(vm_host_id: vmh.id, name: "ubuntu-jammy", version: nil, activated_at: Time.now, size_gib: 3)
       BootImage.create_with_id(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "20240404", activated_at: nil, size_gib: 3)
       vm = create_vm
       described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => true}])


### PR DESCRIPTION
When ordering by version, PostgreSQL defaults to returning NULLs first. This implies that even if we download the most recent version of an image, an available unversioned image will be chosen first. However, as we're beginning to disallow unversioned images, we can consider them outdated and avoid selecting them if an active versioned image exists.