### PR TITLE
User-provided firewall rules for VMs and private subnets

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -158,6 +158,7 @@ module Validation
   end
 
   def self.validate_port_range(port_range)
+    return 0..65535 if port_range.nil?
     fail ValidationFailed.new({port_range: "Invalid port range"}) unless (match = port_range.match(ALLOWED_PORT_RANGE_PATTERN))
     start_port = match[1].to_i
 
@@ -170,7 +171,8 @@ module Validation
       fail ValidationFailed.new({port_range: "Port must be between 0 to 65535"}) unless (0..65535).cover?(start_port)
     end
 
-    end_port ? [start_port, end_port] : [start_port]
+    port_range = end_port ? [start_port, end_port] : [start_port]
+    port_range.first..port_range.last
   end
 
   def self.validate_request_body(request_body, required_keys, allowed_optional_keys = [])

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -145,6 +145,14 @@ module Validation
     end
   end
 
+  def self.validate_firewall_rules(firewall_rules)
+    fail ValidationFailed.new({firewall_rules: "Missing array of firewall rules."}) unless firewall_rules.is_a?(Array)
+    firewall_rules.map do |rule|
+      fail ValidationFailed.new({firewall_rules: "Invalid firewall rule."}) unless rule.is_a?(Hash) && rule.key?("cidr")
+      [validate_cidr(rule["cidr"]).to_s, validate_port_range(rule["port_range"])]
+    end
+  end
+
   def self.validate_cidr(cidr)
     if cidr.include?(".")
       NetAddr::IPv4Net.parse(cidr)

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -18,6 +18,16 @@ class Firewall < Sequel::Model
   dataset_module Pagination
   dataset_module Authorization::Dataset
 
+  def self.create_with_rules(name, description, rules)
+    DB.transaction do
+      firewall = Firewall.create_with_id(name: name, description: description)
+      rules.each do |rule|
+        firewall.insert_firewall_rule(rule[0], Sequel.pg_range(rule[1]))
+      end
+      firewall
+    end
+  end
+
   def path
     "/firewall/#{ubid}"
   end
@@ -60,4 +70,10 @@ class Firewall < Sequel::Model
 
     private_subnet.incr_update_firewall_rules if apply_firewalls
   end
+end
+
+module Firewall::Rules
+  ALLOW_ALL = [["0.0.0.0/0", 0..65535], ["::/0", 0..65535]]
+  ALLOW_SSH = [["0.0.0.0/0", 22..22], ["::/0", 22..22]]
+  ALLOW_NONE = []
 end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -31,7 +31,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         boot_image: postgres_resource.project.get_ff_postgresql_base_image || "postgres-ubuntu-2204",
         private_subnet_id: private_subnet_id,
         enable_ip4: true,
-        allow_only_ssh: true,
+        firewall_rules: Firewall::Rules::ALLOW_SSH,
         exclude_host_ids: exclude_host_ids
       )
 

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -51,7 +51,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true, skip_sync: skip_sync}],
       enable_ip4: true,
       arch: label_data["arch"],
-      allow_only_ssh: true,
+      firewall_rules: Firewall::Rules::ALLOW_SSH,
       swap_size_bytes: 4294963200 # ~4096MB, the same value with GitHub hosted runners
     )
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -75,7 +75,7 @@ class Prog::Vm::Nexus < Prog::Base
           raise "Given subnet doesn't exist with the id #{private_subnet_id}" unless subnet
           raise "Given subnet is not available in the given project" unless project.private_subnets.any? { |ps| ps.id == subnet.id }
         else
-          subnet_s = Prog::Vnet::SubnetNexus.assemble(project_id, name: "#{name}-subnet", location: location, allow_only_ssh: allow_only_ssh)
+          subnet_s = Prog::Vnet::SubnetNexus.assemble(project_id, name: "#{name}-subnet", location: location, firewall_rules: allow_only_ssh ? Firewall::Rules::ALLOW_SSH : Firewall::Rules::ALLOW_ALL)
           subnet = PrivateSubnet[subnet_s.id]
         end
         nic_s = Prog::Vnet::NicNexus.assemble(subnet.id, name: "#{name}-nic")

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -13,7 +13,7 @@ class Prog::Vm::Nexus < Prog::Base
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-hel1", boot_image: Config.default_boot_image_name,
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
-    enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil,
+    enable_ip4: false, pool_id: nil, arch: "x64", firewall_rules: Firewall::Rules::ALLOW_ALL, swap_size_bytes: nil,
     distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [])
 
     unless (project = Project[project_id])
