### PR TITLE
Introduce GitHub Actions Cache endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ group :test do
 end
 
 gem "webauthn", "~> 3.1"
+
+gem "aws-sdk-s3", "~> 1.151"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,22 @@ GEM
     argon2-kdf (0.2.0)
     ast (2.4.2)
     awrence (1.2.1)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.947.0)
+    aws-sdk-core (3.198.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.86.0)
+      aws-sdk-core (~> 3, >= 3.198.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.153.0)
+      aws-sdk-core (~> 3, >= 3.198.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
@@ -102,6 +118,7 @@ GEM
     hashdiff (1.1.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
     json (2.7.2)
     jwt (2.8.2)
       base64
@@ -317,6 +334,7 @@ PLATFORMS
 DEPENDENCIES
   argon2
   argon2-kdf
+  aws-sdk-s3 (~> 1.151)
   bcrypt_pbkdf
   brakeman
   capybara

--- a/clover_runtime.rb
+++ b/clover_runtime.rb
@@ -17,7 +17,7 @@ class CloverRuntime < Roda
   plugin :error_handler do |e|
     error = parse_error(e)
 
-    {error: error}.to_json
+    {error: error}.to_json unless error[:code] == 204
   end
 
   def get_jwt_payload(request)

--- a/config.rb
+++ b/config.rb
@@ -102,6 +102,10 @@ module Config
   optional :github_runner_service_project_id, string
   override :enable_github_workflow_poller, true, bool
 
+  # GitHub Cache
+  optional :github_cache_blob_storage_endpoint, string
+  optional :github_cache_blob_storage_region, string
+
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string
   optional :minio_service_project_id, string

--- a/config.rb
+++ b/config.rb
@@ -105,6 +105,10 @@ module Config
   # GitHub Cache
   optional :github_cache_blob_storage_endpoint, string
   optional :github_cache_blob_storage_region, string
+  optional :github_cache_blob_storage_access_key, string, clear: true
+  optional :github_cache_blob_storage_secret_key, string, clear: true
+  optional :github_cache_blob_storage_account_id, string
+  optional :github_cache_blob_storage_api_key, string, clear: true
 
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string

--- a/lib/cloudflare_client.rb
+++ b/lib/cloudflare_client.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "excon"
+require "json"
+
+class CloudflareClient
+  def initialize(api_key)
+    @connection = Excon.new("https://api.cloudflare.com", headers: {"Authorization" => "Bearer #{api_key}"})
+  end
+
+  def create_token(name, policies)
+    response = @connection.post(path: "/client/v4/user/tokens", body: {name: name, policies: policies}.to_json, expects: 200)
+    data = JSON.parse(response.body)
+    [data["result"]["id"], data["result"]["value"]]
+  end
+
+  def delete_token(token_id)
+    @connection.delete(path: "/client/v4/user/tokens/#{token_id}", expects: [200, 404]).status
+  end
+end

--- a/migrate/20240529_github_cache.rb
+++ b/migrate/20240529_github_cache.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:github_cache_entry) do
+      column :id, :uuid, primary_key: true
+      foreign_key :repository_id, :github_repository, type: :uuid, null: false
+      column :key, :text, collate: '"C"', null: false
+      column :version, :text, collate: '"C"', null: false
+      column :scope, :text, collate: '"C"', null: false
+      column :size, :bigint
+      column :upload_id, :text, collate: '"C"', unique: true
+      column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+      column :created_by, :uuid, null: false
+      column :last_accessed_at, :timestamptz
+      column :last_accessed_by, :uuid
+      column :committed_at, :timestamptz
+      unique [:repository_id, :scope, :key, :version]
+    end
+
+    alter_table(:github_repository) do
+      add_column :access_key, :text, collate: '"C"'
+      add_column :secret_key, :text, collate: '"C"'
+    end
+  end
+end

--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../../model"
+
+class GithubCacheEntry < Sequel::Model
+  many_to_one :repository, key: :repository_id, class: :GithubRepository
+
+  include ResourceMethods
+
+  def self.ubid_type
+    UBID::TYPE_ETC
+  end
+
+  def blob_key
+    "cache/#{ubid}"
+  end
+end

--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -35,4 +35,39 @@ class GithubRepository < Sequel::Model
   def url_presigner
     @url_presigner ||= Aws::S3::Presigner.new(client: blob_storage_client)
   end
+
+  def admin_client
+    @admin_client ||= Aws::S3::Client.new(
+      endpoint: Config.github_cache_blob_storage_endpoint,
+      access_key_id: Config.github_cache_blob_storage_access_key,
+      secret_access_key: Config.github_cache_blob_storage_secret_key,
+      region: Config.github_cache_blob_storage_region
+    )
+  end
+
+  def destroy_blob_storage
+    admin_client.delete_bucket(bucket: bucket_name)
+    CloudflareClient.new(Config.github_cache_blob_storage_api_key).delete_token(access_key)
+    update(access_key: nil, secret_key: nil)
+  end
+
+  def setup_blob_storage
+    DB.transaction do
+      admin_client.create_bucket({
+        bucket: bucket_name,
+        create_bucket_configuration: {location_constraint: Config.github_cache_blob_storage_region}
+      })
+
+      policies = [
+        {
+          "effect" => "allow",
+          "permission_groups" => [{"id" => "2efd5506f9c8494dacb1fa10a3e7d5b6", "name" => "Workers R2 Storage Bucket Item Write"}],
+          "resources" => {"com.cloudflare.edge.r2.bucket.#{Config.github_cache_blob_storage_account_id}_default_#{bucket_name}" => "*"}
+        }
+      ]
+
+      token_id, token = CloudflareClient.new(Config.github_cache_blob_storage_api_key).create_token("#{bucket_name}-token", policies)
+      update(access_key: token_id, secret_key: Digest::SHA256.hexdigest(token))
+    end
+  end
 end

--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -1,14 +1,38 @@
 # frozen_string_literal: true
 
+require "aws-sdk-s3"
+
 require_relative "../../model"
 
 class GithubRepository < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :installation, key: :installation_id, class: :GithubInstallation
   one_to_many :runners, key: :repository_id, class: :GithubRunner
+  one_to_many :cache_entries, key: :repository_id, class: :GithubCacheEntry
 
   include ResourceMethods
   include SemaphoreMethods
 
   semaphore :destroy
+
+  plugin :column_encryption do |enc|
+    enc.column :secret_key
+  end
+
+  def bucket_name
+    ubid
+  end
+
+  def blob_storage_client
+    @blob_storage_client ||= Aws::S3::Client.new(
+      endpoint: Config.github_cache_blob_storage_endpoint,
+      access_key_id: access_key,
+      secret_access_key: secret_key,
+      region: Config.github_cache_blob_storage_region
+    )
+  end
+
+  def url_presigner
+    @url_presigner ||= Aws::S3::Presigner.new(client: blob_storage_client)
+  end
 end

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -6,6 +6,7 @@ require_relative "../model"
 class GithubRunner < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :installation, key: :installation_id, class: :GithubInstallation
+  many_to_one :repository, key: :repository_id, class: :GithubRepository
   one_to_one :vm, key: :id, primary_key: :vm_id
 
   include ResourceMethods

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -115,6 +115,8 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
       nap 5 * 60
     end
 
+    github_repository.destroy_blob_storage if github_repository.access_key
+
     github_repository.destroy
 
     pop "github repository destroyed"

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -202,6 +202,12 @@ class Prog::Vm::GithubRunner < Prog::Base
       # I enrich it with details about the Ubicloud environment and placed it in the runner's home directory.
       # GitHub-hosted runners also use this file as setup_info to show on the GitHub UI.
       jq '. += [#{setup_info.to_json}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+
+
+      # We use a JWT token to authenticate the virtual machines with our runtime API. This token is valid as long as the vm is running.
+      # ubicloud/cache package which forked from the official actions/cache package, sends requests to UBICLOUD_CACHE_URL using this token.
+      echo "UBICLOUD_RUNTIME_TOKEN=#{vm.runtime_token}
+      UBICLOUD_CACHE_URL=#{Config.base_url}/runtime/github/" | sudo tee /etc/environment
     COMMAND
 
     # Remove comments and empty lines before sending them to the machine

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -7,5 +7,41 @@ class CloverRuntime
     end
 
     repository.setup_blob_storage unless repository.access_key
+
+    r.on "caches" do
+      # reserveCache
+      r.post true do
+        key = r.params["key"]
+        version = r.params["version"]
+        size = r.params["cacheSize"].to_i
+        fail CloverError.new(400, "InvalidRequest", "Wrong parameters") if key.nil? || version.nil? || size == 0
+
+        unless (scope = runner.workflow_job&.dig("head_branch"))
+          # YYYY: If the webhook not delivered yet, we can try to get the branch from the API
+          Clog.emit("The runner does not have a workflow job") { {no_workflow_job: {ubid: runner.ubid, repository_ubid: repository.ubid}} }
+          fail CloverError.new(400, "InvalidRequest", "No workflow job data available")
+        end
+
+        if size > 10 * 1024 * 1024 * 1024
+          fail CloverError.new(400, "InvalidRequest", "The cache size is over the 10GB limit")
+        end
+
+        entry = GithubCacheEntry.create_with_id(repository_id: runner.repository.id, key: key, version: version, size: size, scope: scope, created_by: runner.id)
+
+        upload_id = repository.blob_storage_client.create_multipart_upload(bucket: repository.bucket_name, key: entry.blob_key).upload_id
+        entry.update(upload_id: upload_id)
+
+        max_chunk_size = 32 * 1024 * 1024 # 32MB
+        presigned_urls = (1..size.fdiv(max_chunk_size).ceil).map do
+          repository.url_presigner.presigned_url(:upload_part, bucket: repository.bucket_name, key: entry.blob_key, upload_id: upload_id, part_number: _1, expires_in: 900)
+        end
+
+        {
+          uploadId: upload_id,
+          presignedUrls: presigned_urls,
+          chunkSize: max_chunk_size
+        }
+      end
+    end
   end
 end

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CloverRuntime
+  hash_branch("github") do |r|
+    if (runner = GithubRunner[vm_id: @vm.id]).nil? || (repository = runner.repository).nil?
+      fail CloverError.new(400, "InvalidRequest", "invalid JWT format or claim in Authorization header")
+    end
+  end
+end

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -5,5 +5,7 @@ class CloverRuntime
     if (runner = GithubRunner[vm_id: @vm.id]).nil? || (repository = runner.repository).nil?
       fail CloverError.new(400, "InvalidRequest", "invalid JWT format or claim in Authorization header")
     end
+
+    repository.setup_blob_storage unless repository.access_key
   end
 end

--- a/spec/lib/cloudflare_client_spec.rb
+++ b/spec/lib/cloudflare_client_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe CloudflareClient do
+  let(:client) { described_class.new("api_key") }
+
+  it "create_token" do
+    Excon.stub({path: "/client/v4/user/tokens", method: :post}, {status: 200, body: {result: {id: "123", value: "secret"}}.to_json})
+    expect(client.create_token("test-token", [{id: "test-policy"}])).to eq(["123", "secret"])
+  end
+
+  it "delete_token" do
+    token_id = "123"
+    Excon.stub({path: "/client/v4/user/tokens/#{token_id}", method: :delete}, {status: 200})
+    expect(client.delete_token(token_id)).to eq(200)
+  end
+end

--- a/spec/model/github/github_repository_spec.rb
+++ b/spec/model/github/github_repository_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe GithubRepository do
+  subject(:github_repository) { described_class.new(access_key: "my-token-id").tap { _1.id = "8823102a-2d5c-8e16-ac04-c60f1b6b9984" } }
+
+  let(:blob_storage_client) { instance_double(Aws::S3::Client) }
+  let(:cloudflare_client) { instance_double(CloudflareClient) }
+
+  before do
+    allow(CloudflareClient).to receive(:new).and_return(cloudflare_client)
+    allow(Aws::S3::Client).to receive(:new).and_return(blob_storage_client)
+  end
+
+  it ".destroy_blob_storage" do
+    expect(blob_storage_client).to receive(:delete_bucket).with(bucket: "gph0hh0ahdbj6ng2cc3rvdecr8")
+    expect(cloudflare_client).to receive(:delete_token).with(github_repository.access_key)
+    expect(github_repository).to receive(:update).with(access_key: nil, secret_key: nil)
+    github_repository.destroy_blob_storage
+  end
+
+  it ".setup_blob_storage" do
+    expect(Config).to receive_messages(github_cache_blob_storage_region: "weur", github_cache_blob_storage_account_id: "123")
+    expect(blob_storage_client).to receive(:create_bucket).with({bucket: "gph0hh0ahdbj6ng2cc3rvdecr8", create_bucket_configuration: {location_constraint: "weur"}})
+    expected_policy = [
+      {
+        "effect" => "allow",
+        "permission_groups" => [{"id" => "2efd5506f9c8494dacb1fa10a3e7d5b6", "name" => "Workers R2 Storage Bucket Item Write"}],
+        "resources" => {"com.cloudflare.edge.r2.bucket.123_default_gph0hh0ahdbj6ng2cc3rvdecr8" => "*"}
+      }
+    ]
+    expect(cloudflare_client).to receive(:create_token).with("gph0hh0ahdbj6ng2cc3rvdecr8-token", expected_policy).and_return(["test-key", "test-secret"])
+    expect(github_repository).to receive(:update).with(access_key: "test-key", secret_key: Digest::SHA256.hexdigest("test-secret"))
+    github_repository.setup_blob_storage
+  end
+end

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -149,5 +149,14 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
 
       expect { nx.destroy }.to exit({"msg" => "github repository destroyed"})
     end
+
+    it "deletes blob storage if it has one" do
+      expect(nx).to receive(:decr_destroy)
+      expect(github_repository).to receive(:destroy)
+      expect(github_repository).to receive(:access_key).and_return("access-key")
+      expect(github_repository).to receive(:destroy_blob_storage)
+
+      expect { nx.destroy }.to exit({"msg" => "github repository destroyed"})
+    end
   end
 end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -370,12 +370,15 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#setup_environment" do
     it "hops to register_runner" do
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
+      expect(vm).to receive(:runtime_token).and_return("my_token")
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+        echo "UBICLOUD_RUNTIME_TOKEN=my_token
+        UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee /etc/environment
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -43,4 +43,67 @@ RSpec.describe Clover, "github" do
 
     expect(last_response.status).to eq(400)
   end
+
+  describe "cache endpoints" do
+    let(:repository) { GithubRepository.create_with_id(name: "test", default_branch: "main", access_key: "123") }
+    let(:runner) { GithubRunner.create_with_id(vm_id: create_vm.id, repository_name: "test", label: "ubicloud", repository_id: repository.id, workflow_job: {head_branch: "dev"}) }
+    let(:url_presigner) { instance_double(Aws::S3::Presigner, presigned_request: "aa") }
+    let(:blob_storage_client) { instance_double(Aws::S3::Client) }
+
+    before do
+      login_runtime(runner.vm)
+      allow(Aws::S3::Presigner).to receive(:new).and_return(url_presigner)
+      allow(Aws::S3::Client).to receive(:new).and_return(blob_storage_client)
+    end
+
+    describe "reserves cache" do
+      it "fails if one of the parameters are missing" do
+        [
+          ["k1", "v1", nil],
+          [nil, "v1", 10],
+          ["k1", nil, 10]
+        ].each do |key, version, size|
+          params = {key: key, version: version, cacheSize: size}.compact
+          post "/runtime/github/caches", params
+
+          expect(last_response.status).to eq(400)
+          expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Wrong parameters")
+        end
+      end
+
+      it "fails if the runner doesn't have a scope" do
+        runner.update(workflow_job: nil)
+        post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100}
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("No workflow job data available")
+      end
+
+      it "fails if cache is bigger than 10GB" do
+        post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 11 * 1024 * 1024 * 1024}
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("The cache size is over the 10GB limit")
+      end
+
+      it "returns presigned urls and upload id for the reserved cache" do
+        expect(blob_storage_client).to receive(:create_multipart_upload).and_return(instance_double(Aws::S3::Types::CreateMultipartUploadOutput, upload_id: "upload-id"))
+        expect(url_presigner).to receive(:presigned_url).with(:upload_part, hash_including(bucket: repository.bucket_name, upload_id: "upload-id")) do |_, params|
+          "url-#{params[:part_number]}"
+        end.exactly(3).times
+        post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 75 * 1024 * 1024}
+
+        expect(last_response.status).to eq(200)
+        response = JSON.parse(last_response.body)
+        expect(response["uploadId"]).to eq("upload-id")
+        expect(response["presignedUrls"]).to eq(["url-1", "url-2", "url-3"])
+
+        entry = repository.cache_entries.first
+        expect(entry.key).to eq("k1")
+        expect(entry.version).to eq("v1")
+        expect(entry.size).to eq(75 * 1024 * 1024)
+        expect(entry.upload_id).to eq("upload-id")
+      end
+    end
+  end
 end

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -24,11 +24,23 @@ RSpec.describe Clover, "github" do
     end
 
     it "vm has runner and repository" do
