### PR TITLE
Reduce respirate sleep time from 5s to 1s

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -28,6 +28,6 @@ clover_freeze
 loop do
   d.start_cohort
   next if d.wait_cohort > 0
-  duration_slept = sleep 5
+  duration_slept = sleep 1
   Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
 end


### PR DESCRIPTION
We have observed that respirate frequently enters the sleep state, particularly during periods of lower traffic. When new "work" arrives just after respirate begins sleeping, it can introduce a delay of up to 5 seconds. This delay is relatively long, so we are reducing the sleep time to 1 second.

During periods of high traffic, respirate does not sleep often, making the sleep time less relevant. Additionally, sleeping for extended periods during high traffic is undesirable as it increases the risk of falling behind.