### PR TITLE
Allow serializers to be configured with options

### DIFF
--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -83,7 +83,7 @@ class Invoice < Sequel::Model
   end
 
   def send_success_email(below_threshold: false)
-    ser = Serializers::Web::Invoice.new(:detailed).serialize(self)
+    ser = Serializers::Web::Invoice.serialize(self, {detailed: true})
     message = if below_threshold
       "Since the invoice total of #{ser[:total]} is below our minimum charge threshold, there will be no charges for this month."
     else
@@ -99,7 +99,7 @@ class Invoice < Sequel::Model
   end
 
   def send_failure_email(errors)
-    ser = Serializers::Web::Invoice.new(:detailed).serialize(self)
+    ser = Serializers::Web::Invoice.serialize(self, {detailed: true})
     Util.send_email(ser[:billing_email], "Urgent: Action Required to Prevent Service Disruption",
       cc: Config.mail_from,
       greeting: "Dear #{ser[:billing_name]},",

--- a/routes/api/project/firewall.rb
+++ b/routes/api/project/firewall.rb
@@ -49,7 +49,7 @@ class CloverApi
       r.get true do
         Authorization.authorize(@current_user.id, "Firewall:view", @project.id)
 
-        Serializers::Api::Firewall.new(:detailed).serialize(@firewall)
+        Serializers::Api::Firewall.serialize(@firewall, {detailed: true})
       end
 
       r.post "attach-subnet" do
@@ -65,7 +65,7 @@ class CloverApi
 
         @firewall.associate_with_private_subnet(private_subnet)
 
-        Serializers::Api::Firewall.new(:detailed).serialize(@firewall)
+        Serializers::Api::Firewall.serialize(@firewall, {detailed: true})
       end
 
       r.post "detach-subnet" do
@@ -81,7 +81,7 @@ class CloverApi
 
         @firewall.disassociate_from_private_subnet(private_subnet)
 
-        Serializers::Api::Firewall.new(:detailed).serialize(@firewall)
+        Serializers::Api::Firewall.serialize(@firewall, {detailed: true})
       end
 
       r.hash_branches(:project_firewall_prefix)

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -47,7 +47,7 @@ class CloverApi
           ha_type: request_body_params["ha_type"] || PostgresResource::HaType::NONE
         )
 
-        Serializers::Api::Postgres.new(:detailed).serialize(st.subject)
+        Serializers::Api::Postgres.serialize(st.subject, {detailed: true})
       end
 
       pg = @project.postgres_resources_dataset.where(location: @location).where { {Sequel[:postgres_resource][:name] => pg_name} }.first
@@ -63,7 +63,7 @@ class CloverApi
 
     request.get true do
       Authorization.authorize(user.id, "Postgres:view", pg.id)
-      Serializers::Api::Postgres.new(:detailed).serialize(pg)
+      Serializers::Api::Postgres.serialize(pg, {detailed: true})
     end
 
     request.delete true do
@@ -92,7 +92,7 @@ class CloverApi
           pg.incr_update_firewall_rules
         end
 
-        Serializers::Api::Postgres.new(:detailed).serialize(pg)
+        Serializers::Api::Postgres.serialize(pg, {detailed: true})
       end
 
       request.get true do
@@ -136,7 +136,7 @@ class CloverApi
         restore_target: request_body_params["restore_target"]
       )
 
-      Serializers::Api::Postgres.new(:detailed).serialize(st.subject)
+      Serializers::Api::Postgres.serialize(st.subject, {detailed: true})
     end
 
     request.post "reset-superuser-password" do
@@ -158,7 +158,7 @@ class CloverApi
         pg.representative_server.incr_update_superuser_password
       end
 
-      Serializers::Api::Postgres.new(:detailed).serialize(pg)
+      Serializers::Api::Postgres.serialize(pg, {detailed: true})
     end
   end
 end

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -68,7 +68,7 @@ class CloverApi
           **request_body_params.except(*required_parameters).transform_keys(&:to_sym)
         )
 
