### PR TITLE
Use US locations for only standard-60 runners

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -168,7 +168,8 @@ class Prog::Vm::Nexus < Prog::Base
         if frame["force_host_id"]
           [[], [], [], [frame["force_host_id"]]]
         elsif vm.location == "github-runners"
-          [["accepting"], [], ["github-runners"], []]
+          runner_locations = (vm.cores == 30) ? [] : ["github-runners", "hetzner-fsn1", "hetzner-hel1"]
+          [["accepting"], runner_locations, ["github-runners"], []]
         else
           [["accepting"], [vm.location], [], []]
         end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -350,8 +350,24 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.start }.to hop("create_unix_user")
     end
 
-    it "considers all locations for github-runners" do
+    it "considers EU locations for github-runners" do
       vm.location = "github-runners"
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        host_exclusion_filter: [],
+        location_filter: ["github-runners", "hetzner-fsn1", "hetzner-hel1"],
+        location_preference: ["github-runners"],
+        gpu_enabled: false
+      )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
+    it "considers all locations for standard-60 runners" do
+      vm.location = "github-runners"
+      vm.cores = 30
       expect(Scheduling::Allocator).to receive(:allocate).with(
         vm, :storage_volumes,
         allocation_state_filter: ["accepting"],


### PR DESCRIPTION
We can allocate our runners on any location with available capacity, including the US. However, we prefer using EU locations for all runners except the standard-60 runners, as it helps us adhere to GDPR regulations. We make an exception for standard-60 runners due to their high capacity requirements, and US hosts assist us in managing this load.