### PR TITLE
Add rspec helper for API error responses

### DIFF
--- a/spec/routes/api/auth_spec.rb
+++ b/spec/routes/api/auth_spec.rb
@@ -7,32 +7,26 @@ RSpec.describe Clover, "auth" do
 
   it "wrong email" do
     post "/api/login?login=wrong_mail&password=#{TEST_USER_PASSWORD}", nil, {"CONTENT_TYPE" => "application/json"}
-    expect(last_response.status).to eq(401)
-    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("There was an error logging in")
-    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidCredentials")
+
+    expect(last_response).to have_api_error(401, "There was an error logging in")
   end
 
   it "wrong password" do
     post "/api/login?login=#{TEST_USER_EMAIL}&password=wrongpassword", nil, {"CONTENT_TYPE" => "application/json"}
-    expect(last_response.status).to eq(401)
-    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("There was an error logging in")
-    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidCredentials")
+
+    expect(last_response).to have_api_error(401, "There was an error logging in")
   end
 
   it "wrong jwt" do
     header "Authorization", "Bearer wrongjwt"
     get "/api/project"
 
-    expect(last_response.status).to eq(400)
-    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("invalid JWT format or claim in Authorization header")
-    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "no login" do
     get "/api/project"
 
-    expect(last_response.status).to eq(401)
-    expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
-    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("LoginRequired")
+    expect(last_response).to have_api_error(401, "Please login to continue")
   end
 end

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -15,22 +15,19 @@ RSpec.describe Clover, "firewall" do
     it "not post" do
       post "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 
@@ -54,7 +51,7 @@ RSpec.describe Clover, "firewall" do
         port_range: "80..5432"
       }.to_json
 
-      expect(last_response.status).to eq(400)
+      expect(last_response).to have_api_error(400, "cidr and port_range and firewall_id is already taken")
     end
 
     it "firewall rule no port range" do
@@ -93,7 +90,7 @@ RSpec.describe Clover, "firewall" do
     it "get does not exist" do
       get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/fooubid"
 
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_api_error(404)
     end
   end
 end

--- a/spec/routes/api/project/firewall_spec.rb
+++ b/spec/routes/api/project/firewall_spec.rb
@@ -13,43 +13,37 @@ RSpec.describe Clover, "firewall" do
     it "not list" do
       get "/api/project/#{project.ubid}/firewall"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not create" do
       post "/api/project/#{project.ubid}/firewall"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/firewall/#{firewall.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not associate" do
       get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/attach-subnet"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not dissociate" do
       get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/detach-subnet"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 
@@ -76,7 +70,7 @@ RSpec.describe Clover, "firewall" do
     it "get does not exist" do
       get "/api/project/#{project.ubid}/firewall/foo_ubid"
 
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
     end
 
     it "success post" do
@@ -119,7 +113,7 @@ RSpec.describe Clover, "firewall" do
         private_subnet_id: "fooubid"
       }.to_json
 
-      expect(last_response.status).to eq(400)
+      expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id")
     end
 
     it "detach from subnet" do
@@ -139,7 +133,7 @@ RSpec.describe Clover, "firewall" do
         private_subnet_id: "fooubid"
       }.to_json
 
-      expect(last_response.status).to eq(400)
+      expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id")
     end
 
     it "attach and detach" do

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -38,92 +38,79 @@ RSpec.describe Clover, "postgres" do
     it "not location list" do
       get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not create" do
       post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/postgres_name"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete ubid" do
       delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get ubid" do
       get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not create firewall rule" do
       post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete firewall rule" do
       delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not restore" do
       post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not restore ubid" do
       post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/restore"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not reset super user password" do
       post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not reset super user password ubid" do
       post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/reset-superuser-password"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not failover" do
       post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/failover"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 
@@ -182,8 +169,7 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["location"]).to eq("Given location is not a valid postgres location. Available locations: [\"eu-central-h1\"]")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Given location is not a valid postgres location. Available locations: [\"eu-central-h1\"]"})
       end
 
       it "invalid name" do
@@ -192,15 +178,13 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["name"]).to eq("Name must only contain lowercase letters, numbers, and hyphens and have max length 63.")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: name", {"name" => "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."})
       end
 
       it "invalid body" do
         post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", "invalid_body"
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Request body isn't a valid JSON object.")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body isn't a valid JSON object."})
       end
 
       it "missing required key" do
@@ -208,8 +192,7 @@ RSpec.describe Clover, "postgres" do
           unix_user: "ha_type"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Request body must include required parameters: size")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body must include required parameters: size"})
       end
 
       it "non allowed key" do
@@ -218,8 +201,7 @@ RSpec.describe Clover, "postgres" do
           foo_key: "foo_val"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: size, storage_size, ha_type")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Only following parameters are allowed: size, storage_size, ha_type"})
       end
 
       it "firewall-rule" do