-        Serializers::Api::Vm.new(:detailed).serialize(st.subject)
+        Serializers::Api::Vm.serialize(st.subject, {detailed: true})
       end
 
       vm = @project.vms_dataset.where(location: @location).where { {Sequel[:vm][:name] => vm_name} }.first
@@ -84,7 +84,7 @@ class CloverApi
 
     request.get true do
       Authorization.authorize(user.id, "Vm:view", vm.id)
-      Serializers::Api::Vm.new(:detailed).serialize(vm)
+      Serializers::Api::Vm.serialize(vm, {detailed: true})
     end
 
     request.delete true do

--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -161,7 +161,7 @@ class CloverWeb
 
         r.get true do
           @full_page = r.params["print"] == "1"
-          @invoice_data = Serializers::Web::Invoice.new(:detailed).serialize(invoice)
+          @invoice_data = Serializers::Web::Invoice.serialize(invoice, {detailed: true})
           view "project/invoice"
         end
       end

--- a/routes/web/project/firewall.rb
+++ b/routes/web/project/firewall.rb
@@ -89,7 +89,7 @@ class CloverWeb
         project_subnets = @project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all
         attached_subnets = fw.private_subnets_dataset.all
         @attachable_subnets = Serializers::Web::PrivateSubnet.serialize(project_subnets.reject { |ps| attached_subnets.map(&:id).include?(ps.id) })
-        @firewall = Serializers::Web::Firewall.new(:detailed).serialize(fw)
+        @firewall = Serializers::Web::Firewall.serialize(fw, {detailed: true})
 
         view "firewall/show"
       end

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -9,7 +9,7 @@ class CloverWeb
         response.status = 404
         r.halt
       end
-      @pg = Serializers::Web::Postgres.new(:detailed).serialize(pg)
+      @pg = Serializers::Web::Postgres.serialize(pg, {detailed: true})
 
       r.get true do
         Authorization.authorize(@current_user.id, "Postgres:view", pg.id)

--- a/routes/web/project/location/private_subnet.rb
+++ b/routes/web/project/location/private_subnet.rb
@@ -9,7 +9,7 @@ class CloverWeb
         response.status = 404
         r.halt
       end
-      @ps = Serializers::Web::PrivateSubnet.new(:detailed).serialize(ps)
+      @ps = Serializers::Web::PrivateSubnet.serialize(ps, {detailed: true})
 
       r.get true do
         Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps.id)

--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -13,7 +13,7 @@ class CloverWeb
       r.get true do
         Authorization.authorize(@current_user.id, "Vm:view", vm.id)
 
-        @vm = Serializers::Web::Vm.new(:detailed).serialize(vm)
+        @vm = Serializers::Web::Vm.serialize(vm, {detailed: true})
 
         view "vm/show"
       end

--- a/serializers/api/firewall.rb
+++ b/serializers/api/firewall.rb
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
 class Serializers::Api::Firewall < Serializers::Base
-  def self.base(firewall)
-    {
+  def self.serialize_internal(firewall, options = {})
+    base = {
       id: firewall.ubid,
       name: firewall.name,
       description: firewall.description,
       firewall_rules: firewall.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Common::FirewallRule.serialize(fw) }
     }
-  end
 
-  structure(:default) do |firewall|
-    base(firewall)
-  end
+    if options[:detailed]
+      base[:private_subnets] = firewall.private_subnets.map { |ps| Serializers::Api::PrivateSubnet.serialize(ps) }
+    end
 
-  structure(:detailed) do |firewall|
-    base(firewall).merge({
-      private_subnets: firewall.private_subnets.map { |ps| Serializers::Api::PrivateSubnet.serialize(ps) }
-    })
+    base
   end
 end

