### PR TITLE
Assemble Pages with correct Prog

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -92,13 +92,17 @@ SQL
       modified!(:stack)
     end
 
+    effective_prog = prog
     stack.each do |frame|
-      next unless (deadline_at = frame["deadline_at"])
+      if (deadline_at = frame["deadline_at"])
+        if Time.now > Time.parse(deadline_at.to_s)
+          Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", [ubid], "Deadline", id, effective_prog, frame["deadline_target"])
+          modified!(:stack)
+        end
+      end
 
-      if Time.now > Time.parse(deadline_at.to_s)
-        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{prog}.#{label} did not reach #{frame["deadline_target"]} on time", [ubid], "Deadline", id, prog, frame["deadline_target"])
-
-        modified!(:stack)
+      if (link = frame["link"])
+        effective_prog = link[0]
       end
     end
 

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -122,3 +122,6 @@ class Prog::Test < Prog::Base
     push Prog::Test, {"subject_id" => "70b633b7-1d24-4526-a47f-d2580597d53f"}
   end
 end
+
+class Prog::Test2 < Prog::Test
+end


### PR DESCRIPTION
Assume ProgA registers a deadline and then pushes another ProgB. If that deadline expires while ProgB is executing, the Page is created with a reference to ProgB instead of ProgA. As a result, the Page has misleading information and even if ProgA reaches the target state, the Page is never resolved. This commit fixes this issue by walking back the links on the stack to identify the Prog that has registered the deadline.