### PR TITLE
Quotas

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -1,0 +1,3 @@
+- { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmCores,           value: 16  }
+- { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerCores, value: 150 }
+- { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresCores,     value: 64  }

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -227,4 +227,13 @@ module Validation
   rescue URI::InvalidURIError
     fail ValidationFailed.new({url: "Invalid URL"})
   end
+
+  def self.validate_core_quota(project, resource_type, requested_core_count)
+    if !project.quota_available?(resource_type, requested_core_count)
+      current_used_core_count = project.current_resource_usage(resource_type)
+      effective_quota_value = project.effective_quota_value(resource_type)
+
+      fail ValidationFailed.new({size: "Insufficient quota for requested size. Requested core count: #{requested_core_count}, currently used core count: #{current_used_core_count}, maximum allowed core count: #{effective_quota_value}, remaining core count: #{effective_quota_value - current_used_core_count}"})
+    end
+  end
 end

--- a/migrate/20240720_project_quota.rb
+++ b/migrate/20240720_project_quota.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:project_quota) do
+      column :project_id, :uuid, null: false
+      column :quota_id, :uuid, null: false
+      column :value, :integer, null: false
+      primary_key [:project_id, :quota_id]
+    end
+
+    run "INSERT INTO project_quota (SELECT id, '14fa6820-bf63-41d2-b35e-4a4dcefd1b15', runner_core_limit FROM project WHERE runner_core_limit != 150)"
+  end
+
+  down do
+    drop_table(:project_quota)
+  end
+end

--- a/migrate/20240721_drop_runner_core_limit.rb
+++ b/migrate/20240721_drop_runner_core_limit.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:project) do
+      drop_column :runner_core_limit
+    end
+  end
+
+  down do
+    alter_table(:project) do
+      add_column :runner_core_limit, Integer, default: 150, null: false
+    end
+
+    run "UPDATE project SET runner_core_limit = project_quota.value FROM project_quota WHERE project.id = project_quota.project_id AND project_quota.quota_id = '14fa6820-bf63-41d2-b35e-4a4dcefd1b15'"
+  end
+end

--- a/model/project_quota.rb
+++ b/model/project_quota.rb
@@ -1,0 +1,11 @@
+#  frozen_string_literal: true
+
+require_relative "../model"
+
+class ProjectQuota < Sequel::Model
+  def self.default_quotas
+    @@default_quotas ||= YAML.load_file("config/default_quotas.yml").each_with_object({}) do |item, hash|
+      hash[item["resource_type"]] = item
+    end
+  end
+end

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -48,7 +48,7 @@ class CloverApi
         # Same as above, moved the size validation here to not allow users to
         # pass gpu instance while creating a VM.
         if request_body_params["size"]
-          Validation.validate_vm_size(request_body_params["size"], only_visible: true)
+          parsed_size = Validation.validate_vm_size(request_body_params["size"], only_visible: true)
         end
 
         if request_body_params["private_subnet_id"]
@@ -65,6 +65,9 @@ class CloverApi
           request_body_params["storage_volumes"] = [{size_gib: storage_size, encrypted: true}]
           request_body_params.delete("storage_size")
         end
+
+        requested_vm_core_count = parsed_size.nil? ? 1 : parsed_size.vcpu / 2
+        Validation.validate_core_quota(@project, "VmCores", requested_vm_core_count)
 
         st = Prog::Vm::Nexus.assemble(
           request_body_params["public_key"],

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -16,9 +16,13 @@ class CloverWeb
       Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps_id)
 
       Validation.validate_boot_image(r.params["boot-image"])
-      Validation.validate_vm_size(r.params["size"], only_visible: true)
+      parsed_size = Validation.validate_vm_size(r.params["size"], only_visible: true)
       location = LocationNameConverter.to_internal_name(r.params["location"])
       storage_size = Validation.validate_vm_storage_size(r.params["size"], r.params["storage_size"])
