### PR TITLE
Remove the extra curly braces from postgres partner email

### DIFF
--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -263,13 +263,13 @@ class Routes::Common::PostgresHelper < Routes::Common::Base
       Util.send_email(Config.postgres_paradedb_notification_email, "New ParadeDB Postgres database has been created.",
         greeting: "Hello ParadeDB team,",
         body: ["New ParadeDB Postgres database has been created.",
-          "Id: #{resource.ubid}",
-          "Location: #{resource.location}}",
+          "ID: #{resource.ubid}",
+          "Location: #{resource.location}",
           "Name: #{resource.name}",
-          "E-Mail: #{user_email}}",
-          "Instance VM Size: #{resource.target_vm_size}}",
-          "Instance Storage Size: #{resource.target_storage_size_gib}}",
-          "HA: #{resource.ha_type}}"])
+          "E-mail: #{user_email}",
+          "Instance VM Size: #{resource.target_vm_size}",
+          "Instance Storage Size: #{resource.target_storage_size_gib}",
+          "HA: #{resource.ha_type}"])
     end
   end
 end


### PR DESCRIPTION
## Before
<img width="1219" alt="Screenshot 2024-09-28 at 14 21 16" src="https://github.com/user-attachments/assets/456169ca-d124-4664-9462-8bde851da977">

## After
<img width="1215" alt="Screenshot 2024-09-28 at 14 27 21" src="https://github.com/user-attachments/assets/a11f2ee3-cc14-4e79-852f-41b3150bb90f">
