### PR TITLE
Decouple PG compute and storage

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -272,10 +272,11 @@ function setupInstanceSizeBasedOptions() {
 
       let monthlyPrice = $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"]
       $(this).data("monthly-price", monthlyPrice);
-      $(this).next().find(".absolute").each(function(idx) {
-        storage_amount = min_storage_size_gib + idx * storage_size_step_gib;
-        $(this).text(storage_amount + "GB +$" + (storage_amount * monthlyPrice).toFixed(2));
-      });
+      $(this).next().html("");
+      for(var storage_amount = min_storage_size_gib; storage_amount <= max_storage_size_gib; storage_amount += storage_size_step_gib) {
+        let content = storage_amount + "GB<br/>+$" + (storage_amount * monthlyPrice).toFixed(2);
+        $(this).next().append("<li class='flex justify-right sm:justify-center relative items-center rotate-90 sm:rotate-0 mb-6 sm:mb-0'><span class='absolute text-center'>" + content + "</span></li>");
+      }
     }
   });
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,7 +4,6 @@ $(function() {
   setupLocationBasedOptions();
   setupInstanceSizeBasedOptions();
   setupLocationBasedPostgresHaPrices();
-  setupLocationBasedPostgresHaPrices();
   setupAutoRefresh();
   setupPrint();
   setupDatePicker();
@@ -197,6 +196,10 @@ $("input[name=size]").on("change", function (event) {
   setupInstanceSizeBasedOptions();
 });
 
+$("input[name=storage-size]").on("change", function (event) {
+  setupLocationBasedPostgresHaPrices();
+});
+
 function setupLocationBasedPrices() {
   let selectedLocation = $("input[name=location]:checked")
   let prices = selectedLocation.length ? selectedLocation.data("details") : {};
@@ -233,7 +236,9 @@ function setupLocationBasedPrices() {
 function setupLocationBasedPostgresHaPrices() {
   $("input.location-based-postgres-ha-price").each(function(i, obj) {
     let value = $(this).val();
-    let monthlyPrice = $("input[name=size]:checked").data("monthly-price");
+    let monthlyComputePrice = parseFloat($("input[name=size]:checked").data("monthly-price"))
+    let monthlyStoragePrice = parseFloat($("input[name=storage-size]").val()) * parseFloat($("input[name=storage-size]").data("monthly-price"))
+    let monthlyPrice = monthlyComputePrice + monthlyStoragePrice;
     let standbyCount = $(this).data("standby-count");
     $(`.ha-status-${value}`).show();
     $(`.ha-status-${value}-monthly-price`).text(`+$${(standbyCount * monthlyPrice).toFixed(2)}`);
@@ -255,12 +260,14 @@ function setupInstanceSizeBasedOptions() {
       min_storage_size_gib = $("input[name=size]:checked").data("min-storage-size-gib");
       max_storage_size_gib = $("input[name=size]:checked").data("max-storage-size-gib");
       storage_size_step_gib = $("input[name=size]:checked").data("storage-size-step-gib");
+      storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
 
       $(this).attr("min", min_storage_size_gib);
       $(this).attr("max", max_storage_size_gib);
       $(this).attr("step", storage_size_step_gib);
 
-      let monthlyPrice = $("input[name=location]:checked").data("details")["VmStorage"]["standard"]["monthly"]
+      let monthlyPrice = $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"]
+      $(this).data("monthly-price", monthlyPrice);
       $(this).next().find(".absolute").each(function(idx) {
         storage_amount = min_storage_size_gib + idx * storage_size_step_gib;
         $(this).text(storage_amount + "GB +$" + (storage_amount * monthlyPrice).toFixed(2));

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -196,7 +196,10 @@ $("input[name=size]").on("change", function (event) {
   setupLocationBasedPostgresHaPrices();
 });
 
-$("input[name=storage-size]").on("change", function (event) {
+$("input[name=pseudo-storage-size]").on("change", function (event) {
+  storage_size_options = $("input[name=size]:checked").data("storage-size-options");
+  storage_size_index = parseInt($("input[name=pseudo-storage-size]").val());
+  $("input[name=storage-size]").val(storage_size_options[storage_size_index])
   setupLocationBasedPostgresHaPrices();
 });
 
@@ -237,7 +240,7 @@ function setupLocationBasedPostgresHaPrices() {
   $("input.location-based-postgres-ha-price").each(function(i, obj) {
     let value = $(this).val();
     let monthlyComputePrice = parseFloat($("input[name=size]:checked").data("monthly-price"))
-    let monthlyStoragePrice = parseFloat($("input[name=storage-size]").val()) * parseFloat($("input[name=storage-size]").data("monthly-price"))
+    let monthlyStoragePrice = parseFloat($("input[name=storage-size]").val()) * parseFloat($("input[name=pseudo-storage-size]").data("monthly-price"))
     let monthlyPrice = monthlyComputePrice + monthlyStoragePrice;
     let standbyCount = $(this).data("standby-count");
     $(`.ha-status-${value}`).show();
@@ -256,24 +259,20 @@ function setupLocationBasedOptions() {
 function setupInstanceSizeBasedOptions() {
   $(".instance-size-based-option").each(function() {
     let type = $(this).attr("type")
-    if(type == "range" && $(this).attr("name") == "storage-size"){
-      min_storage_size_gib = $("input[name=size]:checked").data("min-storage-size-gib");
-      max_storage_size_gib = $("input[name=size]:checked").data("max-storage-size-gib");
-      storage_size_step_gib = $("input[name=size]:checked").data("storage-size-step-gib");
+    if(type == "range" && $(this).attr("id") == "pseudo-storage-size"){
+      storage_size_options = $("input[name=size]:checked").data("storage-size-options");
       storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
-      // We cache the value here and set it back after changing the min/max/step
-      // Because value might be invalid temporarily while changing min/max/step causing browser to change it automatically 
-      value = $(this).val();
 
-      $(this).attr("min", min_storage_size_gib);
-      $(this).attr("max", max_storage_size_gib);
-      $(this).attr("step", storage_size_step_gib);
-      $(this).val(value);
+      $(this).attr("max", storage_size_options.length - 1);
+      storage_size_index = parseInt($("input[name=pseudo-storage-size]").val());
+      $("input[name=storage-size]").val(storage_size_options[storage_size_index])
 
       let monthlyPrice = $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"]
       $(this).data("monthly-price", monthlyPrice);
+
       $(this).next().html("");
-      for(var storage_amount = min_storage_size_gib; storage_amount <= max_storage_size_gib; storage_amount += storage_size_step_gib) {
+      for(var i = 0; i < storage_size_options.length; i++) {
+        let storage_amount = storage_size_options[i];
         let content = storage_amount + "GB<br/>+$" + (storage_amount * monthlyPrice).toFixed(2);
         $(this).next().append("<li class='flex justify-right sm:justify-center relative items-center rotate-90 sm:rotate-0 mb-6 sm:mb-0'><span class='absolute text-center'>" + content + "</span></li>");
       }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -261,10 +261,14 @@ function setupInstanceSizeBasedOptions() {
       max_storage_size_gib = $("input[name=size]:checked").data("max-storage-size-gib");
       storage_size_step_gib = $("input[name=size]:checked").data("storage-size-step-gib");
       storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
+      // We cache the value here and set it back after changing the min/max/step
+      // Because value might be invalid temporarily while changing min/max/step causing browser to change it automatically 
+      value = $(this).val();
 
       $(this).attr("min", min_storage_size_gib);
       $(this).attr("max", max_storage_size_gib);
       $(this).attr("step", storage_size_step_gib);
+      $(this).val(value);
 
       let monthlyPrice = $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"]
       $(this).data("monthly-price", monthlyPrice);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -186,14 +186,14 @@ function jsonHighlight(str) {
 
 $("input[name=location]").on("change", function (event) {
   setupLocationBasedPrices();
-  setupLocationBasedPostgresHaPrices();
   setupLocationBasedOptions();
   setupInstanceSizeBasedOptions();
+  setupLocationBasedPostgresHaPrices();
 });
 
 $("input[name=size]").on("change", function (event) {
-  setupLocationBasedPostgresHaPrices();
   setupInstanceSizeBasedOptions();
+  setupLocationBasedPostgresHaPrices();
 });
 
 $("input[name=storage-size]").on("change", function (event) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,6 +3,8 @@ $(function() {
   setupLocationBasedPrices();
   setupLocationBasedOptions();
   setupInstanceSizeBasedOptions();
+  setupLocationBasedPostgresHaPrices();
+  setupLocationBasedPostgresHaPrices();
   setupAutoRefresh();
   setupPrint();
   setupDatePicker();

--- a/config/billing_rates.yml
+++ b/config/billing_rates.yml
@@ -32,13 +32,13 @@
 - { id: 80aa487a-0aa7-472f-a52c-d82a96067cba, resource_type: PostgresStorage,         resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
 - { id: c41422cd-9e28-46bd-acd4-02debfcd26a2, resource_type: PostgresStorage,         resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
 - { id: b8d48f79-8131-46aa-b898-dba1c21d0954, resource_type: PostgresStorage,         resource_family: standard,        location: github-runners, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
-- { id: 0a45042a-6d20-8978-af02-dfaf3f40cd28, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
-- { id: 5f19cb91-1cff-8d78-881a-1927e5fcdb98, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: 0a45042a-6d20-8978-af02-dfaf3f40cd28, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0000031000, active_from: 2023-01-01T00:00:00Z }
+- { id: 5f19cb91-1cff-8d78-881a-1927e5fcdb98, resource_type: PostgresStorage,         resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0000031000, active_from: 2023-01-01T00:00:00Z }
 - { id: eaf2d6df-c63c-4dd1-9aa4-00e08785fb59, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: hetzner-fsn1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
 - { id: 10e65151-b0e2-4a33-9834-c3b4549a0d98, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: hetzner-hel1,   unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
 - { id: f9f47985-f9fe-42b6-a8d8-c086d557f224, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: github-runners, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
-- { id: 4b8afe08-bc0e-8978-bc23-e38973e5b3d4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
-- { id: 1172b71c-4c1f-8978-aa10-b9e73822a8e4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0000028100, active_from: 2023-01-01T00:00:00Z }
+- { id: 4b8afe08-bc0e-8978-bc23-e38973e5b3d4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-wdc02, unit_price: 0.0000031000, active_from: 2023-01-01T00:00:00Z }
+- { id: 1172b71c-4c1f-8978-aa10-b9e73822a8e4, resource_type: PostgresStandbyStorage,  resource_family: standard,        location: leaseweb-dal13, unit_price: 0.0000031000, active_from: 2023-01-01T00:00:00Z }
 - { id: d772d0aa-0b40-4b7a-aceb-72f6211f7cad, resource_type: GitHubRunnerMinutes,     resource_family: standard-2,      location: global,         unit_price: 0.0008000000, active_from: 2023-01-01T00:00:00Z }
 - { id: d885c82d-b139-40d5-890f-de3720896b3b, resource_type: GitHubRunnerMinutes,     resource_family: standard-4,      location: global,         unit_price: 0.0016000000, active_from: 2023-01-01T00:00:00Z }
 - { id: e50e6bff-6ee9-493b-bc09-75f122863d08, resource_type: GitHubRunnerMinutes,     resource_family: standard-8,      location: global,         unit_price: 0.0032000000, active_from: 2023-01-01T00:00:00Z }

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -46,17 +46,11 @@ module Option
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
-    min_storage_size_gib = _1 * 20
     max_storage_size_gib = _1 * 40
-    storage_size_step_gib = _1 * 10
-    storage_size_options = (min_storage_size_gib..max_storage_size_gib).step(storage_size_step_gib).to_a
+    storage_size_options = [40, 60, 80, 160, 320, 512, 1024, 2048, 3072, 4096].select { |s| s <= max_storage_size_gib }
     VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, storage_size_options, true, false)
   }.concat([6].map {
-    min_storage_size_gib = _1 * 30
-    max_storage_size_gib = _1 * 60
-    storage_size_step_gib = _1 * 15
-    storage_size_options = (min_storage_size_gib..max_storage_size_gib).step(storage_size_step_gib).to_a
-    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, storage_size_options, false, true)
+    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, [_1 * 30], false, true)
   }).freeze
 
   PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :storage_size_options) do

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -63,10 +63,8 @@ module Option
     alias_method :display_name, :name
   end
   PostgresSizes = [2, 4, 8, 16, 30, 60].map {
-    min_storage_size_gib = _1 * 64
     max_storage_size_gib = _1 * 256
-    storage_size_step_gib = _1 * 64
-    storage_size_options = (min_storage_size_gib..max_storage_size_gib).step(storage_size_step_gib).to_a
+    storage_size_options = [128, 256, 512, 1024, 2048, 3072, 4096].select { |s| s <= max_storage_size_gib }
     PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, storage_size_options)
   }.freeze
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -51,11 +51,11 @@ module Option
     VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, (_1 / 2) * 60, _1 * 60, (_1 / 2) * 60, false, true)
   }).freeze
 
-  PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :storage_size_gib) do
+  PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :min_storage_size_gib, :max_storage_size_gib, :storage_size_step_gib) do
     alias_method :display_name, :name
   end
   PostgresSizes = [2, 4, 8, 16, 30, 60].map {
-    PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 128)
+    PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, _1 * 64, _1 * 256, _1 * 64)
   }.freeze
 
   PostgresHaOption = Struct.new(:name, :standby_count, :title, :explanation)

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -42,20 +42,32 @@ module Option
     ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"]
   ].map { |args| BootImage.new(*args) }.freeze
 
-  VmSize = Struct.new(:name, :family, :vcpu, :memory, :min_storage_size_gib, :max_storage_size_gib, :storage_size_step_gib, :visible, :gpu) do
+  VmSize = Struct.new(:name, :family, :vcpu, :memory, :storage_size_options, :visible, :gpu) do
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
-    VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 40, _1 * 40, (_1 / 2) * 20, true, false)
+    min_storage_size_gib = _1 * 20
+    max_storage_size_gib = _1 * 40
+    storage_size_step_gib = _1 * 10
+    storage_size_options = (min_storage_size_gib..max_storage_size_gib).step(storage_size_step_gib).to_a
+    VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, storage_size_options, true, false)
   }.concat([6].map {
-    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, (_1 / 2) * 60, _1 * 60, (_1 / 2) * 60, false, true)
+    min_storage_size_gib = _1 * 30
+    max_storage_size_gib = _1 * 60
+    storage_size_step_gib = _1 * 15
+    storage_size_options = (min_storage_size_gib..max_storage_size_gib).step(storage_size_step_gib).to_a
+    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, storage_size_options, false, true)
   }).freeze
 
-  PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :min_storage_size_gib, :max_storage_size_gib, :storage_size_step_gib) do
+  PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :storage_size_options) do
     alias_method :display_name, :name
   end
   PostgresSizes = [2, 4, 8, 16, 30, 60].map {
-    PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, _1 * 64, _1 * 256, _1 * 64)
+    min_storage_size_gib = _1 * 64
+    max_storage_size_gib = _1 * 256
+    storage_size_step_gib = _1 * 64
+    storage_size_options = (min_storage_size_gib..max_storage_size_gib).step(storage_size_step_gib).to_a
+    PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, storage_size_options)
   }.freeze
 
   PostgresHaOption = Struct.new(:name, :standby_count, :title, :explanation)

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -113,6 +113,14 @@ module Validation
     postgres_size
   end
 
+  def self.validate_postgres_storage_size(size, storage_size)
+    storage_size = storage_size.to_i
+    pg_size = validate_postgres_size(size)
+    allowed_sizes = (pg_size.min_storage_size_gib..pg_size.max_storage_size_gib).step(pg_size.storage_size_step_gib)
+    fail ValidationFailed.new({storage_size: "Storage size must be one of the following: #{allowed_sizes.to_a.join(", ")}"}) unless allowed_sizes.include?(storage_size)
+    storage_size
+  end
+
   def self.validate_date(date, param = "date")
     # I use DateTime.parse instead of Time.parse because it uses UTC as default
     # timezone but Time.parse uses local timezone

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -71,8 +71,7 @@ module Validation
   def self.validate_vm_storage_size(size, storage_size)
     storage_size = storage_size.to_i
     vm_size = validate_vm_size(size)
-    allowed_sizes = (vm_size.min_storage_size_gib..vm_size.max_storage_size_gib).step(vm_size.storage_size_step_gib)
-    fail ValidationFailed.new({storage_size: "Storage size must be one of the following: #{allowed_sizes.to_a.join(", ")}"}) unless allowed_sizes.include?(storage_size)
+    fail ValidationFailed.new({storage_size: "Storage size must be one of the following: #{vm_size.storage_size_options.join(", ")}"}) unless vm_size.storage_size_options.include?(storage_size)
     storage_size
   end
 
@@ -116,8 +115,7 @@ module Validation
   def self.validate_postgres_storage_size(size, storage_size)
     storage_size = storage_size.to_i
     pg_size = validate_postgres_size(size)
-    allowed_sizes = (pg_size.min_storage_size_gib..pg_size.max_storage_size_gib).step(pg_size.storage_size_step_gib)
-    fail ValidationFailed.new({storage_size: "Storage size must be one of the following: #{allowed_sizes.to_a.join(", ")}"}) unless allowed_sizes.include?(storage_size)
+    fail ValidationFailed.new({storage_size: "Storage size must be one of the following: #{pg_size.storage_size_options.join(", ")}"}) unless pg_size.storage_size_options.include?(storage_size)
     storage_size
   end
 

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -20,6 +20,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     Validation.validate_location(location)
     Validation.validate_name(name)
     Validation.validate_vm_size(target_vm_size)
+    target_storage_size_gib = Validation.validate_postgres_storage_size(target_vm_size, target_storage_size_gib)
     Validation.validate_postgres_ha_type(ha_type)
 
     DB.transaction do

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -26,13 +26,13 @@ class Prog::Vm::Nexus < Prog::Base
     vm_size = Validation.validate_vm_size(size)
 
     storage_volumes ||= [{
-      size_gib: vm_size.min_storage_size_gib,
+      size_gib: vm_size.storage_size_options.first,
       encrypted: true
     }]
 
     # allow missing fields to make testing during development more convenient.
     storage_volumes.each_with_index do |volume, disk_index|
-      volume[:size_gib] ||= vm_size.min_storage_size_gib
+      volume[:size_gib] ||= vm_size.storage_size_options.first
       volume[:skip_sync] ||= false
       volume[:encrypted] = true if !volume.has_key? :encrypted
       volume[:boot] = disk_index == boot_disk_index

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -43,7 +43,7 @@ class CloverApi
           location: @location,
           name: pg_name,
           target_vm_size: parsed_size.vm_size,
-          target_storage_size_gib: request_body_params["storage_size"] || parsed_size.min_storage_size_gib,
+          target_storage_size_gib: request_body_params["storage_size"] || parsed_size.storage_size_options.first,
           ha_type: request_body_params["ha_type"] || PostgresResource::HaType::NONE
         )
 

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -34,7 +34,7 @@ class CloverApi
         Validation.validate_postgres_location(@location)
 
         required_parameters = ["size"]
-        allowed_optional_parameters = ["ha_type"]
+        allowed_optional_parameters = ["storage_size", "ha_type"]
 
         request_body_params = Validation.validate_request_body(r.body.read, required_parameters, allowed_optional_parameters)
         parsed_size = Validation.validate_postgres_size(request_body_params["size"])
@@ -43,7 +43,7 @@ class CloverApi
           location: @location,
           name: pg_name,
           target_vm_size: parsed_size.vm_size,
-          target_storage_size_gib: parsed_size.storage_size_gib,
+          target_storage_size_gib: request_body_params["storage_size"] || parsed_size.min_storage_size_gib,
           ha_type: request_body_params["ha_type"] || PostgresResource::HaType::NONE
         )
 

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -20,7 +20,7 @@ class CloverWeb
         location: location,
         name: r.params["name"],
         target_vm_size: parsed_size.vm_size,
-        target_storage_size_gib: parsed_size.storage_size_gib,
+        target_storage_size_gib: r.params["storage-size"],
         ha_type: r.params["ha_type"]
       )
 

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -177,6 +177,31 @@ RSpec.describe Validation do
       end
     end
 
+    describe "#validate_postgres_storage_size" do
+      it "valid postgres storage sizes" do
+        [
+          ["standard-2", "128"],
+          ["standard-2", "256"],
+          ["standard-4", "1024"]
+        ].each do |pg_size, storage_size|
+          expect(described_class.validate_postgres_storage_size(pg_size, storage_size)).to eq(storage_size.to_f)
+        end
+      end
+
+      it "invalid postgres storage sizes" do
+        [
+          ["standard-2", "1024"],
+          ["standard-2", "37.4"],
+          ["standard-2", ""],
+          ["standard-2", nil],
+          ["standard-5", "128"],
+          [nil, "128"]
+        ].each do |pg_size, storage_size|
+          expect { described_class.validate_postgres_storage_size(pg_size, storage_size) }.to raise_error described_class::ValidationFailed
+        end
+      end
+    end
+
     describe "#validate_postgres_ha_type" do
       it "valid postgres ha_type" do
         [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC].each { |ha_type| expect { described_class.validate_postgres_ha_type(ha_type) }.not_to raise_error }

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -49,49 +49,49 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       expect {
-        described_class.assemble(project_id: "26820e05-562a-4e25-a51b-de5f78bd00af", location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 100)
+        described_class.assemble(project_id: "26820e05-562a-4e25-a51b-de5f78bd00af", location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128)
       }.to raise_error RuntimeError, "No existing project"
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-xxx", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 100)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-xxx", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: provider"
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg/server/name", target_vm_size: "standard-2", target_storage_size_gib: 100)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg/server/name", target_vm_size: "standard-2", target_storage_size_gib: 128)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-128", target_storage_size_gib: 100)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-128", target_storage_size_gib: 128)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: size"
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 100)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128)
       }.not_to raise_error
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 100, parent_id: "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b")
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b")
       }.to raise_error RuntimeError, "No existing parent"
 
       expect {
-        parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 100).subject
+        parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
         parent.timeline.update(earliest_backup_completed_at: Time.now)
         expect(parent.timeline).to receive(:refresh_earliest_backup_completion_time).and_return(Time.now)
         expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 100, parent_id: parent.id, restore_target: Time.now)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: Time.now)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: restore_target"
     end
 
     it "passes timeline of parent resource if parent is passed" do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
