### PR TITLE
Fix Ruby setup in arm64 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.runs-on == 'ubicloud-arm'
       uses: actions/cache@v4
       with:
-        path: /opt/hostedtoolcache/Ruby
+        path: ${{ env.RUNNER_TOOL_CACHE }}/Ruby
         key: ${{ matrix.runs-on }}-ruby-${{ hashFiles('.tool-versions') }}
 
     - name: Install ruby for ARM runners if not cached
@@ -54,9 +54,9 @@ jobs:
         git clone https://github.com/rbenv/ruby-build.git
         sudo ./ruby-build/install.sh
         RUBY_VERSION="$(grep -E '^ruby ' .tool-versions | cut -d' ' -f2)"
-        sudo ruby-build "$RUBY_VERSION" /opt/hostedtoolcache/Ruby/$RUBY_VERSION/arm64
-        sudo chown -R runner:runner /opt/hostedtoolcache/Ruby
-        touch /opt/hostedtoolcache/Ruby/$RUBY_VERSION/arm64.complete
+        sudo ruby-build "$RUBY_VERSION" $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64
+        sudo chown -R runner:runner $RUNNER_TOOL_CACHE/Ruby
+        touch $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64.complete
         rm -rf ruby-build
 
     - name: Set up Ruby


### PR DESCRIPTION
Since setup-ruby doesn't support arm64 by default, we install Ruby manually for arm64. setup-ruby started to check $RUNNER_TOOL_CACHE instead of `/opt/hostedtoolcache` recently, and fails with the following error:

    In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build
    You can take inspiration from this workflow for more details: https://github.com/ruby/ruby-builder/blob/master/.github/workflows/build.yml
    $ ruby-build 3.2.4 /home/runner/work/_tool/Ruby/3.2.4/arm64
    Once that completes successfully, mark it as complete with:
    $ touch /home/runner/work/_tool/Ruby/3.2.4/arm64.complete
    It is your responsibility to ensure installing Ruby like that is not done in parallel.