@@ -243,8 +225,7 @@ RSpec.describe Clover, "postgres" do
           cidr: "0.0.0"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["cidr"]).to eq("Invalid CIDR")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: cidr", {"cidr" => "Invalid CIDR"})
       end
 
       it "restore" do
@@ -269,7 +250,7 @@ RSpec.describe Clover, "postgres" do
           restore_target: Time.now.utc
         }.to_json
 
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: restore_target")
       end
 
       it "reset password" do
@@ -287,8 +268,7 @@ RSpec.describe Clover, "postgres" do
           password: "DummyPassword123"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Superuser password cannot be updated during restore!")
+        expect(last_response).to have_api_error(400, "Superuser password cannot be updated during restore!")
       end
 
       it "invalid password" do
@@ -296,7 +276,7 @@ RSpec.describe Clover, "postgres" do
           password: "dummy"
         }.to_json
 
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: password")
       end
 
       it "reset password ubid" do
@@ -323,8 +303,7 @@ RSpec.describe Clover, "postgres" do
 
         post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/failover"
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Failover cannot be triggered during restore!")
+        expect(last_response).to have_api_error(400, "Failover cannot be triggered during restore!")
       end
 
       it "failover no ff base image" do
@@ -333,8 +312,7 @@ RSpec.describe Clover, "postgres" do
 
         post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/failover"
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Failover cannot be triggered for this resource!")
+        expect(last_response).to have_api_error(400, "Failover cannot be triggered for this resource!")
       end
 
       it "failover no standby" do
@@ -345,8 +323,7 @@ RSpec.describe Clover, "postgres" do
 
         post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/id/#{pg.ubid}/failover"
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("There is not a suitable standby server to failover!")
+        expect(last_response).to have_api_error(400, "There is not a suitable standby server to failover!")
       end
 
       it "invalid payment" do
@@ -357,8 +334,7 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Validation failed for following fields: billing_info")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: billing_info")
       end
     end
 
@@ -380,8 +356,7 @@ RSpec.describe Clover, "postgres" do
       it "not found" do
         get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/not-exists-pg"
 
-        expect(last_response.status).to eq(404)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "show firewall" do

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -17,43 +17,37 @@ RSpec.describe Clover, "private_subnet" do
     it "not location list" do
       get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not create" do
       post "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete ubid" do
       delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get ubid" do
       get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 
@@ -120,14 +114,13 @@ RSpec.describe Clover, "private_subnet" do
       it "invalid name" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/invalid_name"
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["name"]).to eq("Name must only contain lowercase letters, numbers, and hyphens and have max length 63.")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: name", {"name" => "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."})
       end
 
       it "not authorized" do
         post "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/foo_subnet"
 
-        expect(last_response.status).to eq(403)
+        expect(last_response).to have_api_error(403)
       end
 
       it "with valid firewall" do
@@ -143,8 +136,7 @@ RSpec.describe Clover, "private_subnet" do
       it "with invalid firewall id" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: "invalidid"}.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["firewall_id"]).to eq("Firewall with id \"invalidid\" not found")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: firewall_id", {"firewall_id" => "Firewall with id \"invalidid\" not found"})
       end
 
       it "with empty body" do
@@ -173,14 +165,13 @@ RSpec.describe Clover, "private_subnet" do
       it "not found" do
         get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/not-exists-ps"
 
-        expect(last_response.status).to eq(404)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "not authorized" do
         get "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
 
-        expect(last_response.status).to eq(403)
+        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end
     end
 
@@ -218,7 +209,7 @@ RSpec.describe Clover, "private_subnet" do
 
         delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
-        expect(last_response.status).to eq(409)
+        expect(last_response).to have_api_error(409, "Private subnet 'dummy-ps-1' has VMs attached, first, delete them.")
       end
 
       it "not exist" do
@@ -231,7 +222,7 @@ RSpec.describe Clover, "private_subnet" do
       it "not authorized" do
         delete "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
 
-        expect(last_response.status).to eq(403)
+        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end
     end
   end

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -17,43 +17,37 @@ RSpec.describe Clover, "vm" do
     it "not location list" do
       get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not create" do
       post "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
       delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete ubid" do
       delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
       get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get ubid" do
       get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/#{vm.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 
@@ -111,7 +105,7 @@ RSpec.describe Clover, "vm" do
       it "ubid not exist" do
         get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/id/foo_ubid"
 
-        expect(last_response.status).to eq(404)
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
     end
 
@@ -193,8 +187,7 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["boot_image"]).to eq("\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-noble\", \"ubuntu-jammy\", \"almalinux-9\", \"almalinux-8\"]")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: boot_image", {"boot_image" => "\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"ubuntu-noble\", \"ubuntu-jammy\", \"almalinux-9\", \"almalinux-8\"]"})
       end
 
       it "invalid vm size" do
