### PR TITLE
Postgres US Prep to selectively pick the blob storage cluster

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -128,8 +128,6 @@ module Config
   # Postgres
   optional :postgres_service_project_id, string
   override :postgres_service_hostname, "postgres.ubicloud.com", string
-  optional :postgres_service_blob_storage_access_key, string
-  optional :postgres_service_blob_storage_secret_key, string, clear: true
   optional :postgres_service_blob_storage_id, string
   override :postgres_monitor_database_url, Config.clover_database_url, string
   optional :postgres_monitor_database_root_certs, string

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -25,7 +25,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
     DB.transaction do
       superuser_password, timeline_id, timeline_access = if parent_id.nil?
-        [SecureRandom.urlsafe_base64(15), Prog::Postgres::PostgresTimelineNexus.assemble.id, "push"]
+        [SecureRandom.urlsafe_base64(15), Prog::Postgres::PostgresTimelineNexus.assemble(location: location).id, "push"]
       else
         unless (parent = PostgresResource[parent_id])
           fail "No existing parent"


### PR DESCRIPTION
## PostgresTimeline picks the blob store depending on the region
We are introducing a second blob store specifically for the US region
and we should be able to selectively use that. Therefore, we are making
changes to the PostgresTimeline to pick the blob store that is created
for that region. For that, we have to pass the location to the
PostgresTimelineNexus.assemble because there is simply no other way to
reach the location information of that resource. Furthermore, we are
removing the Config elements that are set to access to the MinIO cluster
to create new key pairs per bucket. Instead, we start to read those
values directly from the MinIO entity.