### PR TITLE
Use local ip instead of localhost for cache endpoints

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -235,6 +235,8 @@ class Prog::Vm::GithubRunner < Prog::Base
   label def setup_forked_runner
     tarball_uri = (label_data["arch"] == "arm64") ? Config.github_cache_forked_runner_tarball_uri_arm64 : Config.github_cache_forked_runner_tarball_uri
 
+    local_ip = vm.nics.first.private_ipv4.network.to_s
+
     command = <<~COMMAND
       curl --output actions-runner.tar.gz -L #{tarball_uri}
 
@@ -260,7 +262,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       sudo mv ./actions-runner /home/runner/
       sudo chown -R runner:runner /home/runner/actions-runner
 
-      echo "CUSTOM_ACTIONS_CACHE_URL=http://localhost:51123/random_token/" | sudo tee -a /etc/environment
+      echo "CUSTOM_ACTIONS_CACHE_URL=http://#{local_ip}:51123/random_token/" | sudo tee -a /etc/environment
       echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
     COMMAND
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -419,6 +419,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to register_runner" do
       expect(Config).to receive_messages(github_cache_forked_runner_tarball_uri: "https://github.com/foo/tarball")
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
+      expect(vm.nics.first).to receive(:private_ipv4).and_return(NetAddr::IPv4Net.parse("10.0.0.1/32"))
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         curl --output actions-runner.tar.gz -L https://github.com/foo/tarball
@@ -438,7 +439,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         sudo rm -rf /home/runner/actions-runner
         sudo mv ./actions-runner /home/runner/
         sudo chown -R runner:runner /home/runner/actions-runner
-        echo "CUSTOM_ACTIONS_CACHE_URL=http://localhost:51123/random_token/" | sudo tee -a /etc/environment
+        echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
         echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
       COMMAND
 
@@ -449,6 +450,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(Config).to receive_messages(github_cache_forked_runner_tarball_uri_arm64: "https://github.com/foo/tarball")
       expect(github_runner).to receive(:label).and_return("ubicloud-arm").at_least(:once)
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
+      expect(vm.nics.first).to receive(:private_ipv4).and_return(NetAddr::IPv4Net.parse("10.0.0.1/32"))
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         curl --output actions-runner.tar.gz -L https://github.com/foo/tarball
@@ -468,7 +470,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         sudo rm -rf /home/runner/actions-runner
         sudo mv ./actions-runner /home/runner/
         sudo chown -R runner:runner /home/runner/actions-runner
-        echo "CUSTOM_ACTIONS_CACHE_URL=http://localhost:51123/random_token/" | sudo tee -a /etc/environment
+        echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
         echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
       COMMAND
 


### PR DESCRIPTION
To access the local cache server on port 51123, localhost was used. It was ok to use that to access the server via processes running on the VM itself. Though, processes running in a container can not access the cache server with localhost. So, using local ip address instead to allow processes from both VM and container to access cache server.