### PR TITLE
Replace the old gpu label with ubicloud-gpu

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -30,8 +30,8 @@
 - { name: ubicloud-standard-8-arm-ubuntu-2004,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-16-arm-ubuntu-2004, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2004,     location: github-runners }
 - { name: ubicloud-standard-30-arm-ubuntu-2004, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2004,     location: github-runners }
-- { name: ubicloud-gpu-standard-1-latest,    vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204, location: github-runners, gpu: true  }
-# Deprecated: Remove old arm64 labels once all customers have migrated to new labels.
+- { name: ubicloud-gpu,                         vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204, location: github-runners, gpu: true  }
+# Deprecated: Remove old labels once all customers have migrated to new labels.
 - { name: ubicloud-standard-2-ubuntu-2204-arm,  vm_size: standard-2,  arch: arm64,  storage_size_gib: 86,  boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-4-ubuntu-2204-arm,  vm_size: standard-4,  arch: arm64,  storage_size_gib: 150, boot_image: github-ubuntu-2204, location: github-runners }
 - { name: ubicloud-standard-8-ubuntu-2204-arm,  vm_size: standard-8,  arch: arm64,  storage_size_gib: 200, boot_image: github-ubuntu-2204, location: github-runners }
@@ -40,3 +40,4 @@
 - { name: ubicloud-standard-4-ubuntu-2004-arm,  vm_size: standard-4,  arch: arm64,  storage_size_gib: 150, boot_image: github-ubuntu-2004, location: github-runners }
 - { name: ubicloud-standard-8-ubuntu-2004-arm,  vm_size: standard-8,  arch: arm64,  storage_size_gib: 200, boot_image: github-ubuntu-2004, location: github-runners }
 - { name: ubicloud-standard-16-ubuntu-2004-arm, vm_size: standard-16, arch: arm64,  storage_size_gib: 300, boot_image: github-ubuntu-2004, location: github-runners }
+- { name: ubicloud-gpu-standard-1-latest,       vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204, location: github-runners, gpu: true  }

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "uses separate billing rate for gpu runners" do
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:label).and_return("ubicloud-gpu-standard-1-latest").at_least(:once)
+      expect(github_runner).to receive(:label).and_return("ubicloud-gpu").at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       nx.update_billing_record


### PR DESCRIPTION
The old label was `ubicloud-gpu-standard-1-latest` which is found to be ugly and confusing. We add a new label that does the same job.