### PR TITLE
Use existing ruby toolcache for arm CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,24 +40,18 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Cache ruby for ARM runners
-      id: cache-ruby
-      if: matrix.runs-on == 'ubicloud-arm'
-      uses: ubicloud/cache@v4
-      with:
-        path: ${{ runner.tool_cache }}/Ruby
-        key: ${{ matrix.runs-on }}-ruby-${{ hashFiles('.tool-versions') }}
-
     - name: Install ruby for ARM runners if not cached
-      if: matrix.runs-on == 'ubicloud-arm' && steps.cache-ruby.outputs.cache-hit != 'true'
+      if: matrix.runs-on == 'ubicloud-arm'
       run: |
-        git clone https://github.com/rbenv/ruby-build.git
-        sudo ./ruby-build/install.sh
         RUBY_VERSION="$(grep -E '^ruby ' .tool-versions | cut -d' ' -f2)"
-        sudo ruby-build "$RUBY_VERSION" $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64
-        sudo chown -R runner:runner $RUNNER_TOOL_CACHE/Ruby
-        touch $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64.complete
-        rm -rf ruby-build
+        if [ ! -f $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64.complete ]; then
+          git clone https://github.com/rbenv/ruby-build.git
+          sudo ./ruby-build/install.sh
+          sudo ruby-build "$RUBY_VERSION" $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64
+          sudo chown -R runner:runner $RUNNER_TOOL_CACHE/Ruby
+          touch $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64.complete
+          rm -rf ruby-build
+        fi
 
     - name: Set up Ruby
       uses: ubicloud/setup-ruby@v1


### PR DESCRIPTION
You may experience some slowness with our CI runs on arm64 runners recently. This is because we add more tools to our arm64 runner images and the preinstalled Ruby is the one of them. This preinstalled Ruby conflicts with our workaround for caching Ruby on arm64 as they exist on the same path. However, we no longer need this adhoc cache. I have kept the `ruby-build` for instances where the image lacks the exact required version. If the required version isn't preinstalled, `actions/setup-ruby` will install it for x64 runners but will fail for arm64 runners. Currently, our images come with preinstalled Ruby 3.2.5, which we use. If this changes in the future, `ruby-build` will install the required version until we update the image.

GitHub runner images come with preinstalled versions of various languages like Ruby, Python, etc. Our x64 images also include preinstalled Ruby. However, as GitHub didn't have official arm64 images, our arm64 images did not come with preinstalled Ruby. We used to install and cache the required Ruby version in the workflow. Recently, GitHub launched arm64 runners and released a list of installed tools, including Ruby. Therefore, we have added preinstalled Ruby to our arm64 images to maintain compatibility with official GitHub images. This eliminates the need for adhoc caching.