### PR TITLE
Add support to upgrade Cloud Hypervisor

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -200,6 +200,19 @@ class VmHost < Sequel::Model
     Strand.create_with_id(schedule: Time.now, prog: "DownloadFirmware", label: "start", stack: [{subject_id: id, version: version, sha256: sha256}])
   end
 
+  # Introduced for downloading cloud hypervisor via REPL.
+  def download_cloud_hypervisor(version_x64: nil, version_arm64: nil, sha256_ch_bin_x64: nil, sha256_ch_bin_arm64: nil, sha256_ch_remote_x64: nil, sha256_ch_remote_arm64: nil)
+    version, sha256_ch_bin, sha256_ch_remote = if arch == "x64"
+      [version_x64, sha256_ch_bin_x64, sha256_ch_remote_x64]
+    elsif arch == "arm64"
+      [version_arm64, sha256_ch_bin_arm64, sha256_ch_remote_arm64]
+    else
+      fail "BUG: unexpected architecture"
+    end
+    fail ArgumentError, "No version provided" if version.nil?
+    Strand.create_with_id(schedule: Time.now, prog: "DownloadCloudHypervisor", label: "start", stack: [{subject_id: id, version: version, sha256_ch_bin: sha256_ch_bin, sha256_ch_remote: sha256_ch_remote}])
+  end
+
   def hetznerify(server_id)
     DB.transaction do
       HetznerHost.create(server_identifier: server_id) { _1.id = id }

--- a/prog/download_cloud_hypervisor.rb
+++ b/prog/download_cloud_hypervisor.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Prog::DownloadCloudHypervisor < Prog::Base
+  subject_is :sshable, :vm_host
+
+  def version
+    @version ||= frame.fetch("version")
+  end
+
+  def sha256_ch_bin
+    @sha256_ch_bin ||= frame.fetch("sha256_ch_bin") || sha_256("ch-bin")
+  end
+
+  def sha256_ch_remote
+    @sha256_ch_remote ||= frame.fetch("sha256_ch_remote") || sha_256("ch-remote")
+  end
+
+  label def start
+    fail "Version is required" if version.nil?
+    fail "SHA-256 digest of cloud-hypervisor is required" if sha256_ch_bin.nil?
+    fail "SHA-256 digest of ch-remote is required" if sha256_ch_remote.nil?
+    hop_download
+  end
+
+  label def download
+    q_daemon_name = "download_ch_#{version}".shellescape
+    case sshable.cmd("common/bin/daemonizer --check #{q_daemon_name}")
+    when "Succeeded"
+      sshable.cmd("common/bin/daemonizer --clean #{q_daemon_name}")
+      pop({"msg" => "cloud hypervisor downloaded", "version" => version,
+        "sha256_ch_bin" => sha256_ch_bin, "sha256_ch_remote" => sha256_ch_remote})
+    when "NotStarted"
+      sshable.cmd("common/bin/daemonizer 'host/bin/download-cloud-hypervisor #{version} #{sha256_ch_bin} #{sha256_ch_remote}' #{q_daemon_name}")
+    when "Failed"
+      fail "Failed to download cloud hypervisor version #{version} on #{vm_host}"
+    end
+
+    nap 15
+  end
+
+  def sha_256(bin)
+    hashes = {
+      ["ch-bin", "x64", "35.1"] => "e8426b0733248ed559bea64eb04d732ce8a471edc94807b5e2ecfdfc57136ab4",
+      ["ch-remote", "x64", "35.1"] => "337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0",
+      ["ch-bin", "arm64", "35.1"] => "071a0b4918565ce81671ecd36d65b87351c85ea9ca0fbf73d4a67ec810efe606",
+      ["ch-remote", "arm64", "35.1"] => "355cdb1e2af7653a15912c66f7c76c922ca788fd33d77f6f75846ff41278e249"
+    }
+
+    hashes[[bin, vm_host.arch, version]]
+  end
+end

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -74,3 +74,7 @@ def safe_write_to_file(filename, content = nil)
     File.rename(temp_filename, filename)
   end
 end
+
+def curl_file(url, path)
+  r("bash -c 'curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{path.shellescape}'").split(" ").last
+end

--- a/rhizome/host/bin/download-cloud-hypervisor
+++ b/rhizome/host/bin/download-cloud-hypervisor
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "../lib/cloud_hypervisor"
+
+unless (version = ARGV.shift)
+  puts "expected version as argument"
+  exit 1
+end
+
+unless (sha256_ch_bin = ARGV.shift)
+  puts "expected SHA-256 digest of cloud-hypervisor as argument"
+  exit 1
+end
+
+unless (sha256_ch_remote = ARGV.shift)
+  puts "expected SHA-256 digest of ch-remote as argument"
+  exit 1
+end
+
+CloudHypervisor::VersionClass.new(version, sha256_ch_bin, sha256_ch_remote).download

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -53,12 +53,12 @@ r "chmod +x /etc/update-motd.d/99-clover-motd"
 r "timedatectl set-timezone UTC"
 
 # Download cloud hypervisor binaries.
