### PR TITLE
Update a VMs IPv6 prefix

### DIFF
--- a/prog/vm/update_ipv6.rb
+++ b/prog/vm/update_ipv6.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/util"
+
+class Prog::Vm::UpdateIpv6 < Prog::Base
+  subject_is :vm
+
+  def vm_host
+    @vm_host ||= VmHost[vm.vm_host_id]
+  end
+
+  label def start
+    vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}.service")
+    vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}-dnsmasq.service")
+    vm_host.sshable.cmd("sudo ip netns del #{vm.inhost_name}")
+    hop_rewrite_persisted
+  end
+
+  label def rewrite_persisted
+    vm.update(
+      ephemeral_net6: vm_host.ip6_random_vm_network.to_s
+    )
+
+    write_params_json
+    vm_host.sshable.cmd("sudo host/bin/setup-vm reassign-ip6 #{vm.inhost_name}", stdin: JSON.generate({storage: vm.storage_secrets}))
+    hop_start_vm
+  end
+
+  label def start_vm
+    nic = vm.nics.first
+    addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
+
+    vm_host.sshable.cmd("sudo ip -n #{vm.inhost_name.shellescape} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
+    vm_host.sshable.cmd("sudo systemctl start #{vm.inhost_name}.service")
+    vm.incr_update_firewall_rules
+    pop "VM #{vm.name} updated"
+  end
+
+  def write_params_json
+    vm_host.sshable.cmd("sudo rm /vm/#{vm.inhost_name}/prep.json")
+
+    vm_host.sshable.cmd("sudo -u #{vm.inhost_name} tee /vm/#{vm.inhost_name}/prep.json", stdin: vm.params_json(nil))
+  end
+end

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -71,6 +71,15 @@ when "reinstall-systemd-units"
   vm_setup.install_systemd_unit(
     max_vcpus, cpu_topology, mem_gib, storage_volumes, nics
   )
+when "reassign-ip6"
+  secrets = JSON.parse($stdin.read)
+  unless (storage_secrets = secrets["storage"])
+    puts "need storage secrets in secrets json"
+    exit 1
+  end
+  vm_setup.reassign_ip6(unix_user, ssh_public_key, nics, gua, ip4,
+    local_ip4, max_vcpus, cpu_topology, mem_gib,
+    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 else
   puts "Invalid action #{action}"
   exit 1

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -58,6 +58,14 @@ class VmSetup
     storage(storage_params, storage_secrets, false)
   end
 
+  def reassign_ip6(unix_user, public_key, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
+    setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
+    cloudinit(unix_user, public_key, nics, swap_size_bytes)
+    hugepages(mem_gib)
+    storage(storage_params, storage_secrets, false)
+    install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices)
+  end
+
   def setup_networking(skip_persisted, gua, ip4, local_ip4, nics, ndp_needed, multiqueue:)
     ip4 = nil if ip4.empty?
     guest_ephemeral, clover_ephemeral = subdivide_network(NetAddr.parse_net(gua))

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -189,17 +189,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
   end
 
-  describe "#storage_volumes" do
-    it "includes all storage volumes" do
-      expect(nx.storage_volumes).to eq([
-        {"boot" => true, "disk_index" => 0, "image" => nil, "size_gib" => 20, "device_id" => "vm4hjdwr_0", "encrypted" => true,
-         "spdk_version" => "v1", "use_bdev_ubi" => false, "skip_sync" => false, "storage_device" => "nvme0", "image_version" => nil},
-        {"boot" => false, "disk_index" => 1, "image" => nil, "size_gib" => 15, "device_id" => "vm4hjdwr_1", "encrypted" => false,
-         "spdk_version" => "v1", "use_bdev_ubi" => true, "skip_sync" => true, "storage_device" => "DEFAULT", "image_version" => "20230303"}
-      ])
-    end
-  end
-
   describe "#create_unix_user" do
     it "runs adduser" do
       sshable = instance_double(Sshable)
@@ -243,7 +232,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
       vmh = instance_double(VmHost, sshable: sshable,
         total_cpus: 80, total_cores: 80, total_sockets: 1, ndp_needed: false)
-      expect(vm).to receive(:vm_host).and_return(vmh)
+      expect(vm).to receive(:vm_host).and_return(vmh).at_least(:once)
 
       expect(sshable).to receive(:cmd).with(/sudo -u vm[0-9a-z]+ tee/, stdin: String) do |**kwargs|
         require "json"
@@ -272,16 +261,6 @@ RSpec.describe Prog::Vm::Nexus do
       vmh = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vmh)
       expect { nx.prep }.to nap(1)
-    end
-
-    it "generates local_ipv4 if not set" do
-      expect(nx.local_ipv4).to eq("")
-    end
-
-    it "generates local_ipv4 if set" do
-      vm = nx.vm
-      vm.local_vetho_ip = "169.254.0.0"
-      expect(nx.local_ipv4).to eq("169.254.0.0")
     end
   end
 

--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Vm::UpdateIpv6 do
+  subject(:pr) {
+    described_class.new(Strand.new)
+  }
+
+  let(:vm) {
+    instance_double(Vm,
+      inhost_name: "test",
+      storage_secrets: "storage_secrets",
+      nics: [instance_double(Nic,
+        private_subnet: instance_double(
+          PrivateSubnet,
+          net4: NetAddr::IPv4Net.parse("1.0.0.0/8")
+        ),
+        ubid_to_tap_name: "ubid_to_tap_name")],
+      name: "test",
+      vm_host_id: 1)
+  }
+
+  let(:vm_host) {
+    instance_double(VmHost, sshable: instance_double(Sshable, host: "1.1.1.1"), ip6_random_vm_network: NetAddr::IPv6Net.parse("2001:0::"))
+  }
+
+  before do
+    allow(pr).to receive(:vm).and_return(vm)
+  end
+
+  it "returns vm_host" do
+    expect(VmHost).to receive(:[]).with(1).and_return(vm_host)
+    expect(pr.vm_host).to eq(vm_host)
+  end
+
+  it "stops services and cleans up namespace" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm_host.sshable).to receive(:cmd).with("sudo systemctl stop test.service")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo systemctl stop test-dnsmasq.service")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo ip netns del test")
+    expect(pr).to receive(:hop_rewrite_persisted)
+    pr.start
+  end
+
+  it "rewrites persisted" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm).to receive(:update).with(ephemeral_net6: "2001::/64")
+    expect(pr).to receive(:write_params_json)
+    expect(vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-vm reassign-ip6 test", stdin: JSON.generate({storage: "storage_secrets"}))
+    expect(pr).to receive(:hop_start_vm)
+    pr.rewrite_persisted
+  end
+
+  it "starts vm" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm_host.sshable).to receive(:cmd).with("sudo ip -n test addr replace 1.0.0.1/8 dev ubid_to_tap_name")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo systemctl start test.service")
+    expect(vm).to receive(:incr_update_firewall_rules)
+    expect(pr).to receive(:pop).with("VM test updated")
+    pr.start_vm
+  end
+
+  it "writes params json" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm).to receive(:params_json).with(nil).and_return("params_json")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo rm /vm/test/prep.json")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo -u test tee /vm/test/prep.json", stdin: "params_json")
+    pr.write_params_json
+  end
+end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -612,10 +612,7 @@ RSpec.describe Al do
       described_class.allocate(vm, vol)
       expect(StorageKeyEncryptionKey.count).to eq(0)
       expect(vm.reload.vm_storage_volumes.first.key_encryption_key_1_id).to be_nil
-      nx = Prog::Vm::Nexus.new(Strand.new).tap {
-        _1.instance_variable_set(:@vm, vm)
-      }
-      expect(nx.storage_secrets.count).to eq(0)
+      expect(vm.storage_secrets.count).to eq(0)
     end
 
     it "can have empty allocation state filter" do
@@ -630,10 +627,7 @@ RSpec.describe Al do
       described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
       expect(StorageKeyEncryptionKey.count).to eq(1)
       expect(vm.vm_storage_volumes.first.key_encryption_key_1_id).not_to be_nil
-      nx = Prog::Vm::Nexus.new(Strand.new).tap {
-        _1.instance_variable_set(:@vm, vm)
-      }
-      expect(nx.storage_secrets.count).to eq(1)
+      expect(vm.storage_secrets.count).to eq(1)
     end
 
     it "allocates the latest active boot image for boot volumes" do


### PR DESCRIPTION
## Move params functions from Vm::Nexus to Vm model to reuse

## Add IPv6 reassignment functionality 
This is required because Hetzner decided to renew the IPv6 Prefixes
assigned to our hosts. Therefore, we need a way to update the IPv6
prefix of the VMs running on the impacted hosts. The action plan is
available at
https://github.com/ubicloud/ubinest/wiki/Hetzner-IPv6-Prefix-Change-%E2%80%90-Action-Plan