### PR TITLE
Retry downloading the boot image if it fails non-prod environment

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -136,7 +136,11 @@ class Prog::DownloadBootImage < Prog::Base
       }.to_json
       sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image' #{q_daemon_name}", stdin: params_json)
     when "Failed"
-      BootImage.where(vm_host_id: vm_host.id, name: image_name, version: version).destroy
+      if Config.production?
+        BootImage.where(vm_host_id: vm_host.id, name: image_name, version: version).destroy
+      else
+        sshable.cmd("common/bin/daemonizer --clean #{q_daemon_name}")
+      end
       fail "Failed to download '#{image_name}' image on #{vm_host}"
     end
 

--- a/rhizome/host/lib/boot_image.rb
+++ b/rhizome/host/lib/boot_image.rb
@@ -41,11 +41,13 @@ class BootImage
     # same time.
     temp_file_name = @version.nil? ? @name : "#{@name}-#{@version}"
     temp_path = File.join(image_root, "#{temp_file_name}#{ext}.tmp")
-    file_sha256sum = curl_image(url, temp_path, ca_path)
-    verify_sha256sum(file_sha256sum, sha256sum)
-    convert_image(temp_path, init_format)
-
-    rm_if_exists(temp_path)
+    begin
+      file_sha256sum = curl_image(url, temp_path, ca_path)
+      verify_sha256sum(file_sha256sum, sha256sum)
+      convert_image(temp_path, init_format)
+    ensure
+      rm_if_exists(temp_path)
+    end
   end
 
   def image_ext(url)


### PR DESCRIPTION
**Retry downloading the boot image if it fails non-prod environment**
The boot image download can fail due to various reasons, such as network. We
don't want it to cause failure in our E2E tests. This commit adds a retry logic
to the boot image download in the E2E tests. I didn't add the retry logic for
production case, because we might want to have a deeper look before blindly
retrying.

**Clean up the temp file if image download fails**
If the image download fails, the temp file is left behind, which breaks
the idempotency of the image download. This commit adds a cleanup step
to remove the temp file if the download fails.