### PR TITLE
Revert "Run github runner e2e tests by default"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2204,github_runner_ubuntu_2004'
+        default: 'vm'
         type: string
 
   schedule:
@@ -73,7 +73,7 @@ jobs:
 
     - name: Add e2e script to Procfile
       run: |
-        echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm,github_runner_ubuntu_2204,github_runner_ubuntu_2004' || inputs.test_cases }}" >> Procfile
+        echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm' || inputs.test_cases }}" >> Procfile
 
     - name: Run services
       env:


### PR DESCRIPTION
This reverts commit 84367448337e274d7cec6561f457a74991926551, since we've faced with issues
- Github runner image download might fail depending on when the initial vm group test reboots the host while running github runner e2e tests by default. 
- Triggered runs on `github-e2e-test-workflows` does not start a runner on the host locally.

while running github runner e2e tests. I'll be working on issues.