### PR TITLE
Add custom inspect representation for UBID

### DIFF
--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -264,4 +264,8 @@ RSpec.describe UBID do
       described_class.decode("han2sefsk4f61k91z77vn0y978")
     }.to raise_error RuntimeError, "Couldn't decode ubid: han2sefsk4f61k91z77vn0y978"
   end
+
+  it "can be inspected" do
+    expect(described_class.parse("vmqsknkzw5164hkfnt6z6zgjps").inspect).to eq("#<UBID:Vm @ubid=\"vmqsknkzw5164hkfnt6z6zgjps\" @uuid=\"be6759ff-8509-8b74-8cdf-5d1be6fc256c\">")
+  end
 end

--- a/ubid.rb
+++ b/ubid.rb
@@ -190,6 +190,10 @@ class UBID
     @value
   end
 
+  def inspect
+    "#<UBID:#{TYPE2CLASS[to_s[..1]] || "Unknown"} @ubid=#{to_s.inspect} @uuid=#{to_uuid.inspect}>"
+  end
+
   #
   # Utility functions
   #


### PR DESCRIPTION
When we get a UBID in pry, the displayed value is not useful at all. Usually, I prefer to view the UBID or UUID and use "to_s" or "to_uuid" to retrieve the value. I've updated the inspect method to display the UBID and UUID values by default. I believe this will be helpful for operators.

Before:

    [1] clover-development(main)> UBID.parse("vmy2mfzyj1yj2kv7rpevcp9afs")
    => #<UBID:0x0000000112e55610 @value=319892216702515363489663739989322781948>

After:

    [1] clover-development(main)> UBID.parse("vmy2mfzyj1yj2kv7rpevcp9afs")
    => #<UBID:Vm @ubid="vmy2mfzyj1yj2kv7rpevcp9afs" @uuid="f0a8fffa-41f4-8774-9ecf-8b3b6cb254fc">