### PR TITLE
Handle additional cases in GitHub installation callback

### DIFF
--- a/routes/web/github.rb
+++ b/routes/web/github.rb
@@ -5,14 +5,8 @@ class CloverWeb
     r.get "callback" do
       oauth_code = r.params["code"]
       installation_id = r.params["installation_id"]
-
+      setup_action = r.params["setup_action"]
       code_response = Github.oauth_client.exchange_code_for_token(oauth_code)
-
-      unless (access_token = code_response[:access_token]) &&
-          (installation_response = Octokit::Client.new(access_token: access_token).get("/user/installations")[:installations].find { _1[:id].to_s == installation_id })
-        flash["error"] = "GitHub App installation failed."
-        r.redirect "/dashboard"
-      end
 
       if (installation = GithubInstallation[installation_id: installation_id])
         Authorization.authorize(@current_user.id, "Project:github", installation.project.id)
@@ -21,16 +15,31 @@ class CloverWeb
       end
 
       unless (project = Project[session.delete("github_installation_project_id")])
-        flash["error"] = "Install GitHub App from project's 'GitHub Runners' page."
-        r.redirect "/dashboard"
-      end
-
-      if project.accounts.any? { !_1.suspended_at.nil? }
-        flash["error"] = "GitHub runner integration is not allowed for suspended accounts."
+        flash["error"] = "You should initiate the GitHub App installation request from the project's GitHub runner integration page."
         r.redirect "/dashboard"
       end
 
       Authorization.authorize(@current_user.id, "Project:github", project.id)
