### PR TITLE
Delete cache entries

### DIFF
--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -2,6 +2,8 @@
 
 require_relative "../../model"
 
+require "aws-sdk-s3"
+
 class GithubCacheEntry < Sequel::Model
   many_to_one :repository, key: :repository_id, class: :GithubRepository
 
@@ -13,5 +15,20 @@ class GithubCacheEntry < Sequel::Model
 
   def blob_key
     "cache/#{ubid}"
+  end
+
+  def after_destroy
+    super
+    if committed_at.nil?
+      begin
+        repository.blob_storage_client.abort_multipart_upload(bucket: repository.bucket_name, key: blob_key, upload_id: upload_id)
+      rescue Aws::S3::Errors::NoSuchUpload
+      end
+    end
+
+    begin
+      repository.blob_storage_client.delete_object(bucket: repository.bucket_name, key: blob_key)
+    rescue Aws::S3::Errors::NoSuchKey
+    end
   end
 end

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -115,8 +115,6 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
       nap 5 * 60
     end
 
-    github_repository.destroy_blob_storage if github_repository.access_key
-
     github_repository.destroy
 
     pop "github repository destroyed"

--- a/spec/model/github/github_cache_entry_spec.rb
+++ b/spec/model/github/github_cache_entry_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe GithubCacheEntry do
+  subject(:entry) { described_class.create_with_id(repository_id: repository.id, key: "k1", version: "v1", scope: "main", upload_id: "upload-123", created_by: "3c9a861c-ab14-8218-a175-875ebb652f7b") }
+
+  let(:repository) { GithubRepository.create_with_id(name: "test") }
+
+  describe ".after_destroy" do
+    let(:client) { instance_double(Aws::S3::Client) }
+
+    before { allow(Aws::S3::Client).to receive(:new).and_return(client) }
+
+    it "deletes the object" do
+      expect(entry).to receive(:committed_at).and_return(Time.now)
+      expect(client).to receive(:delete_object).with(bucket: repository.bucket_name, key: entry.blob_key)
+      entry.destroy
+    end
+
+    it "ignores if the object already deleted" do
+      expect(entry).to receive(:committed_at).and_return(Time.now)
+      expect(client).to receive(:delete_object).and_raise(Aws::S3::Errors::NoSuchKey.new(nil, nil))
+      entry.destroy
+    end
+
+    it "aborts the multipart upload if the cache not committed yet" do
+      expect(entry).to receive(:committed_at).and_return(nil)
+      expect(client).to receive(:abort_multipart_upload).with(bucket: repository.bucket_name, key: entry.blob_key, upload_id: entry.upload_id)
+      expect(client).to receive(:delete_object)
+      entry.destroy
+    end
+
+    it "ignores if the multipart upload already aborted" do
+      expect(entry).to receive(:committed_at).and_return(nil)
+      expect(client).to receive(:abort_multipart_upload).and_raise(Aws::S3::Errors::NoSuchUpload.new(nil, nil))
+      expect(client).to receive(:delete_object)
+      entry.destroy
+    end
+  end
+end

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -149,14 +149,5 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
 
       expect { nx.destroy }.to exit({"msg" => "github repository destroyed"})
     end
-
-    it "deletes blob storage if it has one" do
-      expect(nx).to receive(:decr_destroy)
-      expect(github_repository).to receive(:destroy)
-      expect(github_repository).to receive(:access_key).and_return("access-key")
-      expect(github_repository).to receive(:destroy_blob_storage)
-
-      expect { nx.destroy }.to exit({"msg" => "github repository destroyed"})
-    end
   end
 end


### PR DESCRIPTION
### Delete blob storage object when cache entry destroyed

When the cache entry is destroyed, we need to delete the blob storage
object too. We clean up the object in the `after_destroy` hook. If the
cache object is already deleted, we don't need to do anything.

Also, the cache might not be committed yet. So if the multipart upload
is not completed, we abort the upload. If the upload is aborted already,
we don't need to do anything.

###  Delete all cache entries when repository delete

When the repository is deleted, we should delete all assosiated cache
entries. Also blob storage doesn't allow to delete bucket if it's not
empty, so we should delete all object before deleting the bucket. I
moved the bucket deletion to the `after_destroy` hook, so
`association_dependencies` plugin destroys all cache entries first, then
we delete the bucket.