-      repository = GithubRepository.create_with_id(name: "test")
+      repository = GithubRepository.create_with_id(name: "test", access_key: "key")
       GithubRunner.create_with_id(vm_id: vm.id, repository_name: "test", label: "ubicloud", repository_id: repository.id)
       get "/runtime/github"
 
       expect(last_response.status).to eq(404)
     end
+  end
+
+  it "setups blob storage if no access key" do
+    vm = create_vm
+    login_runtime(vm)
+    repository = instance_double(GithubRepository, access_key: nil)
+    expect(GithubRunner).to receive(:[]).with(vm_id: vm.id).and_return(instance_double(GithubRunner, repository: repository))
+    expect(repository).to receive(:setup_blob_storage)
+
+    post "/runtime/github/caches"
+
+    expect(last_response.status).to eq(400)
   end
 end

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "github" do
+  describe "authentication" do
+    let(:vm) { create_vm }
+
+    before { login_runtime(vm) }
+
+    it "vm has no runner" do
+      get "/runtime/github"
+
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+    end
+
+    it "vm has runner but no repository" do
+      GithubRunner.create_with_id(vm_id: vm.id, repository_name: "test", label: "ubicloud")
+      get "/runtime/github"
+
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+    end
+
+    it "vm has runner and repository" do
+      repository = GithubRepository.create_with_id(name: "test")
+      GithubRunner.create_with_id(vm_id: vm.id, repository_name: "test", label: "ubicloud", repository_id: repository.id)
+      get "/runtime/github"
+
+      expect(last_response.status).to eq(404)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,7 @@ DatabaseCleaner.url_allowlist = [
 Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser.*/)
 Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations.*/)
 Warning.ignore(/To use retry middleware with Faraday v2\.0\+, install `faraday-retry` gem/)