-      parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 100).subject
+      parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
       restore_target = Time.now
       parent.timeline.update(earliest_backup_completed_at: restore_target - 10 * 60)
       expect(parent.timeline).to receive(:refresh_earliest_backup_completion_time).and_return(restore_target - 10 * 60)
       expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
       expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_id: parent.timeline.id, timeline_access: "fetch")).and_return(instance_double(Strand, subject: postgres_resource.representative_server))
 
-      described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 100, parent_id: parent.id, restore_target: restore_target)
+      described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: restore_target)
     end
   end
 
@@ -172,7 +172,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         location: "hetzner-hel1",
         name: "pg-name",
         target_vm_size: "standard-2",
-        target_storage_size_gib: 100,
+        target_storage_size_gib: 128,
         superuser_password: "dummy-password"
       )
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         location: "hetzner-hel1",
         name: "pg-name",
         target_vm_size: "standard-2",
-        target_storage_size_gib: 100,
+        target_storage_size_gib: 128,
         superuser_password: "dummy-password"
       )
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "creates with default storage size from vm size" do
       st = described_class.assemble("some_ssh_key", prj.id)
-      expect(requested_disk_size(st)).to eq(Option::VmSizes.first.min_storage_size_gib)
+      expect(requested_disk_size(st)).to eq(Option::VmSizes.first.storage_size_options.first)
     end
 
     it "creates with custom storage size if provided" do

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Clover, "postgres" do
       location: "hetzner-fsn1",
       name: "pg-with-permission",
       target_vm_size: "standard-2",
