### PR TITLE
Fix CertServer waiting for the cert

### DIFF
--- a/prog/vnet/cert_server.rb
+++ b/prog/vnet/cert_server.rb
@@ -30,7 +30,7 @@ class Prog::Vnet::CertServer < Prog::Base
   end
 
   label def put_certificate
-    nap 5 unless load_balancer.active_cert
+    nap 5 unless load_balancer.active_cert&.cert
 
     put_cert_to_vm
     hop_start_certificate_server


### PR DESCRIPTION
We were checking active_cert entity while putting the certificate server to the VM. However, it's possible the active_cert entity is created but the cert field is not just populated, yet. We start checking the cert field and wait until it is there.