+Warning.ignore([:unused_var], /.*lib\/aws-sdk-s3\/endpoint_provider.*/)
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|


### PR DESCRIPTION
### Add base of GitHub runtime API

The VM runtime token is a JWT token used for authenticating virtual machines with our runtime API, and it remains valid while the VM is running. We utilize the runner assigned to the VM and the repository associated with this runner in the "/runtime/github" endpoints. Subsequent commits introduce these new endpoints.

We pass the runtime token and URL to the runner as environment variables during the setup process.

### Add github cache entry migration

We introduced `github_cache_entry` table to track cache entries for "ubicloud/cache" package. Additionally, we added blob storage credentials to the `github_repository` table because we create a new bucket for each repository. The subsequent PRs provide a detailed explanation of these changes.

### Add AWS S3 SDK gem

The beast is back. We initially used the aws-s3-sdk gem to manage blob storage operations when setting up our MinIO cluster with our PostgreSQL service. However, considering its large size and our limited use of its operations, we removed it at 44a92e0d and created our own MinIO client. This has worked well until now, but I've encountered an issue: our client's presigned URLs aren't compatible with Cloudflare R2. Despite my attempts, I couldn't resolve this. So, for now, I'm reintroducing the aws-s3-sdk gem to our project until we can fix our client. Once we've resolved the issue, we'll remove the aws-s3-sdk gem again.

