### PR TITLE
Centralize business logic of PrivateSubnet web and api endpoints

### DIFF
--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -2,17 +2,10 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "private-subnet") do |r|
-    r.get true do
-      result = @project.private_subnets_dataset.where(location: @location).authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
-        start_after: r.params["start_after"],
-        page_size: r.params["page_size"],
-        order_column: r.params["order_column"]
-      )
+    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: @current_user, location: @location, resource: nil)
 
-      {
-        items: Serializers::PrivateSubnet.serialize(result[:records]),
-        count: result[:count]
-      }
+    r.get true do
+      ps_endpoint_helper.list
     end
 
     r.on "id" do
@@ -23,64 +16,33 @@ class CloverApi
           ps = nil
         end
 
-        handle_ps_requests(@current_user, ps)
+        ps_endpoint_helper.instance_variable_set(:@resource, ps)
+        handle_ps_requests(ps_endpoint_helper)
       end
     end
 
     r.is String do |ps_name|
       r.post true do
-        Authorization.authorize(@current_user.id, "PrivateSubnet:create", @project.id)
-
-        request_body = r.body.read
-        firewall_id = unless request_body.empty?
-          request_body_params = Validation.validate_request_body(request_body, [], ["firewall_id"])
-          if request_body_params["firewall_id"]
-            firewall_id = request_body_params["firewall_id"]
-            fw = Firewall.from_ubid(firewall_id)
-            unless fw && fw.location == @location
-              fail Validation::ValidationFailed.new(firewall_id: "Firewall with id \"#{firewall_id}\" and location \"#{@location}\" is not found")
-            end
-            Authorization.authorize(@current_user.id, "Firewall:view", fw.id)
-            fw.id
-          end
-        end
-
-        st = Prog::Vnet::SubnetNexus.assemble(
-          @project.id,
-          name: ps_name,
-          location: @location,
-          firewall_id: firewall_id
-        )
-
-        Serializers::PrivateSubnet.serialize(st.subject)
+        ps_endpoint_helper.post(ps_name)
       end
 
-      ps = @project.private_subnets_dataset.where(location: @location).where { {Sequel[:private_subnet][:name] => ps_name} }.first
-      handle_ps_requests(@current_user, ps)
+      ps_endpoint_helper.instance_variable_set(:@resource, @project.private_subnets_dataset.where(location: @location).where { {Sequel[:private_subnet][:name] => ps_name} }.first)
+      handle_ps_requests(ps_endpoint_helper)
     end
   end
 
-  def handle_ps_requests(user, ps)
-    unless ps
+  def handle_ps_requests(ps_endpoint_helper)
+    unless ps_endpoint_helper.instance_variable_get(:@resource)
       response.status = request.delete? ? 204 : 404
       request.halt
     end
 
     request.get true do
-      Authorization.authorize(user.id, "PrivateSubnet:view", ps.id)
-      Serializers::PrivateSubnet.serialize(ps)
+      ps_endpoint_helper.get
     end
 
     request.delete true do
-      Authorization.authorize(user.id, "PrivateSubnet:delete", ps.id)
-
-      if ps.vms_dataset.count > 0
-        fail DependencyError.new("Private subnet '#{ps.name}' has VMs attached, first, delete them.")
-      end
-
-      ps.incr_destroy
-      response.status = 204
-      request.halt
+      ps_endpoint_helper.delete
     end
   end
 end

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -2,17 +2,10 @@
 
 class CloverApi
   hash_branch(:project_prefix, "private-subnet") do |r|
-    r.get true do
-      result = @project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
-        start_after: r.params["start_after"],
-        page_size: r.params["page_size"],
-        order_column: r.params["order_column"]
-      )
+    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: @current_user, location: nil, resource: nil)
 
-      {
-        items: Serializers::PrivateSubnet.serialize(result[:records]),
-        count: result[:count]
-      }
+    r.get true do
+      ps_endpoint_helper.list
     end
   end
 end

--- a/routes/common/base.rb
+++ b/routes/common/base.rb
@@ -34,6 +34,6 @@ class Routes::Common::Base
   end
 
   def params
-    (@mode == AppMode::API) ? @request.body.read : @request.params.reject { _1 == "_csrf" }.to_json
+    @params ||= (@mode == AppMode::API) ? @request.body.read : @request.params.reject { _1 == "_csrf" }.to_json
   end
 end

