### PR TITLE
Put operator SSH keys to service VMs

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -110,5 +110,5 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys
 end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -204,6 +204,8 @@ class Vm < Sequel::Model
   def params_json(swap_size_bytes)
     topo = cloud_hypervisor_cpu_topology
 
+    project_public_keys = projects.first.get_ff_vm_public_ssh_keys || []
+
     # we don't write secrets to params_json, because it
     # shouldn't be stored in the host for security reasons.
     JSON.pretty_generate({
@@ -212,7 +214,7 @@ class Vm < Sequel::Model
       "public_ipv4" => ip4.to_s || "",
       "local_ipv4" => local_vetho_ip.to_s.shellescape || "",
       "unix_user" => unix_user,
-      "ssh_public_keys" => [public_key],
+      "ssh_public_keys" => [public_key] + project_public_keys,
       "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac] },
       "boot_image" => boot_image,
       "max_vcpus" => topo.max_vcpus,

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -212,7 +212,7 @@ class Vm < Sequel::Model
       "public_ipv4" => ip4.to_s || "",
       "local_ipv4" => local_vetho_ip.to_s.shellescape || "",
       "unix_user" => unix_user,
-      "ssh_public_key" => public_key,
+      "ssh_public_keys" => [public_key],
       "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac] },
       "boot_image" => boot_image,
       "max_vcpus" => topo.max_vcpus,

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -40,7 +40,7 @@ begin
   ip4 = params.fetch("public_ipv4")
   local_ip4 = params.fetch("local_ipv4")
   unix_user = params.fetch("unix_user")
-  ssh_public_key = params.fetch("ssh_public_key")
+  ssh_public_keys = params.fetch("ssh_public_keys") { [params.fetch("ssh_public_key")] }
   nics = params.fetch("nics").map { |args| VmSetup::Nic.new(*args) }.freeze
   max_vcpus = params.fetch("max_vcpus")
   cpu_topology = params.fetch("cpu_topology")
@@ -62,7 +62,7 @@ when "prep"
     exit 1
   end
 
-  vm_setup.prep(unix_user, ssh_public_key, nics, gua, ip4,
+  vm_setup.prep(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 when "recreate-unpersisted"
@@ -87,7 +87,7 @@ when "reassign-ip6"
     puts "need storage secrets in secrets json"
     exit 1
   end
-  vm_setup.reassign_ip6(unix_user, ssh_public_key, nics, gua, ip4,
+  vm_setup.reassign_ip6(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
 else

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -40,7 +40,7 @@ begin
   ip4 = params.fetch("public_ipv4")
   local_ip4 = params.fetch("local_ipv4")
   unix_user = params.fetch("unix_user")
-  ssh_public_keys = params.fetch("ssh_public_keys") { [params.fetch("ssh_public_key")] }
+  ssh_public_keys = params.fetch("ssh_public_keys")
   nics = params.fetch("nics").map { |args| VmSetup::Nic.new(*args) }.freeze
   max_vcpus = params.fetch("max_vcpus")
   cpu_topology = params.fetch("cpu_topology")

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe VmSetup do
     before { expect(vs).to receive(:vp).and_return(vps).at_least(:once) }
 
     it "templates user YAML with no swap" do
-      vs.write_user_data("some_user", "some_ssh_key", nil)
+      vs.write_user_data("some_user", ["some_ssh_key"], nil)
       expect(vps).to have_received(:write_user_data) {
         expect(_1).to match(/some_user/)
         expect(_1).to match(/some_ssh_key/)
@@ -38,7 +38,7 @@ RSpec.describe VmSetup do
     end
 
     it "templates user YAML with swap" do
-      vs.write_user_data("some_user", "some_ssh_key", 123)
+      vs.write_user_data("some_user", ["some_ssh_key"], 123)
       expect(vps).to have_received(:write_user_data) {
         expect(_1).to match(/some_user/)
         expect(_1).to match(/some_ssh_key/)
@@ -48,7 +48,7 @@ RSpec.describe VmSetup do
 
     it "fails if the swap is not an integer" do
       expect {
-        vs.write_user_data("some_user", "some_ssh_key", "123")
+        vs.write_user_data("some_user", ["some_ssh_key"], "123")
       }.to raise_error RuntimeError, "BUG: swap_size_bytes must be an integer"
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Prog::Vm::Nexus do
         expect(params).to include({
           "public_ipv6" => "fe80::/64",
           "unix_user" => "test_user",
-          "ssh_public_key" => "test_ssh_key",
+          "ssh_public_keys" => ["test_ssh_key"],
           "max_vcpus" => 1,
           "cpu_topology" => "1:1:1:1",
           "mem_gib" => 8,

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -227,6 +227,8 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:nics).and_return([nic]).at_least(:once)
       expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(1, 1, 1, 1))
       expect(vm).to receive(:pci_devices).and_return([pci]).at_least(:once)
+      prj.set_ff_vm_public_ssh_keys(["operator_ssh_key"])
+      expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
 
       sshable = instance_spy(Sshable)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
@@ -240,7 +242,7 @@ RSpec.describe Prog::Vm::Nexus do
         expect(params).to include({
           "public_ipv6" => "fe80::/64",
           "unix_user" => "test_user",
-          "ssh_public_keys" => ["test_ssh_key"],
+          "ssh_public_keys" => ["test_ssh_key", "operator_ssh_key"],
           "max_vcpus" => 1,
           "cpu_topology" => "1:1:1:1",
           "mem_gib" => 8,


### PR DESCRIPTION
We deployed [this PR](https://github.com/ubicloud/ubicloud/pull/1744), but it caused failures in VM provisioning. This line was the culprit;

```
ssh_public_keys = params.fetch("ssh_public_keys", params.fetch("ssh_public_key"))
```

Here is what happens. Name of the variable sent from control plane was `ssh_public_key` (i.e. singular) but we are changing it to be `ssh_public_keys` (i.e plural). We added the second branch to fetch, where we fetch the `ssh_public_key` variable if `ssh_public_keys` is not found. In theory, we could deploy data plane that contains the above line first and install rhizome. This would ensure that no matter if the control plane code is old or new, the code would work. However, in the above line, right branch is evaluated first, without checking if `ssh_public_keys` exist or not. Then it throws error if `ssh_public_key` is not found. This makes sense in hindsight; after all variables of the function needs to be evaluated before the function. That means, in the most up-to-date control plane version of the code, where we use the variable name as `ssh_public_keys`, we always throw error due to lack of `ssh_public_key`. The fix is simple, we add a third branch:

```
ssh_public_keys = params.fetch("ssh_public_keys", params.fetch("ssh_public_key", ""))
```

This ensures that evaluation of second branch never throws error. However, in my opinion, having third branch has some problems;
- Three branches for fetching a simple variable is too much.
- We lose the ability to ever throw an error if neither `ssh_public_keys` nor `ssh_public_key` is sent.
- Branching is only useful during the deployment of this patch.

Thus, I added a final commit, that is supposed to be deployed last and remove the branching. The final version of the code looks like this;

```
ssh_public_keys = params.fetch("ssh_public_keys")
```