### PR TITLE
Use more idiomatic(?) style for raising a new exception in one case

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -195,8 +195,8 @@ class VmHost < Sequel::Model
   # Introduced for downloading firmware via REPL.
   def download_firmware(version_x64: nil, version_arm64: nil, sha256_x64: nil, sha256_arm64: nil)
     version, sha256 = (arch == "x64") ? [version_x64, sha256_x64] : [version_arm64, sha256_arm64]
-    raise ArgumentError, "No version provided" if version.nil?
-    raise ArgumentError, "No SHA-256 digest provided" if sha256.nil?
+    fail ArgumentError, "No version provided" if version.nil?
+    fail ArgumentError, "No SHA-256 digest provided" if sha256.nil?
     Strand.create_with_id(schedule: Time.now, prog: "DownloadFirmware", label: "start", stack: [{subject_id: id, version: version, sha256: sha256}])
   end
 


### PR DESCRIPTION
I inherited opinions about this rather than having my own, but upon closer scrutiny, this really doesn't matter, because `raise` and `fail` have identical semantics.

For some reason, I always thought `fail` *would not* do implicit re-raise (but it does), and this is why `fail` was preferred for de-novo exceptions and `raise` was preferred in some other contexts. But it's simply not true.

It's worth thinking if we should teach rubocop to rewrite all `fail` as `raise` by adding a rule.  Or vice versa if we liked being special and saving a character.