### PR TITLE
Reduce logging for up resources

### DIFF
--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -46,7 +46,7 @@ class MonitorableResource
     @pulse_check_started_at = Time.now
     begin
       @pulse = @resource.check_pulse(session: @session, previous_pulse: @pulse)
-      Clog.emit("Got new pulse.") { {got_pulse: {ubid: @resource.ubid, pulse: @pulse}} }
+      Clog.emit("Got new pulse.") { {got_pulse: {ubid: @resource.ubid, pulse: @pulse}} } if @pulse[:reading_rpt] % 5 == 1 || @pulse[:reading] != "up"
     rescue => ex
       Clog.emit("Pulse checking has failed.") { {pulse_check_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
     end

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe MonitorableResource do
       r_w_event_loop.instance_variable_set(:@pulse_thread, pulse_thread)
       r_w_event_loop.check_pulse
     end
+
+    it "logs the pulse if reading is not up" do
+      expect(postgres_server).to receive(:check_pulse).and_return({reading: "down", reading_rpt: 5})
+      expect(Clog).to receive(:emit)
+      r_w_event_loop.check_pulse
+    end
+
+    it "does not log the pulse if reading is up and reading_rpt is not every 5th reading" do
+      expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 3})
+      expect(Clog).not_to receive(:emit)
+      r_w_event_loop.check_pulse
+    end
+
+    it "logs the pulse if reading is up and reading_rpt is every 5th reading" do
+      expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 6})
+      expect(Clog).to receive(:emit)
+      r_w_event_loop.check_pulse
+    end
   end
 
   describe "#close_resource_session" do


### PR DESCRIPTION
If the resource is up, there is no meaning to log it for every check. We can simply do it every 5th time. I am still keeping the logging for down resources at every repeat.