### PR TITLE
Centralize business logic of Vm web and api endpoints

### DIFF
--- a/routes/api/project/vm.rb
+++ b/routes/api/project/vm.rb
@@ -2,17 +2,10 @@
 
 class CloverApi
   hash_branch(:project_prefix, "vm") do |r|
-    r.get true do
-      result = @project.vms_dataset.authorized(@current_user.id, "Vm:view").paginated_result(
-        start_after: r.params["start_after"],
-        page_size: r.params["page_size"],
-        order_column: r.params["order_column"]
-      )
+    vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: @current_user, location: nil, resource: nil)
 
-      {
-        items: Serializers::Vm.serialize(result[:records]),
-        count: result[:count]
-      }
+    r.get true do
+      vm_endpoint_helper.list
     end
   end
 end

--- a/routes/common/vm_helper.rb
+++ b/routes/common/vm_helper.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+class Routes::Common::VmHelper < Routes::Common::Base
+  def list
+    if @mode == AppMode::API
+      dataset = project.vms_dataset
+      dataset = dataset.where(location: @location) if @location
+      result = dataset.authorized(@user.id, "Vm:view").paginated_result(
+        start_after: @request.params["start_after"],
+        page_size: @request.params["page_size"],
+        order_column: @request.params["order_column"]
+      )
+
+      {
+        items: Serializers::Vm.serialize(result[:records]),
+        count: result[:count]
+      }
+    else
+      vms = Serializers::Vm.serialize(project.vms_dataset.authorized(@user.id, "Vm:view").eager(:semaphores, :assigned_vm_address, :vm_storage_volumes).order(Sequel.desc(:created_at)).all, {include_path: true})
+      @app.instance_variable_set(:@vms, vms)
+
+      @app.view "vm/index"
+    end
+  end
+
+  def post(name)
+    Authorization.authorize(@user.id, "Vm:create", project.id)
+    fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless project.has_valid_payment_method?
+    if @mode == AppMode::API
+      required_parameters = ["public_key"]
+      allowed_optional_parameters = ["size", "storage_size", "unix_user", "boot_image", "enable_ip4", "private_subnet_id"]
+
+      request_body_params = Validation.validate_request_body(params, required_parameters, allowed_optional_parameters)
+
+      # Generally parameter validation is handled in progs while creating resources.
+      # Since Vm::Nexus both handles VM creation requests from user and also Postgres
+      # service, moved the boot_image validation here to not allow users to pass
+      # postgres image as boot image while creating a VM.
+      if request_body_params["boot_image"]
+        Validation.validate_boot_image(request_body_params["boot_image"])
+      end
+
+      # Same as above, moved the size validation here to not allow users to
+      # pass gpu instance while creating a VM.
+      if request_body_params["size"]
+        parsed_size = Validation.validate_vm_size(request_body_params["size"], only_visible: true)
+      end
+
+      if request_body_params["private_subnet_id"]
+        ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"])
+        unless ps && ps.location == @location
+          fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{request_body_params["private_subnet_id"]}\" is not found in the location \"#{LocationNameConverter.to_display_name(@location)}\""})
+        end
+        Authorization.authorize(@user.id, "PrivateSubnet:view", ps.id)
+        request_body_params["private_subnet_id"] = ps.id
+      end
+
+      if request_body_params["storage_size"]
+        storage_size = Validation.validate_vm_storage_size(request_body_params["size"], request_body_params["storage_size"])
+        request_body_params["storage_volumes"] = [{size_gib: storage_size, encrypted: true}]
+        request_body_params.delete("storage_size")
+      end
+
+      requested_vm_core_count = parsed_size.nil? ? 1 : parsed_size.vcpu / 2
+      Validation.validate_core_quota(project, "VmCores", requested_vm_core_count)
+
+      st = Prog::Vm::Nexus.assemble(
+        request_body_params["public_key"],
+        project.id,
+        name: name,
+        location: @location,
+        **request_body_params.except(*required_parameters).transform_keys(&:to_sym)
+      )
+
+      Serializers::Vm.serialize(st.subject, {detailed: true})
+    else
+      ps_id = @request.params["private-subnet-id"].empty? ? nil : UBID.parse(@request.params["private-subnet-id"]).to_uuid
+      Authorization.authorize(@user.id, "PrivateSubnet:view", ps_id)
+
+      Validation.validate_boot_image(@request.params["boot-image"])
+      parsed_size = Validation.validate_vm_size(@request.params["size"], only_visible: true)
+      location = LocationNameConverter.to_internal_name(@request.params["location"])
+      storage_size = Validation.validate_vm_storage_size(@request.params["size"], @request.params["storage_size"])
+
+      requested_vm_core_count = parsed_size.vcpu / 2
+      Validation.validate_core_quota(project, "VmCores", requested_vm_core_count)
+
+      st = Prog::Vm::Nexus.assemble(
+        @request.params["public-key"],
+        project.id,
+        name: name,
+        unix_user: @request.params["user"],
+        size: @request.params["size"],
+        storage_volumes: [{size_gib: storage_size, encrypted: true}],
+        location: location,
+        boot_image: @request.params["boot-image"],
+        private_subnet_id: ps_id,
+        enable_ip4: @request.params.key?("enable-ip4")
+      )
+
+      flash["notice"] = "'#{name}' will be ready in a few minutes"
+
+      @request.redirect "#{project.path}#{st.subject.path}"
+    end
+  end
+
+  def get
+    Authorization.authorize(@user.id, "Vm:view", @resource.id)
+    if @mode == AppMode::API
+      Serializers::Vm.serialize(@resource, {detailed: true})
+    else
+      @app.instance_variable_set(:@vm, Serializers::Vm.serialize(@resource, {detailed: true}))
+      @app.view "vm/show"
+    end
+  end
+
+  def delete
+    Authorization.authorize(@user.id, "Vm:delete", @resource.id)
+    @resource.incr_destroy
+    if @mode == AppMode::API
+      response.status = 204
+      @request.halt
+    else
+      {message: "Deleting #{@resource.name}"}.to_json
+    end
+  end
+
+  def get_create
+    Authorization.authorize(@user.id, "Vm:create", project.id)
+    @app.instance_variable_set(:@subnets, Serializers::PrivateSubnet.serialize(project.private_subnets_dataset.authorized(@user.id, "PrivateSubnet:view").all))
+    @app.instance_variable_set(:@prices, @app.fetch_location_based_prices("VmCores", "VmStorage", "IPAddress"))
+    @app.instance_variable_set(:@has_valid_payment_method, project.has_valid_payment_method?)
+    @app.instance_variable_set(:@default_location, project.default_location)
+    @app.instance_variable_set(:@enabled_vm_sizes, Option::VmSizes.select { _1.visible && project.quota_available?("VmCores", _1.vcpu / 2) }.map(&:name))
+
+    @app.view "vm/create"
+  end
+end