-      target_storage_size_gib: 100
+      target_storage_size_gib: 128
     ).subject
   end
 
@@ -25,7 +25,7 @@ RSpec.describe Clover, "postgres" do
       location: "hetzner-fsn1",
       name: "pg-without-permission",
       target_vm_size: "standard-2",
-      target_storage_size_gib: 100
+      target_storage_size_gib: 128
     ).subject
   end
 
@@ -148,7 +148,7 @@ RSpec.describe Clover, "postgres" do
           location: "hetzner-fsn1",
           name: "pg-test-2",
           target_vm_size: "standard-2",
-          target_storage_size_gib: 100
+          target_storage_size_gib: 128
         )
 
         get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"
@@ -212,7 +212,7 @@ RSpec.describe Clover, "postgres" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: size, ha_type")
+        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: size, storage_size, ha_type")
       end
 
       it "firewall-rule" do

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Clover, "vm" do
         location: "hetzner-hel1",
         name: "pg-foo-1",
         target_vm_size: "standard-2",
-        target_storage_size_gib: 100
+        target_storage_size_gib: 128
       )
 
       Prog::Postgres::PostgresResourceNexus.assemble(
@@ -37,7 +37,7 @@ RSpec.describe Clover, "vm" do
         location: "hetzner-fsn1",
         name: "pg-foo-2",
         target_vm_size: "standard-2",
-        target_storage_size_gib: 100
+        target_storage_size_gib: 128
       )
 
       get "/api/project/#{project.ubid}/postgres"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: name
         choose option: "eu-central-h1"
         choose option: "standard-2"
