### PR TITLE
Fix Almalinux nftables usage

### DIFF
--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -50,6 +50,7 @@ begin
   storage_volumes = params.fetch("storage_volumes")
   swap_size_bytes = params["swap_size_bytes"]
   pci_devices = params.fetch("pci_devices", [])
+  boot_image = params["boot_image"]
 rescue KeyError => e
   puts "Needed #{e.key} in parameters json"
   exit 1
@@ -65,7 +66,8 @@ when "prep"
 
   vm_setup.prep(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
-    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
+    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes,
+    pci_devices, boot_image)
 when "recreate-unpersisted"
   secrets = JSON.parse($stdin.read)
   unless (storage_secrets = secrets["storage"])
@@ -90,7 +92,7 @@ when "reassign-ip6"
   end
   vm_setup.reassign_ip6(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
-    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices)
+    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices, boot_image)
 else
   puts "Invalid action #{action}"
   exit 1

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -43,8 +43,8 @@ class VmSetup
     @vp ||= VmPath.new(@vm_name)
   end
 
-  def prep(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
-    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes)
+  def prep(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices, boot_image)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image)
     network_thread = Thread.new do
       setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
     end
@@ -65,8 +65,8 @@ class VmSetup
     start_systemd_unit
   end
 
-  def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices)
-    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes)
+  def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology, mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices, boot_image)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, multiqueue: max_vcpus > 1)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
@@ -404,7 +404,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "ip netns exec #{q_vm} bash -c 'nft -f #{vp.q_nftables_conf}'"
   end
 
-  def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes)
+  def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image)
     vp.write_meta_data(<<EOS)
 instance-id: #{yq(@vm_name)}
 local-hostname: #{yq(@vm_name)}
@@ -451,7 +451,7 @@ ethernets:
 #{ethernets}
 EOS
 
-    write_user_data(unix_user, public_keys, swap_size_bytes)
+    write_user_data(unix_user, public_keys, swap_size_bytes, boot_image)
 
     FileUtils.rm_rf(vp.cloudinit_img)
     r "mkdosfs -n CIDATA -C #{vp.q_cloudinit_img} 8192"
@@ -472,7 +472,20 @@ EOS
     SWAP_CONFIG
   end
 
-  def write_user_data(unix_user, public_keys, swap_size_bytes)
+  def write_user_data(unix_user, public_keys, swap_size_bytes, boot_image)
+    install_cmd = if boot_image.include?("almalinux")
+      "  - [dnf, install, '-y', nftables]\n"
+    else
+      ""
+    end
+    nft_safe_sudo_allow = <<NFT_ADD_COMMS
+  - [nft, add, table, ip6, filter]
+  - [nft, add, chain, ip6, filter, output, "{", type, filter, hook, output, priority, 0, ";", "}"]
+  - [nft, add, rule, ip6, filter, output, ip6, daddr, 'fd00:0b1c:100d:5AFE::/56', meta, skuid, "!=", 0, tcp, flags, syn, reject, with, tcp, reset]
+NFT_ADD_COMMS
+
+    nft_safe_sudo_allow_inst = install_cmd + nft_safe_sudo_allow
+
     vp.write_user_data(<<EOS)
 #cloud-config
 users:
@@ -485,12 +498,11 @@ users:
 ssh_pwauth: False
 
 runcmd:
-  - [ systemctl, daemon-reload]
+  - [systemctl, daemon-reload]
+#{nft_safe_sudo_allow_inst}
 
 bootcmd:
-  - [nft, add, table, ip6, filter]
-  - [nft, add, chain, ip6, filter, output, "{", type, filter, hook, output, priority, 0, ";", "}"]
-  - [nft, add, rule, ip6, filter, output, ip6, daddr, fd00:0b1c:100d:5AFE::/56, meta, skuid, "!=", 0, tcp, flags, syn, reject, with, tcp, reset]
+#{nft_safe_sudo_allow}
 
 #{generate_swap_config(swap_size_bytes)}
 EOS

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe VmSetup do
     before { expect(vs).to receive(:vp).and_return(vps).at_least(:once) }
 
     it "templates user YAML with no swap" do
-      vs.write_user_data("some_user", ["some_ssh_key"], nil)
+      vs.write_user_data("some_user", ["some_ssh_key"], nil, "")
       expect(vps).to have_received(:write_user_data) {
         expect(_1).to match(/some_user/)
         expect(_1).to match(/some_ssh_key/)
@@ -38,7 +38,7 @@ RSpec.describe VmSetup do
     end
 
     it "templates user YAML with swap" do
-      vs.write_user_data("some_user", ["some_ssh_key"], 123)
+      vs.write_user_data("some_user", ["some_ssh_key"], 123, "")
       expect(vps).to have_received(:write_user_data) {
         expect(_1).to match(/some_user/)
         expect(_1).to match(/some_ssh_key/)
@@ -48,7 +48,7 @@ RSpec.describe VmSetup do
 
     it "fails if the swap is not an integer" do
       expect {
-        vs.write_user_data("some_user", ["some_ssh_key"], "123")
+        vs.write_user_data("some_user", ["some_ssh_key"], "123", "")
       }.to raise_error RuntimeError, "BUG: swap_size_bytes must be an integer"
     end
   end


### PR DESCRIPTION
Commit 7303ec6240b8e62b5d2b25316ced5def4dff0057 made a change to how we boot VMs by adding new commands to the cloud-init. However, we realized that almalinux yaml files on cloud-init fail with ipv6 subnet. YAML files are sensitive to ":". Fixing that with escaping surfaced another issue. Almalinux doesn't come with nftables installed by default. Therefore, we are installing it at the time of provisioning.