### PR TITLE
Add vm family to capacity pages

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -188,14 +188,14 @@ class Prog::Vm::Nexus < Prog::Base
 
       incr_waiting_for_capacity unless vm.waiting_for_capacity_set?
       queued_vms = queued_vms.all
-      Prog::PageNexus.assemble("No capacity left at #{vm.location} for #{vm.arch}", queued_vms.first(25).map(&:ubid), "NoCapacity", vm.location, vm.arch)
-      Clog.emit("No capacity left") { {lack_of_capacity: {location: vm.location, arch: vm.arch, queue_size: queued_vms.count}} }
+      Prog::PageNexus.assemble("No capacity left at #{vm.location} for #{vm.family} family of #{vm.arch}", queued_vms.first(25).map(&:ubid), "NoCapacity", vm.location, vm.arch, vm.family)
+      Clog.emit("No capacity left") { {lack_of_capacity: {location: vm.location, arch: vm.arch, family: vm.family, queue_size: queued_vms.count}} }
 
       nap 30
     end
 
     decr_waiting_for_capacity
-    if (page = Page.from_tag_parts("NoCapacity", vm.location, vm.arch)) && page.created_at < Time.now - 15 * 60 && queued_vms.count <= 1
+    if (page = Page.from_tag_parts("NoCapacity", vm.location, vm.arch, vm.family)) && page.created_at < Time.now - 15 * 60 && queued_vms.count <= 1
       page.incr_resolve
     end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nx).to receive(:incr_waiting_for_capacity)
       expect { nx.start }.to nap(30)
       expect(Page.active.count).to eq(1)
-      expect(Page.from_tag_parts("NoCapacity", vm.location, vm.arch)).not_to be_nil
+      expect(Page.from_tag_parts("NoCapacity", vm.location, vm.arch, vm.family)).not_to be_nil
 
       # Second run does not generate another page
       expect(vm).to receive(:waiting_for_capacity_set?).and_return(true)


### PR DESCRIPTION
We've introduced a new VM family called `standard-gpu`. However, when we get a capacity page, it's unclear whether it's `standard` or `standard-gpu`. This commit adds the VM family to the capacity pages.