### PR TITLE
Correct associations in Address and AssignedVmAddress models

### DIFF
--- a/model/address.rb
+++ b/model/address.rb
@@ -3,8 +3,8 @@
 require_relative "../model"
 
 class Address < Sequel::Model
-  one_to_many :assigned_vm_address, key: :address_id, class: :AssignedVmAddress
-  one_to_many :assigned_host_address, key: :address_id, class: :AssignedHostAddress
+  one_to_many :assigned_vm_addresses, key: :address_id, class: :AssignedVmAddress
+  one_to_many :assigned_host_addresses, key: :address_id, class: :AssignedHostAddress
 
   include ResourceMethods
 end

--- a/model/assigned_vm_address.rb
+++ b/model/assigned_vm_address.rb
@@ -3,7 +3,7 @@
 require_relative "../model"
 
 class AssignedVmAddress < Sequel::Model
-  one_to_one :vm, key: :dst_vm_id
+  one_to_one :vm, key: :id, primary_key: :dst_vm_id
   many_to_one :address, key: :address_id
   one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id do |ds| ds.active end
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -113,7 +113,7 @@ class VmHost < Sequel::Model
     # we get the available subnets and if the subnet is /32, we eliminate it
     available_subnets = assigned_subnets.select { |a| a.cidr.version == 4 && a.cidr.network.to_s != sshable.host }
     # we eliminate the subnets that are full
-    used_subnet = available_subnets.select { |as| as.assigned_vm_address.count != 2**(32 - as.cidr.netmask.prefix_len) }.sample
+    used_subnet = available_subnets.select { |as| as.assigned_vm_addresses.count != 2**(32 - as.cidr.netmask.prefix_len) }.sample
 
     # not available subnet
     return [nil, nil] unless used_subnet
@@ -159,7 +159,7 @@ class VmHost < Sequel::Model
         # if it wasn't, we need to create it
         adr = Address.where(cidr: ip_addr).first
         if adr && is_failover_ip
-          if adr.assigned_vm_address.count > 0
+          if adr.assigned_vm_addresses.count > 0
             fail "BUG: failover ip #{ip_addr} is already assigned to a vm"
           end
 

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe VmHost do
 
   it "returns nil if there is no available subnet" do
     expect(vh).to receive(:assigned_subnets).and_return([address])
-    expect(address.assigned_vm_address).to receive(:count).and_return(4)
+    expect(address.assigned_vm_addresses).to receive(:count).and_return(4)
     expect(vh).to receive(:sshable).and_return(instance_double(Sshable, host: "0.0.0.2")).at_least(:once)
     ip4, address = vh.ip4_random_vm_network
     expect(ip4).to be_nil
@@ -295,7 +295,7 @@ RSpec.describe VmHost do
     adr = Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: old_id)
     expect(Address).to receive(:where).with(cidr: "1.1.1.0/30").and_return([adr]).once
 
-    expect(adr).to receive(:assigned_vm_address).and_return([instance_double(Vm)]).at_least(:once)
+    expect(adr).to receive(:assigned_vm_addresses).and_return([instance_double(Vm)]).at_least(:once)
     expect {
       vh.create_addresses
     }.to raise_error RuntimeError, "BUG: failover ip 1.1.1.0/30 is already assigned to a vm"


### PR DESCRIPTION
### Make one_to_many associations of addresses plural

`one_to_many` associations return an array of objects, so it makes sense
to name them in the plural form. This way, it's clear that the method
returns multiple objects.

### Fix vm association in AssignedVmAddress
The current configuration of the `vm` association in the
`AssignedVmAddress` is incorrect, leading to the below exception. This
issue arises because the `key` parameter corresponds to the column name
in the `Vm` table, while the `primary_key` refers to the column name in
the `AssignedVmAddress` table.

    [12] clover-development(main)> AssignedVmAddress.first.vm
    Sequel::DatabaseError: PG::UndefinedColumn: ERROR:  column vm.assigned_vm_address_id does not exist
    LINE 1: SELECT * FROM "vm" WHERE ("vm"."assigned_vm_address_id" = $1...
                                      ^
    from /Users/enescakir/.asdf/installs/ruby/3.2.4/lib/ruby/gems/3.2.0/gems/sequel-5.81.0/lib/sequel/adapters/postgres.rb:171:in `exec_params'
    Caused by PG::UndefinedColumn: ERROR:  column vm.assigned_vm_address_id does not exist
    LINE 1: SELECT * FROM "vm" WHERE ("vm"."assigned_vm_address_id" = $1...
                                      ^
    from /Users/enescakir/.asdf/installs/ruby/3.2.4/lib/ruby/gems/3.2.0/gems/sequel-5.81.0/lib/sequel/adapters/postgres.rb:171:in `exec_params'
