### PR TITLE
Set correct HTTP headers during tests by default

### DIFF
--- a/spec/routes/api/spec_helper.rb
+++ b/spec/routes/api/spec_helper.rb
@@ -7,3 +7,15 @@ def login_api(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
   expect(last_response.status).to eq(200)
   header "Authorization", "Bearer #{last_response.headers["authorization"]}"
 end
+
+RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{\A\./spec/routes/api/}) do |metadata|
+    metadata[:clover_api] = true
+  end
+
+  config.before do |example|
+    next unless example.metadata[:clover_api]
+    header "Content-Type", "application/json"
+    header "Accept", "application/json"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,14 +43,6 @@ Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations.*/)
 Warning.ignore([:unused_var], /.*lib\/aws-sdk-(s3|core)\/(endpoint_provider|cbor).*/)
 
 RSpec.configure do |config|
-  config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|
-    # Extract the name of the subdirectory that the test file is in
-    subdirectory = metadata[:file_path].split("/")[-2]
-
-    # Set the :subdirectory metadata tag to the extracted value
-    metadata[:subdirectory] = subdirectory
-  end
-
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     # Since we have 2 active sequel databases, we need to manually


### PR DESCRIPTION
Push down some currently-unused/leftover code that applies metadata to tests, and then use it to set Content-Type and Accept headers for API tests to the correct default.

Negative tests can override them a second time.

Currently, this doesn't break any tests, but when one enables checking requests and responses to the openapi schema, it does.  This is a backport from an development branch.