### PR TITLE
Persist default branch information for GitHub repositories

### DIFF
--- a/migrate/20240528_github_default_branch.rb
+++ b/migrate/20240528_github_default_branch.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:github_repository) do
+      add_column :default_branch, :text, collate: '"C"'
+    end
+  end
+end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -7,13 +7,13 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   semaphore :destroy
 
-  def self.assemble(installation, repository_name:, label:)
+  def self.assemble(installation, repository_name:, label:, default_branch: nil)
     unless Github.runner_labels[label]
       fail "Invalid GitHub runner label: #{label}"
     end
 
     DB.transaction do
-      repository = Prog::Github::GithubRepositoryNexus.assemble(installation, repository_name).subject
+      repository = Prog::Github::GithubRepositoryNexus.assemble(installation, repository_name, default_branch).subject
       github_runner = GithubRunner.create_with_id(
         installation_id: installation.id,
         repository_name: repository_name,

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -72,7 +72,8 @@ class CloverWeb
       st = Prog::Vm::GithubRunner.assemble(
         installation,
         repository_name: data["repository"]["full_name"],
-        label: label
+        label: label,
+        default_branch: data["repository"]["default_branch"]
       )
       runner = GithubRunner[st.id]
 

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -22,14 +22,17 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
 
       expect {
-        described_class.assemble(installation, "ubicloud/ubicloud")
+        described_class.assemble(installation, "ubicloud/ubicloud", "master")
       }.to change(GithubRepository, :count).from(0).to(1)
       now = Time.now.round(6)
       expect(Time).to receive(:now).and_return(now).at_least(:once)
-      st = described_class.assemble(installation, "ubicloud/ubicloud")
+      st = described_class.assemble(installation, "ubicloud/ubicloud", "main")
       expect(GithubRepository.count).to eq(1)
       expect(Strand.count).to eq(1)
       expect(st.subject.last_job_at).to eq(now)
+      expect(st.subject.default_branch).to eq("main")
+      described_class.assemble(installation, "ubicloud/ubicloud", nil)
+      expect(st.subject.default_branch).to eq("main")
     end
   end
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Clover, "github" do
 
     it "creates runner when receive queued action" do
       st = instance_double(Strand, id: runner.id)
-      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(installation, repository_name: "my-repo", label: "ubicloud").and_return(st)
+      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(installation, repository_name: "my-repo", label: "ubicloud", default_branch: "main").and_return(st)
 
       send_webhook("workflow_job", workflow_job_payload(action: "queued"))
 
@@ -152,7 +152,7 @@ RSpec.describe Clover, "github" do
     {
       action: action,
       installation: {id: installation_id},
-      repository: {full_name: repository_name},
+      repository: {full_name: repository_name, default_branch: "main"},
       workflow_job: workflow_job
     }
   end


### PR DESCRIPTION
We need the default branch information of a GitHub repository to implement certain features. For instance, GitHub Action Cache integration requires all other branches to access the main branch's cache. Continually fetching the default branch isn't feasible when we need it. As the workflow_job webhook event payload already includes the default branch information and we run insert_conflict query for the repository, we also store the default branch information in the repository table.