--- a/routes/common/private_subnet_helper.rb
+++ b/routes/common/private_subnet_helper.rb
@@ -68,24 +68,18 @@ class Routes::Common::PrivateSubnetHelper < Routes::Common::Base
 
   def delete
     Authorization.authorize(@user.id, "PrivateSubnet:delete", @resource.id)
-    if @mode == AppMode::API
-      if @resource.vms_dataset.count > 0
+    if @resource.vms_dataset.count > 0
+      if @mode == AppMode::API
         fail DependencyError.new("Private subnet '#{@resource.name}' has VMs attached, first, delete them.")
-      end
-
-      @resource.incr_destroy
-      response.status = 204
-      @request.halt
-    else
-      if @resource.vms_dataset.count > 0
+      else
         response.status = 400
         return {message: "Private subnet has VMs attached, first, delete them."}.to_json
       end
-
-      @resource.incr_destroy
-
-      {message: "Deleting #{@resource.name}"}.to_json
     end
+
+    @resource.incr_destroy
+    response.status = 204
+    @request.halt
   end
 
   def get_create

--- a/routes/common/private_subnet_helper.rb
+++ b/routes/common/private_subnet_helper.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+class Routes::Common::PrivateSubnetHelper < Routes::Common::Base
+  def list
+    if @mode == AppMode::API
+      dataset = project.private_subnets_dataset
+      dataset = dataset.where(location: @location) if @location
+      result = dataset.authorized(@user.id, "PrivateSubnet:view").eager(nics: [:private_subnet]).paginated_result(
+        start_after: @request.params["start_after"],
+        page_size: @request.params["page_size"],
+        order_column: @request.params["order_column"]
+      )
+
+      {
+        items: Serializers::PrivateSubnet.serialize(result[:records]),
+        count: result[:count]
+      }
+    else
+      pss = Serializers::PrivateSubnet.serialize(project.private_subnets_dataset.authorized(@user.id, "PrivateSubnet:view").all, {include_path: true})
+      @app.instance_variable_set(:@pss, pss)
+
+      @app.view "networking/private_subnet/index"
+    end
+  end
+
+  def post(name)
+    Authorization.authorize(@user.id, "PrivateSubnet:create", project.id)
+    if @mode == AppMode::API
+      firewall_id = unless params.empty?
+        request_body_params = Validation.validate_request_body(params, [], ["firewall_id"])
+        if request_body_params["firewall_id"]
+          firewall_id = request_body_params["firewall_id"]
+          fw = Firewall.from_ubid(firewall_id)
+          unless fw && fw.location == @location
+            fail Validation::ValidationFailed.new(firewall_id: "Firewall with id \"#{firewall_id}\" and location \"#{@location}\" is not found")
+          end
+          Authorization.authorize(@user.id, "Firewall:view", fw.id)
+          fw.id
+        end
+      end
+
+      st = Prog::Vnet::SubnetNexus.assemble(
+        project.id,
+        name: name,
+        location: @location,
+        firewall_id: firewall_id
+      )
+
+      Serializers::PrivateSubnet.serialize(st.subject)
+    else
+      location = LocationNameConverter.to_internal_name(@request.params["location"])
+
+      st = Prog::Vnet::SubnetNexus.assemble(
+        project.id,
+        name: @request.params["name"],
+        location: location
+      )
+
+      flash["notice"] = "'#{@request.params["name"]}' will be ready in a few seconds"
+
+      @request.redirect "#{project.path}#{PrivateSubnet[st.id].path}"
+    end
+  end
+
+  def get
+    Authorization.authorize(@user.id, "PrivateSubnet:view", @resource.id)
+    if @mode == AppMode::API
+      Serializers::PrivateSubnet.serialize(@resource)
+    else
+      @app.instance_variable_set(:@ps, Serializers::PrivateSubnet.serialize(@resource))
+      @app.instance_variable_set(:@nics, Serializers::Nic.serialize(@resource.nics))
+      @app.view "networking/private_subnet/show"
+    end
+  end
+
+  def delete
+    Authorization.authorize(@user.id, "PrivateSubnet:delete", @resource.id)
+    if @mode == AppMode::API
+      if @resource.vms_dataset.count > 0
+        fail DependencyError.new("Private subnet '#{@resource.name}' has VMs attached, first, delete them.")
+      end
+
+      @resource.incr_destroy
+      response.status = 204
+      @request.halt
+    else
+      if @resource.vms_dataset.count > 0
+        response.status = 400
+        return {message: "Private subnet has VMs attached, first, delete them."}.to_json
+      end
+
+      @resource.incr_destroy
+
+      {message: "Deleting #{@resource.name}"}.to_json
+    end
+  end
+
+  def get_create
+    Authorization.authorize(@user.id, "PrivateSubnet:create", project.id)
+    @app.view "networking/private_subnet/create"
+  end
+end