+
+      requested_vm_core_count = parsed_size.vcpu / 2
+      Validation.validate_core_quota(@project, "VmCores", requested_vm_core_count)
+
       st = Prog::Vm::Nexus.assemble(
         r.params["public-key"],
         @project.id,

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -398,4 +398,16 @@ RSpec.describe Validation do
       end
     end
   end
+
+  describe "#validate_core_quota" do
+    it "sufficient core quota" do
+      p = instance_double(Project, current_resource_usage: 5, effective_quota_value: 10, quota_available?: true)
+      expect { described_class.validate_core_quota(p, "VmCores", 1) }.not_to raise_error
+    end
+
+    it "insufficient core quota" do
+      p = instance_double(Project, current_resource_usage: 10, effective_quota_value: 10, quota_available?: false)
+      expect { described_class.validate_core_quota(p, "VmCores", 1) }.to raise_error described_class::ValidationFailed
+    end
+  end
 end

--- a/spec/model/project_quota_spec.rb
+++ b/spec/model/project_quota_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+require "json"
+
+RSpec.describe ProjectQuota do
+  it "has unique resource types" do
+    resource_types = described_class.default_quotas.map { |resource_type, _| resource_type }
+    expect(resource_types.size).to eq(resource_types.uniq.size)
+  end
+
+  it "has unique ids" do
+    ids = described_class.default_quotas.map { |_, quota| quota["id"] }
+    expect(ids.size).to eq(ids.uniq.size)
+  end
+end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -74,4 +74,32 @@ RSpec.describe Project do
       expect(project.default_location).to eq Option.locations.first.name
     end
   end
+
+  it "calculates current resource usage" do
+    expect(project).to receive(:vms).and_return([instance_double(Vm, cores: 2), instance_double(Vm, cores: 4)])
+    expect(project.current_resource_usage("VmCores")).to eq 6
+
+    expect(project).to receive(:github_installations).and_return([instance_double(GithubInstallation, total_active_runner_cores: 10), instance_double(GithubInstallation, total_active_runner_cores: 20)])
+    expect(project.current_resource_usage("GithubRunnerCores")).to eq 30
+
+    expect(project).to receive(:postgres_resources).and_return([instance_double(PostgresResource, servers: [instance_double(PostgresServer, vm: instance_double(Vm, cores: 2)), instance_double(PostgresServer, vm: instance_double(Vm, cores: 4))])])
+    expect(project.current_resource_usage("PostgresCores")).to eq 6
+
+    expect { project.current_resource_usage("UnknownResource") }.to raise_error(RuntimeError)
+  end
+
+  it "calculates effective quota value" do
+    project = described_class.create_with_id(name: "test")
+    project.add_quota(ProjectQuota.new(value: 1000).tap { _1.quota_id = "14fa6820-bf63-41d2-b35e-4a4dcefd1b15" })
+    expect(project.effective_quota_value("VmCores")).to eq 16
+    expect(project.effective_quota_value("GithubRunnerCores")).to eq 1000
+    expect(project.effective_quota_value("PostgresCores")).to eq 64
+  end
+
+  it "checks if quota is available" do
+    expect(project).to receive(:current_resource_usage).and_return(10).twice
+    expect(project).to receive(:effective_quota_value).and_return(20).twice
+    expect(project.quota_available?("VmCores", 5)).to be true
+    expect(project.quota_available?("VmCores", 20)).to be false
+  end
 end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -257,8 +257,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to wait_concurrency_limit if there is no capacity" do
       dataset = instance_double(Sequel::Dataset, for_update: instance_double(Sequel::Dataset, all: []))
 
-      installation = instance_double(GithubInstallation, total_active_runner_cores: 2)
-      project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
+      installation = instance_double(GithubInstallation)
+      project = instance_double(Project, quota_available?: false, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
@@ -270,8 +270,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to allocate_vm if there is capacity" do
       dataset = instance_double(Sequel::Dataset, for_update: instance_double(Sequel::Dataset, all: []))
 
-      installation = instance_double(GithubInstallation, total_active_runner_cores: 1)
-      project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
+      installation = instance_double(GithubInstallation)
+      project = instance_double(Project, quota_available?: true, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
@@ -292,8 +292,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "waits until customer concurrency limit frees up" do
       dataset = instance_double(Sequel::Dataset, for_update: instance_double(Sequel::Dataset, all: []))
 
-      installation = instance_double(GithubInstallation, total_active_runner_cores: 2)
-      project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
+      installation = instance_double(GithubInstallation)
+      project = instance_double(Project, quota_available?: false, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
@@ -305,8 +305,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to allocate_vm when customer concurrency limit frees up" do
       dataset = instance_double(Sequel::Dataset, for_update: instance_double(Sequel::Dataset, all: []))
 
-      installation = instance_double(GithubInstallation, total_active_runner_cores: 1)
-      project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
+      installation = instance_double(GithubInstallation)
+      project = instance_double(Project, quota_available?: true, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
@@ -318,8 +318,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to allocate_vm when customer concurrency limit is full but the overall utilization is low" do
       dataset = instance_double(Sequel::Dataset, for_update: instance_double(Sequel::Dataset, all: []))
 
-      installation = instance_double(GithubInstallation, total_active_runner_cores: 2)
-      project = instance_double(Project, runner_core_limit: 2, github_installations: [installation])
+      installation = instance_double(GithubInstallation)
+      project = instance_double(Project, quota_available?: false, github_installations: [installation])
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -84,13 +84,29 @@ RSpec.describe Clover, "postgres" do
 
     describe "create" do
       it "success" do
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres", {
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-no-ha", {
+          size: "standard-2",
+          ha_type: "none"
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres-no-ha")
+
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-async", {
+          size: "standard-2",
+          ha_type: "async"
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres-async")
+
+        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-sync", {
           size: "standard-2",
           ha_type: "sync"
         }.to_json
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres")
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres-sync")
       end
 
       it "invalid location" do


### PR DESCRIPTION
**Add helper methods for quota calculations**
I was not entirely sure about whether to put default quotas as config file or
as a database table. I decided to go with a config file for now, because
- It is easier to change. Does not require a migration.
- It is easier to view. You can see all the quotas in one place.
- It seldom changes. Control plane does not need to edit default quotas as
part of its normal operation.

The drawback is that, we cannot join with it, so I had to write a helper
function to calculate effective_quota_value. Though, it is small enough that
I'm not sure if the join version would be any better.

**Add quota check for VM provisionings**
There are two important notes about this commit.
1. We don't differentiate between x64 and arm64 VMs for now, as it is not
possible to request arm64 VMs yet. In all cases, we calculate the core count as
vCPU / 2. The logic would need to change when we introduce arm64 VMs.

2. There is one weakness that I'd like to address, but it would touch APIs and
would require a deeper discussion, so I'm leaving that for future. In summary
when the vm size is not specified by user, we default to standard-2, however,
the resolution is done at the prog's assemble method. We are doing the quota
check at the API layer, thus we don't know the size of the VM at this point
(if it is not specified by user). I added a branch to calculate requested cores
as 1 if the size is not specified, but this means we leak information from prog
to API. I'd like to avoid this and I think cleanest solution would be making
VM size a required field. Apart from fixing this problem, I think it would make
more sense semantically as well. It feels bit weird that Vm size is optional
in Vm creation API.

**Add quota check for Github runner provisionings**
We are calling quota_available? method with 0 as requested_additional_usage.

`project.quota_available?("GithubRunnerCores", 0)`

This looks weird, but it is intentional. In existing Github quota calculations,
we compare the total allocated cores with the core limit and allow passing the
limit once. This is because we check quota and allocate VMs in different labels
(hence different transactions) and it is difficult to enforce the quotas in the
environment with lots of concurrent requests. There are some remedies, but it
would require some refactoring that I'm not keen to do at the moment. Passing 0
as requested_additional_usage keeps the existing behavior.

**Add quota check for Postgres provisionings**
Nothing fancy, we just check the current usage and allow provisioning if the
request would not cause quota to be exceeded.