### PR TITLE
Allow creation of subnet with existing firewall

### DIFF
--- a/routes/api/project/firewall/firewall_rule.rb
+++ b/routes/api/project/firewall/firewall_rule.rb
@@ -36,6 +36,13 @@ class CloverApi
         response.status = 204
         r.halt
       end
+
+      request.get true do
+        if firewall_rule
+          Authorization.authorize(@current_user.id, "Firewall:view", @firewall.id)
+          Serializers::FirewallRule.serialize(firewall_rule)
+        end
+      end
     end
   end
 end

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Clover, "firewall" do
       expect(last_response.status).to eq(401)
       expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
     end
+
+    it "not get" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+
+      expect(last_response.status).to eq(401)
+      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+    end
   end
 
   describe "authenticated" do
@@ -75,6 +82,18 @@ RSpec.describe Clover, "firewall" do
     it "firewall rule delete does not exist" do
       delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/fooubid"
       expect(last_response.status).to eq(204)
+    end
+
+    it "success get firewall rule" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it "get does not exist" do
+      get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/fooubid"
+
+      expect(last_response.status).to eq(404)
     end
   end
 end


### PR DESCRIPTION
### API: Add GET for firewall rules
This commit adds a GET endpoint for firewall rules. It allows to retrieve a single firewall rule by its ID.

Example:
```sh
curl "https://api.ubicloud.com/.../firewall-rule/$rule_id" \
  -H "Authorization: Bearer $jwt_token"
```

### Assemble private subnet with an existing firewall

When creating a private subnet, a new firewall is typically generated and linked to the subnet. This commit allows for the option of specifying a firewall_id. By providing an existing firewall_id, no new firewall will be created. Instead, the specified existing firewall will be attached to the newly created private subnet.


### API: Add firewall_id parameter to private subnet creation

This commit introduces an optional firewall_id parameter for private subnet creation. This allows users to create a private subnet attached to an existing firewall, rather than attached to a newly created default firewall.

---

This set of changes allows our Terraform provider, which is currently in development, to create a VM with custom firewall rules. Example:

```tf
terraform {
  required_providers {
    ubicloud = {
      source = "registry.terraform.io/hashicorp/ubicloud"
    }
  }
}

variable "project_id" {
  description = "Ubicloud project"
  type        = string
  default     = "pj01qy4sty1j7nycv8hfqmgy6t"
}

variable "ssh_key" {
  description = "Public SSH key"
  type        = string
  default     = "theactualpublicsshkeyvalue"
}

variable "location" {
  description = "Ubicloud location/region to create resources in."
  type        = string
  default     = "eu-central-h1"
}

resource "ubicloud_firewall" "ssh" {
  project_id  = var.project_id
  name        = "test-firewall"
  description = "description of firewall"
}

resource "ubicloud_firewall_rule" "ssh" {
  project_id  = var.project_id
  firewall_id = ubicloud_firewall.ssh.id
  cidr        = "0.0.0.0/0"
  port_range  = "22..22"
}

resource "ubicloud_private_subnet" "test" {
  project_id  = var.project_id
  location    = var.location
  firewall_id = ubicloud_firewall.ssh.id
  name        = "test-subnet"
}

resource "ubicloud_vm" "test" {
  project_id        = var.project_id
  location          = var.location
  public_key        = var.ssh_key
  private_subnet_id = ubicloud_private_subnet.test.id
  name              = "vm-test"
  unix_user         = "ubi"
  size              = "standard-4"
  enable_ip4        = "true"
  boot_image        = "ubuntu-jammy"
}

output "test_vm" {
  value = ubicloud_vm.test
}
```