@@ -205,8 +198,7 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["size"]).to eq("\"standard-gpu-6\" is not a valid virtual machine size. Available sizes: [\"standard-2\", \"standard-4\", \"standard-8\", \"standard-16\", \"standard-30\", \"standard-60\"]")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: size", {"size" => "\"standard-gpu-6\" is not a valid virtual machine size. Available sizes: [\"standard-2\", \"standard-4\", \"standard-8\", \"standard-16\", \"standard-30\", \"standard-60\"]"})
       end
 
       it "success without vm_size" do
@@ -230,8 +222,7 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["private_subnet_id"]).to eq("Private subnet with the given id \"invalid-ubid\" is not found in the location \"eu-north-h1\"")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id", {"private_subnet_id" => "Private subnet with the given id \"invalid-ubid\" is not found in the location \"eu-north-h1\""})
       end
 
       it "invalid ps id in other location" do
@@ -245,8 +236,7 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["private_subnet_id"]).to eq("Private subnet with the given id \"#{ps_id}\" is not found in the location \"eu-north-h1\"")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id", {"private_subnet_id" => "Private subnet with the given id \"#{ps_id}\" is not found in the location \"eu-north-h1\""})
       end
 
       it "invalid name" do
@@ -257,8 +247,7 @@ RSpec.describe Clover, "vm" do
           boot_image: "ubuntu-jammy"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["name"]).to eq("Name must only contain lowercase letters, numbers, and hyphens and have max length 63.")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: name", {"name" => "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."})
       end
 
       it "invalid payment method" do
@@ -272,15 +261,13 @@ RSpec.describe Clover, "vm" do
           boot_image: "ubuntu-jammy"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["billing_info"]).to eq("Project doesn't have valid billing information")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: billing_info", {"billing_info" => "Project doesn't have valid billing information"})
       end
 
       it "invalid body" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", "invalid_body"
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Request body isn't a valid JSON object.")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body isn't a valid JSON object."})
       end
 
       it "missing required key" do
@@ -288,8 +275,7 @@ RSpec.describe Clover, "vm" do
           unix_user: "ubi"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Request body must include required parameters: public_key")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body must include required parameters: public_key"})
       end
 
       it "non allowed key" do
@@ -298,8 +284,7 @@ RSpec.describe Clover, "vm" do
           foo_key: "foo_val"
         }.to_json
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["details"]["body"]).to eq("Only following parameters are allowed: public_key, size, storage_size, unix_user, boot_image, enable_ip4, private_subnet_id")
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Only following parameters are allowed: public_key, size, storage_size, unix_user, boot_image, enable_ip4, private_subnet_id"})
       end
     end
 
@@ -321,8 +306,7 @@ RSpec.describe Clover, "vm" do
       it "not found" do
         get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/not-exists-vm"
 
-        expect(last_response.status).to eq(404)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
     end
 

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Clover, "vm" do
     it "not list" do
       get "/api/project/#{project.ubid}/pg"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 

--- a/spec/routes/api/project/private_subnet_spec.rb
+++ b/spec/routes/api/project/private_subnet_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Clover, "private_subnet" do
     it "not list" do
       get "/api/project/#{project.ubid}/private-subnet"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 

--- a/spec/routes/api/project/vm_spec.rb
+++ b/spec/routes/api/project/vm_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Clover, "vm" do
     it "not list" do
       get "/api/project/#{project.ubid}/vm"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -11,22 +11,19 @@ RSpec.describe Clover, "vm" do
     it "not list" do
       get "/api/project"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not create" do
       post "/api/project"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
       delete "api/project/#{project.ubid}"
 
-      expect(last_response.status).to eq(401)
-      expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Please login to continue")
+      expect(last_response).to have_api_error(401, "Please login to continue")
     end
   end
 
@@ -59,14 +56,14 @@ RSpec.describe Clover, "vm" do
         project
         get "/api/project?order_column=name"
 
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: order_column")
       end
 
       it "invalid id" do
         project
         get "/api/project?start_after=invalid_id"
 
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: start_after")
       end
     end
 
@@ -83,7 +80,7 @@ RSpec.describe Clover, "vm" do
       it "missing parameter" do
         post "/api/project", {}.to_json
 
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
       end
     end
 
@@ -109,8 +106,7 @@ RSpec.describe Clover, "vm" do
 
         delete "api/project/#{project.ubid}"
 
-        expect(last_response.status).to eq(409)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("'#{project.name}' project has some resources. Delete all related resources first.")
+        expect(last_response).to have_api_error(409, "'#{project.name}' project has some resources. Delete all related resources first.")
       end
 
       it "not authorized" do
