### PR TITLE
Centralize business logic of Postgres web and api endpoints

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -199,7 +199,7 @@ $("input[name=size]").on("change", function (event) {
 $(".storage-slider").on("change", function (event) {
   storage_size_options = $("input[name=size]:checked").data("storage-size-options");
   storage_size_index = parseInt($(".storage-slider").val());
-  $("input[name=storage-size]").val(storage_size_options[storage_size_index])
+  $("input[name=storage_size]").val(storage_size_options[storage_size_index])
   setupLocationBasedPostgresHaPrices();
 });
 
@@ -240,7 +240,7 @@ function setupLocationBasedPostgresHaPrices() {
   $("input.location-based-postgres-ha-price").each(function(i, obj) {
     let value = $(this).val();
     let monthlyComputePrice = parseFloat($("input[name=size]:checked").data("monthly-price"))
-    let monthlyStoragePrice = parseFloat($("input[name=storage-size]").val()) * parseFloat($(".storage-slider").data("monthly-price"))
+    let monthlyStoragePrice = parseFloat($("input[name=storage_size]").val()) * parseFloat($(".storage-slider").data("monthly-price"))
     let monthlyPrice = monthlyComputePrice + monthlyStoragePrice;
     let standbyCount = $(this).data("standby-count");
     $(`.ha-status-${value}`).show();
@@ -265,7 +265,7 @@ function setupInstanceSizeBasedOptions() {
 
       $(this).attr("max", storage_size_options.length - 1);
       storage_size_index = parseInt($(".storage-slider").val());
-      $("input[name=storage-size]").val(storage_size_options[storage_size_index])
+      $("input[name=storage_size]").val(storage_size_options[storage_size_index])
 
       let monthlyPrice = $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"]
       $(this).data("monthly-price", monthlyPrice);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -196,9 +196,9 @@ $("input[name=size]").on("change", function (event) {
   setupLocationBasedPostgresHaPrices();
 });
 
-$("input[name=pseudo-storage-size]").on("change", function (event) {
+$(".storage-slider").on("change", function (event) {
   storage_size_options = $("input[name=size]:checked").data("storage-size-options");
-  storage_size_index = parseInt($("input[name=pseudo-storage-size]").val());
+  storage_size_index = parseInt($(".storage-slider").val());
   $("input[name=storage-size]").val(storage_size_options[storage_size_index])
   setupLocationBasedPostgresHaPrices();
 });
@@ -240,7 +240,7 @@ function setupLocationBasedPostgresHaPrices() {
   $("input.location-based-postgres-ha-price").each(function(i, obj) {
     let value = $(this).val();
     let monthlyComputePrice = parseFloat($("input[name=size]:checked").data("monthly-price"))
-    let monthlyStoragePrice = parseFloat($("input[name=storage-size]").val()) * parseFloat($("input[name=pseudo-storage-size]").data("monthly-price"))
+    let monthlyStoragePrice = parseFloat($("input[name=storage-size]").val()) * parseFloat($(".storage-slider").data("monthly-price"))
     let monthlyPrice = monthlyComputePrice + monthlyStoragePrice;
     let standbyCount = $(this).data("standby-count");
     $(`.ha-status-${value}`).show();
@@ -259,12 +259,12 @@ function setupLocationBasedOptions() {
 function setupInstanceSizeBasedOptions() {
   $(".instance-size-based-option").each(function() {
     let type = $(this).attr("type")
-    if(type == "range" && $(this).attr("id") == "pseudo-storage-size"){
+    if(type == "range" && $(this).hasClass("storage-slider")){
       storage_size_options = $("input[name=size]:checked").data("storage-size-options");
       storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
 
       $(this).attr("max", storage_size_options.length - 1);
-      storage_size_index = parseInt($("input[name=pseudo-storage-size]").val());
+      storage_size_index = parseInt($(".storage-slider").val());
       $("input[name=storage-size]").val(storage_size_options[storage_size_index])
 
       let monthlyPrice = $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"]

--- a/loader.rb
+++ b/loader.rb
@@ -79,7 +79,7 @@ end
 
 autoload_normal.call("model", flat: true)
 %w[lib clover.rb clover_web.rb clover_api.rb clover_runtime.rb routes/clover_base.rb routes/clover_error.rb].each { autoload_normal.call(_1) }
-%w[scheduling prog serializers].each { autoload_normal.call(_1, include_first: true) }
+%w[scheduling prog serializers routes/common].each { autoload_normal.call(_1, include_first: true) }
 
 AUTOLOAD_CONSTANTS.freeze
 

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -2,17 +2,10 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "postgres") do |r|
-    r.get true do
-      result = @project.postgres_resources_dataset.where(location: @location).authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
-        start_after: r.params["start_after"],
-        page_size: r.params["page_size"],
-        order_column: r.params["order_column"]
-      )
+    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: @current_user, location: @location, resource: nil)
 
-      {
-        items: Serializers::Postgres.serialize(result[:records]),
-        count: result[:count]
-      }
+    r.get true do
+      pg_endpoint_helper.list
     end
 
     r.on "id" do
@@ -23,201 +16,74 @@ class CloverApi
           pg = nil
         end
 
-        handle_pg_requests(@current_user, pg, @project)
+        pg_endpoint_helper.instance_variable_set(:@resource, pg)
+        handle_pg_requests(pg_endpoint_helper)
       end
     end
 
     r.on String do |pg_name|
       r.post true do
-        Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
-        fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
-        Validation.validate_postgres_location(@location)
-
-        required_parameters = ["size"]
-        allowed_optional_parameters = ["storage_size", "ha_type"]
-
-        request_body_params = Validation.validate_request_body(r.body.read, required_parameters, allowed_optional_parameters)
-        parsed_size = Validation.validate_postgres_size(request_body_params["size"])
-        st = Prog::Postgres::PostgresResourceNexus.assemble(
-          project_id: @project.id,
-          location: @location,
-          name: pg_name,
-          target_vm_size: parsed_size.vm_size,
-          target_storage_size_gib: request_body_params["storage_size"] || parsed_size.storage_size_options.first,
-          ha_type: request_body_params["ha_type"] || PostgresResource::HaType::NONE
-        )
-
-        Serializers::Postgres.serialize(st.subject, {detailed: true})
+        pg_endpoint_helper.post(name: pg_name)
       end
 
       pg = @project.postgres_resources_dataset.where(location: @location).where { {Sequel[:postgres_resource][:name] => pg_name} }.first
-      handle_pg_requests(@current_user, pg, @project)
+      pg_endpoint_helper.instance_variable_set(:@resource, pg)
+      handle_pg_requests(pg_endpoint_helper)
     end
   end
 
-  def handle_pg_requests(user, pg, project)
-    unless pg
+  def handle_pg_requests(pg_endpoint_helper)
+    unless pg_endpoint_helper.instance_variable_get(:@resource)
       response.status = request.delete? ? 204 : 404
       request.halt
     end
 
     request.get true do
-      Authorization.authorize(user.id, "Postgres:view", pg.id)
-      Serializers::Postgres.serialize(pg, {detailed: true})
+      pg_endpoint_helper.get
     end
 
     request.delete true do
-      Authorization.authorize(user.id, "Postgres:delete", pg.id)
-      pg.incr_destroy
-
-      response.status = 204
-      request.halt
+      pg_endpoint_helper.delete
     end
 
     request.on "firewall-rule" do
       request.post true do
-        Authorization.authorize(user.id, "Postgres:Firewall:edit", pg.id)
-
-        required_parameters = ["cidr"]
-
-        request_body_params = Validation.validate_request_body(request.body.read, required_parameters)
-
-        Validation.validate_cidr(request_body_params["cidr"])
-
-        DB.transaction do
-          PostgresFirewallRule.create_with_id(
-            postgres_resource_id: pg.id,
-            cidr: request_body_params["cidr"]
-          )
-          pg.incr_update_firewall_rules
-        end
-
-        Serializers::Postgres.serialize(pg, {detailed: true})
+        pg_endpoint_helper.post_firewall_rule
       end
 
       request.get true do
-        Authorization.authorize(user.id, "Postgres:Firewall:view", pg.id)
-        Serializers::PostgresFirewallRule.serialize(pg.firewall_rules)
+        pg_endpoint_helper.get_firewall_rule
       end
 
       request.is String do |firewall_rule_ubid|
         request.delete true do
-          Authorization.authorize(user.id, "Postgres:Firewall:edit", pg.id)
-          fwr = PostgresFirewallRule.from_ubid(firewall_rule_ubid)
-
-          if fwr
-            DB.transaction do
-              fwr.destroy
-              pg.incr_update_firewall_rules
-            end
-          end
-
-          response.status = 204
-          request.halt
+          pg_endpoint_helper.delete_firewall_rule(firewall_rule_ubid)
         end
       end
     end
 
     request.on "metric-destination" do
       request.post true do
-        Authorization.authorize(user.id, "Postgres:edit", pg.id)
-
-        required_parameters = ["url", "username", "password"]
-        request_body_params = Validation.validate_request_body(request.body.read, required_parameters)
-
-        Validation.validate_url(request_body_params["url"])
-
-        DB.transaction do
-          PostgresMetricDestination.create_with_id(
-            postgres_resource_id: pg.id,
-            url: request_body_params["url"],
-            username: request_body_params["username"],
-            password: request_body_params["password"]
-          )
-          pg.servers.each(&:incr_configure_prometheus)
-        end
-
-        Serializers::Postgres.serialize(pg, {detailed: true})
+        pg_endpoint_helper.post_metric_destination
       end
 
       request.is String do |metric_destination_ubid|
         request.delete true do
-          Authorization.authorize(user.id, "Postgres:edit", pg.id)
-
-          md = PostgresMetricDestination.from_ubid(metric_destination_ubid)
-          if md
-            DB.transaction do
-              md.destroy
-              pg.servers.each(&:incr_configure_prometheus)
-            end
-          end
-
-          response.status = 204
-          request.halt
+          pg_endpoint_helper.delete_metric_destination(metric_destination_ubid)
         end
       end
     end
 
     request.post "restore" do
-      Authorization.authorize(user.id, "Postgres:create", project.id)
-      Authorization.authorize(user.id, "Postgres:view", pg.id)
-
-      required_parameters = ["name", "restore_target"]
-
-      request_body_params = Validation.validate_request_body(request.body.read, required_parameters)
-
-      st = Prog::Postgres::PostgresResourceNexus.assemble(
-        project_id: project.id,
-        location: pg.location,
-        name: request_body_params["name"],
-        target_vm_size: pg.target_vm_size,
-        target_storage_size_gib: pg.target_storage_size_gib,
-        parent_id: pg.id,
-        restore_target: request_body_params["restore_target"]
-      )
-
-      Serializers::Postgres.serialize(st.subject, {detailed: true})
+      pg_endpoint_helper.restore
     end
 
     request.post "reset-superuser-password" do
-      Authorization.authorize(user.id, "Postgres:create", project.id)
-      Authorization.authorize(user.id, "Postgres:view", pg.id)
-
-      unless pg.representative_server.primary?
-        fail CloverError.new(400, "InvalidRequest", "Superuser password cannot be updated during restore!")
-      end
-
-      required_parameters = ["password"]
-
-      request_body_params = Validation.validate_request_body(request.body.read, required_parameters)
-
-      Validation.validate_postgres_superuser_password(request_body_params["password"])
-
-      DB.transaction do
-        pg.update(superuser_password: request_body_params["password"])
-        pg.representative_server.incr_update_superuser_password
-      end
-
-      Serializers::Postgres.serialize(pg, {detailed: true})
+      pg_endpoint_helper.reset_superuser_password
     end
 
     request.post "failover" do
-      Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
-      Authorization.authorize(@current_user.id, "Postgres:view", pg.id)
-
-      unless pg.representative_server.primary?
-        fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered during restore!")
-      end
-
-      unless @project.get_ff_postgresql_base_image
-        fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered for this resource!")
-      end
-
-      unless pg.representative_server.trigger_failover
-        fail CloverError.new(400, "InvalidRequest", "There is not a suitable standby server to failover!")
-      end
-
-      Serializers::Postgres.serialize(pg, {detailed: true})
+      pg_endpoint_helper.failover
     end
   end
 end

--- a/routes/api/project/postgres.rb
+++ b/routes/api/project/postgres.rb
@@ -2,17 +2,10 @@
 
 class CloverApi
   hash_branch(:project_prefix, "postgres") do |r|
-    r.get true do
-      result = @project.postgres_resources_dataset.authorized(@current_user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
-        start_after: r.params["start_after"],
-        page_size: r.params["page_size"],
-        order_column: r.params["order_column"]
-      )
+    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: @current_user, location: nil, resource: nil)
 
-      {
-        items: Serializers::Postgres.serialize(result[:records]),
-        count: result[:count]
-      }
+    r.get true do
+      pg_endpoint_helper.list
     end
   end
 end

--- a/routes/common/base.rb
+++ b/routes/common/base.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Routes::Common::Base
+  module AppMode
+    API = :api
+    WEB = :web
+  end
+
+  def initialize(app:, request:, user:, location:, resource:)
+    @app = app
+    @request = request
+    @user = user
+    @resource = resource
+    @location = location
+    @mode = if app.instance_of?(::CloverApi)
+      AppMode::API
+    elsif app.instance_of?(::CloverWeb)
+      AppMode::WEB
+    else
+      raise "Unknown app mode"
+    end
+  end
+
+  def project
+    @app.instance_variable_get(:@project)
+  end
+
+  def response
+    @app.response
+  end
+
+  def flash
+    @app.flash
+  end
+end

--- a/routes/common/base.rb
+++ b/routes/common/base.rb
@@ -32,4 +32,8 @@ class Routes::Common::Base
   def flash
     @app.flash
   end
+
+  def params
+    (@mode == AppMode::API) ? @request.body.read : @request.params.reject { _1 == "_csrf" }.to_json
+  end
 end

--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+class Routes::Common::PostgresHelper < Routes::Common::Base
+  def list
+    if @mode == AppMode::API
+      dataset = project.postgres_resources_dataset
+      dataset = dataset.where(location: @location) if @location
+      result = dataset.authorized(@user.id, "Postgres:view").eager(:semaphores, :strand).paginated_result(
+        start_after: @request.params["start_after"],
+        page_size: @request.params["page_size"],
+        order_column: @request.params["order_column"]
+      )
+
+      {
+        items: Serializers::Postgres.serialize(result[:records]),
+        count: result[:count]
+      }
+    else
+      postgres_databases = Serializers::Postgres.serialize(project.postgres_resources_dataset.authorized(@user.id, "Postgres:view").eager(:semaphores, :strand, :representative_server, :timeline).all, {include_path: true})
+      @app.instance_variable_set(:@postgres_databases, postgres_databases)
+      @app.view "postgres/index"
+    end
+  end
+
+  def post(name: nil)
+    Authorization.authorize(@user.id, "Postgres:create", project.id)
+    fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless project.has_valid_payment_method?
+    if @mode == AppMode::API
+      Validation.validate_postgres_location(@location)
+
+      required_parameters = ["size"]
+      allowed_optional_parameters = ["storage_size", "ha_type"]
+      request_body_params = Validation.validate_request_body(@request.body.read, required_parameters, allowed_optional_parameters)
+
+      parsed_size = Validation.validate_postgres_size(request_body_params["size"])
+      st = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location: @location,
+        name: name,
+        target_vm_size: parsed_size.vm_size,
+        target_storage_size_gib: request_body_params["storage_size"] || parsed_size.storage_size_options.first,
+        ha_type: request_body_params["ha_type"] || PostgresResource::HaType::NONE
+      )
+
+      Serializers::Postgres.serialize(st.subject, {detailed: true})
+    else
+      parsed_size = Validation.validate_postgres_size(@request.params["size"])
+      location = LocationNameConverter.to_internal_name(@request.params["location"])
+      Validation.validate_postgres_location(location)
+      st = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location: location,
+        name: @request.params["name"],
+        target_vm_size: parsed_size.vm_size,
+        target_storage_size_gib: @request.params["storage-size"],
+        ha_type: @request.params["ha_type"]
+      )
+
+      flash["notice"] = "'#{@request.params["name"]}' will be ready in a few minutes"
+
+      @request.redirect "#{project.path}#{PostgresResource[st.id].path}"
+    end
+  end
+
+  def get
+    Authorization.authorize(@user.id, "Postgres:view", @resource.id)
+    if @mode == AppMode::API
+      Serializers::Postgres.serialize(@resource, {detailed: true})
+    else
+      @app.instance_variable_set(:@pg, Serializers::Postgres.serialize(@resource, {detailed: true, include_path: true}))
+      @app.view "postgres/show"
+    end
+  end
+
+  def delete
+    Authorization.authorize(@user.id, "Postgres:delete", @resource.id)
+    @resource.incr_destroy
+    if @mode == AppMode::API
+      response.status = 204
+      @request.halt
+    else
+      {message: "Deleting #{@resource.name}"}.to_json
+    end
+  end
+
+  def post_firewall_rule
+    Authorization.authorize(@user.id, "Postgres:Firewall:edit", @resource.id)
+    if @mode == AppMode::API
+      required_parameters = ["cidr"]
+
+      request_body_params = Validation.validate_request_body(@request.body.read, required_parameters)
+      Validation.validate_cidr(request_body_params["cidr"])
+
+      DB.transaction do
+        PostgresFirewallRule.create_with_id(
+          postgres_resource_id: @resource.id,
+          cidr: request_body_params["cidr"]
+        )
+        @resource.incr_update_firewall_rules
+      end
+
+      Serializers::Postgres.serialize(@resource, {detailed: true})
+    else
+      parsed_cidr = Validation.validate_cidr(@request.params["cidr"])
+
+      DB.transaction do
+        PostgresFirewallRule.create_with_id(
+          postgres_resource_id: @resource.id,
+          cidr: parsed_cidr.to_s
+        )
+        @resource.incr_update_firewall_rules
+      end
+
+      flash["notice"] = "Firewall rule is created"
+      @request.redirect "#{project.path}#{@resource.path}"
+    end
+  end
+
+  def get_firewall_rule
+    Authorization.authorize(@user.id, "Postgres:Firewall:view", @resource.id)
+    Serializers::PostgresFirewallRule.serialize(@resource.firewall_rules)
+  end
+
+  def delete_firewall_rule(firewall_rule_ubid)
+    Authorization.authorize(@user.id, "Postgres:Firewall:edit", @resource.id)
+    fwr = PostgresFirewallRule.from_ubid(firewall_rule_ubid)
+    if @mode == AppMode::API
+      if fwr
+        DB.transaction do
+          fwr.destroy
+          @resource.incr_update_firewall_rules
+        end
+      end
+      response.status = 204
+      @request.halt
+    else
+      unless fwr
+        response.status = 404
+        @request.halt
+      end
+
+      DB.transaction do
+        fwr.destroy
+        @resource.incr_update_firewall_rules
+      end
+      {message: "Firewall rule deleted"}.to_json
+    end
+  end
+
+  def post_metric_destination
+    Authorization.authorize(@user.id, "Postgres:edit", @resource.id)
+    if @mode == AppMode::API
+      required_parameters = ["url", "username", "password"]
+      request_body_params = Validation.validate_request_body(@request.body.read, required_parameters)
+
+      Validation.validate_url(request_body_params["url"])
+
+      DB.transaction do
+        PostgresMetricDestination.create_with_id(
+          postgres_resource_id: @resource.id,
+          url: request_body_params["url"],
+          username: request_body_params["username"],
+          password: request_body_params["password"]
+        )
+        @resource.servers.each(&:incr_configure_prometheus)
+      end
+
+      Serializers::Postgres.serialize(@resource, {detailed: true})
+    else
+      Validation.validate_url(@request.params["url"])
+
+      DB.transaction do
+        PostgresMetricDestination.create_with_id(
+          postgres_resource_id: @resource.id,
+          url: @request.params["url"],
+          username: @request.params["username"],
+          password: @request.params["password"]
+        )
+        @resource.servers.each(&:incr_configure_prometheus)
+      end
+
+      flash["notice"] = "Metric destination is created"
+
+      @request.redirect "#{project.path}#{@resource.path}"
+    end
+  end
+
+  def delete_metric_destination(metric_destination_ubid)
+    Authorization.authorize(@user.id, "Postgres:edit", @resource.id)
+    md = PostgresMetricDestination.from_ubid(metric_destination_ubid)
+    if @mode == AppMode::API
+      if md
+        DB.transaction do
+          md.destroy
+          @resource.servers.each(&:incr_configure_prometheus)
+        end
+      end
+    elsif md
+      DB.transaction do
+        md.destroy
+        @resource.servers.each(&:incr_configure_prometheus)
+      end
+
+    end
+    response.status = 204
+    @request.halt
+  end
+
+  def restore
+    Authorization.authorize(@user.id, "Postgres:create", project.id)
+    Authorization.authorize(@user.id, "Postgres:view", @resource.id)
+    if @mode == AppMode::API
+      required_parameters = ["name", "restore_target"]
+      request_body_params = Validation.validate_request_body(@request.body.read, required_parameters)
+
+      st = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location: @resource.location,
+        name: request_body_params["name"],
+        target_vm_size: @resource.target_vm_size,
+        target_storage_size_gib: @resource.target_storage_size_gib,
+        parent_id: @resource.id,
+        restore_target: request_body_params["restore_target"]
+      )
+
+      Serializers::Postgres.serialize(st.subject, {detailed: true})
+    else
+      st = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location: @resource.location,
+        name: @request.params["name"],
+        target_vm_size: @resource.target_vm_size,
+        target_storage_size_gib: @resource.target_storage_size_gib,
+        parent_id: @resource.id,
+        restore_target: @request.params["restore_target"]
+      )
+
+      flash["notice"] = "'#{@request.params["name"]}' will be ready in a few minutes"
+
+      @request.redirect "#{project.path}#{st.subject.path}"
+    end
+  end
+
+  def reset_superuser_password
+    Authorization.authorize(@user.id, "Postgres:create", project.id)
+    Authorization.authorize(@user.id, "Postgres:view", @resource.id)
+    if @mode == AppMode::API
+      unless @resource.representative_server.primary?
+        fail CloverError.new(400, "InvalidRequest", "Superuser password cannot be updated during restore!")
+      end
+
+      required_parameters = ["password"]
+      request_body_params = Validation.validate_request_body(@request.body.read, required_parameters)
+      Validation.validate_postgres_superuser_password(request_body_params["password"])
+
+      DB.transaction do
+        @resource.update(superuser_password: request_body_params["password"])
+        @resource.representative_server.incr_update_superuser_password
+      end
+
+      Serializers::Postgres.serialize(@resource, {detailed: true})
+    else
+      unless @resource.representative_server.primary?
+        flash["error"] = "Superuser password cannot be updated during restore!"
+        return @app.redirect_back_with_inputs
+      end
+
+      Validation.validate_postgres_superuser_password(@request.params["original_password"], @request.params["repeat_password"])
+
+      @resource.update(superuser_password: @request.params["original_password"])
+      @resource.representative_server.incr_update_superuser_password
+
+      flash["notice"] = "The superuser password will be updated in a few seconds"
+
+      @request.redirect "#{project.path}#{@resource.path}"
+    end
+  end
+
+  def restart
+    Authorization.authorize(@user.id, "Postgres:edit", @resource.id)
+    @resource.servers.each do |s|
+      s.incr_restart
+    rescue Sequel::ForeignKeyConstraintViolation
+    end
+    @request.redirect "#{project.path}#{@resource.path}"
+  end
+
+  def view_create_page
+    Authorization.authorize(@user.id, "Postgres:create", project.id)
+    @app.instance_variable_set(:@prices, @app.fetch_location_based_prices("PostgresCores", "PostgresStorage"))
+    @app.instance_variable_set(:@has_valid_payment_method, project.has_valid_payment_method?)
+    @app.view "postgres/create"
+  end
+
+  def failover
+    Authorization.authorize(@user.id, "Postgres:create", project.id)
+    Authorization.authorize(@user.id, "Postgres:view", @resource.id)
+
+    unless @resource.representative_server.primary?
+      fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered during restore!")
+    end
+
+    unless project.get_ff_postgresql_base_image
+      fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered for this resource!")
+    end
+
+    unless @resource.representative_server.trigger_failover
+      fail CloverError.new(400, "InvalidRequest", "There is not a suitable standby server to failover!")
+    end
+
+    Serializers::Postgres.serialize(@resource, {detailed: true})
+  end
+end

--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -64,12 +64,8 @@ class Routes::Common::PostgresHelper < Routes::Common::Base
   def delete
     Authorization.authorize(@user.id, "Postgres:delete", @resource.id)
     @resource.incr_destroy
-    if @mode == AppMode::API
-      response.status = 204
-      @request.halt
-    else
-      {message: "Deleting #{@resource.name}"}.to_json
-    end
+    response.status = 204
+    @request.halt
   end
 
   def post_firewall_rule

--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -52,7 +52,7 @@ class Routes::Common::PostgresHelper < Routes::Common::Base
         location: location,
         name: @request.params["name"],
         target_vm_size: parsed_size.vm_size,
-        target_storage_size_gib: @request.params["storage-size"],
+        target_storage_size_gib: @request.params["storage_size"],
         ha_type: @request.params["ha_type"]
       )
 

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -9,7 +9,12 @@ class CloverWeb
     end
 
     r.post true do
-      pg_endpoint_helper.post
+      # API request for resource creation already has location in the URL.
+      # However for web endpoints the location is selected from the UI and
+      # cannot be dynamically put to the form's action. due to csrf checks.
+      # So we need to set the location here.
+      pg_endpoint_helper.instance_variable_set(:@location, LocationNameConverter.to_internal_name(r.params["location"]))
+      pg_endpoint_helper.post(name: r.params["name"])
     end
 
     r.on "create" do

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -18,7 +18,7 @@ class CloverWeb
       Validation.validate_boot_image(r.params["boot-image"])
       Validation.validate_vm_size(r.params["size"], only_visible: true)
       location = LocationNameConverter.to_internal_name(r.params["location"])
-      storage_size = Validation.validate_vm_storage_size(r.params["size"], r.params["storage-size"])
+      storage_size = Validation.validate_vm_storage_size(r.params["size"], r.params["storage_size"])
       st = Prog::Vm::Nexus.assemble(
         r.params["public-key"],
         @project.id,

--- a/spec/routes/common/base_spec.rb
+++ b/spec/routes/common/base_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "base" do
+  it "raises exception for unexpected class" do
+    expect { Routes::Common::Base.new(app: Object.new, request: nil, user: nil, location: nil, resource: nil) }.to raise_error("Unknown app mode")
+  end
+end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -271,7 +271,6 @@ RSpec.describe Clover, "postgres" do
         btn = find "#fwr-delete-#{pg.firewall_rules.first.ubid} .delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-        expect(page.body).to eq({message: "Firewall rule deleted"}.to_json)
         expect(SemSnap.new(pg.id).set?("update_firewall_rules")).to be true
       end
 
@@ -286,16 +285,6 @@ RSpec.describe Clover, "postgres" do
         visit "#{project_wo_permissions.path}#{pg_wo_permission.path}"
 
         expect { find "#fwr-delete-#{pg.firewall_rules.first.ubid} .delete-btn" }.to raise_error Capybara::ElementNotFound
-      end
-
-      it "can not delete firewall rules if not exist" do
-        pg
-        visit "#{project.path}#{pg.path}"
-
-        btn = find "#fwr-delete-#{pg.firewall_rules.first.ubid} .delete-btn"
-        expect(PostgresFirewallRule).to receive(:from_ubid).and_return(nil)
-        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
-        expect(page.status_code).to eq(404)
       end
 
       it "does not show create firewall rule when does not have permissions" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe Clover, "postgres" do
   end
 
   describe "unauthenticated" do
-    it "can not list without login" do
+    it "cannot list without login" do
       visit "/postgres"
 
       expect(page.title).to eq("Ubicloud - Login")
     end
 
-    it "can not create without login" do
+    it "cannot create without login" do
       visit "/postgres/create"
 
       expect(page.title).to eq("Ubicloud - Login")
@@ -92,23 +92,6 @@ RSpec.describe Clover, "postgres" do
         expect(PostgresResource.first.projects.first.id).to eq(project.id)
       end
 
-      it "can not create PostgreSQL database with invalid name" do
-        visit "#{project.path}/postgres/create"
-
-        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
-
-        fill_in "Name", with: "invalid name"
-        choose option: "eu-central-h1"
-        choose option: "standard-2"
-        choose option: PostgresResource::HaType::NONE
-
-        click_button "Create"
-
-        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
-        expect(page).to have_content "Name must only contain"
-        expect((find "input[name=name]")["value"]).to eq("invalid name")
-      end
-
       it "can not create PostgreSQL database with same name" do
         visit "#{project.path}/postgres/create"
 
@@ -123,26 +106,6 @@ RSpec.describe Clover, "postgres" do
 
         expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
         expect(page).to have_content "name is already taken"
-      end
-
-      it "can not create PostgreSQL database if project has no valid payment method" do
-        expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
-        expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
-
-        visit "#{project.path}/postgres/create"
-
-        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
-        expect(page).to have_content "Project doesn't have valid billing information"
-
-        fill_in "Name", with: "new-pg-db"
-        choose option: "eu-central-h1"
-        choose option: "standard-2"
-        choose option: PostgresResource::HaType::NONE
-
-        click_button "Create"
-
-        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
-        expect(page).to have_content "Project doesn't have valid billing information"
       end
 
       it "can not select invisible location" do
@@ -221,6 +184,7 @@ RSpec.describe Clover, "postgres" do
         find(".reset-superuser-password-new-password-repeat").set("DummyPassword123")
         click_button "Reset"
 
+        expect(pg.reload.superuser_password).to eq("DummyPassword123")
         expect(page.status_code).to eq(200)
       end
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -217,8 +217,8 @@ RSpec.describe Clover, "postgres" do
         visit "#{project.path}#{pg.path}"
         expect(page).to have_content "Reset superuser password"
 
-        fill_in "New password", with: "DummyPassword123"
-        fill_in "New password (repeat)", with: "DummyPassword123"
+        find(".reset-superuser-password-new-password").set("DummyPassword123")
+        find(".reset-superuser-password-new-password-repeat").set("DummyPassword123")
         click_button "Reset"
 
         expect(page.status_code).to eq(200)
@@ -237,8 +237,8 @@ RSpec.describe Clover, "postgres" do
         expect(page).to have_content "Reset superuser password"
 
         pg.representative_server.update(timeline_access: "fetch")
-        fill_in "New password", with: "DummyPassword123"
-        fill_in "New password (repeat)", with: "DummyPassword123"
+        find(".reset-superuser-password-new-password").set("DummyPassword123")
+        find(".reset-superuser-password-new-password-repeat").set("DummyPassword123")
         click_button "Reset"
 
         expect(page.status_code).to eq(200)
@@ -331,7 +331,7 @@ RSpec.describe Clover, "postgres" do
 
         fill_in "url", with: "https://example.com"
         fill_in "username", with: "username"
-        fill_in "password", with: "password"
+        find(".metric-destination-password").set("password")
         find(".metric-destination-create-button").click
         expect(page).to have_content "https://example.com"
         expect(pg.reload.metric_destinations.count).to eq(1)

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -390,7 +390,6 @@ RSpec.describe Clover, "postgres" do
         btn = find "#postgres-delete-#{pg.ubid} .delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-        expect(page.body).to eq({message: "Deleting #{pg.name}"}.to_json)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
       end
 

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -120,7 +120,7 @@
                         locals: {
                           label: "Storage Size",
                           range_labels: size.storage_size_options.map { "#{_1}GB" },
-                          value: flash.dig("old", "storage-size") ? size.storage_size_options.index(flash.dig("old", "storage-size").to_i) : 0,
+                          value: flash.dig("old", "storage_size") ? size.storage_size_options.index(flash.dig("old", "storage_size").to_i) : 0,
                           attributes: {
                             min: 0,
                             max: size.storage_size_options.size - 1,
@@ -129,7 +129,7 @@
                           extra_class: "instance-size-based-option storage-slider",
                         }
                       ) %>
-                      <input type="hidden" name="storage-size" id="storage-size" value="<%= flash.dig("old", "storage-size") || size.storage_size_options[0] %>">
+                      <input type="hidden" name="storage_size" id="storage_size" value="<%= flash.dig("old", "storage_size") || size.storage_size_options[0] %>">
                     </div>
                   </fieldset>
                 </div>

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -118,10 +118,9 @@
                       <%== render(
                         "components/form/range_slider",
                         locals: {
-                          name: "pseudo-storage-size",
                           label: "Storage Size",
                           range_labels: size.storage_size_options.map { "#{_1}GB" },
-                          value: flash.dig("old", "storage_size") || 0,
+                          value: flash.dig("old", "storage-size") ? size.storage_size_options.index(flash.dig("old", "storage-size").to_i) : 0,
                           attributes: {
                             min: 0,
                             max: size.storage_size_options.size - 1,
@@ -130,7 +129,7 @@
                           extra_class: "instance-size-based-option storage-slider",
                         }
                       ) %>
-                      <input type="hidden" name="storage-size" id="storage-size" value="<%= size.storage_size_options[flash.dig("old", "pseudo-storage-size").to_i || 0] %>">
+                      <input type="hidden" name="storage-size" id="storage-size" value="<%= flash.dig("old", "storage-size") || size.storage_size_options[0] %>">
                     </div>
                   </fieldset>
                 </div>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -100,11 +100,12 @@
                   "components/form/text",
                   locals: {
                     label: "New password",
-                    name: "original_password",
+                    name: "password",
                     type: "password",
                     attributes: {
                       required: true
-                    }
+                    },
+                    extra_class: "reset-superuser-password-new-password"
                   }
                 ) %>
               </div>
@@ -117,7 +118,8 @@
                     type: "password",
                     attributes: {
                       required: true
-                    }
+                    },
+                    extra_class: "reset-superuser-password-new-password-repeat"
                   }
                 ) %>
               </div>
@@ -267,7 +269,8 @@
                       attributes: {
                         required: true,
                         autocomplete: "new-password"
-                      }
+                      },
+                      extra_class: "metric-destination-password"
                     }
                   ) %>
                 </td>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -145,10 +145,9 @@
                       <%== render(
                         "components/form/range_slider",
                         locals: {
-                          name: "pseudo-storage-size",
                           label: "Storage Size",
                           range_labels: size.storage_size_options.map { "#{_1}GB" },
-                          value: flash.dig("old", "pseudo-storage-size") || 0,
+                          value: flash.dig("old", "storage-size") ? size.storage_size_options.index(flash.dig("old", "storage-size").to_i) : 0,
                           attributes: {
                             min: 0,
                             max: size.storage_size_options.size - 1,
@@ -157,7 +156,7 @@
                           extra_class: "instance-size-based-option storage-slider",
                         }
                       ) %>
-                      <input type="hidden" name="storage-size" id="storage-size" value="<%= size.storage_size_options[flash.dig("old", "pseudo-storage-size").to_i || 0] %>">
+                      <input type="hidden" name="storage-size" id="storage-size" value="<%= flash.dig("old", "storage-size") || size.storage_size_options[0] %>">
                     </div>
                   </fieldset>
                 </div>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -147,7 +147,7 @@
                         locals: {
                           label: "Storage Size",
                           range_labels: size.storage_size_options.map { "#{_1}GB" },
-                          value: flash.dig("old", "storage-size") ? size.storage_size_options.index(flash.dig("old", "storage-size").to_i) : 0,
+                          value: flash.dig("old", "storage_size") ? size.storage_size_options.index(flash.dig("old", "storage_size").to_i) : 0,
                           attributes: {
                             min: 0,
                             max: size.storage_size_options.size - 1,
@@ -156,7 +156,7 @@
                           extra_class: "instance-size-based-option storage-slider",
                         }
                       ) %>
-                      <input type="hidden" name="storage-size" id="storage-size" value="<%= flash.dig("old", "storage-size") || size.storage_size_options[0] %>">
+                      <input type="hidden" name="storage_size" id="storage_size" value="<%= flash.dig("old", "storage_size") || size.storage_size_options[0] %>">
                     </div>
                   </fieldset>
                 </div>


### PR DESCRIPTION
We implement the almost same business logic in both web and api endpoints. It doubles the work when we need to change or add something. There is also risk of divergence over time. In fact, while preparing this, I noticed few unintentional differences between two endpoints. With this changeset, my goal is having central place for postgres' endpoints business logic, so that both routes can use the same logic, effectively eliminating the divergence possibility as much as possible.

In the ideal world, both routes would do the exact same thing except producing different final output, that is web endpoints would render a HTML page and api endpoints would return a serialized object. I even think that we can power two different applications from same class and routes with some metaprogramming. However, that would require significant refactoring and I don't intend to go that far in convergence work at the moment. Instead, this is a small step towards making endpoint business logic reusable across two apps.