### PR TITLE
Preparations for Postgres metric export via prometheus

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -149,11 +149,21 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     refresh_walg_credentials
 
     when_initial_provisioning_set? do
-      hop_configure
+      hop_configure_prometheus
     end
 
     vm.sshable.cmd("sudo -u postgres pg_ctlcluster 16 main reload")
     hop_wait
+  end
+
+  label def configure_prometheus
+    web_config = <<CONFIG
+tls_server_config:
+  cert_file: /dat/16/data/server.crt
+  key_file: /dat/16/data/server.key
+CONFIG
+    vm.sshable.cmd("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: web_config)
+    hop_configure
   end
 
   label def configure

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -55,6 +55,11 @@ local   replication     all                                     peer
 host    replication     all             127.0.0.1/32            scram-sha-256
 host    replication     all             ::1/128                 scram-sha-256
 
+# Allow connections from localhost with ubi_monitoring OS user as
+# ubi_monitoring database user. This will be used by postgres_exporter
+# to scrape metrics and expose them to prometheus.
+local   all             ubi_monitoring                          peer
+
 # Allow connections from private subnet with SCRAM authentication
 #{private_subnets}
 

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -12,3 +12,4 @@ r "rm -rf /etc/postgresql/16"
 r "pg_createcluster 16 main --start --locale=C"
 
 r "sudo -u postgres psql -c 'CREATE ROLE ubi_replication WITH REPLICATION LOGIN'"
+r "sudo -u postgres psql -c 'CREATE ROLE ubi_monitoring WITH LOGIN IN ROLE pg_monitor'"

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.refresh_certificates }.to nap(5)
     end
 
-    it "pushes certificates to vm and hops to configure during initial provisioning" do
+    it "pushes certificates to vm and hops to configure_prometheus during initial provisioning" do
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/ca.crt > /dev/null", stdin: "root_cert_1\nroot_cert_2")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.crt > /dev/null", stdin: "server_cert")
       expect(sshable).to receive(:cmd).with("sudo -u postgres tee /dat/16/data/server.key > /dev/null", stdin: "server_cert_key")
@@ -247,7 +247,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:refresh_walg_credentials)
 
       expect(nx).to receive(:when_initial_provisioning_set?).and_yield
-      expect { nx.refresh_certificates }.to hop("configure")
+      expect { nx.refresh_certificates }.to hop("configure_prometheus")
     end
 
     it "hops to wait at times other than the initial provisioning" do
@@ -258,6 +258,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:cmd).with("sudo -u postgres pg_ctlcluster 16 main reload")
       expect(nx).to receive(:refresh_walg_credentials)
       expect { nx.refresh_certificates }.to hop("wait")
+    end
+  end
+
+  describe "#configure_prometheus" do
+    it "configures prometheus" do
+      expect(sshable).to receive(:cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
+      expect { nx.configure_prometheus }.to hop("configure")
     end
   end
 


### PR DESCRIPTION
**Configure TLS for prometheus web server**
Prometheus exposes a web server, which both provides a primitive UI and also
endpoints for scraping metrics. This commit configures the web server to use
TLS, which is done by providing a certificate and key file. We are reusing the
certificate we generated for the postgres as both postgres and prometheus
servers are exposed from the same URL, only the ports will differ.

**Add OS users to be used by the prometheus integration**
We added 2 new OS users; prometheus and ubi_monitoring, which are created while
generating the base PostgreSQL OS image. The prometheus user will be used to
run the prometheus server and node_exporter and the former means that it will
be exposed to outside. The ubi_monitoring user will be used to connect to the
database and scrape Postgres metrics. We are adding a special row for allowing
the ubi_monitoring OS user to connect to the database as the ubi_monitoring
database user. This user has pg_monitor rights, thus it is able to read/execute
various monitoring views and functions. I didn't want to allow prometheus to
connect to the database because it is exposed to the outside and potential
vulnerability on the prometheus server could lead to the database compromise
otherwise.