--- a/serializers/api/postgres.rb
+++ b/serializers/api/postgres.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serializers::Api::Postgres < Serializers::Base
-  def self.base(pg)
-    {
+  def self.serialize_internal(pg, options = {})
+    base = {
       id: pg.ubid,
       name: pg.name,
       state: pg.display_state,
@@ -11,20 +11,20 @@ class Serializers::Api::Postgres < Serializers::Base
       storage_size_gib: pg.target_storage_size_gib,
       ha_type: pg.ha_type
     }
-  end
 
-  structure(:default) do |pg|
-    base(pg)
-  end
+    if options[:detailed]
+      base.merge!(
+        connection_string: pg.connection_string,
+        primary: pg.representative_server&.primary?,
+        firewall_rules: pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Common::PostgresFirewallRule.serialize(fw) }
+      )
 
-  structure(:detailed) do |pg|
-    base(pg).merge({
-      connection_string: pg.connection_string,
-      primary: pg.representative_server&.primary?,
-      firewall_rules: pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Common::PostgresFirewallRule.serialize(fw) }
-    }).merge((pg.timeline && pg.representative_server && pg.representative_server.primary?) ? {
-      earliest_restore_time: pg.timeline.earliest_restore_time&.utc&.iso8601,
-      latest_restore_time: pg.timeline.latest_restore_time&.utc&.iso8601
-    } : {})
+      if pg.timeline && pg.representative_server&.primary?
+        base[:earliest_restore_time] = pg.timeline.earliest_restore_time&.utc&.iso8601
+        base[:latest_restore_time] = pg.timeline.latest_restore_time&.utc&.iso8601
+      end
+    end
+
+    base
   end
 end

--- a/serializers/api/private_subnet.rb
+++ b/serializers/api/private_subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serializers::Api::PrivateSubnet < Serializers::Base
-  def self.base(ps)
+  def self.serialize_internal(ps, options = {})
     {
       id: ps.ubid,
       name: ps.name,
@@ -12,9 +12,5 @@ class Serializers::Api::PrivateSubnet < Serializers::Base
       firewalls: Serializers::Api::Firewall.serialize(ps.firewalls),
       nics: Serializers::Common::Nic.serialize(ps.nics)
     }
-  end
-
-  structure(:default) do |ps|
-    base(ps)
   end
 end

--- a/serializers/api/project.rb
+++ b/serializers/api/project.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 class Serializers::Api::Project < Serializers::Base
-  def self.base(p)
+  def self.serialize_internal(p, options = {})
     {
       id: p.ubid,
       name: p.name,
       credit: p.credit.to_f,
       discount: p.discount
     }
-  end
-
-  structure(:default) do |p|
-    base(p)
   end
 end

--- a/serializers/api/vm.rb
+++ b/serializers/api/vm.rb
@@ -3,8 +3,8 @@
 require_relative "../base"
 
 class Serializers::Api::Vm < Serializers::Base
