### PR TITLE
Revert "Revert "Load balancer bug fixes""

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -437,7 +437,7 @@ class Prog::Vm::Nexus < Prog::Base
       nap 30
     end
 
-    vm.load_balancer.remove_vm(vm)
+    vm.load_balancer.remove_vm(vm) if vm.load_balancer
 
     vm.vm_host.sshable.cmd("sudo host/bin/setup-vm delete_net #{q_vm}")
 

--- a/prog/vnet/load_balancer_health_probes.rb
+++ b/prog/vnet/load_balancer_health_probes.rb
@@ -12,7 +12,7 @@ class Prog::Vnet::LoadBalancerHealthProbes < Prog::Base
       cmd = if load_balancer.health_check_protocol == "tcp"
         "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{vm.nics.first.private_ipv4.network} #{load_balancer.dst_port} && echo 200 || echo 400"
       else
-        "sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{vm.nics.first.private_ipv4.network}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
+        "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer.dst_port}:#{vm.nics.first.private_ipv4.network} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{load_balancer.hostname}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
       end
 
       vm.vm_host.sshable.cmd(cmd)
@@ -21,7 +21,7 @@ class Prog::Vnet::LoadBalancerHealthProbes < Prog::Base
     end
 
     vm_state, vm_state_counter = load_balancer.load_balancers_vms_dataset.where(vm_id: vm.id).get([:state, :state_counter])
-    threshold, health_check = (response_code == "200") ?
+    threshold, health_check = (response_code.to_i == 200) ?
       [load_balancer.health_check_up_threshold, "up"] :
       [load_balancer.health_check_down_threshold, "down"]
     counter = (vm_state == health_check) ? vm_state_counter + 1 : 1

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -28,6 +28,7 @@ end
 
 if action == "delete_net"
   vm_setup.purge_network
+  vm_setup.purge_user
   exit 0
 end
 

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -128,6 +128,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   def purge
     purge_network
     purge_without_network
+    purge_user
   end
 
   def purge_network
@@ -147,12 +148,12 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     purge_storage
     unmount_hugepages
+  end
 
-    begin
-      r "deluser --remove-home #{q_vm}"
-    rescue CommandFail => ex
-      raise unless /The user `.*' does not exist./.match?(ex.stderr)
-    end
+  def purge_user
+    r "deluser --remove-home #{q_vm}"
+  rescue CommandFail => ex
+    raise unless /The user `.*' does not exist./.match?(ex.stderr)
   end
 
   def purge_storage

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -768,7 +768,15 @@ RSpec.describe Prog::Vm::Nexus do
       it "destroys properly after 10 minutes" do
         lb = instance_double(LoadBalancer)
         expect(lb).to receive(:remove_vm).with(vm)
-        expect(vm).to receive(:load_balancer).and_return(lb)
+        expect(vm).to receive(:load_balancer).and_return(lb).at_least(:once)
+        expect(vm).to receive(:lb_expiry_started_set?).and_return(true)
+        expect(vm.vm_host.sshable).to receive(:cmd).with(/sudo.*bin\/setup-vm delete_net #{nx.vm_name}/)
+        expect(vm).to receive(:destroy)
+        expect { nx.wait_lb_expiry }.to exit({"msg" => "vm deleted"})
+      end
+
+      it "destroys properly after 10 minutes if the lb is gone" do
+        expect(vm).to receive(:load_balancer).and_return(nil)
         expect(vm).to receive(:lb_expiry_started_set?).and_return(true)
         expect(vm.vm_host.sshable).to receive(:cmd).with(/sudo.*bin\/setup-vm delete_net #{nx.vm_name}/)
         expect(vm).to receive(:destroy)

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
     end
 
     it "naps for 5 seconds and doesn't perform update if health check succeeds" do
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("200")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -47,7 +47,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and doesn't perform update if health check fails the first time" do
       lb.load_balancers_vms_dataset.update(state_counter: 1)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("500")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("500")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -55,7 +55,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and performs update if health check fails the first time via an exception" do
       lb.load_balancers_vms_dataset.update(state_counter: 1)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_raise("error")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_raise("error")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -63,7 +63,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "starts update if health check succeeds and we hit the threshold" do
       lb.load_balancers_vms_dataset.update(state_counter: 2)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("200")
       expect(lb).to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)
@@ -71,7 +71,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
 
     it "naps for 5 seconds and doesn't perform update if health check succeeds and we're already above threshold" do
       lb.load_balancers_vms_dataset.update(state_counter: 3)
-      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://192.168.1.0:80/up").and_return("200")
+      expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.0 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up").and_return("200")
       expect(lb).not_to receive(:incr_update_load_balancer)
 
       expect { nx.health_probe }.to nap(30)


### PR DESCRIPTION
## Revert "Revert "Update health probes to use the hostname and check return type""
This reverts commit 3bf4312908631f68a19fa180a7d25d33fc6f1747.

## Fix "Fix VM removal when its attached to a load balancer""
This fixes commit bb3a0ec68544207e2d178bd85b79fc6b5d940b7e.

In the very first commit 4a00e905, we have introduced a change that
would remove the user home directory before the hugepages and spdk are
cleaned up. Because of active processes, that operation would not
complete and we had the stale vm directories backed up in the hosts.

We then reverted that commit. However, that meant the VM destroy
operation for a load balancer related VM was again, broken. Because,
during VM destroy that is part of a load balancer, we want to remove all
the resources but keep the network namespace and the VM user active so
that we can gracefully remove the node from the load balancer. However,
for regular VM removals, we were first calling remove networking + the
rest of the resources, AND the networking removal was trying to remove
the vm home directory. Since we had the SPDK resources and hugepages
setup, they would not be removed.

In this commit, we move the user removal to its own method, make sure it
is called as the last item for;
1. Regular VM removals from rhizome/host/bin/setup-vm.delete
(vm_setup.purge)
2. LB VM removal from rhizome/host/bin/setup-vm.delete_net
(vm_setup.purge_user)