### PR TITLE
Add retry logic for processes in E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,6 +67,10 @@ jobs:
     - name: Install foreman
       run: gem install foreman
 
+    - name: Modify Procfile to add retry logic
+      run: |
+        sed -i "s/^\([^:]*\): \(.*\)/\1: bash -c 'for i in {1..4}; do \2 \&\& break || echo \"Attempt \$i failed, retrying...\"; sleep 1; done'/" Procfile
+
     - name: Add e2e script to Procfile
       run: |
         echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm' || inputs.test_cases }}" >> Procfile


### PR DESCRIPTION
We realized that in some cases, respirate exits due to a crash or apoptosis, which causes foreman to exit and E2E tests to fail. Foreman is programmed to exit when one of its child processes exits. It doesn't have any retry logic. Recommended way of adding retry logic is combining it with a monitoring tool such as systemd or upstart. However, we don't need such a complex system for our E2E tests. Instead I opted to add retry logic with simple `until` loop.

I didn't add the retry logic for `bin/ci` process we are adding in next step of the workflow file, because tests themselves might not be written in a way that allows them to be executed second time.