### PR TITLE
Do not delete PrivateSubnet during deletion of PostgresServer

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -187,6 +187,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
     strand.children.each { _1.destroy }
     unless servers.empty?
+      servers.first.vm.private_subnets.each(&:incr_destroy)
       servers.each(&:incr_destroy)
       nap 5
     end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -344,7 +344,6 @@ SQL
     decr_destroy
 
     strand.children.each { _1.destroy }
-    vm.private_subnets.each { _1.incr_destroy }
     vm.incr_destroy
     postgres_server.destroy
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         vm: instance_double(
           Vm,
           cores: 1,
-          vm_host: instance_double(VmHost, id: "dd9ef3e7-6d55-8371-947f-a8478b42a17d")
+          vm_host: instance_double(VmHost, id: "dd9ef3e7-6d55-8371-947f-a8478b42a17d"),
+          private_subnets: [instance_double(PrivateSubnet, id: "627a23ee-c1fb-86d9-a261-21cc48415916")]
         )
       )],
       representative_server: instance_double(
@@ -320,6 +321,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       dns_zone = instance_double(DnsZone)
       expect(described_class).to receive(:dns_zone).and_return(dns_zone)
 
+      expect(postgres_resource.servers.first.vm.private_subnets).to all(receive(:incr_destroy))
       expect(postgres_resource.servers).to all(receive(:incr_destroy))
       expect { nx.destroy }.to nap(5)
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -562,7 +562,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#destroy" do
     it "deletes resources and exits" do
-      expect(postgres_server.vm).to receive(:private_subnets).and_return([])
       expect(postgres_server.vm).to receive(:incr_destroy)
       expect(postgres_server).to receive(:destroy)
 


### PR DESCRIPTION
The PrivateSubnet is a shared resource and should not be deleted when the PostgresServer is deleted. It can only be deleted when parent resource, PostgresResource is deleted.