### PR TITLE
Keep $5 pre-authorized money instead of giving it back directly

### DIFF
--- a/migrate/20240913_add_preauth_amount_column.rb
+++ b/migrate/20240913_add_preauth_amount_column.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:payment_method) do
+      add_column :preauth_amount, Integer, null: true
+    end
+  end
+end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -140,7 +140,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # :nocov:
     if github_runner.installation.project.effective_quota_value("GithubRunnerCores") == 0
       Clog.emit("No quota available for this project") { [github_runner] }
-      hop_destroy
+      nap 2592000
     end
     # :nocov:
 

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -137,6 +137,13 @@ class Prog::Vm::GithubRunner < Prog::Base
       sum(:used_cores) * 100.0 / sum(:total_cores)
     }.first.to_f
 
+    # :nocov:
+    if github_runner.installation.project.effective_quota_value("GithubRunnerCores") == 0
+      Clog.emit("No quota available for this project") { [github_runner] }
+      hop_destroy
+    end
+    # :nocov:
+
     unless utilization < 70
       Clog.emit("Waiting for customer concurrency limit, utilization is high") { [github_runner, {utilization: utilization}] }
       nap rand(5..15)

--- a/routes/web/github.rb
+++ b/routes/web/github.rb
@@ -25,6 +25,11 @@ class CloverWeb
         r.redirect "/dashboard"
       end
 
+      if (project.accounts.any?{_1.suspended_at != nil})
+        flash["error"] = "GitHub runner integration is not allowed for suspended accounts."
+        r.redirect "/dashboard"
+      end
+
       Authorization.authorize(@current_user.id, "Project:github", project.id)
 
       GithubInstallation.create_with_id(

--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -74,14 +74,11 @@ class CloverWeb
       begin
         customer_stripe_id = setup_intent["customer"]
 
-        # Pre-authorizing random amount to verify card. As it is
-        # commonly done with other companies, apparently it is
-        # better to detect fraud then pre-authorizing fixed amount.
+        # Pre-authorizing $5 to verify card.
         # That money will be kept until next billing period and if
         # it's not a fraud, it will be applied to the invoice.
-        preauth_amount = [100, 200, 300, 400, 500].sample
         payment_intent = Stripe::PaymentIntent.create({
-          amount: preauth_amount,
+          amount: 500,
           currency: "usd",
           confirm: true,
           off_session: true,
@@ -106,7 +103,7 @@ class CloverWeb
           @project.update(billing_info_id: billing_info.id)
         end
 
-        PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: stripe_id, card_fingerprint: card_fingerprint, preauth_amount: preauth_amount)
+        PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: stripe_id, card_fingerprint: card_fingerprint, preauth_amount: 500)
       end
 
       r.redirect @project.path + "/billing"

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -294,6 +294,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
       installation = instance_double(GithubInstallation)
       project = instance_double(Project, quota_available?: false, github_installations: [installation])
+      expect(project).to receive(:effective_quota_value).with("GithubRunnerCores").and_return(1).at_least(:once)
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
@@ -320,6 +321,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
       installation = instance_double(GithubInstallation)
       project = instance_double(Project, quota_available?: false, github_installations: [installation])
+      expect(project).to receive(:effective_quota_value).with("GithubRunnerCores").and_return(1).at_least(:once)
 
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)


### PR DESCRIPTION
We were preauthorizing $1 to $5 dollars and giving back to customer directly. Changing that to keep that amount chargeable. This commit only changes the logic to keep that money for card's default preauthorization time (by default 7 days). Subsequent PRs will add the logic to keep that amount till the next billing period or the time we detect that the user is fraud.