### PR TITLE
Load Balancer bug fixes and operational improvements

### DIFF
--- a/migrate/20240805_add_lb_health_prob_detaching.rb
+++ b/migrate/20240805_add_lb_health_prob_detaching.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_enum_value(:lb_node_state, "detaching")
+  end
+end

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -75,7 +75,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
 
   label def update_vm_load_balancers
     load_balancer.vms.each do |vm|
-      bud Prog::Vnet::UpdateLoadBalancer, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :update_load_balancer
+      bud Prog::Vnet::UpdateLoadBalancerNode, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :update_load_balancer
     end
 
     hop_wait_update_vm_load_balancers
@@ -83,7 +83,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
 
   label def wait_update_vm_load_balancers
     reap
-    if strand.children_dataset.where(prog: "Vnet::UpdateLoadBalancer").all? { _1.exitval == "load balancer is updated" } || strand.children.empty?
+    if strand.children_dataset.where(prog: "Vnet::UpdateLoadBalancerNode").all? { _1.exitval == "load balancer is updated" } || strand.children.empty?
       decr_update_load_balancer
       hop_wait
     end
@@ -101,7 +101,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
     end
 
     load_balancer.vms.each do |vm|
-      bud Prog::Vnet::UpdateLoadBalancer, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :remove_load_balancer
+      bud Prog::Vnet::UpdateLoadBalancerNode, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :remove_load_balancer
     end
 
     hop_wait_destroy

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -88,9 +88,9 @@ table inet fw_table {
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept
     ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
-    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
+    ip6 daddr @private_ipv6_cidrs ct state established,related,new counter accept
     ip6 saddr #{guest_ephemeral} ct state established,related,new counter accept
-    ip6 daddr #{guest_ephemeral} ct state established,related counter accept
+    ip6 daddr #{guest_ephemeral} ct state established,related,new counter accept
     ip saddr @allowed_ipv4_cidrs ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr @allowed_ipv6_cidrs ip6 daddr #{guest_ephemeral} counter accept
     ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Prog::Vnet::UpdateLoadBalancer < Prog::Base
+class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   subject_is :vm
 
   def load_balancer

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -36,7 +36,7 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
 
   def generate_lb_based_nat_rules
     public_ipv4 = vm.ephemeral_net4.to_s
-    public_ipv6 = vm.ephemeral_net6.to_s
+    public_ipv6 = vm.ephemeral_net6.nth(2).to_s
     private_ipv4 = vm.nics.first.private_ipv4.network
     private_ipv6 = vm.nics.first.private_ipv6.nth(2)
     neighbor_vms = load_balancer.active_vms.reject { _1.id == vm.id }

--- a/routes/common/load_balancer_helper.rb
+++ b/routes/common/load_balancer_helper.rb
@@ -175,8 +175,7 @@ class Routes::Common::LoadBalancerHelper < Routes::Common::Base
 
     Authorization.authorize(@user.id, "Vm:view", vm.id)
 
-    @resource.evacuate_vm(vm)
-    @resource.remove_vm(vm)
+    @resource.detach_vm(vm)
 
     if @mode == AppMode::API
       Serializers::LoadBalancer.serialize(@resource, {detailed: true})

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe LoadBalancer do
 
   describe "add_vm" do
     it "increments update_load_balancer and rewrite_dns_records" do
-      expect(lb).to receive(:incr_update_load_balancer)
       expect(lb).to receive(:incr_rewrite_dns_records)
       lb.add_vm(vm1)
       expect(lb.load_balancers_vms.count).to eq(1)

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect(st.children).to all(receive(:destroy))
       expect { nx.destroy }.to hop("wait_destroy")
 
-      expect(Strand.where(prog: "Vnet::UpdateLoadBalancer").count).to eq 3
+      expect(Strand.where(prog: "Vnet::UpdateLoadBalancerNode").count).to eq 3
     end
 
     it "deletes the dns record" do

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -105,9 +105,9 @@ elements = {2a00:1450:400e:811::200e/128}
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept
     ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
-    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
+    ip6 daddr @private_ipv6_cidrs ct state established,related,new counter accept
     ip6 saddr fd00::/80 ct state established,related,new counter accept
-    ip6 daddr fd00::/80 ct state established,related counter accept
+    ip6 daddr fd00::/80 ct state established,related,new counter accept
     ip saddr @allowed_ipv4_cidrs ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr @allowed_ipv6_cidrs ip6 daddr fd00::/80 counter accept
     ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept
@@ -202,9 +202,9 @@ table inet fw_table {
     ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
     ip daddr @private_ipv4_cidrs ct state established,related counter accept
     ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
-    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
+    ip6 daddr @private_ipv6_cidrs ct state established,related,new counter accept
     ip6 saddr fd00::/80 ct state established,related,new counter accept
-    ip6 daddr fd00::/80 ct state established,related counter accept
+    ip6 daddr fd00::/80 ct state established,related,new counter accept
     ip saddr @allowed_ipv4_cidrs ip daddr @private_ipv4_cidrs counter accept
     ip6 saddr @allowed_ipv6_cidrs ip6 daddr fd00::/80 counter accept
     ip saddr . tcp dport @allowed_ipv4_port_tuple ip daddr @private_ipv4_cidrs counter accept

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe Prog::Vnet::UpdateLoadBalancer do
+RSpec.describe Prog::Vnet::UpdateLoadBalancerNode do
   subject(:nx) {
     described_class.new(st)
   }
 
   let(:st) {
-    Strand.create_with_id(prog: "Vnet::UpdateLoadBalancer", stack: [{"subject_id" => vm.id, "load_balancer_id" => lb.id}], label: "update_load_balancer")
+    Strand.create_with_id(prog: "Vnet::UpdateLoadBalancerNode", stack: [{"subject_id" => vm.id, "load_balancer_id" => lb.id}], label: "update_load_balancer")
   }
   let(:lb) {
     prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -87,7 +87,7 @@ table inet nat {
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
     ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 192.168.1.0 . 8080 }
-    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
   }
 
@@ -127,7 +127,7 @@ table inet nat {
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
     ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to jhash ip saddr . tcp sport . ip daddr . tcp dport mod 1 map { 0 : 192.168.1.0 . 8080 }
-    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to jhash ip6 saddr . tcp sport . ip6 daddr . tcp dport mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to jhash ip6 saddr . tcp sport . ip6 daddr . tcp dport mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
   }
 
@@ -176,7 +176,7 @@ elements = {fd10:9b0b:6b4b:aaa::2}
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
     ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : 192.168.1.0 . 8080, 1 : 172.10.1.0 . 8080 }
-    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080, 1 : fd10:9b0b:6b4b:aaa::2 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080, 1 : fd10:9b0b:6b4b:aaa::2 . 8080 }
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
   }
 
