### PR TITLE
Show hourly pricing in UI

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -231,6 +231,7 @@ function setupLocationBasedPrices() {
     $(this).data("monthly-price", monthly.toFixed(2));
     $(`.${name}-${value}`).show();
     $(`.${name}-${value}-monthly-price`).text(`$${monthly.toFixed(2)}`);
+    $(`.${name}-${value}-hourly-price`).text(`$${(monthly / 672).toFixed(3)}`);
     count[name] = (count[name] || 0) + 1;
   });
 }
@@ -268,7 +269,8 @@ function setupInstanceSizeBasedOptions() {
       $(this).find("input[type=radio]").val(storage_amount);
       $(this).find("input[type=radio]").data("monthly-price", monthlyPrice);
       $(this).find(".storage-size-label").text(storage_amount + "GB (" + (storage_amount / storage_size_options[0]) + "x)");
-      $(this).find(".storage-size-price").text("+$" + (monthlyPrice).toFixed(2));
+      $(this).find(".storage-size-monthly-price").text("+$" + (monthlyPrice).toFixed(2));
+      $(this).find(".storage-size-hourly-price").text("+$" + (monthlyPrice / 672).toFixed(3));
       storage_size_index++;
     });
   });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -197,8 +197,6 @@ $("input[name=size]").on("change", function (event) {
 });
 
 $("input[name=storage_size]").on("change", function (event) {
-  storage_size_options = $("input[name=size]:checked").data("storage-size-options");
-  storage_size_index = parseInt($(".storage-slider").val());
   setupLocationBasedPostgresHaPrices();
 });
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -245,6 +245,7 @@ function setupLocationBasedPostgresHaPrices() {
     let standbyCount = $(this).data("standby-count");
     $(`.ha-status-${value}`).show();
     $(`.ha-status-${value}-monthly-price`).text(`+$${(standbyCount * monthlyPrice).toFixed(2)}`);
+    $(`.ha-status-${value}-hourly-price`).text(`+$${(standbyCount * monthlyPrice / 672).toFixed(3)}`);
   });
 }
 

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -101,8 +101,8 @@
                               </span>
                             </span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
-                              <span class="font-medium size-<%= size.name %>-monthly-price">-</span>
-                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                              <span class="font-medium"><span class="size-<%= size.name %>-monthly-price">-</span>/mo</span>
+                              <span class="ml-1 opacity-50 sm:ml-0"><span class="size-<%= size.name %>-hourly-price">-</span>/hour</span>
                             </span>
                           </span>
                         </label>
@@ -136,8 +136,8 @@
                           >
                             <span class="text-md font-semibold storage-size-label"><%= storage_size %>GB</span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
-                              <span class="font-medium storage-size-price">-</span>
-                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                              <span class="font-medium"><span class="storage-size-monthly-price">-</span>/mo</span>
+                              <span class="ml-1 opacity-50 sm:ml-0"><span class="storage-size-hourly-price">-</span>/hour</span>
                             </span>
                           </span>
                         </label>
@@ -178,8 +178,8 @@
                               </span>
                             </span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
-                              <span class="font-medium ha-status-<%= ha_type.name %>-monthly-price">-</span>
-                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                              <span class="font-medium"><span class="ha-status-<%= ha_type.name %>-monthly-price">-</span>/mo</span>
+                              <span class="ml-1 opacity-50 sm:ml-0"><span class="ha-status-<%= ha_type.name %>-hourly-price">-</span>/hour</span>
                             </span>
                           </span>
                         </label>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -78,7 +78,7 @@
                   "components/form/checkbox",
                   locals: {
                     name: "enable_ip4",
-                    label: "Public IPv4 Support (+<span class='enable-ip4-1-monthly-price'>-</span><span class='text-xs text-gray-500'>/mo</span>)",
+                    label: "Public IPv4 Support (+<span class='enable_ip4-1-monthly-price'>-</span><span class='text-xs text-gray-500'>/mo</span>)",
                     options: [
                      ["1", "Enable Public IPv4", "location-based-price", {"data-amount" => "1", "data-resource-type" => "IPAddress", "data-resource-family" => "IPv4", "data-default" => "true"}]
                     ],

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -129,8 +129,8 @@
                               </span>
                             </span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
-                              <span class="font-medium size-<%= size.name %>-monthly-price">-</span>
-                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                              <span class="font-medium"><span class="size-<%= size.name %>-monthly-price">-</span>/mo</span>
+                              <span class="ml-1 opacity-50 sm:ml-0"><span class="size-<%= size.name %>-hourly-price">-</span>/hour</span>
                             </span>
                           </span>
                         </label>
@@ -164,8 +164,8 @@
                           >
                             <span class="text-md font-semibold storage-size-label"><%= storage_size %>GB</span>
                             <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
-                              <span class="font-medium storage-size-price">-</span>
-                              <span class="ml-1 opacity-50 sm:ml-0">/mo</span>
+                              <span class="font-medium"><span class="storage-size-monthly-price">-</span>/mo</span>
+                              <span class="ml-1 opacity-50 sm:ml-0"><span class="storage-size-hourly-price">-</span>/hour</span>
                             </span>
                           </span>
                         </label>


### PR DESCRIPTION
**Show hourly pricing on VM creation page**
To emphasize that we are not billing monthly, we decided to show the hourly
prices on the VM creation page. We actually bill by minute, not hour, but
showing hourly prices is more common in the industry. Also by minute prices
require lots of significant digits to properly display.

**Show hourly pricing on Postgres creation page**
To emphasize that we are not billing monthly, we decided to show the hourly
prices on the VM creation page. We actually bill by minute, not hour, but
showing hourly prices is more common in the industry. Also by minute prices
require lots of significant digits to properly display

**Fix IP price display**
We find the element that we put the pricing info by concatenating the name of
the input field and "monthly-price" string. We changed the name of the input
field but forgot to change the class of the element that we put the pricing
info. This commit fixes that.

**Delete leftover code from past refactoring**
This code is leftover from the refactoring. It is not used and it does not have
any effect on the page.

![image](https://github.com/user-attachments/assets/53ff009a-9db5-49c1-9aa2-46405cc28a42)