--- a/routes/web/project/location/private_subnet.rb
+++ b/routes/web/project/location/private_subnet.rb
@@ -3,33 +3,19 @@
 class CloverWeb
   hash_branch(:project_location_prefix, "private-subnet") do |r|
     r.on String do |ps_name|
-      ps = @project.private_subnets_dataset.where(location: @location).where { {Sequel[:private_subnet][:name] => ps_name} }.first
-
-      unless ps
+      unless (ps = @project.private_subnets_dataset.where(location: @location).where { {Sequel[:private_subnet][:name] => ps_name} }.first)
         response.status = 404
         r.halt
       end
-      @ps = Serializers::PrivateSubnet.serialize(ps)
+
+      ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: @current_user, location: @location, resource: ps)
 
       r.get true do
-        Authorization.authorize(@current_user.id, "PrivateSubnet:view", ps.id)
-
-        @nics = Serializers::Nic.serialize(ps.nics)
-
-        view "networking/private_subnet/show"
+        ps_endpoint_helper.get
       end
 
       r.delete true do
-        Authorization.authorize(@current_user.id, "PrivateSubnet:delete", ps.id)
-
-        if ps.vms_dataset.count > 0
-          response.status = 400
-          return {message: "Private subnet has VMs attached, first, delete them."}.to_json
-        end
-
-        ps.incr_destroy
-
-        return {message: "Deleting #{ps.name}"}.to_json
+        ps_endpoint_helper.delete
       end
     end
   end

--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -3,9 +3,7 @@
 class CloverWeb
   hash_branch(:project_location_prefix, "vm") do |r|
     r.on String do |vm_name|
-      vm = @project.vms_dataset.where(location: @location).where { {Sequel[:vm][:name] => vm_name} }.first
-
-      unless vm
+      unless (vm = @project.vms_dataset.where(location: @location).where { {Sequel[:vm][:name] => vm_name} }.first)
         response.status = 404
         r.halt
       end

--- a/routes/web/project/private_subnet.rb
+++ b/routes/web/project/private_subnet.rb
@@ -2,32 +2,20 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "private-subnet") do |r|
-    r.get true do
-      @pss = Serializers::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(@current_user.id, "PrivateSubnet:view").all, {include_path: true})
+    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: @current_user, location: nil, resource: nil)
 
-      view "networking/private_subnet/index"
+    r.get true do
+      ps_endpoint_helper.list
     end
 
     r.post true do
-      Authorization.authorize(@current_user.id, "PrivateSubnet:create", @project.id)
-      location = LocationNameConverter.to_internal_name(r.params["location"])
-
-      st = Prog::Vnet::SubnetNexus.assemble(
-        @project.id,
-        name: r.params["name"],
-        location: location
-      )
-
-      flash["notice"] = "'#{r.params["name"]}' will be ready in a few seconds"
-
-      r.redirect "#{@project.path}#{PrivateSubnet[st.id].path}"
+      ps_endpoint_helper.instance_variable_set(:@location, LocationNameConverter.to_internal_name(r.params["location"]))
+      ps_endpoint_helper.post(r.params["name"])
     end
 
     r.on "create" do
       r.get true do
-        Authorization.authorize(@current_user.id, "PrivateSubnet:create", @project.id)
-
-        view "networking/private_subnet/create"
+        ps_endpoint_helper.get_create
       end
     end
   end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -14,40 +14,19 @@ RSpec.describe Clover, "private_subnet" do
   let(:ps_wo_permission) { Prog::Vnet::SubnetNexus.assemble(project_wo_permissions.id, name: "dummy-ps-2").subject }
 
   describe "unauthenticated" do