+
+      if setup_action == "request"
+        flash["notice"] = "The GitHub App installation request is awaiting approval from the GitHub organization's administrator. As GitHub will redirect your admin back to the Ubicloud console, the admin needs to have an Ubicloud account with the necessary permissions to finalize the installation. Please invite the admin to your project if they don't have an account yet."
+        r.redirect "#{project.path}/user"
+      end
+
+      unless (access_token = code_response[:access_token])
+        flash["error"] = "GitHub App installation failed. For any questions or assistance, reach out to our team at support@ubicloud.com"
+        r.redirect "#{project.path}/github"
+      end
+
+      unless (installation_response = Octokit::Client.new(access_token: access_token).get("/user/installations")[:installations].find { _1[:id].to_s == installation_id })
+        flash["error"] = "GitHub App installation failed. For any questions or assistance, reach out to our team at support@ubicloud.com"
+        r.redirect "#{project.path}/github"
+      end
+
+      if @current_user.suspended_at
+        flash["error"] = "GitHub runner integration is not allowed for suspended accounts."
+        r.redirect "#{project.path}/dashboard"
+      end
 
       GithubInstallation.create_with_id(
         installation_id: installation_id,

--- a/routes/web/github.rb
+++ b/routes/web/github.rb
@@ -11,11 +11,13 @@ class CloverWeb
       if (installation = GithubInstallation[installation_id: installation_id])
         Authorization.authorize(@current_user.id, "Project:github", installation.project.id)
         flash["notice"] = "GitHub runner integration is already enabled for #{installation.project.name} project."
+        Clog.emit("GitHub installation already exists") { {installation_failed: {id: installation_id, account_ubid: @current_user.ubid}} }
         r.redirect "#{installation.project.path}/github"
       end
 
       unless (project = Project[session.delete("github_installation_project_id")])
         flash["error"] = "You should initiate the GitHub App installation request from the project's GitHub runner integration page."
+        Clog.emit("GitHub callback failed due to lack of project in the session") { {installation_failed: {id: installation_id, account_ubid: @current_user.ubid}} }
         r.redirect "/dashboard"
       end
 
@@ -23,21 +25,25 @@ class CloverWeb
 
       if setup_action == "request"
         flash["notice"] = "The GitHub App installation request is awaiting approval from the GitHub organization's administrator. As GitHub will redirect your admin back to the Ubicloud console, the admin needs to have an Ubicloud account with the necessary permissions to finalize the installation. Please invite the admin to your project if they don't have an account yet."
+        Clog.emit("GitHub installation initiated by non-admin user") { {installation_failed: {id: installation_id, account_ubid: @current_user.ubid}} }
         r.redirect "#{project.path}/user"
       end
 
       unless (access_token = code_response[:access_token])
         flash["error"] = "GitHub App installation failed. For any questions or assistance, reach out to our team at support@ubicloud.com"
+        Clog.emit("GitHub callback failed due to lack of permission") { {installation_failed: {id: installation_id, account_ubid: @current_user.ubid}} }
         r.redirect "#{project.path}/github"
       end
 
       unless (installation_response = Octokit::Client.new(access_token: access_token).get("/user/installations")[:installations].find { _1[:id].to_s == installation_id })
         flash["error"] = "GitHub App installation failed. For any questions or assistance, reach out to our team at support@ubicloud.com"
+        Clog.emit("GitHub callback failed due to lack of installation") { {installation_failed: {id: installation_id, account_ubid: @current_user.ubid}} }
         r.redirect "#{project.path}/github"
       end
 
       if @current_user.suspended_at
         flash["error"] = "GitHub runner integration is not allowed for suspended accounts."
+        Clog.emit("GitHub callback failed due to suspended account") { {installation_failed: {id: installation_id, account_ubid: @current_user.ubid}} }
         r.redirect "#{project.path}/dashboard"
       end
 

--- a/spec/routes/web/github_spec.rb
+++ b/spec/routes/web/github_spec.rb
@@ -18,28 +18,8 @@ RSpec.describe Clover, "github" do
     allow(Octokit::Client).to receive(:new).and_return(adhoc_client)
   end
 
-  it "fails if oauth code is invalid" do
-    expect(oauth_client).to receive(:exchange_code_for_token).with("invalid").and_return({})
-
-    visit "/github/callback?code=invalid"
-
-    expect(page.title).to eq("Ubicloud - Dashboard")
-    expect(page).to have_content("GitHub App installation failed.")
-  end
-
-  it "fails if installation not found" do
-    expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
-    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: []})
-
-    visit "/github/callback?code=123123"
-
-    expect(page.title).to eq("Ubicloud - Dashboard")
-    expect(page).to have_content("GitHub App installation failed.")
-  end
-
   it "redirects to github page if already installed" do
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
-    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: installation.installation_id}]})
 
     visit "/github/callback?code=123123&installation_id=#{installation.installation_id}"
 
@@ -49,7 +29,6 @@ RSpec.describe Clover, "github" do
 
   it "raises forbidden when does not have permissions to access already enabled installation" do
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
-    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: installation.installation_id}]})
     project.access_policies.first.update(body: {})
 
     visit "/github/callback?code=123123&installation_id=#{installation.installation_id}"
@@ -61,29 +40,15 @@ RSpec.describe Clover, "github" do
 
   it "fails if project not found at session" do
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
-    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345}]})
 
     visit "/github/callback?code=123123&installation_id=345"
 
     expect(page.title).to eq("Ubicloud - Dashboard")
-    expect(page).to have_content("Install GitHub App from project's 'GitHub Runners' page.")
+    expect(page).to have_content("You should initiate the GitHub App installation request from the project's GitHub runner integration page.")
   end
 
-  it "fails if project has at least 1 account suspended" do
+  it "raises forbidden when does not have permissions to the project in session" do
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
-    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
-    expect(Project).to receive(:[]).and_return(project).at_least(:once)
-    account = instance_double(Account, suspended_at: Time.now)
-    expect(project).to receive(:accounts).and_return([account])
-
-    visit "/github/callback?code=123123&installation_id=345"
-    expect(page.title).to eq("Ubicloud - Dashboard")
-    expect(page).to have_content("GitHub runner integration is not allowed for suspended accounts.")
-  end
-
-  it "raises forbidden when does not have permissions to create installation for project" do
-    expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
-    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
     project.access_policies.first.update(body: {})
 