@@ -75,7 +75,7 @@ class Prog::Vm::Nexus < Prog::Base
           raise "Given subnet doesn't exist with the id #{private_subnet_id}" unless subnet
           raise "Given subnet is not available in the given project" unless project.private_subnets.any? { |ps| ps.id == subnet.id }
         else
-          subnet_s = Prog::Vnet::SubnetNexus.assemble(project_id, name: "#{name}-subnet", location: location, firewall_rules: allow_only_ssh ? Firewall::Rules::ALLOW_SSH : Firewall::Rules::ALLOW_ALL)
+          subnet_s = Prog::Vnet::SubnetNexus.assemble(project_id, name: "#{name}-subnet", location: location, firewall_rules: firewall_rules)
           subnet = PrivateSubnet[subnet_s.id]
         end
         nic_s = Prog::Vnet::NicNexus.assemble(subnet.id, name: "#{name}-nic")

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -48,7 +48,7 @@ class Prog::Vm::VmPool < Prog::Base
       enable_ip4: true,
       pool_id: vm_pool.id,
       arch: vm_pool.arch,
-      allow_only_ssh: true,
+      firewall_rules: Firewall::Rules::ALLOW_SSH,
       swap_size_bytes: 4294963200
     )
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -4,7 +4,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
   semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
 
-  def self.assemble(project_id, name: nil, location: "hetzner-hel1", ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false)
+  def self.assemble(project_id, name: nil, location: "hetzner-hel1", ipv6_range: nil, ipv4_range: nil, firewall_rules: Firewall::Rules::ALLOW_ALL)
     unless (project = Project[project_id])
       fail "No existing project"
     end
@@ -20,10 +20,9 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     DB.transaction do
       ps = PrivateSubnet.create(name: name, location: location, net6: ipv6_range, net4: ipv4_range, state: "waiting") { _1.id = ubid.to_uuid }
       ps.associate_with_project(project)
-      port_range = allow_only_ssh ? 22..22 : 0..65535
       fw = Firewall.create_with_id(name: "#{name}-default")
       fw.associate_with_project(project)
-      ["0.0.0.0/0", "::/0"].each { |cidr| FirewallRule.create_with_id(firewall_id: fw.id, cidr: cidr, port_range: Sequel.pg_range(port_range)) }
+      firewall_rules.each { |cidr, port_range| FirewallRule.create_with_id(firewall_id: fw.id, cidr: cidr.to_s, port_range: Sequel.pg_range(port_range)) }
       fw.associate_with_private_subnet(ps, apply_firewalls: false)
 
       Strand.create(prog: "Vnet::SubnetNexus", label: "wait") { _1.id = ubid.to_uuid }

--- a/routes/api/project/firewall.rb
+++ b/routes/api/project/firewall.rb
@@ -18,12 +18,12 @@ class CloverApi
     r.post true do
       Authorization.authorize(@current_user.id, "Firewall:create", @project.id)
 
-      required_parameters = ["name"]
+      required_parameters = ["name", "firewall_rules"]
       allowed_optional_parameters = ["description"]
       request_body_params = Validation.validate_request_body(r.body.read, required_parameters, allowed_optional_parameters)
       Validation.validate_name(request_body_params["name"])
-
-      firewall = Firewall.create_with_id(name: request_body_params["name"], description: request_body_params["description"] || "")
+      rules = Validation.validate_firewall_rules(request_body_params["firewall_rules"])
+      firewall = Firewall.create_with_rules(request_body_params["name"], request_body_params["description"] || "", rules)
       firewall.associate_with_project(@project)
 
       Serializers::Firewall.serialize(firewall)

--- a/routes/api/project/firewall/firewall_rule.rb
+++ b/routes/api/project/firewall/firewall_rule.rb
@@ -11,15 +11,8 @@ class CloverApi
       request_body_params = Validation.validate_request_body(request.body.read, required_parameters, allowed_optional_parameters)
 
       parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
-      port_range = if request_body_params["port_range"].nil?
-        [0, 65535]
-      else
-        request_body_params["port_range"] = Validation.validate_port_range(request_body_params["port_range"])
-      end
-
-      pg_range = Sequel.pg_range(port_range.first..port_range.last)
-
-      firewall_rule = @firewall.insert_firewall_rule(parsed_cidr.to_s, pg_range)
+      port_range = Validation.validate_port_range(request_body_params["port_range"])
+      firewall_rule = @firewall.insert_firewall_rule(parsed_cidr.to_s, Sequel.pg_range(port_range))
 
       Serializers::FirewallRule.serialize(firewall_rule)
     end
