### PR TITLE
Load Balancer Backend

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -159,4 +159,8 @@ module Config
 
   # e2e
   optional :e2e_github_installation_id, string
+
+  # Load Balancer
+  optional :load_balancer_service_project_id, string
+  optional :load_balancer_service_hostname, string
 end

--- a/migrate/20240701_load_balancer.rb
+++ b/migrate/20240701_load_balancer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_enum(:lb_algorithm, %w[round_robin hash_based])
+
+    create_table(:load_balancer) do
+      column :id, :uuid, primary_key: true
+      column :name, :text, null: false
+      column :algorithm, :lb_algorithm, null: false, default: "round_robin"
+      column :src_port, :integer, null: false
+      column :dst_port, :integer, null: false
+      foreign_key :private_subnet_id, :private_subnet, type: :uuid, null: false
+    end
+
+    create_table(:load_balancers_vms) do
+      foreign_key :load_balancer_id, :load_balancer, type: :uuid, null: false
+      foreign_key :vm_id, :vm, type: :uuid, null: false, unique: true
+      primary_key [:load_balancer_id, :vm_id]
+    end
+  end
+end

--- a/migrate/20240702_load_balancer_health_probes.rb
+++ b/migrate/20240702_load_balancer_health_probes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_enum(:lb_node_state, %w[up down evacuating])
+
+    alter_table(:load_balancer) do
+      add_column :health_check_endpoint, :text, collate: '"C"', null: false
+      add_column :health_check_interval, :integer, null: false, default: 10
+      add_column :health_check_timeout, :integer, null: false, default: 5
+      add_column :health_check_up_threshold, :integer, null: false, default: 5
+      add_column :health_check_down_threshold, :integer, null: false, default: 3
+      add_constraint(:health_check_up_threshold_gt_0) { health_check_up_threshold > 0 }
+      add_constraint(:health_check_down_threshold_gt_0) { health_check_down_threshold > 0 }
+      add_constraint(:health_check_timeout_gt_0) { health_check_timeout > 0 }
+      add_constraint(:health_check_interval_gt_0) { health_check_interval > 0 }
+      add_constraint(:health_check_interval_lt_600) { health_check_interval < 600 }
+      add_constraint(:health_check_timeout_lt_health_check_interval) { health_check_timeout <= health_check_interval }
+    end
+
+    alter_table(:load_balancers_vms) do
+      add_column :state, :lb_node_state, null: false, default: "down"
+      add_column :state_counter, Integer, null: false, default: 0
+    end
+  end
+end

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -1,0 +1,37 @@
+#  frozen_string_literal: true
+
+require_relative "../model"
+
+class LoadBalancer < Sequel::Model
+  many_to_many :vms
+  one_to_one :strand, key: :id
+  many_to_one :private_subnet
+  one_to_many :projects, through: :private_subnet
+  one_to_many :load_balancers_vms, key: :load_balancer_id, class: LoadBalancersVms
+
+  plugin :association_dependencies, load_balancers_vms: :destroy
+
+  include ResourceMethods
+  include SemaphoreMethods
+  include Authorization::TaggableMethods
+  include Authorization::HyperTagMethods
+  semaphore :destroy, :update_load_balancer
+
+  def hyper_tag_name(project)
+    "project/#{project.ubid}/location/#{private_subnet.display_location}/load-balancer/#{name}"
+  end
+
+  def add_vm(vm)
+    DB.transaction do
+      super
+      incr_update_load_balancer
+    end
+  end
+
+  def detach_vm(vm)
+    DB.transaction do
+      DB[:load_balancers_vms].where(load_balancer_id: id, vm_id: vm.id).delete(force: true)
+      incr_update_load_balancer
+    end
+  end
+end

--- a/model/load_balancers_vms.rb
+++ b/model/load_balancers_vms.rb
@@ -1,0 +1,7 @@
+#  frozen_string_literal: true
+
+require_relative "../model"
+
+class LoadBalancersVms < Sequel::Model
+  include ResourceMethods
+end

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -7,6 +7,7 @@ class PrivateSubnet < Sequel::Model
   one_to_many :nics, key: :private_subnet_id
   one_to_one :strand, key: :id
   many_to_many :firewalls
+  one_to_many :load_balancers
 
   PRIVATE_SUBNET_RANGES = [
     "10.0.0.0/8",

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -13,8 +13,10 @@ class Vm < Sequel::Model
   one_to_many :vm_storage_volumes, key: :vm_id, order: Sequel.desc(:boot)
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
   one_to_many :pci_devices, key: :vm_id, class: :PciDevice
+  many_to_many :load_balancers, left_key: :vm_id, right_key: :load_balancer_id, join_table: :load_balancers_vms
+  one_to_many :load_balancers_vms, key: :vm_id, class: LoadBalancersVms
 
-  plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy
+  plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy, load_balancers_vms: :destroy
 
   dataset_module Pagination
   dataset_module Authorization::Dataset
@@ -22,7 +24,7 @@ class Vm < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity
+  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
 
   include Authorization::HyperTagMethods
 

--- a/prog/vnet/load_balancer_health_probes.rb
+++ b/prog/vnet/load_balancer_health_probes.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Prog::Vnet::LoadBalancerHealthProbes < Prog::Base
+  subject_is :load_balancer
+
+  def vm
+    @vm ||= Vm[frame.fetch("vm_id")]
+  end
+
+  label def health_probe
+    response_code = nil
+    begin
+      endpoint = "#{vm.nics.first.private_ipv4.network}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
+      response_code = vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} curl --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{endpoint}")
+    rescue
+      response_code = "500"
+    end
+
+    vm_state, vm_state_counter = load_balancer.load_balancers_vms_dataset.where(vm_id: vm.id).get([:state, :state_counter])
+    threshold, health_check = (response_code == "200") ?
+      [load_balancer.health_check_up_threshold, "up"] :
+      [load_balancer.health_check_down_threshold, "down"]
+    counter = (vm_state == health_check) ? vm_state_counter + 1 : 1
+
+    load_balancer.load_balancers_vms_dataset.where(vm_id: vm.id).update(state: health_check, state_counter: counter)
+    if counter == threshold
+      load_balancer.incr_update_load_balancer
+    end
+
+    nap load_balancer.health_check_interval
+  end
+end

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -2,7 +2,7 @@
 
 class Prog::Vnet::LoadBalancerNexus < Prog::Base
   subject_is :load_balancer
