### PR TITLE
Add create_vm spec helper

### DIFF
--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe InvoiceGenerator do
     Account.create_with_id(email: "auth1@example.com")
     Project.create_with_id(name: "cool-project")
   }
-  let(:vm1) { Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", family: "standard", cores: 2, location: "hetzner-hel1", boot_image: "x") }
+  let(:vm1) { create_vm }
 
   let(:day) { 24 * 60 * 60 }
   let(:begin_time) { Time.parse("2023-06-01") }
@@ -148,7 +148,7 @@ RSpec.describe InvoiceGenerator do
 
   it "generates invoice for a single project" do
     p2 = Project.create_with_id(name: "cool-project")
-    vm2 = Vm.create_with_id(unix_user: "x", public_key: "x", name: "vm-1", family: "standard", cores: 2, location: "hetzner-hel1", boot_image: "x")
+    vm2 = create_vm
 
     generate_billing_record(p1, vm1, Sequel::Postgres::PGRange.new(begin_time, end_time))
     generate_billing_record(p2, vm2, Sequel::Postgres::PGRange.new(begin_time, end_time))

--- a/spec/model/github_installation_spec.rb
+++ b/spec/model/github_installation_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe GithubInstallation do
   }
 
   it "returns sum of used vm cores" do
-    vms = [2, 4, 8].map do |core_count|
-      Vm.create_with_id(display_state: "running", unix_user: "x", public_key: "x", name: "x", family: "standard", cores: core_count, location: "x", boot_image: "x")
-    end
+    vms = [2, 4, 8].map { create_vm(cores: _1) }
 
     # let's not create runner for the last vm
     vms[..1].each do |vm|

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -20,11 +20,10 @@ RSpec.describe MinioCluster do
       storage_size_gib: 100,
       vm_size: "standard-2"
     )
-    vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
     MinioServer.create_with_id(
       minio_pool_id: mp.id,
-      vm_id: vm.id,
+      vm_id: create_vm.id,
       index: 0
     )
     mc

--- a/spec/model/minio/minio_pool_spec.rb
+++ b/spec/model/minio/minio_pool_spec.rb
@@ -20,11 +20,10 @@ RSpec.describe MinioPool do
       storage_size_gib: 100,
       vm_size: "standard-2"
     )
-    vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
     MinioServer.create_with_id(
       minio_pool_id: mp.id,
-      vm_id: vm.id,
+      vm_id: create_vm.id,
       index: 0
     )
     mp
@@ -64,11 +63,10 @@ RSpec.describe MinioPool do
 
   it "returns servers in ordered way" do
     mp.update(drive_count: 4, server_count: 2)
-    vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
 
     MinioServer.create_with_id(
       minio_pool_id: mp.id,
-      vm_id: vm.id,
+      vm_id: create_vm.id,
       index: 2
     )
 

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe MinioServer do
       storage_size_gib: 100,
       vm_size: "standard-2"
     )
-    vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2, ephemeral_net6: "fdfa:b5aa:14a3:4a3d::/64")
+    vm = create_vm(ephemeral_net6: "fdfa:b5aa:14a3:4a3d::/64")
 
     described_class.create_with_id(
       minio_pool_id: mp.id,

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -19,10 +19,7 @@ RSpec.describe VmPool do
     end
 
     it "returns nil if there are no vms in running state" do
-      Vm.create_with_id(
-        pool_id: pool.id, display_state: "creating", unix_user: "x", public_key: "x",
-        name: "x", family: "x", cores: 2, location: "x", boot_image: "x"
-      )
+      create_vm(pool_id: pool.id, display_state: "creating")
       expect(pool.pick_vm).to be_nil
     end
   end
@@ -32,10 +29,7 @@ RSpec.describe VmPool do
       Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
     }
     let(:vm) {
-      vm = Vm.create_with_id(
-        pool_id: pool.id, display_state: "running", unix_user: "x", public_key: "x",
-        name: "x", family: "standard", cores: 2, location: "x", boot_image: "x"
-      )
+      vm = create_vm(pool_id: pool.id, display_state: "running")
       vm.associate_with_project(prj)
       vm
     }

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -31,10 +31,9 @@ RSpec.describe Prog::Minio::SetupMinio do
       server_count: 1,
       drive_count: 1
     )
