### PR TITLE
Emit log line when respirate sleeps

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -28,5 +28,6 @@ clover_freeze
 loop do
   d.start_cohort
   next if d.wait_cohort > 0
-  sleep 5
+  duration_slept = sleep 5
+  Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
 end


### PR DESCRIPTION
Emit a log entry and the sleep duration each time the respirate process sleeps. This is useful for troubleshooting delays in strand executions.

Example log line:
`{"sleep_duration_sec":5,"message":"respirate finished sleep","time":"2024-06-18 12:30:18 +0200"}`