-  semaphore :destroy, :update_load_balancer
+  semaphore :destroy, :update_load_balancer, :rewrite_dns_records
 
   def self.assemble(private_subnet_id, name: nil, algorithm: "round_robin", src_port: nil, dst_port: nil)
 
@@ -33,6 +33,11 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
       hop_update_vm_load_balancers
     end
 
+    when_rewrite_dns_records_set? do
+      rewrite_dns_records
+      decr_rewrite_dns_records
+    end
+
     nap 5
   end
 
@@ -57,6 +62,11 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   label def destroy
     decr_destroy
     strand.children.map { _1.destroy }
+    # The following if statement makes sure that it's OK to not have dns_zone
+    # only if it's not in production.
+    if (dns_zone = Prog::Vnet::LoadBalancerNexus.dns_zone) && (Config.production? || dns_zone)
+      dns_zone.delete_record(record_name: load_balancer.hostname)
+    end
 
     load_balancer.vms.each do |vm|
       bud Prog::Vnet::UpdateLoadBalancer, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :remove_load_balancer
@@ -75,5 +85,18 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
     end
 
     nap 5
+  end
+
+  def rewrite_dns_records
+    Prog::Vnet::LoadBalancerNexus.dns_zone&.delete_record(record_name: load_balancer.hostname)
+
+    load_balancer.vms_to_dns.map do |vm|
+      Prog::Vnet::LoadBalancerNexus.dns_zone&.insert_record(record_name: load_balancer.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s) if vm.ephemeral_net4
+      Prog::Vnet::LoadBalancerNexus.dns_zone&.insert_record(record_name: load_balancer.hostname, type: "AAAA", ttl: 10, data: vm.ephemeral_net6.nth(2).to_s)
+    end
+  end
+
+  def self.dns_zone
+    @@dns_zone ||= DnsZone[project_id: Config.load_balancer_service_project_id, name: Config.load_balancer_service_hostname]
   end
 end

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class Prog::Vnet::LoadBalancerNexus < Prog::Base
+  subject_is :load_balancer
+  semaphore :destroy, :update_load_balancer
+
+  def self.assemble(private_subnet_id, name: nil, algorithm: "round_robin", src_port: nil, dst_port: nil)
+
+    unless (ps = PrivateSubnet[private_subnet_id])
+      fail "Given subnet doesn't exist with the id #{private_subnet_id}"
+    end
+
+    Validation.validate_name(name)
+
+    DB.transaction do
+      lb = LoadBalancer.create_with_id(
+        private_subnet_id: private_subnet_id, name: name, algorithm: algorithm,
+        src_port: src_port, dst_port: dst_port)
+      lb.associate_with_project(ps.projects.first)
+
+      Strand.create(prog: "Vnet::LoadBalancerNexus", label: "wait") { _1.id = lb.id }
+    end
+  end
+
+  def before_run
+    when_destroy_set? do
+      hop_destroy unless %w[destroy wait_destroy].include?(strand.label)
+    end
+  end
+
+  label def wait
+    when_update_load_balancer_set? do
+      hop_update_vm_load_balancers
+    end
+
+    nap 5
+  end
+
+  label def update_vm_load_balancers
+    load_balancer.vms.each do |vm|
+      bud Prog::Vnet::UpdateLoadBalancer, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :update_load_balancer
+    end
+
+    hop_wait_update_vm_load_balancers
+  end
+
+  label def wait_update_vm_load_balancers
+    reap
+    if strand.children_dataset.where(prog: "Vnet::UpdateLoadBalancer").all? { _1.exitval == "load balancer is updated" } || strand.children.empty?
+      decr_update_load_balancer
+      hop_wait
+    end
+
+    nap 1
+  end
+
+  label def destroy
+    decr_destroy
+    strand.children.map { _1.destroy }
+
+    load_balancer.vms.each do |vm|
+      bud Prog::Vnet::UpdateLoadBalancer, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :remove_load_balancer
+    end
+
+    hop_wait_destroy
+  end
+
+  label def wait_destroy
+    reap
+    if leaf?
+      load_balancer.projects.each { |prj| load_balancer.dissociate_with_project(prj) }
+      load_balancer.destroy
+
+      pop "load balancer deleted"
+    end
+
+    nap 5
+  end
+end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -152,7 +152,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     strand.children.each { _1.destroy }
     private_subnet.firewalls.map { _1.disassociate_from_private_subnet(private_subnet, apply_firewalls: false) }
 
-    if private_subnet.nics.empty?
+    if private_subnet.nics.empty? && private_subnet.load_balancers.empty?
       DB.transaction do
         private_subnet.projects.each { |p| private_subnet.dissociate_with_project(p) }
         private_subnet.destroy
@@ -160,6 +160,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       pop "subnet destroyed"
     else
       private_subnet.nics.map { |n| n.incr_destroy }
