### PR TITLE
Enable CI to run on macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubicloud, ubicloud-arm]
+        runs-on: [ubicloud, ubicloud-arm, macos-latest]
     name: Ruby CI - ${{matrix.runs-on}}
     runs-on: ${{matrix.runs-on}}
 


### PR DESCRIPTION
I wasn't aware of that macOS runners are free for open source projects. Our development team is mostly using macOS, so it would be great to have CI running on macOS runners. Previously, we hit macOS specific package issues.