### PR TITLE
Add location check to location based resource endpoints with id

### DIFF
--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -18,6 +18,11 @@ class CloverApi
     r.on "id" do
       r.on String do |pg_ubid|
         pg = PostgresResource.from_ubid(pg_ubid)
+
+        if pg&.location != @location
+          pg = nil
+        end
+
         handle_pg_requests(@current_user, pg, @project)
       end
     end

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -18,6 +18,11 @@ class CloverApi
     r.on "id" do
       r.is String do |ps_id|
         ps = PrivateSubnet.from_ubid(ps_id)
+
+        if ps&.location != @location
+          ps = nil
+        end
+
         handle_ps_requests(@current_user, ps)
       end
     end

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -18,6 +18,11 @@ class CloverApi
     r.on "id" do
       r.on String do |vm_ubid|
         vm = Vm.from_ubid(vm_ubid)
+
+        if vm&.location != @location
+          vm = nil
+        end
+
         handle_vm_requests(@current_user, vm)
       end
     end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -372,6 +372,13 @@ RSpec.describe Clover, "postgres" do
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 
+      it "not exist ubid in location" do
+        delete "/api/project/#{project.ubid}/location/foo_location/postgres/id/#{pg.ubid}"
+
+        expect(last_response.status).to eq(204)
+        expect(SemSnap.new(pg.id).set?("destroy")).to be false
+      end
+
       it "firewall-rule" do
         delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -175,6 +175,20 @@ RSpec.describe Clover, "private_subnet" do
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
       end
 
+      it "not exist ubid in location" do
+        delete "/api/project/#{project.ubid}/location/foo_location/private-subnet/id/#{ps.ubid}"
+
+        expect(last_response.status).to eq(204)
+        expect(SemSnap.new(ps.id).set?("destroy")).to be false
+      end
+
+      it "not exist ubid" do
+        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/foo_ubid"
+
+        expect(last_response.status).to eq(204)
+        expect(SemSnap.new(ps.id).set?("destroy")).to be false
+      end
+
       it "dependent vm failure" do
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, private_subnet_id: ps.id, name: "dummy-vm-2")
 

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -343,6 +343,13 @@ RSpec.describe Clover, "vm" do
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
       end
+
+      it "not exist ubid in location" do
+        delete "/api/project/#{project.ubid}/location/foo_location/vm/id/#{vm.ubid}"
+
+        expect(last_response.status).to eq(204)
+        expect(SemSnap.new(vm.id).set?("destroy")).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
While processing a request coming to location based resource with id, we were not checking whether the resource with the given id lives in the given location. It causes managing resources from another location and counterintuitive results for client, fixing that.