-  def self.base(vm)
-    {
+  def self.serialize_internal(vm, options = {})
+    base = {
       id: vm.ubid,
       name: vm.name,
       state: vm.display_state,
@@ -15,18 +15,16 @@ class Serializers::Api::Vm < Serializers::Base
       ip6: vm.ephemeral_net6&.nth(2),
       ip4: vm.ephemeral_net4
     }
-  end
 
-  structure(:default) do |vm|
-    base(vm)
-  end
+    if options[:detailed]
+      base.merge!(
+        firewalls: vm.firewalls.map { |fw| Serializers::Api::Firewall.serialize(fw) },
+        private_ipv4: vm.nics.first.private_ipv4.network,
+        private_ipv6: vm.nics.first.private_ipv6.nth(2),
+        subnet: vm.nics.first.private_subnet.name
+      )
+    end
 
-  structure(:detailed) do |vm|
-    base(vm).merge(
-      firewalls: vm.firewalls.map { |fw| Serializers::Api::Firewall.serialize(fw) },
-      private_ipv4: vm.nics.first.private_ipv4.network,
-      private_ipv6: vm.nics.first.private_ipv6.nth(2),
-      subnet: vm.nics.first.private_subnet.name
-    )
+    base
   end
 end

--- a/serializers/base.rb
+++ b/serializers/base.rb
@@ -24,33 +24,17 @@
 
 module Serializers
   class Base
-    @@structures = {}
-
-    def self.structure(type, &blk)
-      @@structures["#{name}::#{type}"] = blk
-    end
-
-    def self.serialize(object)
-      new.serialize(object)
-    end
-
-    def initialize(type = :default)
-      @type = type
-    end
-
-    def serialize(object)
+    def self.serialize(object, options = {})
       return if object.nil?
       if object.respond_to?(:map) && !object.is_a?(Hash)
-        object.map { |item| serializer.call(item) }
+        object.map { |item| serialize_internal(item, options) }
       else
-        serializer.call(object)
+        serialize_internal(object, options)
       end
     end
 
-    private
-
-    def serializer
-      @@structures["#{self.class.name}::#{@type}"]
+    def self.serialize_internal(object, options = {})
+      raise NoMethodError
     end
   end
 end

--- a/serializers/common/firewall_rule.rb
+++ b/serializers/common/firewall_rule.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 class Serializers::Common::FirewallRule < Serializers::Base
-  def self.base(firewall_rule)
+  def self.serialize_internal(firewall_rule, options = {})
     {
       id: firewall_rule.ubid,
       cidr: firewall_rule.cidr,
       port_range: firewall_rule.port_range&.begin ? "#{firewall_rule.port_range.begin}..#{firewall_rule.port_range.end - 1}" : "0..65535"
     }
-  end
-
-  structure(:default) do |firewall_rule|
-    base(firewall_rule)
   end
 end

--- a/serializers/common/nic.rb
+++ b/serializers/common/nic.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serializers::Common::Nic < Serializers::Base
-  def self.base(nic)
+  def self.serialize_internal(nic, options = {})
     {
       id: nic.ubid,
       name: nic.name,
@@ -9,9 +9,5 @@ class Serializers::Common::Nic < Serializers::Base
       private_ipv6: nic.private_ipv6.nth(2).to_s,
       vm_name: nic.vm&.name
     }
-  end
-
-  structure(:default) do |nic|
-    base(nic)
   end
 end

--- a/serializers/common/postgres_firewall_rule.rb
+++ b/serializers/common/postgres_firewall_rule.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 class Serializers::Common::PostgresFirewallRule < Serializers::Base
-  def self.base(postgres_firewall_rule)
+  def self.serialize_internal(postgres_firewall_rule, options = {})
     {
       id: postgres_firewall_rule.ubid,
       cidr: postgres_firewall_rule.cidr
     }
-  end
-
-  structure(:default) do |postgres_firewall_rule|
-    base(postgres_firewall_rule)
   end
 end

--- a/serializers/web/access_policy.rb
+++ b/serializers/web/access_policy.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 class Serializers::Web::AccessPolicy < Serializers::Base
-  def self.base(ap)
+  def self.serialize_internal(ap, options = {})
     {
       id: ap.id,
       ubid: ap.ubid,
       name: ap.name,
       body: ap.body.to_json
     }
-  end
-
-  structure(:default) do |ap|
-    base(ap)
   end
 end

--- a/serializers/web/account.rb
+++ b/serializers/web/account.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 class Serializers::Web::Account < Serializers::Base
-  def self.base(a)
+  def self.serialize_internal(a, options = {})
     {
       id: a.id,
       ubid: a.ubid,
       email: a.email
     }
-  end
-
-  structure(:default) do |a|
-    base(a)
   end
 end

--- a/serializers/web/billing_info.rb
+++ b/serializers/web/billing_info.rb
@@ -3,7 +3,7 @@
 require "countries"
 
 class Serializers::Web::BillingInfo < Serializers::Base
-  def self.base(bi)
+  def self.serialize_internal(bi, options = {})
     {
       id: bi.id,
       ubid: bi.ubid
@@ -18,9 +18,5 @@ class Serializers::Web::BillingInfo < Serializers::Base
       tax_id: bi.stripe_data["metadata"]["tax_id"],
       company_name: bi.stripe_data["metadata"]["company_name"]
     } : {})
-  end
-
-  structure(:default) do |bi|
-    base(bi)
   end
 end

