### PR TITLE
Add more details to pages

### DIFF
--- a/migrate/20240711_add_severity_to_page.rb
+++ b/migrate/20240711_add_severity_to_page.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_enum(:page_severity, %w[critical error warning info])
+
+    alter_table(:page) do
+      add_column :severity, :page_severity, default: "error", null: false
+    end
+  end
+end

--- a/model/page.rb
+++ b/model/page.rb
@@ -29,7 +29,7 @@ class Page < Sequel::Model
     end
 
     incident = pagerduty_client.incident(OpenSSL::HMAC.hexdigest("SHA256", "ubicloud-page-key", tag))
-    incident.trigger(summary: summary, severity: "error", source: "clover", custom_details: details, links: links)
+    incident.trigger(summary: summary, severity: severity, source: "clover", custom_details: details, links: links)
   end
 
   def resolve

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -96,7 +96,7 @@ SQL
     stack.each do |frame|
       if (deadline_at = frame["deadline_at"])
         if Time.now > Time.parse(deadline_at.to_s)
-          Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", [ubid], "Deadline", id, effective_prog, frame["deadline_target"])
+          Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid)
           modified!(:stack)
         end
       end

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -4,13 +4,12 @@ class Prog::PageNexus < Prog::Base
   subject_is :page
   semaphore :resolve
 
-  def self.assemble(summary, related_resources, *tag_parts)
+  def self.assemble(summary, tag_parts, related_resources, severity: "error", extra_data: {})
     DB.transaction do
-      pg = Page.from_tag_parts(tag_parts)
-      unless pg
-        pg = Page.create_with_id(summary: summary, details: {"related_resources" => Array(related_resources)}, tag: Page.generate_tag(tag_parts))
-        Strand.create(prog: "PageNexus", label: "start") { _1.id = pg.id }
-      end
+      return if Page.from_tag_parts(tag_parts)
+
+      pg = Page.create_with_id(summary: summary, details: extra_data.merge({"related_resources" => Array(related_resources)}), tag: Page.generate_tag(tag_parts), severity: severity)
+      Strand.create(prog: "PageNexus", label: "start") { _1.id = pg.id }
     end
   end
 

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -58,7 +58,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     # if no backup is taken for 2 days.
     latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max || postgres_timeline.created_at
     if postgres_timeline.leader && latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60 # 2 days
-      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", [postgres_timeline.ubid], "MissingBackup", postgres_timeline.id)
+      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid)
     else
       Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
     end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -212,7 +212,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def unavailable
-    Prog::PageNexus.assemble("#{vm_host} is unavailable", vm_host.ubid, "VmHostUnavailable", vm_host.ubid)
+    Prog::PageNexus.assemble("#{vm_host} is unavailable", ["VmHostUnavailable", vm_host.ubid], vm_host.ubid)
     if available?
       Page.from_tag_parts("VmHostUnavailable", vm_host.ubid)&.incr_resolve
       decr_checkup

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -188,7 +188,8 @@ class Prog::Vm::Nexus < Prog::Base
 
       incr_waiting_for_capacity unless vm.waiting_for_capacity_set?
       queued_vms = queued_vms.all
-      Prog::PageNexus.assemble("No capacity left at #{vm.location} for #{vm.family} family of #{vm.arch}", ["NoCapacity", vm.location, vm.arch, vm.family], queued_vms.first(25).map(&:ubid))
+      utilization = VmHost.where(allocation_state: "accepting", arch: vm.arch).select_map { sum(:used_cores) * 100.0 / sum(:total_cores) }.first.to_f
+      Prog::PageNexus.assemble("No capacity left at #{vm.location} for #{vm.family} family of #{vm.arch}", ["NoCapacity", vm.location, vm.arch, vm.family], queued_vms.first(25).map(&:ubid), severity: "warning", extra_data: {queue_size: queued_vms.count, utilization: utilization})
       Clog.emit("No capacity left") { {lack_of_capacity: {location: vm.location, arch: vm.arch, family: vm.family, queue_size: queued_vms.count}} }
 
       nap 30

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -188,7 +188,7 @@ class Prog::Vm::Nexus < Prog::Base
 
       incr_waiting_for_capacity unless vm.waiting_for_capacity_set?
       queued_vms = queued_vms.all
