### PR TITLE
ACME Certificate Integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ end
 gem "webauthn", "~> 3.1"
 
 gem "aws-sdk-s3", "~> 1.158"
+
+gem "acme-client", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    acme-client (2.0.18)
+      faraday (>= 1.0, < 3.0.0)
+      faraday-retry (>= 1.0, < 3.0.0)
     actionview (7.2.0)
       activesupport (= 7.2.0)
       builder (~> 3.1)
@@ -107,6 +110,8 @@ GEM
       logger
     faraday-net_http (3.1.1)
       net-http
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-aarch64-linux-musl)
     ffi (1.17.0-arm64-darwin)
@@ -336,6 +341,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  acme-client (~> 2.0)
   argon2
   argon2-kdf
   aws-sdk-s3 (~> 1.158)

--- a/config.rb
+++ b/config.rb
@@ -164,4 +164,12 @@ module Config
   # Load Balancer
   optional :load_balancer_service_project_id, string
   optional :load_balancer_service_hostname, string
+
+  # ACME
+  # The following are optional because they are only needed in production.
+  # They are not needed in development or test.
+  optional :acme_email, string
+  override :acme_directory, "https://acme.zerossl.com/v2/DV90", string
+  optional :acme_eab_kid, string, clear: true
+  optional :acme_eab_hmac_key, string, clear: true
 end

--- a/migrate/20240723_add_acme_cert.rb
+++ b/migrate/20240723_add_acme_cert.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:cert) do
+      column :id, :uuid, primary_key: true
+      column :hostname, :text, collate: '"C"', null: false
+      foreign_key :dns_zone_id, :dns_zone, type: :uuid, null: false
+      column :created_at, :timestamp, null: false, default: Sequel.function(:now)
+      column :cert, :text, collate: '"C"'
+      column :account_key, :text, collate: '"C"'
+      column :kid, :text, collate: '"C"'
+      column :order_url, :text, collate: '"C"'
+      column :csr_key, :text, collate: '"C"'
+    end
+  end
+end

--- a/migrate/20240801_add_load_balancer_cert.rb
+++ b/migrate/20240801_add_load_balancer_cert.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:certs_load_balancers) do
+      foreign_key :load_balancer_id, :load_balancer, type: :uuid, null: false
+      foreign_key :cert_id, :cert, type: :uuid, null: false
+      primary_key [:load_balancer_id, :cert_id]
+    end
+
+    create_enum(:lb_hc_protocol, %w[tcp http https])
+    alter_table(:load_balancer) do
+      add_column :health_check_protocol, :lb_hc_protocol, null: false, default: "http"
+    end
+  end
+end

--- a/model/cert.rb
+++ b/model/cert.rb
@@ -1,0 +1,20 @@
+#  frozen_string_literal: true
+
+require_relative "../model"
+
+class Cert < Sequel::Model
+  one_to_one :strand, key: :id
+
+  include ResourceMethods
+  include SemaphoreMethods
+  semaphore :destroy
+
+  plugin :column_encryption do |enc|
+    enc.column :account_key
+    enc.column :csr_key
+  end
+
+  def self.redacted_columns
+    super + [:cert]
+  end
+end

--- a/model/cert.rb
+++ b/model/cert.rb
@@ -3,7 +3,11 @@
 require_relative "../model"
 
 class Cert < Sequel::Model
+  one_through_one :load_balancer, join_table: :certs_load_balancers, left_key: :cert_id, right_key: :load_balancer_id
+  one_to_one :certs_load_balancers, key: :cert_id, class: CertsLoadBalancers
   one_to_one :strand, key: :id
+
+  plugin :association_dependencies, certs_load_balancers: :destroy
 
   include ResourceMethods
   include SemaphoreMethods

