### PR TITLE
Assign private IPv4 address to Dnsmasq

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -213,6 +213,7 @@ class Vm < Sequel::Model
       "public_ipv6" => ephemeral_net6.to_s,
       "public_ipv4" => ip4.to_s || "",
       "local_ipv4" => local_vetho_ip.to_s.shellescape || "",
+      "dns_ipv4" => nics.first.private_subnet.net4.nth(2).to_s,
       "unix_user" => unix_user,
       "ssh_public_keys" => [public_key] + project_public_keys,
       "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac] },

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -51,6 +51,7 @@ begin
   swap_size_bytes = params["swap_size_bytes"]
   pci_devices = params.fetch("pci_devices", [])
   boot_image = params["boot_image"]
+  dns_ipv4 = params["dns_ipv4"]
 rescue KeyError => e
   puts "Needed #{e.key} in parameters json"
   exit 1
@@ -67,7 +68,7 @@ when "prep"
   vm_setup.prep(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes,
-    pci_devices, boot_image)
+    pci_devices, boot_image, dns_ipv4)
 when "recreate-unpersisted"
   secrets = JSON.parse($stdin.read)
   unless (storage_secrets = secrets["storage"])
@@ -77,7 +78,7 @@ when "recreate-unpersisted"
 
   vm_setup.recreate_unpersisted(
     gua, ip4, local_ip4, nics, mem_gib,
-    ndp_needed, storage_volumes, storage_secrets,
+    ndp_needed, storage_volumes, storage_secrets, dns_ipv4,
     multiqueue: max_vcpus > 1
   )
 when "reinstall-systemd-units"
@@ -92,7 +93,7 @@ when "reassign-ip6"
   end
   vm_setup.reassign_ip6(unix_user, ssh_public_keys, nics, gua, ip4,
     local_ip4, max_vcpus, cpu_topology, mem_gib,
-    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices, boot_image)
+    ndp_needed, storage_volumes, storage_secrets, swap_size_bytes, pci_devices, boot_image, dns_ipv4)
 else
   puts "Invalid action #{action}"
   exit 1

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -145,12 +145,12 @@ RSpec.describe VmSetup do
 
   describe "#recreate_unpersisted" do
     it "can recreate unpersisted state" do
-      expect(vs).to receive(:setup_networking).with(true, "gua", "ip4", "local_ip4", "nics", false, multiqueue: true)
+      expect(vs).to receive(:setup_networking).with(true, "gua", "ip4", "local_ip4", "nics", false, "10.0.0.2", multiqueue: true)
       expect(vs).to receive(:hugepages).with(4)
       expect(vs).to receive(:storage).with("storage_params", "storage_secrets", false)
       expect(vs).to receive(:start_systemd_unit)
 
-      vs.recreate_unpersisted("gua", "ip4", "local_ip4", "nics", 4, false, "storage_params", "storage_secrets", multiqueue: true)
+      vs.recreate_unpersisted("gua", "ip4", "local_ip4", "nics", 4, false, "storage_params", "storage_secrets", "10.0.0.2", multiqueue: true)
     end
   end
 
@@ -215,7 +215,7 @@ RSpec.describe VmSetup do
         expect(_3).to eq(gua)
         expect(_4).to be(false)
       }
-      expect(vs).to receive(:setup_taps_6).with(gua, [])
+      expect(vs).to receive(:setup_taps_6).with(gua, [], "10.0.0.2")
       expect(vs).to receive(:routes4).with(ip4, "local_ip4", [])
       expect(vs).to receive(:write_nftables_conf).with(ip4, gua, [])
       expect(vs).to receive(:forwarding)
@@ -223,19 +223,19 @@ RSpec.describe VmSetup do
       expect(vps).to receive(:write_guest_ephemeral).with(guest_ephemeral.to_s)
       expect(vps).to receive(:write_clover_ephemeral).with(clover_ephemeral.to_s)
 
-      vs.setup_networking(false, gua, ip4, "local_ip4", [], false, multiqueue: true)
+      vs.setup_networking(false, gua, ip4, "local_ip4", [], false, "10.0.0.2", multiqueue: true)
     end
 
     it "can setup networking for empty ip4" do
       gua = "fddf:53d2:4c89:2305:46a0::"
       expect(vs).to receive(:interfaces).with([], false)
       expect(vs).to receive(:setup_veths_6)
-      expect(vs).to receive(:setup_taps_6).with(gua, [])
+      expect(vs).to receive(:setup_taps_6).with(gua, [], "10.0.0.2")
       expect(vs).to receive(:routes4).with(nil, "local_ip4", [])
       expect(vs).to receive(:forwarding)
       expect(vs).to receive(:write_nftables_conf)
 
-      vs.setup_networking(true, gua, "", "local_ip4", [], false, multiqueue: false)
+      vs.setup_networking(true, gua, "", "local_ip4", [], false, "10.0.0.2", multiqueue: false)
     end
 
     it "can generate nftables config" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -228,10 +228,12 @@ RSpec.describe Prog::Vm::Nexus do
       vm.unix_user = "test_user"
       vm.public_key = "test_ssh_key"
       vm.local_vetho_ip = "169.254.0.0"
+      ps = instance_double(PrivateSubnet, location: "hetzner-hel1", net4: NetAddr::IPv4Net.parse("10.0.0.0/26"))
       nic = Nic.new(private_ipv6: "fd10:9b0b:6b4b:8fbb::/64", private_ipv4: "10.0.0.3/32", mac: "5a:0f:75:80:c3:64")
       pci = PciDevice.new(slot: "01:00.0", iommu_group: 23)
       expect(nic).to receive(:ubid_to_tap_name).and_return("tap4ncdd56m")
       expect(vm).to receive(:nics).and_return([nic]).at_least(:once)
+      expect(nic).to receive(:private_subnet).and_return(ps).at_least(:once)
       expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(1, 1, 1, 1))
       expect(vm).to receive(:pci_devices).and_return([pci]).at_least(:once)
       prj.set_ff_vm_public_ssh_keys(["operator_ssh_key"])


### PR DESCRIPTION
We had reserved the first 4 addresses from the private subnet for our own usage. They sit still and now we need one of them. Ubicloud VMs are totally fine using IPv6 for dns queries, however, the container landscape is not like that... The docker containers running on these VMs prefer (have to) use IPv4. This is why our dnsmasq based dns solution tend to break for containers. Here, in this commit, we are assigning the second address from the private subnet to dns. AWS does the same thing. More information available here:
https://docs.aws.amazon.com/vpc/latest/userguide/subnet-sizing.html