### PR TITLE
Add predefined address mapping for blob storage cache

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -425,6 +425,9 @@ DHCP
     raparams = nics.map { "ra-param=#{_1.tap}" }.join("\n")
     interfaces = nics.map { "interface=#{_1.tap}" }.join("\n")
     dnsmasq_address_ip6 = NetAddr::IPv6.parse("fd00:0b1c:100d:53::")
+    address_mapping = boot_image.include?("github") ?
+      "address=/localhost.blob.core.windows.net/#{nics.first.net4.split("/").first}" :
+      ""
     vp.write_dnsmasq_conf(<<DNSMASQ_CONF)
 pid-file=
 leasefile-ro
@@ -445,6 +448,7 @@ dhcp-option=option6:dns-server,#{dnsmasq_address_ip6}
 listen-address=#{dnsmasq_address_ip6}
 dhcp-option=26,1400
 bind-interfaces
+#{address_mapping}
 DNSMASQ_CONF
 
     ethernets = nics.map do |nic|


### PR DESCRIPTION
When restoring a cache, the local cache server uses localhost.blob.core.windows.net as the host for file requests. This setup enables the toolkit’s concurrent download functionality (refer to the cacheHttpClient in the actions/toolkit repository for more details). The local cache server then expects to receive these requests. To ensure this, we map the VM's local IP so that any requests to that URL are always redirected back to the VM itself.