--- a/model/certs_load_balancers.rb
+++ b/model/certs_load_balancers.rb
@@ -1,0 +1,15 @@
+#  frozen_string_literal: true
+
+require_relative "../model"
+
+class CertsLoadBalancers < Sequel::Model
+  many_to_one :cert
+  include ResourceMethods
+
+  def destroy
+    DB.transaction do
+      cert.incr_destroy
+      super
+    end
+  end
+end

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "acme-client"
+require "openssl"
+
+class Prog::Vnet::CertNexus < Prog::Base
+  subject_is :cert
+  semaphore :destroy
+
+  REVOKE_REASON = "cessationOfOperation" # unspecified
+
+  def self.assemble(hostname, dns_zone_id)
+    unless DnsZone[dns_zone_id]
+      fail "Given DNS zone doesn't exist with the id #{dns_zone_id}"
+    end
+
+    DB.transaction do
+      cert = Cert.create_with_id(hostname: hostname, dns_zone_id: dns_zone_id)
+
+      Strand.create(prog: "Vnet::CertNexus", label: "start") { _1.id = cert.id }
+    end
+  end
+
+  def before_run
+    when_destroy_set? do
+      hop_destroy unless %w[destroy].include?(strand.label)
+    end
+  end
+
+  label def start
+    register_deadline(:wait, 10 * 60)
+
+    account_key = OpenSSL::PKey::EC.generate("prime256v1")
+    client = Acme::Client.new(private_key: account_key, directory: Config.acme_directory)
+    account = client.new_account(contact: "mailto:#{Config.acme_email}", terms_of_service_agreed: true, external_account_binding: {kid: Config.acme_eab_kid, hmac_key: Config.acme_eab_hmac_key})
+    order = client.new_order(identifiers: [cert.hostname])
+    authorization = order.authorizations.first
+    cert.update(kid: account.kid, account_key: account_key.to_der, order_url: order.url)
+    dns_challenge = authorization.dns
+    dns_zone.insert_record(record_name: dns_record_name, type: dns_challenge.record_type, ttl: 600, data: dns_challenge.record_content)
+
+    hop_wait_dns_update
+  end
+
+  label def wait_dns_update
+    dns_record = DnsRecord[dns_zone_id: dns_zone.id, name: dns_record_name + ".", tombstoned: false, data: dns_challenge.record_content]
+    if DB[:seen_dns_records_by_dns_servers].where(dns_record_id: dns_record.id).empty?
+      nap 10
+    end
+
+    dns_challenge.request_validation
+
+    hop_wait_dns_validation
+  end
+
+  label def wait_dns_validation
+    case dns_challenge.status
+    when "pending"
+      nap 10
+    when "valid"
+      csr_key = OpenSSL::PKey::RSA.new(4096)
+      csr = Acme::Client::CertificateRequest.new(private_key: csr_key, common_name: cert.hostname)
+      acme_order.finalize(csr: csr)
+      cert.update(csr_key: csr_key.to_der)
+
+      hop_wait_cert_finalization
+    else
+      Clog.emit("DNS validation failed") { {order_status: dns_challenge.status} }
+      dns_zone.delete_record(record_name: dns_record_name)
+      hop_start
+    end
+  end
+
+  label def wait_cert_finalization
+    case acme_order.status
+    when "processing"
+      nap 10
+    when "valid"
+      cert.update(cert: acme_order.certificate, created_at: Time.now)
+
+      dns_zone.delete_record(record_name: dns_record_name)
+      hop_wait
+    else
+      Clog.emit("Certificate finalization failed") { {order_status: acme_order.status} }
+      dns_zone.delete_record(record_name: dns_record_name)
+      hop_start
+    end
+  end
+
+  label def wait
+    if cert.created_at < Time.now - 60 * 60 * 24 * 30 * 3 # 3 months
+      cert.incr_destroy
+      nap 0
+    end
+
+    nap 60 * 60 * 24 * 30 # 1 month
+  end
+
+  label def destroy
+    # the reason is chosen as "cessationOfOperation"
+    acme_client.revoke(certificate: cert.cert, reason: REVOKE_REASON) if cert.cert
+
+    dns_zone.delete_record(record_name: dns_record_name) if dns_challenge
+    cert.destroy
+    pop "certificate revoked and destroyed"
+  end
+
+  def acme_client
+    # If the private_key is not yet set, we did not start the communication with
+    # ACME server yet, therefore, we return nil.
+    Acme::Client.new(private_key: OpenSSL::PKey::EC.new(cert.account_key), directory: Config.acme_directory, kid: cert.kid) if cert.account_key
+  end
+
+  def acme_order
+    # If the order_url is set, acme_client cannot be nil, so, this is nullref safe
+    acme_client.order(url: cert.order_url) if cert.order_url
+  end
+
+  def dns_challenge
+    acme_order.authorizations.first.dns
+  end
+
+  def dns_record_name
+    dns_challenge.record_name + "." + cert.hostname
+  end
+
+  def dns_zone
+    @dns_zone ||= DnsZone[cert.dns_zone_id]
+  end
+end

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -9,7 +9,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
 
   def self.assemble(private_subnet_id, name: nil, algorithm: "round_robin", src_port: nil, dst_port: nil,
     health_check_endpoint: "/up", health_check_interval: 30, health_check_timeout: 15,
-    health_check_up_threshold: 3, health_check_down_threshold: 2)
+    health_check_up_threshold: 3, health_check_down_threshold: 2, health_check_protocol: "http")
 
     unless (ps = PrivateSubnet[private_subnet_id])
       fail "Given subnet doesn't exist with the id #{private_subnet_id}"
