### PR TITLE
Manage Postgres' subnet and firewalls through the parent entity

### DIFF
--- a/migrate/20240711_attach_subnets_and_firewall_to_pg_resource.rb
+++ b/migrate/20240711_attach_subnets_and_firewall_to_pg_resource.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:postgres_resource) do
+      add_column :private_subnet_id, :uuid
+    end
+  end
+end

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -38,6 +38,19 @@ class Firewall < Sequel::Model
     fwr
   end
 
+  def replace_firewall_rules(new_firewall_rules)
+    firewall_rules.each(&:destroy)
+    new_firewall_rules.each do |fwr|
+      FirewallRule.create_with_id(
+        firewall_id: id,
+        cidr: fwr[:cidr],
+        port_range: fwr[:port_range]
+      )
+    end
+
+    private_subnets.each(&:incr_update_firewall_rules)
+  end
+
   def destroy
     DB.transaction do
       private_subnets.each(&:incr_update_firewall_rules)

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -12,6 +12,7 @@ class PostgresResource < Sequel::Model
   one_through_one :timeline, class: PostgresTimeline, join_table: :postgres_server, left_key: :resource_id, right_key: :timeline_id
   one_to_many :firewall_rules, class: PostgresFirewallRule, key: :postgres_resource_id
   one_to_many :metric_destinations, class: PostgresMetricDestination, key: :postgres_resource_id
+  many_to_one :private_subnet
 
   plugin :association_dependencies, firewall_rules: :destroy, metric_destinations: :destroy
   dataset_module Authorization::Dataset

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -91,6 +91,13 @@ class PostgresResource < Sequel::Model
     required_standby_count_map[ha_type]
   end
 
+  def set_firewall_rules
+    vm_firewall_rules = firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(5432..5432)} }
+    vm_firewall_rules.push({cidr: "0.0.0.0/0", port_range: Sequel.pg_range(22..22)})
+    vm_firewall_rules.push({cidr: "::/0", port_range: Sequel.pg_range(22..22)})
+    private_subnet.firewalls.first.replace_firewall_rules(vm_firewall_rules)
+  end
+
   module HaType
     NONE = "none"
     ASYNC = "async"

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -17,7 +17,7 @@ class PostgresServer < Sequel::Model
   include HealthMonitorMethods
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
-  semaphore :restart, :configure, :update_firewall_rules, :take_over, :configure_prometheus, :destroy
+  semaphore :restart, :configure, :take_over, :configure_prometheus, :destroy
 
   def configure_hash
     configs = {
@@ -181,14 +181,6 @@ class PostgresServer < Sequel::Model
 
   def health_monitor_socket_path
     @health_monitor_socket_path ||= File.join(Dir.pwd, "var", "health_monitor_sockets", "pg_#{vm.ephemeral_net6.nth(2)}")
-  end
-
-  def create_resource_firewall_rules
-    fw = Firewall.create_with_id(name: ubid.to_s, description: "Postgres default firewall")
-    fw.add_private_subnet(vm.private_subnets.first)
-    resource.firewall_rules.each do |pg_fwr|
-      fw.insert_firewall_rule(pg_fwr.cidr.to_s, Sequel.pg_range(5432..5432))
-    end
   end
 
   def lsn2int(lsn)

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
   semaphore :restart, :configure, :update_firewall_rules, :take_over, :configure_prometheus, :destroy
 
-  def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil, private_subnet_id: nil, exclude_host_ids: [])
+  def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil, exclude_host_ids: [])
     DB.transaction do
       ubid = PostgresServer.generate_ubid
 
@@ -29,7 +29,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
           {encrypted: true, size_gib: postgres_resource.target_storage_size_gib}
         ],
         boot_image: postgres_resource.project.get_ff_postgresql_base_image || "postgres-ubuntu-2204",
-        private_subnet_id: private_subnet_id,
+        private_subnet_id: postgres_resource.private_subnet_id,
         enable_ip4: true,
         allow_only_ssh: true,
         exclude_host_ids: exclude_host_ids

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe Firewall do
       fw.insert_firewall_rule("0.0.0.0/0", nil)
     end
 
+    it "bulk sets firewall rules" do
+      fw.insert_firewall_rule("10.0.0.16/28", Sequel.pg_range(80..5432))
+      fw.insert_firewall_rule("0.0.0.0/32", Sequel.pg_range(5432..5432))
+      fw.replace_firewall_rules([{cidr: "0.0.0.0/32", port_range: Sequel.pg_range(5432..5432)}])
+      expect(fw.reload.firewall_rules.count).to eq(1)
+      expect(fw.reload.firewall_rules.first.cidr.to_s).to eq("0.0.0.0/32")
+    end
+
     it "associates with a private subnet" do
       ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(ps).to receive(:incr_update_firewall_rules)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -480,11 +480,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.wait }.to nap(30)
     end
 
-    it "hops to update_firewall_rules if update_firewall_rules is set" do
-      expect(nx).to receive(:when_update_firewall_rules_set?).and_yield
-      expect { nx.wait }.to hop("update_firewall_rules")
-    end
-
     it "hops to configure_prometheus if configure_prometheus is set" do
       expect(nx).to receive(:when_configure_prometheus_set?).and_yield
       expect { nx.wait }.to hop("configure_prometheus")
@@ -499,18 +494,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:when_restart_set?).and_yield
       expect(nx).to receive(:push).with(described_class, {}, "restart").and_call_original
       expect { nx.wait }.to hop("restart")
-    end
-  end
-
-  describe "#update_firewall_rules" do
-    it "updates firewall rules and hops to wait" do
-      expect(postgres_server).to receive(:ubid).and_return("dummy-ubid")
-      fw = instance_double(Firewall, name: "dummy-ubid")
-      expect(postgres_server.vm).to receive(:firewalls).and_return([fw])
-      expect(fw).to receive(:destroy)
-      expect(postgres_server).to receive(:create_resource_firewall_rules)
-
-      expect { nx.update_firewall_rules }.to hop("wait")
     end
   end
 


### PR DESCRIPTION
**Allow setting firewall rules in bulk for firewalls**
Firewalls have helper methods to add and remove rules, but they increment the
update_firewall_rules semaphore for each rule added or removed. This is fine in
terms of correctness, because the operation is done in transaction and other
entities will saw the change atomically. However, it is slower, because we need
to go to database multiple times. It also adds unnecessary entries for each
incremented semaphore. Instead, I added a bulk firewall rule set method to
handle this case more efficiently.

**Attach Postgres' subnet to resource instead of servers**
We used to not keep track of the private subnet in the resource level. Instead,
we would access it through representative_server's VM. Since we are moving
towards centralizing management of firewalls and private subnets, it is better
to track the private subnet in the resource level.

**Manage PostgreSQL firewalls from the parent resource**
Each PostgresServer used to manage its own firewall and we used to attach each
firewall to the private subnet. However, we were not properly cleaning up the
firewalls when the PostgresServer was deleted, causing the old rules in the
firewall to be active for that particular subnet. We could fix that particular
bug by better managing firewall of each PostgresServer (e.g. properly cleaning
them up after the deletion of the PostgresServer). However, it is better to
centralize the management of the firewalls in the parent entity, that is
PostgresResource.