### PR TITLE
Add Ubuntu 24.04 support

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -131,6 +131,7 @@ module Config
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
   optional :ubicloud_images_blob_storage_certs, string
 
+  override :ubuntu_noble_version, "20240523.1", string
   override :ubuntu_jammy_version, "20240319", string
   override :almalinux_9_version, "9.4-20240507", string
   override :almalinux_8_version, "8.10-20240530", string

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -39,6 +39,7 @@ module Option
 
   BootImage = Struct.new(:name, :display_name)
   BootImages = [
+    ["ubuntu-noble", "Ubuntu Noble 24.04 LTS"],
     ["ubuntu-jammy", "Ubuntu Jammy 22.04 LTS"],
     ["almalinux-9", "AlmaLinux 9"],
     ["almalinux-8", "AlmaLinux 8"]

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -19,6 +19,8 @@ class Prog::DownloadBootImage < Prog::Base
 
   def default_boot_image_version(image_name)
     case image_name
+    when "ubuntu-noble"
+      Config.ubuntu_noble_version
     when "ubuntu-jammy"
       Config.ubuntu_jammy_version
     when "almalinux-9"
@@ -44,6 +46,9 @@ class Prog::DownloadBootImage < Prog::Base
         frame["custom_url"]
       elsif download_from_blob_storage?
         blob_storage_client.get_presigned_url("GET", Config.ubicloud_images_bucket_name, "#{image_name}-#{vm_host.arch}-#{version}.raw", 60 * 60).to_s
+      elsif image_name == "ubuntu-noble"
+        arch = (vm_host.arch == "x64") ? "amd64" : "arm64"
+        "https://cloud-images.ubuntu.com/releases/noble/release-#{version}/ubuntu-24.04-server-cloudimg-#{arch}.img"
       elsif image_name == "ubuntu-jammy"
         arch = (vm_host.arch == "x64") ? "amd64" : "arm64"
         "https://cloud-images.ubuntu.com/releases/jammy/release-#{version}/ubuntu-22.04-server-cloudimg-#{arch}.img"
@@ -60,6 +65,8 @@ class Prog::DownloadBootImage < Prog::Base
 
   def sha256_sum
     hashes = {
+      ["ubuntu-noble", "x64", "20240523.1"] => "b60205f4cc48a24b999ad0bd61ceb9fe28abfe4ac3701acb7bb5d6b0b5fdc624",
+      ["ubuntu-noble", "arm64", "20240523.1"] => "54f6b62cc8d393e5c82495a49b8980157dfa6a13b930d8d4170e34e30742d949",
       ["ubuntu-jammy", "x64", "20240319"] => "304983616fcba6ee1452e9f38993d7d3b8a90e1eb65fb0054d672ce23294d812",
       ["ubuntu-jammy", "arm64", "20240319"] => "40ea1181447b9395fa03f6f2c405482fe532a348cc46fbb876effcfbbb35336f",
       ["almalinux-8", "x64", "8.10-20240530"] => "41a6bcdefb35afbd2819f0e6c68005cd5e9a346adf2dc093b1116a2b7c647d86",

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Prog::DownloadBootImage do
 
   describe "#default_boot_image_version" do
     it "returns the version for the default image" do
+      expect(dbi.default_boot_image_version("ubuntu-noble")).to eq(Config.ubuntu_noble_version)
       expect(dbi.default_boot_image_version("ubuntu-jammy")).to eq(Config.ubuntu_jammy_version)
       expect(dbi.default_boot_image_version("almalinux-9")).to eq(Config.almalinux_9_version)
       expect(dbi.default_boot_image_version("almalinux-8")).to eq(Config.almalinux_8_version)
@@ -61,6 +62,17 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dbi).to receive(:frame).and_return({"image_name" => "github-ubuntu-2204", "version" => Config.github_ubuntu_2204_version}).at_least(:once)
       expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, get_presigned_url: "https://minio.example.com/my-image.raw"))
       expect(dbi.url).to eq("https://minio.example.com/my-image.raw")
+    end
+
+    it "returns URL for x64 ubuntu-noble image" do
+      expect(dbi).to receive(:frame).and_return({"image_name" => "ubuntu-noble", "version" => "20240523.1"}).at_least(:once)
+      expect(dbi.url).to eq("https://cloud-images.ubuntu.com/releases/noble/release-20240523.1/ubuntu-24.04-server-cloudimg-amd64.img")
+    end
+
+    it "returns URL for arm64 ubuntu-noble image" do
+      expect(dbi).to receive(:frame).and_return({"image_name" => "ubuntu-noble", "version" => "20240523.1"}).at_least(:once)
+      vm_host.update(arch: "arm64")
+      expect(dbi.url).to eq("https://cloud-images.ubuntu.com/releases/noble/release-20240523.1/ubuntu-24.04-server-cloudimg-arm64.img")
     end
 
     it "returns URL for x64 ubuntu-jammy image" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Clover, "vm" do
         }.to_json
 
         expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-jammy\", \"almalinux-9\", \"almalinux-8\"]")
+        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-noble\", \"ubuntu-jammy\", \"almalinux-9\", \"almalinux-8\"]")
       end
 
       it "invalid vm size" do


### PR DESCRIPTION
### Add Ubuntu 24.04 LTS support

Ubuntu 24.04 (Noble Numbat) was launched in April 2024 as the latest LTS release following Ubuntu 22.04. It comes with 5 years of support, ending in April 2029.

https://ubuntu.com/about/release-cycle

Like other cloud providers, we have added support for Ubuntu 24.04 LTS to our platform.

I tested the new image and it works as expected.

    ubi@vmgsy6jv:~$ lsb_release -a
    No LSB modules are available.
    Distributor ID: Ubuntu
    Description:    Ubuntu 24.04 LTS
    Release:        24.04
    Codename:       noble

    ubi@vmgsy6jv:~$ uname -r
    6.8.0-31-generic
    

~~### Test the boot images exposed to customers~~

~~Since we disabled Alma Linux 9, our customers can only provision Ubuntu 22.04 virtual machines. However, with the launch of Ubuntu 24.04, customers can now provision virtual machines with two different images. We need to test all the boot images exposed to customers to ensure they function as expected. In the past, we've encountered issues with various boot images that we couldn't detect in time.  Therefore, it's crucial to include them in our E2E tests.~~

~~The VmGroup E2E test provisions 3 virtual machines and checks basic features like network connectivity. I've updated it to provision virtual machines using a boot image randomly selected from the available options. This way, we can test different combinations of boot images.~~