@@ -92,6 +57,49 @@ RSpec.describe Clover, "github" do
     expect(page.title).to eq("Ubicloud - Forbidden")
     expect(page.status_code).to eq(403)
     expect(page).to have_content "Forbidden"
+  end
+
+  it "redirects to user management page if it requires approval" do
+    expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({})
+    expect(Project).to receive(:[]).and_return(project).at_least(:once)
+
+    visit "/github/callback?code=123123&setup_action=request"
+
+    expect(page.title).to eq("Ubicloud - #{project.name} - Users")
+    expect(page).to have_content("awaiting approval from the GitHub organization's administrator")
+  end
+
+  it "fails if oauth code is invalid" do
+    expect(oauth_client).to receive(:exchange_code_for_token).with("invalid").and_return({})
+    expect(Project).to receive(:[]).and_return(project).at_least(:once)
+
+    visit "/github/callback?code=invalid"
+
+    expect(page.title).to eq("Ubicloud - GitHub Runners")
+    expect(page).to have_content("GitHub App installation failed.")
+  end
+
+  it "fails if installation not found" do
+    expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
+    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: []})
+    expect(Project).to receive(:[]).and_return(project).at_least(:once)
+
+    visit "/github/callback?code=123123"
+
+    expect(page.title).to eq("Ubicloud - GitHub Runners")
+    expect(page).to have_content("GitHub App installation failed.")
+  end
+
+  it "fails if the current user's account suspended" do
+    expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
+    expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
+    expect(Project).to receive(:[]).and_return(project).at_least(:once)
+    user.update(suspended_at: Time.now)
+
+    visit "/github/callback?code=123123&installation_id=345"
+
+    expect(page.title).to eq("Ubicloud - project-1 Dashboard")
+    expect(page).to have_content("GitHub runner integration is not allowed for suspended accounts.")
   end
 
   it "creates installation with project from session" do


### PR DESCRIPTION
### Handle additional cases in GitHub installation callback

When a new user installs our GitHub app, GitHub redirects them to a
callback URL in our console to finalize the installation. We perform
some checks and create a GithubInstallation record if it doesn't already
exist. This redirection also occurs when a user updates the installation
via the GitHub UI. Recently, we identified a need to handle more
scenarios in the callback. The current implementation provides unclear
error messages, leading to user confusion. This PR introduces handling
for the following situations:

Typically, GitHub includes a code as a query parameter in the callback
URL. We use this code to obtain the OAuth token and verify the user's
installation. Although the code is mandatory as per GitHub's
documentation, we've encountered instances where it's absent for update
callbacks. Consequently, customers receive an installation failed error
message even when they already have a GithubInstallation record. To
address this, I've moved the code check to precede the creation of the
installation record. This way, we can provide clearer messages to users
if they encounter other issues. If they've already installed the app and
have access permission, we can redirect them to the project's runner
page.

Another issue we've recently faced is when a user, who isn't an
administrator of the GitHub organization, needs approval from the admin.
In such cases, GitHub sends a notification to the admin and redirects
the non-admin user to the callback URL with "setup_action=request" and
without an installation ID. When the admin approves the installation,
GitHub redirects the admin to the callback URL to finalize the
installation. This implies that the admin needs an Ubicloud account with
appropriate project permissions. This way, we can create a
GithubInstallation record for their project. I've added a more detailed
error message for this scenario and implemented a redirect to the
project's user management page. This allows the user to add the admin to
the project with ease. While this process isn't yet seamless, it's the
best solution we currently have.

Finally, I've refactored the fraud check slightly. Since we have the
current user, we can use it to check for suspension.

### Add more log to GitHub callback endpoint

In our GitHub callback endpoint, we conduct multiple checks and return
relevant error messages to the user. However, if the user doesn't share
the error message they received, it becomes challenging to troubleshoot
the installation issue. To address this, this PR introduces logs for
each check, enabling us to effortlessly track which check failed.

