### PR TITLE
Use UTF8 encoding instead of SQL_ASCII

### DIFF
--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -9,7 +9,7 @@ r "chown postgres /dat"
 r "rm -rf /dat/16"
 r "rm -rf /etc/postgresql/16"
 
-r "pg_createcluster 16 main --start --locale=C"
+r "pg_createcluster 16 main --start --locale=C.UTF8"
 
 r "sudo -u postgres psql -c 'CREATE ROLE ubi_replication WITH REPLICATION LOGIN'"
 r "sudo -u postgres psql -c 'CREATE ROLE ubi_monitoring WITH LOGIN IN ROLE pg_monitor'"


### PR DESCRIPTION
Previously, we set the locale to `C` using `pg_createcluster`'s `--locale` option, which unintentionally also set the encoding to `SQL_ASCII`. We prefer `UTF8` as the default encoding.