### PR TITLE
Load balancer bug fixes

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -437,7 +437,7 @@ class Prog::Vm::Nexus < Prog::Base
       nap 30
     end
 
-    vm.load_balancer.remove_vm(vm)
+    vm.load_balancer.remove_vm(vm) if vm.load_balancer
 
     vm.vm_host.sshable.cmd("sudo host/bin/setup-vm delete_net #{q_vm}")
 

--- a/prog/vnet/load_balancer_health_probes.rb
+++ b/prog/vnet/load_balancer_health_probes.rb
@@ -12,7 +12,7 @@ class Prog::Vnet::LoadBalancerHealthProbes < Prog::Base
       cmd = if load_balancer.health_check_protocol == "tcp"
         "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{vm.nics.first.private_ipv4.network} #{load_balancer.dst_port} && echo 200 || echo 400"
       else
-        "sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{vm.nics.first.private_ipv4.network}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
+        "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer.dst_port}:#{vm.nics.first.private_ipv4.network} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{load_balancer.hostname}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
       end
 
       vm.vm_host.sshable.cmd(cmd)
@@ -21,7 +21,7 @@ class Prog::Vnet::LoadBalancerHealthProbes < Prog::Base
     end
 
     vm_state, vm_state_counter = load_balancer.load_balancers_vms_dataset.where(vm_id: vm.id).get([:state, :state_counter])
-    threshold, health_check = (response_code == "200") ?
+    threshold, health_check = (response_code.to_i == 200) ?
       [load_balancer.health_check_up_threshold, "up"] :
       [load_balancer.health_check_down_threshold, "down"]
     counter = (vm_state == health_check) ? vm_state_counter + 1 : 1

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -138,6 +138,12 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     rescue CommandFail => ex
       raise unless /Cannot remove namespace file ".*": No such file or directory/.match?(ex.stderr)
     end
+
+    begin
+      r "deluser --remove-home #{q_vm}"
+    rescue CommandFail => ex
+      raise unless /The user `.*' does not exist./.match?(ex.stderr)
+    end
   end
 
   def purge_without_network
@@ -147,12 +153,6 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     purge_storage
     unmount_hugepages
-
-    begin
-      r "deluser --remove-home #{q_vm}"
-    rescue CommandFail => ex
-      raise unless /The user `.*' does not exist./.match?(ex.stderr)
-    end
   end
 
   def purge_storage

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -768,7 +768,15 @@ RSpec.describe Prog::Vm::Nexus do
       it "destroys properly after 10 minutes" do
         lb = instance_double(LoadBalancer)
         expect(lb).to receive(:remove_vm).with(vm)
-        expect(vm).to receive(:load_balancer).and_return(lb)
+        expect(vm).to receive(:load_balancer).and_return(lb).at_least(:once)
+        expect(vm).to receive(:lb_expiry_started_set?).and_return(true)
+        expect(vm.vm_host.sshable).to receive(:cmd).with(/sudo.*bin\/setup-vm delete_net #{nx.vm_name}/)
+        expect(vm).to receive(:destroy)
+        expect { nx.wait_lb_expiry }.to exit({"msg" => "vm deleted"})
+      end
+
+      it "destroys properly after 10 minutes if the lb is gone" do
+        expect(vm).to receive(:load_balancer).and_return(nil)
         expect(vm).to receive(:lb_expiry_started_set?).and_return(true)
         expect(vm.vm_host.sshable).to receive(:cmd).with(/sudo.*bin\/setup-vm delete_net #{nx.vm_name}/)
         expect(vm).to receive(:destroy)

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
     end
 
     it "naps for 5 seconds and doesn't perform update if health check succeeds" do
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("200")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -47,7 +47,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and doesn't perform update if health check fails the first time" do
       lb.load_balancers_vms_dataset.update(state_counter: 1)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("500")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("500")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -55,7 +55,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and performs update if health check fails the first time via an exception" do
       lb.load_balancers_vms_dataset.update(state_counter: 1)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_raise("error")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_raise("error")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -63,7 +63,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "starts update if health check succeeds and we hit the threshold" do
       lb.load_balancers_vms_dataset.update(state_counter: 2)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("200")
       expect(lb).to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -71,7 +71,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and doesn't perform update if health check succeeds and we're already above threshold" do
       lb.load_balancers_vms_dataset.update(state_counter: 3)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("200")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)


### PR DESCRIPTION
## Update health probes to use the hostname and check return type
We are updating the health probes to use the hostname to perform the
health checks. This is important for HTTPS health checks because it is
possible the customers will only accept that virtual hosting endpoint,
instead of raw IP.

Since we are in the network namespace and do not need to perform
a lookup, we resolve the hostname automatically by using the --resolve
option of curl.

We also make a small fix here to transform response_code to an integer
and perform the check. This is necessary in case the response_code has
spaces or \n characters at the start or end of the response code.

## Fix VM removal when its attached to a load balancer
We need to remove the vm user only after the cert server is removed
because it is used by cert server and deluser command fails otherwise.

The other case is that, we might start deleting VM and then the load
balancer is deleted before VM deletion completes. In that case, we
should perform a check at the last state to verify the load balancer is
still intact before removing VM from the load balancer.