### PR TITLE
Introduce standard-30 VM size and surface "out of capacity" issues to users

### DIFF
--- a/config/billing_rates.yml
+++ b/config/billing_rates.yml
@@ -37,9 +37,11 @@
 - { id: d885c82d-b139-40d5-890f-de3720896b3b, resource_type: GitHubRunnerMinutes,     resource_family: standard-4,      location: global,         unit_price: 0.0016 }
 - { id: e50e6bff-6ee9-493b-bc09-75f122863d08, resource_type: GitHubRunnerMinutes,     resource_family: standard-8,      location: global,         unit_price: 0.0032 }
 - { id: 89cda6c2-2650-4ac1-bc28-deeae5e3b756, resource_type: GitHubRunnerMinutes,     resource_family: standard-16,     location: global,         unit_price: 0.0064 }
+- { id: c5c0b29f-1ea9-437c-8ab8-c9395ec7e46d, resource_type: GitHubRunnerMinutes,     resource_family: standard-30,     location: global,         unit_price: 0.0120 }
 - { id: ab92083e-2be7-4038-b946-b060af3994fb, resource_type: GitHubRunnerMinutes,     resource_family: standard-2-arm,  location: global,         unit_price: 0.0008 }
 - { id: 078d2f47-5827-49fa-9d13-bee6d1d8cadd, resource_type: GitHubRunnerMinutes,     resource_family: standard-4-arm,  location: global,         unit_price: 0.0016 }
 - { id: 0fc7f264-87f0-446d-bee7-c0454149b1bc, resource_type: GitHubRunnerMinutes,     resource_family: standard-8-arm,  location: global,         unit_price: 0.0032 }
 - { id: 995ab760-5d97-4a7b-981e-c9947233c78e, resource_type: GitHubRunnerMinutes,     resource_family: standard-16-arm, location: global,         unit_price: 0.0064 }
+- { id: 5b49ad57-1bac-4c35-84d4-9545876ecb65, resource_type: GitHubRunnerMinutes,     resource_family: standard-30-arm, location: global,         unit_price: 0.0120 }
 - { id: 27d84309-e39d-8d78-b603-7632dafe374e, resource_type: GitHubRunnerMinutes,     resource_family: standard-gpu-6,  location: global,         unit_price: 0.0320 }
 - { id: c31b3640-92fa-49c3-bae8-c1011cc5f917, resource_type: GitHubRunnerConcurrency, resource_family: standard,        location: global,         unit_price: 0.0000248016 }

--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -3,27 +3,33 @@
 - { name: ubicloud-standard-4,                  vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-8,                  vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-16,                 vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-standard-30,                 vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-2-ubuntu-2204,      vm_size: standard-2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-4-ubuntu-2204,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-8-ubuntu-2204,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-16-ubuntu-2204,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-standard-30-ubuntu-2204,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-2-ubuntu-2004,      vm_size: standard-2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-4-ubuntu-2004,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-8-ubuntu-2004,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-16-ubuntu-2004,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2004,     location: github-runners }
+- { name: ubicloud-standard-30-ubuntu-2004,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-arm,                         vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-2-arm,              vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-4-arm,              vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-8-arm,              vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-16-arm,             vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-standard-30-arm,             vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-2-arm-ubuntu-2204,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-4-arm-ubuntu-2204,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-8-arm-ubuntu-2204,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-16-arm-ubuntu-2204, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-standard-30-arm-ubuntu-2204, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-2-arm-ubuntu-2004,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-4-arm-ubuntu-2004,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-8-arm-ubuntu-2004,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-16-arm-ubuntu-2004, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2004,     location: github-runners }
+- { name: ubicloud-standard-30-arm-ubuntu-2004, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-gpu-standard-1-latest,    vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204, location: github-runners, gpu: true  }
 # Deprecated: Remove old arm64 labels once all customers have migrated to new labels.
 - { name: ubicloud-standard-2-ubuntu-2204-arm,  vm_size: standard-2,  arch: arm64,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -45,7 +45,7 @@ module Option
   VmSize = Struct.new(:name, :family, :vcpu, :memory, :storage_size_gib, :visible, :gpu) do
     alias_method :display_name, :name
   end
-  VmSizes = [2, 4, 8, 16].map {
+  VmSizes = [2, 4, 8, 16, 30].map {
     VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 25, true, false)
   }.concat([6].map {
     VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, (_1 / 2) * 60, false, true)

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -21,7 +21,7 @@ class Vm < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency
+  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity
 
   include Authorization::HyperTagMethods
 
@@ -52,7 +52,8 @@ class Vm < Sequel::Model
   end
 
   def display_state
-    return "deleting" if destroy_set?
+    return "deleting" if destroy_set? || strand&.label == "destroy"
+    return "waiting for capacity" if waiting_for_capacity_set?
     super
   end
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Vm do
       expect(vm.display_state).to eq("deleting")
     end
 
+    it "returns waiting for capacity if semaphore increased" do
+      expect(vm).to receive(:semaphores).twice.and_return([instance_double(Semaphore, name: "waiting_for_capacity")])
+      expect(vm.display_state).to eq("waiting for capacity")
+    end
+
     it "return same if semaphores not increased" do
       expect(vm.display_state).to eq("creating")
     end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Vm do
       expect(vm.mem_gib).to eq 64
     end
 
+    it "handles standard-30" do
+      vm.family = "standard"
+      vm.cores = 15
+      expect(vm.mem_gib).to eq 120
+    end
+
     it "handles standard-6" do
       vm.family = "standard-gpu"
       vm.cores = 3

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["size"]).to eq("\"standard-gpu-6\" is not a valid virtual machine size. Available sizes: [\"standard-2\", \"standard-4\", \"standard-8\", \"standard-16\"]")
+        expect(JSON.parse(last_response.body)["error"]["details"]["size"]).to eq("\"standard-gpu-6\" is not a valid virtual machine size. Available sizes: [\"standard-2\", \"standard-4\", \"standard-8\", \"standard-16\", \"standard-30\"]")
       end
 
       it "success without vm_size" do

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -1,7 +1,7 @@
 <% case state %>
 <% when "running" %>
   <% color = "bg-green-100 text-green-800" %>
-<% when "creating", "rebooting", "starting" %>
+<% when "creating", "rebooting", "starting", "waiting for capacity" %>
   <% color = "bg-yellow-100 text-yellow-800" %>
 <% when "deleting", "deleted" %>
   <% color = "bg-red-100 text-red-800" %>


### PR DESCRIPTION
A VM's display state is set to `waiting for capacity` if allocation is not able to find any eligible host. It's switched back to `creating` when a suitable host was found.

Add `standard-30` VM size as well as these new runner labels:
* ubicloud-standard-30
* ubicloud-standard-30-ubuntu-2204
* ubicloud-standard-30-ubuntu-2004
* ubicloud-standard-30-arm
* ubicloud-standard-30-arm-ubuntu-2204
* ubicloud-standard-30-arm-ubuntu-2004