### PR TITLE
Test the boot images exposed to customers in E2E

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -69,7 +69,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       frame["hostname"],
       provider: "hetzner",
       hetzner_server_identifier: frame["server_id"],
-      default_boot_images: [Config.default_boot_image_name]
+      default_boot_images: Option::BootImages.map { _1.name }
     ).subject
     update_stack({"vm_host_id" => vm_host.id})
 

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -22,8 +22,15 @@ class Prog::Test::Vm < Prog::Test::Base
   end
 
   label def install_packages
-    sshable.cmd("sudo apt update")
-    sshable.cmd("sudo apt install -y build-essential")
+    if vm.boot_image.start_with?("ubuntu")
+      sshable.cmd("sudo apt update")
+      sshable.cmd("sudo apt install -y build-essential")
+    elsif vm.boot_image.start_with?("almalinux")
+      sshable.cmd("sudo dnf check-update || [ $? -eq 100 ]")
+      sshable.cmd("sudo dnf install -y gcc gcc-c++ make")
+    else
+      fail_test "unexpected boot image: #{vm.boot_image}"
+    end
 
     hop_verify_extra_disks
   end

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -10,7 +10,7 @@ class Prog::Test::Vm < Prog::Test::Base
   label def verify_dd
     # Verifies basic block device health
     # See https://github.com/ubicloud/ubicloud/issues/276
-    sshable.cmd("dd if=/dev/random of=~/1.txt bs=512 count=1000000")
+    sshable.cmd("dd if=/dev/urandom of=~/1.txt bs=512 count=1000000")
     sshable.cmd("sync ~/1.txt")
     size_info = sshable.cmd("ls -s ~/1.txt").split
 
@@ -42,7 +42,7 @@ class Prog::Test::Vm < Prog::Test::Base
       sshable.cmd("sudo mkfs.ext4 #{volume.device_path.shellescape}")
       sshable.cmd("sudo mount #{volume.device_path.shellescape} #{mount_path}")
       sshable.cmd("sudo chown ubi #{mount_path}")
-      sshable.cmd("dd if=/dev/random of=#{mount_path}/1.txt bs=512 count=10000")
+      sshable.cmd("dd if=/dev/urandom of=#{mount_path}/1.txt bs=512 count=10000")
       sshable.cmd("sync #{mount_path}/1.txt")
     }
 

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -40,6 +40,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
         {encrypted: storage_encrypted, skip_sync: true},
         {encrypted: storage_encrypted, size_gib: 5}
       ],
+      boot_image: Option::BootImages.map { _1.name }.sample,
       enable_ip4: true
     )
 
@@ -47,6 +48,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
       "ubi", project.id,
       private_subnet_id: subnet1_s.id,
       storage_volumes: [{encrypted: storage_encrypted, skip_sync: false}],
+      boot_image: Option::BootImages.map { _1.name }.sample,
       enable_ip4: true
     )
 
@@ -54,6 +56,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
       "ubi", project.id,
       private_subnet_id: subnet2_s.id,
       storage_volumes: [{encrypted: storage_encrypted, skip_sync: false}],
+      boot_image: Option::BootImages.map { _1.name }.sample,
       enable_ip4: true
     )
 

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -61,14 +61,14 @@ RSpec.describe Prog::Test::Vm do
 
   describe "#verify_dd" do
     it "verifies dd" do
-      expect(sshable).to receive(:cmd).with("dd if=/dev/random of=~/1.txt bs=512 count=1000000")
+      expect(sshable).to receive(:cmd).with("dd if=/dev/urandom of=~/1.txt bs=512 count=1000000")
       expect(sshable).to receive(:cmd).with("sync ~/1.txt")
       expect(sshable).to receive(:cmd).with("ls -s ~/1.txt").and_return "500004 /home/xyz/1.txt"
       expect { vm_test.verify_dd }.to hop("install_packages")
     end
 
     it "fails to verify if size is not in expected range" do
-      expect(sshable).to receive(:cmd).with("dd if=/dev/random of=~/1.txt bs=512 count=1000000")
+      expect(sshable).to receive(:cmd).with("dd if=/dev/urandom of=~/1.txt bs=512 count=1000000")
       expect(sshable).to receive(:cmd).with("sync ~/1.txt")
       expect(sshable).to receive(:cmd).with("ls -s ~/1.txt").and_return "300 /home/xyz/1.txt"
       expect(vm_test.strand).to receive(:update).with(exitval: {msg: "unexpected size after dd"})
