### PR TITLE
Make GPU instance not selectable to regular VM customers

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -60,9 +60,10 @@ module Validation
     fail ValidationFailed.new({location: msg}) unless available_pg_locs.include?(location)
   end
 
-  def self.validate_vm_size(size)
-    unless (vm_size = Option::VmSizes.find { _1.name == size })
-      fail ValidationFailed.new({size: "\"#{size}\" is not a valid virtual machine size. Available sizes: #{Option::VmSizes.map(&:name)}"})
+  def self.validate_vm_size(size, only_visible: false)
+    available_vm_sizes = Option::VmSizes.select { !only_visible || _1.visible }
+    unless (vm_size = available_vm_sizes.find { _1.name == size })
+      fail ValidationFailed.new({size: "\"#{size}\" is not a valid virtual machine size. Available sizes: #{available_vm_sizes.map(&:name)}"})
     end
     vm_size
   end

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -42,6 +42,12 @@ class CloverApi
           Validation.validate_boot_image(request_body_params["boot_image"])
         end
 
+        # Same as above, moved the size validation here to not allow users to
+        # pass gpu instance while creating a VM.
+        if request_body_params["size"]
+          Validation.validate_vm_size(request_body_params["size"], only_visible: true)
+        end
+
         if request_body_params["private_subnet_id"]
           ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"])
           unless ps && ps.location == @location

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -17,6 +17,7 @@ class CloverWeb
       ps_id = r.params["private-subnet-id"].empty? ? nil : UBID.parse(r.params["private-subnet-id"]).to_uuid
       Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps_id)
 
+      Validation.validate_boot_image(r.params["boot-image"])
       Validation.validate_vm_size(r.params["size"], only_visible: true)
       location = LocationNameConverter.to_internal_name(r.params["location"])
       st = Prog::Vm::Nexus.assemble(

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -17,6 +17,7 @@ class CloverWeb
       ps_id = r.params["private-subnet-id"].empty? ? nil : UBID.parse(r.params["private-subnet-id"]).to_uuid
       Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps_id)
 
+      Validation.validate_vm_size(r.params["size"], only_visible: true)
       location = LocationNameConverter.to_internal_name(r.params["location"])
       st = Prog::Vm::Nexus.assemble(
         r.params["public-key"],

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -186,6 +186,29 @@ RSpec.describe Clover, "vm" do
         expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\"]")
       end
 
+      it "invalid vm size" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          size: "standard-gpu-6",
+          enable_ip4: true
+        }.to_json
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body)["error"]["details"]["size"]).to eq("\"standard-gpu-6\" is not a valid virtual machine size. Available sizes: [\"standard-2\", \"standard-4\", \"standard-8\", \"standard-16\"]")
+      end
+
+      it "success without vm_size" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          boot_image: "ubuntu-jammy",
+          enable_ip4: true
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+      end
+
       it "invalid ps id" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",


### PR DESCRIPTION
## Make GPU instance not selectable to regular VM customers via APIs 
The APIs allow all vm size family to be selectable. In the web, we don't
visualize them anyway, however, in the APIs, they were selectable. With
this commit, we perform size validation in the API and only allow
visible vm_sizes to be picked.

## Disallow gpu instance in web route


## Validate boot-image in web
Without this check, customers can edit the parameter via inspect element
and use postgres base image as a base image for a VM. We do the same for
APIs.