### PR TITLE
Disable Octokit warnings in all environments

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -11,9 +11,11 @@ Bundler.setup
 
 require_relative "config"
 require "mail"
+require "warning"
 require "rack/unreloader"
 
 REPL = false unless defined? REPL
+Warning.ignore(/To use (retry|multipart) middleware with Faraday v2\.0\+, install `faraday-(retry|multipart)` gem/)
 
 Unreloader = Rack::Unreloader.new(reload: Config.development?, autoload: true) { Clover }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,6 @@ require "rspec"
 require "database_cleaner/sequel"
 require "logger"
 require "sequel/core"
-require "warning"
 require "webmock/rspec"
 
 # DatabaseCleaner assumes the usual DATABASE_URL, but the
@@ -41,7 +40,6 @@ DatabaseCleaner.url_allowlist = [
 
 Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser.*/)
 Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations.*/)
-Warning.ignore(/To use retry middleware with Faraday v2\.0\+, install `faraday-retry` gem/)
 Warning.ignore([:unused_var], /.*lib\/aws-sdk-s3\/endpoint_provider.*/)
 
 RSpec.configure do |config|


### PR DESCRIPTION
Octokit prints warnings upon loading if certain optional Faraday packages are not installed. We aren't planning to install these packages. We disabled these warnings using the `ruby-warning` package in tests. They become annoying in production, as they appear every time we initiate pry. They also introduce a new package warning [^1].

    ➜  ubicloud git:(main) heroku run ./bin/pry
    Running ./bin/pry on ⬢ ubicloud-console... up, run.1413 (Standard-1X)
    To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
    To use multipart middleware with Faraday v2.0+, install `faraday-multipart` gem; note: this is used by the ManageGHES client for uploading licenses
    [1] ⚠️  clover-production(main)>

There is no blocker to use `ruby-warning` in other environments too.

I have disabled these warnings in both production and testing. However, I have left them enabled in development as they also print some deprecation warnings, which we might find useful.

[^1]: https://github.com/octokit/octokit.rb/commit/7bc6dd50d9d82cd1ce1e025b8aaf34f9823846a2.
[^2]: https://github.com/octokit/octokit.rb/blob/10886bff72ce90621bbfa7863ce340991cef0851/lib/octokit/warnable.rb#L13.