### PR TITLE
Have e2e test environment loader similar to production environment

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -83,7 +83,7 @@ autoload_normal.call("model", flat: true)
 
 AUTOLOAD_CONSTANTS.freeze
 
-if Config.production?
+if Config.production? || Config.e2e_test?
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
 end
 
@@ -110,7 +110,7 @@ when :test
 end
 
 def clover_freeze
-  return unless Config.production?
+  return unless Config.production? || Config.e2e_test?
   require "refrigerator"
 
   # Take care of library dependencies that modify core classes.


### PR DESCRIPTION
We've introduced a new e2e test environment recently, we haven't updated the loader code with the new environment which causes issues of updating frozen classes on e2e tests. With this commit having similar loader logic with production environment for e2e test environment.