-ch_dir = CloudHypervisor::VERSION.dir
+ch_dir = CloudHypervisor::VERSION_LEGACY.dir
 FileUtils.mkdir_p(ch_dir)
 FileUtils.cd ch_dir do
-  r "curl -L3 -o ch-remote #{CloudHypervisor::VERSION.ch_remote_url.shellescape}"
+  r "curl -L3 -o ch-remote #{CloudHypervisor::VERSION_LEGACY.ch_remote_url.shellescape}"
   FileUtils.chmod "a+x", "ch-remote"
-  r "curl -L3 -o cloud-hypervisor #{CloudHypervisor::VERSION.url.shellescape}"
+  r "curl -L3 -o cloud-hypervisor #{CloudHypervisor::VERSION_LEGACY.url.shellescape}"
   FileUtils.chmod "a+x", "cloud-hypervisor"
 end
 

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -61,6 +61,7 @@ FileUtils.cd ch_dir do
   r "curl -L3 -o cloud-hypervisor #{CloudHypervisor::VERSION_LEGACY.url.shellescape}"
   FileUtils.chmod "a+x", "cloud-hypervisor"
 end
+CloudHypervisor::VERSION.download
 
 # Download firmware binaries.
 fw_dir = File.dirname(CloudHypervisor::FIRMWARE.path)

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -50,7 +50,7 @@ module CloudHypervisor
   NEW_FIRMWARE = FirmwareClass.new(Arch.render(x64: "202311", arm64: "202211"),
     Arch.render(x64: "e31738aacd3d68d30f8f9a4d09711cca3dfb414e8910dc3af90c50f36885380a", arm64: "482f428f782591d7c2222e0bc8240d25fb200fb21fd984b3339c85979d94b4d8"))
 
-  VersionClass = Struct.new(:version) {
+  VersionClassLegacy = Struct.new(:version) {
     def ch_remote_url
       "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/ch-remote" + Arch.render(x64: "", arm64: "-static-aarch64")
     end
@@ -72,11 +72,55 @@ module CloudHypervisor
     end
   }
 
-  VERSION = if Arch.arm64?
-    VersionClass.new("35.0")
+  VERSION_LEGACY = if Arch.arm64?
+    VersionClassLegacy.new("35.0")
   elsif Arch.x64?
-    VersionClass.new("31.0")
+    VersionClassLegacy.new("31.0")
   else
     fail "BUG: unexpected architecture"
+  end
+
+  VersionClass = Struct.new(:version, :sha256_ch_bin, :sha256_ch_remote) {
+    def ch_remote_url
+      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/ch-remote" + Arch.render(x64: "-static", arm64: "-static-aarch64")
+    end
+
+    def cloud_hypervisor_url
+      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/cloud-hypervisor" + Arch.render(x64: "-static", arm64: "-static-aarch64")
+    end
+
+    def dir
+      "/opt/cloud-hypervisor/v#{version}"
+    end
+
+    def ch_remote_bin
+      File.join(dir, "ch-remote")
+    end
+
+    def bin
+      File.join(dir, "cloud-hypervisor")
+    end
+
+    def download
+      download_file(ch_remote_url, ch_remote_bin, sha256_ch_remote)
+      download_file(cloud_hypervisor_url, bin, sha256_ch_bin)
+    end
+
+    def download_file(url, path, sha256)
+      return if File.exist?(path)
+      FileUtils.mkdir_p(dir)
+      sha256_curl = nil
+      safe_write_to_file(path) do |f|
+        sha256_curl = curl_file(url, f.path)
+        fail "Invalid SHA-256 digest" unless sha256 == sha256_curl
+      end
+      FileUtils.chmod "a+x", path
+    end
+  }
+
+  VERSION = if Arch.arm64?
+    VersionClass.new("35.1", "071a0b4918565ce81671ecd36d65b87351c85ea9ca0fbf73d4a67ec810efe606", "355cdb1e2af7653a15912c66f7c76c922ca788fd33d77f6f75846ff41278e249")
+  elsif Arch.x64?
+    VersionClass.new("35.1", "e8426b0733248ed559bea64eb04d732ce8a471edc94807b5e2ecfdfc57136ab4", "337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0")
   end
 end

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -40,14 +40,10 @@ module CloudHypervisor
       FileUtils.mkdir_p(firmware_root)
       sha256_curl = nil
       safe_write_to_file(path) do |f|
-        sha256_curl = curl_firmware(f)
+        sha256_curl = curl_file(url, f.path)
         fail "Invalid SHA-256 digest" unless sha256 == sha256_curl
       end
       sha256_curl
-    end
-
-    def curl_firmware(file)
-      r("bash -c 'curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{file.path.shellescape}'").split(" ").last
     end
   }
 

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -556,7 +556,7 @@ Requires=#{@vm_name}-dnsmasq.service
 NetworkNamespacePath=/var/run/netns/#{@vm_name}
 ExecStartPre=/usr/bin/rm -f #{vp.ch_api_sock}
 
