### PR TITLE
Persist project invitation if account doesn't exists

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -23,6 +23,8 @@ Strand.dataset.insert_conflict.insert(id: "c3b200ed-ce22-c33a-0326-06d735551d9f"
 # We always insert this strand using the same UBID ("stcheckzvsagezalertszzzzza")
 Strand.dataset.insert_conflict.insert(id: "645cc9ff-7954-1f3a-fa82-ec6b3ffffff5", prog: "CheckUsageAlerts", label: "wait")
 
+# We always insert this strand using the same UBID ("stexp1repr0ject1nv1tat10na")
+Strand.dataset.insert_conflict.insert(id: "776c1c3a-d804-9f3a-6683-5d874ad04155", prog: "ExpireProjectInvitations", label: "wait")
 clover_freeze
 
 loop do

--- a/clover_web.rb
+++ b/clover_web.rb
@@ -156,7 +156,12 @@ class CloverWeb < Roda
       Validation.validate_account_name(account[:name])
     end
     after_create_account do
-      Account[account_id].create_project_with_default_policy("Default")
+      account = Account[account_id]
+      account.create_project_with_default_policy("Default")
+      ProjectInvitation.where(email: account.email).each do |inv|
+        account.associate_with_project(inv.project)
+        inv.destroy
+      end
     end
 
     reset_password_view { view "auth/reset_password", "Request Password" }

--- a/migrate/20240827_add_project_invitation.rb
+++ b/migrate/20240827_add_project_invitation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:project_invitation) do
+      column :project_id, :uuid, null: false
+      column :email, :text, collate: '"C"', null: false
+      column :inviter_id, :uuid, null: false
+      column :expires_at, :timestamp, null: false
+      primary_key [:project_id, :email]
+    end
+  end
+end

--- a/model/project.rb
+++ b/model/project.rb
@@ -19,6 +19,7 @@ class Project < Sequel::Model
 
   one_to_many :invoices, order: Sequel.desc(:created_at)
   one_to_many :quotas, class: ProjectQuota, key: :project_id
+  one_to_many :invitations, class: ProjectInvitation, key: :project_id
 
   dataset_module Authorization::Dataset
   dataset_module Pagination

--- a/model/project_invitation.rb
+++ b/model/project_invitation.rb
@@ -1,0 +1,9 @@
+#  frozen_string_literal: true
+
+require_relative "../model"
+
+class ProjectInvitation < Sequel::Model
+  many_to_one :project
+end
+
+ProjectInvitation.unrestrict_primary_key

--- a/prog/expire_project_invitations.rb
+++ b/prog/expire_project_invitations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Prog::ExpireProjectInvitations < Prog::Base
+  label def wait
+    ProjectInvitation.where { _1.expires_at < Time.now }.all.each(&:destroy)
+
+    nap 6 * 60 * 60
+  end
+end

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -19,6 +19,9 @@ class CloverWeb
       elsif ProjectInvitation[project_id: @project.id, email: email]
         flash["error"] = "'#{email}' already invited to join the project."
         r.redirect "#{@project.path}/user"
+      elsif @project.invitations_dataset.count >= 50
+        flash["error"] = "You can't have more than 50 pending invitations."
+        r.redirect "#{@project.path}/user"
       else
         @project.add_invitation(email: email, inviter_id: @current_user.id, expires_at: Time.now + 7 * 24 * 60 * 60)
       end

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -6,6 +6,7 @@ class CloverWeb
 
     r.get true do
       @users = Serializers::Account.serialize(@project.accounts)
+      @invitations = Serializers::ProjectInvitation.serialize(@project.invitations)
 
       view "project/user"
     end

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -36,6 +36,16 @@ class CloverWeb
       r.redirect "#{@project.path}/user"
     end
 
+    r.on "invitation" do
+      r.is String do |email|
+        r.delete true do
+          @project.invitations_dataset.where(email: email).destroy
+          flash["notice"] = "Invitation for '#{email}' is removed successfully."
+          r.halt
+        end
+      end
+    end
+
     r.is String do |user_ubid|
       user = Account.from_ubid(user_ubid)
 

