### PR TITLE
Dependabot configs improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,10 @@ updates:
     allow:
       - dependency-type: "all"
     groups:
-      ruby-dependencies:
-        patterns:
-          - "*"
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     allow:
       - dependency-type: "all"
     groups:
@@ -23,7 +23,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     allow:
       - dependency-type: "all"
     groups:


### PR DESCRIPTION
### Check npm and docker packages version updates weekly

npm libraries are divided into many small packages, with at least one of
them receiving updates daily. This results in a high volume of pull
requests.

The versions of npm and docker packages aren't as mission-critical for
us as Ruby packages are.

Dependabot generates security incident pull requests apart from version
updates anyway. To reduce workload, we can update npm and docker
packages on a weekly basis.

### Divide Dependabot version updates for production and development

As our number of dependencies grows, it results in large PRs that are
difficult to review. The recent aws-sdk-s3 failures highlight the need
for us to be more cautious with these updates.

Dependabot has a feature that allows us to group updates by type,
enabling us to update development dependencies separately from
production dependencies.
