### PR TITLE
Remove unnecessary explicit schedule values

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -9,19 +9,19 @@ Signal.trap("TERM") { d.shutdown }
 if Config.heartbeat_url
   puts "Starting heartbeat prog"
   # We always insert the heartbeat using the same UBID ("stheartbeatheartbheartheaz")
-  Strand.dataset.insert_conflict.insert(id: "8b958d2d-cad4-5f3a-5634-b8b958d45caf", schedule: Time.now, prog: "Heartbeat", label: "wait")
+  Strand.dataset.insert_conflict.insert(id: "8b958d2d-cad4-5f3a-5634-b8b958d45caf", prog: "Heartbeat", label: "wait")
 end
 
 if Config.github_app_id
   # We always insert this strand using the same UBID ("stredelivergith0bfail0reaz")
-  Strand.dataset.insert_conflict.insert(id: "c39ae087-6ec4-033a-d440-b7a821061caf", schedule: Time.now, prog: "RedeliverGithubFailures", label: "wait", stack: [{last_check_at: Time.now}].to_json)
+  Strand.dataset.insert_conflict.insert(id: "c39ae087-6ec4-033a-d440-b7a821061caf", prog: "RedeliverGithubFailures", label: "wait", stack: [{last_check_at: Time.now}].to_json)
 end
 
 # We always insert this strand using the same UBID ("stresolvee4block0dnsnamesz")
-Strand.dataset.insert_conflict.insert(id: "c3b200ed-ce22-c33a-0326-06d735551d9f", schedule: Time.now, prog: "ResolveGloballyBlockedDnsnames", label: "wait")
+Strand.dataset.insert_conflict.insert(id: "c3b200ed-ce22-c33a-0326-06d735551d9f", prog: "ResolveGloballyBlockedDnsnames", label: "wait")
 
 # We always insert this strand using the same UBID ("stcheckzvsagezalertszzzzza")
-Strand.dataset.insert_conflict.insert(id: "645cc9ff-7954-1f3a-fa82-ec6b3ffffff5", schedule: Time.now, prog: "CheckUsageAlerts", label: "wait")
+Strand.dataset.insert_conflict.insert(id: "645cc9ff-7954-1f3a-fa82-ec6b3ffffff5", prog: "CheckUsageAlerts", label: "wait")
 
 clover_freeze
 

--- a/model/boot_image.rb
+++ b/model/boot_image.rb
@@ -14,7 +14,7 @@ class BootImage < Sequel::Model
 
   # Introduced for removing a boot image via REPL.
   def remove_boot_image
-    Strand.create_with_id(schedule: Time.now, prog: "RemoveBootImage", label: "start", stack: [{subject_id: id}])
+    Strand.create_with_id(prog: "RemoveBootImage", label: "start", stack: [{subject_id: id}])
   end
 
   def path

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -177,19 +177,19 @@ class VmHost < Sequel::Model
       end
     end
 
-    Strand.create_with_id(schedule: Time.now, prog: "SetupNftables", label: "start", stack: [{subject_id: id}])
+    Strand.create_with_id(prog: "SetupNftables", label: "start", stack: [{subject_id: id}])
   end
 
   # Operational Functions
 
   # Introduced for refreshing rhizome programs via REPL.
   def install_rhizome(install_specs: false)
-    Strand.create_with_id(schedule: Time.now, prog: "InstallRhizome", label: "start", stack: [{subject_id: id, target_folder: "host", install_specs: install_specs}])
+    Strand.create_with_id(prog: "InstallRhizome", label: "start", stack: [{subject_id: id, target_folder: "host", install_specs: install_specs}])
   end
 
   # Introduced for downloading a new boot image via REPL.
   def download_boot_image(image_name, version:, custom_url: nil)
-    Strand.create_with_id(schedule: Time.now, prog: "DownloadBootImage", label: "start", stack: [{subject_id: id, image_name: image_name, custom_url: custom_url, version: version}])
+    Strand.create_with_id(prog: "DownloadBootImage", label: "start", stack: [{subject_id: id, image_name: image_name, custom_url: custom_url, version: version}])
   end
 
   # Introduced for downloading firmware via REPL.
@@ -197,7 +197,7 @@ class VmHost < Sequel::Model
     version, sha256 = (arch == "x64") ? [version_x64, sha256_x64] : [version_arm64, sha256_arm64]
     fail ArgumentError, "No version provided" if version.nil?
     fail ArgumentError, "No SHA-256 digest provided" if sha256.nil?
-    Strand.create_with_id(schedule: Time.now, prog: "DownloadFirmware", label: "start", stack: [{subject_id: id, version: version, sha256: sha256}])
+    Strand.create_with_id(prog: "DownloadFirmware", label: "start", stack: [{subject_id: id, version: version, sha256: sha256}])
   end
 
   # Introduced for downloading cloud hypervisor via REPL.
@@ -210,7 +210,7 @@ class VmHost < Sequel::Model
       fail "BUG: unexpected architecture"
     end
     fail ArgumentError, "No version provided" if version.nil?
-    Strand.create_with_id(schedule: Time.now, prog: "DownloadCloudHypervisor", label: "start", stack: [{subject_id: id, version: version, sha256_ch_bin: sha256_ch_bin, sha256_ch_remote: sha256_ch_remote}])
+    Strand.create_with_id(prog: "DownloadCloudHypervisor", label: "start", stack: [{subject_id: id, version: version, sha256_ch_bin: sha256_ch_bin, sha256_ch_remote: sha256_ch_remote}])
   end
 
   def hetznerify(server_id)


### PR DESCRIPTION
The `schedule` column already has a default value of `Sequel.lit("now()")`. Therefore, there's no need to explicitly set it to `Time.now` when creating a new strand.