### PR TITLE
Fix small typo on Postgres views

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -66,8 +66,8 @@ module Option
 
   PostgresHaOption = Struct.new(:name, :standby_count, :title, :explanation)
   PostgresHaOptions = [[PostgresResource::HaType::NONE, 0, "No Standbys", "No replication"],
-    [PostgresResource::HaType::ASYNC, 1, "1 Standby", "Asyncronous replication"],
-    [PostgresResource::HaType::SYNC, 2, "2 Standbys", "Syncronous replication with quorum"]].map {
+    [PostgresResource::HaType::ASYNC, 1, "1 Standby", "Asynchronous replication"],
+    [PostgresResource::HaType::SYNC, 2, "2 Standbys", "Synchronous replication with quorum"]].map {
     PostgresHaOption.new(*_1)
   }.freeze
 end

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -35,9 +35,9 @@
   when PostgresResource::HaType::NONE
     data.push(["High Availability", "Inactive"])
   when PostgresResource::HaType::ASYNC
-    data.push(["High Availability", "Active (1 standby with asyncronous replication)"])
+    data.push(["High Availability", "Active (1 standby with asynchronous replication)"])
   when PostgresResource::HaType::SYNC
-    data.push(["High Availability", "Active (2 standbys with syncronous replication)"])
+    data.push(["High Availability", "Active (2 standbys with synchronous replication)"])
   end
   
   if @pg[:connection_string] == ""


### PR DESCRIPTION
On the views to create/show Postgres DBs there are small typos related to replication options, which are corrected by this commit:
* `Asyncronous` -> `Asynchronous`
* `Syncronous` -> `Synchronous`