--- a/serializers/web/firewall.rb
+++ b/serializers/web/firewall.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serializers::Web::Firewall < Serializers::Base
-  def self.base(firewall)
-    {
+  def self.serialize_internal(firewall, options = {})
+    base = {
       ubid: firewall.ubid,
       id: firewall.id,
       name: firewall.name,
@@ -10,15 +10,11 @@ class Serializers::Web::Firewall < Serializers::Base
       path: firewall.path,
       firewall_rules: firewall.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Common::FirewallRule.serialize(fw) }
     }
-  end
 
-  structure(:default) do |firewall|
-    base(firewall)
-  end
+    if options[:detailed]
+      base[:private_subnets] = firewall.private_subnets.map { |ps| Serializers::Web::PrivateSubnet.serialize(ps) }
+    end
 
-  structure(:detailed) do |firewall|
-    base(firewall).merge(
-      private_subnets: firewall.private_subnets.map { |ps| Serializers::Web::PrivateSubnet.serialize(ps) }
-    )
+    base
   end
 end

--- a/serializers/web/github_installation.rb
+++ b/serializers/web/github_installation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serializers::Web::GithubInstallation < Serializers::Base
-  def self.base(ins)
+  def self.serialize_internal(ins, options = {})
     {
       id: ins.id,
       name: ins.name,
@@ -9,9 +9,5 @@ class Serializers::Web::GithubInstallation < Serializers::Base
       installation_id: ins.installation_id,
       installation_url: ins.installation_url
     }
-  end
-
-  structure(:default) do |ins|
-    base(ins)
   end
 end

--- a/serializers/web/github_runner.rb
+++ b/serializers/web/github_runner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serializers::Web::GithubRunner < Serializers::Base
-  def self.base(runner)
+  def self.serialize_internal(runner, options = {})
     {
       id: runner.id,
       ubid: runner.ubid,
@@ -20,9 +20,5 @@ class Serializers::Web::GithubRunner < Serializers::Base
       } : nil,
       state: runner.display_state
     }
-  end
-
-  structure(:default) do |runner|
-    base(runner)
   end
 end

--- a/serializers/web/payment_method.rb
+++ b/serializers/web/payment_method.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serializers::Web::PaymentMethod < Serializers::Base
-  def self.base(pm)
+  def self.serialize_internal(pm, options = {})
     {
       id: pm.id,
       ubid: pm.ubid,
@@ -11,9 +11,5 @@ class Serializers::Web::PaymentMethod < Serializers::Base
       exp_year: pm.stripe_data["card"]["exp_year"],
       order: pm.order
     }
-  end
-
-  structure(:default) do |pm|
-    base(pm)
   end
 end

--- a/serializers/web/postgres.rb
+++ b/serializers/web/postgres.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serializers::Web::Postgres < Serializers::Base
-  def self.base(pg)
-    {
+  def self.serialize_internal(pg, options = {})
+    base = {
       id: pg.id,
       ubid: pg.ubid,
       path: pg.path,
@@ -13,20 +13,20 @@ class Serializers::Web::Postgres < Serializers::Base
       storage_size_gib: pg.target_storage_size_gib,
       ha_type: pg.ha_type
     }
-  end
 
-  structure(:default) do |pg|
-    base(pg)
-  end
+    if options[:detailed]
+      base.merge!(
+        connection_string: pg.connection_string,
+        primary?: pg.representative_server&.primary?,
+        firewall_rules: pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Common::PostgresFirewallRule.serialize(fw) }
+      )
 
-  structure(:detailed) do |pg|
-    base(pg).merge({
-      connection_string: pg.connection_string,
-      primary?: pg.representative_server&.primary?,
-      firewall_rules: pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }.map { |fw| Serializers::Common::PostgresFirewallRule.serialize(fw) }
-    }).merge((pg.timeline && pg.representative_server && pg.representative_server.primary?) ? {
-      earliest_restore_time: pg.timeline.earliest_restore_time&.utc&.iso8601,
-      latest_restore_time: pg.timeline.latest_restore_time&.utc&.iso8601
-    } : {})
+      if pg.timeline && pg.representative_server&.primary?
+        base[:earliest_restore_time] = pg.timeline.earliest_restore_time&.utc&.iso8601
+        base[:latest_restore_time] = pg.timeline.latest_restore_time&.utc&.iso8601
+      end
+    end
+
+    base
   end
 end

