### PR TITLE
Use temporary tokens instead of permanent ones to access R2 buckets

### DIFF
--- a/lib/cloudflare_client.rb
+++ b/lib/cloudflare_client.rb
@@ -8,13 +8,16 @@ class CloudflareClient
     @connection = Excon.new("https://api.cloudflare.com", headers: {"Authorization" => "Bearer #{api_key}"})
   end
 
-  def create_token(name, policies)
-    response = @connection.post(path: "/client/v4/user/tokens", body: {name: name, policies: policies}.to_json, expects: 200)
+  def create_temporary_token(bucket_name, permission, ttl)
+    path = "/client/v4/accounts/#{Config.github_cache_blob_storage_account_id}/r2/temp-access-credentials"
+    body = {
+      bucket: bucket_name,
+      parentAccessKeyId: Config.github_cache_blob_storage_access_key,
+      permission: permission,
+      ttlSeconds: ttl
+    }
+    response = @connection.post(path: path, body: body.to_json, expects: 200)
     data = JSON.parse(response.body)
-    [data["result"]["id"], data["result"]["value"]]
-  end
-
-  def delete_token(token_id)
-    @connection.delete(path: "/client/v4/user/tokens/#{token_id}", expects: [200, 404]).status
+    [data["result"]["accessKeyId"], data["result"]["secretAccessKey"], data["result"]["sessionToken"]]
   end
 end

--- a/migrate/20240821_github_repository_temporary_access_key.rb
+++ b/migrate/20240821_github_repository_temporary_access_key.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:github_repository) do
+      add_column :session_token, :text, collate: '"C"'
+      add_column :last_token_refreshed_at, :timestamptz
+    end
+  end
+end

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -101,6 +101,11 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
 
   def check_token_lifetime
     remaining_lifetime = GithubRepository::BLOB_STORAGE_TOKEN_TTL - (Time.now - github_repository.last_token_refreshed_at)
+    if remaining_lifetime < 24 * 60 * 60
+      Prog::PageNexus.assemble("Expiring blob storage token for #{github_repository.ubid}", ["ExpiringBlobToken", github_repository.id], github_repository.ubid)
+    else
+      Page.from_tag_parts("ExpiringBlobToken", github_repository.id)&.incr_resolve
+    end
     if remaining_lifetime < 2 * 24 * 60 * 60
       github_repository.refresh_blob_storage_token
     end

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -109,6 +109,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
   end
 
   label def wait
+    cleanup_cache if github_repository.access_key
     nap 15 * 60 if Time.now - github_repository.last_job_at > 6 * 60 * 60
 
     begin
@@ -120,8 +121,6 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
         nap 0
       end
     end
-
-    cleanup_cache if github_repository.access_key
 
     # check_queued_jobs may have changed the default polling interval based on
     # the remaining rate limit.

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -99,6 +99,13 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     end
   end
 
+  def check_token_lifetime
+    remaining_lifetime = GithubRepository::BLOB_STORAGE_TOKEN_TTL - (Time.now - github_repository.last_token_refreshed_at)
+    if remaining_lifetime < 2 * 24 * 60 * 60
+      github_repository.refresh_blob_storage_token
+    end
+  end
+
   def before_run
     when_destroy_set? do
       if strand.label != "destroy"
@@ -109,7 +116,11 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
   end
 
   label def wait
-    cleanup_cache if github_repository.access_key
+    if github_repository.access_key
+      check_token_lifetime
+      cleanup_cache
+    end
+
     nap 15 * 60 if Time.now - github_repository.last_job_at > 6 * 60 * 60
 
     begin

--- a/spec/lib/cloudflare_client_spec.rb
+++ b/spec/lib/cloudflare_client_spec.rb
@@ -3,14 +3,10 @@
 RSpec.describe CloudflareClient do
   let(:client) { described_class.new("api_key") }
 
-  it "create_token" do
-    Excon.stub({path: "/client/v4/user/tokens", method: :post}, {status: 200, body: {result: {id: "123", value: "secret"}}.to_json})
-    expect(client.create_token("test-token", [{id: "test-policy"}])).to eq(["123", "secret"])
-  end
-
-  it "delete_token" do
-    token_id = "123"
-    Excon.stub({path: "/client/v4/user/tokens/#{token_id}", method: :delete}, {status: 200})
-    expect(client.delete_token(token_id)).to eq(200)
+  it "create_temporary_token" do
+    expect(Config).to receive(:github_cache_blob_storage_account_id).and_return("account-123")
+    Excon.stub({path: "/client/v4/accounts/account-123/r2/temp-access-credentials", method: :post},
+      {status: 200, body: {result: {accessKeyId: "123", secretAccessKey: "secret", sessionToken: "token"}}.to_json})
+    expect(client.create_temporary_token("bucket", "object-read-write", 123)).to eq(["123", "secret", "token"])
   end
 end