+      private_subnet.load_balancers.map { |lb| lb.incr_destroy }
       nap 1
     end
   end

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -74,7 +74,7 @@ table inet fw_table {
 
   flowtable ubi_flowtable {
     hook ingress priority filter
-    devices = { #{vm.nics.map(&:ubid_to_tap_name).join(",")}, vethi#{vm.inhost_name} }
+    devices = { #{vm.nics.map(&:ubid_to_tap_name).join(",")} }
   }
 
   chain forward_ingress {

--- a/prog/vnet/update_load_balancer.rb
+++ b/prog/vnet/update_load_balancer.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class Prog::Vnet::UpdateLoadBalancer < Prog::Base
+  subject_is :vm
+
+  def load_balancer
+    @load_balancer ||= LoadBalancer[frame.fetch("load_balancer_id")]
+  end
+
+  label def update_load_balancer
+    vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: generate_lb_based_nat_rules)
+
+    pop "load balancer is updated"
+  end
+
+  label def remove_load_balancer
+    vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: generate_nat_rules(vm.ephemeral_net4.to_s, vm.nics.first.private_ipv4.network.to_s))
+    pop "load balancer is updated"
+  end
+
+  def generate_lb_based_nat_rules
+    public_ipv4 = vm.ephemeral_net4.to_s
+    public_ipv6 = vm.ephemeral_net6.to_s
+    private_ipv4 = vm.nics.first.private_ipv4.network
+    private_ipv6 = vm.nics.first.private_ipv6.nth(2)
+    neighbor_vms = load_balancer.vms.reject { _1.id == vm.id }
+    neighbor_ips_v4_set, neighbor_ips_v6_set = generate_lb_ip_set_definition(neighbor_vms)
+    modulo = load_balancer.vms.count
+    ipv4_map_def, ipv6_map_def = generate_lb_map_defs
+
+    balance_mode_ip4, balance_mode_ip6 = if load_balancer.algorithm == "round_robin"
+      ["numgen inc", "numgen inc"]
+    elsif load_balancer.algorithm == "hash_based"
+      ["jhash ip saddr . tcp sport . ip daddr . tcp dport", "jhash ip6 saddr . tcp sport . ip6 daddr . tcp dport"]
+    else
+      fail ArgumentError, "Unsupported load balancer algorithm: #{load_balancer.algorithm}"
+    end
+
+    <<TEMPLATE
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table inet nat {
+  set neighbor_ips_v4 {
+    type ipv4_addr;
+#{neighbor_ips_v4_set}
+  }
+
+  set neighbor_ips_v6 {
+    type ipv6_addr;
+#{neighbor_ips_v6_set}
+  }
+
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr #{public_ipv4} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to #{balance_mode_ip4} mod #{modulo} map { #{ipv4_map_def} }
+    ip6 daddr #{public_ipv6} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to #{balance_mode_ip6} mod #{modulo} map { #{ipv6_map_def} }
+    ip daddr #{public_ipv4} dnat to #{private_ipv4}
+  }
+
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip daddr @neighbor_ips_v4 tcp dport #{load_balancer.dst_port} ct state established,related,new counter snat to #{private_ipv4}
+    ip6 daddr @neighbor_ips_v6 tcp dport #{load_balancer.dst_port} ct state established,related,new counter snat to #{private_ipv6}
+    ip saddr #{private_ipv4} ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to #{public_ipv4}
+    ip saddr #{private_ipv4} ip daddr #{private_ipv4} snat to #{public_ipv4}
+  }
+}
+TEMPLATE
+  end
+
+  def generate_lb_ip_set_definition(neighbor_vms)
+    return ["", ""] if neighbor_vms.empty?
+
+    ["elements = {#{neighbor_vms.map { _1.nics.first.private_ipv4.network }.join(", ")}}",
+      "elements = {#{neighbor_vms.map { _1.nics.first.private_ipv6.nth(2) }.join(", ")}}"]
+  end
+
+  def generate_lb_map_defs
+    [load_balancer.vms.map.with_index { |vm, i| "#{i} : #{vm.nics.first.private_ipv4.network} . #{load_balancer.dst_port}" }.join(", "),
+      load_balancer.vms.map.with_index { |vm, i| "#{i} : #{vm.nics.first.private_ipv6.nth(2)} . #{load_balancer.dst_port}" }.join(", ")]
+  end
+
+  def generate_nat_rules(current_public_ipv4, current_private_ipv4)
+    <<NAT
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table ip nat {
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr #{current_public_ipv4} dnat to #{current_private_ipv4}
+  }
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip saddr #{current_private_ipv4} ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to #{current_public_ipv4}
+    ip saddr #{current_private_ipv4} ip daddr #{current_private_ipv4} snat to #{current_public_ipv4}
+  }
+}
+NAT
+  end
+end

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -21,6 +21,16 @@ if action == "delete"
   exit 0
 end
 
+if action == "delete_keep_net"
+  vm_setup.purge_without_network
+  exit 0
+end
+
+if action == "delete_net"
+  vm_setup.purge_network
+  exit 0
+end
+
 params = JSON.parse(File.read(VmPath.new(vm_name).prep_json))
 
 begin

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -119,6 +119,11 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
   # Delete all traces of the VM.
   def purge
+    purge_network
+    purge_without_network
+  end
+
+  def purge_network
     block_ip4
 
     begin
@@ -126,7 +131,9 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     rescue CommandFail => ex
       raise unless /Cannot remove namespace file ".*": No such file or directory/.match?(ex.stderr)
     end
+  end
 
