### PR TITLE
Decouple VM compute and storage

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,6 +2,7 @@ $(function() {
   setupPolicyEditor();
   setupLocationBasedPrices();
   setupLocationBasedOptions();
+  setupInstanceSizeBasedOptions();
   setupAutoRefresh();
   setupPrint();
   setupDatePicker();
@@ -186,10 +187,12 @@ $("input[name=location]").on("change", function (event) {
   setupLocationBasedPrices();
   setupLocationBasedPostgresHaPrices();
   setupLocationBasedOptions();
+  setupInstanceSizeBasedOptions();
 });
 
 $("input[name=size]").on("change", function (event) {
   setupLocationBasedPostgresHaPrices();
+  setupInstanceSizeBasedOptions();
 });
 
 function setupLocationBasedPrices() {
@@ -241,6 +244,27 @@ function setupLocationBasedOptions() {
   if (selectedLocation) {
     $(`.location-based-option.${selectedLocation}`).show().prop('disabled', false);
   }
+}
+
+function setupInstanceSizeBasedOptions() {
+  $(".instance-size-based-option").each(function() {
+    let type = $(this).attr("type")
+    if(type == "range" && $(this).attr("name") == "storage-size"){
+      min_storage_size_gib = $("input[name=size]:checked").data("min-storage-size-gib");
+      max_storage_size_gib = $("input[name=size]:checked").data("max-storage-size-gib");
+      storage_size_step_gib = $("input[name=size]:checked").data("storage-size-step-gib");
+
+      $(this).attr("min", min_storage_size_gib);
+      $(this).attr("max", max_storage_size_gib);
+      $(this).attr("step", storage_size_step_gib);
+
+      let monthlyPrice = $("input[name=location]:checked").data("details")["VmStorage"]["standard"]["monthly"]
+      $(this).next().find(".absolute").each(function(idx) {
+        storage_amount = min_storage_size_gib + idx * storage_size_step_gib;
+        $(this).text(storage_amount + "GB +$" + (storage_amount * monthlyPrice).toFixed(2));
+      });
+    }
+  });
 }
 
 function setupAutoRefresh() {

--- a/config/billing_rates.yml
+++ b/config/billing_rates.yml
@@ -1,13 +1,19 @@
-- { id: 139d9a67-8182-8578-a303-235cabd5161c, resource_type: VmCores,                 resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
-- { id: 08c502f7-df5d-8978-9896-feafa0ec5c40, resource_type: VmCores,                 resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
-- { id: 2acc2bbf-d451-49c6-93de-db8d15311042, resource_type: VmCores,                 resource_family: standard,        location: github-runners, unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
-- { id: 8cc76122-1463-8178-a89a-3b74434d1943, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0008500000, active_from: 2023-01-01T00:00:00Z }
-- { id: 0f189c1f-b182-8978-bc1c-d1e0412718c3, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0008500000, active_from: 2023-01-01T00:00:00Z }
-- { id: 8c82e087-10aa-8d78-876f-88afcc162d4c, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-fsn1,   unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
-- { id: 80c193bc-528a-8d78-9377-17523b162c58, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-hel1,   unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
-- { id: c1eb36d9-6b46-8578-869a-92e64646b547, resource_type: VmCores,                 resource_family: standard-gpu,    location: github-runners, unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
-- { id: b44a8854-f7fb-8578-b1b8-f38b218b52e3, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-wdc02, unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
-- { id: 88dcb876-0a21-8978-bc58-558b1755ad29, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-dal13, unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+# Active billing rates
+- { id: 8a890156-96cb-4087-878c-51dc4ed2ad8a, resource_type: VmCores,                 resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0005525180, active_from: 2024-05-27T00:00:00Z }
+- { id: 0a2eb7b7-dfc7-4232-9b75-7e162020dc4c, resource_type: VmCores,                 resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0005257320, active_from: 2024-05-27T00:00:00Z }
+- { id: a63fc107-176f-41e6-baf6-a1399446f616, resource_type: VmCores,                 resource_family: standard,        location: github-runners, unit_price: 0.0005257320, active_from: 2024-05-27T00:00:00Z }
+- { id: 724069e2-fa28-46d9-918c-666d1fbe80ba, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0007725000, active_from: 2024-05-27T00:00:00Z }
+- { id: 534e85b6-2ba2-44c7-b799-8a1b99f8cd50, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0007725000, active_from: 2024-05-27T00:00:00Z }
+- { id: d030c059-89cb-471b-9c6b-806b0b0a6994, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-fsn1,   unit_price: 0.0005525180, active_from: 2024-05-27T00:00:00Z }
+- { id: 7dc9b906-efb1-4b02-b32d-05561994a4d9, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-hel1,   unit_price: 0.0005257320, active_from: 2024-05-27T00:00:00Z }
+- { id: 9c7ae621-9175-4187-a635-62948cfacb1d, resource_type: VmCores,                 resource_family: standard-gpu,    location: github-runners, unit_price: 0.0005257320, active_from: 2024-05-27T00:00:00Z }
+- { id: 8bff7562-7f1b-4c68-9e3a-682385fa2d7a, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-wdc02, unit_price: 0.0007725000, active_from: 2024-05-27T00:00:00Z }
+- { id: 4ddb3928-5efa-44b4-b380-39bf64c4a7f1, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-dal13, unit_price: 0.0007725000, active_from: 2024-05-27T00:00:00Z }
+- { id: 717caef1-e7b1-43fd-8526-fa02d5caa87c, resource_type: VmStorage,               resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0000028100, active_from: 2024-05-27T00:00:00Z }
+- { id: 39796c71-9d4d-4d6d-ab2a-17c225d59c8f, resource_type: VmStorage,               resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0000028100, active_from: 2024-05-27T00:00:00Z }
+- { id: af340cfe-70ea-4122-b23e-66e9de8502e3, resource_type: VmStorage,               resource_family: standard,        location: github-runners, unit_price: 0.0000028100, active_from: 2024-05-27T00:00:00Z }
+- { id: ed244151-1199-4734-9b6d-4ec7d3da7227, resource_type: VmStorage,               resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0000031000, active_from: 2024-05-27T00:00:00Z }
+- { id: ea875583-660e-4a27-b95c-ccf6d321230c, resource_type: VmStorage,               resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0000031000, active_from: 2024-05-27T00:00:00Z }
 - { id: 118b7e2d-fa8d-8d78-910d-1f62fcc657ec, resource_type: IPAddress,               resource_family: IPv4,            location: hetzner-fsn1,   unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
 - { id: 1bde2200-545a-8d78-960e-08a303111e3d, resource_type: IPAddress,               resource_family: IPv4,            location: hetzner-hel1,   unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
 - { id: 38685ec4-38eb-4460-aed3-8a36bab14175, resource_type: IPAddress,               resource_family: IPv4,            location: github-runners, unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
@@ -45,3 +51,15 @@
 - { id: 5b49ad57-1bac-4c35-84d4-9545876ecb65, resource_type: GitHubRunnerMinutes,     resource_family: standard-30-arm, location: global,         unit_price: 0.0120000000, active_from: 2023-01-01T00:00:00Z }
 - { id: 27d84309-e39d-8d78-b603-7632dafe374e, resource_type: GitHubRunnerMinutes,     resource_family: standard-gpu-6,  location: global,         unit_price: 0.0320000000, active_from: 2023-01-01T00:00:00Z }
 - { id: c31b3640-92fa-49c3-bae8-c1011cc5f917, resource_type: GitHubRunnerConcurrency, resource_family: standard,        location: global,         unit_price: 0.0000248016, active_from: 2023-01-01T00:00:00Z }
+
+# Deprecated billing rates
+- { id: 139d9a67-8182-8578-a303-235cabd5161c, resource_type: VmCores,                 resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+- { id: 08c502f7-df5d-8978-9896-feafa0ec5c40, resource_type: VmCores,                 resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: 2acc2bbf-d451-49c6-93de-db8d15311042, resource_type: VmCores,                 resource_family: standard,        location: github-runners, unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: 8cc76122-1463-8178-a89a-3b74434d1943, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0008500000, active_from: 2023-01-01T00:00:00Z }
+- { id: 0f189c1f-b182-8978-bc1c-d1e0412718c3, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0008500000, active_from: 2023-01-01T00:00:00Z }
+- { id: 8c82e087-10aa-8d78-876f-88afcc162d4c, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-fsn1,   unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+- { id: 80c193bc-528a-8d78-9377-17523b162c58, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-hel1,   unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: c1eb36d9-6b46-8578-869a-92e64646b547, resource_type: VmCores,                 resource_family: standard-gpu,    location: github-runners, unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: b44a8854-f7fb-8578-b1b8-f38b218b52e3, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-wdc02, unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+- { id: 88dcb876-0a21-8978-bc58-558b1755ad29, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-dal13, unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }

--- a/config/billing_rates.yml
+++ b/config/billing_rates.yml
@@ -1,47 +1,47 @@
-- { id: 139d9a67-8182-8578-a303-235cabd5161c, resource_type: VmCores,                 resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.000622768 }
-- { id: 08c502f7-df5d-8978-9896-feafa0ec5c40, resource_type: VmCores,                 resource_family: standard,        location: hetzner-hel1,   unit_price: 0.000595982 }
-- { id: 2acc2bbf-d451-49c6-93de-db8d15311042, resource_type: VmCores,                 resource_family: standard,        location: github-runners, unit_price: 0.000595982 }
-- { id: 8cc76122-1463-8178-a89a-3b74434d1943, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.000850000 }
-- { id: 0f189c1f-b182-8978-bc1c-d1e0412718c3, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-dal13, unit_price: 0.000850000 }
-- { id: 8c82e087-10aa-8d78-876f-88afcc162d4c, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-fsn1,   unit_price: 0.000622768 }
-- { id: 80c193bc-528a-8d78-9377-17523b162c58, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-hel1,   unit_price: 0.000595982 }
-- { id: c1eb36d9-6b46-8578-869a-92e64646b547, resource_type: VmCores,                 resource_family: standard-gpu,    location: github-runners, unit_price: 0.000595982 }
-- { id: b44a8854-f7fb-8578-b1b8-f38b218b52e3, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-wdc02, unit_price: 0.000622768 }
-- { id: 88dcb876-0a21-8978-bc58-558b1755ad29, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-dal13, unit_price: 0.000622768 }
-- { id: 118b7e2d-fa8d-8d78-910d-1f62fcc657ec, resource_type: IPAddress,               resource_family: IPv4,            location: hetzner-fsn1,   unit_price: 0.000074405 }
-- { id: 1bde2200-545a-8d78-960e-08a303111e3d, resource_type: IPAddress,               resource_family: IPv4,            location: hetzner-hel1,   unit_price: 0.000074405 }
-- { id: 38685ec4-38eb-4460-aed3-8a36bab14175, resource_type: IPAddress,               resource_family: IPv4,            location: github-runners, unit_price: 0.000074405 }
-- { id: eda0ff7c-23b4-8178-8184-722acbffcbb8, resource_type: IPAddress,               resource_family: IPv4,            location: leaseweb-wdc02, unit_price: 0.000074405 }
-- { id: 13e58492-7cff-8d78-adf4-e44561d9346d, resource_type: IPAddress,               resource_family: IPv4,            location: leaseweb-dal13, unit_price: 0.000074405 }
-- { id: 36b3883a-a72a-4c08-a4c6-482f4f91e148, resource_type: PostgresCores,           resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.001252425 }
-- { id: a5ef9efa-95eb-400b-a66a-31dd9d7a654a, resource_type: PostgresCores,           resource_family: standard,        location: hetzner-hel1,   unit_price: 0.001198557 }
-- { id: 10ac0c66-ad6f-49f9-9c89-f676501eacea, resource_type: PostgresCores,           resource_family: standard,        location: github-runners, unit_price: 0.001198557 }
-- { id: a35575ae-a5dd-8578-961c-021c7e8e2514, resource_type: PostgresCores,           resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.001252425 }
-- { id: 3d692cf3-804c-8d78-9b38-c54854052e71, resource_type: PostgresCores,           resource_family: standard,        location: leaseweb-dal13, unit_price: 0.001252425 }
-- { id: 46db9ff6-7f5a-4942-bd1a-6feccfe6c970, resource_type: PostgresStandbyCores,    resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.001252425 }
-- { id: 9cf57048-6fcf-43f7-9dc6-b712e4778ff7, resource_type: PostgresStandbyCores,    resource_family: standard,        location: hetzner-hel1,   unit_price: 0.001198557 }
-- { id: 958daf3e-df4e-4f5d-93be-7ca63ef742ce, resource_type: PostgresStandbyCores,    resource_family: standard,        location: github-runners, unit_price: 0.001198557 }
-- { id: 3baf8cbe-4f67-8d78-a71e-328d695e87b1, resource_type: PostgresStandbyCores,    resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.001252425 }
-- { id: 29e4c2f7-f012-8978-8e08-7606c607ac9c, resource_type: PostgresStandbyCores,    resource_family: standard,        location: leaseweb-dal13, unit_price: 0.001252425 }
-- { id: 80aa487a-0aa7-472f-a52c-d82a96067cba, resource_type: PostgresStorage,         resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.000002810 }
-- { id: c41422cd-9e28-46bd-acd4-02debfcd26a2, resource_type: PostgresStorage,         resource_family: standard,        location: hetzner-hel1,   unit_price: 0.000002810 }
-- { id: b8d48f79-8131-46aa-b898-dba1c21d0954, resource_type: PostgresStorage,         resource_family: standard,        location: github-runners, unit_price: 0.000002810 }
-- { id: 0a45042a-6d20-8978-af02-dfaf3f40cd28, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.000002810 }
-- { id: 5f19cb91-1cff-8d78-881a-1927e5fcdb98, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-dal13, unit_price: 0.000002810 }
-- { id: eaf2d6df-c63c-4dd1-9aa4-00e08785fb59, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.000002810 }
-- { id: 10e65151-b0e2-4a33-9834-c3b4549a0d98, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: hetzner-hel1,   unit_price: 0.000002810 }
-- { id: f9f47985-f9fe-42b6-a8d8-c086d557f224, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: github-runners, unit_price: 0.000002810 }
-- { id: 4b8afe08-bc0e-8978-bc23-e38973e5b3d4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.000002810 }
-- { id: 1172b71c-4c1f-8978-aa10-b9e73822a8e4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-dal13, unit_price: 0.000002810 }
-- { id: d772d0aa-0b40-4b7a-aceb-72f6211f7cad, resource_type: GitHubRunnerMinutes,     resource_family: standard-2,      location: global,         unit_price: 0.0008 }
-- { id: d885c82d-b139-40d5-890f-de3720896b3b, resource_type: GitHubRunnerMinutes,     resource_family: standard-4,      location: global,         unit_price: 0.0016 }
-- { id: e50e6bff-6ee9-493b-bc09-75f122863d08, resource_type: GitHubRunnerMinutes,     resource_family: standard-8,      location: global,         unit_price: 0.0032 }
-- { id: 89cda6c2-2650-4ac1-bc28-deeae5e3b756, resource_type: GitHubRunnerMinutes,     resource_family: standard-16,     location: global,         unit_price: 0.0064 }
-- { id: c5c0b29f-1ea9-437c-8ab8-c9395ec7e46d, resource_type: GitHubRunnerMinutes,     resource_family: standard-30,     location: global,         unit_price: 0.0120 }
-- { id: ab92083e-2be7-4038-b946-b060af3994fb, resource_type: GitHubRunnerMinutes,     resource_family: standard-2-arm,  location: global,         unit_price: 0.0008 }
-- { id: 078d2f47-5827-49fa-9d13-bee6d1d8cadd, resource_type: GitHubRunnerMinutes,     resource_family: standard-4-arm,  location: global,         unit_price: 0.0016 }
-- { id: 0fc7f264-87f0-446d-bee7-c0454149b1bc, resource_type: GitHubRunnerMinutes,     resource_family: standard-8-arm,  location: global,         unit_price: 0.0032 }
-- { id: 995ab760-5d97-4a7b-981e-c9947233c78e, resource_type: GitHubRunnerMinutes,     resource_family: standard-16-arm, location: global,         unit_price: 0.0064 }
-- { id: 5b49ad57-1bac-4c35-84d4-9545876ecb65, resource_type: GitHubRunnerMinutes,     resource_family: standard-30-arm, location: global,         unit_price: 0.0120 }
-- { id: 27d84309-e39d-8d78-b603-7632dafe374e, resource_type: GitHubRunnerMinutes,     resource_family: standard-gpu-6,  location: global,         unit_price: 0.0320 }
-- { id: c31b3640-92fa-49c3-bae8-c1011cc5f917, resource_type: GitHubRunnerConcurrency, resource_family: standard,        location: global,         unit_price: 0.0000248016 }
+- { id: 139d9a67-8182-8578-a303-235cabd5161c, resource_type: VmCores,                 resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+- { id: 08c502f7-df5d-8978-9896-feafa0ec5c40, resource_type: VmCores,                 resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: 2acc2bbf-d451-49c6-93de-db8d15311042, resource_type: VmCores,                 resource_family: standard,        location: github-runners, unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: 8cc76122-1463-8178-a89a-3b74434d1943, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0008500000, active_from: 2023-01-01T00:00:00Z }
+- { id: 0f189c1f-b182-8978-bc1c-d1e0412718c3, resource_type: VmCores,                 resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0008500000, active_from: 2023-01-01T00:00:00Z }
+- { id: 8c82e087-10aa-8d78-876f-88afcc162d4c, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-fsn1,   unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+- { id: 80c193bc-528a-8d78-9377-17523b162c58, resource_type: VmCores,                 resource_family: standard-gpu,    location: hetzner-hel1,   unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: c1eb36d9-6b46-8578-869a-92e64646b547, resource_type: VmCores,                 resource_family: standard-gpu,    location: github-runners, unit_price: 0.0005959820, active_from: 2023-01-01T00:00:00Z }
+- { id: b44a8854-f7fb-8578-b1b8-f38b218b52e3, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-wdc02, unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+- { id: 88dcb876-0a21-8978-bc58-558b1755ad29, resource_type: VmCores,                 resource_family: standard-gpu,    location: leaseweb-dal13, unit_price: 0.0006227680, active_from: 2023-01-01T00:00:00Z }
+- { id: 118b7e2d-fa8d-8d78-910d-1f62fcc657ec, resource_type: IPAddress,               resource_family: IPv4,            location: hetzner-fsn1,   unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
+- { id: 1bde2200-545a-8d78-960e-08a303111e3d, resource_type: IPAddress,               resource_family: IPv4,            location: hetzner-hel1,   unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
+- { id: 38685ec4-38eb-4460-aed3-8a36bab14175, resource_type: IPAddress,               resource_family: IPv4,            location: github-runners, unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
+- { id: eda0ff7c-23b4-8178-8184-722acbffcbb8, resource_type: IPAddress,               resource_family: IPv4,            location: leaseweb-wdc02, unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
+- { id: 13e58492-7cff-8d78-adf4-e44561d9346d, resource_type: IPAddress,               resource_family: IPv4,            location: leaseweb-dal13, unit_price: 0.0000744050, active_from: 2023-01-01T00:00:00Z }
+- { id: 36b3883a-a72a-4c08-a4c6-482f4f91e148, resource_type: PostgresCores,           resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0012524250, active_from: 2023-01-01T00:00:00Z }
+- { id: a5ef9efa-95eb-400b-a66a-31dd9d7a654a, resource_type: PostgresCores,           resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0011985570, active_from: 2023-01-01T00:00:00Z }
+- { id: 10ac0c66-ad6f-49f9-9c89-f676501eacea, resource_type: PostgresCores,           resource_family: standard,        location: github-runners, unit_price: 0.0011985570, active_from: 2023-01-01T00:00:00Z }
+- { id: a35575ae-a5dd-8578-961c-021c7e8e2514, resource_type: PostgresCores,           resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0012524250, active_from: 2023-01-01T00:00:00Z }
+- { id: 3d692cf3-804c-8d78-9b38-c54854052e71, resource_type: PostgresCores,           resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0012524250, active_from: 2023-01-01T00:00:00Z }
+- { id: 46db9ff6-7f5a-4942-bd1a-6feccfe6c970, resource_type: PostgresStandbyCores,    resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0012524250, active_from: 2023-01-01T00:00:00Z }
+- { id: 9cf57048-6fcf-43f7-9dc6-b712e4778ff7, resource_type: PostgresStandbyCores,    resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0011985570, active_from: 2023-01-01T00:00:00Z }
+- { id: 958daf3e-df4e-4f5d-93be-7ca63ef742ce, resource_type: PostgresStandbyCores,    resource_family: standard,        location: github-runners, unit_price: 0.0011985570, active_from: 2023-01-01T00:00:00Z }
+- { id: 3baf8cbe-4f67-8d78-a71e-328d695e87b1, resource_type: PostgresStandbyCores,    resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0012524250, active_from: 2023-01-01T00:00:00Z }
+- { id: 29e4c2f7-f012-8978-8e08-7606c607ac9c, resource_type: PostgresStandbyCores,    resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0012524250, active_from: 2023-01-01T00:00:00Z }
+- { id: 80aa487a-0aa7-472f-a52c-d82a96067cba, resource_type: PostgresStorage,         resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: c41422cd-9e28-46bd-acd4-02debfcd26a2, resource_type: PostgresStorage,         resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: b8d48f79-8131-46aa-b898-dba1c21d0954, resource_type: PostgresStorage,         resource_family: standard,        location: github-runners, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: 0a45042a-6d20-8978-af02-dfaf3f40cd28, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: 5f19cb91-1cff-8d78-881a-1927e5fcdb98, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: eaf2d6df-c63c-4dd1-9aa4-00e08785fb59, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: 10e65151-b0e2-4a33-9834-c3b4549a0d98, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: f9f47985-f9fe-42b6-a8d8-c086d557f224, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: github-runners, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: 4b8afe08-bc0e-8978-bc23-e38973e5b3d4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: 1172b71c-4c1f-8978-aa10-b9e73822a8e4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: d772d0aa-0b40-4b7a-aceb-72f6211f7cad, resource_type: GitHubRunnerMinutes,     resource_family: standard-2,      location: global,         unit_price: 0.0008000000, active_from: 2023-01-01T00:00:00Z }
+- { id: d885c82d-b139-40d5-890f-de3720896b3b, resource_type: GitHubRunnerMinutes,     resource_family: standard-4,      location: global,         unit_price: 0.0016000000, active_from: 2023-01-01T00:00:00Z }
+- { id: e50e6bff-6ee9-493b-bc09-75f122863d08, resource_type: GitHubRunnerMinutes,     resource_family: standard-8,      location: global,         unit_price: 0.0032000000, active_from: 2023-01-01T00:00:00Z }
+- { id: 89cda6c2-2650-4ac1-bc28-deeae5e3b756, resource_type: GitHubRunnerMinutes,     resource_family: standard-16,     location: global,         unit_price: 0.0064000000, active_from: 2023-01-01T00:00:00Z }
+- { id: c5c0b29f-1ea9-437c-8ab8-c9395ec7e46d, resource_type: GitHubRunnerMinutes,     resource_family: standard-30,     location: global,         unit_price: 0.0120000000, active_from: 2023-01-01T00:00:00Z }
+- { id: ab92083e-2be7-4038-b946-b060af3994fb, resource_type: GitHubRunnerMinutes,     resource_family: standard-2-arm,  location: global,         unit_price: 0.0008000000, active_from: 2023-01-01T00:00:00Z }
+- { id: 078d2f47-5827-49fa-9d13-bee6d1d8cadd, resource_type: GitHubRunnerMinutes,     resource_family: standard-4-arm,  location: global,         unit_price: 0.0016000000, active_from: 2023-01-01T00:00:00Z }
+- { id: 0fc7f264-87f0-446d-bee7-c0454149b1bc, resource_type: GitHubRunnerMinutes,     resource_family: standard-8-arm,  location: global,         unit_price: 0.0032000000, active_from: 2023-01-01T00:00:00Z }
+- { id: 995ab760-5d97-4a7b-981e-c9947233c78e, resource_type: GitHubRunnerMinutes,     resource_family: standard-16-arm, location: global,         unit_price: 0.0064000000, active_from: 2023-01-01T00:00:00Z }
+- { id: 5b49ad57-1bac-4c35-84d4-9545876ecb65, resource_type: GitHubRunnerMinutes,     resource_family: standard-30-arm, location: global,         unit_price: 0.0120000000, active_from: 2023-01-01T00:00:00Z }
+- { id: 27d84309-e39d-8d78-b603-7632dafe374e, resource_type: GitHubRunnerMinutes,     resource_family: standard-gpu-6,  location: global,         unit_price: 0.0320000000, active_from: 2023-01-01T00:00:00Z }
+- { id: c31b3640-92fa-49c3-bae8-c1011cc5f917, resource_type: GitHubRunnerConcurrency, resource_family: standard,        location: global,         unit_price: 0.0000248016, active_from: 2023-01-01T00:00:00Z }

--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -4,13 +4,13 @@ require "yaml"
 
 class BillingRate
   def self.rates
-    @@rates ||= YAML.load_file("config/billing_rates.yml")
+    @@rates ||= YAML.load_file("config/billing_rates.yml", permitted_classes: [Time])
   end
 
-  def self.from_resource_properties(resource_type, resource_family, location)
-    rates.find {
-      _1["resource_type"] == resource_type && _1["resource_family"] == resource_family && _1["location"] == location
-    }
+  def self.from_resource_properties(resource_type, resource_family, location, active_at = Time.now)
+    rates.select {
+      _1["resource_type"] == resource_type && _1["resource_family"] == resource_family && _1["location"] == location && _1["active_from"] < active_at
+    }.max_by { _1["active_from"] }
   end
 
   def self.from_id(billing_rate_id)

--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -21,6 +21,8 @@ class BillingRate
     case resource_type
     when "VmCores"
       "#{resource_family}-#{(amount * 2).to_i} Virtual Machine"
+    when "VmStorage"
+      "#{amount.to_i} GiB Storage for Virtual Machine"
     when "IPAddress"
       "#{resource_family} Address"
     when "PostgresCores"

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -42,13 +42,13 @@ module Option
     ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"]
   ].map { |args| BootImage.new(*args) }.freeze
 
-  VmSize = Struct.new(:name, :family, :vcpu, :memory, :storage_size_gib, :visible, :gpu) do
+  VmSize = Struct.new(:name, :family, :vcpu, :memory, :min_storage_size_gib, :max_storage_size_gib, :storage_size_step_gib, :visible, :gpu) do
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
-    VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 25, true, false)
+    VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 25, _1 * 25, (_1 / 2) * 12.5, true, false)
   }.concat([6].map {
-    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, (_1 / 2) * 60, false, true)
+    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, (_1 / 2) * 60, _1 * 60, (_1 / 2) * 60, false, true)
   }).freeze
 
   PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :storage_size_gib) do

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -46,7 +46,7 @@ module Option
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
-    VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 25, _1 * 25, (_1 / 2) * 12.5, true, false)
+    VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 40, _1 * 40, (_1 / 2) * 20, true, false)
   }.concat([6].map {
     VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, (_1 / 2) * 60, _1 * 60, (_1 / 2) * 60, false, true)
   }).freeze

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -68,6 +68,14 @@ module Validation
     vm_size
   end
 
+  def self.validate_vm_storage_size(size, storage_size)
+    storage_size = storage_size.to_i
+    vm_size = validate_vm_size(size)
+    allowed_sizes = (vm_size.min_storage_size_gib..vm_size.max_storage_size_gib).step(vm_size.storage_size_step_gib)
+    fail ValidationFailed.new({storage_size: "Storage size must be one of the following: #{allowed_sizes.to_a.join(", ")}"}) unless allowed_sizes.include?(storage_size)
+    storage_size
+  end
+
   def self.validate_boot_image(image_name)
     unless Option::BootImages.find { _1.name == image_name }
       fail ValidationFailed.new({boot_image: "\"#{image_name}\" is not a valid boot image name. Available boot image names are: #{Option::BootImages.map(&:name)}"})

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -10,7 +10,7 @@ class Vm < Sequel::Model
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
   one_to_many :vm_storage_volumes, key: :vm_id, order: Sequel.desc(:boot)
-  one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
+  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
   one_to_many :pci_devices, key: :vm_id, class: :PciDevice
 
   plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -180,7 +180,7 @@ class Prog::Vm::Nexus < Prog::Base
   def before_run
     when_destroy_set? do
       if strand.label != "destroy"
-        vm.active_billing_record&.finalize
+        vm.active_billing_records.each(&:finalize)
         vm.assigned_vm_address&.active_billing_record&.finalize
         register_deadline(nil, 5 * 60)
         hop_destroy

--- a/routes/clover_base.rb
+++ b/routes/clover_base.rb
@@ -62,6 +62,8 @@ module CloverBase
     # to price calculator and also we charge same amount no matter
     # the number of days in a given month.
     BillingRate.rates.filter { resource_types.include?(_1["resource_type"]) }
+      .group_by { [_1["resource_type"], _1["resource_family"], _1["location"]] }
+      .map { |_, brs| brs.max_by { _1["active_from"] } }
       .each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
       hash[br["location"]][br["resource_type"]][br["resource_family"]] = {
         hourly: br["unit_price"].to_f * 60,

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -41,7 +41,7 @@ class CloverWeb
       r.get true do
         Authorization.authorize(@current_user.id, "Vm:create", @project.id)
         @subnets = Serializers::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
-        @prices = fetch_location_based_prices("VmCores", "IPAddress")
+        @prices = fetch_location_based_prices("VmCores", "VmStorage", "IPAddress")
         @has_valid_payment_method = @project.has_valid_payment_method?
 
         view "vm/create"

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -18,12 +18,14 @@ class CloverWeb
       Validation.validate_boot_image(r.params["boot-image"])
       Validation.validate_vm_size(r.params["size"], only_visible: true)
       location = LocationNameConverter.to_internal_name(r.params["location"])
+      storage_size = Validation.validate_vm_storage_size(r.params["size"], r.params["storage-size"])
       st = Prog::Vm::Nexus.assemble(
         r.params["public-key"],
         @project.id,
         name: r.params["name"],
         unix_user: r.params["user"],
         size: r.params["size"],
+        storage_volumes: [{size_gib: storage_size, encrypted: true}],
         location: location,
         boot_image: r.params["boot-image"],
         private_subnet_id: ps_id,

--- a/spec/lib/billing_rate_spec.rb
+++ b/spec/lib/billing_rate_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe BillingRate do
       expect(described_class.line_item_usage("GitHubRunnerMinutes", "standard-2", 5, 1)).to eq("5 minutes")
     end
   end
+
+  it "can unambiguously find active rate" do
+    expect(described_class.rates.group_by { [_1["resource_type"], _1["resource_family"], _1["location"], _1["active_from"]] }).not_to be_any { |k, v| v.count != 1 }
+  end
 end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -41,6 +41,31 @@ RSpec.describe Validation do
       end
     end
 
+    describe "#validate_vm_storage_size" do
+      it "valid vm storage sizes" do
+        [
+          ["standard-2", "25"],
+          ["standard-2", "37.5"],
+          ["standard-4", "100"]
+        ].each do |vm_size, storage_size|
+          expect(described_class.validate_vm_storage_size(vm_size, storage_size)).to eq(storage_size.to_f)
+        end
+      end
+
+      it "invalid vm storage sizes" do
+        [
+          ["standard-2", "100"],
+          ["standard-2", "37.4"],
+          ["standard-2", ""],
+          ["standard-2", nil],
+          ["standard-5", "37.4"],
+          [nil, "25"]
+        ].each do |vm_size, storage_size|
+          expect { described_class.validate_vm_storage_size(vm_size, storage_size) }.to raise_error described_class::ValidationFailed
+        end
+      end
+    end
+
     describe "#validate_location" do
       it "valid locations" do
         [

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Validation do
     describe "#validate_vm_storage_size" do
       it "valid vm storage sizes" do
         [
-          ["standard-2", "25"],
-          ["standard-2", "37.5"],
-          ["standard-4", "100"]
+          ["standard-2", "40"],
+          ["standard-2", "60"],
+          ["standard-4", "160"]
         ].each do |vm_size, storage_size|
           expect(described_class.validate_vm_storage_size(vm_size, storage_size)).to eq(storage_size.to_f)
         end
@@ -54,12 +54,12 @@ RSpec.describe Validation do
 
       it "invalid vm storage sizes" do
         [
-          ["standard-2", "100"],
+          ["standard-2", "160"],
           ["standard-2", "37.4"],
           ["standard-2", ""],
           ["standard-2", nil],
-          ["standard-5", "37.4"],
-          [nil, "25"]
+          ["standard-5", "40"],
+          [nil, "40"]
         ].each do |vm_size, storage_size|
           expect { described_class.validate_vm_storage_size(vm_size, storage_size) }.to raise_error described_class::ValidationFailed
         end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "create a new record for a new day" do
       today = Time.now
       tomorrow = today + 24 * 60 * 60
-      expect(Time).to receive(:now).and_return(today).exactly(4)
+      expect(Time).to receive(:now).and_return(today).exactly(5)
       expect(github_runner).to receive(:ready_at).and_return(today - 5 * 60).twice
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       # Create today record

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe Prog::Vm::Nexus do
       _1.vm_storage_volumes.append(disk_2)
       disk_1.vm = _1
       disk_2.vm = _1
-      allow(_1).to receive(:active_billing_record).and_return(BillingRecord.new(
+      allow(_1).to receive(:active_billing_records).and_return([BillingRecord.new(
         project_id: "50089dcf-b472-8ad2-9ca6-b3e70d12759d",
         resource_name: _1.name,
         billing_rate_id: BillingRate.from_resource_properties("VmCores", _1.family, _1.location)["id"],
         amount: _1.cores
-      ))
+      )])
     }
     vm
   }
@@ -569,7 +569,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "stops billing before hops to destroy" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(vm.active_billing_record).to receive(:finalize)
+      expect(vm.active_billing_records.first).to receive(:finalize)
       assigned_adr = instance_double(AssignedVmAddress)
       expect(vm).to receive(:assigned_vm_address).and_return(assigned_adr)
       expect(assigned_adr).to receive(:active_billing_record).and_return(instance_double(BillingRecord)).at_least(:once)
@@ -579,14 +579,14 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "hops to destroy if billing record is not found" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(vm).to receive(:active_billing_record).and_return(nil)
+      expect(vm).to receive(:active_billing_records).and_return([])
       expect(vm).to receive(:assigned_vm_address).and_return(nil)
       expect { nx.before_run }.to hop("destroy")
     end
 
     it "hops to destroy if billing record is not found for ipv4" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(vm.active_billing_record).to receive(:finalize)
+      expect(vm.active_billing_records.first).to receive(:finalize)
       assigned_adr = instance_double(AssignedVmAddress)
       expect(vm).to receive(:assigned_vm_address).and_return(assigned_adr)
       expect(assigned_adr).to receive(:active_billing_record).and_return(nil)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "creates with default storage size from vm size" do
       st = described_class.assemble("some_ssh_key", prj.id)
-      expect(requested_disk_size(st)).to eq(Option::VmSizes.first.storage_size_gib)
+      expect(requested_disk_size(st)).to eq(Option::VmSizes.first.min_storage_size_gib)
     end
 
     it "creates with custom storage size if provided" do
@@ -535,14 +535,14 @@ RSpec.describe Prog::Vm::Nexus do
       vm_addr = instance_double(AssignedVmAddress, id: "46ca6ded-b056-4723-bd91-612959f52f6f", ip: NetAddr::IPv4Net.parse("10.0.0.1"))
       expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)
       expect(vm).to receive(:ip4_enabled).and_return(true)
-      expect(BillingRecord).to receive(:create_with_id).twice
+      expect(BillingRecord).to receive(:create_with_id).exactly(4).times
       expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
       expect { nx.create_billing_record }.to hop("wait")
     end
 
     it "creates billing records when ip4 is not enabled" do
       expect(vm).to receive(:ip4_enabled).and_return(false)
-      expect(BillingRecord).to receive(:create_with_id)
+      expect(BillingRecord).to receive(:create_with_id).exactly(3).times
       expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
       expect { nx.create_billing_record }.to hop("wait")
     end

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -156,9 +156,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(200)
-        parsed_body = JSON.parse(last_response.body)
-        expect(parsed_body["name"]).to eq("test-vm")
-        expect(parsed_body["name"]).to eq("test-vm")
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-vm")
         expect(Vm.first.ip4_enabled).to be true
       end
 

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Clover, "vm" do
           unix_user: "ubi",
           size: "standard-2",
           boot_image: "ubuntu-jammy",
-          storage_size: "50"
+          storage_size: "40"
         }.to_json
 
         expect(last_response.status).to eq(200)

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -162,6 +162,19 @@ RSpec.describe Clover, "vm" do
         expect(Vm.first.ip4_enabled).to be true
       end
 
+      it "success with storage size" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          size: "standard-2",
+          boot_image: "ubuntu-jammy",
+          storage_size: "50"
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-vm")
+      end
+
       it "boot image doesn't passed" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
@@ -288,7 +301,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: public_key, size, unix_user, boot_image, enable_ip4, private_subnet_id")
+        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: public_key, size, storage_size, unix_user, boot_image, enable_ip4, private_subnet_id")
       end
     end
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Clover, "vm" do
         uncheck "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(25)
+        find(".storage-slider").set(40)
 
         click_button "Create"
 
@@ -95,7 +95,7 @@ RSpec.describe Clover, "vm" do
         check "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(25)
+        find(".storage-slider").set(40)
 
         click_button "Create"
 
@@ -142,7 +142,7 @@ RSpec.describe Clover, "vm" do
         choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(25)
+        find(".storage-slider").set(40)
 
         click_button "Create"
 
@@ -161,7 +161,7 @@ RSpec.describe Clover, "vm" do
         choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(25)
+        find(".storage-slider").set(40)
 
         click_button "Create"
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Clover, "vm" do
         uncheck "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
+        find(".storage-slider").set(25)
 
         click_button "Create"
 
@@ -94,6 +95,7 @@ RSpec.describe Clover, "vm" do
         check "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
+        find(".storage-slider").set(25)
 
         click_button "Create"
 
@@ -119,6 +121,7 @@ RSpec.describe Clover, "vm" do
         select match: :prefer_exact, text: ps.name
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
+        find(".storage-slider").set("25")
 
         click_button "Create"
 
@@ -139,6 +142,7 @@ RSpec.describe Clover, "vm" do
         choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
+        find(".storage-slider").set(25)
 
         click_button "Create"
 
@@ -157,6 +161,7 @@ RSpec.describe Clover, "vm" do
         choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
+        find(".storage-slider").set(25)
 
         click_button "Create"
 

--- a/views/components/form/range_slider.erb
+++ b/views/components/form/range_slider.erb
@@ -5,6 +5,7 @@
 <% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
 <% description = (defined?(description) && description) ? description : nil %>
 <% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
+<% extra_class = (defined?(extra_class) && extra_class) ? extra_class : {} %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>
@@ -18,12 +19,12 @@
       <% if value %>
       value="<%= value %>"
       <% end %>
-      class="w-full range-lg h-2 bg-gray-200 accent-orange-600 rounded-lg appearance-none cursor-pointer border-transparent <%= error ? "text-red-900 ring-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 focus:ring-orange-600"%>"
+      class="w-full range-lg h-2 bg-gray-200 accent-orange-600 rounded-lg appearance-none cursor-pointer border-transparent <%=extra_class %> <%= error ? "text-red-900 ring-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 focus:ring-orange-600"%>"
       <% attributes.each do |atr_key, atr_value| %>
       <%= atr_key %>="<%= atr_value %>"
       <% end%>
     >
-    <ul class="flex justify-between w-full px-[10px] pt-1 sm:pt-3">
+    <ul class="flex justify-between w-full px-[10px] pt-2 sm:pt-8">
       <% range_labels.each do |lbl| %>
         <li class="flex justify-right sm:justify-center relative items-center rotate-90 sm:rotate-0 mb-6 sm:mb-0"><span class="absolute"><%= lbl %></span></li>
       <% end %>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -120,7 +120,7 @@
                                   GB
                                 </span>
                                 <span class="hidden sm:mx-0.5 sm:inline" aria-hidden="true">&middot;</span>
-                                <span class="block sm:inline"><%= size.storage_size_gib %>
+                                <span class="block sm:inline"><%= size.min_storage_size_gib %>
                                   GB disk</span>
                               </span>
                             </span>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -102,6 +102,9 @@
                             data-resource-type="VmCores"
                             data-resource-family="<%= size.family %>"
                             data-amount="<%= size.vcpu / 2 %>"
+                            data-min-storage-size-gib="<%= size.min_storage_size_gib %>"
+                            data-max-storage-size-gib="<%= size.max_storage_size_gib %>"
+                            data-storage-size-step-gib="<%= size.storage_size_step_gib %>"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                           >
@@ -119,9 +122,6 @@
                                   <%= size.memory %>
                                   GB
                                 </span>
-                                <span class="hidden sm:mx-0.5 sm:inline" aria-hidden="true">&middot;</span>
-                                <span class="block sm:inline"><%= size.min_storage_size_gib %>
-                                  GB disk</span>
                               </span>
                             </span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
@@ -135,6 +135,33 @@
                   </fieldset>
                 </div>
               </div>
+
+              <div class="col-span-full">
+                <div class="space-y-2">
+                  <fieldset class="radio-small-cards" id="storage-size-radios">
+                    <div class="col-span-full">
+                      <% size = flash.dig("old", "size") ? Option::VmSizes.find { _1.name == flash.dig("old", "size") } : Option::VmSizes[0] %>
+                      <%== render(
+                        "components/form/range_slider",
+                        locals: {
+                          name: "storage-size",
+                          label: "Storage Size",
+                          range_labels: (size.min_storage_size_gib..size.max_storage_size_gib).step(size.storage_size_step_gib).map { "#{_1}GB" },
+                          value: flash.dig("old", "storage_size") || size.min_storage_size_gib,
+                          attributes: {
+                            min: size.min_storage_size_gib,
+                            max: size.max_storage_size_gib,
+                            step: size.storage_size_step_gib,
+                            required: true
+                          },
+                          extra_class: "instance-size-based-option storage-slider",
+                        }
+                      ) %>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+
               <div class="col-span-full">
                 <%== render(
                   "components/form/radio_small_cards",

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -92,7 +92,7 @@
                   <fieldset class="radio-small-cards" id="size-radios">
                     <legend class="sr-only">Server size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                      <% Option::VmSizes.select { _1.visible }.each do |size| %>
+                      <% Option::VmSizes.select { _1.visible }.each_with_index do |size, idx| %>
                         <label class="size-<%= size.name %>">
                           <input
                             type="radio"
@@ -103,7 +103,7 @@
                             data-resource-family="<%= size.family %>"
                             data-amount="<%= size.vcpu / 2 %>"
                             required
-                            <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>
+                            <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                           >
                           <span
                             class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none


### PR DESCRIPTION
**Add active_from field to billing rates**
We sometimes need to update billing rates, however, directly changing the rates
would affect the historical data. To avoid this, we are adding an active_from
field. Thanks to this field, we can create a new billing rate with the updated
data and more recent active_from date. The old billing rate will still be used
for the historical data and existing resources, but new resources will use the
new billing rate.

**Add billing rates for VM storage**
We used to have a single billing rate for VMs, which was combination of the
amount we would want to charge for both compute and storage. We are planning to
decouple storage and compute, thus we need to have separate billing rates for
each. This commit adds the billing rates for VM storage and also adds new rates
for VM compute, which is lower than the combined rate we used to have.

**Add backend code allowing picking storage independently from VM size**
We are expanding the VmSize option to include minimum and maximum storage sizes
as well as step size per each instance size. These will be passed to frontend
to dynamically update the user interface.

We are also adding storage_size option to API, which needs to be added to our
API documentation.

**Add frontend code allowing picking storage independently from VM size**
This frontend code is admittedly a bit of patch work on top of our existing UI
code. So far frontend code was not our primary focus and as a result of that,
it become a bit difficult to extend and test. I initially wanted to clean the
UI code up a bit, but that effort quickly exploded into a big refactor touching
lots of different areas, such as adding javascript tests, modifying the way we
render the forms, etc. I decided to postpone that work for now and make minimal
set of changes to get the storage decoupling feature working.

I'm planning to come back to form rendering part of the UI code in the future
and refactor it to make it more maintainable and testable.

**Remove unnecessary expectation in tests**

**Automatically select first instance size in VM creation form**
This ensures that the javascript code depending on instance size works even at
the initial load. It also makes the form more user-friendly by requiring one
less click.

**Increase default VM storage size to 40GB**
We decided to increase default VM storage size to 40GB.

![image](https://github.com/ubicloud/ubicloud/assets/2082070/144a7541-21aa-41ff-a266-6a15e8155525)
