### PR TITLE
Inline serializers in roda branches

### DIFF
--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch("project") do |r|
-    @serializer = Serializers::Api::Project
-
     r.get true do
       result = Project.authorized(@current_user.id, "Project:view").where(visible: true).paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::Project.serialize(result[:records]),
         count: result[:count]
       }
     end
@@ -24,7 +22,7 @@ class CloverApi
 
       project = @current_user.create_project_with_default_policy(request_body_params["name"])
 
-      serialize(project)
+      Serializers::Api::Project.serialize(project)
     end
 
     r.on String do |project_ubid|
@@ -57,7 +55,7 @@ class CloverApi
       r.get true do
         Authorization.authorize(@current_user.id, "Project:view", @project.id)
 
-        serialize(@project)
+        Serializers::Api::Project.serialize(@project)
       end
 
       r.hash_branches(:project_prefix)

--- a/routes/api/project/firewall.rb
+++ b/routes/api/project/firewall.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_prefix, "firewall") do |r|
-    @serializer = Serializers::Api::Firewall
-
     r.get true do
       result = @project.firewalls_dataset.authorized(@current_user.id, "Firewall:view").eager(:firewall_rules).paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::Firewall.serialize(result[:records]),
         count: result[:count]
       }
     end
@@ -28,7 +26,7 @@ class CloverApi
       firewall = Firewall.create_with_id(name: request_body_params["name"], description: request_body_params["description"] || "")
       firewall.associate_with_project(@project)
 
-      serialize(firewall)
+      Serializers::Api::Firewall.serialize(firewall)
     end
 
     r.on String do |firewall_ubid|
@@ -51,7 +49,7 @@ class CloverApi
       r.get true do
         Authorization.authorize(@current_user.id, "Firewall:view", @project.id)
 
-        serialize(@firewall, :detailed)
+        Serializers::Api::Firewall.new(:detailed).serialize(@firewall)
       end
 
       r.post "attach-subnet" do
@@ -67,7 +65,7 @@ class CloverApi
 
         @firewall.associate_with_private_subnet(private_subnet)
 
-        serialize(@firewall, :detailed)
+        Serializers::Api::Firewall.new(:detailed).serialize(@firewall)
       end
 
       r.post "detach-subnet" do
@@ -83,7 +81,7 @@ class CloverApi
 
         @firewall.disassociate_from_private_subnet(private_subnet)
 
-        serialize(@firewall, :detailed)
+        Serializers::Api::Firewall.new(:detailed).serialize(@firewall)
       end
 
       r.hash_branches(:project_firewall_prefix)

--- a/routes/api/project/firewall/firewall_rule.rb
+++ b/routes/api/project/firewall/firewall_rule.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_firewall_prefix, "firewall-rule") do |r|
-    @serializer = Serializers::Api::FirewallRule
-
     r.post true do
       Authorization.authorize(@current_user.id, "Firewall:edit", @firewall.id)
 
@@ -23,7 +21,7 @@ class CloverApi
 
       firewall_rule = @firewall.insert_firewall_rule(parsed_cidr.to_s, pg_range)
 
-      serialize(firewall_rule)
+      Serializers::Api::FirewallRule.serialize(firewall_rule)
     end
 
     r.is String do |firewall_rule_ubid|

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "postgres") do |r|
-    @serializer = Serializers::Api::Postgres
-
     r.get true do
       result = @project.postgres_resources_dataset.where(location: @location).authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::Postgres.serialize(result[:records]),
         count: result[:count]
       }
     end
@@ -44,7 +42,7 @@ class CloverApi
           ha_type: request_body_params["ha_type"] || PostgresResource::HaType::NONE
         )
 
-        serialize(st.subject, :detailed)
+        Serializers::Api::Postgres.new(:detailed).serialize(st.subject)
       end
 
       pg = @project.postgres_resources_dataset.where(location: @location).where { {Sequel[:postgres_resource][:name] => pg_name} }.first
