### PR TITLE
Enable Ubuntu 24.04 x64 runners

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -148,6 +148,7 @@ module Config
   override :ubuntu_jammy_version, "20240701", string
   override :almalinux_9_version, "9.4-20240507", string
   override :almalinux_8_version, "8.10-20240530", string
+  override :github_ubuntu_2404_version, "20240721.1.0", string
   override :github_ubuntu_2204_version, "20240721.1.0", string
   override :github_ubuntu_2004_version, "20240721.1.0", string
   override :postgres_ubuntu_2204_version, "20240702.3.0", string

--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -5,6 +5,12 @@
 - { name: ubicloud-standard-16,                 vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-30,                 vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-60,                 vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-standard-2-ubuntu-2404,      vm_size: standard-2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-4-ubuntu-2404,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-8-ubuntu-2404,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-16-ubuntu-2404,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-30-ubuntu-2404,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-60-ubuntu-2404,     vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2404,     location: github-runners }
 - { name: ubicloud-standard-2-ubuntu-2204,      vm_size: standard-2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-4-ubuntu-2204,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-8-ubuntu-2204,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -27,6 +27,8 @@ class Prog::DownloadBootImage < Prog::Base
       Config.almalinux_9_version
     when "almalinux-8"
       Config.almalinux_8_version
+    when "github-ubuntu-2404"
+      Config.github_ubuntu_2404_version
     when "github-ubuntu-2204"
       Config.github_ubuntu_2204_version
     when "github-ubuntu-2004"
@@ -84,6 +86,7 @@ class Prog::DownloadBootImage < Prog::Base
       ["almalinux-8", "x64", "8.10-20240530"] => "41a6bcdefb35afbd2819f0e6c68005cd5e9a346adf2dc093b1116a2b7c647d86",
       ["almalinux-9", "x64", "9.4-20240507"] => "bff0885c804c01fff8aac4b70c9ca4f04e8c119f9ee102043838f33e06f58390",
       ["almalinux-9", "arm64", "9.4-20240507"] => "75b2e68f6aaa41c039274595ff15968201b7201a7f2f03b109af691f2d3687a1",
+      ["github-ubuntu-2404", "x64", "20240721.1.0"] => "6efeba655fc023e22ac9d540c704b49792ee4ebd90d1ec73f80d87e3345f9352",
       ["github-ubuntu-2204", "x64", "20240630.1.1"] => "7c4cf6d984aacdc80d1932c95d2b89ceff9d2b0d9090b99be3f2b61d9d5feaeb",
       ["github-ubuntu-2204", "x64", "20240721.1.0"] => "d865fe797f7deaf2b6800392b31d5a8cd9861f5f105a0c3d8bd023f96577ce6d",
       ["github-ubuntu-2204", "arm64", "20240630.1.1"] => "b98f857ca681dc545a4159ef82298274fff0c5fdc4746cca9cd0745dd31fe868",

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dbi.default_boot_image_version("ubuntu-jammy")).to eq(Config.ubuntu_jammy_version)
       expect(dbi.default_boot_image_version("almalinux-9")).to eq(Config.almalinux_9_version)
       expect(dbi.default_boot_image_version("almalinux-8")).to eq(Config.almalinux_8_version)
+      expect(dbi.default_boot_image_version("github-ubuntu-2404")).to eq(Config.github_ubuntu_2404_version)
       expect(dbi.default_boot_image_version("github-ubuntu-2204")).to eq(Config.github_ubuntu_2204_version)
       expect(dbi.default_boot_image_version("github-ubuntu-2004")).to eq(Config.github_ubuntu_2004_version)
       expect(dbi.default_boot_image_version("github-gpu-ubuntu-2204")).to eq(Config.github_gpu_ubuntu_2204_version)


### PR DESCRIPTION
GitHub has announced that Ubuntu 24.04 runners are now available in public beta [^1]. They've also shared the packer template for this. However, the default labels still point to Ubuntu 22.04. We have added new labels for our customers who wish to migrate to Ubuntu 24.04.

Build run: https://github.com/ubicloud/runner-images/actions/runs/10266787533

[^1]: https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/