### PR TITLE
Use more descriptive region names in UI

### DIFF
--- a/config/providers.yml
+++ b/config/providers.yml
@@ -3,17 +3,17 @@
     provider_display_name: Hetzner,
     provider_internal_name: hetzner,
     locations: [
-      {display_name: eu-central-h1, internal_name: hetzner-fsn1, visible: true },
-      {display_name: eu-north-h1, internal_name: hetzner-hel1, visible: true },
-      {display_name: github-runners, internal_name: github-runners, visible: false }
+      {display_name: eu-central-h1, internal_name: hetzner-fsn1, ui_name: "Germany", visible: true },
+      {display_name: eu-north-h1, internal_name: hetzner-hel1, ui_name: "Finland", visible: true },
+      {display_name: github-runners, internal_name: github-runners, ui_name: "GithubRunner", visible: false }
     ]
   },
   {
     provider_display_name: Leaseweb,
     provider_internal_name: leaseweb,
     locations: [
-      {display_name: us-east-a2, internal_name: leaseweb-wdc02, visible: false},
-      {display_name: us-south-a13, internal_name: leaseweb-dal13, visible: false},
+      {display_name: us-east-a2, internal_name: leaseweb-wdc02, ui_name: "Washington D.C., US", visible: false},
+      {display_name: us-south-a13, internal_name: leaseweb-dal13,  ui_name: "Dallas, US", visible: false},
     ]
   }
 ]

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -6,7 +6,7 @@ module Option
   providers = YAML.load_file("config/providers.yml")
 
   Provider = Struct.new(:name, :display_name)
-  Location = Struct.new(:provider, :name, :display_name, :visible)
+  Location = Struct.new(:provider, :name, :display_name, :ui_name, :visible)
 
   PROVIDERS = {}
   LOCATIONS = []
@@ -21,6 +21,7 @@ module Option
         PROVIDERS[provider_internal_name],
         location["internal_name"],
         location["display_name"],
+        location["ui_name"],
         location["visible"]
       ))
     end

--- a/views/networking/firewall/create.erb
+++ b/views/networking/firewall/create.erb
@@ -58,7 +58,7 @@
                   locals: {
                     name: "location",
                     label: "Location",
-                    options: Option.locations.to_h { |l| [l.display_name, l.display_name] },
+                    options: Option.locations.to_h { |l| [l.display_name, l.ui_name] },
                     selected: Option.locations.detect { |l| l.name == @default_location }&.display_name,
                     attributes: {
                       required: true

--- a/views/networking/private_subnet/create.erb
+++ b/views/networking/private_subnet/create.erb
@@ -46,7 +46,7 @@
                   locals: {
                     name: "location",
                     label: "Location",
-                    options: Option.locations.to_h { |l| [l.display_name, l.display_name] },
+                    options: Option.locations.to_h { |l| [l.display_name, l.ui_name] },
                     attributes: {
                       required: true
                     }

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -45,7 +45,7 @@
               <div class="col-span-full">
                 <% locations = Option
                     .postgres_locations
-                    .map { |l| [l.display_name, l.display_name, @prices[l.name].to_json] }
+                    .map { |l| [l.display_name, l.ui_name, @prices[l.name].to_json] }
                 %>
                 <%== render(
                   "components/form/radio_small_cards",

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -45,7 +45,7 @@
               <div class="col-span-full">
                 <% locations = Option
                     .locations
-                    .map { |l| [l.display_name, l.display_name, @prices[l.name].to_json] }
+                    .map { |l| [l.display_name, l.ui_name, @prices[l.name].to_json] }
 
                    default_location = Option.locations.detect { |l| l.name == @default_location }&.display_name
                 %>


### PR DESCRIPTION
We have been using region names like "eu-central-h1" in the UI which is cryptic for users. We decided to simplify them and use more descriptive names referring to the actual location of the respective data centers. What we would do in case of having multiple data centers in the location is an open question currently, we would probably use the city name or a number suffix. However, it does not look like we would have that problem soon.

We are keeping the names in the API as is, because we don't want to introduce a breaking change at the moment.

![image](https://github.com/user-attachments/assets/cb04c107-fc52-4383-be82-94b7aa9a171b)
