### PR TITLE
Allow to pin the runners of a project to specific location

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -131,5 +131,5 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image, :vm_public_ssh_keys
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :runner_preferred_location
 end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -31,11 +31,12 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   def pick_vm
+    location = project.get_ff_runner_preferred_location || label_data["location"]
     skip_sync = true
     pool = VmPool.where(
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
-      location: label_data["location"],
+      location: location,
       storage_size_gib: label_data["storage_size_gib"],
       storage_encrypted: true,
       storage_skip_sync: skip_sync,
@@ -51,7 +52,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       Config.github_runner_service_project_id,
       name: github_runner.ubid.to_s,
       size: label_data["vm_size"],
-      location: label_data["location"],
+      location: location,
       boot_image: label_data["boot_image"],
       storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true, skip_sync: skip_sync}],
       enable_ip4: true,


### PR DESCRIPTION
We use all locations for GitHub runners to increase our overall utilization. However, some customers experience job failures in certain locations and need to be pin them to a specific one. While we don't have a blanket policy to assign all customers to a specific location, we have decided to accommodate this if a customer has a specific requirement.