### PR TITLE
Put operator SSH keys to service VMs

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -109,5 +109,5 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys
 end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -202,6 +202,8 @@ class Vm < Sequel::Model
   def params_json(swap_size_bytes)
     topo = cloud_hypervisor_cpu_topology
 
+    project_public_keys = projects.first.get_ff_vm_public_ssh_keys || []
+
     # we don't write secrets to params_json, because it
     # shouldn't be stored in the host for security reasons.
     JSON.pretty_generate({
@@ -210,7 +212,7 @@ class Vm < Sequel::Model
       "public_ipv4" => ip4.to_s || "",
       "local_ipv4" => local_vetho_ip.to_s.shellescape || "",
       "unix_user" => unix_user,
-      "ssh_public_keys" => [public_key],
+      "ssh_public_keys" => [public_key] + project_public_keys,
       "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac] },
       "boot_image" => boot_image,
       "max_vcpus" => topo.max_vcpus,

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -210,7 +210,7 @@ class Vm < Sequel::Model
       "public_ipv4" => ip4.to_s || "",
       "local_ipv4" => local_vetho_ip.to_s.shellescape || "",
       "unix_user" => unix_user,
-      "ssh_public_key" => public_key,
+      "ssh_public_keys" => [public_key],
       "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac] },
       "boot_image" => boot_image,
       "max_vcpus" => topo.max_vcpus,

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -30,7 +30,7 @@ begin
   ip4 = params.fetch("public_ipv4")
   local_ip4 = params.fetch("local_ipv4")
   unix_user = params.fetch("unix_user")
-  ssh_public_key = params.fetch("ssh_public_key")
+  ssh_public_keys = params.fetch("ssh_public_keys", params.fetch("ssh_public_key"))
   nics = params.fetch("nics").map { |args| VmSetup::Nic.new(*args) }.freeze
   max_vcpus = params.fetch("max_vcpus")
   cpu_topology = params.fetch("cpu_topology")
@@ -52,7 +52,7 @@ when "prep"
     exit 1
   end
 
-  vm_setup.prep(unix_user, ssh_public_key, nics, gua, ip4,
+  vm_setup.prep(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 when "recreate-unpersisted"
@@ -77,7 +77,7 @@ when "reassign-ip6"
     puts "need storage secrets in secrets json"
     exit 1
   end
-  vm_setup.reassign_ip6(unix_user, ssh_public_key, nics, gua, ip4,
+  vm_setup.reassign_ip6(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 else

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -43,9 +43,9 @@ class VmSetup
     @vp ||= VmPath.new(@vm_name)
   end
 
-  def prep(unix_user, public_key, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
+  def prep(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
-    cloudinit(unix_user, public_key, nics, swap_size_bytes)
+    cloudinit(unix_user, public_keys, nics, swap_size_bytes)
     storage(storage_params, storage_secrets, true)
     hugepages(mem_gib)
     prepare_pci_devices(pci_devices)
@@ -58,9 +58,9 @@ class VmSetup
     storage(storage_params, storage_secrets, false)
   end
 
-  def reassign_ip6(unix_user, public_key, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
+  def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
-    cloudinit(unix_user, public_key, nics, swap_size_bytes)
+    cloudinit(unix_user, public_keys, nics, swap_size_bytes)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
     install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices)
@@ -387,7 +387,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "ip netns exec #{q_vm} bash -c 'nft -f #{vp.q_nftables_conf}'"
   end
 
-  def cloudinit(unix_user, public_key, nics, swap_size_bytes)
+  def cloudinit(unix_user, public_keys, nics, swap_size_bytes)
     vp.write_meta_data(<<EOS)
 instance-id: #{yq(@vm_name)}
 local-hostname: #{yq(@vm_name)}
@@ -434,7 +434,7 @@ ethernets:
 #{ethernets}
 EOS
 
-    write_user_data(unix_user, public_key, swap_size_bytes)
+    write_user_data(unix_user, public_keys, swap_size_bytes)
 
     FileUtils.rm_rf(vp.cloudinit_img)
     r "mkdosfs -n CIDATA -C #{vp.q_cloudinit_img} 8192"
@@ -455,7 +455,7 @@ EOS
     SWAP_CONFIG
   end
 
-  def write_user_data(unix_user, public_key, swap_size_bytes)
+  def write_user_data(unix_user, public_keys, swap_size_bytes)
     vp.write_user_data(<<EOS)
 #cloud-config
 users:
@@ -463,7 +463,7 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
     ssh_authorized_keys:
-      - #{yq(public_key)}
+#{public_keys.map { "      - #{yq(_1)}" }.join("\n")}
 
 ssh_pwauth: False
 

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe VmSetup do
     before { expect(vs).to receive(:vp).and_return(vps).at_least(:once) }
 
     it "templates user YAML with no swap" do
-      vs.write_user_data("some_user", "some_ssh_key", nil)
+      vs.write_user_data("some_user", ["some_ssh_key"], nil)
       expect(vps).to have_received(:write_user_data) {
         expect(_1).to match(/some_user/)
         expect(_1).to match(/some_ssh_key/)
@@ -38,7 +38,7 @@ RSpec.describe VmSetup do
     end
 
     it "templates user YAML with swap" do
-      vs.write_user_data("some_user", "some_ssh_key", 123)
+      vs.write_user_data("some_user", ["some_ssh_key"], 123)
       expect(vps).to have_received(:write_user_data) {
         expect(_1).to match(/some_user/)
         expect(_1).to match(/some_ssh_key/)
@@ -48,7 +48,7 @@ RSpec.describe VmSetup do
 
     it "fails if the swap is not an integer" do
       expect {
-        vs.write_user_data("some_user", "some_ssh_key", "123")
+        vs.write_user_data("some_user", ["some_ssh_key"], "123")
       }.to raise_error RuntimeError, "BUG: swap_size_bytes must be an integer"
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -227,6 +227,8 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:nics).and_return([nic]).at_least(:once)
       expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(1, 1, 1, 1))
       expect(vm).to receive(:pci_devices).and_return([pci]).at_least(:once)
+      prj.set_ff_vm_public_ssh_keys(["operator_ssh_key"])
+      expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
 
       sshable = instance_spy(Sshable)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
@@ -240,7 +242,7 @@ RSpec.describe Prog::Vm::Nexus do
         expect(params).to include({
           "public_ipv6" => "fe80::/64",
           "unix_user" => "test_user",
-          "ssh_public_key" => "test_ssh_key",
+          "ssh_public_keys" => ["test_ssh_key", "operator_ssh_key"],
           "max_vcpus" => 1,
           "cpu_topology" => "1:1:1:1",
           "mem_gib" => 8,


### PR DESCRIPTION
**Allow passing multiple ssh keys while setting up VM**
We used to allow passing only one ssh key while setting up a VM. For the VMs
that belongs to services, it would be useful to pass multiple ssh keys. For
example, we can pass array of operator keys to be put into the VMs.

An alternative approach would be adding SSH keys to the VM using the sshable
interface. However, that would happen after certain steps in the service setup,
thus wouldn't be useful for debugging bootstrapping issues. It would also
require each service to implement key addition logic.

**Add feature flag for passing SSH keys to VMs**
We are passing the content of this feature flag as authorized_keys to the VMs.
This allows us to operator SSH keys to the VMs that belongs to service
accounts.