-ExecStart=#{CloudHypervisor::VERSION.bin} -v \
+ExecStart=#{CloudHypervisor::VERSION_LEGACY.bin} -v \
 --api-socket path=#{vp.ch_api_sock} \
 --kernel #{CloudHypervisor::NEW_FIRMWARE.path} \
 #{disk_params.join("\n")}
@@ -567,7 +567,7 @@ ExecStart=#{CloudHypervisor::VERSION.bin} -v \
 #{pci_device_params} \
 #{net_params.join(" \\\n")}
 
-ExecStop=#{CloudHypervisor::VERSION.ch_remote_bin} --api-socket #{vp.ch_api_sock} shutdown-vmm
+ExecStop=#{CloudHypervisor::VERSION_LEGACY.ch_remote_bin} --api-socket #{vp.ch_api_sock} shutdown-vmm
 Restart=no
 User=#{@vm_name}
 Group=#{@vm_name}

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -117,6 +117,35 @@ RSpec.describe VmHost do
     expect { vh.download_firmware(version_arm64: "202406") }.to raise_error(ArgumentError, "No SHA-256 digest provided")
   end
 
+  it "has a shortcut to download a new version of cloud hypervisor for x64" do
+    vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
+    vh.arch = "x64"
+    expect(Strand).to receive(:create) do |args|
+      expect(args[:prog]).to eq("DownloadCloudHypervisor")
+      expect(args[:stack]).to eq([subject_id: vh.id, version: "35.1", sha256_ch_bin: "sha-1", sha256_ch_remote: "sha-2"])
+    end
+    vh.download_cloud_hypervisor(version_x64: "35.1", sha256_ch_bin_x64: "sha-1", sha256_ch_remote_x64: "sha-2")
+  end
+
+  it "has a shortcut to download a new version of cloud hypervisor for arm64" do
+    vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
+    vh.arch = "arm64"
+    expect(Strand).to receive(:create) do |args|
+      expect(args[:prog]).to eq("DownloadCloudHypervisor")
+      expect(args[:stack]).to eq([subject_id: vh.id, version: "35.1", sha256_ch_bin: "sha-3", sha256_ch_remote: "sha-4"])
+    end
+    vh.download_cloud_hypervisor(version_arm64: "35.1", sha256_ch_bin_arm64: "sha-3", sha256_ch_remote_arm64: "sha-4")
+  end
+
+  it "requires version to download a new version of cloud hypervisor" do
+    vh.arch = "x64"
+    expect { vh.download_cloud_hypervisor(sha256_ch_bin_x64: "ch_sha", sha256_ch_remote_x64: "remote_sha") }.to raise_error(ArgumentError, "No version provided")
+    vh.arch = "arm64"
+    expect { vh.download_cloud_hypervisor(sha256_ch_bin_arm64: "ch_sha", sha256_ch_remote_arm64: "remote_sha") }.to raise_error(ArgumentError, "No version provided")
+    vh.arch = "unexpectedarch"
+    expect { vh.download_cloud_hypervisor(version_x64: "35.1", version_arm64: "35.1") }.to raise_error("BUG: unexpected architecture")
+  end
+
   it "assigned_subnets returns the assigned subnets" do
     expect(vh).to receive(:assigned_subnets).and_return([address])
     expect(vh).to receive(:vm_addresses).and_return([])