--- a/serializers/project_invitation.rb
+++ b/serializers/project_invitation.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Serializers::ProjectInvitation < Serializers::Base
+  def self.serialize_internal(pi, options = {})
+    {
+      email: pi.email,
+      expires_at: pi.expires_at.strftime("%B %d, %Y")
+    }
+  end
+end

--- a/spec/prog/expire_project_invitations_spec.rb
+++ b/spec/prog/expire_project_invitations_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::ExpireProjectInvitations do
+  subject(:epi) { described_class.new(Strand.new(prog: "ExpireProjectInvitations")) }
+
+  describe "#wait" do
+    it "expires project invitations that pass the expiration date" do
+      ProjectInvitation.create(expires_at: Time.now - 10, email: "test1@example.com", project_id: "8d8dc04b-c718-86d2-b75c-634d8091e448", inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf")
+      not_expired = ProjectInvitation.create(expires_at: Time.now + 10, email: "test2@example.com", project_id: "8d8dc04b-c718-86d2-b75c-634d8091e448", inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf")
+
+      expect { epi.wait }.to nap(6 * 60 * 60)
+      expect(ProjectInvitation.all).to contain_exactly(not_expired)
+    end
+  end
+end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -42,7 +42,10 @@ RSpec.describe Clover, "auth" do
     expect(page).to have_content("Name must only contain letters, numbers, spaces, and hyphens and have max length 63.")
   end
 
-  it "can create new account and verify it" do
+  it "can create new account, verify it, and visit project which invited" do
+    p = Project.create_with_id(name: "Invited project").tap { _1.associate_with_project(_1) }
+    p.add_invitation(email: TEST_USER_EMAIL, inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)
+
     visit "/create-account"
     fill_in "Full Name", with: "John Doe"
     fill_in "Email Address", with: TEST_USER_EMAIL
@@ -59,6 +62,9 @@ RSpec.describe Clover, "auth" do
 
     click_button "Verify Account"
     expect(page.title).to eq("Ubicloud - #{Account[email: TEST_USER_EMAIL].projects.first.name} Dashboard")
+
+    visit "#{p.path}/dashboard"
+    expect(page.title).to eq("Ubicloud - #{p.name} Dashboard")
   end
 
   it "can remember login" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -235,6 +235,22 @@ RSpec.describe Clover, "project" do
         expect(page).to have_no_content user2.email
       end
 
+      it "can remove invited user from project" do
+        invited_email = "invited@example.com"
+        project.add_invitation(email: invited_email, inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)
+
+        visit "#{project.path}/user"
+        expect(page).to have_content invited_email
+
+        # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
+        # UI tests run without a JavaScript enginer.
+        btn = find "#invitation-#{invited_email.gsub(/\W+/, "")} .delete-btn"
+        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+        visit "#{project.path}/user"
+        expect { find "#invitation-#{invited_email.gsub(/\W+/, "")} .delete-btn" }.to raise_error Capybara::ElementNotFound
+      end
+
       it "raises bad request when it's the last user" do
         user
         visit "#{project.path}/user"

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -251,6 +251,19 @@ RSpec.describe Clover, "project" do
         expect { find "#invitation-#{invited_email.gsub(/\W+/, "")} .delete-btn" }.to raise_error Capybara::ElementNotFound
       end
 
+      it "can not have more than 50 pending invitations" do
+        visit "#{project.path}/user"
+
+        expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
+        expect(project).to receive(:invitations_dataset).and_return(instance_double(Sequel::Dataset, count: 50))
+
+        fill_in "Email", with: "new@example.com"
+        click_button "Invite"
+
+        expect(page).to have_no_content "new@example.com"
+        expect(page).to have_content "You can't have more than 50 pending invitations"
+      end
+
       it "raises bad request when it's the last user" do
         user
         visit "#{project.path}/user"

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Clover, "project" do
         expect(page).to have_content "Forbidden"
       end
 
-      it "can invite new user to project" do
+      it "can invite existing user to project" do
         visit "#{project.path}/user"
 
         expect(page).to have_content user.email
@@ -195,17 +195,24 @@ RSpec.describe Clover, "project" do
         expect(Mail::TestMailer.deliveries.length).to eq 1
       end
 
-      it "can invite new existing email to project and nothing happens" do
+      it "can invite non-existent user to project" do
         visit "#{project.path}/user"
-
+        new_email = "new@example.com"
         expect(page).to have_content user.email
 
-        fill_in "Email", with: "new@example.com"
+        fill_in "Email", with: new_email
         click_button "Invite"
 
         expect(page).to have_content user.email
-        expect(page).to have_content "Invitation sent successfully to 'new@example.com'."
+        expect(page).to have_content new_email
+        expect(page).to have_content "Invitation sent successfully to '#{new_email}'."
         expect(Mail::TestMailer.deliveries.length).to eq 1
+        expect(ProjectInvitation.where(email: new_email).count).to eq 1
+
+        fill_in "Email", with: new_email
+        click_button "Invite"
+
+        expect(page).to have_content "'#{new_email}' already invited to join the project."
       end
 
       it "can remove user from project" do

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -82,6 +82,21 @@
             </td>
           </tr>
         <% end %>
+        <% @invitations.each do |invitation| %>
+          <tr id="invitation-<%= invitation[:email] %>" class="whitespace-nowrap text-sm font-medium">
+            <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row">
+              <%= invitation[:email] %>
+              <span
+                class="inline-flex items-baseline rounded-full ml-1 px-2 text-xs font-semibold leading-5 bg-yellow-100 text-yellow-800"
+              >
+                Invitation expires on
+                <%= invitation[:expires_at] %>
+              </span>
+            </td>
+            <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
+            </td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -83,7 +83,7 @@
           </tr>
         <% end %>
         <% @invitations.each do |invitation| %>
-          <tr id="invitation-<%= invitation[:email] %>" class="whitespace-nowrap text-sm font-medium">
+          <tr id="invitation-<%= invitation[:email].gsub(/\W+/, "") %>" class="whitespace-nowrap text-sm font-medium">
             <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row">
               <%= invitation[:email] %>
               <span
@@ -94,6 +94,15 @@
               </span>
             </td>
             <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
+              <%== render(
+                "components/delete_button",
+                locals: {
+                  text: "Remove",
+                  url: "#{@project_data[:path]}/user/invitation/#{invitation[:email]}",
+                  confirmation: invitation[:email],
+                  redirect: "#{@project_data[:path]}/user"
+                }
+              ) %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
### Add migration to create ProjectInvitation table

### Persist project invitation if account doesn't exists

When a user is invited to a project, we associate them to it if they
already have an account. If they don't, we send an invitation email.
However, this approach often leads to a poor user experience, as the
admin must resend the invitation once the user creates an account. To
address this, I've implemented a fix that persists the invitation and
automatically associates the user to the project upon account creation.

I considered creating a temporary account in the existing accounts table
with a different status ID, but this would require extensive Rodauth
overrides. Therefore, I chose not to include non-existing users in the
accounts table, which serves as the backbone of our authentication
system.

Another alternative could involve not automatically associating the user
to the project upon account creation. Instead, users could explicitly
accept the invitation post-account creation. However, I found no
compelling reason to avoid automatic project-user association.

### Show invited users on the project user list

### Allow to remove user invitations
The admin might want to revoke the invitation if the user has not
created an account yet. This feature allows the admin to remove the
invitation.

### Expire project invitation after 7 days

Long-lasting project invitation links pose a security risk because email
address ownership can change over time. I've noticed other providers
expire these links after 7 days, which I believe is a good practice.
Therefore, I've implemented the same feature. This prog now expires
project invitation links every 7 days, with checks occurring every 6
hours.

### Add 50 pending invitations limit

Users can send invitations to any email address, which could potentially
allow a malicious actor to send a mass of invitations. To prevent this,
I added a limit of 50 pending invitations. This limit does not include
email addresses already registered in our system.


--------

_The last one is the user who was invited but doesn't have an account_

<img width="2560" alt="Screenshot 2024-08-29 at 10 05 25" src="https://github.com/user-attachments/assets/8289da48-80e9-446f-a9be-75d425cc5f03">
