### PR TITLE
Add new deadlines to vm host nexus

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -124,6 +124,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def prep_reboot
+    register_deadline(:wait, 15 * 60)
     boot_id = get_boot_id
     vm_host.update(last_boot_id: boot_id)
 

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -37,7 +37,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def start
-    register_deadline(:wait, 15 * 60)
+    register_deadline(:download_boot_images, 10 * 60)
     hop_prep if retval&.dig("msg") == "rhizome user bootstrapped and source installed"
 
     push Prog::BootstrapRhizome, {"target_folder" => "host"}
@@ -107,6 +107,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def download_boot_images
+    register_deadline(:prep_reboot, 4 * 60 * 60)
     frame["default_boot_images"].each { |image_name|
       bud Prog::DownloadBootImage, {
         "image_name" => image_name


### PR DESCRIPTION
### Tune deadlines for vm host setup
We started to download boot images during the setup of the VM host at e745f82b47151dc2b2077f209244390f30ef5654, instead of while provisioning virtual machines. Our runner images, which are 75GB in size, are downloaded from our internal blob storage. However, some hosts have a slow network connection to our blob storage, leading to lengthy download times. Previously, we had a single deadline for the VM host setup. It's now more efficient to divide the deadline into two pieces, allowing at least 4 hours for the image download. While the fastest hosts can complete this in 5 minutes, slower connections may require at least 4 hours.

### Add deadline for vm host reboot

There's no set deadline for the VM host reboot. The host might remain in the reboot state for an extended period due to various factors. We've experienced this issue before and we noticed it was stuck after a long time.