### PR TITLE
Reinstate AlmaLinux images with a different versioning strategy

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -132,6 +132,8 @@ module Config
   optional :ubicloud_images_blob_storage_certs, string
 
   override :ubuntu_jammy_version, "20240319", string
+  override :almalinux_9_version, "9.4-20240507", string
+  override :almalinux_8_version, "8.9-20231128", string
   override :github_ubuntu_2204_version, "20240422.1.0", string
   override :github_ubuntu_2004_version, "20240422.1.0", string
   override :postgres_ubuntu_2204_version, "20240226.1.0", string

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -39,7 +39,9 @@ module Option
 
   BootImage = Struct.new(:name, :display_name)
   BootImages = [
-    ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"]
+    ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"],
+    ["almalinux-9", "AlmaLinux 9"],
+    ["almalinux-8", "AlmaLinux 8"]
   ].map { |args| BootImage.new(*args) }.freeze
 
   VmSize = Struct.new(:name, :family, :vcpu, :memory, :min_storage_size_gib, :max_storage_size_gib, :storage_size_step_gib, :visible, :gpu) do

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -21,6 +21,10 @@ class Prog::DownloadBootImage < Prog::Base
     case image_name
     when "ubuntu-jammy"
       Config.ubuntu_jammy_version
+    when "almalinux-9"
+      Config.almalinux_9_version
+    when "almalinux-8"
+      Config.almalinux_8_version
     when "github-ubuntu-2204"
       Config.github_ubuntu_2204_version
     when "github-ubuntu-2004"
@@ -43,9 +47,12 @@ class Prog::DownloadBootImage < Prog::Base
       elsif image_name == "ubuntu-jammy"
         arch = (vm_host.arch == "x64") ? "amd64" : "arm64"
         "https://cloud-images.ubuntu.com/releases/jammy/release-#{version}/ubuntu-22.04-server-cloudimg-#{arch}.img"
-      elsif image_name == "almalinux-9.3"
+      elsif image_name == "almalinux-8"
+        fail "Only x64 is supported for almalinux-8" unless vm_host.arch == "x64"
+        "https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-#{version}.x86_64.qcow2"
+      elsif image_name == "almalinux-9"
         arch = (vm_host.arch == "x64") ? "x86_64" : "aarch64"
-        "https://vault.almalinux.org/9.3/cloud/#{arch}/images/AlmaLinux-9-GenericCloud-9.3-#{version}.#{arch}.qcow2"
+        "https://repo.almalinux.org/almalinux/9/cloud/#{arch}/images/AlmaLinux-9-GenericCloud-#{version}.#{arch}.qcow2"
       else
         fail "Unknown image name: #{image_name}"
       end
@@ -55,8 +62,9 @@ class Prog::DownloadBootImage < Prog::Base
     hashes = {
       ["ubuntu-jammy", "x64", "20240319"] => "304983616fcba6ee1452e9f38993d7d3b8a90e1eb65fb0054d672ce23294d812",
       ["ubuntu-jammy", "arm64", "20240319"] => "40ea1181447b9395fa03f6f2c405482fe532a348cc46fbb876effcfbbb35336f",
-      ["almalinux-9.3", "x64", "20231113"] => "6bbd060c971fd827a544c7e5e991a7d9e44460a449d2d058a0bb1290dec5a114",
-      ["almalinux-9.3", "arm64", "20231113"] => "a064715bc755346d5a8e1a4c6b1b7abffe4de03f1b0584942d5483ed32aafd67",
+      ["almalinux-8", "x64", "8.9-20231128"] => "a1686bc537bce699b512e3233666f5b8f69ed797ff1ce0af52c17fdc52942621",
+      ["almalinux-9", "x64", "9.4-20240507"] => "bff0885c804c01fff8aac4b70c9ca4f04e8c119f9ee102043838f33e06f58390",
+      ["almalinux-9", "arm64", "9.4-20240507"] => "75b2e68f6aaa41c039274595ff15968201b7201a7f2f03b109af691f2d3687a1",
       ["github-ubuntu-2204", "x64", "20240422.1.0"] => "8b1b7af6941ce7b8b93d0c20af712e04e8ceedbd673b29fd4fba3406a3ba133c",
       ["github-ubuntu-2204", "arm64", "20240422.1.0"] => "e14a7176070af022ace0e057a93beaa420602fa331dc67353ea4ce2459344265",
       ["github-ubuntu-2004", "x64", "20240422.1.0"] => "cf4f3bd4fc43de5804eac32e810101fcfe078aafeb46cb5a34fff8f8f76b360d",

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -257,6 +257,7 @@ RSpec.describe Validation do
     describe "#validate_boot_image" do
       it "valid boot image" do
         expect { described_class.validate_boot_image("ubuntu-jammy") }.not_to raise_error
+        expect { described_class.validate_boot_image("almalinux-9") }.not_to raise_error
       end
 
       it "invalid boot image" do

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Prog::DownloadBootImage do
   describe "#default_boot_image_version" do
     it "returns the version for the default image" do
       expect(dbi.default_boot_image_version("ubuntu-jammy")).to eq(Config.ubuntu_jammy_version)
+      expect(dbi.default_boot_image_version("almalinux-9")).to eq(Config.almalinux_9_version)
+      expect(dbi.default_boot_image_version("almalinux-8")).to eq(Config.almalinux_8_version)
       expect(dbi.default_boot_image_version("github-ubuntu-2204")).to eq(Config.github_ubuntu_2204_version)
       expect(dbi.default_boot_image_version("github-ubuntu-2004")).to eq(Config.github_ubuntu_2004_version)
       expect(dbi.default_boot_image_version("github-gpu-ubuntu-2204")).to eq(Config.github_gpu_ubuntu_2204_version)
@@ -72,15 +74,27 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dbi.url).to eq("https://cloud-images.ubuntu.com/releases/jammy/release-20240319/ubuntu-22.04-server-cloudimg-arm64.img")
     end
 