+  def purge_without_network
     FileUtils.rm_f(vp.systemd_service)
     FileUtils.rm_f(vp.dnsmasq_service)
     r "systemctl daemon-reload"

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe LoadBalancer do
+  subject(:lb) {
+    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps")
+    Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 80).subject
+  }
+
+  let(:vm1) {
+    prj = lb.private_subnet.projects.first
+    Prog::Vm::Nexus.assemble("pub-key", prj.id, name: "test-vm1", private_subnet_id: lb.private_subnet.id).subject
+  }
+
+  describe "util funcs" do
+    before do
+      allow(Config).to receive(:load_balancer_service_hostname).and_return("lb.ubicloud.com")
+    end
+
+    it "returns hyper_tag_name" do
+      prj = lb.private_subnet.projects.first
+      expect(lb.hyper_tag_name(prj)).to eq("project/#{prj.ubid}/location/eu-north-h1/load-balancer/test-lb")
+    end
+
+    it "returns hostname" do
+      expect(lb.hostname).to eq("test-lb.#{lb.ubid[-5...]}.lb.ubicloud.com")
+    end
+  end
+
+  describe "add_vm" do
+    it "increments update_load_balancer and rewrite_dns_records" do
+      expect(lb).to receive(:incr_update_load_balancer)
+      expect(lb).to receive(:incr_rewrite_dns_records)
+      lb.add_vm(vm1)
+      expect(lb.load_balancers_vms.count).to eq(1)
+    end
+  end
+
+  describe "evacuate_vm" do
+    before do
+      lb.add_vm(vm1)
+    end
+
+    it "increments update_load_balancer and rewrite_dns_records" do
+      expect(lb).to receive(:incr_update_load_balancer)
+      expect(lb).to receive(:incr_rewrite_dns_records)
+      health_probe = instance_double(Strand, stack: [{"subject_id" => lb.id, "vm_id" => vm1.id}])
+      expect(lb.strand).to receive(:children_dataset).and_return(instance_double(Sequel::Dataset, where: instance_double(Sequel::Dataset, all: [health_probe])))
+      expect(health_probe).to receive(:destroy)
+      lb.evacuate_vm(vm1)
+      expect(lb.load_balancers_vms.first[:state]).to eq("evacuating")
+    end
+  end
+
+  describe "remove_vm" do
+    before do
+      lb.add_vm(vm1)
+    end
+
+    it "deletes the vm" do
+      lb.remove_vm(vm1)
+      expect(lb.load_balancers_vms.count).to eq(0)
+    end
+  end
+end

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
+  subject(:nx) {
+    described_class.new(st)
+  }
+
+  let(:st) {
+    Strand.create_with_id(prog: "Vnet::LoadBalancerHealthProbes", stack: [{"subject_id" => lb.id, "vm_id" => vm.id}], label: "health_probe")
+  }
+  let(:lb) {
+    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
+    Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 80).subject
+  }
+  let(:vm) {
+    Prog::Vm::Nexus.assemble("pub-key", lb.projects.first.id, name: "test-vm", private_subnet_id: lb.private_subnet.id).subject
+  }
+
+  before do
+    allow(nx).to receive_messages(load_balancer: lb)
+  end
+
+  describe "#health_probe" do
+    let(:vmh) {
+      instance_double(VmHost, sshable: instance_double(Sshable))
+    }
+
+    before do
+      allow(vm).to receive(:vm_host).and_return(vmh)
+      lb.add_vm(vm)
+      lb.load_balancers_vms_dataset.update(state: "up")
+      expect(Vm).to receive(:[]).with(vm.id).and_return(vm)
+      expect(vm.nics.first).to receive(:private_ipv4).and_return(NetAddr::IPv4Net.parse("192.168.1.0"))
+    end
+
+    it "naps for 5 seconds and doesn't perform update if health check succeeds" do
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 3 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("200")
+      expect(lb).not_to receive(:incr_update_load_balancer)
+
+      expect { nx.health_probe }.to nap(5)
+    end
+
+    it "naps for 5 seconds and doesn't perform update if health check fails the first time" do
+      lb.load_balancers_vms_dataset.update(state_counter: 1)
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 3 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("500")
+      expect(lb).not_to receive(:incr_update_load_balancer)
+
+      expect { nx.health_probe }.to nap(5)
+    end
+
+    it "naps for 5 seconds and performs update if health check fails the first time via an exception" do
+      lb.load_balancers_vms_dataset.update(state_counter: 1)
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 3 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_raise("error")
+      expect(lb).not_to receive(:incr_update_load_balancer)
+
+      expect { nx.health_probe }.to nap(5)
+    end
+
+    it "starts update if health check succeeds and we hit the threshold" do
+      lb.load_balancers_vms_dataset.update(state_counter: 2)
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 3 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("200")
+      expect(lb).to receive(:incr_update_load_balancer)
+
+      expect { nx.health_probe }.to nap(5)
+    end
+
+    it "naps for 5 seconds and doesn't perform update if health check succeeds and we're already above threshold" do
+      lb.load_balancers_vms_dataset.update(state_counter: 3)
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 3 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("200")
+      expect(lb).not_to receive(:incr_update_load_balancer)
+
+      expect { nx.health_probe }.to nap(5)
+    end
+  end
+end

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::LoadBalancerNexus do
+  subject(:nx) {
+    described_class.new(st)
+  }
+
+  let(:st) {
+    described_class.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 80)
+  }
+  let(:ps) {
+    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
+  }
+  let(:dns_zone) {
+    DnsZone.create_with_id(project_id: ps.projects.first.id, name: "lb.ubicloud.com")
+  }
+
+  before do
+    allow(nx).to receive_messages(load_balancer: st.subject)
+    allow(Config).to receive(:load_balancer_service_hostname).and_return("lb.ubicloud.com")
+  end
+
+  describe ".assemble" do
+    it "fails if private subnet does not exist" do
+      expect {
+        described_class.assemble("0a9a166c-e7e7-4447-ab29-7ea442b5bb0e")
+      }.to raise_error RuntimeError, "Given subnet doesn't exist with the id 0a9a166c-e7e7-4447-ab29-7ea442b5bb0e"
+    end
+
+    it "creates a new load balancer" do
+      lb = described_class.assemble(ps.id, name: "test-lb2", src_port: 80, dst_port: 80).subject
+      expect(LoadBalancer.count).to eq 2
+      expect(lb.projects.first).to eq ps.projects.first
+      expect(lb.hostname).to eq "test-lb2.#{lb.ubid[-5...]}.lb.ubicloud.com"
+    end
+  end
+
+  describe "#before_run" do
+    it "hops to destroy when needed" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "does not hop to destroy if already in the destroy state" do
+      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect { nx.before_run }.not_to hop("destroy")
+    end
+
+    it "does not hop to destroy if already in the wait_destroy state" do
+      expect(nx.strand).to receive(:label).and_return("wait_destroy").at_least(:once)
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect { nx.before_run }.not_to hop("destroy")
+    end
+  end
+
+  describe "#wait" do
+    it "naps for 5 seconds if nothing to do" do
+      expect { nx.wait }.to nap(5)
+    end
+
+    it "creates new health probe if needed" do
+      vm = Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "test-vm1", private_subnet_id: ps.id).subject
+      st.subject.add_vm(vm)
+      expect { nx.wait }.to hop("create_new_health_probe")
+    end
+
+    it "hops to update vm load balancers" do
+      expect(nx).to receive(:when_update_load_balancer_set?).and_yield
+      expect { nx.wait }.to hop("update_vm_load_balancers")
+    end
+
+    it "rewrites dns records" do
+      expect(nx).to receive(:when_rewrite_dns_records_set?).and_yield
+      expect(nx).to receive(:rewrite_dns_records)
+      expect(nx).to receive(:decr_rewrite_dns_records)
+      expect { nx.wait }.to nap(5)
+    end
+  end
+
+  describe "#create_new_health_probe" do
+    it "creates health probes for all vms" do
+      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "test-vm#{_1}", private_subnet_id: ps.id).subject }
+      vms.each { st.subject.add_vm(_1) }
+      expect { nx.create_new_health_probe }.to hop("wait")
+      expect(Strand.where(prog: "Vnet::LoadBalancerHealthProbes").count).to eq 3
+      expect(st.children_dataset.count).to eq 3
+    end
+  end
+
+  describe "#update_vm_load_balancers" do
+    it "updates load balancers for all vms" do
+      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "test-vm#{_1}", private_subnet_id: ps.id).subject }
+      vms.each { st.subject.add_vm(_1) }
+      expect { nx.update_vm_load_balancers }.to hop("wait_update_vm_load_balancers")
+      expect(st.children_dataset.count).to eq 3
+    end
+  end
+
+  describe "#wait_update_vm_load_balancers" do
+    before do
+      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "test-vm#{_1}", private_subnet_id: ps.id).subject }
+      vms.each { st.subject.add_vm(_1) }
+      expect { nx.update_vm_load_balancers }.to hop("wait_update_vm_load_balancers")
+    end
+
+    it "naps for 1 second if not all children are done" do
+      expect(nx).to receive(:reap)
+      expect { nx.wait_update_vm_load_balancers }.to nap(1)
+    end
+
+    it "decrements update_load_balancer and hops to wait if all children are done" do
+      st.children.map(&:destroy)
+      expect(nx).to receive(:decr_update_load_balancer)
+      expect { nx.wait_update_vm_load_balancers }.to hop("wait")
+    end
+  end
+
+  describe "#destroy" do
+    before do
+      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "test-vm#{_1}", private_subnet_id: ps.id).subject }
+      vms.each { st.subject.add_vm(_1) }
+      expect { nx.update_vm_load_balancers }.to hop("wait_update_vm_load_balancers")
+      st.children.map(&:destroy)
+    end
+
+    it "decrements destroy and destroys all children" do
+      expect(nx).to receive(:decr_destroy)
+      expect(st.children).to all(receive(:destroy))
+      expect { nx.destroy }.to hop("wait_destroy")
+
+      expect(Strand.where(prog: "Vnet::UpdateLoadBalancer").count).to eq 3
+    end
+
+    it "deletes the dns record" do
+      expect(described_class).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
+      expect(dns_zone).to receive(:delete_record).with(record_name: st.subject.hostname)
+      expect(nx).to receive(:decr_destroy)
+      expect(st.children).to all(receive(:destroy))
+      expect { nx.destroy }.to hop("wait_destroy")
+    end
+  end
+
+  describe "#rewrite_dns_records" do
+    it "rewrites the dns records" do
+      vms = [instance_double(Vm, ephemeral_net4: NetAddr::IPv4Net.parse("192.168.1.0"), ephemeral_net6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fb0::"))]
+      expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
+      expect(described_class).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
+      expect(dns_zone).to receive(:delete_record).with(record_name: st.subject.hostname)
+      expect(dns_zone).to receive(:insert_record).with(record_name: st.subject.hostname, type: "A", data: "192.168.1.0/32", ttl: 10)
+      expect(dns_zone).to receive(:insert_record).with(record_name: st.subject.hostname, type: "AAAA", data: "fd10:9b0b:6b4b:8fb0::2", ttl: 10)
+      nx.rewrite_dns_records
+    end
+
+    it "does not rewrite dns records if no vms" do
+      expect(described_class).to receive(:dns_zone).and_return(dns_zone)
+      expect(dns_zone).to receive(:delete_record).with(record_name: st.subject.hostname)
+      expect(nx.load_balancer).to receive(:vms_to_dns).and_return([])
+      expect(described_class).not_to receive(:dns_zone)
+      nx.rewrite_dns_records
+    end
+
+    it "does not rewrite dns records if no dns zone" do
+      vms = [instance_double(Vm, ephemeral_net4: NetAddr::IPv4Net.parse("192.168.1.0"), ephemeral_net6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fb0::"))]
+      expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
+      expect(DnsRecord).not_to receive(:create)
+      nx.rewrite_dns_records
+    end
+
+    it "does not create dns record if ephemeral_net4 doesn't exist" do
+      vms = [instance_double(Vm, ephemeral_net4: nil, ephemeral_net6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fb0::"))]
+      expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
+      expect(described_class).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
+      expect(dns_zone).to receive(:delete_record).with(record_name: st.subject.hostname)
+      expect(dns_zone).not_to receive(:insert_record).with(record_name: st.subject.hostname, type: "A", data: "192.168.1.0/32", ttl: 10)
+      expect(dns_zone).to receive(:insert_record).with(record_name: st.subject.hostname, type: "AAAA", data: "fd10:9b0b:6b4b:8fb0::2", ttl: 10)
+      nx.rewrite_dns_records
+    end
+  end
+
+  describe "#wait_destroy" do
+    it "naps for 5 seconds if not all children are done" do
+      expect(nx).to receive(:reap)
+      expect(nx).to receive(:leaf?).and_return(false)
+
+      expect { nx.wait_destroy }.to nap(5)
+    end
+
+    it "deletes the load balancer and pops" do
+      expect(nx).to receive(:reap)
+      expect(nx).to receive(:leaf?).and_return(true)
+      expect(nx.load_balancer).to receive(:destroy)
+      expect { nx.wait_destroy }.to exit({"msg" => "load balancer deleted"})
+      expect(LoadBalancersVms.count).to eq 0
+    end
+  end
+end

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -91,7 +91,7 @@ elements = {2a00:1450:400e:811::200e/128}
 
   flowtable ubi_flowtable {
     hook ingress priority filter
-    devices = { tap0, vethix }
+    devices = { tap0 }
   }
 
   chain forward_ingress {
@@ -188,7 +188,7 @@ table inet fw_table {
 
   flowtable ubi_flowtable {
     hook ingress priority filter
-    devices = { tap0, vethix }
+    devices = { tap0 }
   }
 
   chain forward_ingress {

--- a/spec/prog/vnet/update_load_balancer_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_spec.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::UpdateLoadBalancer do
+  subject(:nx) {
+    described_class.new(st)
+  }
+
+  let(:st) {
+    Strand.create_with_id(prog: "Vnet::UpdateLoadBalancer", stack: [{"subject_id" => vm.id, "load_balancer_id" => lb.id}], label: "update_load_balancer")
+  }
+  let(:lb) {
+    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
+    Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080).subject
+  }
+  let(:vm) {
+    Prog::Vm::Nexus.assemble("pub-key", lb.projects.first.id, name: "test-vm", private_subnet_id: lb.private_subnet.id).subject
+  }
+  let(:neighbor_vm) {
+    Prog::Vm::Nexus.assemble("pub-key", lb.projects.first.id, name: "neighbor-vm", private_subnet_id: lb.private_subnet.id).subject
+  }
+
+  before do
+    lb.add_vm(vm)
+    allow(nx).to receive_messages(vm: vm, load_balancer: lb)
+    allow(vm).to receive_messages(ephemeral_net4: NetAddr::IPv4Net.parse("100.100.100.100/32"), ephemeral_net6: NetAddr::IPv6Net.parse("2a02:a464:deb2:a000::/64"))
+  end
+
+  describe "#update_load_balancer" do
+    context "when no healthy vm exists" do
+      it "hops to remove load balancer" do
+        expect(lb).to receive(:active_vms).and_return([])
+        expect { nx.update_load_balancer }.to hop("remove_load_balancer")
+      end
+    end
+
+    context "when a single vm exists and it is the subject" do
+      let(:vmh) {
+        instance_double(VmHost, sshable: instance_double(Sshable))
+      }
+
+      before do
+        lb.load_balancers_vms_dataset.update(state: "up")
+        allow(vm).to receive(:vm_host).and_return(vmh)
+      end
+
+      it "does not hop to remove load balancer and creates basic load balancing with nat" do
+        expect(lb).to receive(:active_vms).and_return([vm]).at_least(:once)
+        expect(vm.nics.first).to receive(:private_ipv4).and_return(NetAddr::IPv4Net.parse("192.168.1.0/32")).at_least(:once)
+        expect(vm.nics.first).to receive(:private_ipv6).and_return(NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fbb::/64")).at_least(:once)
+        expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<LOAD_BALANCER)
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table inet nat {
+  set neighbor_ips_v4 {
+    type ipv4_addr;
+
+  }
+
+  set neighbor_ips_v6 {
+    type ipv6_addr;
+
+  }
+
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 192.168.1.0 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+    ip daddr 100.100.100.100/32 dnat to 192.168.1.0
+  }
+
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
+    ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+    ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
+    ip saddr 192.168.1.0 ip daddr 192.168.1.0 snat to 100.100.100.100/32
+  }
+}
+LOAD_BALANCER
+        expect { nx.update_load_balancer }.to exit({"msg" => "load balancer is updated"})
+      end
+
+      it "creates basic load balancing with hashing" do
+        lb.update(algorithm: "hash_based")
+        expect(lb).to receive(:active_vms).and_return([vm]).at_least(:once)
+        expect(vm.nics.first).to receive(:private_ipv4).and_return(NetAddr::IPv4Net.parse("192.168.1.0/32")).at_least(:once)
+        expect(vm.nics.first).to receive(:private_ipv6).and_return(NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fbb::/64")).at_least(:once)
+        expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<LOAD_BALANCER)
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table inet nat {
+  set neighbor_ips_v4 {
+    type ipv4_addr;
+
+  }
+
+  set neighbor_ips_v6 {
+    type ipv6_addr;
+
+  }
+
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to jhash ip saddr . tcp sport . ip daddr . tcp dport mod 1 map { 0 : 192.168.1.0 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to jhash ip6 saddr . tcp sport . ip6 daddr . tcp dport mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+    ip daddr 100.100.100.100/32 dnat to 192.168.1.0
+  }
+
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
+    ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+    ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
+    ip saddr 192.168.1.0 ip daddr 192.168.1.0 snat to 100.100.100.100/32
+  }
+}
+LOAD_BALANCER
+        expect { nx.update_load_balancer }.to exit({"msg" => "load balancer is updated"})
+      end
+    end
+
+    context "when multiple vms exist" do
+      let(:vmh) {
+        instance_double(VmHost, sshable: instance_double(Sshable))
+      }
+
+      before do
+        allow(lb).to receive(:active_vms).and_return([vm, neighbor_vm]).at_least(:once)
+        allow(vm).to receive(:vm_host).and_return(vmh)
+        allow(vm.nics.first).to receive_messages(private_ipv4: NetAddr::IPv4Net.parse("192.168.1.0/32"), private_ipv6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fbb::/64"))
+        allow(neighbor_vm.nics.first).to receive_messages(private_ipv4: NetAddr::IPv4Net.parse("172.10.1.0/32"), private_ipv6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:aaa::2/64"))
+      end
+
+      it "creates load balancing with multiple vms if all active" do
+        expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<LOAD_BALANCER)
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table inet nat {
+  set neighbor_ips_v4 {
+    type ipv4_addr;
+elements = {172.10.1.0}
+  }
+
+  set neighbor_ips_v6 {
+    type ipv6_addr;
+elements = {fd10:9b0b:6b4b:aaa::2}
+  }
+
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : 192.168.1.0 . 8080, 1 : 172.10.1.0 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080, 1 : fd10:9b0b:6b4b:aaa::2 . 8080 }
+    ip daddr 100.100.100.100/32 dnat to 192.168.1.0
+  }
+
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
+    ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+    ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
+    ip saddr 192.168.1.0 ip daddr 192.168.1.0 snat to 100.100.100.100/32
+  }
+}
+LOAD_BALANCER
+
+        expect { nx.update_load_balancer }.to exit({"msg" => "load balancer is updated"})
+      end
+
+      it "creates load balancing with multiple vms if the vm we work on is down" do
+        expect(lb).to receive(:active_vms).and_return([neighbor_vm]).at_least(:once)
+        expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<LOAD_BALANCER)
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table inet nat {
+  set neighbor_ips_v4 {
+    type ipv4_addr;
+elements = {172.10.1.0}
+  }
+
+  set neighbor_ips_v6 {
+    type ipv6_addr;
+elements = {fd10:9b0b:6b4b:aaa::2}
+  }
+
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 172.10.1.0 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:aaa::2 . 8080 }
+    ip daddr 100.100.100.100/32 dnat to 192.168.1.0
+  }
+
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
+    ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+    ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
+    ip saddr 192.168.1.0 ip daddr 192.168.1.0 snat to 100.100.100.100/32
+  }
+}
+LOAD_BALANCER
+
+        expect { nx.update_load_balancer }.to exit({"msg" => "load balancer is updated"})
+      end
+
+      it "creates load balancing with multiple vms if the vm we work on is up but the neighbor is down" do
+        expect(lb).to receive(:active_vms).and_return([vm]).at_least(:once)
+        expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<LOAD_BALANCER)
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table inet nat {
+  set neighbor_ips_v4 {
+    type ipv4_addr;
+
+  }
+
+  set neighbor_ips_v6 {
+    type ipv6_addr;
+
+  }
+
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 192.168.1.0 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+    ip daddr 100.100.100.100/32 dnat to 192.168.1.0
+  }
+
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
+    ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+    ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
+    ip saddr 192.168.1.0 ip daddr 192.168.1.0 snat to 100.100.100.100/32
+  }
+}
+LOAD_BALANCER
+
+        expect { nx.update_load_balancer }.to exit({"msg" => "load balancer is updated"})
+      end
+
+      it "raises exception if the algorithm is not supported" do
+        expect(lb).to receive(:algorithm).and_return("least_conn").at_least(:once)
+        expect { nx.update_load_balancer }.to raise_error("Unsupported load balancer algorithm: least_conn")
+      end
+    end
+  end
+
+  describe "#remove_load_balancer" do
+    let(:vmh) {
+      instance_double(VmHost, sshable: instance_double(Sshable))
+    }
+
+    before do
+      allow(vm).to receive(:vm_host).and_return(vmh)
+      allow(vm.nics.first).to receive_messages(private_ipv4: NetAddr::IPv4Net.parse("192.168.1.0/32"), private_ipv6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fbb::/64"))
+    end
+
+    it "creates basic nat rules" do
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<REMOVE_LOAD_BALANCER)
+table ip nat;
+delete table ip nat;
+table inet nat;
+delete table inet nat;
+table ip nat {
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip daddr 100.100.100.100/32 dnat to 192.168.1.0
+  }
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
+    ip saddr 192.168.1.0 ip daddr 192.168.1.0 snat to 100.100.100.100/32
+  }
+}
+REMOVE_LOAD_BALANCER
+      expect { nx.remove_load_balancer }.to exit({"msg" => "load balancer is updated"})
+    end
+  end
+
+  it "returns load_balancer" do
+    expect(nx).to receive(:load_balancer).and_call_original
+    expect(nx.load_balancer.id).to eq(lb.id)
+  end
+end

