### PR TITLE
Change github monitored memory to "available" rather than "free"

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -57,7 +57,7 @@ class GithubRunner < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      available_memory = session[:ssh_session].exec!("free | awk 'NR==2 {print $4}'").chomp
+      available_memory = session[:ssh_session].exec!("awk '/MemAvailable/ {print $2}' /proc/meminfo").chomp
       "up"
     rescue
       "down"

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe GithubRunner do
       reading_chg: Time.now - 30
     }
 
-    expect(session[:ssh_session]).to receive(:exec!).and_return("123\n")
+    expect(session[:ssh_session]).to receive(:exec!).with("awk '/MemAvailable/ {print $2}' /proc/meminfo").and_return("123\n")
     github_runner.check_pulse(session: session, previous_pulse: pulse)
 
     expect(session[:ssh_session]).to receive(:exec!).and_raise Sshable::SshError


### PR DESCRIPTION
"Free" is defined very particularly in Linux systems, to mean space not used by either page caches nor applications. As such, "free" tends towards a small number of any long-lived system, as pages are kept in the cache.

The "available" statistic subtracts out the page cache, it refers to memory that can be made available to applications, e.g. it is more related to whether the OOM killer will run. Most of the time, this is the more useful metric.

Finally, by running awk against the Linux VFS /proc/meminfo file, the implementation can optimize out one process spawn, for `free` (which does much the same, as confirmed by `strace`)