### PR TITLE
Fix typo in the mail we send to ParadeDB team

### DIFF
--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -264,12 +264,12 @@ class Routes::Common::PostgresHelper < Routes::Common::Base
         greeting: "Hello ParadeDB team,",
         body: ["New ParadeDB Postgres database has been created.",
           "Id: #{resource.ubid}",
-          "Location: #{resource.location}}",
+          "Location: #{resource.location}",
           "Name: #{resource.name}",
-          "E-Mail: #{user_email}}",
-          "Instance VM Size: #{resource.target_vm_size}}",
-          "Instance Storage Size: #{resource.target_storage_size_gib}}",
-          "HA: #{resource.ha_type}}"])
+          "E-Mail: #{user_email}",
+          "Instance VM Size: #{resource.target_vm_size}",
+          "Instance Storage Size: #{resource.target_storage_size_gib}",
+          "HA: #{resource.ha_type}"])
     end
   end
 end


### PR DESCRIPTION
There are few extra `}` characters left from the editor's auto-complete. This commit removes the extra characters.