### PR TITLE
Destroy account when it's closed

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -216,6 +216,17 @@ class CloverWeb < Roda
     close_account_redirect "/login"
     close_account_route "account/close-account"
     close_account_view { view "account/close_account", "My Account" }
+
+    before_close_account do
+      account = Account[account_id]
+      # Do not allow to close account if the project has resources and
+      # the account is the only user
+      if (project = account.projects.find { _1.accounts.count == 1 && _1.has_resources })
+        flash["error"] = "'#{project.name}' project has some resources. Delete all related resources first."
+        redirect "/project"
+      end
+    end
+
     delete_account_on_close? true
     delete_account do
       account = Account[account_id]

--- a/clover_web.rb
+++ b/clover_web.rb
@@ -216,6 +216,12 @@ class CloverWeb < Roda
     close_account_redirect "/login"
     close_account_route "account/close-account"
     close_account_view { view "account/close_account", "My Account" }
+    delete_account_on_close? true
+    delete_account do
+      account = Account[account_id]
+      account.projects.each { account.dissociate_with_project(_1) }
+      account.destroy
+    end
 
     argon2_secret { Config.clover_session_secret }
     require_bcrypt? false

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -261,5 +261,17 @@ RSpec.describe Clover, "auth" do
       expect(Account[email: TEST_USER_EMAIL]).to be_nil
       expect(AccessTag.where(name: "user/#{TEST_USER_EMAIL}").count).to eq 0
     end
+
+    it "can not close account if the project has some resources" do
+      vm = create_vm
+      vm.associate_with_project(Account[email: TEST_USER_EMAIL].projects.first)
+
+      visit "/account/close-account"
+
+      click_button "Close Account"
+
+      expect(page.title).to eq("Ubicloud - Projects")
+      expect(page).to have_content("project has some resources. Delete all related resources first")
+    end
   end
 end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -249,5 +249,17 @@ RSpec.describe Clover, "auth" do
 
       click_button "Sign in"
     end
+
+    it "can close account" do
+      visit "/account/close-account"
+
+      click_button "Close Account"
+
+      expect(page.title).to eq("Ubicloud - Login")
+      expect(page).to have_content("Your account has been closed")
+
+      expect(Account[email: TEST_USER_EMAIL]).to be_nil
+      expect(AccessTag.where(name: "user/#{TEST_USER_EMAIL}").count).to eq 0
+    end
   end
 end


### PR DESCRIPTION
### Destroy account when it's closed 
Rodauth marks accounts as deleted when they are closed but not actually
delete records from the accounts table. It has
`delete_account_on_close?` option [^1] that can be set to `true` to
actually delete records from the accounts table when they are closed.
But it calls `.delete` method on account dataset [^2]. It has two
drawbacks:
  - It doesn't delete access tags of the account in the projects.
  - It calls `.delete` instead of `.destroy`. So the account doesn't
    archived to `deleted_records` table. We want to archive it for audit
    purposes.
  
So I override `delete_account` method to solve these drawbacks.
  
[^1]: https://github.com/jeremyevans/rodauth/blob/2412336a6107feb5e8e3f107c9dc50c781a5d42d/lib/rodauth/features/close_account.rb#L48
[^2]: https://github.com/jeremyevans/rodauth/blob/2412336a6107feb5e8e3f107c9dc50c781a5d42d/lib/rodauth/features/close_account.rb#L77  

### Do not allow to close account if the project has some resources**
If the account to be closed is the only one associated with the project
and the project has resources, we shouldn't allow the account closure.
Otherwise, these resources would become unclaimed.
  