### PR TITLE
Increase quotas after successful payment

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -1,3 +1,3 @@
-- { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmCores,           value: 16  }
-- { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerCores, value: 150 }
-- { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresCores,     value: 64  }
+- { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmCores,           new_value: 16,  verified_value: 128 }
+- { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerCores, new_value: 150, verified_value: 150 }
+- { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresCores,     new_value: 64,  verified_value: 128 }

--- a/migrate/20240722_add_project_reputation.rb
+++ b/migrate/20240722_add_project_reputation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_enum(:project_reputation, %w[new verified])
+
+    alter_table(:project) do
+      add_column :reputation, :project_reputation, default: "new", null: false
+    end
+
+    run "UPDATE project SET reputation = 'verified' WHERE id IN (SELECT project_id FROM invoice WHERE (content->'cost')::float > 5)"
+  end
+end

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -73,6 +73,8 @@ class Invoice < Sequel::Model
         "payment_intent" => payment_intent.id
       })
       save(columns: [:status, :content])
+      project.update(reputation: "verified") if amount > 5
+
       send_success_email
       return true
     end

--- a/model/project.rb
+++ b/model/project.rb
@@ -112,7 +112,7 @@ class Project < Sequel::Model
   def effective_quota_value(resource_type)
     default_quota = ProjectQuota.default_quotas[resource_type]
     override_quota_value = quotas_dataset.first(quota_id: default_quota["id"])&.value
-    override_quota_value || default_quota["value"]
+    override_quota_value || default_quota["#{reputation}_value"]
   end
 
   def quota_available?(resource_type, requested_additional_usage)

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -94,6 +94,11 @@ RSpec.describe Project do
     expect(project.effective_quota_value("VmCores")).to eq 16
     expect(project.effective_quota_value("GithubRunnerCores")).to eq 1000
     expect(project.effective_quota_value("PostgresCores")).to eq 64
+
+    expect(project).to receive(:reputation).and_return("verified").at_least(:once)
+    expect(project.effective_quota_value("VmCores")).to eq 128
+    expect(project.effective_quota_value("GithubRunnerCores")).to eq 1000
+    expect(project.effective_quota_value("PostgresCores")).to eq 128
   end
 
   it "checks if quota is available" do


### PR DESCRIPTION
**Add different quotas for different reputation levels**
Currently we have 2 levels of reputation: new and verified. Each have different
default quotas. I think we can have more levels of reputation such as sponsored
or enterprise. Depending on the reputation level, we can have different default
quotas for each of them.

I'm not entirely sold on the naming "reputation", "type" feels more appropriate
but it is too generic, so I didn't want to use it.

**Update project's reputation after successful payment**
After a successful payment, the project becomes less risky against the fraud,
so we can increase its quotas, which is done by updating its reputation as
verified.