### PR TITLE
Combine create_unix_user commands to single command

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -239,9 +239,6 @@ class Prog::Vm::Nexus < Prog::Base
         storage: vm.storage_secrets
       })
 
-      # Enable KVM access for VM user.
-      host.sshable.cmd("sudo usermod -a -G kvm #{q_vm}")
-
       write_params_json
 
       host.sshable.cmd("common/bin/daemonizer 'sudo host/bin/setup-vm prep #{q_vm}' prep_#{q_vm}", stdin: secrets_json)

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -260,9 +260,9 @@ class Prog::Vm::Nexus < Prog::Base
     unless vm.update_firewall_rules_set?
       vm.incr_update_firewall_rules
       # This is the first time we get into this state and we know that
-      # wait_sshable will take definitely more than 12 seconds. So, we nap here
+      # wait_sshable will take definitely more than 10 seconds. So, we nap here
       # to reduce the amount of load on the control plane unnecessarily.
-      nap 12
+      nap 10
     end
     addr = vm.ephemeral_net4
     hop_create_billing_record unless addr

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -496,10 +496,10 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#wait_sshable" do
-    it "naps 12 second if it's the first time we execute wait_sshable" do
+    it "naps 10 second if it's the first time we execute wait_sshable" do
       expect(vm).to receive(:update_firewall_rules_set?).and_return(false)
       expect(vm).to receive(:incr_update_firewall_rules)
-      expect { nx.wait_sshable }.to nap(12)
+      expect { nx.wait_sshable }.to nap(10)
     end
 
     it "naps if not sshable" do


### PR DESCRIPTION
### Combine create_unix_user commands to single command

We cache SSH connections to our host to run commands more quickly. Even
for short commands, the network adds ~0.4s of overhead. Previously, we
achieved a few seconds of gain by merging multiple commands into a
single one in GithubRunner, which makes a significant difference in
time-sensitive operations.

We can also consolidate the `create_unix_user` commands into a single
command. Additionally, I have relocated `sudo usermod -a -G kvm #{q_vm}`
from the `prep` label to this command, as it is more logical to execute
it here. I will remove it from the `prep` label in the next commit. If
there are any strands that have already passed `create_unix_user` but
haven't run `prep` yet. Since this operation is idempotent, it's safe to
run it multiple times.

### Remove duplicate command from prep label

I relocated it from `prep` to `create_unix_user` in the previous commit.
I removed it in this commit for a smoother deployment.

### Reduce sleep time in vm provisioning from 12 to 10 seconds

In the `wait_sshable` label, we initially set a long sleep time because
we expected the first run to take some time. The sleep time was
initially set at 12 seconds. However, we noticed that some duration
times were approaching this 12-second mark. As a result, we decided to
decrease the sleep time to 10 seconds.

