### PR TITLE
Clear explicit dns resolution for runners

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -266,6 +266,18 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     vm.sshable.cmd(command.gsub(/^\s*\n/, ""))
 
+    hop_clear_ubicloud_resolve_conf
+  end
+
+  label def clear_ubicloud_resolve_conf
+    command = <<~COMMAND
+      sudo rm -f /etc/systemd/resolved.conf.d/Ubicloud.conf
+      sudo systemctl restart systemd-resolved
+      sudo systemctl restart docker
+    COMMAND
+
+    vm.sshable.cmd(command.gsub(/^\s*\n/, ""))
+
     hop_download_proxy
   end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -442,7 +442,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
       COMMAND
 
-      expect { nx.setup_forked_runner }.to hop("download_proxy")
+      expect { nx.setup_forked_runner }.to hop("clear_ubicloud_resolve_conf")
     end
 
     it "hops to register_runner arm" do
@@ -472,7 +472,19 @@ RSpec.describe Prog::Vm::GithubRunner do
         echo "127.0.0.1 localhost.blob.core.windows.net" | sudo tee -a /etc/hosts
       COMMAND
 
-      expect { nx.setup_forked_runner }.to hop("download_proxy")
+      expect { nx.setup_forked_runner }.to hop("clear_ubicloud_resolve_conf")
+    end
+  end
+
+  describe "#clear_ubicloud_resolve_conf" do
+    it "hops to download_proxy" do
+      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+        sudo rm -f /etc/systemd/resolved.conf.d/Ubicloud.conf
+        sudo systemctl restart systemd-resolved
+        sudo systemctl restart docker
+      COMMAND
+
+      expect { nx.clear_ubicloud_resolve_conf }.to hop("download_proxy")
     end
   end
 


### PR DESCRIPTION
Since we were not using dnsmasq to resolve dns names on github runners, we've added an explicit configuration to resolved configuration. So, runner VMs can resolve names directly using the information passed on the configuration file. As we've decided to use dnsmasq for resolution, removing explicit configuration.

Note that, this commit will be removed once the explicit configuration setting is removed from the runner image.