### PR TITLE
Use vm.id while generating billing record for the IP address

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -349,7 +349,7 @@ class Prog::Vm::Nexus < Prog::Base
     if vm.ip4_enabled
       BillingRecord.create_with_id(
         project_id: project.id,
-        resource_id: vm.assigned_vm_address.id,
+        resource_id: vm.id,
         resource_name: vm.assigned_vm_address.ip,
         billing_rate_id: BillingRate.from_resource_properties("IPAddress", "IPv4", vm.location)["id"],
         amount: 1


### PR DESCRIPTION
We are grouping the billing records by the resource id while generating the invoices. Thanks to this both compute and storage billing records of VMs are grouped together. It makes sense to group the IP address billing records with the VM billing records as well.

With this change, we also don't need to finalize the billing record through the IP address, as the billing record will belong to VM and will be finalized as part of VM's billing record finalization. However for the existing records still needs to be finalized through the IP address. In the future, when there is no such billing record left, we can remove the finalize call for the IP address.