### PR TITLE
Make project invitation emails case insensitive

### DIFF
--- a/migrate/20240918_make_invitation_email_citex.rb
+++ b/migrate/20240918_make_invitation_email_citex.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:project_invitation) do
+      set_column_type :email, :citext
+    end
+  end
+
+  down do
+    alter_table(:project_invitation) do
+      set_column_type :email, :text
+    end
+  end
+end

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Clover, "project" do
 
       it "can invite non-existent user to project" do
         visit "#{project.path}/user"
-        new_email = "new@example.com"
+        new_email = "newUpper@example.com"
         expect(page).to have_content user.email
 
         fill_in "Email", with: new_email
@@ -209,10 +209,10 @@ RSpec.describe Clover, "project" do
         expect(Mail::TestMailer.deliveries.length).to eq 1
         expect(ProjectInvitation.where(email: new_email).count).to eq 1
 
-        fill_in "Email", with: new_email
+        fill_in "Email", with: new_email.downcase
         click_button "Invite"
 
-        expect(page).to have_content "'#{new_email}' already invited to join the project."
+        expect(page).to have_content "'#{new_email.downcase}' already invited to join the project."
       end
 
       it "can remove user from project" do


### PR DESCRIPTION
When a user registers using an invitation email with different casing, the system fails to find the invitation because the email column is case-sensitive. I reviewed the rodauth code and found that it uses a `citext` column for emails to ensure case insensitivity [^1]. Given that we match `accounts.email` with `project_invitation.email`, we also need to make `project_invitations.email` case-insensitive.

[^1]: https://github.com/jeremyevans/rodauth/blob/24bc83ff54c66b0251e26facba63b8777f586eac/README.rdoc?plain=1#L317