### PR TITLE
UI: Default to location with highest available capacity

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -37,6 +37,21 @@ class Project < Sequel::Model
     !!billing_info&.payment_methods&.any?
   end
 
+  def default_location
+    location_max_capacity = DB[:vm_host]
+      .where(location: Option.locations.map { _1.name })
+      .where(allocation_state: "accepting")
+      .select_group(:location)
+      .order { sum(Sequel[:total_cores] - Sequel[:used_cores]).desc }
+      .first
+
+    if location_max_capacity.nil?
+      Option.locations.first.name
+    else
+      location_max_capacity[:location]
+    end
+  end
+
   def path
     "/project/#{ubid}"
   end

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -43,6 +43,7 @@ class CloverWeb
         @subnets = Serializers::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all)
         @prices = fetch_location_based_prices("VmCores", "VmStorage", "IPAddress")
         @has_valid_payment_method = @project.has_valid_payment_method?
+        @default_location = @project.default_location
 
         view "vm/create"
       end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -57,4 +57,21 @@ RSpec.describe Project do
       project.soft_delete
     end
   end
+
+  describe ".default_location" do
+    it "returns the location with the highest available core capacity" do
+      VmHost.create(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3) { _1.id = Sshable.create_with_id.id }
+      VmHost.create(allocation_state: "accepting", location: "hetzner-hel1", total_cores: 10, used_cores: 3) { _1.id = Sshable.create_with_id.id }
+      VmHost.create(allocation_state: "accepting", location: "hetzner-hel1", total_cores: 10, used_cores: 1) { _1.id = Sshable.create_with_id.id }
+      VmHost.create(allocation_state: "accepting", location: "leaseweb-wdc02", total_cores: 100, used_cores: 99) { _1.id = Sshable.create_with_id.id }
+      VmHost.create(allocation_state: "draining", location: "location-4", total_cores: 100, used_cores: 0) { _1.id = Sshable.create_with_id.id }
+      VmHost.create(allocation_state: "accepting", location: "github-runners", total_cores: 100, used_cores: 0) { _1.id = Sshable.create_with_id.id }
+
+      expect(project.default_location).to eq("hetzner-hel1")
+    end
+
+    it "provides first location when location with highest available core capacity cannot be determined" do
+      expect(project.default_location).to eq Option.locations.first.name
+    end
+  end
 end

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -46,6 +46,8 @@
                 <% locations = Option
                     .locations
                     .map { |l| [l.display_name, l.display_name, @prices[l.name].to_json] }
+
+                   default_location = Option.locations.detect { |l| l.name == @default_location }&.display_name
                 %>
                 <%== render(
                   "components/form/radio_small_cards",
@@ -53,7 +55,7 @@
                     name: "location",
                     label: "Location",
                     options: locations,
-                    selected: locations.first[0],
+                    selected: default_location,
                     attributes: {
                       required: true
                     }


### PR DESCRIPTION
Before this change, during VM creation, the first element of of the "Location" radio button is selected by default.  After this change, the location with the highest available capacity is selected.

"Available capacity" is determined as the sum of available cores in a location. There are other options to calculate/interpret available capacity. The main drawback of this approach is that it doesn't consider fragmentation. Another option would be to pick the location with the host that has the max available capacity.  But in that case we'd currently default to our smallest location (US South).