@@ -106,7 +106,7 @@ RSpec.describe Prog::Test::Vm do
       expect(sshable).to receive(:cmd).with("sudo mkfs.ext4 #{disk_path}")
       expect(sshable).to receive(:cmd).with("sudo mount #{disk_path} #{mount_path}")
       expect(sshable).to receive(:cmd).with("sudo chown ubi #{mount_path}")
-      expect(sshable).to receive(:cmd).with("dd if=/dev/random of=#{mount_path}/1.txt bs=512 count=10000")
+      expect(sshable).to receive(:cmd).with("dd if=/dev/urandom of=#{mount_path}/1.txt bs=512 count=10000")
       expect(sshable).to receive(:cmd).with("sync #{mount_path}/1.txt")
       expect { vm_test.verify_extra_disks }.to hop("ping_google")
     end


### PR DESCRIPTION
### Make VM E2E tests compatible with AlmaLinux images

We've made AlmaLinux 8 and AlmaLinux 9 available to our customers. AlmaLinux uses the dnf package manager, not apt. The changes in this PR ensure that our E2E tests are compatible with AlmaLinux images.

The command `sudo dnf groupinstall -y 'Development Tools'` is similar to `sudo apt install -y build-essential`, which we use for Ubuntu images. However, the AlmaLinux version is significantly larger, so we've opted for a lighter version instead.

`sudo dnf check-update` exits with 100 if there are available package updates. Since non-zero exit codes indicate failure in bash world, I added `|| [ $? -eq 100 ]` condition to suppress false error if it's 100.

### Use /dev/urandom instead of /dev/random in E2E tests.

Interestingly, /dev/random takes a while to generate random data in AlmaLinux 8, but this issue doesn't occur in AlmaLinux 9.

**almalinux-8:**

    [ubi@vm0nvcjs ~]$ time dd if=/dev/random of=~/1.txt bs=512 count=1000000
    dd: warning: partial read (75 bytes); suggest iflag=fullblock
    0+1000000 records in
    0+1000000 records out
    76425780 bytes (76 MB, 73 MiB) copied, 98.7824 s, 774 kB/s

    real    1m38.788s
    user    0m0.174s
    sys     1m36.413s

**ubuntu-jammy:**

    ubi@vmsdbzfv:~$ time dd if=/dev/random of=~/1.txt bs=512 count=1000000
    1000000+0 records in
    1000000+0 records out
    512000000 bytes (512 MB, 488 MiB) copied, 3.4936 s, 147 MB/s

    real    0m3.496s
    user    0m0.113s
    sys     0m3.382s

After doing some research, I discovered that `/dev/random` blocks when the entropy pool is empty. This issue doesn't occur with `/dev/urandom`, which is suitable for our use case.

**almalinux-8:**

    [ubi@vm0nvcjs ~]$ time dd if=/dev/urandom of=~/1.txt bs=512 count=1000000
    1000000+0 records in
    1000000+0 records out
    512000000 bytes (512 MB, 488 MiB) copied, 15.0144 s, 34.1 MB/s

    real    0m15.017s
    user    0m0.161s
    sys     0m14.799s

**ubuntu-jammy:**

    ubi@vmsdbzfv:~$ time dd if=/dev/urandom of=~/1.txt bs=512 count=1000000
    1000000+0 records in
    1000000+0 records out
    512000000 bytes (512 MB, 488 MiB) copied, 3.79444 s, 135 MB/s

    real    0m3.894s
    user    0m0.125s
    sys     0m3.349s


### Test the boot images exposed to customers in E2E

Since disabling Alma Linux 9, our customers could only provision Ubuntu 22.04 virtual machines. However, things changed last week. We launched Ubuntu 24.04, AlmaLinux 9, and AlmaLinux 8 in our service. Now, customers can provision virtual machines with four different images.

It's essential to test all the boot images available to customers to ensure their proper functioning. We've previously faced issues with various boot images that we didn't detect in time. Hence, incorporating them into our E2E tests is crucial.

The VmGroup E2E test provisions three virtual machines and checks basic features like network connectivity. I've updated it to provision virtual machines using a boot image randomly selected from the available options. This way, we can test different combinations of boot images.