### PR TITLE
Enable standard-60 vm size with 60 vCPUs

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -45,7 +45,7 @@ module Option
   VmSize = Struct.new(:name, :family, :vcpu, :memory, :storage_size_gib, :visible, :gpu) do
     alias_method :display_name, :name
   end
-  VmSizes = [2, 4, 8, 16, 30].map {
+  VmSizes = [2, 4, 8, 16, 30, 60].map {
     VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 25, true, false)
   }.concat([6].map {
     VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, (_1 / 2) * 60, false, true)

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -22,22 +22,12 @@ RSpec.describe Vm do
   end
 
   describe "#mem_gib" do
-    it "handles standard-2" do
+    it "handles standard family" do
       vm.family = "standard"
-      vm.cores = 1
-      expect(vm.mem_gib).to eq 8
-    end
-
-    it "handles standard-16" do
-      vm.family = "standard"
-      vm.cores = 8
-      expect(vm.mem_gib).to eq 64
-    end
-
-    it "handles standard-30" do
-      vm.family = "standard"
-      vm.cores = 15
-      expect(vm.mem_gib).to eq 120
+      [1, 2, 4, 8, 15, 30].each do |cores|
+        expect(vm).to receive(:cores).and_return(cores)
+        expect(vm.mem_gib).to eq cores * 8
+      end
     end
 
     it "handles standard-6" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["size"]).to eq("\"standard-gpu-6\" is not a valid virtual machine size. Available sizes: [\"standard-2\", \"standard-4\", \"standard-8\", \"standard-16\", \"standard-30\"]")
+        expect(JSON.parse(last_response.body)["error"]["details"]["size"]).to eq("\"standard-gpu-6\" is not a valid virtual machine size. Available sizes: [\"standard-2\", \"standard-4\", \"standard-8\", \"standard-16\", \"standard-30\", \"standard-60\"]")
       end
 
       it "success without vm_size" do


### PR DESCRIPTION
This PR enables standard-60 vm size, which comes with 60 vCPUs.