### PR TITLE
Run github runner e2e tests by default again

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm'
+        default: 'vm,github_runner_ubuntu_2204,github_runner_ubuntu_2004'
         type: string
 
   schedule:
@@ -73,7 +73,7 @@ jobs:
 
     - name: Add e2e script to Procfile
       run: |
-        echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm' || inputs.test_cases }}" >> Procfile
+        echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm,github_runner_ubuntu_2204,github_runner_ubuntu_2004' || inputs.test_cases }}" >> Procfile
 
     - name: Run services
       env:


### PR DESCRIPTION
As we've fixed two minor issues with PRs #1694 and #1692, running github runner e2e tests by default again.