@@ -19,10 +19,10 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
 
     DB.transaction do
       lb = LoadBalancer.create_with_id(
-        private_subnet_id: private_subnet_id, name: name, algorithm: algorithm,
-        src_port: src_port, dst_port: dst_port, health_check_endpoint: health_check_endpoint,
-        health_check_interval: health_check_interval, health_check_timeout: health_check_timeout,
-        health_check_up_threshold: health_check_up_threshold, health_check_down_threshold: health_check_down_threshold
+        private_subnet_id: private_subnet_id, name: name, algorithm: algorithm, src_port: src_port, dst_port: dst_port,
+        health_check_endpoint: health_check_endpoint, health_check_interval: health_check_interval,
+        health_check_timeout: health_check_timeout, health_check_up_threshold: health_check_up_threshold,
+        health_check_down_threshold: health_check_down_threshold, health_check_protocol: health_check_protocol
       )
       lb.associate_with_project(ps.projects.first)
 

--- a/routes/common/load_balancer_helper.rb
+++ b/routes/common/load_balancer_helper.rb
@@ -25,9 +25,10 @@ class Routes::Common::LoadBalancerHelper < Routes::Common::Base
   def post(name: nil)
     Authorization.authorize(@user.id, "LoadBalancer:create", project.id)
 
-    required_parameters = %w[private_subnet_id algorithm src_port dst_port health_check_endpoint]
+    required_parameters = %w[private_subnet_id algorithm src_port dst_port health_check_protocol]
     required_parameters << "name" if @mode == AppMode::WEB
-    request_body_params = Validation.validate_request_body(params, required_parameters)
+    optional_parameters = %w[health_check_endpoint]
+    request_body_params = Validation.validate_request_body(params, required_parameters, optional_parameters)
 
     ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"])
     unless ps
@@ -47,7 +48,8 @@ class Routes::Common::LoadBalancerHelper < Routes::Common::Base
       algorithm: request_body_params["algorithm"],
       src_port: Validation.validate_port(:src_port, request_body_params["src_port"]),
       dst_port: Validation.validate_port(:dst_port, request_body_params["dst_port"]),
-      health_check_endpoint: request_body_params["health_check_endpoint"]
+      health_check_endpoint: request_body_params["health_check_endpoint"],
+      health_check_protocol: request_body_params["health_check_protocol"]
     ).subject
 
     if @mode == AppMode::API

--- a/serializers/load_balancer.rb
+++ b/serializers/load_balancer.rb
@@ -8,6 +8,7 @@ class Serializers::LoadBalancer < Serializers::Base
       hostname: lb.hostname,
       algorithm: lb.algorithm,
       health_check_endpoint: lb.health_check_endpoint,
+      health_check_protocol: lb.health_check_protocol,
       src_port: lb.src_port,
       dst_port: lb.dst_port
     }

--- a/spec/model/resource_methods_spec.rb
+++ b/spec/model/resource_methods_spec.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper"
 
 RSpec.describe ResourceMethods do
   it "hides sensitive and long columns" do
