### PR TITLE
Remove Dnsmasq hard dependency to avoid VM reboot

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -611,7 +611,7 @@ After=network.target
 #{spdk_after}
 After=#{@vm_name}-dnsmasq.service
 #{spdk_requires}
-Requires=#{@vm_name}-dnsmasq.service
+Wants=#{@vm_name}-dnsmasq.service
 
 [Service]
 NetworkNamespacePath=/var/run/netns/#{@vm_name}


### PR DESCRIPTION
Using Requires together with After in systemd definition causes VM service to restart whenever we restart dnsmasq service, too. Replacing with Want still keeps the initial dependency of spin up dnsmasq before VM but restarts won't cause the VM restart as well. This way, we can add, remove arguments properly to dnsmasq; such as custom hostnames.