### PR TITLE
Specify that the number in resource creation UI is memory

### DIFF
--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -93,7 +93,7 @@
                                   <%= size.vcpu %>
                                   vCPUs /
                                   <%= size.memory %>
-                                  GB
+                                  GB RAM
                                 </span>
                               </span>
                             </span>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -121,7 +121,7 @@
                                   <%= size.vcpu %>
                                   vCPUs /
                                   <%= size.memory %>
-                                  GB
+                                  GB RAM
                                 </span>
                               </span>
                             </span>


### PR DESCRIPTION
We specify the vCPU but not the RAM. I think most people already understands it implicitly thanks to context, but there is no harm in making it explicit. there are other resources whole unit is GB, such as storage, bandwidth, etc.

Before:
![image](https://github.com/ubicloud/ubicloud/assets/2082070/12bde757-7393-4923-b27d-8e637d5ca9f4)

After:
![image](https://github.com/ubicloud/ubicloud/assets/2082070/237c59e2-e11c-4f1b-a5fa-51c69e3d451e)
