### PR TITLE
NAT MetadataEndpoint to port 8080 from 80

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -389,6 +389,14 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
           #{generate_ip6_private_filter_rules(nics[1..])}
         }
       }
+
+      table ip6 nat_metadata_endpoint {
+        chain prerouting {
+          type nat hook prerouting priority dstnat; policy accept;
+          ip6 daddr FD00:0B1C:100D:5AFE:CE:: tcp dport 80 dnat to [FD00:0B1C:100D:5AFE:CE::]:8080
+        }
+      }
+
       # NAT4 rules
       #{generate_nat4_rules(ip4, nics.first.net4)}
       table inet fw_table {

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -264,6 +264,14 @@ table ip6 raw {
     ether saddr fb:55:dd:ba:21:0a ip6 saddr != fddf:53d2:4c89:2305:46a0::/79 drop
   }
 }
+
+table ip6 nat_metadata_endpoint {
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    ip6 daddr FD00:0B1C:100D:5AFE:CE:: tcp dport 80 dnat to [FD00:0B1C:100D:5AFE:CE::]:8080
+  }
+}
+
 # NAT4 rules
 table ip nat {
   chain prerouting {


### PR DESCRIPTION
Our metadata provider runs on port 8080. Here, we add a simple nat rule to dnat requests on that address and port 80 to 8080. This way, customer can simply run the following to get cert.pem
curl [FD00:0B1C:100D:5afe:CE::]/load-balancer/cert.pem

Before, this was:
curl [FD00:0B1C:100D:5afe:CE::]:8080/load-balancer/key.pem