### Introduce GitHubCacheEntry model and add blob to repository

The cache entry contains metadata about the available caches for a specific repository. The unique identifiers for the cache, `key` and `version`, are used by the action client to either retrieve or upload a cache. The `scope` aids in maintaining the branch where the cache was created, as each branch cannot access the cache of another. The `upload_id` is generated when creating a multipart upload request on blob storage, which is then used to upload cache parts and complete the upload. Additionally, we keep track of the cache's last access time to clear old caches that haven't been accessed for a considerable period.

Each repository has its unique cache, necessitating a separate bucket for each repository. This separation naturally demarcates the caches of different repositories. Services like S3 and MinIO, which are S3 compatible, allow for the creation of access policies based on the object key prefix. Thus, we can limit access to a repository's cache by using the repository name as the object key prefix within the same bucket. However, Cloudflare R2 doesn't currently support this feature, requiring us to create a separate bucket and access token for each repository.

Since these credentials can only access the repository's bucket, we use them for object-level operations like generating presigned URLs and managing multipart uploads.

`url_presigner` helps to generate presigned URLs. We don't do any call to generate resigned URLs, it's generatable on the client side using its credentials.

### Manage setup/destroy of the repository's blob storage.

The blob storage credentials stored in github_repository table only have access to the repository's blob storage, so we need more powerful credentials to manage buckets. We supply these administrator credentials, which can create and delete buckets, through a Config value. We then use these credentials to initialize the admin client.

