### PR TITLE
Configure OpenSSH settings according to Mozilla guidelines

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -99,3 +99,23 @@ CRON
 
 r "systemctl enable cron"
 r "systemctl start cron"
+
+# Taken from https://infosec.mozilla.org/guidelines/openssh
+safe_write_to_file("/etc/ssh/ssh_config.d/10-clover.conf", <<~SSHD_CONFIG)
+# Supported HostKey algorithms by order of preference.
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+
+KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+
+# Password based logins are disabled - only public key based logins are allowed.
+AuthenticationMethods publickey
+
+# LogLevel VERBOSE logs user's key fingerprint on login. Needed to have a clear audit track of which key was using to log in.
+LogLevel VERBOSE
+SSHD_CONFIG


### PR DESCRIPTION
Mozilla has a set of guidelines for secure SSH configuration, which can be found at https://infosec.mozilla.org/guidelines/openssh.

This commit creates a config file for OpenSSH that is based on the Mozilla's guidelines for secure SSH configuration. This configuration;
- Sets the preference order of HostKey algorithms
- Sets the allowed KexAlgorithms, Ciphers and MAC algorithms
- Disables the use of password authentication
- Increases logging level to VERBOSE

Final one also ensures that we are logging which SSH key is used to login to the server. This is useful for auditing purposes and SOC2.

Mozilla also recommends disabling root login, but this is not done in this commit, because implementing that requires a bit more work and some change in how we set the hosts up. I wanted to push this commit out quickly.