### PR TITLE
Fix E2E test schedule

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Add e2e script to Procfile
       run: |
-        echo "e2e: bin/ci --test-cases=${{ inputs.test_cases }}" >> Procfile
+        echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm' || inputs.test_cases }}" >> Procfile
 
     - name: Run services
       env:


### PR DESCRIPTION
I assumed that the inputs would have default values when the event isn't
'workflow_dispatch' which is manually triggered. However, it appears
that the inputs are null when the event isn't 'workflow_dispatch'. As a
result, the 'test_cases' are null for scheduled E2E tests.
