### PR TITLE
Cache ngrok binary in E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,15 @@ jobs:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: bundle exec rake test_up
 
+    - name: Cache ngrok binary
+      id: cache-ngrok
+      uses: ubicloud/cache@v4
+      with:
+        path: /usr/local/bin/ngrok
+        key: ngrok-binary
+
     - name: Install ngrok
+      if: steps.cache-ngrok.outputs.cache-hit != 'true'
       run: curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list && sudo apt update && sudo apt install ngrok
 
     - name: Set ngrok token


### PR DESCRIPTION
We install ngrok from their official apt repository in the E2E tests. We encountered following issues multiple times:

     E: The repository 'https://ngrok-agent.s3.amazonaws.com buster InRelease' is not signed.
     E: Failed to fetch https://ngrok-agent.s3.amazonaws.com/pool/main/n/ngrok/ngrok_3.14.0-0_amd64.deb Connection timed out [IP: 52.218.133.73 443]
     E: Failed to fetch https://ngrok-agent.s3.amazonaws.com/dists/buster/InRelease 403  Forbidden [IP: 52.92.236.161 443]

Their apt repository is not very reliable. This causes the E2E tests to fail. We can cache the ngrok binary in the E2E tests to avoid this issue.