@@ -118,8 +114,7 @@ RSpec.describe Clover, "vm" do
         p = u.create_project_with_default_policy("project-1")
         delete "api/project/#{p.ubid}"
 
-        expect(last_response.status).to eq(403)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, you don't have permission to continue with this request.")
+        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end
     end
 
@@ -134,8 +129,7 @@ RSpec.describe Clover, "vm" do
       it "not found" do
         get "/api/project/08s56d4kaj94xsmrnf5v5m3mav"
 
-        expect(last_response.status).to eq(404)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, we couldn’t find the resource you’re looking for.")
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "not authorized" do
@@ -143,8 +137,7 @@ RSpec.describe Clover, "vm" do
         p = u.create_project_with_default_policy("project-1")
         get "/api/project/#{p.ubid}"
 
-        expect(last_response.status).to eq(403)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Sorry, you don't have permission to continue with this request.")
+        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end
     end
   end

--- a/spec/routes/runtime/auth_spec.rb
+++ b/spec/routes/runtime/auth_spec.rb
@@ -6,16 +6,14 @@ RSpec.describe Clover, "auth" do
   it "no jwt token" do
     get "/runtime"
 
-    expect(last_response.status).to eq(400)
-    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "wrong jwt token" do
     header "Authorization", "Bearer wrongjwt"
     get "/runtime"
 
-    expect(last_response.status).to eq(400)
-    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "valid jwt token but no active vm" do
@@ -23,8 +21,7 @@ RSpec.describe Clover, "auth" do
     header "Authorization", "Bearer #{vm.runtime_token}"
     get "/runtime"
 
-    expect(last_response.status).to eq(400)
-    expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "valid jwt token with an active vm" do

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -13,16 +13,14 @@ RSpec.describe Clover, "github" do
     it "vm has no runner" do
       get "/runtime/github"
 
-      expect(last_response.status).to eq(400)
-      expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+      expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
     end
 
     it "vm has runner but no repository" do
       GithubRunner.create_with_id(vm_id: vm.id, repository_name: "test", label: "ubicloud")
       get "/runtime/github"
 
-      expect(last_response.status).to eq(400)
-      expect(JSON.parse(last_response.body)["error"]["type"]).to eq("InvalidRequest")
+      expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
     end
 
     it "vm has runner and repository" do
@@ -43,7 +41,7 @@ RSpec.describe Clover, "github" do
 
     post "/runtime/github/caches"
 
-    expect(last_response.status).to eq(400)
+    expect(last_response).to have_api_error(400, "Wrong parameters")
   end
 
   describe "cache endpoints" do
@@ -68,8 +66,7 @@ RSpec.describe Clover, "github" do
           params = {key: key, version: version, cacheSize: size}.compact
           post "/runtime/github/caches", params
 
-          expect(last_response.status).to eq(400)
-          expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Wrong parameters")
+          expect(last_response).to have_api_error(400, "Wrong parameters")
         end
       end
 
@@ -77,15 +74,13 @@ RSpec.describe Clover, "github" do
         runner.update(workflow_job: nil)
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100}
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("No workflow job data available")
+        expect(last_response).to have_api_error(400, "No workflow job data available")
       end
 
       it "fails if cache is bigger than 10GB" do
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 11 * 1024 * 1024 * 1024}
 
-        expect(last_response.status).to eq(400)
-        expect(JSON.parse(last_response.body)["error"]["message"]).to eq("The cache size is over the 10GB limit")
+        expect(last_response).to have_api_error(400, "The cache size is over the 10GB limit")
       end
 
       it "returns presigned urls and upload id for the reserved cache" do
@@ -118,8 +113,7 @@ RSpec.describe Clover, "github" do
           params = {etags: etags, uploadId: upload_id, size: size}.compact
           post "/runtime/github/caches/commit", params
 
-          expect(last_response.status).to eq(400)
-          expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Wrong parameters")
+          expect(last_response).to have_api_error(400, "Wrong parameters")
         end
       end
 
@@ -134,7 +128,7 @@ RSpec.describe Clover, "github" do
         expect(blob_storage_client).to receive(:complete_multipart_upload).and_raise(Aws::S3::Errors::NoSuchUpload.new("error", "error"))
         post "/runtime/github/caches/commit", {etags: ["etag-1", "etag-2"], uploadId: "upload-id", size: 100}
 
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_api_error(400, "Wrong parameters")
       end
 
       it "completes multipart upload" do
@@ -159,8 +153,7 @@ RSpec.describe Clover, "github" do
           params = {keys: keys, version: version}.compact
           get "/runtime/github/cache", params
 
-          expect(last_response.status).to eq(400)
-          expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Wrong parameters")
+          expect(last_response).to have_api_error(400, "Wrong parameters")
         end
       end
 


### PR DESCRIPTION
API error responses are always in the same format, so we can add a helper to expect them in our tests.