+        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"
@@ -100,6 +101,7 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: "invalid name"
         choose option: "eu-central-h1"
         choose option: "standard-2"
+        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"
@@ -117,6 +119,7 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: pg.name
         choose option: "eu-central-h1"
         choose option: "standard-2"
+        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"
@@ -137,6 +140,7 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: "new-pg-db"
         choose option: "eu-central-h1"
         choose option: "standard-2"
+        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: name
         choose option: "eu-central-h1"
         choose option: "standard-2"
-        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"
@@ -101,7 +100,6 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: "invalid name"
         choose option: "eu-central-h1"
         choose option: "standard-2"
-        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"
@@ -119,7 +117,6 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: pg.name
         choose option: "eu-central-h1"
         choose option: "standard-2"
-        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"
@@ -140,7 +137,6 @@ RSpec.describe Clover, "postgres" do
         fill_in "Name", with: "new-pg-db"
         choose option: "eu-central-h1"
         choose option: "standard-2"
-        find(".storage-slider").set(128)
         choose option: PostgresResource::HaType::NONE
 
         click_button "Create"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Clover, "postgres" do
       location: "hetzner-fsn1",
       name: "pg-with-permission",
       target_vm_size: "standard-2",
-      target_storage_size_gib: 100
+      target_storage_size_gib: 128
     ).subject
   end
 
