### PR TITLE
Add common extensions to shared_preload_libraries

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -52,7 +52,8 @@ class PostgresServer < Sequel::Model
       lc_messages: "'C.UTF-8'",
       lc_monetary: "'C.UTF-8'",
       lc_numeric: "'C.UTF-8'",
-      lc_time: "'C.UTF-8'"
+      lc_time: "'C.UTF-8'",
+      shared_preload_libraries: "'pg_cron,pg_stat_statements'"
     }
 
     if timeline.blob_storage


### PR DESCRIPTION
Updating shared_preload_libraries requires server restart, which is doable but we can eliminate the extra work for some of the most common extensions such as pg_cron and pg_stat_statements by adding them to shared_preload_libraries by default.

pg_stat_statements allocate small amount of memory by default, which is not a big concern for regular servers. When we introduce smaller SKUs, we probably wouldn't add it to shared_preload_libraries for small SKUs by default.