### PR TITLE
Measure runner concurrency based on cores instead of vCPUs

### DIFF
--- a/migrate/20240705_change_runner_core_limit.rb
+++ b/migrate/20240705_change_runner_core_limit.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:project) do
+      set_column_default :runner_core_limit, 150
+    end
+
+    run "UPDATE project SET runner_core_limit = runner_core_limit / 2"
+  end
+
+  down do
+    alter_table(:project) do
+      set_column_default :runner_core_limit, 300
+    end
+
+    run "UPDATE project SET runner_core_limit = runner_core_limit * 2"
+  end
+end

--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -18,7 +18,14 @@ class GithubInstallation < Sequel::Model
 
   def total_active_runner_cores
     runner_labels = runners_dataset.left_join(:strand, id: :id).exclude(Sequel[:strand][:label] => "start").exclude(Sequel[:strand][:label] => "wait_concurrency_limit").select_map(Sequel[:github_runner][:label])
-    vm_size_data_set = runner_labels.map { |label| Github.runner_labels[label]["vm_size"] }
-    vm_size_data_set.sum { |size| Validation.validate_vm_size(size).vcpu }
+    label_record_data_set = runner_labels.map { |label| Github.runner_labels[label] }
+    label_record_data_set.sum do |label_record|
+      vcpu = Validation.validate_vm_size(label_record["vm_size"]).vcpu
+      if label_record["arch"] == "arm64"
+        vcpu
+      else
+        vcpu / 2
+      end
+    end
   end
 end

--- a/spec/model/github_installation_spec.rb
+++ b/spec/model/github_installation_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe GithubInstallation do
       Strand.create(prog: "Github::RunnerNexus", label: "allocate_vm") { _1.id = gr.id }
     end
 
+    expect(installation.total_active_runner_cores).to eq(3)
+  end
+
+  it "returns sum of used vm cores for arm64" do
+    vms = [2, 4].map { create_vm(cores: _1, arch: "arm64") }
+
+    vms.each do |vm|
+      gr = GithubRunner.create_with_id(installation_id: installation.id, vm_id: vm.id, repository_name: "test-repo", label: "ubicloud-standard-#{vm.cores}-arm")
+      Strand.create(prog: "Github::RunnerNexus", label: "allocate_vm") { _1.id = gr.id }
+    end
+
     expect(installation.total_active_runner_cores).to eq(6)
   end
 end


### PR DESCRIPTION
**Change total_active_runner_cores to count cores**
Before this commit, total_active_runner_cores returned the number active
runner vCPUs. This commit changes the logic to return the number of
active cores.

**Reduce runner_core_limit from 300 to 150**
The logic to check active runner concurrency was previously changed to
count cores instead of vCPUs. For x64 a core corresponds to 2 vCPUs.
This commit updates runner_core_limit from 300 (vCPUs) to 150 (cores).