### PR TITLE
Firmware download improvement

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -188,6 +188,14 @@ class VmHost < Sequel::Model
     Strand.create_with_id(schedule: Time.now, prog: "DownloadBootImage", label: "start", stack: [{subject_id: id, image_name: image_name, custom_url: custom_url, version: version}])
   end
 
+  # Introduced for downloading firmware via REPL.
+  def download_firmware(version_x64: nil, version_arm64: nil, sha256_x64: nil, sha256_arm64: nil)
+    version, sha256 = (arch == "x64") ? [version_x64, sha256_x64] : [version_arm64, sha256_arm64]
+    raise ArgumentError, "No version provided" if version.nil?
+    raise ArgumentError, "No SHA-256 digest provided" if sha256.nil?
+    Strand.create_with_id(schedule: Time.now, prog: "DownloadFirmware", label: "start", stack: [{subject_id: id, version: version, sha256: sha256}])
+  end
+
   def hetznerify(server_id)
     DB.transaction do
       HetznerHost.create(server_identifier: server_id) { _1.id = id }

--- a/prog/download_firmware.rb
+++ b/prog/download_firmware.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Prog::DownloadFirmware < Prog::Base
+  subject_is :sshable, :vm_host
+
+  def version
+    @version ||= frame.fetch("version")
+  end
+
+  def sha256
+    @sha256 ||= frame.fetch("sha256")
+  end
+
+  label def start
+    fail "Version is required" if version.nil?
+    fail "SHA-256 digest is required" if sha256.nil?
+    hop_download
+  end
+
+  label def download
+    q_daemon_name = "download_firmware_#{version}".shellescape
+    case sshable.cmd("common/bin/daemonizer --check #{q_daemon_name}")
+    when "Succeeded"
+      sshable.cmd("common/bin/daemonizer --clean #{q_daemon_name}")
+      pop({"msg" => "firmware downloaded", "version" => version, "sha256" => sha256})
+    when "NotStarted"
+      sshable.cmd("common/bin/daemonizer 'host/bin/download-firmware #{version} #{sha256}' #{q_daemon_name}")
+    when "Failed"
+      fail "Failed to download firmware version #{version} on #{vm_host}"
+    end
+
+    nap 15
+  end
+end

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -57,11 +57,16 @@ def sync_parent_dir(f)
   }
 end
 
-def safe_write_to_file(filename, content)
+def safe_write_to_file(filename, content = nil)
+  raise ArgumentError, "must provide either content or block" if (content.nil? && !block_given?) || (!content.nil? && block_given?)
   temp_filename = filename + ".tmp"
   File.open(temp_filename, File::RDWR | File::CREAT) do |f|
     f.flock(File::LOCK_EX)
-    f.puts(content)
+    if block_given?
+      yield f
+    else
+      f.puts(content)
+    end
     File.rename(temp_filename, filename)
   end
 end

--- a/rhizome/host/bin/download-firmware
+++ b/rhizome/host/bin/download-firmware
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "../lib/cloud_hypervisor"
+
+unless (version = ARGV.shift)
+  puts "expected version as argument"
+  exit 1
+end
+
+unless (sha256 = ARGV.shift)
+  puts "expected SHA-256 digest as argument"
+  exit 1
+end
+
+CloudHypervisor::FirmwareClass.new(version, sha256).download

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -68,6 +68,7 @@ FileUtils.mkdir_p(fw_dir)
 FileUtils.cd fw_dir do
   r "curl -L3 -o #{CloudHypervisor::FIRMWARE.name.shellescape} #{CloudHypervisor::FIRMWARE.url.shellescape}"
 end
+CloudHypervisor::NEW_FIRMWARE.download
 
 # Err towards listing ('l') and not restarting services by default,
 # otherwise a stray keystroke when using "apt install" for unrelated

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require_relative "../../common/lib/arch"
 
 module CloudHypervisor