-    vm = Vm.create_with_id(unix_user: "u", public_key: "k", name: "n", location: "l", boot_image: "i", family: "f", cores: 2)
     MinioServer.create_with_id(
       minio_pool_id: mp.id,
-      vm_id: vm.id,
+      vm_id: create_vm.id,
       index: 0,
       cert: "cert",
       cert_key: "key"

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Prog::Test::VmGroup do
     it "returns first VM's host" do
       sshable = Sshable.create_with_id
       vm_host = VmHost.create(location: "A") { _1.id = sshable.id }
-      vm = Vm.create_with_id(unix_user: "root", public_key: "", name: "xyz", location: "a", boot_image: "b", family: "z", cores: 1, vm_host_id: vm_host.id)
+      vm = create_vm(vm_host_id: vm_host.id)
       expect(vg_test).to receive(:frame).and_return({"vms" => [vm.id]})
       expect(vg_test.vm_host).to eq(vm_host)
     end

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
   let(:tunnel) {
     sa = Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
     vmh = VmHost.create(location: "test-location") { _1.id = sa.id }
-    vm_src = Vm.create_with_id(name: "hellovm", vm_host_id: vmh.id, unix_user: "root", public_key: "public-key", family: "standard", cores: 1, location: "location", boot_image: "image")
-    vm_dst = Vm.create_with_id(name: "hellovm2", vm_host_id: vmh.id, unix_user: "root", public_key: "public-key", family: "standard", cores: 1, location: "location", boot_image: "image")
+    vm_src = create_vm(name: "hellovm", vm_host_id: vmh.id)
+    vm_dst = create_vm(name: "hellovm2", vm_host_id: vmh.id)
     n_src = Nic.create_with_id(private_subnet_id: ps.id,
       private_ipv6: "fd10:9b0b:6b4b:8fbb:abc::",
       private_ipv4: "10.0.0.1",

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -223,15 +223,7 @@ RSpec.describe Clover, "billing" do
 
     describe "invoices" do
       def billing_record(begin_time, end_time)
-        vm = Vm.create_with_id(
-          unix_user: "x",
-          public_key: "x",
-          name: "vm-1",
-          family: "standard",
-          cores: 1,
-          location: "hetzner-hel1",
-          boot_image: "x"
-        )
+        vm = create_vm
         BillingRecord.create_with_id(
           project_id: billing_info.project.id,
           resource_id: vm.id,

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe Al do
       vmh = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
       sd1 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
-      Vm.create_with_id(vm_host_id: vmh.id, family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: false, created_at: Time.now, unix_user: "", public_key: "", boot_image: "")
-      Vm.create_with_id(vm_host_id: vmh.id, family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: false, created_at: Time.now, unix_user: "", public_key: "", boot_image: "ubuntu-jammy")
+      create_vm(vm_host_id: vmh.id, location: vmh.location, boot_image: "", display_state: "creating")
+      create_vm(vm_host_id: vmh.id, location: vmh.location, boot_image: "ubuntu-jammy", display_state: "creating")
       BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
 
       expect(Al::Allocation.candidate_hosts(req))
@@ -484,10 +484,6 @@ RSpec.describe Al do
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
       PciDevice.create_with_id(vm_host_id: vmh.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
       PciDevice.create_with_id(vm_host_id: vmh.id, slot: "01:00.1", device_class: "0420", vendor: "vd", device: "dv2", numa_node: 0, iommu_group: 3)
-    end
-
-    def create_vm
-      Vm.create_with_id(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "loc1", ip4_enabled: false, created_at: Time.now, unix_user: "", public_key: "", boot_image: "ubuntu-jammy")
     end
 
     def create_req(vm, storage_volumes, target_host_utilization: 0.55, distinct_storage_devices: false, gpu_enabled: false, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], location_filter: [], location_preference: [])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -232,3 +232,8 @@ RSpec.configure do |config|
     end
   end
 end
+
+def create_vm(**args)
+  defaults = {unix_user: "ubi", public_key: "ssh-ed25519 key", name: "test-vm", family: "standard", cores: 1, arch: "x64", location: "hetzner-hel1", boot_image: "ubuntu-jammy", display_state: "running", ip4_enabled: false, created_at: Time.now}
+  Vm.create_with_id(**defaults.merge(args))
+end

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe UBID do
     host = VmHost.create(location: "x") { _1.id = sshable.id }
     si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
 
-    vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
+    vm = create_vm
     expect(vm.ubid).to start_with UBID::TYPE_VM
 
     dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
@@ -222,7 +222,7 @@ RSpec.describe UBID do
     sshable = Sshable.create_with_id
     host = VmHost.create(location: "x") { _1.id = sshable.id }
     si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
-    vm = Vm.create_with_id(unix_user: "x", public_key: "x", name: "x", family: "x", cores: 2, location: "x", boot_image: "x")
+    vm = create_vm
     dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
     sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id, storage_device_id: dev.id)
     kek = StorageKeyEncryptionKey.create_with_id(algorithm: "x", key: "x", init_vector: "x", auth_data: "x")


### PR DESCRIPTION
We create a VM model using dummy data in several test locations. This dummy data is duplicated across these locations. Although allocator tests already include this type of helper, I've made it available for other tests as well.