-    it "not location list" do
-      get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
+    it "cannot perform authenticated operations" do
+      [
+        [:get, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"],
+        [:post, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"],
+        [:delete, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
+        [:delete, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"],
+        [:get, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
+        [:get, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"]
+      ].each do |method, path|
+        send method, path
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
-    end
-
-    it "not create" do
-      post "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"
-
-      expect(last_response).to have_api_error(401, "Please login to continue")
-    end
-
-    it "not delete" do
-      delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
-
-      expect(last_response).to have_api_error(401, "Please login to continue")
-    end
-
-    it "not delete ubid" do
-      delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
-
-      expect(last_response).to have_api_error(401, "Please login to continue")
-    end
-
-    it "not get" do
-      get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
-
-      expect(last_response).to have_api_error(401, "Please login to continue")
-    end
-
-    it "not get ubid" do
-      get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/id/#{ps.ubid}"
-
-      expect(last_response).to have_api_error(401, "Please login to continue")
+        expect(last_response).to have_api_error(401, "Please login to continue")
+      end
     end
   end
 

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -81,22 +81,6 @@ RSpec.describe Clover, "private subnet" do
         expect(PrivateSubnet.first.projects.first.id).to eq(project.id)
       end
 
-      it "can not create private subnet with invalid name" do
-        project
-        visit "#{project.path}/private-subnet/create"
-
-        expect(page.title).to eq("Ubicloud - Create Private Subnet")
-
-        fill_in "Name", with: "invalid name"
-        choose option: "eu-north-h1"
-
-        click_button "Create"
-
-        expect(page.title).to eq("Ubicloud - Create Private Subnet")
-        expect(page).to have_content "Name must only contain"
-        expect((find "input[name=name]")["value"]).to eq("invalid name")
-      end
-
       it "can not create private subnet with same name" do
         project
         visit "#{project.path}/private-subnet/create"
@@ -110,15 +94,6 @@ RSpec.describe Clover, "private subnet" do
 
         expect(page.title).to eq("Ubicloud - Create Private Subnet")
         expect(page).to have_content "name is already taken"
-      end
-
-      it "can not create vm in a project when does not have permissions" do
-        project_wo_permissions
-        visit "#{project_wo_permissions.path}/private-subnet/create"
-
-        expect(page.title).to eq("Ubicloud - Forbidden")
-        expect(page.status_code).to eq(403)
-        expect(page).to have_content "Forbidden"
       end
     end
 
@@ -134,14 +109,6 @@ RSpec.describe Clover, "private subnet" do
 
         expect(page.title).to eq("Ubicloud - #{private_subnet.name}")
         expect(page).to have_content private_subnet.name
-      end
-
-      it "raises forbidden when does not have permissions" do
-        visit "#{project_wo_permissions.path}#{ps_wo_permission.path}"
-
-        expect(page.title).to eq("Ubicloud - Forbidden")
-        expect(page.status_code).to eq(403)
-        expect(page).to have_content "Forbidden"
       end
 
       it "raises not found when private subnet not exists" do

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -191,7 +191,6 @@ RSpec.describe Clover, "private subnet" do
         btn = find ".delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-        expect(page.body).to eq({message: "Deleting #{private_subnet.name}"}.to_json)
         expect(SemSnap.new(private_subnet.id).set?("destroy")).to be true
       end
 


### PR DESCRIPTION
This is continuation of #1658 and #1867, where we did a similar thing for Postgres and Vm endpoints. The goal is doing this for all resources, so that we wouldn't need to write a similar code twice. Like before, I used the API code as base to ensure that we don't introduce unintended breaking changes.

**Cache params in base route**
Subsequent requests for request.body.read returns an empty string, because it
is already read. This caches the result of request.body.read so that it can be
called multiple times.

**Add helper class for PrivateSubnet routes**
The business logic in both web and api endpoints are combined in the helper
class. Currently the combination is made simply adding a branch for each option
and copying the business logic from each endpoint to their respective branches.
Rubocop also moved some common lines out of the branches, but other than that
the logic is exactly same. There is no change in any functionality. We did not
try to converge to single logic and eliminate the branches in this commit. This
is intentional as I wanted to keep this commit as boring and add a separate
commit with the more interesting convergence stuff.

**Combine business logic for PrivateSubnet resource creation endpoints**
Most of the code is straightforward changes to merge the logic in two branches
in the private_subnet_helper.

**Combine business logic for PrivateSubnet resource deletion endpoints**
For web, we used to return message in the response, however it is not used in
the frontend. We also returned 404 when the resource is not found, but that is
already handled as success case. This commit removes both thus makes overall
logic to more similar to API endpoints.

**Clean up PrivateSubnet endpoint tests**
This is an opportunistic cleanup of some endpoint logic that were being tested
by both api and web tests. I think with a deeper inspection, we can clean the
tests up even more, but I only deleted most obvious duplicates for now.