-    it "returns URL for x64 almalinux-9.3 image" do
-      expect(dbi).to receive(:frame).and_return({"image_name" => "almalinux-9.3", "version" => "20231113"}).at_least(:once)
-      expect(dbi.url).to eq("https://vault.almalinux.org/9.3/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.3-20231113.x86_64.qcow2")
+    it "returns URL for x64 almalinux-9 image" do
+      expect(dbi).to receive(:frame).and_return({"image_name" => "almalinux-9", "version" => "9.4-20240507"}).at_least(:once)
+      expect(dbi.url).to eq("https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.4-20240507.x86_64.qcow2")
     end
 
-    it "returns URL for arm64 almalinux-9.3 image" do
-      expect(dbi).to receive(:frame).and_return({"image_name" => "almalinux-9.3", "version" => "20231113"}).at_least(:once)
+    it "returns URL for x64 almalinux-8 image" do
+      expect(dbi).to receive(:frame).and_return({"image_name" => "almalinux-8", "version" => "8.9-20231128"}).at_least(:once)
+      expect(dbi.url).to eq("https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.9-20231128.x86_64.qcow2")
+    end
+
+    it "crashes when asked for almalinux-8 on arm64" do
+      expect(dbi).to receive(:frame).and_return({"image_name" => "almalinux-8", "version" => "8.9-20231128"}).at_least(:once)
       vm_host.update(arch: "arm64")
-      expect(dbi.url).to eq("https://vault.almalinux.org/9.3/cloud/aarch64/images/AlmaLinux-9-GenericCloud-9.3-20231113.aarch64.qcow2")
+      expect { dbi.url }.to raise_error RuntimeError, "Only x64 is supported for almalinux-8"
+    end
+
+    it "returns URL for arm64 almalinux-9 image" do
+      expect(dbi).to receive(:frame).and_return({"image_name" => "almalinux-9", "version" => "9.4-20240507"}).at_least(:once)
+      vm_host.update(arch: "arm64")
+
+      expect(dbi.url).to eq("https://repo.almalinux.org/almalinux/9/cloud/aarch64/images/AlmaLinux-9-GenericCloud-9.4-20240507.aarch64.qcow2")
     end
 
     it "fails if image name is unknown" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\", \"almalinux-9\"]")
+        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\", \"almalinux-9\", \"almalinux-8\"]")
       end
 
       it "invalid vm size" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\"]")
+        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\", \"almalinux-9\"]")
       end
 
       it "invalid vm size" do


### PR DESCRIPTION
This is sort of a revert of
69bf5c861656dc4423c5772ffd1747651661f307. But it also modifies the versioning to be less specific: AlmaLinux is now requested only by its major version, e.g. "9", not "9.3"

This method is the most like Ubuntu even though it includes one less version number component.  Ubuntu has releases like "22.04.3", where we never displayed the last version component.  The "3" in AlmaLinux "9.3" is a similar minor version that we don't need to display while remaining consistent with Ubuntu.

That I included the second digit of AlmaLinux before was a mistake I made in the most ancient era: March 2023, whereas the entire code base began in January 2023, adc109d2ea570a170e71e339304c502b7d03c798.