@@ -23,7 +23,7 @@ RSpec.describe Clover, "postgres" do
       location: "hetzner-fsn1",
       name: "pg-without-permission",
       target_vm_size: "standard-2",
-      target_storage_size_gib: 100
+      target_storage_size_gib: 128
     ).subject
   end
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Clover, "vm" do
         uncheck "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(40)
 
         click_button "Create"
 
@@ -95,7 +94,6 @@ RSpec.describe Clover, "vm" do
         check "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(40)
 
         click_button "Create"
 
@@ -121,7 +119,6 @@ RSpec.describe Clover, "vm" do
         select match: :prefer_exact, text: ps.name
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set("25")
 
         click_button "Create"
 
@@ -142,7 +139,6 @@ RSpec.describe Clover, "vm" do
         choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(40)
 
         click_button "Create"
 
@@ -161,7 +157,6 @@ RSpec.describe Clover, "vm" do
         choose option: "eu-north-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
-        find(".storage-slider").set(40)
 
         click_button "Create"
 

--- a/views/components/form/range_slider.erb
+++ b/views/components/form/range_slider.erb
@@ -26,7 +26,7 @@
     >
     <ul class="flex justify-between w-full px-[10px] pt-2 sm:pt-8">
       <% range_labels.each do |lbl| %>
