### PR TITLE
Revert aws-sdk-s3 to 1.163.0 from 1.166.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,6 @@ end
 
 gem "webauthn", "~> 3.1"
 
-gem "aws-sdk-s3", "~> 1.166"
+gem "aws-sdk-s3", "~> 1.163"
 
 gem "acme-client", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,17 +39,17 @@ GEM
     ast (2.4.2)
     awrence (1.2.1)
     aws-eventstream (1.3.0)
-    aws-partitions (1.979.0)
-    aws-sdk-core (3.209.1)
+    aws-partitions (1.977.0)
+    aws-sdk-core (3.206.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.9)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.94.0)
-      aws-sdk-core (~> 3, >= 3.207.0)
+    aws-sdk-kms (1.91.0)
+      aws-sdk-core (~> 3, >= 3.205.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.166.0)
-      aws-sdk-core (~> 3, >= 3.207.0)
+    aws-sdk-s3 (1.163.0)
+      aws-sdk-core (~> 3, >= 3.205.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.0)
@@ -343,7 +343,7 @@ DEPENDENCIES
   acme-client (~> 2.0)
   argon2
   argon2-kdf
-  aws-sdk-s3 (~> 1.166)
+  aws-sdk-s3 (~> 1.163)
   bcrypt_pbkdf
   brakeman
   capybara


### PR DESCRIPTION
Dependabot upgraded it at 0eb6a12f

But it fails at production with the following exception

```
TypeError: superclass mismatch for class AbortIncompleteMultipartUpload

app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/types.rb:31:in `<module:Types>'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/types.rb:11:in `<module:S3>'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/types.rb:10:in `<top (required)>'
internal:/app/vendor/ruby-3.2.5/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
internal:/app/vendor/ruby-3.2.5/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/client_api.rb:626:in `<module:ClientApi>'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/client_api.rb:13:in `<module:S3>'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/client_api.rb:11:in `<top (required)>'
internal:/app/vendor/ruby-3.2.5/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
internal:/app/vendor/ruby-3.2.5/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/client.rb:79:in `<class:Client>'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/client.rb:73:in `<module:S3>'
app/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.166.0/lib/aws-sdk-s3/client.rb:60:in `<top (required)>'
internal:/app/vendor/ruby-3.2.5/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
internal:/app/vendor/ruby-3.2.5/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
app/model/github/github_repository.rb:31:in `blob_storage_client'

```

But I couldn't reproduce it at local