### PR TITLE
Suppress new spec warnings

### DIFF
--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe PostgresResource do
 
   it "sets firewall rules" do
     firewall = instance_double(Firewall, name: "#{postgres_resource.ubid}-firewall")
-    expect(postgres_resource.private_subnet).to receive(:firewalls).and_return([firewall])
+    expect(postgres_resource).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, firewalls: [firewall]))
     expect(postgres_resource).to receive(:firewall_rules).and_return([instance_double(PostgresFirewallRule, cidr: "0.0.0.0/0")])
     expect(firewall).to receive(:replace_firewall_rules).with([
       {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(5432..5432)},

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ DatabaseCleaner.url_allowlist = [
 
 Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser.*/)
 Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations.*/)
-Warning.ignore([:unused_var], /.*lib\/aws-sdk-s3\/endpoint_provider.*/)
+Warning.ignore([:unused_var], /.*lib\/aws-sdk-(s3|core)\/(endpoint_provider|cbor).*/)
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|


### PR DESCRIPTION
rspec displays a warning when an expectation is set on a nil object. We
can refactor this expectation to prevent this warning.

    WARNING: An expectation of `:firewalls` was set on `nil`. To allow
    expectations on `nil` and suppress this message, set
    `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to
    `true`. To disallow expectations on `nil`, set
    `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to
    `false`. Called from
    spec/model/postgres/postgres_resource_spec.rb:61:in `block (2
    levels) in <top (required)>'.

aws-sdk-s3 has begun to print a warning about an unused variable. We
already have a suppression in place for this library, and I've added
another one to it.

    ruby/3.2.4/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.201.1/lib/aws-sdk-core/cbor/encoder.rb:131:
    warning: assigned but unused variable - base
