### PR TITLE
Reapply "Start using new firmware"

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -550,7 +550,7 @@ ExecStartPre=/usr/bin/rm -f #{vp.ch_api_sock}
 
 ExecStart=#{CloudHypervisor::VERSION.bin} -v \
 --api-socket path=#{vp.ch_api_sock} \
---kernel #{CloudHypervisor::FIRMWARE.path} \
+--kernel #{CloudHypervisor::NEW_FIRMWARE.path} \
 #{disk_params.join("\n")}
 --disk path=#{vp.cloudinit_img} \
 --console off --serial file=#{vp.serial_log} \


### PR DESCRIPTION
We ran into an issue with the x64 version of the new firmware. VMs with GPU passthrough wouldn't boot with edk2-stable202402. We changed the x64 version to edk2-stable202311 in https://github.com/ubicloud/ubicloud/commit/d3b06b58b799a166c71c2f0f9a9f41397be23bba as we tracked the issue down to this commit https://github.com/tianocore/edk2/commit/e51965ddd1816a0506818e66644a635ae830e20f, and edk2-stable202311 is the most recent release without it.

We should be good to start using the new firmware.

This reverts commit 8090df77b4fd85f8a4cf174ac1392d2dac5af640.