### PR TITLE
Reduce nap times related to provisioning

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -157,8 +157,8 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   label def wait_vm
     # If the vm is not allocated yet, we know that the vm provisioning will take
-    # definitely more than 18 seconds.
-    nap 18 unless vm.allocated_at
+    # definitely more than 15 seconds.
+    nap 15 unless vm.allocated_at
     nap 1 unless vm.provisioned_at
     register_deadline(:wait, 10 * 60)
     hop_setup_environment

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -254,9 +254,9 @@ class Prog::Vm::Nexus < Prog::Base
     unless vm.update_firewall_rules_set?
       vm.incr_update_firewall_rules
       # This is the first time we get into this state and we know that
-      # wait_sshable will take definitely more than 15 seconds. So, we nap here
+      # wait_sshable will take definitely more than 12 seconds. So, we nap here
       # to reduce the amount of load on the control plane unnecessarily.
-      nap 15
+      nap 12
     end
     addr = vm.ephemeral_net4
     hop_create_billing_record unless addr

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -355,9 +355,9 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe "#wait_vm" do
-    it "naps 18 seconds if vm is not allocated yet" do
+    it "naps 15 seconds if vm is not allocated yet" do
       expect(vm).to receive(:allocated_at).and_return(nil)
-      expect { nx.wait_vm }.to nap(18)
+      expect { nx.wait_vm }.to nap(15)
     end
 
     it "naps a second if vm is allocated but not provisioned yet" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -471,10 +471,10 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#wait_sshable" do
-    it "naps 15 second if it's the first time we execute wait_sshable" do
+    it "naps 12 second if it's the first time we execute wait_sshable" do
       expect(vm).to receive(:update_firewall_rules_set?).and_return(false)
       expect(vm).to receive(:incr_update_firewall_rules)
-      expect { nx.wait_sshable }.to nap(15)
+      expect { nx.wait_sshable }.to nap(12)
     end
 
     it "naps if not sshable" do


### PR DESCRIPTION
Recent update of firmware reduced VM boot time by roughly 2-3 sec. Hence, we need to adjust provisioning related nap times.