### PR TITLE
Configure basic auth for prometheus web server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "stripe"
 gem "countries"
 gem "octokit"
 gem "argon2-kdf"
+gem "bcrypt"
 
 group :development do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
     ast (2.4.2)
     awrence (1.2.1)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x86_64-darwin)
@@ -317,6 +318,7 @@ PLATFORMS
 DEPENDENCIES
   argon2
   argon2-kdf
+  bcrypt
   bcrypt_pbkdf
   brakeman
   capybara

--- a/migrate/20240625_add_prometheus_password.rb
+++ b/migrate/20240625_add_prometheus_password.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:postgres_resource) do
+      add_column :prometheus_password, :text, collate: '"C"'
+    end
+  end
+end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -25,6 +25,7 @@ class PostgresResource < Sequel::Model
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password
+    enc.column :prometheus_password
     enc.column :root_cert_key_1
     enc.column :root_cert_key_2
     enc.column :server_cert_key

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -43,8 +43,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         project_id: project_id, location: location, name: name,
         target_vm_size: target_vm_size, target_storage_size_gib: target_storage_size_gib,
         superuser_password: superuser_password, ha_type: ha_type, parent_id: parent_id,
-        restore_target: restore_target,
-        hostname_version: "v2"
+        restore_target: restore_target, hostname_version: "v2",
+        prometheus_password: SecureRandom.urlsafe_base64(15)
       )
       postgres_resource.associate_with_project(project)
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "forwardable"
+require "bcrypt"
 
 require_relative "../../lib/util"
 
@@ -161,6 +162,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 tls_server_config:
   cert_file: /dat/16/data/server.crt
   key_file: /dat/16/data/server.key
+basic_auth_users:
+    #{postgres_server.resource.ubid}: #{BCrypt::Password.create(postgres_server.resource.prometheus_password)}
 CONFIG
     vm.sshable.cmd("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: web_config)
     hop_configure

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -28,11 +28,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   let(:resource) {
     instance_double(
       PostgresResource,
+      ubid: "pgresourceubid",
       root_cert_1: "root_cert_1",
       root_cert_2: "root_cert_2",
       server_cert: "server_cert",
       server_cert_key: "server_cert_key",
       superuser_password: "dummy-password",
+      prometheus_password: "dummy-password",
       representative_server: postgres_server
     )
   }


### PR DESCRIPTION
Prometheus exposes a web server that can be used to query metrics. This web
server accepts unauthenticated requests by default. This commit adds basic
authentication to the web server. We use the ubid of the PostgresResource as
the username and the password is a random string that is generated when the
resource is created.