### PR TITLE
Fix GitHub installation configuration URL

### DIFF
--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -9,13 +9,6 @@ class GithubInstallation < Sequel::Model
 
   include ResourceMethods
 
-  def installation_url
-    if type == "Organization"
-      return "https://github.com/organizations/#{name}/settings/installations/#{installation_id}"
-    end
-    "https://github.com/settings/installations/#{installation_id}"
-  end
-
   def total_active_runner_cores
     runner_labels = runners_dataset.left_join(:strand, id: :id).exclude(Sequel[:strand][:label] => "start").exclude(Sequel[:strand][:label] => "wait_concurrency_limit").select_map(Sequel[:github_runner][:label])
     label_record_data_set = runner_labels.map { |label| Github.runner_labels[label] }

--- a/serializers/github_installation.rb
+++ b/serializers/github_installation.rb
@@ -7,7 +7,7 @@ class Serializers::GithubInstallation < Serializers::Base
       name: ins.name,
       type: ins.type,
       installation_id: ins.installation_id,
-      installation_url: ins.installation_url
+      installation_url: "https://github.com/apps/#{Config.github_app_name}/installations/#{ins.installation_id}"
     }
   end
 end

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Clover, "github" do
       expect(page.status_code).to eq(200)
       expect(page.title).to eq("Ubicloud - GitHub Runners")
       expect(page).to have_content "test-user"
-      expect(page).to have_link "Configure", href: ins1.installation_url
+      expect(page).to have_link "Configure", href: /\/apps\/runner-app\/installations\/#{ins1.installation_id}/
       expect(page).to have_content "test-org"
-      expect(page).to have_link "Configure", href: ins2.installation_url
+      expect(page).to have_link "Configure", href: /\/apps\/runner-app\/installations\/#{ins2.installation_id}/
     end
 
     it "can list active runners" do


### PR DESCRIPTION
We direct users to the installation configuration page on GitHub's UI when they want to add more repositories and so on. However, I discovered yesterday that non-admin users of an organization are led to a 404 page. I found a more generic URL that works for everyone. GitHub has decided to redirect users to the appropriate page.

Since we don't have separate branches for different installation types, I've moved it to the serializer as it's only used once.