### PR TITLE
Add E2E tests for the vm pool

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,6 +95,7 @@ jobs:
         GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
         GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
         GITHUB_RUNNER_SERVICE_PROJECT_ID: ${{ secrets.GH_RUNNER_SERVICE_PROJECT_ID }}
+        VM_POOL_PROJECT_ID: ${{ secrets.VM_POOL_PROJECT_ID }}
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
       run: timeout 40m foreman start
 


### PR DESCRIPTION
We maintain VM pools for the most commonly used runner labels to reduce queue time for our customers. This code path is heavily used during periods of high load. It's important to conduct E2E tests for this path. Essentially, we create a new VM pool of size one, after downloading the runner images. We initiate creation after the download, as the VM designated for the pool requires the image. Once the VM is ready for the pool, we adjust the VM pool size to zero. This approach assists us in confirming that the VM is selected from the pool. At the end of the test, the pool should contain zero VMs.