-      Prog::PageNexus.assemble("No capacity left at #{vm.location} for #{vm.family} family of #{vm.arch}", queued_vms.first(25).map(&:ubid), "NoCapacity", vm.location, vm.arch, vm.family)
+      Prog::PageNexus.assemble("No capacity left at #{vm.location} for #{vm.family} family of #{vm.arch}", ["NoCapacity", vm.location, vm.arch, vm.family], queued_vms.first(25).map(&:ubid))
       Clog.emit("No capacity left") { {lack_of_capacity: {location: vm.location, arch: vm.arch, family: vm.family, queue_size: queued_vms.count}} }
 
       nap 30
@@ -365,7 +365,7 @@ class Prog::Vm::Nexus < Prog::Base
         decr_checkup
         hop_wait
       else
-        Prog::PageNexus.assemble("#{vm} is unavailable", vm.ubid, "VmUnavailable", vm.ubid)
+        Prog::PageNexus.assemble("#{vm} is unavailable", ["VmUnavailable", vm.ubid], vm.ubid)
       end
     rescue Sshable::SshError
       # Host is likely to be down, which will be handled by HostNexus. No need

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Prog::Base do
 
     it "resolves the page once the target is reached" do
       st = Strand.create_with_id(prog: "Test", label: :napper)
-      page_id = Prog::PageNexus.assemble("dummy-summary", [st.ubid], "Deadline", st.id, st.prog, :napper).id
+      page_id = Prog::PageNexus.assemble("dummy-summary", ["Deadline", st.id, st.prog, :napper], st.ubid).id
 
       st.stack.first["deadline_target"] = :napper
       st.stack.first["deadline_at"] = Time.now - 1
@@ -250,7 +250,7 @@ RSpec.describe Prog::Base do
 
     it "resolves the page once a new deadline is registered" do
       st = Strand.create_with_id(prog: "Test", label: :start)
-      page_id = Prog::PageNexus.assemble("dummy-summary", [st.ubid], "Deadline", st.id, st.prog, :napper).id
+      page_id = Prog::PageNexus.assemble("dummy-summary", ["Deadline", st.id, st.prog, :napper], st.ubid).id
 
       st.stack.first["deadline_target"] = :napper
       st.stack.first["deadline_at"] = Time.now - 1


### PR DESCRIPTION
### Add severity column to page table

Currently, we trigger all pages labeled with 'error' severity. However, certain pages, like capacity incidents, don't require immediate phone calls. Using the severity column, we can filter out non-urgent pages.

### Add extra data and severity to pages
The `severity` field allows us to designate the alert's severity level. PagerDuty uses this field to assess the alert's urgency. The severity field can be assigned one of the following values: `critical`, `error`, `warning`, `info` [^1]. In the past, we assigned the `error` value to all alerts.

Additionally, I added the `extra_data` parameter. This facilitates the addition of extra details to incidents, along with related resources. For instance, we can include utilization in capacity incidents.

While I usually appreciate the splat operator `*tag_parts`, its comprehension becomes challenging as the number of parameters increases. Therefore, I modified it to accept a list of tags.

[^1]: https://support.pagerduty.com/docs/dynamic-notifications#severity-and-urgency-mapping

###  Lower capacity incident severity and add utilization data

We don't have an immediate response for capacity incidents. They simply alert us when our utilization is higher than usual. If this persists, we can investigate for any unusual usage. Therefore, it's not necessary to make a phone call about it given its low severity. I've downgraded its severity to 'warning'. Additionally, I included utilization data in the incident details, which can be viewed on Slack messages.