Cloudflare R2 markets itself as S3-compatible, but it doesn't support all S3 operations. Its authentication service is distinct from the storage service. Since it doesn't have ACL endpoints, we can't use the S3 client to create users and access keys. Instead, we must use the Cloudflare API for these operations.

When we receive the first cache request for a repository, we create a new bucket and an access token for it if it doesn't already have one. We store this access token in an encrypted database column, which we then use for generating presigned URLs for the specific bucket.

Alternatively, we could create a bucket at the time of repository creation. However, since not all repositories will use the cache feature, I prefer to only create a bucket when the repository actually needs it.

### Add reserveCache endpoint

The client reserves a cache entry before beginning to upload content to the blob storage. S3 compatible blob storage necessitates sending a `CreateMultipartUpload` request prior to the content upload. This returns an `UploadId`.

The 'POST /caches' endpoint, ('reserveCache' [^1]), creates a cache entry using the given "key" and "version" parameters. This prevents any other runner from starting to upload the same cache. It returns an `upload_id` from the blob storage and a list of presigned URLs for each 32MB part, which the client will use to upload each chunk.

The cache client uses the `cacheId` in some logics. This is unnecessary for our forked version since we already have `uploadId`. However, to avoid extensive modifications to the client code, a fixed `cacheId` is returned for each request.