--- a/spec/model/github/github_repository_spec.rb
+++ b/spec/model/github/github_repository_spec.rb
@@ -16,17 +16,15 @@ RSpec.describe GithubRepository do
   describe ".destroy_blob_storage" do
     it "deletes the bucket and token" do
       expect(blob_storage_client).to receive(:delete_bucket).with(bucket: "gph0hh0ahdbj6ng2cc3rvdecr8")
-      expect(cloudflare_client).to receive(:delete_token).with(github_repository.access_key)
       expect(github_repository).to receive(:this).and_return(github_repository)
-      expect(github_repository).to receive(:update).with(access_key: nil, secret_key: nil)
+      expect(github_repository).to receive(:update).with(access_key: nil, secret_key: nil, session_token: nil, last_token_refreshed_at: nil)
       github_repository.destroy_blob_storage
     end
 
     it "succeeds if the bucket is already deleted" do
       expect(blob_storage_client).to receive(:delete_bucket).and_raise(Aws::S3::Errors::NoSuchBucket.new(nil, nil))
-      expect(cloudflare_client).to receive(:delete_token).with(github_repository.access_key)
       expect(github_repository).to receive(:this).and_return(github_repository)
-      expect(github_repository).to receive(:update).with(access_key: nil, secret_key: nil)
+      expect(github_repository).to receive(:update).with(access_key: nil, secret_key: nil, session_token: nil, last_token_refreshed_at: nil)
       github_repository.destroy_blob_storage
     end
   end
@@ -52,26 +50,25 @@ RSpec.describe GithubRepository do
 
   describe ".setup_blob_storage" do
     it "creates a bucket and token" do
-      expect(Config).to receive_messages(github_cache_blob_storage_region: "weur", github_cache_blob_storage_account_id: "123")
+      expect(Config).to receive_messages(github_cache_blob_storage_region: "weur")
       expect(blob_storage_client).to receive(:create_bucket).with({bucket: "gph0hh0ahdbj6ng2cc3rvdecr8", create_bucket_configuration: {location_constraint: "weur"}})
-      expected_policy = [
-        {
-          "effect" => "allow",
-          "permission_groups" => [{"id" => "2efd5506f9c8494dacb1fa10a3e7d5b6", "name" => "Workers R2 Storage Bucket Item Write"}],
-          "resources" => {"com.cloudflare.edge.r2.bucket.123_default_gph0hh0ahdbj6ng2cc3rvdecr8" => "*"}
-        }
-      ]
-      expect(cloudflare_client).to receive(:create_token).with("gph0hh0ahdbj6ng2cc3rvdecr8-token", expected_policy).and_return(["test-key", "test-secret"])
-      expect(github_repository).to receive(:update).with(access_key: "test-key", secret_key: Digest::SHA256.hexdigest("test-secret"))
+      expect(github_repository).to receive(:refresh_blob_storage_token)
       github_repository.setup_blob_storage
     end
 
     it "succeeds if the bucket already exists" do
-      expect(Config).to receive_messages(github_cache_blob_storage_region: "weur", github_cache_blob_storage_account_id: "123")
+      expect(Config).to receive_messages(github_cache_blob_storage_region: "weur")
       expect(blob_storage_client).to receive(:create_bucket).and_raise(Aws::S3::Errors::BucketAlreadyOwnedByYou.new(nil, nil))
-      expect(cloudflare_client).to receive(:create_token).and_return(["test-key", "test-secret"])
-      expect(github_repository).to receive(:update).with(access_key: "test-key", secret_key: Digest::SHA256.hexdigest("test-secret"))
+      expect(github_repository).to receive(:refresh_blob_storage_token)
       github_repository.setup_blob_storage
+    end
+  end
+
+  describe ".refresh_blob_storage_token" do
+    it "create a new temporary token" do
+      expect(cloudflare_client).to receive(:create_temporary_token).with("gph0hh0ahdbj6ng2cc3rvdecr8", "object-read-write", 432000).and_return(["test-key", "test-secret", "test-token"])
+      expect(github_repository).to receive(:update).with(access_key: "test-key", secret_key: "test-secret", session_token: "test-token", last_token_refreshed_at: instance_of(Time))
+      github_repository.refresh_blob_storage_token
     end
   end
 end

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -151,9 +151,11 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect { nx.wait }.to nap(5 * 60)
     end
 
-    it "does not check queued jobs if 6 hours passed from the last job" do
+    it "does not check queued jobs but check cache usage if 6 hours passed from the last job" do
+      expect(github_repository).to receive(:access_key).and_return("key")
       expect(github_repository).to receive(:last_job_at).and_return(Time.now - 7 * 60 * 60)
       expect(nx).not_to receive(:check_queued_jobs)
