### PR TITLE
Suppress exception stack trace for a expected exception in the test output

### DIFF
--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Clover, "github" do
       end
 
       it "Rollbacks inconsistent cache entry if a failure occurs in the middle" do
-        expect(blob_storage_client).to receive(:create_multipart_upload).and_raise("error")
+        expect(blob_storage_client).to receive(:create_multipart_upload).and_raise(CloverError.new(500, "UnexceptedError", "Sorry, we couldn’t process your request because of an unexpected error."))
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 75 * 1024 * 1024}
 
         expect(last_response).to have_api_error(500, "Sorry, we couldn’t process your request because of an unexpected error.")


### PR DESCRIPTION


Recently, I enhanced the robustness of our GitHub cache reserving endpoint in commit 3129af12. To verify this feature, I created a test case that triggers an exception. Our web routes print a stack trace for unknown exceptions [^1], so this test case was designed to expect an exception. While the case was successful, it also printed the stack trace of the exception, which cluttered our test output. This commit resolves the issue by suppressing the stack trace, changing the exception to an expected exception.

[^1]: https://github.com/ubicloud/ubicloud/blob/9a0ad0305f8d7d807baadc1b64004d35a5eee50a/routes/clover_base.rb#L35