### PR TITLE
Run networking and storage setup in parallel during vm prep

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -45,7 +45,7 @@ class VmSetup
 
   def prep(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
-    cloudinit(unix_user, public_keys, nics, swap_size_bytes)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes)
     storage(storage_params, storage_secrets, true)
     hugepages(mem_gib)
     prepare_pci_devices(pci_devices)
@@ -62,7 +62,7 @@ class VmSetup
 
   def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
-    cloudinit(unix_user, public_keys, nics, swap_size_bytes)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
     install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices)
@@ -396,13 +396,13 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "ip netns exec #{q_vm} bash -c 'nft -f #{vp.q_nftables_conf}'"
   end
 
-  def cloudinit(unix_user, public_keys, nics, swap_size_bytes)
+  def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes)
     vp.write_meta_data(<<EOS)
 instance-id: #{yq(@vm_name)}
 local-hostname: #{yq(@vm_name)}
 EOS
 
-    guest_network = NetAddr.parse_net(vp.read_guest_ephemeral)
+    guest_network = subdivide_network(NetAddr.parse_net(gua)).first
     private_ip_dhcp = nics.map do |nic|
       vm_sub_6 = NetAddr::IPv6Net.parse(nic.net6)
       vm_sub_4 = NetAddr::IPv4Net.parse(nic.net4)


### PR DESCRIPTION
### Decouple cloudinit and networking setup in vm prepare

I'm planning to run a few vm preparation steps in parallel. To achieve
this, we need to decouple these steps as much as possible. The
`cloudinit` uses `guest_ephemeral` from the `setup_networking` step. In
reality, this is a subdivide of the gua and we've calculated it in
various places. Therefore, we can also calculate it here.

### Run networking and storage setup in parallel during vm prep

Setting up networking and storage are the most time-consuming steps in
our VM preparation script, taking up the majority of the process.
Ideally, each step takes 1 second, but when we have too many active vm
provisioning, each can take up to 5-8 seconds. However, as these steps
are independent, we can execute them in parallel to save time. This
approach could save us 1 second in the best-case scenario and 5-8
seconds in the worst-case scenario.
