### PR TITLE
Remove legacy code for cloud hypervisor and firmware

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -64,12 +64,7 @@ end
 CloudHypervisor::VERSION.download
 
 # Download firmware binaries.
-fw_dir = File.dirname(CloudHypervisor::FIRMWARE.path)
-FileUtils.mkdir_p(fw_dir)
-FileUtils.cd fw_dir do
-  r "curl -L3 -o #{CloudHypervisor::FIRMWARE.name.shellescape} #{CloudHypervisor::FIRMWARE.url.shellescape}"
-end
-CloudHypervisor::NEW_FIRMWARE.download
+CloudHypervisor::FIRMWARE.download
 
 # Err towards listing ('l') and not restarting services by default,
 # otherwise a stray keystroke when using "apt install" for unrelated

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -53,14 +53,6 @@ r "chmod +x /etc/update-motd.d/99-clover-motd"
 r "timedatectl set-timezone UTC"
 
 # Download cloud hypervisor binaries.
-ch_dir = CloudHypervisor::VERSION_LEGACY.dir
-FileUtils.mkdir_p(ch_dir)
-FileUtils.cd ch_dir do
-  r "curl -L3 -o ch-remote #{CloudHypervisor::VERSION_LEGACY.ch_remote_url.shellescape}"
-  FileUtils.chmod "a+x", "ch-remote"
-  r "curl -L3 -o cloud-hypervisor #{CloudHypervisor::VERSION_LEGACY.url.shellescape}"
-  FileUtils.chmod "a+x", "cloud-hypervisor"
-end
 CloudHypervisor::VERSION.download
 
 # Download firmware binaries.

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -32,36 +32,6 @@ module CloudHypervisor
   FIRMWARE = FirmwareClass.new(Arch.render(x64: "202311", arm64: "202211"),
     Arch.render(x64: "e31738aacd3d68d30f8f9a4d09711cca3dfb414e8910dc3af90c50f36885380a", arm64: "482f428f782591d7c2222e0bc8240d25fb200fb21fd984b3339c85979d94b4d8"))
 
-  VersionClassLegacy = Struct.new(:version) {
-    def ch_remote_url
-      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/ch-remote" + Arch.render(x64: "", arm64: "-static-aarch64")
-    end
-
-    def url
-      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/cloud-hypervisor" + Arch.render(x64: "", arm64: "-static-aarch64")
-    end
-
-    def dir
-      "/opt/cloud-hypervisor/v#{version}"
-    end
-
-    def bin
-      File.join(dir, "cloud-hypervisor")
-    end
-
-    def ch_remote_bin
-      File.join(dir, "ch-remote")
-    end
-  }
-
-  VERSION_LEGACY = if Arch.arm64?
-    VersionClassLegacy.new("35.0")
-  elsif Arch.x64?
-    VersionClassLegacy.new("31.0")
-  else
-    fail "BUG: unexpected architecture"
-  end
-
   VersionClass = Struct.new(:version, :sha256_ch_bin, :sha256_ch_remote) {
     def ch_remote_url
       "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/ch-remote" + Arch.render(x64: "-static", arm64: "-static-aarch64")

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -4,24 +4,6 @@ require "fileutils"
 require_relative "../../common/lib/arch"
 
 module CloudHypervisor
-  FirmwareClassLegacy = Struct.new(:version, :name) {
-    def url
-      "https://github.com/fdr/edk2/releases/download/#{version}/#{name}"
-    end
-
-    def path
-      "/opt/fw/#{version}/#{Arch.sym}/#{name}"
-    end
-  }
-
-  FIRMWARE = if Arch.arm64?
-    FirmwareClassLegacy.new("edk2-stable202308", "CLOUDHV_EFI.fd")
-  elsif Arch.x64?
-    FirmwareClassLegacy.new("edk2-stable202302", "CLOUDHV.fd")
-  else
-    fail "BUG: unexpected architecture"
-  end
-
   FirmwareClass = Struct.new(:version, :sha256) {
     def url
       "https://github.com/ubicloud/build-edk2-firmware/releases/download/edk2-stable#{version}-#{Arch.sym}/CLOUDHV-#{Arch.sym}.fd"
@@ -47,7 +29,7 @@ module CloudHypervisor
     end
   }
 
-  NEW_FIRMWARE = FirmwareClass.new(Arch.render(x64: "202311", arm64: "202211"),
+  FIRMWARE = FirmwareClass.new(Arch.render(x64: "202311", arm64: "202211"),
     Arch.render(x64: "e31738aacd3d68d30f8f9a4d09711cca3dfb414e8910dc3af90c50f36885380a", arm64: "482f428f782591d7c2222e0bc8240d25fb200fb21fd984b3339c85979d94b4d8"))
 
   VersionClassLegacy = Struct.new(:version) {

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -565,7 +565,7 @@ ExecStartPre=/usr/bin/rm -f #{vp.ch_api_sock}
 
 ExecStart=#{CloudHypervisor::VERSION.bin} -v \
 --api-socket path=#{vp.ch_api_sock} \
---kernel #{CloudHypervisor::NEW_FIRMWARE.path} \
+--kernel #{CloudHypervisor::FIRMWARE.path} \
 #{disk_params.join("\n")}
 --disk path=#{vp.cloudinit_img} \
 --console off --serial file=#{vp.serial_log} \


### PR DESCRIPTION
This PR removes legacy data plane code to download cloud hypervisor and firmware binaries. We introduced new download/setup code for these two components with additional features like upgrades, checking the digest of binaries, etc. That new code has been used in production for several weeks now. So it's very unlikely we would want to switch back and it should be safe now to remove the legacy code. 