@@ -214,7 +214,7 @@ elements = {fd10:9b0b:6b4b:aaa::2}
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
     ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 172.10.1.0 . 8080 }
-    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:aaa::2 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:aaa::2 . 8080 }
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
   }
 
@@ -252,7 +252,7 @@ table inet nat {
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
     ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 192.168.1.0 . 8080 }
-    ip6 daddr 2a02:a464:deb2:a000::/64 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+    ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
   }
 

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -255,7 +255,9 @@ RSpec.describe Clover, "load balancer" do
 
         expect(page.title).to eq("Ubicloud - #{lb.name}")
         expect(page).to have_content "VM is detached"
-        expect(lb.vms.count).to eq(0)
+        expect(Strand.where(prog: "Vnet::LoadBalancerHealthProbes").all.count { |st| st.stack[0]["subject_id"] == lb.id && st.stack[0]["vm_id"] == vm.id }).to eq(0)
+        expect(lb.update_load_balancer_set?).to be(true)
+        expect(lb.load_balancers_vms_dataset.where(vm_id: vm.id).first.state).to eq("detaching")
       end
 
       it "can not detach vm when it does not exist" do


### PR DESCRIPTION
## Add Load Balancer VM detaching state

## Fix crash when VM is concurrently deleted

## Rename UpdateLoadBalancer to UpdateLoadBalancerNode
This was a review in the initial PR, since the name is a little bit
confusing, we decided to make it more clear

## Separate VM Destroy logic from VM Detach for LBs
We used to manage VMs that are being destroyed or detached through the
same state "evacuating". That is causing issues since there are
different steps to take for both.
1. For VMs that are being destroyed, keep the load balancer definition
in place but remove self from the pool until DNS TTL is expired, and
then remove the VM <-> Load Balancer relationship and destroy the VM
entity.

2. For VMs that are being detached, we need to update DNS immediately,
remove the load balancer definition, update all of the nodes immediately
and remove the VM <-> load balancer relationship.

## Move Health Probe Lifecycle Management to LoadBalancer model
We used to create new health probes from nexus but destroy them through
model. This is not nice since they are two independent files. This
commit moves health probe creation to the model as well.

## In case Cert is already revoked, simply omit the error message

## Fix Load Balancer for IPv6
The Load Balancer was not working when there were only IPv6 only VMs in
the load balancing pool. The reason is, when there is only IPv6 only
VMs, the DNS resolves to an IPv6 address and the load balancer was
unable to route the traffic properly. Main reason of that bug is the
firewall rules implementation. When we started implementing firewalls,
we decided that the traffic in private network would be excempt from the
firewall rules. However, we made a concious decision to block packets
that blong to a NEW connection if they have the destination address of
the private ipv6. Because, it would be weird to have such a packet when
we are communicating in between different VMs. The whole private
networking logic depends on public IPs in pre forward hook + the IPSec
Tunnels.

Now, fast forward to the load balancer implementation, we DNAT the
packets destined to the public IPv6 of the VM and route them through the
Private IPv6 address. Therefore, when we evaluate the firewalls, just
before completing SNAT + IPSec Tunnelling, the firewalls see that there
is a NEW connection that is destined to the private IPv6 address of the
VM and drops the packet. With this commit, we change that logic to
accept such packets.