-    [GithubRunner, PostgresResource, Vm, VmHost, MinioCluster, MinioServer].each do |klass|
+    [GithubRunner, PostgresResource, Vm, VmHost, MinioCluster, MinioServer, Cert].each do |klass|
       inspect_output = klass.new.inspect
       klass.redacted_columns.each do |column_key|
         expect(inspect_output).not_to include column_key.to_s

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::CertNexus do
+  subject(:nx) {
+    described_class.new(st)
+  }
+
+  let(:st) { Strand.new }
+  let(:project) {
+    Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+  }
+  let(:dns_zone) {
+    DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
+  }
+  let(:cert) {
+    described_class.assemble("cert-hostname", dns_zone.id).subject
+  }
+
+  before do
+    allow(nx).to receive(:cert).and_return(cert)
+  end
+
+  describe ".assemble" do
+    it "creates a new certificate" do
+      st = described_class.assemble("test-hostname", dns_zone.id)
+      expect(Cert[st.id].hostname).to eq "test-hostname"
+      expect(st.label).to eq "start"
+    end
+
+    it "fails if dns_zone is not valid" do
+      id = SecureRandom.uuid
+      expect {
+        described_class.assemble("test-hostname", id)
+      }.to raise_error RuntimeError, "Given DNS zone doesn't exist with the id #{id}"
+    end
+  end
+
+  describe "#before_run" do
+    it "hops to destroy when needed" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "does not hop to destroy if already in the destroy state" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx).to receive(:strand).and_return(Strand.new(label: "destroy"))
+      expect { nx.before_run }.not_to hop
+    end
+  end
+
+  describe "#start" do
+    let(:order) {
+      dns_challenge = instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name", record_type: "test-record-type", record_content: "test-record-content")
+      authorization = instance_double(Acme::Client::Resources::Authorization, dns: dns_challenge)
+      instance_double(Acme::Client::Resources::Order, authorizations: [authorization], url: "test-order-url")
+    }
+
+    it "registers a deadline and starts the certificate creation process" do
+      client = instance_double(Acme::Client)
+      key = OpenSSL::PKey::EC.generate("prime256v1")
+      expect(OpenSSL::PKey::EC).to receive(:generate).with("prime256v1").and_return(key)
+      expect(Acme::Client).to receive(:new).with(private_key: key, directory: Config.acme_directory).and_return(client)
+      expect(client).to receive(:new_account).with(contact: "mailto:#{Config.acme_email}", terms_of_service_agreed: true, external_account_binding: {kid: Config.acme_eab_kid, hmac_key: Config.acme_eab_hmac_key}).and_return(instance_double(Acme::Client::Resources::Account, kid: "test-kid"))
+      expect(client).to receive(:new_order).with(identifiers: [cert.hostname]).and_return(order)
+      expect(cert).to receive(:update).with(kid: "test-kid", account_key: key.to_der, order_url: "test-order-url")
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name"))
+      expect(dns_zone).to receive(:insert_record).with(record_name: "test-record-name.cert-hostname", type: "test-record-type", ttl: 600, data: "test-record-content")
+
+      expect { nx.start }.to hop("wait_dns_update")
+    end
+  end
+
+  describe "#wait_dns_update" do
+    it "waits for dns_record to be seen by all servers" do
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name", record_content: "content")).at_least(:once)
+      dns_record = instance_double(DnsRecord, id: SecureRandom.uuid)
+      expect(DnsRecord).to receive(:[]).with(dns_zone_id: dns_zone.id, name: "test-record-name.cert-hostname.", tombstoned: false, data: "content").and_return(dns_record)
+      expect { nx.wait_dns_update }.to nap(10)
+    end
+
+    it "requests validation when dns_record is seen by all servers" do
+      challenge = instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name", record_content: "content")
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(nx).to receive(:dns_challenge).and_return(challenge).at_least(:once)
+      dns_record = DnsRecord.create_with_id(dns_zone_id: dns_zone.id, name: "test-record-name.cert-hostname.", type: "test-record-type", ttl: 600, data: "content")
+      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{dns_record.id}', NULL)"].insert
+
+      expect(challenge).to receive(:request_validation)
+      expect { nx.wait_dns_update }.to hop("wait_dns_validation")
+    end
+  end
+
+  describe "#wait_dns_validation" do
+    let(:challenge) {
+      instance_double(Acme::Client::Resources::Challenges::DNS01, status: "pending", record_name: "test-record-name", record_content: "content")
+    }
+
+    before do
+      expect(nx).to receive(:dns_challenge).and_return(challenge).at_least(:once)
+    end
+
+    it "waits for dns_challenge to be validated" do
+      expect { nx.wait_dns_validation }.to nap(10)
+    end
+
+    it "returns back to start if dns_challenge validation fails" do
+      expect(challenge).to receive(:status).and_return("failed")
+      expect(Clog).to receive(:emit).with("DNS validation failed")
+      expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect { nx.wait_dns_validation }.to hop("start")
+    end
+
+    it "finalizes the certificate when dns_challenge is valid" do
+      expect(challenge).to receive(:status).and_return("valid")
+
+      key = OpenSSL::PKey::RSA.new(4096)
+      expect(OpenSSL::PKey::RSA).to receive(:new).with(4096).and_return(key)
+      csr = instance_double(Acme::Client::CertificateRequest)
+      acme_order = instance_double(Acme::Client::Resources::Order)
+      expect(nx).to receive(:acme_order).and_return(acme_order).at_least(:once)
+      expect(Acme::Client::CertificateRequest).to receive(:new).with(private_key: key, common_name: "cert-hostname").and_return(csr)
+      expect(acme_order).to receive(:finalize).with(csr: csr)
+      expect(cert).to receive(:update).with(csr_key: key.to_der)
+      expect { nx.wait_dns_validation }.to hop("wait_cert_finalization")
+    end
+  end
+
+  describe "#wait_cert_finalization" do
+    let(:acme_order) {
+      instance_double(Acme::Client::Resources::Order, status: "processing")
+    }
+
+    before do
+      expect(nx).to receive(:acme_order).and_return(acme_order).at_least(:once)
+    end
+
+    it "waits for certificate to be finalized" do
+      expect { nx.wait_cert_finalization }.to nap(10)
+    end
+
+    it "returns back to start if certificate finalization fails" do
+      challenge = instance_double(Acme::Client::Resources::Challenges::DNS01, status: "pending", record_name: "test-record-name", record_content: "content")
+      expect(nx).to receive(:dns_challenge).and_return(challenge).at_least(:once)
+      expect(acme_order).to receive(:status).and_return("failed")
+      expect(Clog).to receive(:emit).with("Certificate finalization failed")
+      expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect { nx.wait_cert_finalization }.to hop("start")
+    end
+
+    it "updates the certificate when certificate is valid" do
+      expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name"))
+      expect(acme_order).to receive(:status).and_return("valid")
+      expect(acme_order).to receive(:certificate).and_return("test-certificate")
+      expect(Time).to receive(:now).and_return(Time.new(2021, 1, 1, 0, 0, 0))
+      expect(cert).to receive(:update).with(cert: "test-certificate", created_at: Time.new(2021, 1, 1, 0, 0, 0))
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
+      expect { nx.wait_cert_finalization }.to hop("wait")
+    end
+  end
+
+  describe "#wait" do
+    it "waits for 1 month" do
+      expect(cert).to receive(:created_at).and_return(Time.new(2021, 4, 1, 0, 0, 0))
+      expect(Time).to receive(:now).and_return(Time.new(2021, 4, 1, 0, 0, 0))
+      expect { nx.wait }.to nap(60 * 60 * 24 * 30 * 1)
+    end
+
+    it "destroys the certificate after 3 months" do
+      created_at = Time.new(2021, 1, 1, 0, 0, 0)
+      expect(cert).to receive(:created_at).and_return(created_at)
+      expect(Time).to receive(:now).and_return(created_at + 60 * 60 * 24 * 30 * 3 + 1)
+      expect(cert).to receive(:incr_destroy)
+      expect { nx.wait }.to nap(0)
+    end
+  end
+
+  describe "#destroy" do
+    it "revokes the certificate and deletes the dns record" do
+      client = instance_double(Acme::Client)
+      expect(cert).to receive(:cert).and_return("test-cert").at_least(:once)
+      expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name")).at_least(:once)
+      expect(nx).to receive(:acme_client).and_return(client)
+      expect(client).to receive(:revoke).with(certificate: "test-cert", reason: "cessationOfOperation")
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
+
+      expect { nx.destroy }.to exit({"msg" => "certificate revoked and destroyed"})
+    end
+
+    it "does not revoke the certificate if it doesn't exist" do
+      expect(cert).to receive(:cert).and_return(nil)
+      expect(nx).not_to receive(:acme_client)
+      expect(nx).to receive(:dns_zone).and_return(dns_zone)
+      expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
+      expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name")).at_least(:once)
+
+      expect { nx.destroy }.to exit({"msg" => "certificate revoked and destroyed"})
+    end
+
+    it "skips deleting the dns record if dns_challenge doesn't exist" do
+      expect(cert).to receive(:cert).and_return(nil)
+      expect(nx).to receive(:dns_challenge).and_return(nil)
+
+      expect { nx.destroy }.to exit({"msg" => "certificate revoked and destroyed"})
+    end
+  end
+
+  describe "#acme_client" do
+    it "returns a new acme client" do
+      expect(cert).to receive(:account_key).and_return("test-account-key").at_least(:once)
+      expect(cert).to receive(:kid).and_return("test-kid")
+      expect(OpenSSL::PKey::EC).to receive(:new).with("test-account-key").and_return("account-key")
+      expect(Acme::Client).to receive(:new).with(private_key: "account-key", directory: Config.acme_directory, kid: "test-kid").and_return("client")
+
+      expect(nx.acme_client).to eq "client"
+    end
+
+    it "returns nil if account key is not set" do
+      expect(cert).to receive(:account_key).and_return(nil)
+
+      expect(nx.acme_client).to be_nil
+    end
+  end
+
+  describe "#acme_order" do
+    it "returns the acme order" do
+      expect(cert).to receive(:order_url).and_return("test-order-url").at_least(:once)
+      client = instance_double(Acme::Client)
+      expect(nx).to receive(:acme_client).and_return(client)
+      expect(client).to receive(:order).with(url: "test-order-url").and_return("order")
+
+      expect(nx.acme_order).to eq "order"
+    end
+
+    it "returns nil if order_url is nil" do
+      expect(cert).to receive(:order_url).and_return(nil)
+      expect(nx.acme_order).to be_nil
+    end
+  end
+
+  describe "#dns_challenge" do
+    it "returns the dns challenge" do
+      order = instance_double(Acme::Client::Resources::Order)
+      expect(nx).to receive(:acme_order).and_return(order)
+      expect(order).to receive(:authorizations).and_return([instance_double(Acme::Client::Resources::Authorization, dns: "dns")])
+
+      expect(nx.dns_challenge).to eq "dns"
+    end
+  end
+
+  describe "#dns_zone" do
+    it "returns the dns zone" do
+      expect(DnsZone).to receive(:[]).with(cert.dns_zone_id).and_return("dns-zone")
+      expect(nx.dns_zone).to eq "dns-zone"
+    end
+
+    it "returns nil if dns_zone_id is not set" do
+      expect(cert).to receive(:dns_zone_id).and_return(nil)
+      expect(nx.dns_zone).to be_nil
+    end
+  end
+end

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
     end
 
     it "naps for 5 seconds and doesn't perform update if health check succeeds" do
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 15 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -43,7 +43,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and doesn't perform update if health check fails the first time" do
       lb.load_balancers_vms_dataset.update(state_counter: 1)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 15 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("500")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("500")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -51,7 +51,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and performs update if health check fails the first time via an exception" do
       lb.load_balancers_vms_dataset.update(state_counter: 1)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 15 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_raise("error")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_raise("error")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -59,7 +59,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "starts update if health check succeeds and we hit the threshold" do
       lb.load_balancers_vms_dataset.update(state_counter: 2)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 15 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
       expect(lb).to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -67,7 +67,15 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and doesn't perform update if health check succeeds and we're already above threshold" do
       lb.load_balancers_vms_dataset.update(state_counter: 3)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --max-time 15 --silent --output /dev/null --write-out '%{http_code}' 192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
