### PR TITLE
Calculate earliest_restore_time based on the backups in blob storage

### DIFF
--- a/migrate/20240826_drop_earliest_backup_completed_at.rb
+++ b/migrate/20240826_drop_earliest_backup_completed_at.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:postgres_timeline) do
+      drop_column :earliest_backup_completed_at
+    end
+  end
+
+  down do
+    alter_table(:postgres_timeline) do
+      add_column :earliest_backup_completed_at, :timestamptz
+    end
+  end
+end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -50,8 +50,8 @@ PGHOST=/var/run/postgresql
       blob_storage_client
         .list_objects(ubid, "basebackups_005/")
         .select { _1.key.end_with?("backup_stop_sentinel.json") }
-    rescue RuntimeError => ex
-      recoverable_errors = ["The Access Key Id you provided does not exist in our records.", "AccessDenied"]
+    rescue => ex
+      recoverable_errors = ["The Access Key Id you provided does not exist in our records.", "AccessDenied", "No route to host", "Connection refused"]
       return [] if recoverable_errors.any? { ex.message.include?(_1) }
       raise
     end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -36,7 +36,6 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         end
 
         restore_target = Validation.validate_date(restore_target, "restore_target")
-        parent.timeline.refresh_earliest_backup_completion_time
         unless (earliest_restore_time = parent.timeline.earliest_restore_time) && earliest_restore_time <= restore_target &&
             parent.timeline.latest_restore_time && restore_target <= parent.timeline.latest_restore_time
           fail Validation::ValidationFailed.new({restore_target: "Restore target must be between #{earliest_restore_time} and #{parent.timeline.latest_restore_time}"})

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -101,22 +101,6 @@ PGHOST=/var/run/postgresql
     end
   end
 
-  it "refreshes the earliest backup time" do
-    stub_const("Backup", Struct.new(:last_modified))
-    most_oldest_backup_time = Time.now - 300
-    expect(postgres_timeline).to receive(:backups).and_return(
-      [
-        instance_double(Backup, key: "basebackups_005/0001_backup_stop_sentinel.json", last_modified: most_oldest_backup_time),
-        instance_double(Backup, key: "basebackups_005/0002_backup_stop_sentinel.json", last_modified: most_oldest_backup_time + 100),
-        instance_double(Backup, key: "basebackups_005/0003_backup_stop_sentinel.json", last_modified: most_oldest_backup_time + 200)
-      ]
-    )
-
-    expect(postgres_timeline).to receive(:update).with(earliest_backup_completed_at: most_oldest_backup_time).and_call_original
-    expect(postgres_timeline.refresh_earliest_backup_completion_time).to eq(most_oldest_backup_time)
-    expect(postgres_timeline.earliest_restore_time).to eq(most_oldest_backup_time + 5 * 60)
-  end
-
   it "returns empty array if blob storage is not configured" do
     expect(postgres_timeline).to receive(:blob_storage).and_return(nil)
     expect(postgres_timeline.backups).to eq([])

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -75,8 +75,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
       expect {
         parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
-        parent.timeline.update(earliest_backup_completed_at: Time.now)
-        expect(parent.timeline).to receive(:refresh_earliest_backup_completion_time).and_return(Time.now)
         expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
         described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: Time.now)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: restore_target"
@@ -86,8 +84,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
       parent.update(target_storage_size_gib: 1024)
-      parent.timeline.update(earliest_backup_completed_at: Time.now - 10 * 60)
-      expect(parent.timeline).to receive(:refresh_earliest_backup_completion_time).and_return(Time.now - 10 * 60)
+      expect(parent.timeline).to receive(:earliest_restore_time).and_return(Time.now - 10 * 60)
       expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent).at_least(:once)
       expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_id: parent.timeline.id, timeline_access: "fetch")).and_return(instance_double(Strand, subject: postgres_resource.representative_server))
 
@@ -105,8 +102,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
       restore_target = Time.now
-      parent.timeline.update(earliest_backup_completed_at: restore_target - 10 * 60)
-      expect(parent.timeline).to receive(:refresh_earliest_backup_completion_time).and_return(restore_target - 10 * 60)
+      expect(parent.timeline).to receive(:earliest_restore_time).and_return(restore_target - 10 * 60)
       expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
       expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_id: parent.timeline.id, timeline_access: "fetch")).and_return(instance_double(Strand, subject: postgres_resource.representative_server))
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -157,12 +157,10 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can restore PostgreSQL database" do
-        stub_const("Backup", Struct.new(:last_modified))
+        stub_const("Backup", Struct.new(:key, :last_modified))
         restore_target = Time.now.utc
-        pg.timeline.update(earliest_backup_completed_at: restore_target - 10 * 60)
-        expect(pg.timeline).to receive(:refresh_earliest_backup_completion_time).and_return(restore_target - 10 * 60)
-        expect(PostgresResource).to receive(:[]).with(pg.id).and_return(pg)
-        expect(PostgresResource).to receive(:[]).and_call_original.at_least(:once)
+        expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
+        expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, list_objects: [Backup.new("basebackups_005/backup_stop_sentinel.json", restore_target - 10 * 60)])).at_least(:once)
 
         visit "#{project.path}#{pg.path}"
         expect(page).to have_content "Fork PostgreSQL database"


### PR DESCRIPTION
We used to cache the earliest_backup_completed_at in the database, with the
intention of updating it when we purge the backups. However, we decided to
purge backups with blob storage policy. Hence, there is no opportunity in the
code to update the earliest_backup_completed_at. This causes displaying wrong
potential restore times in the UI. To fix this, although it is slower, I'm
calculating the earliest_restore_time based on the backups in the blob storage.