### PR TITLE
Restart prometheus exporters along with prometheus service

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -205,6 +205,8 @@ CONFIG
       hop_configure
     end
 
+    vm.sshable.cmd("sudo systemctl reload postgres_exporter || sudo systemctl restart postgres_exporter")
+    vm.sshable.cmd("sudo systemctl reload node_exporter || sudo systemctl restart node_exporter")
     vm.sshable.cmd("sudo systemctl reload prometheus || sudo systemctl restart prometheus")
 
     hop_wait

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -283,6 +283,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "configures prometheus and hops wait at times other than the initial provisioning" do
       expect(sshable).to receive(:cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
       expect(sshable).to receive(:cmd).with("sudo -u prometheus tee /home/prometheus/prometheus.yml > /dev/null", stdin: anything)
+      expect(sshable).to receive(:cmd).with("sudo systemctl reload postgres_exporter || sudo systemctl restart postgres_exporter")
+      expect(sshable).to receive(:cmd).with("sudo systemctl reload node_exporter || sudo systemctl restart node_exporter")
       expect(sshable).to receive(:cmd).with("sudo systemctl reload prometheus || sudo systemctl restart prometheus")
       expect(resource).to receive(:representative_server).and_return(instance_double(PostgresServer, id: "random-id"))
       expect { nx.configure_prometheus }.to hop("wait")


### PR DESCRIPTION
In my tests, I had few cases where faulty configuration causes exporters to fail. In such cases, even if configuration is fixed, there is no mechanism to restart the exporters. This commit fixes that problem by restarting exporters along with prometheus service when configuration is updated.