-        <li class="flex justify-right sm:justify-center relative items-center rotate-90 sm:rotate-0 mb-6 sm:mb-0"><span class="absolute"><%= lbl %></span></li>
+        <li class="flex justify-right sm:justify-center relative items-center rotate-90 sm:rotate-0 mb-6 sm:mb-0"><span class="absolute text-center"><%= lbl %></span></li>
       <% end %>
     </ul>
   </div>

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -73,9 +73,13 @@
                             name="size"
                             value="<%= size.name %>"
                             class="peer sr-only location-based-price"
-                            data-resource-type="[&quot;PostgresCores&quot;, &quot;PostgresStorage&quot;]"
-                            data-resource-family="[&quot;<%= size.family %>&quot;, &quot;<%= size.family %>&quot;]"
-                            data-amount="[<%= size.vcpu / 2 %>, <%= size.min_storage_size_gib %>]"
+                            data-resource-type="PostgresCores"
+                            data-resource-family="<%= size.family %>"
+                            data-amount="<%= size.vcpu / 2 %>"
+                            data-min-storage-size-gib="<%= size.min_storage_size_gib %>"
+                            data-max-storage-size-gib="<%= size.max_storage_size_gib %>"
+                            data-storage-resource-type="PostgresStorage"
+                            data-storage-size-step-gib="<%= size.storage_size_step_gib %>"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                           >
@@ -93,9 +97,6 @@
                                   <%= size.memory %>
                                   GB
                                 </span>
