### PR TITLE
GitHub Cache UI

### DIFF
--- a/routes/web/project/github.rb
+++ b/routes/web/project/github.rb
@@ -39,5 +39,15 @@ class CloverWeb
         r.redirect "https://github.com/apps/#{Config.github_app_name}/installations/new", 302
       end
     end
+
+    r.on "cache" do
+      r.get true do
+        repository_id_q = @project.github_installations_dataset.join(:github_repository, installation_id: :id).select(Sequel[:github_repository][:id])
+        @entries = Serializers::GithubCacheEntry.serialize(GithubCacheEntry.where(repository_id: repository_id_q).exclude(committed_at: nil).eager(:repository).order(Sequel.desc(:created_at)).all)
+        @total_usage = Serializers::GithubCacheEntry.humanize_size(@entries.filter_map { _1[:size] }.sum)
+
+        view "github/cache"
+      end
+    end
   end
 end

--- a/routes/web/project/github.rb
+++ b/routes/web/project/github.rb
@@ -48,6 +48,22 @@ class CloverWeb
 
         view "github/cache"
       end
+
+      r.is String do |entry_ubid|
+        entry = GithubCacheEntry.from_ubid(entry_ubid)
+
+        unless entry
+          response.status = 404
+          r.halt
+        end
+
+        r.delete true do
+          entry.destroy
+          flash["notice"] = "Cache '#{entry.key}' deleted."
+          response.status = 204
+          request.halt
+        end
+      end
     end
   end
 end

--- a/serializers/github_cache_entry.rb
+++ b/serializers/github_cache_entry.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Serializers::GithubCacheEntry < Serializers::Base
+  def self.serialize_internal(entry, options = {})
+    {
+      id: entry.ubid,
+      key: entry.key,
+      repository_name: entry.repository.name,
+      scope: entry.scope,
+      created_at: entry.created_at.strftime("%Y-%m-%d %H:%M UTC"),
+      created_at_human: humanize_time(entry.created_at),
+      last_accessed_at: entry.last_accessed_at&.strftime("%Y-%m-%d %H:%M UTC"),
+      last_accessed_at_human: humanize_time(entry.last_accessed_at),
+      size: entry.size,
+      size_human: humanize_size(entry.size)
+    }
+  end
+
+  def self.humanize_size(bytes)
+    return nil if bytes.nil? || bytes.zero?
+    units = %w[B KB MB GB]
+    exp = (Math.log(bytes) / Math.log(1024)).to_i
+    exp = [exp, units.size - 1].min
+
+    return "%d %s" % [bytes.to_f / 1024**exp, units[exp]] if exp == 0
+    "%.1f %s" % [bytes.to_f / 1024**exp, units[exp]]
+  end
+
+  def self.humanize_time(time)
+    return nil unless time
+    seconds = Time.now - time
+    return "just now" if seconds < 60
+    return "#{(seconds / 60).to_i} minutes ago" if seconds < 3600
+    return "#{(seconds / 3600).to_i} hours ago" if seconds < 86400
+    "#{(seconds / 86400).to_i} days ago"
+  end
+end

--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -33,7 +33,13 @@
     <% end%>
   >
     <% if icon %>
-      <%== render("components/icon", locals: { name: icon, classes: "ml-0.5 mr-1.5 h-5 w-5" }) %>
+      <%== render(
+        "components/icon",
+        locals: {
+          name: icon,
+          classes: "h-5 w-5 #{(text && !text.empty?) ? "ml-0.5 mr-1.5" : "ml-0.5 mr-0.5 "}"
+        }
+      ) %>
     <% end %>
     <%= text %>
     <% if right_icon %>

--- a/views/components/delete_button.erb
+++ b/views/components/delete_button.erb
@@ -1,5 +1,6 @@
 <% csrf_url = (defined?(csrf_url) && csrf_url) ? csrf_url : url %>
 <% text = (defined?(text) && text) ? text : "Delete" %>
