### PR TITLE
Restart primary postgres server after failover

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -369,6 +369,7 @@ SQL
       postgres_server.resource.incr_refresh_dns_record
       postgres_server.resource.servers.each(&:incr_configure)
       postgres_server.resource.servers.reject(&:primary?).each { _1.update(synchronization_status: "catching_up") }
+      postgres_server.incr_restart
       hop_configure
     when "Failed", "NotStarted"
       vm.sshable.cmd("common/bin/daemonizer 'sudo pg_ctlcluster 16 main promote' promote_postgres")

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -555,6 +555,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(postgres_server.resource).to receive(:incr_refresh_dns_record)
       expect(postgres_server).to receive(:primary?).and_return(true)
       expect(postgres_server).to receive(:incr_configure)
+      expect(postgres_server).to receive(:incr_restart)
 
       standby = instance_double(PostgresServer, primary?: false)
       expect(standby).to receive(:update).with(synchronization_status: "catching_up")


### PR DESCRIPTION
This is required for archive_mode change to take effect after failover. Better solution would be setting archive_mode to on at the standby all the time and changing the archival behavior using archive_command, which doesn't require restarting the server. However, I'm not entirely sure about the logistics of that especially right after the failover time yet, so I'm going with the simpler solution for now.