+      expect(lb).not_to receive(:incr_update_load_balancer)
+
+      expect { nx.health_probe }.to nap(30)
+    end
+
+    it "uses nc for tcp health checks" do
+      lb.update(health_check_protocol: "tcp")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nc -z -w 15 192.168.1.0 80 && echo 200 || echo 400").and_return("200")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe Clover, "load-balancer" do
         post "/api/project/#{project.ubid}/load-balancer/lb1", {
           private_subnet_id: ps.ubid,
           src_port: "80", dst_port: "80",
-          health_check_endpoint: "/up", algorithm: "round_robin"
+          health_check_endpoint: "/up", algorithm: "round_robin",
+          health_check_protocol: "http"
         }.to_json
 
         expect(last_response.status).to eq(200)
@@ -103,7 +104,8 @@ RSpec.describe Clover, "load-balancer" do
         post "/api/project/#{project.ubid}/load-balancer/lb1", {
           private_subnet_id: "invalid",
           src_port: "80", dst_port: "80",
-          health_check_endpoint: "/up", algorithm: "round_robin"
+          health_check_endpoint: "/up", algorithm: "round_robin",
+          health_check_protocol: "http"
         }.to_json
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Clover, "load balancer" do
         select "Round Robin", from: "algorithm"
         fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
+        select "HTTP", from: "health_check_protocol"
 
         click_button "Create"
 
