### PR TITLE
Update storage selection UI to limit options

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -239,7 +239,7 @@ function setupLocationBasedPostgresHaPrices() {
   $("input.location-based-postgres-ha-price").each(function(i, obj) {
     let value = $(this).val();
     let monthlyComputePrice = parseFloat($("input[name=size]:checked").data("monthly-price"))
-    let monthlyStoragePrice = parseFloat($("input[name=storage_size]").val()) * parseFloat($(".storage-slider").data("monthly-price"))
+    let monthlyStoragePrice = parseFloat($("input[name=storage_size]:checked").data("monthly-price"))
     let monthlyPrice = monthlyComputePrice + monthlyStoragePrice;
     let standbyCount = $(this).data("standby-count");
     $(`.ha-status-${value}`).show();
@@ -266,6 +266,7 @@ function setupInstanceSizeBasedOptions() {
       let monthlyPrice = storage_amount * $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"];
 
       $(this).find("input[type=radio]").val(storage_amount);
+      $(this).find("input[type=radio]").data("monthly-price", monthlyPrice);
       $(this).find(".storage-size-label").text(storage_amount + "GB (" + (storage_amount / storage_size_options[0]) + "x)");
       $(this).find(".storage-size-price").text("+$" + (monthlyPrice).toFixed(2));
       storage_size_index++;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -196,10 +196,9 @@ $("input[name=size]").on("change", function (event) {
   setupLocationBasedPostgresHaPrices();
 });
 
-$(".storage-slider").on("change", function (event) {
+$("input[name=storage_size]").on("change", function (event) {
   storage_size_options = $("input[name=size]:checked").data("storage-size-options");
   storage_size_index = parseInt($(".storage-slider").val());
-  $("input[name=storage_size]").val(storage_size_options[storage_size_index])
   setupLocationBasedPostgresHaPrices();
 });
 
@@ -257,26 +256,20 @@ function setupLocationBasedOptions() {
 }
 
 function setupInstanceSizeBasedOptions() {
-  $(".instance-size-based-option").each(function() {
-    let type = $(this).attr("type")
-    if(type == "range" && $(this).hasClass("storage-slider")){
-      storage_size_options = $("input[name=size]:checked").data("storage-size-options");
-      storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
+  $(".instance-size-based-storage-sizes").each(function() {
+    storage_size_options = $("input[name=size]:checked").data("storage-size-options");
+    storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
+    storage_size_index = 0;
 
-      $(this).attr("max", storage_size_options.length - 1);
-      storage_size_index = parseInt($(".storage-slider").val());
-      $("input[name=storage_size]").val(storage_size_options[storage_size_index])
+    $(this).find(".storage-size").each(function() {
+      let storage_amount = storage_size_options[storage_size_index];
+      let monthlyPrice = storage_amount * $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"];
 
-      let monthlyPrice = $("input[name=location]:checked").data("details")[storage_resource_type]["standard"]["monthly"]
-      $(this).data("monthly-price", monthlyPrice);
-
-      $(this).next().html("");
-      for(var i = 0; i < storage_size_options.length; i++) {
-        let storage_amount = storage_size_options[i];
-        let content = storage_amount + "GB<br/>+$" + (storage_amount * monthlyPrice).toFixed(2);
-        $(this).next().append("<li class='flex justify-right sm:justify-center relative items-center rotate-90 sm:rotate-0 mb-6 sm:mb-0'><span class='absolute text-center'>" + content + "</span></li>");
-      }
-    }
+      $(this).find("input[type=radio]").val(storage_amount);
+      $(this).find(".storage-size-label").text(storage_amount + "GB (" + (storage_amount / storage_size_options[0]) + "x)");
+      $(this).find(".storage-size-price").text("+$" + (monthlyPrice).toFixed(2));
+      storage_size_index++;
+    });
   });
 }
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -59,8 +59,8 @@ module Option
     alias_method :display_name, :name
   end
   PostgresSizes = [2, 4, 8, 16, 30, 60].map {
-    max_storage_size_gib = _1 * 256
-    storage_size_options = [128, 256, 512, 1024, 2048, 3072, 4096].select { |s| s <= max_storage_size_gib }
+    storage_size_options = [_1 * 64, _1 * 128, _1 * 256]
+    storage_size_options = [1024, 2048, 4096] if [30, 60].include?(_1)
     PostgresSize.new("standard-#{_1}", "standard-#{_1}", "standard", _1, _1 * 4, storage_size_options)
   }.freeze
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -49,8 +49,7 @@ module Option
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
-    max_storage_size_gib = _1 * 40
-    storage_size_options = [40, 60, 80, 160, 320, 512, 1024, 2048, 3072, 4096].select { |s| s <= max_storage_size_gib }
+    storage_size_options = [_1 * 20, _1 * 40]
     VmSize.new("standard-#{_1}", "standard", _1, _1 * 4, storage_size_options, true, false)
   }.concat([6].map {
     VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, [_1 * 30], false, true)

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Validation do
       it "valid vm storage sizes" do
         [
           ["standard-2", "40"],
-          ["standard-2", "60"],
+          ["standard-2", "80"],
           ["standard-4", "160"]
         ].each do |vm_size, storage_size|
           expect(described_class.validate_vm_storage_size(vm_size, storage_size)).to eq(storage_size.to_f)

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -109,27 +109,36 @@
                 </div>
               </div>
 
-              <div class="col-span-full">
+              <div class="col-span-full instance-size-based-storage-sizes">
                 <div class="space-y-2">
-                  <label for="size" class="text-sm font-medium leading-6 text-gray-900">Storage size</label>
+                  <label for="storage_size" class="text-sm font-medium leading-6 text-gray-900">Storage size</label>
                   <fieldset class="radio-small-cards" id="storage-size-radios">
-                    <div class="col-span-full">
+                  <legend class="sr-only">Storage size</legend>
+                    <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
                       <% size = flash.dig("old", "size") ? Option::PostgresSizes.find { _1.name == flash.dig("old", "size") } : Option::PostgresSizes[0] %>
-                      <%== render(
-                        "components/form/range_slider",
-                        locals: {
-                          label: "Storage Size",
-                          range_labels: size.storage_size_options.map { "#{_1}GB" },
-                          value: flash.dig("old", "storage_size") ? size.storage_size_options.index(flash.dig("old", "storage_size").to_i) : 0,
-                          attributes: {
-                            min: 0,
-                            max: size.storage_size_options.size - 1,
-                            required: true
-                          },
-                          extra_class: "instance-size-based-option storage-slider",
-                        }
-                      ) %>
-                      <input type="hidden" name="storage_size" id="storage_size" value="<%= flash.dig("old", "storage_size") || size.storage_size_options[0] %>">
+                      <% size.storage_size_options.each_with_index do |storage_size, idx| %>
+                        <label class="storage-size storage-size-<%= storage_size %>">
+                          <input
+                            type="radio"
+                            name="storage_size"
+                            value="<%= storage_size %>"
+                            class="peer sr-only"
+                            required
+                            <%= (flash.dig("old", "storage_size") == storage_size || flash.dig("old", "storage_size").nil? && idx == 0) ? "checked" : "" %>
+                          >
+                          <span
+                            class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
+                                ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
+                                peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700"
+                          >
+                            <span class="text-md font-semibold storage-size-label"><%= storage_size %>GB</span>
+                            <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
+                              <span class="font-medium storage-size-price">-</span>
+                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                            </span>
+                          </span>
+                        </label>
+                      <% end %>
                     </div>
                   </fieldset>
                 </div>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -137,26 +137,36 @@
                 </div>
               </div>
 
-              <div class="col-span-full">
+              <div class="col-span-full instance-size-based-storage-sizes">
                 <div class="space-y-2">
+                  <label for="storage_size" class="text-sm font-medium leading-6 text-gray-900">Storage size</label>
                   <fieldset class="radio-small-cards" id="storage-size-radios">
-                    <div class="col-span-full">
+                  <legend class="sr-only">Storage size</legend>
+                    <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
                       <% size = flash.dig("old", "size") ? Option::VmSizes.find { _1.name == flash.dig("old", "size") } : Option::VmSizes[0] %>
-                      <%== render(
-                        "components/form/range_slider",
-                        locals: {
-                          label: "Storage Size",
-                          range_labels: size.storage_size_options.map { "#{_1}GB" },
-                          value: flash.dig("old", "storage_size") ? size.storage_size_options.index(flash.dig("old", "storage_size").to_i) : 0,
-                          attributes: {
-                            min: 0,
-                            max: size.storage_size_options.size - 1,
-                            required: true
-                          },
-                          extra_class: "instance-size-based-option storage-slider",
-                        }
-                      ) %>
-                      <input type="hidden" name="storage_size" id="storage_size" value="<%= flash.dig("old", "storage_size") || size.storage_size_options[0] %>">
+                      <% size.storage_size_options.each_with_index do |storage_size, idx| %>
+                        <label class="storage-size storage-size-<%= storage_size %>">
+                          <input
+                            type="radio"
+                            name="storage_size"
+                            value="<%= storage_size %>"
+                            class="peer sr-only"
+                            required
+                            <%= (flash.dig("old", "storage_size") == storage_size || flash.dig("old", "storage_size").nil? && idx == 0) ? "checked" : "" %>
+                          >
+                          <span
+                            class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
+                                ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
+                                peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700"
+                          >
+                            <span class="text-md font-semibold storage-size-label"><%= storage_size %>GB</span>
+                            <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
+                              <span class="font-medium storage-size-price">-</span>
+                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                            </span>
+                          </span>
+                        </label>
+                      <% end %>
                     </div>
                   </fieldset>
                 </div>


### PR DESCRIPTION
We decided to simplify storage selection for VMs and Postgres by reducing the number of available options. Whit this PR, we start to allows only following storage sizes:

**VM:** 40GB per core (1x), 80GB per core (2x)
**Postgres:** 128GB per core (1x), 256GB per core (2x), 512GB per core (4x) (However for bigger instance types, we set the default to be 1TB instead of continuing to increase storage size proportionally)

Since number of different options is low, we also started to use radio cards instead of sliders.

**VM Options Before:**
![image](https://github.com/ubicloud/ubicloud/assets/2082070/636a82ae-6004-4124-b76c-9b38bfd02d33)

**VM Options After:**
![image](https://github.com/ubicloud/ubicloud/assets/2082070/c42f92b9-ae05-45c1-884b-64580e65a77a)

**Postgres Options Before:**
![image](https://github.com/ubicloud/ubicloud/assets/2082070/81e95254-4c17-4a67-859e-3066a7a9e326)

**Postgres Options After:**
![image](https://github.com/ubicloud/ubicloud/assets/2082070/fa073ba8-26f8-4414-8d55-7b1c505da1df)