@@ -60,7 +58,7 @@ class CloverApi
 
     request.get true do
       Authorization.authorize(user.id, "Postgres:view", pg.id)
-      serialize(pg, :detailed)
+      Serializers::Api::Postgres.new(:detailed).serialize(pg)
     end
 
     request.delete true do
@@ -89,7 +87,7 @@ class CloverApi
           pg.incr_update_firewall_rules
         end
 
-        serialize(pg, :detailed)
+        Serializers::Api::Postgres.new(:detailed).serialize(pg)
       end
 
       request.get true do
@@ -133,7 +131,7 @@ class CloverApi
         restore_target: request_body_params["restore_target"]
       )
 
-      serialize(st.subject, :detailed)
+      Serializers::Api::Postgres.new(:detailed).serialize(st.subject)
     end
 
     request.post "reset-superuser-password" do
@@ -155,7 +153,7 @@ class CloverApi
         pg.representative_server.incr_update_superuser_password
       end
 
-      serialize(pg, :detailed)
+      Serializers::Api::Postgres.new(:detailed).serialize(pg)
     end
   end
 end

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "private-subnet") do |r|
-    @serializer = Serializers::Api::PrivateSubnet
-
     r.get true do
       result = @project.private_subnets_dataset.where(location: @location).authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::PrivateSubnet.serialize(result[:records]),
         count: result[:count]
       }
     end
@@ -34,7 +32,7 @@ class CloverApi
           location: @location
         )
 
-        serialize(st.subject)
+        Serializers::Api::PrivateSubnet.serialize(st.subject)
       end
 
       ps = @project.private_subnets_dataset.where(location: @location).where { {Sequel[:private_subnet][:name] => ps_name} }.first
@@ -50,7 +48,7 @@ class CloverApi
 
     request.get true do
       Authorization.authorize(user.id, "PrivateSubnet:view", ps.id)
-      serialize(ps)
+      Serializers::Api::PrivateSubnet.serialize(ps)
     end
 
     request.delete true do

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "vm") do |r|
-    @serializer = Serializers::Api::Vm
-
     r.get true do
       result = @project.vms_dataset.where(location: @location).authorized(@current_user.id, "Vm:view").paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::Vm.serialize(result[:records]),
         count: result[:count]
       }
     end
@@ -65,7 +63,7 @@ class CloverApi
           **request_body_params.except(*required_parameters).transform_keys(&:to_sym)
         )
 
-        serialize(st.subject, :detailed)
+        Serializers::Api::Vm.new(:detailed).serialize(st.subject)
       end
 
       vm = @project.vms_dataset.where(location: @location).where { {Sequel[:vm][:name] => vm_name} }.first
@@ -81,7 +79,7 @@ class CloverApi
 
     request.get true do
       Authorization.authorize(user.id, "Vm:view", vm.id)
-      serialize(vm, :detailed)
+      Serializers::Api::Vm.new(:detailed).serialize(vm)
     end
 
     request.delete true do

--- a/routes/api/project/postgres.rb
+++ b/routes/api/project/postgres.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_prefix, "postgres") do |r|
-    @serializer = Serializers::Api::Postgres
-
     r.get true do
       result = @project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::Postgres.serialize(result[:records]),
         count: result[:count]
       }
     end

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_prefix, "private-subnet") do |r|
-    @serializer = Serializers::Api::PrivateSubnet
-
     r.get true do
       result = @project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::PrivateSubnet.serialize(result[:records]),
         count: result[:count]
       }
     end

--- a/routes/api/project/vm.rb
+++ b/routes/api/project/vm.rb
@@ -2,8 +2,6 @@
 
 class CloverApi
   hash_branch(:project_prefix, "vm") do |r|
-    @serializer = Serializers::Api::Vm
-
     r.get true do
       result = @project.vms_dataset.authorized(@current_user.id, "Vm:view").paginated_result(
         start_after: r.params["start_after"],
@@ -12,7 +10,7 @@ class CloverApi
       )
 
       {
-        items: serialize(result[:records]),
+        items: Serializers::Api::Vm.serialize(result[:records]),
         count: result[:count]
       }
     end

