### PR TITLE
Log github installation deletion for easy monitoring

### DIFF
--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -48,6 +48,7 @@ class CloverWeb
       installation.runners.each(&:incr_destroy)
       installation.repositories.each(&:incr_destroy)
       installation.destroy
+      Clog.emit("GithubInstallation is deleted.") { {github_installation: {ubid: installation.ubid, type: installation.type}} }
       return success("GithubInstallation[#{installation.ubid}] deleted")
     end
 


### PR DESCRIPTION
To monitor github installation deletion via logs easily, emitting clog when the user deletes a github installation.