### PR TITLE
Decrease sleep times in provisioning

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -158,8 +158,8 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   label def wait_vm
     # If the vm is not allocated yet, we know that the vm provisioning will take
-    # definitely more than 15 seconds.
-    nap 15 unless vm.allocated_at
+    # definitely more than 13 seconds.
+    nap 13 unless vm.allocated_at
     nap 1 unless vm.provisioned_at
     register_deadline(:wait, 10 * 60)
     hop_setup_environment

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -255,9 +255,9 @@ class Prog::Vm::Nexus < Prog::Base
     unless vm.update_firewall_rules_set?
       vm.incr_update_firewall_rules
       # This is the first time we get into this state and we know that
-      # wait_sshable will take definitely more than 10 seconds. So, we nap here
+      # wait_sshable will take definitely more than 8 seconds. So, we nap here
       # to reduce the amount of load on the control plane unnecessarily.
-      nap 10
+      nap 8
     end
     addr = vm.ephemeral_net4
     hop_create_billing_record unless addr

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -341,9 +341,9 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe "#wait_vm" do
-    it "naps 15 seconds if vm is not allocated yet" do
+    it "naps 13 seconds if vm is not allocated yet" do
       expect(vm).to receive(:allocated_at).and_return(nil)
-      expect { nx.wait_vm }.to nap(15)
+      expect { nx.wait_vm }.to nap(13)
     end
 
     it "naps a second if vm is allocated but not provisioned yet" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -487,10 +487,10 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#wait_sshable" do
-    it "naps 10 second if it's the first time we execute wait_sshable" do
+    it "naps 8 second if it's the first time we execute wait_sshable" do
       expect(vm).to receive(:update_firewall_rules_set?).and_return(false)
       expect(vm).to receive(:incr_update_firewall_rules)
-      expect { nx.wait_sshable }.to nap(10)
+      expect { nx.wait_sshable }.to nap(8)
     end
 
     it "naps if not sshable" do


### PR DESCRIPTION
### Decrease sleep time in wait_sshable while provisioning a vm

The initial wait time for `wait_sshable` is longer than subsequent ones,
as we know that the VM booting takes some time. Previously, this wait
time was set at 10 seconds. However, due to recent optimizations at
https://github.com/ubicloud/ubicloud/commit/c84228d4f5bd5258be9c8f54d562f58342d00574 and https://github.com/ubicloud/ubicloud/commit/9d018f09183aedc472317c8a907e777a4e04f5ae, the boot time has decreased. Consequently, we can
now reduce the wait time by 2 seconds

### Decrease sleep time in wait_vm for GitHub runners

The initial nap time for `wait_vm` is longer than the following ones
because we know our VM provisioning takes a bit of time. Previously,
this sleep time was 15 seconds. However, after recent enhancements to
the VM provisioning process, it now takes less time. Therefore, we can
reduce the wait time by 2 seconds.