--- a/spec/prog/download_cloud_hypervisor_spec.rb
+++ b/spec/prog/download_cloud_hypervisor_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::DownloadCloudHypervisor do
+  subject(:df) { described_class.new(Strand.new(stack: [{"version" => "35.1", "sha256_ch_bin" => "thesha", "sha256_ch_remote" => "anothersha"}])) }
+
+  let(:sshable) { Sshable.create_with_id }
+  let(:vm_host) { VmHost.create(location: "hetzner-hel1", arch: "x64") { _1.id = sshable.id } }
+
+  before do
+    allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)
+  end
+
+  describe "#start" do
+    it "hops to download" do
+      expect { df.start }.to hop("download")
+    end
+
+    it "fails if version is nil" do
+      df = described_class.new(Strand.new(stack: [{"version" => nil, "sha256_ch_bin" => "thesha", "sha256_ch_remote" => "anothersha"}]))
+      expect { df.start }.to raise_error RuntimeError, "Version is required"
+    end
+
+    it "fails if sha256 for cloud-hypervisor is nil" do
+      df = described_class.new(Strand.new(stack: [{"version" => "35.0", "sha256_ch_bin" => nil, "sha256_ch_remote" => "anothersha"}]))
+      allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)
+      expect { df.start }.to raise_error RuntimeError, "SHA-256 digest of cloud-hypervisor is required"
+    end
+
+    it "fails if sha256 for ch-remote is nil" do
+      df = described_class.new(Strand.new(stack: [{"version" => "35.0", "sha256_ch_bin" => "thesha", "sha256_ch_remote" => nil}]))
+      allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)
+      expect { df.start }.to raise_error RuntimeError, "SHA-256 digest of ch-remote is required"
+    end
+  end
+
+  describe "#download" do
+    it "starts to download assets if not started" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("NotStarted")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-cloud-hypervisor 35.1 thesha anothersha' download_ch_35.1")
+      expect { df.download }.to nap(15)
+    end
+
+    it "uses known sha256s" do
+      df = described_class.new(Strand.new(stack: [{"version" => "35.1", "sha256_ch_bin" => nil, "sha256_ch_remote" => nil}]))
+      allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("NotStarted")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'host/bin/download-cloud-hypervisor 35.1 e8426b0733248ed559bea64eb04d732ce8a471edc94807b5e2ecfdfc57136ab4 337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0' download_ch_35.1")
+      expect { df.download }.to nap(15)
+    end
+
+    it "waits for manual intervention if failed" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("Failed")
+      expect { df.download }.to raise_error RuntimeError, "Failed to download cloud hypervisor version 35.1 on VmHost[#{vm_host.ubid}]"
+    end
+
+    it "waits for the download to complete" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("InProgess")
+      expect { df.download }.to nap(15)
+    end
+
+    it "exits if succeeded" do
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("Succeeded")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --clean download_ch_35.1")
+      expect { df.download }.to exit({"msg" => "cloud hypervisor downloaded", "version" => "35.1", "sha256_ch_bin" => "thesha", "sha256_ch_remote" => "anothersha"})
+    end
+  end
+end


### PR DESCRIPTION
**Introduce utility function to download a file**
`curl_file` downloads a file from a `url` and writes it to a `path` on
the local file system. It returns the SHA-256 digest of the downloaded
file.

**Leverage utility function to download firmware**
Use a utility function from rhizome lib to download firmware instead of
a custom `curl_firmware` method.

**Introduce new CloudHypervisor version class**
The new implementation supports downloading cloud hypervisor assets from
https://github.com/cloud-hypervisor/cloud-hypervisor. It downloads
`cloud-hypervisor-static` and `ch-remote-static` for x64 and
`cloud-hypervisor-static-aarch64` and `ch-remote-static-aarch64` for
arm64. It verifies the SHA-256 digest of these files during download.
The destination and naming pattern of the downloaded files does not
change, i.e. they are stored as:
`/opt/cloud-hypervisor/v#{version}/cloud-hypervisor`
`/opt/cloud-hypervisor/v#{version}/ch-remote`

**Download new Cloud Hypervisor version during host prep**
Start downloading new cloud hypervisor versions in addition to
legacy versions during host preparation. When legacy cloud
hypervisor has become obsolete, we will stop downloading it.

**Standalone executable to download Cloud Hypervisor**
`download-cloud-hypervisor` can be run independent of preparing
a host to download cloud hypervisor.

**Add Prog to download Cloud Hypervisor on-demand**
Introduce a `DownloadCloudHypervisor` prog that facilitates
downloading new versions of cloud hypervisor from the control
plane. This functionality depends on the
`host/bin/download-cloud-hypervisor` script. A new method,
`download_cloud_hypervisor`, has been added to `VmHost`,
enabling the download of new firmware versions to hosts via REPL.

Usage examples:

To download a new version 35.1 to a single host:
```ruby
vmh.download_cloud_hypervisor(
  version_x64: "35.1",
  sha256_ch_bin_x64: "e842...",
  sha256_ch_remote_x64: "337b..."
)
```

To download a new version to all hosts:
```ruby
VmHost.all.map { _1.download_cloud_hypervisor(
  version_x64: "35.1",
  sha256_ch_bin_x64: "e842...",
  sha256_ch_remote_x64: "337b...",
  version_arm64: "38.0",
  sha256_ch_bin_arm64: "c1c0...",
  sha256_ch_remote_arm64: "008f..."
)}
```

For knows versions (see `Prog::DownloadCloudHypervisor.sha_256`), the sha256 digest can be omitted:

```ruby
vmh.download_cloud_hypervisor(version_x64: "35.1")

VmHost.all.map { _1.download_cloud_hypervisor(version_x64: "35.1", version_arm64: "35.1") }
```