### PR TITLE
Set a fixed column width for the amount column in the invoice PDF

### DIFF
--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -195,12 +195,12 @@ class Invoice < Sequel::Model
     else
       data[:items].map { [_1[:name], _1[:description], _1[:usage], _1[:cost_humanized]] }
     end
-    pdf.table items, header: true, width: pdf.bounds.width, cell_style: {size: 9, border_color: "E5E7EB", borders: [], padding: [8, 5, 8, 5]} do
+    pdf.table items, header: true, width: pdf.bounds.width, cell_style: {size: 9, border_color: "E5E7EB", borders: [], padding: [5, 6, 12, 6], valign: :center} do
       style(row(0), size: 12, font_style: :semibold, text_color: dark_gray, background_color: "F9FAFB")
       style(column(0), text_color: dark_gray)
       style(columns(-2..-1), align: :right)
       style(column(0), borders: [:left, :top, :bottom])
-      style(column(-1), borders: [:right, :top, :bottom])
+      style(column(-1), borders: [:right, :top, :bottom], width: 70)
       style(columns(1..-2), borders: [:top, :bottom])
     end
     pdf.move_down 10


### PR DESCRIPTION
When the resource name is too long, it causes the amount column header to wrap to two lines, which doesn't look good. I set a fixed width for the amount column to prevent this.

I also vertically aligned the rows to the middle when they have more than one line.


**Before:**
<img width="1562" alt="Screenshot 2024-10-01 at 11 32 55" src="https://github.com/user-attachments/assets/921eb1e5-4bd9-42e6-907d-990d3bdd1ed7">

**After:**
<img width="806" alt="Screenshot 2024-10-01 at 11 55 47" src="https://github.com/user-attachments/assets/d1bf59ac-1508-45da-8034-4377394b0775">
