### PR TITLE
Do not invite deleted accounts to the project

### DIFF
--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -12,7 +12,8 @@ class CloverWeb
 
     r.post true do
       email = r.params["email"]
-      user = Account[email: email]
+      # Don't invite deleted accounts
+      user = Account.exclude(status_id: 3)[email: email]
 
       user&.associate_with_project(@project)
 


### PR DESCRIPTION
Typically, user accounts are identified uniquely by their email. However, this only applies to active accounts. When an account is deleted, Rodauth changes its status to '3:deleted' and allows the creation of a new account with the same email. Therefore, when we select a user solely by email, we might retrieve a deleted account. To prevent this, we need to exclude deleted accounts. Some of our customers have already encountered this issue.