### PR TITLE
Some cleanups to introduce a new roda app

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -30,7 +30,11 @@ class CloverWeb < Roda
     csp.frame_ancestors :none
   end
 
-  plugin :route_csrf
+  plugin :route_csrf do |token|
+    flash["error"] = "An invalid security token submitted with this request, please try again"
+    return redirect_back_with_inputs
+  end
+
   plugin :disallow_file_uploads
   plugin :flash
   plugin :assets, js: "app.js", css: "app.css", css_opts: {style: :compressed, cache: false}, timestamp_paths: true
@@ -72,9 +76,6 @@ class CloverWeb < Roda
       return redirect_back_with_inputs
     when Validation::ValidationFailed
       flash["errors"] = (flash["errors"] || {}).merge(@error[:details])
-      return redirect_back_with_inputs
-    when Roda::RodaPlugins::RouteCsrf::InvalidToken
-      flash["error"] = "An invalid security token submitted with this request, please try again"
       return redirect_back_with_inputs
     end
 

--- a/routes/clover_base.rb
+++ b/routes/clover_base.rb
@@ -26,10 +26,6 @@ module CloverBase
       code = 400
       type = "InvalidRequest"
       message = e.to_s
-    when Roda::RodaPlugins::RouteCsrf::InvalidToken
-      code = 419
-      type = "InvalidSecurityToken"
-      message = "An invalid security token was submitted with this request, and this request could not be processed."
     when CloverError
       code = e.code
       type = e.type

--- a/spec/routes/api/spec_helper.rb
+++ b/spec/routes/api/spec_helper.rb
@@ -2,19 +2,8 @@
 
 require_relative "../spec_helper"
 
-require "rack/test"
-require "argon2"
-
-RSpec.configure do |config|
-  include Rack::Test::Methods
-
-  def app
-    Clover.freeze.app
-  end
-end
-
 def login_api(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
-  post "/api/login?login=#{email}&password=#{password}", nil, {"CONTENT_TYPE" => "application/json"}
+  post "/api/login", JSON.generate(login: email, password: password), {"CONTENT_TYPE" => "application/json"}
   expect(last_response.status).to eq(200)
   header "Authorization", "Bearer #{last_response.headers["authorization"]}"
 end

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -3,9 +3,20 @@
 require_relative "../spec_helper"
 raise "test database doesn't end with test" if DB.opts[:database] && !/test\d*\z/.match?(DB.opts[:database])
 
+require "rack/test"
+require "argon2"
+
 TEST_USER_EMAIL = "user@example.com"
 TEST_USER_PASSWORD = "Secret@Password123"
 TEST_LOCATION = "eu-north-h1"
+
+RSpec.configure do |config|
+  include Rack::Test::Methods
+
+  def app
+    Clover.freeze.app
+  end
+end
 
 def create_account(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD, with_project: true, enable_otp: false, enable_webauthn: false)
   hash = Argon2::Password.new({

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -4,8 +4,6 @@ require_relative "../spec_helper"
 
 require "capybara"
 require "capybara/rspec"
-require "rack/test"
-require "argon2"
 
 Gem.suffix_pattern
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,7 @@ DatabaseCleaner.url_allowlist = [
 
 Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser.*/)
 Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations.*/)
+Warning.ignore(/To use retry middleware with Faraday v2\.0\+, install `faraday-retry` gem/)
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|


### PR DESCRIPTION
### Clean up invalid CSRF exception handling

The `parse_error` in `clover_base` expects the `Roda::RodaPlugins::RouteCsrf::InvalidToken` to be defined. This is true if the `route_csrf` plugin is enabled, but it might not be in some cases. Only `CloverWeb` uses CSRF protection and has an additional check for it. Thus, we can combine them and pass it during the plugin configuration.

### Clean up routes spec helpers

- We had a similar setup and required the same libraries in the sub-routes spec helpers. I've now moved them to the main routes spec helper.
- In the API test, we log in using query parameters. Who put the password to the query parameters? I've moved it to the body, aligning with how it's done in production.
- When running tests, Octokit displays a warning: "To use retry middleware with Faraday v2.0+, install `faraday-retry` gem". It seems there's a design oversight in the library. I added a warning ignore for it. For more information https://github.com/octokit/octokit.rb/discussions/1486