@@ -35,6 +28,13 @@ class CloverApi
 
         response.status = 204
         r.halt
+      end
+
+      request.get true do
+        if firewall_rule
+          Authorization.authorize(@current_user.id, "Firewall:view", @firewall.id)
+          Serializers::FirewallRule.serialize(firewall_rule)
+        end
       end
     end
   end

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -30,11 +30,14 @@ class CloverApi
     r.is String do |ps_name|
       r.post true do
         Authorization.authorize(@current_user.id, "PrivateSubnet:create", @project.id)
+        request_body = r.body.read
+        firewall_rules = request_body.empty? ? Firewall::Rules::ALLOW_ALL : Validation.validate_firewall_rules(Validation.validate_request_body(request_body, ["firewall_rules"])["firewall_rules"])
 
         st = Prog::Vnet::SubnetNexus.assemble(
           @project.id,
           name: ps_name,
-          location: @location
+          location: @location,
+          firewall_rules: firewall_rules
         )
 
         Serializers::PrivateSubnet.serialize(st.subject)

--- a/routes/web/project/firewall.rb
+++ b/routes/web/project/firewall.rb
@@ -99,15 +99,13 @@ class CloverWeb
           Authorization.authorize(@current_user.id, "Firewall:edit", fw.id)
 
           port_range = if r.params["port_range"].empty?
-            [0, 65535]
+            0..65535
           else
             Validation.validate_port_range(r.params["port_range"])
           end
-
           parsed_cidr = Validation.validate_cidr(r.params["cidr"])
-          pg_range = Sequel.pg_range(port_range.first..port_range.last)
 
-          fw.insert_firewall_rule(parsed_cidr.to_s, pg_range)
+          fw.insert_firewall_rule(parsed_cidr.to_s, Sequel.pg_range(port_range))
           flash["notice"] = "Firewall rule is created"
 
           r.redirect "#{@project.path}#{fw.path}"

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -202,6 +202,26 @@ RSpec.describe Validation do
       end
     end
 
+    describe "#validate_firewall_rules" do
+      it "succeeds for valid input" do
+        expect(described_class.validate_firewall_rules([
+          {"cidr" => "0.0.0.0/32", "port_range" => "11111"},
+          {"cidr" => "0.0.0.1/32", "port_range" => "22..80"},
+          {"cidr" => "::/64"}
+        ])).to eq([
+          ["0.0.0.0/32", 11111..11111],
+          ["0.0.0.1/32", 22..80],
+          ["::/64", 0..65535]
+        ])
+      end
+
+      it "fails for invalid input" do
+        expect { described_class.validate_firewall_rules("not an array") }.to raise_error described_class::ValidationFailed, "Validation failed for following fields: firewall_rules"
+        expect { described_class.validate_firewall_rules(["not a hash"]) }.to raise_error described_class::ValidationFailed, "Validation failed for following fields: firewall_rules"
+        expect { described_class.validate_firewall_rules([{"no cidr" => ""}]) }.to raise_error described_class::ValidationFailed, "Validation failed for following fields: firewall_rules"
+      end
+    end
+
     describe "#validate_postgres_ha_type" do
       it "valid postgres ha_type" do
         [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC].each { |ha_type| expect { described_class.validate_postgres_ha_type(ha_type) }.not_to raise_error }

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -242,9 +242,9 @@ RSpec.describe Validation do
 
     describe "#validate_port_range" do
       it "valid port range" do
-        expect(described_class.validate_port_range("1234")).to eq([1234])
-        expect(described_class.validate_port_range("1234..1235")).to eq([1234, 1235])
-        expect(described_class.validate_port_range("1234..1234")).to eq([1234, 1234])
+        expect(described_class.validate_port_range("1234")).to eq(1234..1234)
+        expect(described_class.validate_port_range("1234..1235")).to eq(1234..1235)
+        expect(described_class.validate_port_range("1234..1234")).to eq(1234..1234)
       end
 
       it "invalid port range" do

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Clover, "firewall" do
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
+
+    it "not get" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
   end
 
   describe "authenticated" do
@@ -75,6 +82,18 @@ RSpec.describe Clover, "firewall" do
     it "firewall rule delete does not exist" do
       delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/fooubid"
       expect(last_response.status).to eq(204)
+    end
+
+    it "success get firewall rule" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "get does not exist" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/fooubid"
+
+      expect(last_response.status).to eq(404)
     end
   end
 end