--- a/ubid.rb
+++ b/ubid.rb
@@ -69,6 +69,7 @@ class UBID
   TYPE_FIREWALL = "fw"
   TYPE_POSTGRES_FIREWALL_RULE = "pf"
   TYPE_GITHUB_REPOSITORY = "gp"
+  TYPE_LOAD_BALANCER = "1b"
 
   # Common entropy-based type for everything else
   TYPE_ETC = "et"


### PR DESCRIPTION
# How to test this PR locally?
It's a bit of a pain but you can do it. First and most important thing to have is a domain with access to dns management. Keep that at hand.
1. Run respirate and create a project.
2. Set environment variables;
```
ENV["LOAD_BALANCER_SERVICE_PROJECT_ID"] ||= "YOUR_PROJECT_ID"
ENV["LOAD_BALANCER_SERVICE_HOSTNAME"] ||= "lb.YOUR_DOMAIN"
```
3. Restart respirate.
4. Setup DNS zone for lb.YOUR_DOMAIN following this [wiki](https://github.com/ubicloud/ubinest/wiki/Setup-DNS-Server)
5. Once you have the dns server and zone setup, add the NS records for that dns server.
6. Provision 2 new VMs *in the same subnet* and start a web server in them (replace PONG_VM_NAME with the name of the VM. An example is this;
```python
from http.server import BaseHTTPRequestHandler, HTTPServer

class HealthCheckHandler(BaseHTTPRequestHandler):
    def do_GET(self):
        if self.path == '/up':
            self.send_response(200)
            self.send_header('Content-type', 'text/plain')
            self.end_headers()
            self.wfile.write(b'healthy')
        elif self.path == '/ping':
            self.send_response(200)
            self.send_header('Content-type', 'text/plain')
            self.end_headers()
            self.wfile.write(b'PONG_VM_NAME')
        else:
            self.send_response(404)
            self.end_headers()

def run(server_class=HTTPServer, handler_class=HealthCheckHandler, port=8000):
    server_address = ('', port)
    httpd = server_class(server_address, handler_class)
    print(f'Starting httpd server on port {port}...')
    httpd.serve_forever()

if __name__ == "__main__":
    run()
```
7. Provision a load balancer using a command like this;
```ruby
Prog::Vnet::LoadBalancerNexus.assemble(private_subnet.id, name: "my-first-lb", algorithm: "round_robin", src_port: 80, dst_port: 8000, health_check_endpoint: "/up")
```
8. Get the hostname of load balancer via;
```
LoadBalancer.first.hostname
```
9. Run this command locally, repetitively to see which server you get the answer back;
```
curl HOST_NAME/ping
```

After this initial setup, you can test different stuff like adding a new VM, removing one, shutting down one of the web servers, etc.

# Commits
## Remove flowtables from the veth interface
Keeping flowtables for the veth interface causes routing failure for
consecutive packages. After the initial packet hits the prerouting chain
and perform the dnat, we want it to continue with the post routing and
then resubmitted immediately to the kernel for ESP encapsulation.
However, with flowtable, the packets are immediately transformed to
their pre ESP phase (having private addresses in source and destination)
and then submitted back to veth interface. This causes packets to leak
out to vetho* interface, therefore, we miss the chance of creating an
ESP packet. This caused failures for balancing, therefore, we limit the
flowtables to the tap* device.

## Load Balancer Basic Migration

## Add Basic Load Balancing
This commit adds the basic Ubicloud load balancer. There are two main
parts of this commit:
1. Control plane implementation for VM <-> Load Balancer interactions.
2. Data plane implementation of the load balancer itself.

The first part involves managing the many-to-many entity relationship
between VMs and load balancers. This relationship is handled through
a join table called `load_balancers_vms`, which is automatically managed
by Sequel. Functions like `load_balancer.add_vm` create the intermediary
data in `DB[:load_balancers_vms]`.

The second part is more complex. The Ubicloud Load Balancer is
integrated into a VM's namespace. Each VM on a host has a dedicated
network namespace used for packet filtering, IPv4 NAT, and various
operational tasks. Our implementation uses nftables definitions within
the namespace. Based on packet descriptions and algorithms, we decide
whether to DNAT the packet to a neighboring VM or accept it on the
current one. We use private networking between VMs to transfer packets
when load balancing is required. Additionally, we support load balancing
for both IPv4 and IPv6. Customers can use the public IPv4 address of any
VM being load balanced. If there is only one VM, we perform port
remapping and leave the packet unchanged.

Our load balancer also supports 2 types of algorithms;
1. round_robin
2. source_hash

The important part to note for a load balancer with multiple VMs is
that, each load balancer node will keep their own round_robin counter or
the source_hash result. Therefore, if the client resolves to different
load balancer node at the DNS level, they may not see the behavior
exactly what the algorithm requires. For example, if they use
round_robin with 2 VMs;
1. The first connection is opened to vm1 which points the customer to
vm1.
2. The second connection  is opened to vm1 which points the customer to
vm2.
3. The third connection is opened to vm2 and it points the customer to
vm2.
As you can see, the expected behavior was vm1, vm2, vm1 but we broke it
because the 3rd time we went to a new load balancer.

## Load Balancer DNS integration
We need to provide a hostname to the customers to be able to face a
single address to provide continuous connectivity even when the
underlying IP addresses of the load balancer changes. We accomplish this
by integrating load balancer with our existing DNS service. We will
create a new dns zone and manage individual host names depending on the
load balancer activity.

## Load Balancer Health Probes Migration

## Add Load Balancer Health Probes
Health probes are an important part of a load balancer. The main
objective is to be able to find nodes that are down and remove them from
the load balancer so that the new connections are directed to the
healthy instances. In this commit, we implement health probes as a
separate Prog which is a child of the load balancer strand. This way,
the load balancer can update the state of individual nodes while the
health probes are individually performed. We create a single prog per
node in the load balancer. This way, a faulty node does not block the
health checks of other VMs. In case a status change is detected, we
start an update on the load balancer which reprograms all of the
nftables rules (including the failing one) to redirect the traffic to
only active VMs. In case the process is accessible again, we include it
in the load balancer.

## VM destroy that is part of a load balancer is handled
When we need to destroy a VM, we need to be able to graciously remove it
from the load balancer, give enough time to the clients of the load
balancer to start using other nodes. For that, we are removing most of
the entities at the VM destroy time but still keep the network namespace
running for 10 more minutes. That is more than enough for dns to expire
and all of the connections to be rerouted to the other load balancer
nodes.

## Load balancer tests
Since the project is very sizable and the commits tend to update similar
parts of the code to implement different features of the load balancer,
we had to write the tests at the very end to minimize the effort.
