### PR TITLE
LB Certificate Server

### DIFF
--- a/prog/vnet/cert_server.rb
+++ b/prog/vnet/cert_server.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class Prog::Vnet::CertServer < Prog::Base
+  subject_is :load_balancer
+
+  def vm
+    @vm ||= Vm[frame.fetch("vm_id")]
+  end
+
+  def cert_folder
+    "/vm/#{vm.inhost_name}/cert"
+  end
+
+  def cert_path
+    "#{cert_folder}/cert.pem"
+  end
+
+  def key_path
+    "#{cert_folder}/key.pem"
+  end
+
+  label def before_run
+    pop "vm is destroyed" unless vm
+  end
+
+  label def reshare_certificate
+    put_cert_to_vm
+
+    pop "certificate is reshared"
+  end
+
+  label def put_certificate
+    nap 5 unless load_balancer.active_cert
+
+    put_cert_to_vm
+    hop_start_certificate_server
+  end
+
+  label def start_certificate_server
+    vm.vm_host.sshable.cmd("sudo host/bin/setup-cert-server setup #{vm.inhost_name}")
+    pop "certificate server is started"
+  end
+
+  label def remove_cert_server
+    vm.vm_host.sshable.cmd("sudo host/bin/setup-cert-server stop_and_remove #{vm.inhost_name}")
+    pop "certificate resources and server are removed"
+  end
+
+  def put_cert_to_vm
+    cert = load_balancer.active_cert
+
+    cert_payload = cert.cert
+    cert_key_payload = OpenSSL::PKey::RSA.new(cert.csr_key).to_pem
+    vm.vm_host.sshable.cmd("sudo -u #{vm.inhost_name} mkdir -p #{cert_folder}")
+    vm.vm_host.sshable.cmd("sudo -u #{vm.inhost_name} tee #{cert_path}", stdin: cert_payload)
+    vm.vm_host.sshable.cmd("sudo -u #{vm.inhost_name} tee #{key_path}", stdin: cert_key_payload)
+  end
+end

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -18,7 +18,6 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   label def update_load_balancer
     if vm_load_balancer_state == "detaching"
       load_balancer.remove_vm(vm)
-      hop_remove_load_balancer
     end
 
     # if there is literally no up resources to balance for, we simply not do
@@ -31,7 +30,8 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
 
   label def remove_load_balancer
     vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: generate_nat_rules(vm.ephemeral_net4.to_s, vm.nics.first.private_ipv4.network.to_s))
-    pop "load balancer is updated"
+
+    pop "load balancer is removed"
   end
 
   def generate_lb_based_nat_rules

--- a/rhizome/host/bin/setup-cert-server
+++ b/rhizome/host/bin/setup-cert-server
@@ -1,0 +1,28 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "../lib/cert_server_setup"
+require "fileutils"
+
+unless (verb = ARGV.shift)
+  puts "expected verb as argument"
+  exit 1
+end
+
+unless (vm_name = ARGV.shift)
+  puts "expected vm_name as argument"
+  exit 1
+end
+
+cert_server_setup = CertServerSetup.new(vm_name)
+
+case verb
+when "setup"
+  cert_server_setup.copy_server
+  cert_server_setup.create_service
+  cert_server_setup.enable_and_start_service
+when "stop_and_remove"
+  cert_server_setup.stop_and_remove_service
+  cert_server_setup.remove_paths
+end