--- a/serializers/web/private_subnet.rb
+++ b/serializers/web/private_subnet.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serializers::Web::PrivateSubnet < Serializers::Base
-  def self.base(ps)
-    {
+  def self.serialize_internal(ps, options = {})
+    base = {
       id: ps.id,
       ubid: ps.ubid,
       path: ps.path,
@@ -12,15 +12,11 @@ class Serializers::Web::PrivateSubnet < Serializers::Base
       net4: ps.net4.to_s,
       net6: ps.net6.to_s
     }
-  end
 
-  structure(:default) do |ps|
-    base(ps)
-  end
+    if options[:detailed]
+      base[:attached_firewalls] = ps.firewalls.map { |f| Serializers::Web::Firewall.serialize(f) }
+    end
 
-  structure(:detailed) do |ps|
-    base(ps).merge(
-      attached_firewalls: ps.firewalls.map { |f| Serializers::Web::Firewall.serialize(f) }
-    )
+    base
   end
 end

--- a/serializers/web/project.rb
+++ b/serializers/web/project.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serializers::Web::Project < Serializers::Base
-  def self.base(p)
+  def self.serialize_internal(p, options = {})
     {
       id: p.id,
       ubid: p.ubid,
@@ -10,9 +10,5 @@ class Serializers::Web::Project < Serializers::Base
       credit: p.credit.to_f,
       discount: p.discount
     }
-  end
-
-  structure(:default) do |p|
-    base(p)
   end
 end

--- a/serializers/web/usage_alert.rb
+++ b/serializers/web/usage_alert.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 class Serializers::Web::UsageAlert < Serializers::Base
-  def self.base(ua)
+  def self.serialize_internal(ua, options = {})
     {
       ubid: ua.ubid,
       name: ua.name,
       limit: ua.limit,
       email: ua.user.email
     }
-  end
-
-  structure(:default) do |ua|
-    base(ua)
   end
 end

--- a/serializers/web/vm.rb
+++ b/serializers/web/vm.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serializers::Web::Vm < Serializers::Base
-  def self.base(vm)
-    {
+  def self.serialize_internal(vm, options = {})
+    base = {
       id: vm.id,
       ubid: vm.ubid,
       path: vm.path,
@@ -16,18 +16,16 @@ class Serializers::Web::Vm < Serializers::Base
       ip4: vm.ephemeral_net4,
       unix_user: vm.unix_user
     }
-  end
 
-  structure(:default) do |vm|
-    base(vm)
-  end
+    if options[:detailed]
+      base.merge!(
+        firewalls: vm.firewalls.map { |fw| Serializers::Web::Firewall.serialize(fw) },
+        private_ip4: vm.nics.first.private_ipv4.network,
+        private_ip6: vm.nics.first.private_ipv6.nth(2),
+        subnet: vm.nics.first.private_subnet.name
+      )
+    end
 
-  structure(:detailed) do |vm|
-    base(vm).merge(
-      firewalls: vm.firewalls.map { |fw| Serializers::Web::Firewall.serialize(fw) },
-      private_ip4: vm.nics.first.private_ipv4.network,
-      private_ip6: vm.nics.first.private_ipv6.nth(2),
-      subnet: vm.nics.first.private_subnet.name
-    )
+    base
   end
 end

--- a/spec/serializers/api/postgres_spec.rb
+++ b/spec/serializers/api/postgres_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Serializers::Api::Postgres do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
   end
@@ -19,7 +19,7 @@ RSpec.describe Serializers::Api::Postgres do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).exactly(3)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:earliest_restore_time]).to eq(time.iso8601)
     expect(data[:latest_restore_time]).to eq(time.iso8601)
   end
