### PR TITLE
Move the trigger for starting vm's systemd unit to rhizome

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -251,11 +251,6 @@ class Prog::Vm::Nexus < Prog::Base
     host.sshable.cmd("sudo -u #{q_vm} tee #{params_path.shellescape}", stdin: vm.params_json(frame["swap_size_bytes"]))
   end
 
-  label def run
-    host.sshable.cmd("sudo systemctl start #{q_vm}")
-    hop_wait_sshable
-  end
-
   label def wait_sshable
     unless vm.update_firewall_rules_set?
       vm.incr_update_firewall_rules
@@ -470,7 +465,6 @@ class Prog::Vm::Nexus < Prog::Base
     })
 
     host.sshable.cmd("sudo host/bin/setup-vm recreate-unpersisted #{q_vm}", stdin: secrets_json)
-    host.sshable.cmd("sudo systemctl start #{q_vm}")
     vm.nics.each { _1.incr_repopulate }
 
     vm.update(display_state: "running")

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -233,7 +233,7 @@ class Prog::Vm::Nexus < Prog::Base
     when "Succeeded"
       host.sshable.cmd("common/bin/daemonizer --clean prep_#{q_vm}")
       vm.nics.each { _1.incr_setup_nic }
-      hop_run
+      hop_wait_sshable
     when "NotStarted", "Failed"
       secrets_json = JSON.generate({
         storage: vm.storage_secrets

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -50,12 +50,14 @@ class VmSetup
     hugepages(mem_gib)
     prepare_pci_devices(pci_devices)
     install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices)
+    start_systemd_unit
   end
 
   def recreate_unpersisted(gua, ip4, local_ip4, nics, mem_gib, ndp_needed, storage_params, storage_secrets, multiqueue:)
     setup_networking(true, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: multiqueue)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
+    start_systemd_unit
   end
 
   def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
@@ -583,6 +585,10 @@ LimitNOFILE=500000
 #{limit_memlock}
 SERVICE
     r "systemctl daemon-reload"
+  end
+
+  def start_systemd_unit
+    r "systemctl start #{q_vm}"
   end
 
   # Generate a MAC with the "local" (generated, non-manufacturer) bit

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:setup_networking).with(true, "gua", "ip4", "local_ip4", "nics", false, multiqueue: true)
       expect(vs).to receive(:hugepages).with(4)
       expect(vs).to receive(:storage).with("storage_params", "storage_secrets", false)
+      expect(vs).to receive(:start_systemd_unit)
 
       vs.recreate_unpersisted("gua", "ip4", "local_ip4", "nics", 4, false, "storage_params", "storage_secrets", multiqueue: true)
     end
@@ -296,6 +297,13 @@ NFTABLES_CONF
       expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/hugepages")
       expect(vs).to receive(:r).with("mount -t hugetlbfs -o uid=test,size=2G nodev /vm/test/hugepages")
       vs.hugepages(2)
+    end
+  end
+
+  describe "#start_systemd_unit" do
+    it "can start systemd unit" do
+      expect(vs).to receive(:r).with("systemctl start test")
+      vs.start_systemd_unit
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nic).to receive(:incr_setup_nic)
       vmh = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vmh)
-      expect { nx.prep }.to hop("run")
+      expect { nx.prep }.to hop("wait_sshable")
     end
 
     it "generates and passes a params json if prep command is not started yet" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -486,15 +486,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
   end
 
-  describe "#run" do
-    it "runs the vm" do
-      sshable = instance_double(Sshable)
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, sshable: sshable))
-      expect(sshable).to receive(:cmd).with(/sudo systemctl start vm/)
-      expect { nx.run }.to hop("wait_sshable")
-    end
-  end
-
   describe "#wait_sshable" do
     it "naps 10 second if it's the first time we execute wait_sshable" do
       expect(vm).to receive(:update_firewall_rules_set?).and_return(false)
@@ -828,7 +819,6 @@ RSpec.describe Prog::Vm::Nexus do
         /sudo host\/bin\/setup-vm recreate-unpersisted #{nx.vm_name}/,
         {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/}
       )
-      expect(sshable).to receive(:cmd).with(/sudo systemctl start vm[0-9a-z]+/)
       expect(vm).to receive(:update).with(display_state: "starting")
       expect(vm).to receive(:update).with(display_state: "running")
       expect(vm).to receive(:incr_update_firewall_rules)


### PR DESCRIPTION
### Move the trigger for starting vm's systemd unit to rhizome

After the `prep` label is complete, the control plane run the systemd
unit in the `run` label. The `prep` script is daemonized, which causes
the control plane to poll too frequently to check its status, then it
starts the systemd unit. When we move this run command to the end of the
prep script at rhizome, the vm starts to boot immediately after it is
prepared. Thus, it will start booting even before the control plane
acknowledges that the prep is complete.

Our main goal is to minimize the interaction between the control plane
and the data plane to enhance our provisioning times. By removing the
`run` label and initiating the booting process earlier, I anticipate a
1-2 second improvement in provisioning time.

`VmSetup.recreate_unpersisted` is invoked in
`Vm::Nexus.start_after_host_reboot` and shares similar logic with
`VmSetup.prep`. Although it's not time-sensitive, I've changed it for
consistency.

I remove the `run` label in the next commit for smoother deployment.

### Skip the run label in nexus since it's moved to rhizome
We moved the run command of the vm's systemd unit to rhizome in the
previous commit. After installing rhizome to all hosts, we can start to
skip the `run` label.

### Remove the run label in nexus
It's skipped in the previous commit. So there is no nexus strand on the
`run` label. We can remove it now.

We also also moved start command in `start_after_host_reboot` to
rhizome.