-  FirmwareClass = Struct.new(:version, :name) {
+  FirmwareClassLegacy = Struct.new(:version, :name) {
     def url
       "https://github.com/fdr/edk2/releases/download/#{version}/#{name}"
     end
@@ -14,12 +15,44 @@ module CloudHypervisor
   }
 
   FIRMWARE = if Arch.arm64?
-    FirmwareClass.new("edk2-stable202308", "CLOUDHV_EFI.fd")
+    FirmwareClassLegacy.new("edk2-stable202308", "CLOUDHV_EFI.fd")
   elsif Arch.x64?
-    FirmwareClass.new("edk2-stable202302", "CLOUDHV.fd")
+    FirmwareClassLegacy.new("edk2-stable202302", "CLOUDHV.fd")
   else
     fail "BUG: unexpected architecture"
   end
+
+  FirmwareClass = Struct.new(:version, :sha256) {
+    def url
+      "https://github.com/ubicloud/build-edk2-firmware/releases/download/edk2-stable#{version}-#{Arch.sym}/CLOUDHV-#{Arch.sym}.fd"
+    end
+
+    def firmware_root
+      "/opt/fw"
+    end
+
+    def path
+      "#{firmware_root}/CLOUDHV-#{version}.fd"
+    end
+
+    def download
+      return if File.exist?(path)
+      FileUtils.mkdir_p(firmware_root)
+      sha256_curl = nil
+      safe_write_to_file(path) do |f|
+        sha256_curl = curl_firmware(f)
+        fail "Invalid SHA-256 digest" unless sha256 == sha256_curl
+      end
+      sha256_curl
+    end
+
+    def curl_firmware(file)
+      r("bash -c 'curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{file.path.shellescape}'").split(" ").last
+    end
+  }
+
+  NEW_FIRMWARE = FirmwareClass.new(Arch.render(x64: "202402", arm64: "202211"),
+    Arch.render(x64: "2cf0e7bd7164cbe1d353ccfe176f41e57b8036492eb7b0a94f9b04c0c973764d", arm64: "3e34934478870a2ce67eb76bef6f9f38eb6a8b16849115b64473f05c2ccb922a"))
 
   VersionClass = Struct.new(:version) {
     def ch_remote_url

--- a/rhizome/host/spec/cloud_hypervisor_spec.rb
+++ b/rhizome/host/spec/cloud_hypervisor_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../lib/cloud_hypervisor"
+
+RSpec.describe CloudHypervisor do
+  subject(:fw) { CloudHypervisor::FirmwareClass.new("202402", "thesha") }
+
+  describe "#download" do
+    it "can use an existing firmware" do
+      expect(File).to receive(:exist?).with("/opt/fw/CLOUDHV-202402.fd").and_return(true)
+      expect(fw).not_to receive(:curl_firmware)
+      fw.download
+    end
+
+    it "can download a firmware" do
+      expect(File).to receive(:exist?).with("/opt/fw/CLOUDHV-202402.fd").and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with("/opt/fw")
+      f = instance_double(File)
+      expect(fw).to receive(:safe_write_to_file).with("/opt/fw/CLOUDHV-202402.fd").and_yield(f)
+      expect(fw).to receive(:curl_firmware).with(f).and_return("thesha")
+      fw.download
+    end
+
+    it "fails if sha is incorrect" do
+      expect(File).to receive(:exist?).with("/opt/fw/CLOUDHV-202402.fd").and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with("/opt/fw")
+      f = instance_double(File)
+      expect(fw).to receive(:safe_write_to_file).with("/opt/fw/CLOUDHV-202402.fd").and_yield(f)
+      expect(fw).to receive(:curl_firmware).with(f).and_return("anothersha")
+      expect { fw.download }.to raise_error("Invalid SHA-256 digest")
+    end
+  end
+end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -82,6 +82,35 @@ RSpec.describe VmHost do
     vh.download_boot_image("my-image", custom_url: "https://example.com/my-image.raw", version: "20230303")
   end
 
+  it "has a shortcut to download a new firmware for x64" do
+    vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
+    vh.arch = "x64"
+    expect(Strand).to receive(:create) do |args|
+      expect(args[:prog]).to eq("DownloadFirmware")
+      expect(args[:stack]).to eq([subject_id: vh.id, version: "202405", sha256: "sha-1"])
+    end
+    vh.download_firmware(version_x64: "202405", sha256_x64: "sha-1")
+  end
+
+  it "has a shortcut to download a new firmware for arm64" do
+    vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
+    vh.arch = "arm64"
+    expect(Strand).to receive(:create) do |args|
+      expect(args[:prog]).to eq("DownloadFirmware")
+      expect(args[:stack]).to eq([subject_id: vh.id, version: "202406", sha256: "sha-2"])
+    end
+    vh.download_firmware(version_arm64: "202406", sha256_arm64: "sha-2")
+  end
+
+  it "requires version and sha256 to download a new firmware" do
+    vh.arch = "x64"
+    expect { vh.download_firmware(sha256_x64: "thesha") }.to raise_error(ArgumentError, "No version provided")
+    expect { vh.download_firmware(version_x64: "202405") }.to raise_error(ArgumentError, "No SHA-256 digest provided")
+    vh.arch = "arm64"
+    expect { vh.download_firmware(sha256_arm64: "thesha") }.to raise_error(ArgumentError, "No version provided")
+    expect { vh.download_firmware(version_arm64: "202406") }.to raise_error(ArgumentError, "No SHA-256 digest provided")
+  end
+
   it "assigned_subnets returns the assigned subnets" do
     expect(vh).to receive(:assigned_subnets).and_return([address])
     expect(vh).to receive(:vm_addresses).and_return([])

--- a/spec/prog/download_firmware_spec.rb
+++ b/spec/prog/download_firmware_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::DownloadFirmware do
+  subject(:df) { described_class.new(Strand.new(stack: [{"version" => "202405", "sha256" => "thesha"}])) }
+
+  let(:sshable) { Sshable.create_with_id }
+  let(:vm_host) { VmHost.create(location: "hetzner-hel1", arch: "x64") { _1.id = sshable.id } }
+
+  before do
+    allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)
+  end
+
+  describe "#start" do
+    it "hops to download" do
+      expect { df.start }.to hop("download")
+    end
+
+    it "fails if version is nil" do
+      df = described_class.new(Strand.new(stack: [{"version" => nil, "sha256" => "thesha"}]))
+      expect { df.start }.to raise_error RuntimeError, "Version is required"
+    end
+
+    it "fails if sha256 is nil" do
+      df = described_class.new(Strand.new(stack: [{"version" => "202405", "sha256" => nil}]))
+      expect { df.start }.to raise_error RuntimeError, "SHA-256 digest is required"
+    end
+  end
+
+  describe "#download" do
+    it "starts to download firmware if not started" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_firmware_202405").and_return("NotStarted")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-firmware 202405 thesha' download_firmware_202405")
+      expect { df.download }.to nap(15)
+    end
+
+    it "waits for manual intervention if failed" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_firmware_202405").and_return("Failed")
+      expect { df.download }.to raise_error RuntimeError, "Failed to download firmware version 202405 on VmHost[#{vm_host.ubid}]"
+    end
+
+    it "waits for the download to complete" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_firmware_202405").and_return("InProgess")
+      expect { df.download }.to nap(15)
+    end
+
+    it "exits if succeeded" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_firmware_202405").and_return("Succeeded")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --clean download_firmware_202405")
+      expect { df.download }.to exit({"msg" => "firmware downloaded", "version" => "202405", "sha256" => "thesha"})
+    end
+  end
+end


### PR DESCRIPTION
With this PR, we add the ability to download firmware from https://github.com/ubicloud/build-edk2-firmware and store it on the host in `/opt/fw` as files named 'CLOUDHV-`version`.fd'. New hosts will start to download the firmware (in addition to legacy firmware) during `prep_host`. The PR also adds capabilities to download specified versions to hosts on demand. With this, new firmware versions can be deployed to and enabled for all hosts by performing these steps:

1. Execute new method `download_firmware` on each host to download the new version
2. Update the version in `rhizome/host/lib/cloud_hypervisor.rb` to the new version

In order to switch from legacy to new firmware, instead of step 2, we need to rename `FIRMWARE` to `FIRMWARE_LEGACY` and `NEW_FIRMWARE` to `FIRMWARE`, to enable the new firmware for VMs.