### PR TITLE
Update reserve cache to return error if cache already exists

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -78,6 +78,10 @@ class CloverRuntime
           fail CloverError.new(400, "InvalidRequest", "No workflow job data available")
         end
 
+        if repository.cache_entries_dataset[key: key, version: version, scope: scope]
+          fail CloverError.new(409, "AlreadyExists", "A cache entry for #{scope} scope already exists with #{key} key and #{version} version.")
+        end
+
         if size > GithubRepository::CACHE_SIZE_LIMIT
           fail CloverError.new(400, "InvalidRequest", "The cache size is over the 10GB limit")
         end


### PR DESCRIPTION
If the cache exists for the passed key and version, github itself returns "cache already exists" with a message including scope, key and version information. To mimic the behavior, returning and error including same information.

Note that, such a scenario might occur if explicit save action used on the workflow and that workflow is run multiple times.