--- a/routes/common/vm_helper.rb
+++ b/routes/common/vm_helper.rb
@@ -93,12 +93,8 @@ class Routes::Common::VmHelper < Routes::Common::Base
   def delete
     Authorization.authorize(@user.id, "Vm:delete", @resource.id)
     @resource.incr_destroy
-    if @mode == AppMode::API
-      response.status = 204
-      @request.halt
-    else
-      {message: "Deleting #{@resource.name}"}.to_json
-    end
+    response.status = 204
+    @request.halt
   end
 
   def get_create

--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -10,20 +10,14 @@ class CloverWeb
         r.halt
       end
 
+      vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: @current_user, location: @location, resource: vm)
+
       r.get true do
-        Authorization.authorize(@current_user.id, "Vm:view", vm.id)
-
-        @vm = Serializers::Vm.serialize(vm, {detailed: true})
-
-        view "vm/show"
+        vm_endpoint_helper.get
       end
 
       r.delete true do
-        Authorization.authorize(@current_user.id, "Vm:delete", vm.id)
-
-        vm.incr_destroy
-
-        return {message: "Deleting #{vm.name}"}.to_json
+        vm_endpoint_helper.delete
       end
     end
   end

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -243,7 +243,6 @@ RSpec.describe Clover, "vm" do
         btn = find "#vm-delete-#{vm.ubid} .delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-        expect(page.body).to eq({message: "Deleting #{vm.name}"}.to_json)
         expect(SemSnap.new(vm.id).set?("destroy")).to be true
       end
 

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -66,7 +66,7 @@
                 <%== render(
                   "components/form/select",
                   locals: {
-                    name: "private-subnet-id",
+                    name: "private_subnet_id",
                     label: "Private Subnet",
                     placeholder: "Create new subnet",
                     options: @subnets.map { |s| [s[:id], s[:name], "location-based-option #{s[:location]}"] }
@@ -77,7 +77,7 @@
                 <%== render(
                   "components/form/checkbox",
                   locals: {
-                    name: "enable-ip4",
+                    name: "enable_ip4",
                     label: "Public IPv4 Support (+<span class='enable-ip4-1-monthly-price'>-</span><span class='text-xs text-gray-500'>/mo</span>)",
                     options: [
                      ["1", "Enable Public IPv4", "location-based-price", {"data-amount" => "1", "data-resource-type" => "IPAddress", "data-resource-family" => "IPv4", "data-default" => "true"}]
@@ -179,7 +179,7 @@
                 <%== render(
                   "components/form/radio_small_cards",
                   locals: {
-                    name: "boot-image",
+                    name: "boot_image",
                     label: "Boot Image",
                     options: Option::BootImages.to_h { |bi| [bi.name, bi.display_name] },
                     attributes: {
@@ -199,7 +199,7 @@
                 <%== render(
                   "components/form/text",
                   locals: {
-                    name: "user",
+                    name: "unix_user",
                     label: "User",
                     value: "ubi",
                     attributes: {
@@ -214,7 +214,7 @@
                 <%== render(
                   "components/form/textarea",
                   locals: {
-                    name: "public-key",
+                    name: "public_key",
                     label: "SSH Public Key",
                     description: "SSH keys are a more secure method of logging into a server.",
                     attributes: {


### PR DESCRIPTION
This is continuation from #1658, where we did a similar thing for Postgres endpoints. The goal is doing this for all resources, so that we wouldn't need to write a similar code twice. Like before, I used the API code as base to ensure that we don't introduce unintended breaking changes.

**Add helper class for Vm routes**
The business logic in both web and api endpoints are combined in the helper
class. Currently the combination is made simply adding a branch for each option
and copying the business logic from each endpoint to their respective branches.
Rubocop also moved some common lines out of the branches, but other than that
the logic is exactly same. There is no change in any functionality. We did not
try to converge to single logic and eliminate the branches in this commit. This
is intentional as I wanted to keep this commit as boring and add a separate
commit with the more interesting convergence stuff.

**Combine business logic for Vm resource creation endpoints**
Most of the code is straightforward changes to merge the logic in two branches
in the vm_helper. We had to rename the some fields in the UI to match to the
API.

**Combine business logic for Vm resource deletion endpoints**
For web, we used to return message in the response, however it is not used in
the frontend. We also returned 404 when the resource is not found, but that is
already handled as success case. This commit removes both thus makes overall
logic to more similar to API endpoints.

**Clean up Vm endpoint tests**
This is an opportunistic cleanup of some endpoint logic that were being tested
by both api and web tests. I think with a deeper inspection, we can clean the
tests up even more, but I only deleted most obvious duplicates for now.