### PR TITLE
Add the implicit_subquery extension

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -28,5 +28,5 @@ end
 
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic
-DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range, :pg_array
+DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range, :pg_array, :implicit_subquery
 Sequel.extension :pg_range_ops

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -120,7 +120,7 @@ SQL
     rescue Prog::Base::Nap => e
       save_changes
 
-      scheduled = DB[<<SQL, e.seconds, id].get
+      scheduled = DB[<<SQL, e.seconds, id].single_value
 UPDATE strand
 SET try = 0, schedule = now() + (? * '1 second'::interval)
 WHERE id = ?


### PR DESCRIPTION
Sometime around 787be9b1cee393cd152e7135b8b035af98a5daf4, we ran into an interesting behavior in Sequel, where raw-SQL datasets ignore methods chained onto them.  Cosider the following two expressions:

    DB["select * from pg_class"].where { oid > 7 }.sql
    => "select * from pg_class"

    DB[:pg_class].where { oid > 7 }.sql
    => "SELECT * FROM "pg_class" WHERE ("oid" > $1::int4); [7]"

At the time, we worked around this with a small tweak to the code. But, it always bothered me that the ignoring of `where` clauses could have a disastrous effect in a multi-tenant application.

Some months later, I wrote in to express my concern about this: https://github.com/jeremyevans/sequel/discussions/2208.  I basically became convinced to enable the `implicit_subquery` plugin anyway.

The change to `strand.rb` here was not expected.  It's either a bug (`.get` perhaps should not wrap, much as `.first` does not) or an unfortunate interaction with raw SQL.  I will report it.