### PR TITLE
Add failover endpoint for Postgres

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -92,6 +92,17 @@ class PostgresServer < Sequel::Model
     }
   end
 
+  def trigger_failover
+    if primary? && (standby = failover_target)
+      standby.incr_take_over
+      incr_destroy
+      true
+    else
+      Clog.emit("Failed to trigger failover")
+      false
+    end
+  end
+
   def primary?
     timeline_access == "push"
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -300,11 +300,7 @@ SQL
   label def unavailable
     register_deadline(:wait, 10 * 60)
 
-    if postgres_server.primary? && (standby = postgres_server.failover_target)
-      standby.incr_take_over
-      postgres_server.incr_destroy
-      nap 0
-    end
+    nap 0 if postgres_server.trigger_failover
 
     reap
     nap 5 unless strand.children.select { _1.prog == "Postgres::PostgresServerNexus" && _1.label == "restart" }.empty?

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -160,5 +160,24 @@ class CloverApi
 
       Serializers::Postgres.serialize(pg, {detailed: true})
     end
+
+    request.post "failover" do
+      Authorization.authorize(@current_user.id, "Postgres:create", @project.id)
+      Authorization.authorize(@current_user.id, "Postgres:view", pg.id)
+
+      unless pg.representative_server.primary?
+        fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered during restore!")
+      end
+
+      unless @project.get_ff_postgresql_base_image
+        fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered for this resource!")
+      end
+
+      unless pg.representative_server.trigger_failover
+        fail CloverError.new(400, "InvalidRequest", "There is not a suitable standby server to failover!")
+      end
+
+      Serializers::Postgres.serialize(pg, {detailed: true})
+    end
   end
 end


### PR DESCRIPTION
## Add trigger_failover function to PostgresServer model
Triggering failover in Ubicloud means;
1. The server that needs to be failed over is a primary.
2. There is a valid standby we can failover to.
3. The standby needs to takeover.
4. The primary needs to be destroyed.

We add a function to the model to perform the above checks and increment
necessary semaphores.

## Refactor PostgresServerNexus to use trigger_failover
To avoid code duplication, we reuse the trigger_failover function in
case of primary unavailability.

## Add Failover endpoint to the APIs
This endpoint is needed for our partners to be able to manually trigger
a failover.