--- a/rhizome/host/lib/cert_server_setup.rb
+++ b/rhizome/host/lib/cert_server_setup.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "../../common/lib/arch"
+require_relative "vm_path"
+require "fileutils"
+require "json"
+
+class CertServerSetup
+  def initialize(vm_name)
+    @vm_name = vm_name
+  end
+
+  def vp
+    @vp ||= VmPath.new(@vm_name)
+  end
+
+  def cert_folder
+    vp.q_cert
+  end
+
+  def cert_path
+    "#{cert_folder}/cert.pem"
+  end
+
+  def key_path
+    "#{cert_folder}/key.pem"
+  end
+
+  def service_name
+    "#{@vm_name}-metadata-endpoint"
+  end
+
+  def service_file_path
+    "/etc/systemd/system/#{service_name}.service"
+  end
+
+  def server_main_path
+    File.join("", "opt", "metadata-endpoint")
+  end
+
+  def vm_server_path
+    File.join(cert_folder, "metadata-endpoint")
+  end
+
+  def package_url
+    Arch.render(
+      x64: "https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.3/metadata-endpoint_Linux_x86_64.tar.gz",
+      arm64: "https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.3/metadata-endpoint_Linux_arm64.tar.gz"
+    )
+  end
+
+  def copy_server
+    unless File.exist?(server_main_path)
+      download_server
+    end
+
+    r "cp #{server_main_path}/metadata-endpoint #{vm_server_path}"
+    r "sudo chown #{@vm_name}:#{@vm_name} #{vm_server_path}"
+  end
+
+  def download_server
+    temp_tarball = "/tmp/metadata-endpoint.tar.gz"
+    r "curl -L3 -o #{temp_tarball} #{package_url}"
+
+    FileUtils.mkdir_p(server_main_path)
+    FileUtils.cd server_main_path do
+      r "tar -xzf #{temp_tarball}"
+    end
+  end
+
+  def create_service
+    service = "#{service_name}.service"
+    File.write("/etc/systemd/system/#{service}", <<CERT_SERVICE
+[Unit]
+Description=Certificate Server
+After=network.target
+
+[Service]
+NetworkNamespacePath=/var/run/netns/#{@vm_name}
+ExecStart=#{vm_server_path}
+Restart=always
+Type=simple
+ProtectSystem=strict
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+NoNewPrivileges=yes
+ReadOnlyPaths=#{cert_path} #{key_path}
+User=#{@vm_name}
+Group=#{@vm_name}
+Environment=VM_INHOST_NAME=#{@vm_name}
+Environment=IPV6_ADDRESS="FD00:0B1C:100D:5AFE:CE::"
+Environment=GOMEMLIMIT=9MiB
+Environment=GOMAXPROCS=1
+CPUQuota=50%
+MemoryLimit=10M
+
+CERT_SERVICE
+    )
+  end
+
+  def enable_and_start_service
+    r "systemctl enable #{service_file_path}"
+    r "systemctl start #{service_name}"
+  end
+
+  def stop_and_remove_service
+    r "systemctl stop #{service_name}"
+    r "systemctl disable #{service_name}"
+    FileUtils.rm_f(service_file_path)
+  end
+
+  def remove_paths
+    FileUtils.rm_rf(cert_folder)
+  end
+end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -55,6 +55,7 @@ class VmPath
     public_ipv4
     nftables_conf
     prep.json
+    cert
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
     fail "BUG" if method_defined?(method_name)

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -32,13 +32,22 @@ RSpec.describe LoadBalancer do
   describe "add_vm" do
     it "increments update_load_balancer and rewrite_dns_records" do
       expect(lb).to receive(:incr_rewrite_dns_records)
+      dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: lb.projects.first.id)
+      cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+      lb.add_cert(cert)
       lb.add_vm(vm1)
       expect(lb.load_balancers_vms.count).to eq(1)
     end
   end
 
   describe "evacuate_vm" do
+    let(:ce) {
+      dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: lb.projects.first.id)
+      Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+    }
+
     before do
+      lb.add_cert(ce)
       lb.add_vm(vm1)
     end
 
@@ -54,7 +63,13 @@ RSpec.describe LoadBalancer do
   end
 
   describe "remove_vm" do
+    let(:ce) {
+      dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: lb.projects.first.id)
+      Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+    }
+
     before do
