### PR TITLE
Apply concurrent vm provisioning and AX161 penalties to all locations

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -152,13 +152,11 @@ module Scheduling::Allocator
       # imbalance score, in range [0, 1]
       score += util.max - util.min
 
-      if @candidate_host[:location] == "github-runners"
-        # penalty for ongoing vm provisionings on the host
-        score += @candidate_host[:vm_provisioning_count] * 0.5
+      # penalty for ongoing vm provisionings on the host
+      score += @candidate_host[:vm_provisioning_count] * 0.5
 
-        # penalty for AX161, TODO: remove after migration to AX162
-        score += 0.5 if @candidate_host[:total_cores] == 32
-      end
+      # penalty for AX161, TODO: remove after migration to AX162
+      score += 0.5 if @candidate_host[:total_cores] == 32
 
       # penalty of 5 if host has a GPU but VM doesn't require a GPU
       score += 5 unless @request.gpu_enabled || @candidate_host[:num_gpus] == 0


### PR DESCRIPTION
Given that concurrent provisionings take noticeably longer, we had started to apply penalties on VMs that are provisioned simultaneously to distribute them across as many hosts as possible. We also prioritize AX162 over AX161. These penalties only apply to hosts in 'github-runners' locations. However, as we're consolidating our fleet, we're moving them to their original locations instead of the reserved 'github-runners' locations. Therefore, we need to extend these penalties to all locations.