+      expect(nx).to receive(:cleanup_cache)
       expect { nx.wait }.to nap(15 * 60)
     end
 

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -129,6 +129,20 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
     end
   end
 
+  describe ".check_token_lifetime" do
+    it "refresh blob storage token if it has less than 2 days lifetime" do
+      expect(github_repository).to receive(:last_token_refreshed_at).and_return(Time.now - GithubRepository::BLOB_STORAGE_TOKEN_TTL)
+      expect(github_repository).to receive(:refresh_blob_storage_token)
+      nx.check_token_lifetime
+    end
+
+    it "does not refresh blob storage token if it has more than 2 days lifetime" do
+      expect(github_repository).to receive(:last_token_refreshed_at).and_return(Time.now - 24 * 60 * 60)
+      expect(github_repository).not_to receive(:refresh_blob_storage_token)
+      nx.check_token_lifetime
+    end
+  end
+
   describe "#before_run" do
     it "hops to destroy when needed" do
       expect(nx).to receive(:when_destroy_set?).and_yield
@@ -146,6 +160,7 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
   describe "#wait" do
     it "checks queued jobs and cache usage then naps" do
       expect(github_repository).to receive(:access_key).and_return("key")
+      expect(nx).to receive(:check_token_lifetime)
       expect(nx).to receive(:check_queued_jobs)
       expect(nx).to receive(:cleanup_cache)
       expect { nx.wait }.to nap(5 * 60)
@@ -156,6 +171,7 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect(github_repository).to receive(:last_job_at).and_return(Time.now - 7 * 60 * 60)
       expect(nx).not_to receive(:check_queued_jobs)
       expect(nx).to receive(:cleanup_cache)
+      expect(nx).to receive(:check_token_lifetime)
       expect { nx.wait }.to nap(15 * 60)
     end
 

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -141,6 +141,19 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect(github_repository).not_to receive(:refresh_blob_storage_token)
       nx.check_token_lifetime
     end
+
+    it "creates a page if the token has lifetime less than a day" do
+      expect(github_repository).to receive(:last_token_refreshed_at).and_return(Time.now - GithubRepository::BLOB_STORAGE_TOKEN_TTL + 12 * 60 * 60)
+      expect(github_repository).to receive(:refresh_blob_storage_token)
+      expect { nx.check_token_lifetime }.to change { Page.active.count }.from(0).to(1)
+
+      # resolve the page
+      expect(github_repository).to receive(:last_token_refreshed_at).and_return(Time.now)
+      page = instance_double(Page)
+      expect(page).to receive(:incr_resolve)
+      expect(Page).to receive(:from_tag_parts).and_return(page)
+      nx.check_token_lifetime
+    end
   end
 
   describe "#before_run" do


### PR DESCRIPTION
### Check cache usage in repository nexus as first step

The repository nexus checks two things in the `wait` state: queued jobs
and cache usage, in that order. However, since polling jobs is
resource-intensive, it won't poll if no job has been triggered for the
repository in the past 6 hours. This can lead to the cache usage check
being skipped, preventing the cleanup of expired caches after 7 days if
no job has been triggered in that 6-hour window. Therefore, to ensure we
can clean up expired caches, the cache usage check should be prioritized
as the first step in the `wait` state.

### Add migration to add temp access token columns to GitHub repository table

### Use temporary tokens instead of permanent ones to access R2 buckets

We were using permanent tokens to access R2 buckets. However, we found
that we could only create 50 permanent API tokens. Given we create
tokens for each customer/bucket, this approach isn't scalable.
Unfortunately, there's no easy way to increase this limit. While an
enterprise account allows for more tokens, upgrading is not practical
for us. We learned from the community that temporary tokens don't have
this restriction [^1] [^2]. Thus, we've decided to switch to temporary
tokens.  Another future benefit is that temporary tokens allow us to set
more specific permissions at the bucket, prefix, and object levels.

We've chosen to use temporary tokens for accessing R2 buckets. Unlike
permanent tokens, this requires sending a session_token with each
request, and we must refresh the token before it expires. I've
implemented refreshing part in the next commit.

[^1]: https://developers.cloudflare.com/r2/api/s3/tokens/#temporary-access-credentials
[^2]: https://developers.cloudflare.com/api/operations/r2-create-temp-access-credentials

### Refresh the repository's blob storage token if has less than 2 days

We started to create R2 access tokens with a 5-day TTL. It's important
to refresh the token before it expires. 2-day serves as a suitable time
for token refreshment, providing a satisfactory buffer in case of any
issues

### Create a page if the repository blob token will expire in 1 day

If the repository nexus is unable to refresh the blob storage token for
any reason, it may fail silently. We generate tokens that last for 5
days and refresh them when there are 2 days left. If the token can't be
refreshed with 1 day remaining, we create a page. The on-call engineer
should investigate the issue before it expires.