### PR TITLE
Start using new firmware

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -550,7 +550,7 @@ ExecStartPre=/usr/bin/rm -f #{vp.ch_api_sock}
 
 ExecStart=#{CloudHypervisor::VERSION.bin} -v \
 --api-socket path=#{vp.ch_api_sock} \
---kernel #{CloudHypervisor::FIRMWARE.path} \
+--kernel #{CloudHypervisor::NEW_FIRMWARE.path} \
 #{disk_params.join("\n")}
 --disk path=#{vp.cloudinit_img} \
 --console off --serial file=#{vp.serial_log} \


### PR DESCRIPTION
Start using `NEW_FIRMWARE` in vm setup. The new firmware was downloaded to all existing hosts. I plan to `install_rhizome` first to one `x64` and one `arm64` runner host. If VM provisioning looks fine, I'll `install_rhizome` to the rest of the fleet. If all looks good for at least a week, I'll remove the legacy firmware code. 