### PR TITLE
Update to Ruby 3.2.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.2.4
+ruby 3.2.5
 postgres 15.4
 nodejs 22.5.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM ruby:3.2.4-alpine3.19 as bundler
+FROM ruby:3.2.5-alpine3.19 as bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -19,7 +19,7 @@ RUN bundle config set --local without development:test
 RUN bundle install
 
 
-FROM ruby:3.2.4-alpine3.19
+FROM ruby:3.2.5-alpine3.19
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "argon2"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
     parallel (1.25.1)
     parallel_tests (4.7.1)
       parallel
-    parser (3.3.4.0)
+    parser (3.3.4.1)
       ast (~> 2.4.1)
       racc
     pg (1.5.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,7 +385,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,4 +388,4 @@ RUBY VERSION
    ruby 3.2.5p208
 
 BUNDLED WITH
-   2.5.10
+   2.5.17


### PR DESCRIPTION
We have no particular problems with 3.2.4.  The list of bugs intended to be addressed are at
https://github.com/ruby/ruby/releases/tag/v3_2_5.