### PR TITLE
Remove downloading cache proxy code

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -105,9 +105,6 @@ module Config
   optional :github_cache_blob_storage_secret_key, string, clear: true
   optional :github_cache_blob_storage_account_id, string
   optional :github_cache_blob_storage_api_key, string, clear: true
-  optional :github_cache_forked_runner_tarball_uri, string
-  optional :github_cache_forked_runner_tarball_uri_arm64, string
-  optional :github_cache_proxy_repo_uri, string, clear: true
 
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -398,10 +398,11 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect { nx.setup_environment }.to hop("register_runner")
     end
 
-    it "hops to setup_forked_runner" do
+    it "hops to register_runner with after enabling transparent cache" do
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx", get_ff_transparent_cache: true)).at_least(:once)
+      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"
@@ -409,110 +410,10 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
-      COMMAND
-
-      expect { nx.setup_environment }.to hop("setup_forked_runner")
-    end
-  end
-
-  describe "#setup_forked_runner" do
-    it "hops to register_runner" do
-      expect(Config).to receive_messages(github_cache_forked_runner_tarball_uri: "https://github.com/foo/tarball")
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
-      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        curl --output actions-runner.tar.gz -L https://github.com/foo/tarball
-        rm -rf actions-runner
-        mkdir -p actions-runner
-        tar xzf actions-runner.tar.gz -C actions-runner
-        sudo chown -R runneradmin:runneradmin ./actions-runner
-        ./actions-runner/env.sh
-        cat <<EOT > ./actions-runner/run-withenv.sh
-        #!/bin/bash
-        mapfile -t env </etc/environment
-        exec env -- "\\${env[@]}" ./actions-runner/run.sh --jitconfig "\\$1"
-        EOT
-        chmod +x ./actions-runner/run-withenv.sh
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json > ./actions-runner/.setup_info
-        echo "PATH=$PATH" >> ./actions-runner/.env
-        sudo rm -rf /home/runner/actions-runner
-        sudo mv ./actions-runner /home/runner/
-        sudo chown -R runner:runner /home/runner/actions-runner
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
-        echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
       COMMAND
 
-      expect { nx.setup_forked_runner }.to hop("clear_ubicloud_resolve_conf")
-    end
-
-    it "hops to register_runner arm" do
-      expect(Config).to receive_messages(github_cache_forked_runner_tarball_uri_arm64: "https://github.com/foo/tarball")
-      expect(github_runner).to receive(:label).and_return("ubicloud-arm").at_least(:once)
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
-      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        curl --output actions-runner.tar.gz -L https://github.com/foo/tarball
-        rm -rf actions-runner
-        mkdir -p actions-runner
-        tar xzf actions-runner.tar.gz -C actions-runner
-        sudo chown -R runneradmin:runneradmin ./actions-runner
-        ./actions-runner/env.sh
-        cat <<EOT > ./actions-runner/run-withenv.sh
-        #!/bin/bash
-        mapfile -t env </etc/environment
-        exec env -- "\\${env[@]}" ./actions-runner/run.sh --jitconfig "\\$1"
-        EOT
-        chmod +x ./actions-runner/run-withenv.sh
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-arm\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json > ./actions-runner/.setup_info
-        echo "PATH=$PATH" >> ./actions-runner/.env
-        sudo rm -rf /home/runner/actions-runner
-        sudo mv ./actions-runner /home/runner/
-        sudo chown -R runner:runner /home/runner/actions-runner
-        echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
-        echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
-      COMMAND
-
-      expect { nx.setup_forked_runner }.to hop("clear_ubicloud_resolve_conf")
-    end
-  end
-
-  describe "#clear_ubicloud_resolve_conf" do
-    it "hops to download_proxy" do
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        sudo rm -f /etc/systemd/resolved.conf.d/Ubicloud.conf
-        sudo systemctl restart systemd-resolved
-        sudo systemctl restart docker
-      COMMAND
-
-      expect { nx.clear_ubicloud_resolve_conf }.to hop("download_proxy")
-    end
-  end
-
-  describe "#download_proxy" do
-    it "hops to start_proxy" do
-      expect(Config).to receive_messages(github_cache_proxy_repo_uri: "https://github.com/foo/cache_proxy")
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        sudo rm -rf cache-proxy
-        sudo git clone https://github.com/foo/cache_proxy cache-proxy
-      COMMAND
-
-      expect { nx.download_proxy }.to hop("start_proxy")
-    end
-  end
-
-  describe "#start_proxy" do
-    it "hops to register_runner" do
-      expect(vm).to receive(:runtime_token).and_return("my_token")
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        export UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/
-        export UBICLOUD_RUNTIME_TOKEN=my_token
-        cd cache-proxy
-        go run transparent_cache_proxy.go > ~/cacheproxy.log 2>&1 &
-      COMMAND
-
-      expect { nx.start_proxy }.to hop("register_runner")
+      expect { nx.setup_environment }.to hop("register_runner")
     end
   end
 


### PR DESCRIPTION
Since proxy code will be working via a service installed on the runner image, don't need to download and run the code directly anymore.

Updating CUSTOM_ACTIONS_CACHE_URL and manual resolvement of localhost.blob.core.windows.net are still required. First is to send cache api requests to local proxy and the second to redirect blob request to local proxy as well.

Once we'lll make sure to use transparent cache for all users, that part will be moved out of project flag check later.