### PR TITLE
Fix prep_host script to create missing directories

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -61,6 +61,7 @@ CloudHypervisor::FIRMWARE.download
 # Err towards listing ('l') and not restarting services by default,
 # otherwise a stray keystroke when using "apt install" for unrelated
 # packages can restart systemd services that interrupt customers.
+FileUtils.mkdir_p("/etc/needrestart/conf.d")
 File.write("/etc/needrestart/conf.d/82-clover-default-list.conf", <<CONF)
 $nrconf{restart} = 'l';
 CONF


### PR DESCRIPTION
While I was setting up a new arm64 host, the prep_host script failed with the following error:

    host/bin/prep_host.rb:64:in `write': No such file or directory
    @rb_sysope - /etc/needrestart/conf.d/82-clover-default-list.conf (Errno::ENOENT)
    from host/bin/prep_host.rb:64:in `<main>'

Writing to `/etc/needrestart/conf.d/82-clover-default-list.conf` failed due to `/etc/needrestart/conf.d` directory is missing.

We can try to create this directory anyway since it's idempotent.