### PR TITLE
Support leaseweb culprits ipv6

### DIFF
--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -34,7 +34,7 @@ class Prog::LearnNetwork < Prog::Base
     case JSON.parse(s)
     in [iface]
       case iface.fetch("addr_info").filter_map { |info|
-             if (local = info["local"]) && (prefixlen = info["prefixlen"]) && prefixlen <= 68
+             if (local = info["local"]) && (prefixlen = info["prefixlen"]) && prefixlen <= 112
                Ip6.new(local, prefixlen)
              end
            }

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -244,6 +244,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       routes = r "ip -j route"
       main_device = parse_routes(routes)
       r "ip -6 neigh add proxy #{guest_ephemeral.nth(2)} dev #{main_device}"
+      r "ip -6 neigh add proxy #{clover_ephemeral.nth(0)} dev #{main_device}"
     end
 
     # Accept clover traffic within the namespace (don't just let it

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -64,10 +64,28 @@ RSpec.describe VmHost do
     expect(vh.ip6_random_vm_network.to_s).not_to eq(vh.ip6_reserved_network)
   end
 
-  it "can generate ipv6 for hosts with smaller than /64 prefix with single byte" do
+  it "can generate ipv6 for hosts with smaller than /64 prefix with two bytes" do
     vh.net6 = NetAddr.parse_net("2a01:4f9:2b:35a::/68")
-    expect(SecureRandom).to receive(:random_number).with(2...256).and_return(5)
-    expect(vh.ip6_random_vm_network.to_s).to eq("2a01:4f9:2b:35a:4::/79")
+    expect(SecureRandom).to receive(:random_number).with(2...2**16).and_return(5)
+    expect(vh.ip6_random_vm_network.to_s).to eq("2a01:4f9:2b:35a:0:4000:0:0/83")
+
+    expect(SecureRandom).to receive(:random_number).with(2...2**16).and_return(2)
+    expect(vh.ip6_random_vm_network.to_s).to eq("2a01:4f9:2b:35a:0:2000:0:0/83")
+
+    expect(SecureRandom).to receive(:random_number).with(2...2**16).and_return(2**16 - 1)
+    expect(vh.ip6_random_vm_network.to_s).to eq("2a01:4f9:2b:35a:fff:e000::/83")
+  end
+
+  it "can generate the mask properly" do
+    vh.net6 = NetAddr.parse_net("::/64")
+    expect(SecureRandom).to receive(:random_number).with(2...2**16).and_return(5001)
+    expect(vh.ip6_random_vm_network.to_s).to eq("::1388:0:0:0/79")
+    expect(SecureRandom).to receive(:random_number).with(2...2**16).and_return(2)
+    expect(vh.ip6_random_vm_network.to_s).to eq("::2:0:0:0/79")
+    expect(SecureRandom).to receive(:random_number).with(2...2**16).and_return(2**16 - 1)
+    expect(vh.ip6_random_vm_network.to_s).to eq("::fffe:0:0:0/79")
+    expect(SecureRandom).to receive(:random_number).with(2...2**16).and_return(2**15)
+    expect(vh.ip6_random_vm_network.to_s).to eq("::8000:0:0:0/79")
   end
 
   it "has a shortcut to install Rhizome" do


### PR DESCRIPTION
## Remove the prefix to be shorter than 68 bits condition
We were expecting the prefix to be shorter than 68 bits but the latest
leaseweb hosts came with ipv6 blocks like:
2607:f5b7:1:64:1::_112/64
2607:f5b7:1:64:2::_112/64
2607:f5b7:1:64:3::_112/64

As you can see, they give /64 but the address space is not actually as
big as /64. Because, the :1, :2, :3 at the end of the prefix is actually
to 80th bit. We must see them like the following for it to make sense;
2607:f5b7:1:64:0001::/64
2607:f5b7:1:64:0002::/64

Here, the differentiating bit is in the residue part of a /64 network.
So, if we use them as they are, we need to actually map them to
2607:f5b7:1:64::/64 which would not work because then we would have
multiple hosts with the same prefix and we cannot assign ipv6 addresses
to the VMs correctly.

To solve this issue, we assign the prefixes correctly using /80. So, the
hosts become
2607:f5b7:1:64:0001::/80
2607:f5b7:1:64:0002::/80

This requires modification in learn_network prog because it was
previously expecting at least /68. We remove the condition.

The main idea of /68 was that so that we can delegeta prefixes at the
size of /80 which doesn't really work because dnsmasq cannot delegate
the prefixes anyway. So, in any case, we simply give /128 to anyone. So,
I remove that condition.

## Update vm_host to support allocation of longer prefixes to VMs
We always tried to allocate /79 to the VM to be used as 2 /80s.This
doesn't work with the new leaseweb hosts because we already get a /80
from them for the host. Therefore, we need to be able to allocate much
smaller. Keeping the entropy the same (2 bytes), we change the ipv6
allocation logic. This way, hetzner hosts will continue allocation /79
while leaseweb allocates /95.

## Use proxy ndp for both clover and guest ephemeral
With the recent change to use dnsmasq as the first level dns server, we
get out to the internet with the clover_ephemeral address. The existing
ndp proxy logic was only proxying the guest ephemeral which makes the VM
IPv6 stack working as expected. However, we realized that the dns
queries through dnsmasq was failing. Further investigation showed that
the dnsmasq was able to send packets out but no response was getting
back in. I realized the source address is the first half of the /95
prefix for dnsmasq. Therefore, we need to enable ndp_proxy for that
prefix, too. This way, our response packets started to flow back in.