### PR TITLE
Add musl platform to use ffi gem in the alpine image

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,9 +90,11 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -313,10 +315,12 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  aarch64-linux-musl
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-20
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   argon2


### PR DESCRIPTION
Dependabot recently updated our ffi gem from 1.16.3 to 1.17 in #1663, which resulted in our Docker image build failing with the following error:

```
    #21 [bundler 6/6] RUN bundle install
    #21 0.278 Bundler 2.4.19 is running, but your lockfile was generated with 2.5.10. Installing Bundler 2.5.10 and restarting using that version.
    #21 1.288 Fetching gem metadata from [https://rubygems.org/.](https://rubygems.org/)
    #21 1.325 Fetching bundler 2.5.10
    #21 1.488 Installing bundler 2.5.10
    #21 2.894 Fetching gem metadata from https://rubygems.org/.........
    #21 6.498 Fetching https://github.com/***/erb-formatter.git
    #21 8.495 Resolving dependencies...
    #21 8.957 Resolving dependencies...
    #21 9.313 Could not find gems matching 'ffi (= 1.17.0)' valid for all resolution platforms
    #21 9.313 (aarch64-linux, arm64-darwin-22, arm64-darwin-23, x86_64-darwin-20,
    #21 9.313 x86_64-linux) in rubygems repository https://rubygems.org/, cached gems or
    #21 9.313 installed locally.
    #21 9.313
    #21 9.313 The source contains the following gems matching 'ffi (= 1.17.0)':
    #21 9.313   * ffi-1.17.0-aarch64-linux-gnu
    #21 9.313   * ffi-1.17.0-aarch64-linux-musl
    #21 9.313   * ffi-1.17.0-arm-linux-gnu
    #21 9.313   * ffi-1.17.0-arm-linux-musl
    #21 9.313   * ffi-1.17.0-arm64-darwin
    #21 9.313   * ffi-1.17.0-java
    #21 9.313 * ffi-1.17.0
    #21 9.313 * ffi-1.17.0-x64-mingw-ucrt
    #21 9.313 * ffi-1.17.0-x64-mingw32
    #21 9.313 * ffi-1.17.0-x86-linux-gnu
    #21 9.313 * ffi-1.17.0-x86-linux-musl
    #21 9.313 * ffi-1.17.0-x86-mingw32
    #21 9.313 * ffi-1.17.0-x86_64-darwin
    #21 9.313 * ffi-1.17.0-x86_64-linux-gnu
    #21 9.313 * ffi-1.17.0-x86_64-linux-musl
    #21 ERROR: process "/bin/sh -c bundle install" did not complete successfully: exit code: 7
```

The ffi gem has started releasing different versions for various platforms, like nokogiri. For nokogiri, we support `aarch64-linux` and `x86_64-linux` platforms, as reflected in our Gemfile.lock file. However, the ffi gem releases distinct versions for GNU and musl platforms. As alpine is based on musl, we need to include the musl platform in our Gemfile.lock file to ensure compatibility with alpine.

More information: https://github.com/ffi/ffi/issues/1105