+<% confirmation = (defined?(confirmation) && confirmation) ? confirmation : nil %>
 
 <%== render(
   "components/button",

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -47,6 +47,16 @@
                   <div>Never used</div>
                 <% end %>
               </td>
+              <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
+                <%== render(
+                  "components/delete_button",
+                  locals: {
+                    url: "#{@project_data[:path]}/github/cache/#{entry[:id]}",
+                    text: "",
+                    redirect: request.path
+                  }
+                ) %>
+              </td>
             </tr>
           <% end %>
         <% else %>

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -1,0 +1,67 @@
+<% @page_title = "GitHub Runners" %>
+
+<div class="space-y-1">
+  <%== render(
+    "components/breadcrumb",
+    locals: {
+      back: @project_data[:path],
+      parts: [%w[Projects /project], [@project_data[:name], @project_data[:path]], ["GitHub Runners", "#{@project_data[:path]}/github"], ["Caches", "#"]]
+    }
+  ) %>
+  <%== render("components/page_header", locals: { title: "GitHub Runner Integration" }) %>
+</div>
+
+<%== render("github/tabbar") %>
+
+<div class="grid gap-6">
+  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <table class="min-w-full divide-y divide-gray-300">
+      <thead class="bg-gray-50 whitespace-nowrap">
+        <tr>
+          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6" colspan="2"><%= @entries.count %> cache entries</th>
+          <th scope="col" class="relative py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6" colspan="3"><%= @total_usage %> used</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200 bg-white">
+        <% if @entries.count > 0 %>
+          <% @entries.each do |entry| %>
+            <tr id="entry-<%= entry[:id]%>">
+              <td class="py-3 pl-4 pr-3 text-sm sm:pl-6" scope="row">
+                <div class="font-medium text-gray-900"><%= entry[:key] %></div>
+                <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry[:created_at] %>"><%= entry[:created_at_human] %></span></div>
+              </td>
+              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                <div><%= entry[:scope] %></div>
+                <div class="mt-1 text-gray-500 text-xs"><%= entry[:repository_name] %></div>
+              </td>
+              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                <div class="inline-flex items-baseline rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800" title="<%= entry[:size] %> bytes">
+                  <%= entry[:size_human] %>
+                </div>
+              </td>
+              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                <% if entry[:last_accessed_at] %>
+                  <div>Last used</div>
+                  <div title="<%= entry[:last_accessed_at] %>"> <%= entry[:last_accessed_at_human] %></div>
+                <% else %>
+                  <div>Never used</div>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <td colspan="6">
+              <div class="text-center py-4 px-8 lg:px-32">
+                <h3 class="text-xl leading-10 font-medium mb-2">No cache entries</h3>
+                <p class="leading-6">
+                  Check out <a href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache" class="text-orange-500 font-medium">our documentation</a> to use Ubicloud Cache for faster caching.
+                </p>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/views/github/tabbar.erb
+++ b/views/github/tabbar.erb
@@ -3,6 +3,7 @@
   locals: {
     tabs: [
       ["Active Runners", "#{@project_data[:path]}/github/runner"],
+      ["Caches", "#{@project_data[:path]}/github/cache"],
       ["Settings", "#{@project_data[:path]}/github/setting"]
     ]
   }


### PR DESCRIPTION
<img width="2560" alt="Screenshot 2024-10-01 at 14 50 20" src="https://github.com/user-attachments/assets/7b99c459-23d1-411c-a761-4fe14c91e7ed">

### **Add cache entry list to UI**
  I added the list of cache entries as a subpage to the GitHub runners
  page. It shows data sizes and timestamps in humanized format. To
  accomplish this, I wrote two simple helper functions.
  
  GitHub Actions cache has similar page 
  (https://github.com/ubicloud/ubicloud/actions/caches). There are several
use cases for this UI:
  - We give 10GB of free cache storage and purge any caches that haven't
    been accessed for 7 days or that exceed the storage limit. This new
    UI allows users to monitor their cache storage usage and see future
    needs. They can choose to clear some caches to free up space and
    prevent cache eviction.
  - Sometimes, users might need to delete certain caches to force their
    regeneration, especially if the caches are corrupted.


### **Allow centered icon without text in the button component**
  When no text is provided in the button component, the icon should be
  centered within the button. Right now, the icon is not centered.
  
  Additionally, if no confirmation is provided for the delete button, the
  confirmation dialog shouldn't prompt for text input.
  

### **Add a delete function for cache entries to the UI**
  