+      lb.add_cert(ce)
       lb.add_vm(vm1)
     end
 

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::CertServer do
+  subject(:nx) {
+    described_class.new(st)
+  }
+
+  let(:st) {
+    Strand.create_with_id(prog: "Vnet::CertServer", stack: [{"subject_id" => lb.id, "vm_id" => vm.id}], label: "update_load_balancer")
+  }
+
+  let(:cert) {
+    lb.certs.first
+  }
+
+  let(:lb) {
+    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
+    lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080).subject
+    dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: prj.id)
+    cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+    cert.update(cert: "cert", csr_key: OpenSSL::PKey::RSA.new(4096).to_der)
+    lb.add_cert(cert)
+    lb
+  }
+
+  let(:vm) {
+    vm_host = instance_double(VmHost, sshable: instance_double(Sshable))
+    instance_double(Vm, inhost_name: "test-vm", vm_host: vm_host, id: "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e")
+  }
+
+  before do
+    allow(lb).to receive(:active_cert).and_return(lb.certs.first)
+    allow(Vm).to receive(:[]).and_return(vm)
+  end
+
+  describe ".before_run" do
+    it "pops if vm is nil" do
+      expect(nx).to receive(:vm).and_return(nil)
+      expect { nx.before_run }.to exit({"msg" => "vm is destroyed"})
+    end
+
+    it "if vm exists, does nothing" do
+      expect(nx).to receive(:vm).and_return(vm)
+      nx.before_run
+    end
+  end
+
+  describe "#reshare_certificate" do
+    it "reates a certificate folder, puts the certificate and pops" do
+      expect(nx).to receive(:put_cert_to_vm)
+      expect { nx.reshare_certificate }.to exit({"msg" => "certificate is reshared"})
+    end
+  end
+
+  describe "#put_certificate" do
+    it "creates a certificate folder, puts the certificate and hops to start_certificate_server" do
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo -u #{vm.inhost_name} mkdir -p /vm/#{vm.inhost_name}/cert")
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo -u #{vm.inhost_name} tee /vm/#{vm.inhost_name}/cert/cert.pem", stdin: "cert")
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo -u #{vm.inhost_name} tee /vm/#{vm.inhost_name}/cert/key.pem", stdin: OpenSSL::PKey::RSA.new(cert.csr_key).to_pem)
+      expect { nx.put_certificate }.to hop("start_certificate_server")
+    end
+
+    it "naps if load_balancer.active_cert is nil" do
+      expect(nx.load_balancer).to receive(:active_cert).and_return(nil)
+      expect { nx.put_certificate }.to nap(5)
+    end
+  end
+
+  describe "#start_certificate_server" do
+    it "starts the certificate server and pops" do
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-cert-server setup test-vm")
+      expect { nx.start_certificate_server }.to exit({"msg" => "certificate server is started"})
+    end
+  end
+
+  describe "#remove_cert_server" do
+    it "removes the certificate files, server and hops to remove_load_balancer" do
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-cert-server stop_and_remove test-vm")
+
+      expect { nx.remove_cert_server }.to exit({"msg" => "certificate resources and server are removed"})
+    end
+  end
+end

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
   let(:lb) {
     prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
-    Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 80).subject
+    dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: prj.id)
+    cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+    lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 80).subject
+    lb.add_cert(cert)
+    lb
   }
   let(:vm) {
     Prog::Vm::Nexus.assemble("pub-key", lb.projects.first.id, name: "test-vm", private_subnet_id: lb.private_subnet.id).subject

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       vms.each { st.subject.add_vm(_1) }
       expect { nx.update_vm_load_balancers }.to hop("wait_update_vm_load_balancers")
       # Update progs are budded in update_vm_load_balancers
-      expect(st.children_dataset.where(prog: "Vnet::UpdateLoadBalancerNode").count).to eq 3
+      expect(st.children_dataset.where(prog: "Vnet::UpdateLoadBalancerNode", label: "update_load_balancer").count).to eq 3
     end
   end
 

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
   }
 
   let(:st) {
-    described_class.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 80)
+    cert = Prog::Vnet::CertNexus.assemble("test-host-name", dns_zone.id).subject
+    lb = described_class.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 80).subject
+    lb.add_cert(cert)
+    lb.strand
   }
   let(:ps) {
     prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
@@ -75,6 +78,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
     end
 
     it "creates new cert if needed" do
+      expect(nx.load_balancer).to receive(:need_certificates?).and_return(true)
       expect { nx.wait }.to hop("create_new_cert")
     end
   end
@@ -84,8 +88,8 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       dns_zone = DnsZone.create_with_id(name: "test-dns-zone", project_id: nx.load_balancer.private_subnet.projects.first.id)
       allow(described_class).to receive(:dns_zone).and_return(dns_zone)
       expect { nx.create_new_cert }.to hop("wait_cert_provisioning")
-      expect(Strand.where(prog: "Vnet::CertNexus").count).to eq 1
-      expect(nx.load_balancer.certs.count).to eq 1
+      expect(Strand.where(prog: "Vnet::CertNexus").count).to eq 2
+      expect(nx.load_balancer.certs.count).to eq 2
     end
   end
 
@@ -95,9 +99,37 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect { nx.wait_cert_provisioning }.to nap(60)
     end
 
-    it "hops to wait if need_certificates? is false" do
+    it "hops to wait_cert_broadcast if need_certificates? is false and refresh_cert is set" do
+      vm = Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "testvm", private_subnet_id: ps.id).subject
+      nx.load_balancer.add_vm(vm)
+      nx.load_balancer.incr_refresh_cert
+      expect(Strand.where(prog: "Vnet::CertServer", label: "put_certificate").count).to eq 1
+      expect(nx.load_balancer).to receive(:need_certificates?).and_return(false)
+      expect { nx.wait_cert_provisioning }.to hop("wait_cert_broadcast")
+      expect(Strand.where(prog: "Vnet::CertServer", label: "reshare_certificate").count).to eq 1
+    end
+
+    it "hops to wait need_certificates? and refresh_cert are false" do
+      vm = Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "testvm", private_subnet_id: ps.id).subject
+      nx.load_balancer.add_vm(vm)
+      expect(Strand.where(prog: "Vnet::CertServer", label: "put_certificate").count).to eq 1
       expect(nx.load_balancer).to receive(:need_certificates?).and_return(false)
       expect { nx.wait_cert_provisioning }.to hop("wait")
