### PR TITLE
Start using new Cloud Hypervisor version

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -556,7 +556,7 @@ Requires=#{@vm_name}-dnsmasq.service
 NetworkNamespacePath=/var/run/netns/#{@vm_name}
 ExecStartPre=/usr/bin/rm -f #{vp.ch_api_sock}
 
-ExecStart=#{CloudHypervisor::VERSION_LEGACY.bin} -v \
+ExecStart=#{CloudHypervisor::VERSION.bin} -v \
 --api-socket path=#{vp.ch_api_sock} \
 --kernel #{CloudHypervisor::NEW_FIRMWARE.path} \
 #{disk_params.join("\n")}
@@ -567,7 +567,7 @@ ExecStart=#{CloudHypervisor::VERSION_LEGACY.bin} -v \
 #{pci_device_params} \
 #{net_params.join(" \\\n")}
 
-ExecStop=#{CloudHypervisor::VERSION_LEGACY.ch_remote_bin} --api-socket #{vp.ch_api_sock} shutdown-vmm
+ExecStop=#{CloudHypervisor::VERSION.ch_remote_bin} --api-socket #{vp.ch_api_sock} shutdown-vmm
 Restart=no
 User=#{@vm_name}
 Group=#{@vm_name}


### PR DESCRIPTION
With this change, newly created VMs will use a new version of Cloud Hypervisor: v35.1 for both x64 and arm64. Before this change, that version of Cloud Hypervisor was downloaded to all existing hosts.