--- a/spec/routes/api/project/firewall_spec.rb
+++ b/spec/routes/api/project/firewall_spec.rb
@@ -82,9 +82,25 @@ RSpec.describe Clover, "firewall" do
     it "success post" do
       post "/api/project/#{project.ubid}/firewall", {
         name: "foo-name",
-        description: "Firewall description"
+        description: "Firewall description",
+        firewall_rules: []
       }.to_json
 
+      expect(last_response.status).to eq(200)
+    end
+
+    it "can be created with rules" do
+      post "/api/project/#{project.ubid}/firewall", {
+        name: "foo-name",
+        description: "Firewall description",
+        firewall_rules: [
+          {cidr: "0.0.0.0/32", port_range: "11111"},
+          {cidr: "0.0.0.1/32", port_range: "22..80"},
+          {cidr: "0.0.0.3/32"}
+        ]
+      }.to_json
+
+      expect(Firewall.first.firewall_rules.count).to eq(3)
       expect(last_response.status).to eq(200)
     end
 

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -110,8 +110,20 @@ RSpec.describe Clover, "private_subnet" do
     end
 
     describe "create" do
-      it "success" do
+      it "success with default firewall rules" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-ps")
+      end
+
+      it "success with provided firewall rules" do
+        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {
+          firewall_rules: [
+            {cidr: "0.0.0.0/32", port_range: "11111"},
+            {cidr: "0.0.0.1/32", port_range: "22..80"}
+          ]
+        }.to_json
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-ps")


### PR DESCRIPTION
### API: Add GET for firewall rules
This commit adds a GET endpoint for firewall rules. It allows to retrieve a single firewall rule by its ID.

Example:
```sh
curl "https://api.ubicloud.com/.../firewall-rule/$rule_id" \
  -H "Authorization: Bearer $jwt_token"
```

### API: Allow to create firewall with rules
Previously, it was only possible to create a firewall without rules.

```sh
curl "https://.../firewall" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
      "name": "api-firewall"
}'
```

This commit adds the possibility to specify the firewall rules when creating a firewall.

```sh
curl "https://.../firewall" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
      "name": "api-firewall",
      "firewall_rules": [
       {"cidr": "10.0.0.0/24", "port_range": "22"},
       {"cidr": "0.0.0.0/0", "port_range": "5432..5434"},
       {"cidr": "10.1.2.3/32"} 
  ]}'
```

It's still possible to create a firewall without rules.

```sh
curl "https://.../firewall" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
      "name": "api-firewall",
      "firewall_rules": []
}'
```

### Allow to specify default firewall rules for private subnets
When a private subnet is created, it also creates a firewall under the hood. This firewall is created with a default set of rules that allow all traffic. This is not always desirable, so this commit allows to specify the default rules when creating a private subnet.

The call to create a private subnet without firewall rules still works and continues to create a default firewall with "allow all" rules.

```sh
curl "https:/private-subnet/subnet-name" \
  -X POST \
  -H "Authorization: Bearer $jwt_token"
```

But now it's also possible to specify the rules of the default firewall when creating the subnet, like this:

```sh
curl "https:/private-subnet/subnet-name" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
    "firewall_rules": [
       {"cidr": "10.0.0.0/24", "port_range": "22"},
       {"cidr": "0.0.0.0/0", "port_range": "5432..5434"},
       {"cidr": "10.1.2.3/32"} 
  ]}'
```
This creates a private subnet with a default firewall that denies all incoming traffic:

```sh
curl "https:/private-subnet/subnet-name" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
      "firewall_rules": []
}'
```
### Allow to specify default firewall rules for a vm
When a VM is created without a private network, a private subnet is created and the VM is attached to it. This subnet is created with a default firewall that allows all traffic. This commit allows to specify the firewall rules when creating a VM.

Omitting firewall rules will continue to create a default subnet with a firewall that allows all traffic.

```sh
curl "https://.../vm/vm-name" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
	    "public_key": "the public ssh key"
}'
```

But now it's possible to specify the firewall rules:

```sh
curl "https://.../vm/vm-name" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
    "public_key": "the public ssh key",
    "firewall_rules": [
       {"cidr": "10.0.0.0/24", "port_range": "22"},
       {"cidr": "0.0.0.0/0", "port_range": "5432..5434"},
       {"cidr": "10.1.2.3/32"} 
  ]}'
```

It is also still possible to specify the private subnet to attach the VM to, in which case no additional firewalls or firewall rules are created:

```sh
curl "https://.../vm/vm-name" \
  -X POST \
  -H "Authorization: Bearer $jwt_token" \
  -H "Content-Type: application/json" \
  -d '{
       "public_key": "the public ssh key",
       "private_subnet_id": "the ps id"
  }'
```