+      expect(Strand.where(prog: "Vnet::CertServer", label: "reshare_certificate").count).to eq 0
+    end
+  end
+
+  describe "#wait_cert_broadcast" do
+    it "naps for 1 second if not all children are done" do
+      vm = Prog::Vm::Nexus.assemble("pub-key", ps.projects.first.id, name: "testvm", private_subnet_id: ps.id).subject
+      nx.load_balancer.add_vm(vm)
+      expect(nx).to receive(:reap)
+      expect { nx.wait_cert_broadcast }.to nap(1)
+    end
+
+    it "hops to wait if all children are done" do
+      expect(nx).to receive(:reap)
+      expect { nx.wait_cert_broadcast }.to hop("wait")
     end
   end
 
@@ -212,7 +244,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       cert = Prog::Vnet::CertNexus.assemble(st.subject.hostname, dns_zone.id).subject
       lb = st.subject
       lb.add_cert(cert)
-      expect(lb.certs.count).to eq 1
+      expect(lb.certs.count).to eq 2
       expect(nx).to receive(:reap)
       expect(nx).to receive(:leaf?).and_return(true)
       expect { nx.wait_destroy }.to exit({"msg" => "load balancer deleted"})

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -190,6 +190,10 @@ RSpec.describe Clover, "load balancer" do
       it "can attach vm" do
         ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000, algorithm: "hash_based").subject
+        dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
+        cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+        cert.update(cert: "cert", csr_key: OpenSSL::PKey::RSA.new(4096).to_der)
+        lb.add_cert(cert)
         vm = Prog::Vm::Nexus.assemble("key", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
 
         visit "#{project.path}#{lb.path}"
@@ -213,6 +217,10 @@ RSpec.describe Clover, "load balancer" do
         ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
         lb1 = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
         lb2 = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-4", src_port: 80, dst_port: 8000).subject
+        dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
+        cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+        cert.update(cert: "cert", csr_key: OpenSSL::PKey::RSA.new(4096).to_der)
+        lb1.add_cert(cert)
         vm = Prog::Vm::Nexus.assemble("key", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
 
         visit "#{project.path}#{lb2.path}"
@@ -244,6 +252,10 @@ RSpec.describe Clover, "load balancer" do
       it "can detach vm" do
         ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
+        dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
+        cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+        cert.update(cert: "cert", csr_key: OpenSSL::PKey::RSA.new(4096).to_der)
+        lb.add_cert(cert)
         vm = Prog::Vm::Nexus.assemble("key", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
         expect(page).to have_no_content vm.name
 
@@ -263,6 +275,10 @@ RSpec.describe Clover, "load balancer" do
       it "can not detach vm when it does not exist" do
         ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
+        dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
+        cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+        cert.update(cert: "cert", csr_key: OpenSSL::PKey::RSA.new(4096).to_der)
+        lb.add_cert(cert)
         vm = Prog::Vm::Nexus.assemble("key", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
 
         visit "#{project.path}#{lb.path}"


### PR DESCRIPTION
## Add Ubicloud IPv6 address space to the namespace
This commit adds the new address space "oo-bic-lood-safe-ce" to the tap
devices.  This address space will be used for providing private endpoint
to the VMs so that we can serve certificate and key files.

In relation to that, we are making another change to add some nftables
rules to the cloudinit.img. With the help of new nftables rules inside
the VM, we are blocking access to the "oo-bic-lood-safe" address space
if the user is not root which has skuid 0.

## Add Cert Server initializer
We are adding new states to the UpdateLoadBalancerNode prog to;
1. Publish cert and key files to the /vm/vmxxxxx/cert directory
2. Create a new web server to serve the files to the VM.
3. Remove the files and service in case the node is removed from the
loadbalancer.

We are utilizing go as the web server. The server source code lives in
ubicloud/cert-server. We are also starting it on the private address
[FD00:0B1C:100D:5AFE:CE::]:8080 because it is cool and looks like
"oo-bic-lood-safe-ce".

## Add certificate server initialization to load_balancer.add_vm
We are simply creating a prog to initialize the certificate server and
publish the cert files to the vm folder at the time of add_vm.

## LoadBalancerNexus update to reshare certificates
This commit makes the changes necessary to update the certificates and
the web server in case we provision new certificates.

## Update health probes to use the hostname and check return type
We are updating the healthprobes to use the hostname to perform the
healthchecks. This is important for HTTPS healthchecks because it is
possible the customers will only accept the hostname, instead of raw ip.
Since we are in the network namespace, and we do not need to perform
lookup, we resolve the hostname automatically by using --resolve of
curl.

We also make a small fix here to transform response_code to integer and
perform the check. This is necessary in case the response_code has
spaces or \n characters at the start or end of the response code.

## Fix VM removal when its attached to a load balancer
We need to remove the vm user only after the cert server is removed
because it is used by cert server and deluser command fails otherwise.

The other case is that, we might start deleting VM and then the load
balancer is deleted before VM deletion completes. In that case, we
should perform a check at the last state to verify the load balancer is
still intact before removing VM from the load balancer.