-                                <span class="hidden sm:mx-0.5 sm:inline" aria-hidden="true">&middot;</span>
-                                <span class="block sm:inline"><%= size.min_storage_size_gib %>
-                                  GB disk</span>
                               </span>
                             </span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
@@ -105,6 +106,33 @@
                           </span>
                         </label>
                       <% end %>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+
+              <div class="col-span-full">
+                <div class="space-y-2">
+                  <label for="size" class="text-sm font-medium leading-6 text-gray-900">Storage size</label>
+                  <fieldset class="radio-small-cards" id="storage-size-radios">
+                    <div class="col-span-full">
+                      <% size = flash.dig("old", "size") ? Option::PostgresSizes.find { _1.name == flash.dig("old", "size") } : Option::PostgresSizes[0] %>
+                      <%== render(
+                        "components/form/range_slider",
+                        locals: {
+                          name: "storage-size",
+                          label: "Storage Size",
+                          range_labels: (size.min_storage_size_gib..size.max_storage_size_gib).step(size.storage_size_step_gib).map { "#{_1}GB" },
+                          value: flash.dig("old", "storage_size") || size.min_storage_size_gib,
+                          attributes: {
+                            min: size.min_storage_size_gib,
+                            max: size.max_storage_size_gib,
+                            step: size.storage_size_step_gib,
+                            required: true
+                          },
+                          extra_class: "instance-size-based-option storage-slider",
+                        }
+                      ) %>
                     </div>
                   </fieldset>
                 </div>

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -76,10 +76,8 @@
                             data-resource-type="PostgresCores"
                             data-resource-family="<%= size.family %>"
                             data-amount="<%= size.vcpu / 2 %>"
-                            data-min-storage-size-gib="<%= size.min_storage_size_gib %>"
-                            data-max-storage-size-gib="<%= size.max_storage_size_gib %>"
                             data-storage-resource-type="PostgresStorage"
-                            data-storage-size-step-gib="<%= size.storage_size_step_gib %>"
+                            data-storage-size-options="<%= size.storage_size_options %>"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                           >
@@ -120,19 +118,19 @@
                       <%== render(
                         "components/form/range_slider",
                         locals: {
-                          name: "storage-size",
+                          name: "pseudo-storage-size",
                           label: "Storage Size",
-                          range_labels: (size.min_storage_size_gib..size.max_storage_size_gib).step(size.storage_size_step_gib).map { "#{_1}GB" },
-                          value: flash.dig("old", "storage_size") || size.min_storage_size_gib,
+                          range_labels: size.storage_size_options.map { "#{_1}GB" },
+                          value: flash.dig("old", "storage_size") || 0,
                           attributes: {
-                            min: size.min_storage_size_gib,
-                            max: size.max_storage_size_gib,
-                            step: size.storage_size_step_gib,
+                            min: 0,
+                            max: size.storage_size_options.size - 1,
                             required: true
                           },
                           extra_class: "instance-size-based-option storage-slider",
                         }
                       ) %>
+                      <input type="hidden" name="storage-size" id="storage-size" value="<%= size.storage_size_options[flash.dig("old", "pseudo-storage-size").to_i || 0] %>">
                     </div>
                   </fieldset>
                 </div>

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -66,7 +66,7 @@
                   <fieldset class="radio-small-cards" id="size-radios">
                     <legend class="sr-only">Server size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                      <% Option::PostgresSizes.each do |size| %>
+                      <% Option::PostgresSizes.each_with_index do |size, idx| %>
                         <label class="size-<%= size.name %>">
                           <input
                             type="radio"
@@ -77,7 +77,7 @@
                             data-resource-family="[&quot;<%= size.family %>&quot;, &quot;<%= size.family %>&quot;]"
                             data-amount="[<%= size.vcpu / 2 %>, <%= size.min_storage_size_gib %>]"
                             required
-                            <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>
+                            <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                           >
                           <span
                             class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
@@ -116,7 +116,7 @@
                   <fieldset class="radio-small-cards" id="size-radios">
                     <legend class="sr-only">Server size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                      <% Option::PostgresHaOptions.each do |ha_type| %>
