### PR TITLE
Update default Ubuntu 22/24 versions due openssh vulnerability

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -144,8 +144,8 @@ module Config
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
   optional :ubicloud_images_blob_storage_certs, string
 
-  override :ubuntu_noble_version, "20240523.1", string
-  override :ubuntu_jammy_version, "20240319", string
+  override :ubuntu_noble_version, "20240702", string
+  override :ubuntu_jammy_version, "20240701", string
   override :almalinux_9_version, "9.4-20240507", string
   override :almalinux_8_version, "8.10-20240530", string
   override :github_ubuntu_2204_version, "20240609.1.1", string

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -75,8 +75,12 @@ class Prog::DownloadBootImage < Prog::Base
     hashes = {
       ["ubuntu-noble", "x64", "20240523.1"] => "b60205f4cc48a24b999ad0bd61ceb9fe28abfe4ac3701acb7bb5d6b0b5fdc624",
       ["ubuntu-noble", "arm64", "20240523.1"] => "54f6b62cc8d393e5c82495a49b8980157dfa6a13b930d8d4170e34e30742d949",
+      ["ubuntu-noble", "x64", "20240702"] => "182dc760bfca26c45fb4e4668049ecd4d0ecdd6171b3bae81d0135e8f1e9d93e",
+      ["ubuntu-noble", "arm64", "20240702"] => "5fe06e10a3b53cfff06edcb8595552b1f0372265b69fa424aa464eb4bcba3b09",
       ["ubuntu-jammy", "x64", "20240319"] => "304983616fcba6ee1452e9f38993d7d3b8a90e1eb65fb0054d672ce23294d812",
       ["ubuntu-jammy", "arm64", "20240319"] => "40ea1181447b9395fa03f6f2c405482fe532a348cc46fbb876effcfbbb35336f",
+      ["ubuntu-jammy", "x64", "20240701"] => "769f0355acc3f411251aeb96401a827248aae838b91c637d991ea51bed30eeeb",
+      ["ubuntu-jammy", "arm64", "20240701"] => "76423945c97fddd415fa17610c7472b07c46d6758d42f4f706f1bbe972f51155",
       ["almalinux-8", "x64", "8.10-20240530"] => "41a6bcdefb35afbd2819f0e6c68005cd5e9a346adf2dc093b1116a2b7c647d86",
       ["almalinux-9", "x64", "9.4-20240507"] => "bff0885c804c01fff8aac4b70c9ca4f04e8c119f9ee102043838f33e06f58390",
       ["almalinux-9", "arm64", "9.4-20240507"] => "75b2e68f6aaa41c039274595ff15968201b7201a7f2f03b109af691f2d3687a1",


### PR DESCRIPTION
The Ubuntu team has uncovered a significant vulnerability in the OpenSSH package which requires an update to the latest version.

We've already updated our fleet, but we must also ensure that new virtual machines come equipped with the most recent OpenSSH version.

[^1]: https://ubuntu.com/security/CVE-2024-6387