@@ -27,15 +27,16 @@ RSpec.describe Serializers::Api::Postgres do
   it "can serialize when not primary" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil, strand: nil)).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
   end
 
   it "can serialize when there is no server" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil))
     expect(pg).to receive(:representative_server).and_return(nil).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:primary?]).to be_nil
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil

--- a/spec/serializers/base_spec.rb
+++ b/spec/serializers/base_spec.rb
@@ -3,16 +3,7 @@
 require_relative "../spec_helper"
 
 RSpec.describe Serializers::Base do
-  it "use default structure when not provided" do
-    ser = described_class.new
-    expect(ser.instance_variable_get(:@type)).to eq(:default)
-  end
-
-  it "initilize new seriliazer when class method called" do
-    ser = instance_double(described_class)
-    expect(described_class).to receive(:new).and_return(ser)
-    expect(ser).to receive(:serialize).and_return({})
-
-    expect(described_class.serialize(nil)).to eq({})
+  it "raises an error when serialize_internal is called" do
+    expect { described_class.serialize_internal(nil) }.to raise_error(NoMethodError)
   end
 end

--- a/spec/serializers/web/postgres_spec.rb
+++ b/spec/serializers/web/postgres_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Serializers::Web::Postgres do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
   end
@@ -19,7 +19,7 @@ RSpec.describe Serializers::Web::Postgres do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).exactly(3)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:earliest_restore_time]).to eq(time.iso8601)
     expect(data[:latest_restore_time]).to eq(time.iso8601)
   end
@@ -27,15 +27,16 @@ RSpec.describe Serializers::Web::Postgres do
   it "can serialize when not primary" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil, strand: nil)).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil
   end
 
   it "can serialize when there is no server" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil))
     expect(pg).to receive(:representative_server).and_return(nil).at_least(:once)
-    data = described_class.new(:detailed).serialize(pg)
+    data = described_class.serialize(pg, {detailed: true})
     expect(data[:primary?]).to be_nil
     expect(data[:earliest_restore_time]).to be_nil
     expect(data[:latest_restore_time]).to be_nil

--- a/spec/serializers/web/vm_spec.rb
+++ b/spec/serializers/web/vm_spec.rb
@@ -12,20 +12,19 @@ RSpec.describe Serializers::Web::Vm do
     ).tap { _1.id = "a410a91a-dc31-4119-9094-3c6a1fb49601" }
   }
   let(:vm) { Vm.new(name: "test-vm", family: "standard", cores: 1).tap { _1.id = "a410a91a-dc31-4119-9094-3c6a1fb49601" } }
-  let(:ser) { described_class.new }
 
   before do
     allow(vm).to receive(:nics).and_return([nic])
   end
 
   it "can serialize with the default structure" do
-    data = ser.serialize(vm)
+    data = described_class.serialize(vm)
     expect(data[:name]).to eq(vm.name)
   end
 
   it "can serialize when disk not encrypted" do
     expect(vm).to receive(:storage_encrypted?).and_return(false)
-    data = ser.serialize(vm)
+    data = described_class.serialize(vm)
     expect(data[:storage_encryption]).to eq("not encrypted")
   end
 end


### PR DESCRIPTION
We currently use structures for serializing same objects in different formats, such as :default and :detailed. However, this approach is not flexible, because to add an option which modifies both :default and :detailed formats, you need to create 2 new structures.

For example, if you want to output slightly different information for :api and :web options, you need to define :default_api, :detailed_api, :default_web and :detailed_web structures.

With this change, you can pass options to the serializer, which then can be used to alter the output. We also started to use options to distinguish between default and detailed formats.

Apart from being more flexible, this approach allows using serializers without creating serializer instances as all the methods become class methods. We also cut the line count by 123.

I'm splitting this PR into 2 commits for ease of review. First commit has the actual change along with 2 refactored serializers to showcase the idea. The second commit is just refactoring of the remaining serializers. While it is easier to review, it also means that just the first commit itself wouldn't work on its own. I can squash the commits before merging to prevent having broken code in the git history.