### PR TITLE
Allow to set customer quota for GitHub cache storage

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -1,3 +1,4 @@
-- { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmCores,           new_value: 16,  verified_value: 128 }
-- { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerCores, new_value: 150, verified_value: 150 }
-- { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresCores,     new_value: 64,  verified_value: 128 }
+- { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmCores,                  new_value: 16,  verified_value: 128 }
+- { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerCores,        new_value: 150, verified_value: 150 }
+- { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, new_value: 10,  verified_value: 10 }
+- { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresCores,            new_value: 64,  verified_value: 128 }

--- a/model/project_quota.rb
+++ b/model/project_quota.rb
@@ -10,3 +10,5 @@ class ProjectQuota < Sequel::Model
     end
   end
 end
+
+ProjectQuota.unrestrict_primary_key

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -90,9 +90,10 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
 
     # Destroy oldest cache entries if the total usage exceeds the limit.
     total_usage = github_repository.cache_entries_dataset.sum(:size).to_i
-    if total_usage > GithubRepository::CACHE_SIZE_LIMIT
+    storage_limit = github_repository.installation.project.effective_quota_value("GithubRunnerCacheStorage") * 1024 * 1024 * 1024
+    if total_usage > storage_limit
       github_repository.cache_entries_dataset.order(:created_at).each do |oldest_entry|
-        break if total_usage <= GithubRepository::CACHE_SIZE_LIMIT
+        break if total_usage <= storage_limit
         oldest_entry.destroy
         total_usage -= oldest_entry.size
       end


### PR DESCRIPTION
We allow 10GB of free cache storage per repository, a limit we've set in line with the official GitHub Actions cache.

However, some customers may need more than 10GB of cache storage. This PR enables us to assign a custom cache storage quota to all repositories within a project, though the quota still applies on a per-repository basis.