### PR TITLE
Add password requirements for user accounts

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -328,6 +328,17 @@ class CloverWeb < Roda
     auto_add_recovery_codes? true
     auto_remove_recovery_codes? true
     recovery_auth_view { view "auth/recovery_auth", "Recovery Codes" }
+
+    # Password Requirements
+    password_minimum_length 8
+    password_maximum_bytes 72
+    password_meets_requirements? do |password|
+      password.match?(/[a-z]/) && password.match?(/[A-Z]/) && password.match?(/[0-9]/)
+    end
+
+    invalid_password_message = "Password must have 8 characters minimum and contain at least one lowercase letter, one uppercase letter, and one digit."
+    password_does_not_meet_requirements_message invalid_password_message
+    password_too_short_message invalid_password_message
   end
 
   def csrf_tag(*)


### PR DESCRIPTION
Previously, we used the default password requirements that comes with rodauth, which are 6 characters minimum and no requirement on the type of characters.

The defaults are too permissive. With this commit we are increasing minimum length to 8 and also require passwords to contain at least one lowercase, one uppercase and one digit.

Finally, we also set a maximum length as well, this closes a low risk attack vector (DoS with long password). The length 72 is used becase it seems bcrypt only uses first 72 bytes of password while creating the hash. Source: https://github.com/jeremyevans/rodauth/blob/master/doc/login_password_requirements_base.rdoc