--- a/routes/clover_base.rb
+++ b/routes/clover_base.rb
@@ -54,10 +54,6 @@ module CloverBase
     }
   end
 
-  def serialize(data, structure = :default)
-    @serializer.new(structure).serialize(data)
-  end
-
   def fetch_location_based_prices(*resource_types)
     # We use 1 month = 672 hours for conversion. Number of hours
     # in a month changes between 672 and 744, We are  also capping

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -2,10 +2,8 @@
 
 class CloverWeb
   hash_branch("project") do |r|
-    @serializer = Serializers::Web::Project
-
     r.get true do
-      @projects = serialize(@current_user.projects.filter(&:visible))
+      @projects = Serializers::Web::Project.serialize(@current_user.projects.filter(&:visible))
 
       view "project/index"
     end
@@ -35,7 +33,7 @@ class CloverWeb
         fail Authorization::Unauthorized
       end
 
-      @project_data = serialize(@project)
+      @project_data = Serializers::Web::Project.serialize(@project)
       @project_permissions = Authorization.all_permissions(@current_user.id, @project.id)
 
       r.get true do

--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -148,8 +148,6 @@ class CloverWeb
 
     r.on "invoice" do
       r.is String do |invoice_ubid|
-        @serializer = Serializers::Web::Invoice
-
         invoice = (invoice_ubid == "current") ? @project.current_invoice : Invoice.from_ubid(invoice_ubid)
 
         unless invoice
@@ -159,7 +157,7 @@ class CloverWeb
 
         r.get true do
           @full_page = r.params["print"] == "1"
-          @invoice_data = serialize(invoice, :detailed)
+          @invoice_data = Serializers::Web::Invoice.new(:detailed).serialize(invoice)
           view "project/invoice"
         end
       end

--- a/routes/web/project/firewall.rb
+++ b/routes/web/project/firewall.rb
@@ -2,11 +2,9 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "firewall") do |r|
-    @serializer = Serializers::Web::Firewall
-
     r.get true do
       authorized_firewalls = @project.firewalls_dataset.authorized(@current_user.id, "Firewall:view").all
-      @firewalls = serialize(authorized_firewalls)
+      @firewalls = Serializers::Web::Firewall.serialize(authorized_firewalls)
 
       view "firewall/index"
     end
@@ -91,7 +89,7 @@ class CloverWeb
         project_subnets = @project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all
         attached_subnets = fw.private_subnets_dataset.all
         @attachable_subnets = Serializers::Web::PrivateSubnet.serialize(project_subnets.reject { |ps| attached_subnets.map(&:id).include?(ps.id) })
-        @firewall = serialize(fw, :detailed)
+        @firewall = Serializers::Web::Firewall.new(:detailed).serialize(fw)
 
         view "firewall/show"
       end

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -2,8 +2,6 @@
 
 class CloverWeb
   hash_branch(:project_location_prefix, "postgres") do |r|
-    @serializer = Serializers::Web::Postgres
-
     r.on String do |pg_name|
       pg = @project.postgres_resources_dataset.where(location: @location).where { {Sequel[:postgres_resource][:name] => pg_name} }.first
 
@@ -11,7 +9,7 @@ class CloverWeb
         response.status = 404
         r.halt
       end
-      @pg = serialize(pg, :detailed)
+      @pg = Serializers::Web::Postgres.new(:detailed).serialize(pg)
 
       r.get true do
         Authorization.authorize(@current_user.id, "Postgres:view", pg.id)

--- a/routes/web/project/location/private_subnet.rb
+++ b/routes/web/project/location/private_subnet.rb
@@ -2,8 +2,6 @@
 
 class CloverWeb
   hash_branch(:project_location_prefix, "private-subnet") do |r|
