### PR TITLE
Download boot images from blob storage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Run services
       env:
-        RACK_ENV: development
+        RACK_ENV: e2e_test
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
         CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
         CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=

--- a/config.rb
+++ b/config.rb
@@ -34,6 +34,10 @@ module Config
     Config.rack_env == "test"
   end
 
+  def self.e2e_test?
+    Config.rack_env == "e2e_test"
+  end
+
   # Mandatory -- exception is raised for these variables when missing.
   mandatory :clover_database_url, string, clear: true
   mandatory :rack_env, string


### PR DESCRIPTION
**Download boot images from blob storage for E2E tests**
There are several benefits of downloading boot images from blob storage:

- It is faster as most of the data transfer would be done in same region or in
the network of same provider.
- It is more reliable because there is no risk of source to be deleted or moved
without our knowledge.

The motivation trigger for this change was to reduce the time taken to download
the boot images, because our E2E tests are timing out due to slow download, but
the change is useful even out of E2E tests. So currently, I enabled this only
for E2E tests, but we can enable this for production as well in the future. We
would probably keep existing way for development because it doesn't require
setting up blob storage, thus it keeps the development setup simple.