### PR TITLE
Load Balancer API Updates for the Terraform Provider

### DIFF
--- a/routes/api/project/location/load_balancer.rb
+++ b/routes/api/project/location/load_balancer.rb
@@ -41,6 +41,10 @@ class CloverApi
       load_balancer_endpoint_helper.delete
     end
 
+    request.patch true do
+      load_balancer_endpoint_helper.patch
+    end
+
     request.on "attach-vm" do
       request.post true do
         load_balancer_endpoint_helper.post_attach_vm

--- a/routes/common/load_balancer_helper.rb
+++ b/routes/common/load_balancer_helper.rb
@@ -58,6 +58,45 @@ class Routes::Common::LoadBalancerHelper < Routes::Common::Base
     end
   end
 
+  def patch
+    Authorization.authorize(@user.id, "LoadBalancer:edit", @resource.id)
+    request_body_params = Validation.validate_request_body(params, %w[algorithm src_port dst_port health_check_endpoint vms])
+    @resource.update(
+      algorithm: request_body_params["algorithm"],
+      src_port: Validation.validate_port(:src_port, request_body_params["src_port"]),
+      dst_port: Validation.validate_port(:dst_port, request_body_params["dst_port"]),
+      health_check_endpoint: request_body_params["health_check_endpoint"]
+    )
+
+    request_body_params["vms"].each do |vm_id|
+      vm_id = vm_id.delete("\"")
+      vm = Vm.from_ubid(vm_id)
+      unless vm
+        response.status = 404
+        @request.halt
+      end
+
+      Authorization.authorize(@user.id, "Vm:view", vm.id)
+      if vm.reload.load_balancer && vm.load_balancer.id != @resource.id
+        fail Validation::ValidationFailed.new("vm_id" => "VM is already attached to a load balancer")
+      elsif vm.load_balancer && vm.load_balancer.id == @resource.id
+        next
+      end
+
+      @resource.add_vm(vm)
+    end
+
+    @resource.vms.map { _1.ubid }.reject { request_body_params["vms"].map { |vm_id| vm_id.delete("\"") }.include?(_1) }.each do |vm_id|
+      vm = Vm.from_ubid(vm_id)
+      @resource.evacuate_vm(vm)
+      @resource.remove_vm(vm)
+    end
+
+    response.status = 200
+    @resource.incr_update_load_balancer
+    Serializers::LoadBalancer.serialize(@resource.reload, {detailed: true})
+  end
+
   def get
     Authorization.authorize(@user.id, "LoadBalancer:view", @resource.id)
     if @mode == AppMode::API
@@ -66,7 +105,7 @@ class Routes::Common::LoadBalancerHelper < Routes::Common::Base
       vms = @resource.private_subnet.vms_dataset.authorized(@user.id, "Vm:view").all
       attached_vm_ids = @resource.vms.map(&:id)
       @app.instance_variable_set(:@attachable_vms, Serializers::Vm.serialize(vms.reject { attached_vm_ids.include?(_1.id) }))
-      @app.instance_variable_set(:@lb, Serializers::LoadBalancer.serialize(@resource, {detailed: true}))
+      @app.instance_variable_set(:@lb, Serializers::LoadBalancer.serialize(@resource, {detailed: true, vms_serialized: true}))
 
       @app.view "networking/load_balancer/show"
     end

--- a/serializers/load_balancer.rb
+++ b/serializers/load_balancer.rb
@@ -6,7 +6,7 @@ class Serializers::LoadBalancer < Serializers::Base
       id: lb.ubid,
       name: lb.name,
       hostname: lb.hostname,
-      algorithm: (lb.algorithm == "round_robin") ? "Round Robin" : "Hash Based",
+      algorithm: lb.algorithm,
       health_check_endpoint: lb.health_check_endpoint,
       src_port: lb.src_port,
       dst_port: lb.dst_port
@@ -17,7 +17,12 @@ class Serializers::LoadBalancer < Serializers::Base
     end
 
     if options[:detailed]
-      base[:subnet] = Serializers::PrivateSubnet.serialize(lb.private_subnet, {include_path: true})
+      base[:subnet] = lb.private_subnet.name
+      base[:location] = lb.private_subnet.display_location
+      base[:vms] = lb.vms.map { _1.ubid } || []
+    end
+
+    if options[:vms_serialized]
       base[:vms] = Serializers::Vm.serialize(lb.vms, {load_balancer: true})
     end
 

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Clover, "load balancer" do
         fill_in "Name", with: name
         fill_in "Load Balancer Port", with: 80
         fill_in "Application Port", with: 8000
-        select "round-robin", from: "algorithm"
+        select "Round Robin", from: "algorithm"
         fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
 
@@ -97,7 +97,7 @@ RSpec.describe Clover, "load balancer" do
         fill_in "Name", with: "invalid name"
         fill_in "Load Balancer Port", with: 80
         fill_in "Application Port", with: 8000
-        select "round-robin", from: "algorithm"
+        select "Round Robin", from: "algorithm"
         fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
 
@@ -127,7 +127,7 @@ RSpec.describe Clover, "load balancer" do
         fill_in "Name", with: "dummy-lb-1"
         fill_in "Load Balancer Port", with: 80
         fill_in "Application Port", with: 8000
-        select "round-robin", from: "algorithm"
+        select "Round Robin", from: "algorithm"
         fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
 
@@ -247,6 +247,7 @@ RSpec.describe Clover, "load balancer" do
         lb.add_vm(vm)
 
         visit "#{project.path}#{lb.path}"
+        expect(page).to have_content vm.name
         click_button "Detach"
 
         expect(page.title).to eq("Ubicloud - #{lb.name}")

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -61,7 +61,7 @@
                   locals: {
                     name: "algorithm",
                     label: "Load Balancing Algorithm",
-                    options: ["round-robin", "hash-based"].map { |a| [a.tr("-", "_"), a] },
+                    options: ["Round Robin", "Hash Based"].map { |a| [a.downcase.tr(" ", "_"), a] },
                   }
                 ) %>
               </div>

--- a/views/networking/load_balancer/show.erb
+++ b/views/networking/load_balancer/show.erb
@@ -26,10 +26,10 @@
         ["Connection String", @lb[:hostname], { copieble: true }],
         [
           "Private Subnet",
-          "<a href='#{@project_data[:path]}#{@lb[:subnet][:path]}' class='text-rose-500 hover:underline'>#{@lb[:subnet][:name]}</a>",
+          "<a href='#{@project_data[:path]}/location/#{@lb[:location]}/private-subnet/#{@lb[:subnet]}' class='text-rose-500 hover:underline'>#{@lb[:subnet]}</a>",
           { escape: false }
         ],
-        ["Algorithm", @lb[:algorithm]],
+        ["Algorithm", (@lb[:algorithm] == "round_robin") ? "Round Robin" : "Hash Based"],
         ["Load Balancer Port", @lb[:src_port]],
         ["Application Port", @lb[:dst_port]],
         ["HTTP Health Check Endpoint", @lb[:health_check_endpoint]]


### PR DESCRIPTION
This commit tweaks some of the endpoints to accommodate Terraform
Provider implementation in an easier way. It also contains an additional
PATCH endpoint which is a much better approach than implementing
individual resource types to handle /attach-vm /detach-vm endpoints.
Another change is using the vm ubids in an array form instead of
serializing multiple VMs in the response body for a load balancer. It is
still used in the WEB endpoints but not in the APIs.