### PR TITLE
Introduce runtime API endpoints

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -30,6 +30,10 @@ class Clover < Roda
     end
     # :nocov:
 
+    r.on "runtime" do
+      r.run CloverRuntime
+    end
+
     r.run CloverWeb
   end
 end

--- a/clover_runtime.rb
+++ b/clover_runtime.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "jwt"
+
+class CloverRuntime < Roda
+  include CloverBase
+
+  plugin :default_headers, "Content-Type" => "application/json"
+
+  plugin :hash_branches
+  plugin :json
+  plugin :all_verbs
+  plugin :json_parser
+
+  autoload_routes("runtime")
+
+  plugin :error_handler do |e|
+    error = parse_error(e)
+
+    {error: error}.to_json
+  end
+
+  def get_jwt_payload(request)
+    return unless (v = request.env["HTTP_AUTHORIZATION"])
+    jwt_token = v.sub(%r{\ABearer:?\s+}, "")
+    begin
+      JWT.decode(jwt_token, Config.clover_runtime_token_secret, true, {algorithm: "HS256"})[0]
+    rescue JWT::DecodeError
+    end
+  end
+
+  route do |r|
+    if (jwt_payload = get_jwt_payload(r)).nil? || (@vm = Vm.from_ubid(jwt_payload["sub"])).nil?
+      fail CloverError.new(400, "InvalidRequest", "invalid JWT format or claim in Authorization header")
+    end
+
+    r.hash_branches("")
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -47,6 +47,7 @@ module Config
   optional :versioning_default, string
   optional :versioning_app_name, string
   optional :clover_session_secret, base64, clear: true
+  optional :clover_runtime_token_secret, base64, clear: true
   optional :clover_column_encryption_key, base64, clear: true
   optional :stripe_public_key, string, clear: true
   optional :stripe_secret_key, string, clear: true

--- a/loader.rb
+++ b/loader.rb
@@ -78,7 +78,7 @@ autoload_normal = ->(subdirectory, include_first: false, flat: false) do
 end
 
 autoload_normal.call("model", flat: true)
-%w[lib clover.rb clover_web.rb clover_api.rb routes/clover_base.rb routes/clover_error.rb].each { autoload_normal.call(_1) }
+%w[lib clover.rb clover_web.rb clover_api.rb clover_runtime.rb routes/clover_base.rb routes/clover_error.rb].each { autoload_normal.call(_1) }
 %w[scheduling prog serializers].each { autoload_normal.call(_1, include_first: true) }
 
 AUTOLOAD_CONSTANTS.freeze

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "jwt"
 require_relative "../model"
 
 class Vm < Sequel::Model
@@ -49,6 +50,10 @@ class Vm < Sequel::Model
 
   def ip4
     assigned_vm_address&.ip
+  end
+
+  def runtime_token
+    JWT.encode({sub: ubid, iat: Time.now.to_i}, Config.clover_runtime_token_secret, "HS256")
   end
 
   def display_state

--- a/spec/routes/runtime/auth_spec.rb
+++ b/spec/routes/runtime/auth_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "auth" do
+  it "no jwt token" do
+    get "/runtime"
+
+    expect(last_response.status).to eq(400)
+    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+  end
+
+  it "wrong jwt token" do
+    header "Authorization", "Bearer wrongjwt"
+    get "/runtime"
+
+    expect(last_response.status).to eq(400)
+    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+  end
+
+  it "valid jwt token but no active vm" do
+    vm = Vm.new_with_id
+    header "Authorization", "Bearer #{vm.runtime_token}"
+    get "/runtime"
+
+    expect(last_response.status).to eq(400)
+    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+  end
+
+  it "valid jwt token with an active vm" do
+    login_runtime(create_vm)
+    get "/runtime"
+
+    expect(last_response.status).to eq(404)
+  end
+end

--- a/spec/routes/runtime/spec_helper.rb
+++ b/spec/routes/runtime/spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.configure do |config|
+  config.before {
+    allow(Config).to receive(:clover_runtime_token_secret).and_return(Config.clover_session_secret)
+  }
+end
+
+def login_runtime(vm)
+  header "Authorization", "Bearer #{vm.runtime_token}"
+end


### PR DESCRIPTION
Generally, the controlplane has been passing necessary data to the dataplane at the start of operations. However, this approach can't pre-determine the information needed for future operations. There are instances where the control plane sends additional data to the dataplane during later stages, once it identifies the needed data. However, this polling method introduces delays. In some scenarios, the dataplane should have the capability to directly request this information from the controlplane during runtime, eliminating any delay. I needed this feature for implementing GitHub Actions Cache integration. The GitHub runner requires pre-signed blob storage URLs for uploading and downloading cache, a decision made at runtime. It calculates the required cache keys and versions. Rather than developing this feature solely for GitHub integration, I opted to create a more generic solution to identify the requesting virtual machine. This can be utilized for other integrations as well. The dataplane may need information from the controlplane or may need to trigger an operation on the controlplane.

When a request arrives at the controlplane, we must verify that it originates from our virtual machines and authenticate it. I selected JWT tokens for this authentication process, the same method we use for our customer API. We embed the UBID of the virtual machines into the JWT token. Thus, if the token signature is valid, we can identify the source virtual machines. One common criticism of JWT tokens is their statelessness; they can't be revoked by default. However, there are workarounds. Firstly, the token is only valid for the lifetime of the virtual machine. Once the runner is destroyed, the token is no longer valid. Additionally, we include a creation date in the token, allowing us to set an expiration time. I haven't yet implemented this expiration feature since the runners are typically short-lived. However, it can be easily added when we introduce runtime API endpoints for long-lived resources.