### PR TITLE
Aggregate GitHub usage by installation not projects

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -79,7 +79,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       end_time = begin_time + 24 * 60 * 60
       used_amount = ((Time.now - github_runner.ready_at) / 60).ceil
       today_record = BillingRecord
-        .where(project_id: project.id, resource_id: project.id, billing_rate_id: rate_id)
+        .where(project_id: project.id, resource_id: installation.id, billing_rate_id: rate_id)
         .where { Sequel.pg_range(_1.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
         .first
 
@@ -89,8 +89,8 @@ class Prog::Vm::GithubRunner < Prog::Base
       else
         BillingRecord.create_with_id(
           project_id: project.id,
-          resource_id: project.id,
-          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")}",
+          resource_id: installation.id,
+          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")} (#{installation.name})",
           billing_rate_id: rate_id,
           span: Sequel.pg_range(begin_time...end_time),
           amount: used_amount

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require "forwardable"
 require "net/ssh"
 
 class Prog::Vm::GithubRunner < Prog::Base
   subject_is :github_runner
+
+  extend Forwardable
+  def_delegators :github_runner, :installation, :vm
+  def_delegators :installation, :project
 
   semaphore :destroy
 
@@ -62,7 +67,6 @@ class Prog::Vm::GithubRunner < Prog::Base
     # If the runner is destroyed before it's ready or doesn't pick a job, don't charge for it.
     return unless github_runner.ready_at && github_runner.workflow_job
 
-    project = github_runner.installation.project
     rate_id = if label_data["arch"] == "arm64"
       BillingRate.from_resource_properties("GitHubRunnerMinutes", "#{label_data["vm_size"]}-arm", "global")["id"]
     else
@@ -102,12 +106,8 @@ class Prog::Vm::GithubRunner < Prog::Base
     end
   end
 
-  def vm
-    @vm ||= github_runner.vm
-  end
-
   def github_client
-    @github_client ||= Github.installation_client(github_runner.installation.installation_id)
+    @github_client ||= Github.installation_client(installation.installation_id)
   end
 
   def label_data
@@ -166,8 +166,8 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   def concurrency_available?
-    github_runner.installation.project_dataset.for_update.all
-    github_runner.installation.project.runner_core_limit > github_runner.installation.project.github_installations.sum(&:total_active_runner_cores)
+    project.this.for_update.all
+    project.runner_core_limit > project.github_installations.sum(&:total_active_runner_cores)
   end
 
   def setup_info
@@ -182,8 +182,8 @@ class Prog::Vm::GithubRunner < Prog::Base
         "VM Pool" => vm.pool_id ? UBID.from_uuidish(vm.pool_id).to_s : nil,
         "Location" => vm.vm_host.location,
         "Datacenter" => vm.vm_host.data_center,
-        "Project" => github_runner.installation.project.ubid,
-        "Console URL" => "#{Config.base_url}#{github_runner.installation.project.path}/github"
+        "Project" => project.ubid,
+        "Console URL" => "#{Config.base_url}#{project.path}/github"
       }.map { "#{_1}: #{_2}" }.join("\n")
     }
   end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
+      expect(project).to receive(:this).and_return(dataset)
       expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
 
       expect { nx.start }.to hop("wait_concurrency_limit")
@@ -274,7 +274,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
+      expect(project).to receive(:this).and_return(dataset)
       expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
 
       expect { nx.start }.to hop("allocate_vm")
@@ -296,7 +296,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
+      expect(project).to receive(:this).and_return(dataset)
       expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
 
       expect { nx.wait_concurrency_limit }.to nap
@@ -309,7 +309,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
+      expect(project).to receive(:this).and_return(dataset)
       expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
 
       expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
@@ -322,7 +322,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
+      expect(project).to receive(:this).and_return(dataset)
       expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
       VmHost[arch: "x64"].update(used_cores: 4)
       expect { nx.wait_concurrency_limit }.to hop("allocate_vm")


### PR DESCRIPTION
We decided to aggregate daily GitHub usage to reduce the number of billing records during implementation. Currently, we aggregated them by project. However, since a project can have multiple installations, it's difficult to determine which installation is responsible for the usage. While the billing record already has a project ID column, it would be more efficient to use the installation ID to aggregate usage.