### PR TITLE
Remove us-south-a13 region from UI

### DIFF
--- a/config/providers.yml
+++ b/config/providers.yml
@@ -13,7 +13,7 @@
     provider_internal_name: leaseweb,
     locations: [
       {display_name: us-east-a2, internal_name: leaseweb-wdc02, visible: false},
-      {display_name: us-south-a13, internal_name: leaseweb-dal13, visible: true},
+      {display_name: us-south-a13, internal_name: leaseweb-dal13, visible: false},
     ]
   }
 ]


### PR DESCRIPTION
We are planning to close this region and open another US region soon. To ensure no new resources are created in this region, we are removing it from the UI.