### PR TITLE
Enable standard-30 and standard-60 instance sizes for PostgreSQL

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -54,7 +54,7 @@ module Option
   PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :storage_size_gib) do
     alias_method :display_name, :name
   end
-  PostgresSizes = [2, 4, 8, 16].map {
+  PostgresSizes = [2, 4, 8, 16, 30, 60].map {
     PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, (_1 / 2) * 128)
   }.freeze
 


### PR DESCRIPTION
We recently enabled the standard-30 and standard-60 instance sizes for VMs. This commit enables these sizes for PostgreSQL as well.

![image](https://github.com/ubicloud/ubicloud/assets/2082070/4ee2ef84-db47-46d6-8f99-737184b0ea8a)