### PR TITLE
Load Aws::S3 module before freezing them

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ end
 
 gem "webauthn", "~> 3.1"
 
-gem "aws-sdk-s3", "~> 1.163"
+gem "aws-sdk-s3", "~> 1.167"
 
 gem "acme-client", "~> 2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,17 +41,17 @@ GEM
     ast (2.4.2)
     awrence (1.2.1)
     aws-eventstream (1.3.0)
-    aws-partitions (1.977.0)
-    aws-sdk-core (3.206.0)
+    aws-partitions (1.983.0)
+    aws-sdk-core (3.209.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.9)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.91.0)
-      aws-sdk-core (~> 3, >= 3.205.0)
+    aws-sdk-kms (1.94.0)
+      aws-sdk-core (~> 3, >= 3.207.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.163.0)
-      aws-sdk-core (~> 3, >= 3.205.0)
+    aws-sdk-s3 (1.167.0)
+      aws-sdk-core (~> 3, >= 3.207.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.0)
@@ -362,7 +362,7 @@ DEPENDENCIES
   acme-client (~> 2.0)
   argon2
   argon2-kdf
-  aws-sdk-s3 (~> 1.163)
+  aws-sdk-s3 (~> 1.167)
   bcrypt_pbkdf
   brakeman
   capybara

--- a/loader.rb
+++ b/loader.rb
@@ -128,6 +128,14 @@ def clover_freeze
   # this Ruby standard library method patches core classes.
   "".unicode_normalize(:nfc)
 
+  # Aws SDK started to autoload modules when used, so we need to load them
+  # before freezing. https://github.com/aws/aws-sdk-ruby/pull/3105
+  # rubocop:disable Lint/Void
+  Aws::S3::Client
+  Aws::S3::Presigner
+  Aws::S3::Errors
+  # rubocop:enable Lint/Void
+
   # A standard library method that edits/creates a module variable as
   # a side effect.  We encountered it when using rubygems for its tar
   # file writing.


### PR DESCRIPTION
We freeze everything to catch malicious self modifying code from user input. Since the Aws SDK started to autoload modules when used, so we need to load them before freezing.

https://github.com/aws/aws-sdk-ruby/pull/3105