### PR TITLE
Keep pre-authorized money chargeable

### DIFF
--- a/migrate/20240913_add_preauth_columns.rb
+++ b/migrate/20240913_add_preauth_columns.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:payment_method) do
+      add_column :preauth_amount, Integer, null: true
+      add_column :preauth_intent_id, :text, collate: '"C"', null: true, unique: true
+    end
+  end
+end

--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -77,8 +77,11 @@ class CloverWeb
         # Pre-authorizing random amount to verify card. As it is
         # commonly done with other companies, apparently it is
         # better to detect fraud then pre-authorizing fixed amount.
+        # That money will be kept until next billing period and if
+        # it's not a fraud, it will be applied to the invoice.
+        preauth_amount = [100, 200, 300, 400, 500].sample
         payment_intent = Stripe::PaymentIntent.create({
-          amount: [100, 200, 300, 400, 500].sample, # 100 cents to charge $1.00
+          amount: preauth_amount,
           currency: "usd",
           confirm: true,
           off_session: true,
@@ -90,8 +93,6 @@ class CloverWeb
         if payment_intent.status != "requires_capture"
           raise "Authorization failed"
         end
-
-        Stripe::PaymentIntent.cancel(payment_intent.id)
       rescue
         # Log and redirect if Stripe card error or our manual raise
         Clog.emit("Couldn't pre-authorize card") { {card_authorization: {project_id: @project.id, customer_stripe_id: customer_stripe_id}} }
@@ -105,7 +106,7 @@ class CloverWeb
           @project.update(billing_info_id: billing_info.id)
         end
 
-        PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: stripe_id, card_fingerprint: card_fingerprint)
+        PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: stripe_id, card_fingerprint: card_fingerprint, preauth_intent_id: payment_intent.id, preauth_amount: preauth_amount)
       end
 
       r.redirect @project.path + "/billing"

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe Clover, "billing" do
       expect(Stripe::SetupIntent).to receive(:retrieve).with("st_123456790").and_return({"customer" => "cs_1234567890", "payment_method" => "pm_1234567890"})
       expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}, "metadata" => {"company_name" => "Foo Companye Name"}})
       expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return({"card" => {"brand" => "visa"}}).twice
-      expect(Stripe::PaymentIntent).to receive(:cancel).with("pi_1234567890").once
 
       visit project.path
 
@@ -135,7 +134,6 @@ RSpec.describe Clover, "billing" do
       # rubocop:enable RSpec/VerifiedDoubles
       expect(Stripe::Checkout::Session).to receive(:retrieve).with("session_123").and_return({"setup_intent" => "st_123456790"})
       expect(Stripe::SetupIntent).to receive(:retrieve).with("st_123456790").and_return({"payment_method" => "pm_222222222"})
-      expect(Stripe::PaymentIntent).to receive(:cancel).with("pi_1234567890").once
 
       visit "#{project.path}/billing"
 


### PR DESCRIPTION
We were pre-authorizing $1 to $5 dollars and giving back to customer directly. Changing that to keep that amount chargeable. This PR only changes the logic to keep that money for card's default pre-authorization time (by default 7 days). Subsequent PRs will add the logic to keep that amount till the next billing period or the time we detect that the user is fraud.