@@ -100,6 +101,7 @@ RSpec.describe Clover, "load balancer" do
         select "Round Robin", from: "algorithm"
         fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
+        select "HTTP", from: "health_check_protocol"
 
         click_button "Create"
 
@@ -130,6 +132,7 @@ RSpec.describe Clover, "load balancer" do
         select "Round Robin", from: "algorithm"
         fill_in "HTTP Health Check Endpoint", with: "/up"
         select ps.name, from: "private_subnet_id"
+        select "HTTP", from: "health_check_protocol"
 
         ps.destroy
 

--- a/ubid.rb
+++ b/ubid.rb
@@ -70,6 +70,7 @@ class UBID
   TYPE_POSTGRES_FIREWALL_RULE = "pf"
   TYPE_GITHUB_REPOSITORY = "gp"
   TYPE_LOAD_BALANCER = "1b"
+  TYPE_CERT = "ce"
 
   # Common entropy-based type for everything else
   TYPE_ETC = "et"

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -108,22 +108,40 @@
         </div>
       </div>
       <div class="px-4 py-5 mt-6 sm:p-6">
-        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="col-span-6 md:col-span-2 xl:col-span-1">
-            <%== render(
-              "components/form/text",
-              locals: {
-                name: "health_check_endpoint",
-                label: "HTTP Health Check Endpoint",
-                attributes: {
-                  required: true,
-                  placeholder: "/up"
-                }
-              }
-            ) %>
+        <div class="space-y-12">
+          <div>
+            <h2 class="text-base font-semibold leading-7 text-gray-900">Monitoring</h2>
+            <p class="mt-1 text-sm leading-6 text-gray-600">The health check endpoint is used in combination with the Application Port. Make sure it returns 200.</p>
+            <div class="mt-6 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-6">
+              <div class="col-span-6 md:col-span-2 xl:col-span-1">
+                <%== render(
+                  "components/form/text",
+                  locals: {
+                    name: "health_check_endpoint",
+                    label: "HTTP Health Check Endpoint",
+                    attributes: {
+                      placeholder: "/up"
+                    }
+                  }
+                ) %>
+              </div>
+              <div class="col-span-6 md:col-span-2 xl:col-span-1">
+                <%== render(
+                  "components/form/select",
+                  locals: {
+                    name: "health_check_protocol",
+                    label: "Health Check Protocol",
+                    options: ["http", "https", "tcp"].map { |p| [p, p.upcase] },
+                    placeholder: "Select health check protocol",
+                    attributes: {
+                      required: true
+                    }
+                  }
+                ) %>
+              </div>
+            </div>
           </div>
         </div>
