### PR TITLE
Fix class variable modification on quotas

### DIFF
--- a/model/project_quota.rb
+++ b/model/project_quota.rb
@@ -3,6 +3,7 @@
 require_relative "../model"
 
 class ProjectQuota < Sequel::Model
+  @@default_quotas = nil
   def self.default_quotas
     @@default_quotas ||= YAML.load_file("config/default_quotas.yml").each_with_object({}) do |item, hash|
       hash[item["resource_type"]] = item


### PR DESCRIPTION
We initialize the class variable @@quotas in the ProjectQuota class, which fails because we freeze all classes in the production.