### PR TITLE
Quotas UI

### DIFF
--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -227,6 +227,7 @@ class Routes::Common::PostgresHelper < Routes::Common::Base
     Authorization.authorize(@user.id, "Postgres:create", project.id)
     @app.instance_variable_set(:@prices, @app.fetch_location_based_prices("PostgresCores", "PostgresStorage"))
     @app.instance_variable_set(:@has_valid_payment_method, project.has_valid_payment_method?)
+    @app.instance_variable_set(:@enabled_postgres_sizes, Option::VmSizes.select { project.quota_available?("PostgresCores", _1.vcpu / 2) }.map(&:name))
     @app.view "postgres/create"
   end
 

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -35,6 +35,13 @@ class CloverWeb
 
       @project_data = Serializers::Project.serialize(@project, {include_path: true})
       @project_permissions = Authorization.all_permissions(@current_user.id, @project.id)
+      @quotas = ["VmCores", "PostgresCores"].map {
+        {
+          resource_type: _1,
+          current_resource_usage: @project.current_resource_usage(_1),
+          quota: @project.effective_quota_value(_1) * 2
+        }
+      }
 
       r.get true do
         Authorization.authorize(@current_user.id, "Project:view", @project.id)

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -48,6 +48,7 @@ class CloverWeb
         @prices = fetch_location_based_prices("VmCores", "VmStorage", "IPAddress")
         @has_valid_payment_method = @project.has_valid_payment_method?
         @default_location = @project.default_location
+        @enabled_vm_sizes = Option::VmSizes.select { _1.visible && @project.quota_available?("VmCores", _1.vcpu / 2) }.map(&:name)
 
         view "vm/create"
       end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,4 +11,10 @@ module.exports = {
     require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),
   ],
+  safelist: [
+    ...[...Array(101).keys()].flatMap(i => `w-[${i}%]`),
+    {
+      pattern: /bg-[a-z]+-500/,
+    }
+  ]
 }

--- a/views/components/progress_bar.erb
+++ b/views/components/progress_bar.erb
@@ -1,0 +1,10 @@
+<% progress = [100, 100 * numerator / denominator].min %>
+<% color = (progress < 60) ? "bg-blue-500" : (progress < 80) ? "bg-yellow-500" : "bg-red-500" %>
+<div class="flex justify-between mb-1">
+  <span class="text-base font-medium"><%= title %></span>
+  <span class="text-sm font-medium"><%= numerator %>/<%= denominator %>
+    (<%= progress %>%)</span>
+</div>
+<div class="w-full bg-gray-200 rounded-full h-3">
+  <div class="<%= color %> h-3 rounded-full w-[<%= progress %>%]"></div>
+</div>

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -67,7 +67,8 @@
                     <legend class="sr-only">Server size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
                       <% Option::PostgresSizes.each_with_index do |size, idx| %>
-                        <label class="size-<%= size.name %>">
+                        <% disabled = !@enabled_postgres_sizes.include?(size.name) %>
+                        <label class="size-<%= size.name %>" title="<%= disabled ? "Insufficient quota. You can reach us at support@ubicloud.com to increase your quota." : "" %>">
                           <input
                             type="radio"
                             name="size"
@@ -80,11 +81,13 @@
                             data-storage-size-options="<%= size.storage_size_options %>"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
+                            <%= disabled ? "disabled" : "" %>
                           >
                           <span
                             class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
                                 ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
-                                peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700"
+                                peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700
+                                <%= disabled ? "opacity-50" : "" %>"
                           >
                             <span class="flex flex-col">
                               <span class="text-md font-semibold"><%= size.display_name %></span>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -46,6 +46,32 @@
       }
     ) %>
   </form>
+  <!-- Quota Card -->
+  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div class="px-4 py-5 sm:p-6">
+      <h3 class="text-base font-semibold leading-6 text-gray-900">Quotas</h3>
+      <div class="mt-2 text-sm text-gray-500">
+        <p>If you want to increase your quota, please get in touch at
+          <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">support@ubicloud.com</a>.</p>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <% @quotas.each do |quota| %>
+        <div class="p-6">
+          <%== render(
+            "components/progress_bar",
+            locals: {
+              title: quota[:resource_type],
+              numerator: quota[:current_resource_usage],
+              denominator: quota[:quota]
+            }
+          ) %>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
   <!-- Delete Card -->
   <% if Authorization.has_permission?(@current_user.id, "Project:delete", @project_data[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -95,7 +95,8 @@
                     <legend class="sr-only">Server size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
                       <% Option::VmSizes.select { _1.visible }.each_with_index do |size, idx| %>
-                        <label class="size-<%= size.name %>">
+                        <% disabled = !@enabled_vm_sizes.include?(size.name) %>
+                        <label class="size-<%= size.name %>" title="<%= disabled ? "Insufficient quota. You can reach us at support@ubicloud.com to increase your quota." : "" %>">
                           <input
                             type="radio"
                             name="size"
@@ -108,11 +109,13 @@
                             data-storage-size-options="<%= size.storage_size_options %>"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
+                            <%= disabled ? "disabled" : "" %>
                           >
                           <span
                             class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none
                                 ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50
-                                peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700"
+                                peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700
+                                <%= disabled ? "opacity-50" : "" %>"
                           >
                             <span class="flex flex-col">
                               <span class="text-md font-semibold"><%= size.display_name %></span>


### PR DESCRIPTION
**Disable VM options from UI if user has insufficient quota**
We still display the options, but they are disabled/grayouted if the user has
insufficient quota.

**Disable Postgres options from UI if user has insufficient quota**
We still display the options, but they are disabled/grayouted if the user has
insufficient quota.

**Add certain colors and width percentages to safelist**
While rendering the progress bar, we set the width property of it to percentage
value. We cannot do it via inline style because of the security policy. We need
to set it via tailwind class. However, since the value is dynamic and tailwind
class is not known at the compile time, thus not added to the generated css. To
solve this, we add certain colors and width percentages to the safelist.

**Add overall quota information to UI**

![image](https://github.com/user-attachments/assets/a598d28e-b276-4e7a-878c-7b4b37ba9f81)
![image](https://github.com/user-attachments/assets/f2081cc0-55a1-4210-bd14-2e72ca1ed14c)