### PR TITLE
Download arm tarball for arm runners

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -110,6 +110,7 @@ module Config
   optional :github_cache_blob_storage_account_id, string
   optional :github_cache_blob_storage_api_key, string, clear: true
   optional :github_cache_forked_runner_tarball_uri, string
+  optional :github_cache_forked_runner_tarball_uri_arm64, string
   optional :github_cache_proxy_repo_uri, string, clear: true
 
   # Minio

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -233,8 +233,10 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def setup_forked_runner
+    tarball_uri = (label_data["arch"] == "arm64") ? Config.github_cache_forked_runner_tarball_uri_arm64 : Config.github_cache_forked_runner_tarball_uri
+
     command = <<~COMMAND
-      curl --output actions-runner.tar.gz -L #{Config.github_cache_forked_runner_tarball_uri}
+      curl --output actions-runner.tar.gz -L #{tarball_uri}
 
       rm -rf actions-runner
       mkdir -p actions-runner


### PR DESCRIPTION
To forward cache requests to proxy on runner vms, forked tarball is downloaded during runner provision. Download the arm one if the runner is an arm runner.