### Add commitCache endpoint

The client commit the cache entry after uploading content to the blob storage. S3 compatible blob storage requires sending a `CompleteMultipartUpload` request following the content upload. This necessitates an `UploadId` and `ETags` from each part of the upload.

The 'POST /caches/commit' endpoint ('commitCache' [^2]) sends a `CompleteMultipartUpload` request to the blob storage using the etags provided by the client. Afterward, it marks the cache entry as committed, allowing other runners to access it.

### Add getCacheEntry endpoint

We've implemented caching endpoints based on GitHub's official cache client. We also have a forked version, which gives us flexibility, but we've tried to stay as close as possible to the official client, maintaining similar endpoints and parameters.

The official GitHub cache client is open-source and can be accessed here [^3]

The 'GET /cache' endpoint ('getCacheEntry' [^4]) retrieves cache entry using comma-separated 'keys' and 'version', returning a pre-signed URL to download the cache. If no cache entry is found, it returns a 204 status code.

Therefore, careful selection of cache entries is crucial.

Initially, we only consider committed caches for the repository of the authenticated runner. The runner can only access caches for the same branch or the default branch, but not for other branches.

The client can send multiple keys, and we should return the first matching cache entry in the same order as the keys are provided. The `.min_by { keys.index(_1.key) }` function assists with this. The `(scopes.index(_1.scope) * keys.size)` part helps us sort the caches by scope. If the same cache exists for the head_branch and the default branch, we should return the cache for the head_branch.

### Add listCache endpoint

The 'GET /caches' endpoint, ('listCache' [^5]), retrieves a list of cache entries for a single 'key' parameter. It does not provide presigned URLs. This endpoint is used by the client when no cache entry matches the 'getCacheEntry' request, and when debugging is turned on.

[^1]: https://github.com/ubicloud/toolkit/blob/d1df13e178816d69d96bdc5c753b36a66ad03728/packages/cache/src/internal/cacheHttpClient.ts#L204
[^2]: https://github.com/ubicloud/toolkit/blob/d1df13e178816d69d96bdc5c753b36a66ad03728/packages/cache/src/internal/cacheHttpClient.ts#L339
[^3]: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheHttpClient.ts
[^4]: https://github.com/ubicloud/toolkit/blob/d1df13e178816d69d96bdc5c753b36a66ad03728/packages/cache/src/internal/cacheHttpClient.ts#L103
[^5]: https://github.com/ubicloud/toolkit/blob/d1df13e178816d69d96bdc5c753b36a66ad03728/packages/cache/src/internal/cacheHttpClient.ts#L146
