### PR TITLE
Set Content-Type of not_found plugin for API

### DIFF
--- a/clover_api.rb
+++ b/clover_api.rb
@@ -24,6 +24,7 @@ class CloverApi < Roda
   end
 
   plugin :error_handler do |e|
+    response["Content-Type"] = "application/json"
     error = parse_error(e)
 
     {error: error}.to_json

--- a/clover_api.rb
+++ b/clover_api.rb
@@ -13,6 +13,7 @@ class CloverApi < Roda
   autoload_routes("api")
 
   plugin :not_found do
+    response["Content-Type"] = "application/json"
     {
       error: {
         code: 404,

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe Clover, "firewall" do
     it "get does not exist" do
       get "/api/project/#{project.ubid}/firewall/#{firewall.ubid}/firewall-rule/fooubid"
 
+      expect(last_response.content_type).to eq("application/json")
       expect(last_response).to have_api_error(404)
     end
   end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe Clover, "private_subnet" do
       it "not authorized" do
         post "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/foo_subnet"
 
+        expect(last_response.content_type).to eq("application/json")
         expect(last_response).to have_api_error(403)
       end
 


### PR DESCRIPTION
Previously, this was returning JSON content with a text/html Content-Type.

I noticed this when trying to get our OpenAPI schema into shape, as to validate, the content type must match specification, and in the API, that is all `application/json` for now.