### PR TITLE
Fix Ruby cache in arm64 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.runs-on == 'ubicloud-arm'
       uses: actions/cache@v4
       with:
-        path: ${{ env.RUNNER_TOOL_CACHE }}/Ruby
+        path: ${{ runner.tool_cache }}/Ruby
         key: ${{ matrix.runs-on }}-ruby-${{ hashFiles('.tool-versions') }}
 
     - name: Install ruby for ARM runners if not cached


### PR DESCRIPTION
I updated the cached Ruby path for arm64 runners from a hardcoded path to the $RUNNER_TOOL_CACHE environment variable at 69353ca. It appears this variable isn't set in the reusable workflows. Therefore, we retrieve the value from the `runner` context [^1] instead of directly from the environment variable.

[^1]: https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context