### PR TITLE
Allocate primaries and standbys at different hosts 

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -49,10 +49,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       PostgresFirewallRule.create_with_id(postgres_resource_id: postgres_resource.id, cidr: "0.0.0.0/0")
 
-      primary = Prog::Postgres::PostgresServerNexus.assemble(resource_id: postgres_resource.id, timeline_id: timeline_id, timeline_access: timeline_access, representative_at: Time.now).subject
-      postgres_resource.required_standby_count.times do
-        Prog::Postgres::PostgresServerNexus.assemble(resource_id: postgres_resource.id, timeline_id: timeline_id, timeline_access: "fetch", private_subnet_id: primary.vm.private_subnets.first.id)
-      end
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: postgres_resource.id, timeline_id: timeline_id, timeline_access: timeline_access, representative_at: Time.now)
 
       Strand.create(prog: "Postgres::PostgresResourceNexus", label: "start") { _1.id = postgres_resource.id }
     end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
   semaphore :restart, :configure, :update_firewall_rules, :take_over, :destroy
 
-  def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil, private_subnet_id: nil)
+  def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil, private_subnet_id: nil, exclude_host_ids: [])
     DB.transaction do
       ubid = PostgresServer.generate_ubid
 
@@ -31,7 +31,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         boot_image: postgres_resource.project.get_ff_postgresql_base_image || "postgres-ubuntu-2204",
         private_subnet_id: private_subnet_id,
         enable_ip4: true,
-        allow_only_ssh: true
+        allow_only_ssh: true,
+        exclude_host_ids: exclude_host_ids
       )
 
       synchronization_status = representative_at ? "ready" : "catching_up"

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -50,4 +50,9 @@ RSpec.describe PostgresResource do
     expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server"))
     expect(postgres_resource.display_state).to eq("creating")
   end
+
+  it "returns required_standby_count correctly" do
+    expect(postgres_resource).to receive(:ha_type).and_return(PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC)
+    (0..2).each { expect(postgres_resource.required_standby_count).to eq(_1) }
+  end
 end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -91,12 +91,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
       described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 100, parent_id: parent.id, restore_target: restore_target)
     end
-
-    it "creates additional servers for HA" do
-      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_access: "push")).and_return(instance_double(Strand, subject: postgres_resource.representative_server))
-      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_access: "fetch")).twice
-      described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 100, ha_type: "sync")
-    end
   end
 
   describe "#before_run" do


### PR DESCRIPTION
**Create standbys in PostgresResource's wait state**
We have very similar standby creation logic in two places: assemble and wait.
When we need to make a change on the standby creation logic, we need to update
two places. We can consolidate the standby creation logic into the wait state
since all creations would eventually reach there. One drawback of this is we
would create standbys ~2-3 minutes later than before, but it is a small time
window and it is at the beginning of the resource's lifecycle, hence not very
critical.

**Create standbys at different hosts than primary**
We recently added ability to exclude hosts during allocation. This change uses
that new ability to create primary and standbys at different hosts. This is to
ensure if a host goes down, we still have either standby or primary available.