### PR TITLE
Check cache usage in repository nexus as first step

### DIFF
--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -109,6 +109,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
   end
 
   label def wait
+    cleanup_cache if github_repository.access_key
     nap 15 * 60 if Time.now - github_repository.last_job_at > 6 * 60 * 60
 
     begin
@@ -120,8 +121,6 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
         nap 0
       end
     end
-
-    cleanup_cache if github_repository.access_key
 
     # check_queued_jobs may have changed the default polling interval based on
     # the remaining rate limit.

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -151,9 +151,11 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect { nx.wait }.to nap(5 * 60)
     end
 
-    it "does not check queued jobs if 6 hours passed from the last job" do
+    it "does not check queued jobs but check cache usage if 6 hours passed from the last job" do
+      expect(github_repository).to receive(:access_key).and_return("key")
       expect(github_repository).to receive(:last_job_at).and_return(Time.now - 7 * 60 * 60)
       expect(nx).not_to receive(:check_queued_jobs)
+      expect(nx).to receive(:cleanup_cache)
       expect { nx.wait }.to nap(15 * 60)
     end
 


### PR DESCRIPTION
The repository nexus checks two things in the `wait` state: queued jobs and cache usage, in that order. However, since polling jobs is resource-intensive, it won't poll if no job has been triggered for the repository in the past 6 hours. This can lead to the cache usage check being skipped, preventing the cleanup of expired caches after 7 days if no job has been triggered in that 6-hour window. Therefore, to ensure we can clean up expired caches, the cache usage check should be prioritized as the first step in the `wait` state.