### PR TITLE
Add cache proxy for projects with transparent cache flag

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -109,6 +109,8 @@ module Config
   optional :github_cache_blob_storage_secret_key, string, clear: true
   optional :github_cache_blob_storage_account_id, string
   optional :github_cache_blob_storage_api_key, string, clear: true
+  optional :github_cache_forked_runner_tarball_uri, string
+  optional :github_cache_proxy_repo_uri, string, clear: true
 
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string

--- a/model/project.rb
+++ b/model/project.rb
@@ -132,5 +132,5 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image, :vm_public_ssh_keys
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache
 end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -220,6 +220,69 @@ class Prog::Vm::GithubRunner < Prog::Base
     # Remove comments and empty lines before sending them to the machine
     vm.sshable.cmd(command.gsub(/^(\s*# .*)?\n/, ""))
 
+    if github_runner.installation.project.get_ff_transparent_cache
+      hop_setup_forked_runner
+    end
+
+    hop_register_runner
+  end
+
+  label def setup_forked_runner
+    command = <<~COMMAND
+      curl --output actions-runner.tar.gz -L #{Config.github_cache_forked_runner_tarball_uri}
+
+      rm -rf actions-runner
+      mkdir -p actions-runner
+      tar xzf actions-runner.tar.gz -C actions-runner
+
+      sudo chown -R runneradmin:runneradmin ./actions-runner
+      ./actions-runner/env.sh
+
+      cat <<EOT > ./actions-runner/run-withenv.sh
+      #!/bin/bash
+      mapfile -t env </etc/environment
+      exec env -- "\\${env[@]}" ./actions-runner/run.sh --jitconfig "\\$1"
+      EOT
+      chmod +x ./actions-runner/run-withenv.sh
+
+      jq '. += [#{setup_info.to_json}]' /imagegeneration/imagedata.json > ./actions-runner/.setup_info
+
+      echo "PATH=$PATH" >> ./actions-runner/.env
+
+      sudo rm -rf /home/runner/actions-runner
+      sudo mv ./actions-runner /home/runner/
+      sudo chown -R runner:runner /home/runner/actions-runner
+
+      echo "CUSTOM_ACTIONS_CACHE_URL=http://localhost:51123/random_token/" | sudo tee -a /etc/environment
+      echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
+    COMMAND
+
+    vm.sshable.cmd(command.gsub(/^\s*\n/, ""))
+
+    hop_download_proxy
+  end
+
+  label def download_proxy
+    command = <<~COMMAND
+      sudo rm -rf cache-proxy
+      sudo git clone #{Config.github_cache_proxy_repo_uri} cache-proxy
+    COMMAND
+
+    vm.sshable.cmd(command)
+
+    hop_start_proxy
+  end
+
+  label def start_proxy
+    command = <<~COMMAND
+      export UBICLOUD_CACHE_URL=#{Config.base_url}/runtime/github/
+      export UBICLOUD_RUNTIME_TOKEN=#{vm.runtime_token}
+      cd cache-proxy
+      go run transparent_cache_proxy.go > ~/cacheproxy.log 2>&1 &
+    COMMAND
+
+    vm.sshable.cmd(command)
+
     hop_register_runner
   end
 


### PR DESCRIPTION
This commit introduces support for transparent cache, enabling the use of our own infrastructure for saving and restoring caches without changing anything on the test workflow files. The proxy is now run on runner VMs to intercept and handle all cache-related requests. The proxy will only be activated for projects where the transparent_cache flag is set to true.

Key changes include:

**Proxy Setup:** A proxy is deployed on the runner VMs to handle cache requests. This proxy intercepts requests intended for GitHub's cache API and redirects them to our infrastructure.

**Forked Runner Script:** A forked version of the runner script is downloaded and used instead of the pre-existing one on the VM. This modification is necessary because redirecting requests from GitHub's cache URI isn't straightforward. By setting CUSTOM_ACTIONS_CACHE_URL to localhost:8080, all cache requests are directed to the proxy running locally on port 8080.

**Blob Storage Redirection:** Requests to localhost.blob.core.windows.net are also redirected to the local proxy, as GitHub's toolkit directly accesses blob storage during file restoration rather than routing through the cache API.

Note that the current implementation downloads and runs the forked runner and proxy while initiating runner vm for ease of testing. In future iterations, both steps will be integrated into the image generation process to reduce VM setup time.