### PR TITLE
Fix strand delay calculation to use old schedule time instead of updated one

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -29,7 +29,7 @@ SQL
     return false unless affected
     lease_time = affected.fetch(:lease)
 
-    Clog.emit("obtained lease") { {lease_acquired: {time: lease_time}} }
+    Clog.emit("obtained lease") { {lease_acquired: {time: lease_time, delay: Time.now - schedule}} }
     reload
 
     begin
@@ -79,7 +79,7 @@ SQL
   def unsynchronized_run
     start_time = Time.now
     prog_label = "#{prog}.#{label}"
-    Clog.emit("starting strand") { {strand: values, strand_started: {delay: start_time - schedule, prog_label: prog_label}} }
+    Clog.emit("starting strand") { {strand: values, strand_started: {prog_label: prog_label}} }
 
     if label == stack.first["deadline_target"].to_s
       if (pg = Page.from_tag_parts("Deadline", id, prog, stack.first["deadline_target"]))


### PR DESCRIPTION
I've identified some inconsistencies between the VM creation time and the strand schedule time. There are instances where the initial strand schedule time and VM creation time differ significantly, yet the schedule delay is minimal. This led me to look deeper to our strand running code further.

We started to reload the strand at
bbf3e142bda5b408cd94150a435efca6bd40204c when we take the lease. This ensures we have the most recent version of the strand. However, we also update the try count and schedule time while taking the lease. Thus, upon taking the lease, we have a new schedule time for the strand in this context. We then calculate the delay based on strand's schedule time, so the new schedule time. This results in us observing a smaller delay than expected, or even a negative delay. As the try count increases, this negative delay also increases. This bug also provides an explanation for the the respirate picking jobs from the future mystery.

Fixes #1089

It seems the respirate may not be keeping up with the current load, but this issue has been overlooked due to this bug.