### PR TITLE
Add option to bypass runner deregistration and destroy vm immediately

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -12,7 +12,7 @@ class GithubRunner < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :destroy
+  semaphore :destroy, :skip_deregistration
 
   def run_url
     "http://github.com/#{repository_name}/actions/runs/#{workflow_job["run_id"]}"

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -610,6 +610,15 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect { nx.destroy }.to hop("wait_vm_destroy")
     end
 
+    it "skip deregistration and destroy vm immediately" do
+      expect(nx).to receive(:decr_destroy)
+      expect(github_runner).to receive(:skip_deregistration_set?).and_return(true)
+      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"}).at_least(:once)
+      expect(vm).to receive(:incr_destroy)
+
+      expect { nx.destroy }.to hop("wait_vm_destroy")
+    end
+
     it "destroys resources and hops if runner deregistered, also, copies serial log if workflow_job is nil" do
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)


### PR DESCRIPTION
When we attempt to destroy the runner, we also deregister it from GitHub.  We wait to receive a 'not found' response for the runner. If the runner is still running a job and, due to stale data, it gets mistakenly hopped to destroy, this prevents the underlying VM from being destroyed and the job from failing. However, in certain situations like fraudulent activity, we might need to bypass this verification and immediately remove the runner.

First I named the semaphore as `force_destroy`, but then I renamed it as `skip_deregistration`.  The former name was misleading, because the operator should increment the `destroy` semaphore too.