-    @serializer = Serializers::Web::PrivateSubnet
-
     r.on String do |ps_name|
       ps = @project.private_subnets_dataset.where(location: @location).where { {Sequel[:private_subnet][:name] => ps_name} }.first
 
@@ -11,7 +9,7 @@ class CloverWeb
         response.status = 404
         r.halt
       end
-      @ps = serialize(ps, :detailed)
+      @ps = Serializers::Web::PrivateSubnet.new(:detailed).serialize(ps)
 
       r.get true do
         Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps.id)

--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -2,8 +2,6 @@
 
 class CloverWeb
   hash_branch(:project_location_prefix, "vm") do |r|
-    @serializer = Serializers::Web::Vm
-
     r.on String do |vm_name|
       vm = @project.vms_dataset.where(location: @location).where { {Sequel[:vm][:name] => vm_name} }.first
 
@@ -15,7 +13,7 @@ class CloverWeb
       r.get true do
         Authorization.authorize(@current_user.id, "Vm:view", vm.id)
 
-        @vm = serialize(vm, :detailed)
+        @vm = Serializers::Web::Vm.new(:detailed).serialize(vm)
 
         view "vm/show"
       end

--- a/routes/web/project/policy.rb
+++ b/routes/web/project/policy.rb
@@ -3,11 +3,10 @@
 class CloverWeb
   hash_branch(:project_prefix, "policy") do |r|
     Authorization.authorize(@current_user.id, "Project:policy", @project.id)
-    @serializer = Serializers::Web::AccessPolicy
 
     r.get true do
       # For UI simplicity, we are showing only one policy at the moment
-      @policy = serialize(@project.access_policies.first)
+      @policy = Serializers::Web::AccessPolicy.serialize(@project.access_policies.first)
 
       view "project/policy"
     end

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -2,10 +2,8 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "postgres") do |r|
-    @serializer = Serializers::Web::Postgres
-
     r.get true do
-      @postgres_databases = serialize(@project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand, :representative_server, :timeline).all)
+      @postgres_databases = Serializers::Web::Postgres.serialize(@project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand, :representative_server, :timeline).all)
 
       view "postgres/index"
     end

--- a/routes/web/project/private_subnet.rb
+++ b/routes/web/project/private_subnet.rb
@@ -2,10 +2,8 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "private-subnet") do |r|
-    @serializer = Serializers::Web::PrivateSubnet
-
     r.get true do
-      @pss = serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
+      @pss = Serializers::Web::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
 
       view "private_subnet/index"
     end

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -3,10 +3,9 @@
 class CloverWeb
   hash_branch(:project_prefix, "user") do |r|
     Authorization.authorize(@current_user.id, "Project:user", @project.id)
-    @serializer = Serializers::Web::Account
 
     r.get true do
-      @users = serialize(@project.accounts)
+      @users = Serializers::Web::Account.serialize(@project.accounts)
 
       view "project/user"
     end

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -2,10 +2,8 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "vm") do |r|
-    @serializer = Serializers::Web::Vm
-
     r.get true do
-      @vms = serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").eager(:semaphores, :assigned_vm_address, :vm_storage_volumes).order(Sequel.desc(:created_at)).all)
+      @vms = Serializers::Web::Vm.serialize(@project.vms_dataset.authorized(@current_user.id, "Vm:view").eager(:semaphores, :assigned_vm_address, :vm_storage_volumes).order(Sequel.desc(:created_at)).all)
 
       view "vm/index"
     end


### PR DESCRIPTION
We used to define a global serializer at the top of the roda branch, and then calls to `serialize` would use that serializer. This was a bit confusing for few reasons;

1. In some cases, we use different serializers in same branch. To be able to use second serializer, we need to explicitly call define which serializer to use, however for the default case we don't need to do that. At a glance, it's hard to understand which serializer would be used while resolving `serialize` calls.
2. In most cases, we define global serializer but use it only once.

Overall, I think it is better to explicitly set the serializer at the time of the serialization, not at the top of the branch.

As an extra benefit, this also reduces the line count by 42.