+                      <% Option::PostgresHaOptions.each_with_index do |ha_type, idx| %>
                         <label>
                           <input
                             type="radio"
@@ -125,7 +125,7 @@
                             class="peer sr-only location-based-postgres-ha-price"
                             data-standby-count="<%= ha_type.standby_count %>"
                             required
-                            <%= (flash.dig("old", "ha_type") == ha_type.name) ? "checked" : "" %>
+                            <%= (flash.dig("old", "ha_type") == ha_type.name || flash.dig("old", "ha_type").nil? && idx == 0) ? "checked" : "" %>
                           >
                           <span
                             class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -75,7 +75,7 @@
                             class="peer sr-only location-based-price"
                             data-resource-type="[&quot;PostgresCores&quot;, &quot;PostgresStorage&quot;]"
                             data-resource-family="[&quot;<%= size.family %>&quot;, &quot;<%= size.family %>&quot;]"
-                            data-amount="[<%= size.vcpu / 2 %>, <%= size.storage_size_gib %>]"
+                            data-amount="[<%= size.vcpu / 2 %>, <%= size.min_storage_size_gib %>]"
                             required
                             <%= (flash.dig("old", "size") == size.name) ? "checked" : "" %>
                           >
@@ -94,7 +94,7 @@
                                   GB
                                 </span>
                                 <span class="hidden sm:mx-0.5 sm:inline" aria-hidden="true">&middot;</span>
-                                <span class="block sm:inline"><%= size.storage_size_gib %>
+                                <span class="block sm:inline"><%= size.min_storage_size_gib %>
                                   GB disk</span>
                               </span>
                             </span>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -105,6 +105,7 @@
                             data-min-storage-size-gib="<%= size.min_storage_size_gib %>"
                             data-max-storage-size-gib="<%= size.max_storage_size_gib %>"
                             data-storage-size-step-gib="<%= size.storage_size_step_gib %>"
+                            data-storage-resource-type="VmStorage"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                           >

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -102,10 +102,8 @@
                             data-resource-type="VmCores"
                             data-resource-family="<%= size.family %>"
                             data-amount="<%= size.vcpu / 2 %>"
-                            data-min-storage-size-gib="<%= size.min_storage_size_gib %>"
-                            data-max-storage-size-gib="<%= size.max_storage_size_gib %>"
-                            data-storage-size-step-gib="<%= size.storage_size_step_gib %>"
                             data-storage-resource-type="VmStorage"
+                            data-storage-size-options="<%= size.storage_size_options %>"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                           >
@@ -145,19 +143,19 @@
                       <%== render(
                         "components/form/range_slider",
                         locals: {
-                          name: "storage-size",
+                          name: "pseudo-storage-size",
                           label: "Storage Size",
-                          range_labels: (size.min_storage_size_gib..size.max_storage_size_gib).step(size.storage_size_step_gib).map { "#{_1}GB" },
-                          value: flash.dig("old", "storage_size") || size.min_storage_size_gib,
+                          range_labels: size.storage_size_options.map { "#{_1}GB" },
+                          value: flash.dig("old", "pseudo-storage-size") || 0,
                           attributes: {
-                            min: size.min_storage_size_gib,
-                            max: size.max_storage_size_gib,
-                            step: size.storage_size_step_gib,
+                            min: 0,
+                            max: size.storage_size_options.size - 1,
                             required: true
                           },
                           extra_class: "instance-size-based-option storage-slider",
                         }
                       ) %>
+                      <input type="hidden" name="storage-size" id="storage-size" value="<%= size.storage_size_options[flash.dig("old", "pseudo-storage-size").to_i || 0] %>">
                     </div>
                   </fieldset>
                 </div>


### PR DESCRIPTION
**Update PostgreSQL storage prices for US regions**
The cost of storage in the US regions is higher than EU regions, so we are
increasing the price of PostgreSQL storage in the US regions to reflect this.
Since these rates are not used previously, we can update them directly without
adding a new rate version.

**Add backend code allowing picking storage independently from PG size**

**Automatically select first options in PostgreSQL creation form**
This ensures that the javascript code depending on instance size works even at
the initial load. It also makes the form more user-friendly by requiring one
less click.

**Add frontend code allowing picking storage independently from PG size**

**Reorder form updates to make HA calculations at the end**
Since HA price depends on other selections, it should be calculated after
calculations based on previous selections are done. Otherwise, the price we
list in the form would be incorrect.

**Cache and set the value of slider while changing its properties**
Value in the slider might be invalid temporarily while changing min/max/step.
In such cases browser assigns a valid value automatically, which is not
necessarily the value we would pick. To prevent this, we read the value of the
slider before changing its properties and set it back after changing them.

![image](https://github.com/ubicloud/ubicloud/assets/2082070/56ce7c66-0430-4a40-847e-1b6ff18b679e)
