### PR TITLE
Delete any cache that not accessed in the last 7 days and keep usage at 10GB

### DIFF
--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -21,6 +21,8 @@ class GithubRepository < Sequel::Model
     enc.column :secret_key
   end
 
+  CACHE_SIZE_LIMIT = 10 * 1024 * 1024 * 1024 # 10GB
+
   def bucket_name
     ubid
   end

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -78,7 +78,7 @@ class CloverRuntime
           fail CloverError.new(400, "InvalidRequest", "No workflow job data available")
         end
 
-        if size > 10 * 1024 * 1024 * 1024
+        if size > GithubRepository::CACHE_SIZE_LIMIT
           fail CloverError.new(400, "InvalidRequest", "The cache size is over the 10GB limit")
         end
 


### PR DESCRIPTION
We offer 10GB of free cache storage per repository each week, similar to GitHub's approach.

Any cache that hasn't been accessed in the past 7 days is removed. Furthermore, when cache usage exceeds 10GB, we delete the oldest cache until the usage falls below 10GB.

GithubRepositoryNexus already checks for jobs every 5 minutes. I think it can check cache usage too. If we find that every 5 minutes is too frequent, we can adjust this timing in the future.