### PR TITLE
Fix flaky test failure caused by array order

### DIFF
--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Invoice do
 
       invoice.send_failure_email([])
 
-      expect(Mail::TestMailer.deliveries.first.to).to eq(["billing@example.com", accounts[0].email, accounts[2].email])
+      expect(Mail::TestMailer.deliveries.first.to).to contain_exactly("billing@example.com", accounts[0].email, accounts[2].email)
     end
   end
 


### PR DESCRIPTION
The order of the array may vary due to the physical scan order, and it causes test failures. However the order isn't crucial for our use case. Therefore, I switched from `eq` to the `match_array` matcher. Rubocop then updated it from `match_array` to the `contain_exactly` matcher.