-        <p class="mt-1 text-sm leading-6 text-gray-600">The health check endpoint is used in combination with the Application Port. Make sure it returns 200.</p>
       </div>
       <div class="px-4 py-5 sm:p-6">
         <div class="flex items-center justify-end gap-x-6">


### PR DESCRIPTION
## Add ACME Cert Migration
The cert table is added.

## Add ACME Cert provisioning
This commit adds the ACME certificate provisioning integration. We are
creating a generic cert nexus. This way, we will be able to utilize the
same Certificate provisioning experience for different resources. The
most important part of this commit is the acme-client integration.

The flow of the operations for provisioning acme cert is the following;
1. Login to one of the authorities such as ZeroSSL.
2. Put an order for authorization.
3. Create the necessary dns record to solve the dns challenge.
4. Perform the dns challenge validation.
5. Put a new order to provision a certificate.
7. Finalize the order and download certs.

After the provisioning, we simply start napping for a month and we check
the expiry date every month. If it has been more than 3 months, we
assume it's expired and get into the destroy path.

Refreshing the certificates should be managed by the user of this Cert
provisioner.

## Load Balancer's Cert integration Migration

## Load Balancer's Cert integration
This commit simply implements the load balancer's certificate
integration by utilizing the FSMs implemented in the previous commit.

## Add Support to download certificates in the UI
Adds a new field to the Load Balancer show page to be able to download
the private_key and the certificate files.

## FIX: load balancer archival is fixed in case of VM archival

## Load Balancer Health Probs Protocol Support
This commit adds the health check protocol support. This is needed once
we start providing certificates. If the customer implements an
application that runs HTTPS endpoints, we must use that. For that, we
already provide the certificate to them. It's also possible that they
don't want the health checks to be performed at the TCP level without
any specific endpoint. This commit supports that as well.

## ACME Cert integration tests