### PR TITLE
Fix CI workflow run conclusion when a job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   ruby-ci:
     strategy:
+      fail-fast: false
       matrix:
         runs-on: [ubicloud, ubicloud-arm]
-    continue-on-error: true
     name: Ruby CI - ${{matrix.runs-on}}
     runs-on: ${{matrix.runs-on}}
 


### PR DESCRIPTION
We run our CI on both x64 and arm64. When a job fails, GitHub automatically cancels all remaining jobs. Previously, we wanted to keep the unaffected job running to obtain its results, so we added the `continue-on-error: true` config [^1]. However, this led to a misleading situation where, even if a job failed, the overall workflow run status was marked as successful. This wasn't our intention, as it made it appear as all workflow runs were successful in the GitHub UI. To fix this, we can use the `fail-fast: false` config [^2], which only disables this behavior and doesn't effect the workflow run conclusion. Therefore, it's better to use the `fail-fast` configuration instead of `continue-on-error`.

[^1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error

[^2]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast