### PR TITLE
Load balancer Refactor

### DIFF
--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -51,6 +51,6 @@ class LoadBalancer < Sequel::Model
   end
 
   def hostname
-    "#{name}.#{ubid[-5...]}.#{Config.load_balancer_service_hostname}"
+    "#{name}.#{private_subnet.ubid[-5...]}.#{Config.load_balancer_service_hostname}"
   end
 end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -434,7 +434,7 @@ class Prog::Vm::Nexus < Prog::Base
     unless vm.lb_expiry_started_set?
       vm.incr_lb_expiry_started
       vm.load_balancer.evacuate_vm(vm)
-      nap 10 * 60
+      nap 30
     end
 
     vm.load_balancer.remove_vm(vm)

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe LoadBalancer do
     end
 
     it "returns hostname" do
-      expect(lb.hostname).to eq("test-lb.#{lb.ubid[-5...]}.lb.ubicloud.com")
+      expect(lb.hostname).to eq("test-lb.#{lb.private_subnet.ubid[-5...]}.lb.ubicloud.com")
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -743,12 +743,12 @@ RSpec.describe Prog::Vm::Nexus do
         expect { nx.destroy }.to exit({"msg" => "vm deleted"})
       end
 
-      it "naps for 10 minutes" do
+      it "naps for 30 seconds" do
         lb = instance_double(LoadBalancer)
         expect(lb).to receive(:evacuate_vm).with(vm)
         expect(vm).to receive(:load_balancer).and_return(lb)
         expect(vm).to receive(:incr_lb_expiry_started)
-        expect { nx.wait_lb_expiry }.to nap(600)
+        expect { nx.wait_lb_expiry }.to nap(30)
       end
 
       it "destroys properly after 10 minutes" do

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       lb = described_class.assemble(ps.id, name: "test-lb2", src_port: 80, dst_port: 80).subject
       expect(LoadBalancer.count).to eq 2
       expect(lb.projects.first).to eq ps.projects.first
-      expect(lb.hostname).to eq "test-lb2.#{lb.ubid[-5...]}.lb.ubicloud.com"
+      expect(lb.hostname).to eq "test-lb2.#{ps.ubid[-5...]}.lb.ubicloud.com"
     end
   end
 

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Clover, "load balancer" do
         fill_in "Load Balancer Port", with: 80
         fill_in "Application Port", with: 8000
         select "round-robin", from: "algorithm"
-        fill_in "Health Check Endpoint", with: "/up"
+        fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
 
         click_button "Create"
@@ -98,7 +98,7 @@ RSpec.describe Clover, "load balancer" do
         fill_in "Load Balancer Port", with: 80
         fill_in "Application Port", with: 8000
         select "round-robin", from: "algorithm"
-        fill_in "Health Check Endpoint", with: "/up"
+        fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
 
         click_button "Create"
@@ -128,7 +128,7 @@ RSpec.describe Clover, "load balancer" do
         fill_in "Load Balancer Port", with: 80
         fill_in "Application Port", with: 8000
         select "round-robin", from: "algorithm"
-        fill_in "Health Check Endpoint", with: "/up"
+        fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
 
         ps.destroy

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Clover, "load balancer" do
         expect(page.title).to eq("Ubicloud - Create Load Balancer")
         name = "dummy-lb-1"
         fill_in "Name", with: name
-        fill_in "Source Port", with: 80
-        fill_in "Destination Port", with: 8000
+        fill_in "Load Balancer Port", with: 80
+        fill_in "Application Port", with: 8000
         select "round-robin", from: "algorithm"
         fill_in "Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
@@ -95,8 +95,8 @@ RSpec.describe Clover, "load balancer" do
         expect(page.title).to eq("Ubicloud - Create Load Balancer")
 
         fill_in "Name", with: "invalid name"
-        fill_in "Source Port", with: 80
-        fill_in "Destination Port", with: 8000
+        fill_in "Load Balancer Port", with: 80
+        fill_in "Application Port", with: 8000
         select "round-robin", from: "algorithm"
         fill_in "Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
@@ -125,8 +125,8 @@ RSpec.describe Clover, "load balancer" do
         expect(page.title).to eq("Ubicloud - Create Load Balancer")
 
         fill_in "Name", with: "dummy-lb-1"
-        fill_in "Source Port", with: 80
-        fill_in "Destination Port", with: 8000
+        fill_in "Load Balancer Port", with: 80
+        fill_in "Application Port", with: 8000
         select "round-robin", from: "algorithm"
         fill_in "Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -54,8 +54,8 @@
                 ) %>
               </div>
             </div>
-            <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-              <div class="col-span-6 md:col-span-2 xl:col-span-1">
+            <div class="mt-6 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-6">
+              <div class="col-span-6 md:col-span-4 xl:col-span-2">
                 <%== render(
                   "components/form/select",
                   locals: {
@@ -65,27 +65,22 @@
                   }
                 ) %>
               </div>
-              <div class="col-span-6 md:col-span-2 xl:col-span-1">
-                <%== render(
-                  "components/form/text",
-                  locals: {
-                    name: "health_check_endpoint",
-                    label: "Health Check Endpoint",
-                    attributes: {
-                      required: true,
-                      placeholder: "/up"
-                    }
-                  }
-                ) %>
-              </div>
             </div>
+          </div>
+        </div>
+      </div>
+      <div class="px-4 py-5 mt-6 sm:p-6">
+        <div class="space-y-12">
+          <div>
+            <h2 class="text-base font-semibold leading-7 text-gray-900">Forwarding Rule</h2>
+            <p class="mt-1 text-sm leading-6 text-gray-600">Configures the routing of traffic from the load balancer to your virtual machines.</p>
             <div class="mt-6 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-6">
               <div class="col-span-6 md:col-span-2 xl:col-span-1">
                 <%== render(
                   "components/form/text",
                   locals: {
                     name: "src_port",
-                    label: "Source Port",
+                    label: "Load Balancer Port",
                     type: "number",
                     attributes: {
                       required: true,
@@ -99,7 +94,7 @@
                   "components/form/text",
                   locals: {
                     name: "dst_port",
-                    label: "Destination Port",
+                    label: "Application Port",
                     type: "number",
                     attributes: {
                       required: true,
@@ -111,6 +106,24 @@
             </div>
           </div>
         </div>
+      </div>
+      <div class="px-4 py-5 mt-6 sm:p-6">
+        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="col-span-6 md:col-span-2 xl:col-span-1">
+            <%== render(
+              "components/form/text",
+              locals: {
+                name: "health_check_endpoint",
+                label: "HTTP Health Check Endpoint",
+                attributes: {
+                  required: true,
+                  placeholder: "/up"
+                }
+              }
+            ) %>
+          </div>
+        </div>
+        <p class="mt-1 text-sm leading-6 text-gray-600">The health check endpoint is used in combination with the Application Port. Make sure it returns 200.</p>
       </div>
       <div class="px-4 py-5 sm:p-6">
         <div class="flex items-center justify-end gap-x-6">

--- a/views/networking/load_balancer/show.erb
+++ b/views/networking/load_balancer/show.erb
@@ -30,9 +30,9 @@
           { escape: false }
         ],
         ["Algorithm", @lb[:algorithm]],
-        ["Health Check Endpoint", @lb[:health_check_endpoint]],
-        ["Source Port", @lb[:src_port]],
-        ["Destination Port", @lb[:dst_port]]
+        ["Load Balancer Port", @lb[:src_port]],
+        ["Application Port", @lb[:dst_port]],
+        ["HTTP Health Check Endpoint", @lb[:health_check_endpoint]]
       ]
     }
   ) %>
@@ -48,7 +48,7 @@
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">VM</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Application State</th>
           <% if Authorization.has_permission?(@current_user.id, "LoadBalancer:edit", @lb[:id]) %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           <% end %>


### PR DESCRIPTION
## Refactor Load Balancer Create Page
<img width="1614" alt="Screenshot 2024-07-18 at 16 55 44" src="https://github.com/user-attachments/assets/d8fb99a7-7997-4684-ba21-870abf68779a">

## Refactor Load Balancer Show page
<img width="1648" alt="Screenshot 2024-07-18 at 16 55 57" src="https://github.com/user-attachments/assets/a1d3f33f-4f22-4e9b-b116-55c598710e45">

## Update Load Balancer hostname to use subnet.ubid
Load Balancer names are unique in a given project. Furthermore, there
must be a private subnet that a load balancer is created under. Instead
of generating unique hostnames per load balancer, we are reusing the
private subnet ubid. This will be useful in future when we introduce the
TLS integration and manage certificates for the customer.

## Decrease deleted VMs' evacuation time to 30 seconds
We started with 10 minutes of wait time but this is not necessary. The
main reason is, the DNS TTL is set to 10 seconds. Therefore, 30 seconds
is more than enough to evacuate a VM.