### PR TITLE
Fix the condition check during installation destroy

### DIFF
--- a/prog/github/destroy_github_installation.rb
+++ b/prog/github/destroy_github_installation.rb
@@ -36,8 +36,8 @@ class Prog::Github::DestroyGithubInstallation < Prog::Base
   end
 
   label def destroy
-    nap 10 if github_installation.runners_dataset.exists
-    nap 10 if github_installation.repositories_dataset.exists
+    nap 10 unless github_installation.runners_dataset.empty?
+    nap 10 unless github_installation.repositories_dataset.empty?
 
     github_installation.destroy
     Clog.emit("GithubInstallation is deleted.") { github_installation }

--- a/spec/prog/github/destroy_github_installation_spec.rb
+++ b/spec/prog/github/destroy_github_installation_spec.rb
@@ -57,19 +57,19 @@ RSpec.describe Prog::Github::DestroyGithubInstallation do
 
   describe "#destroy" do
     it "naps if not all runners destroyed" do
-      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, exists: true))
+      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, empty?: false))
       expect { dgi.destroy }.to nap(10)
     end
 
     it "naps if not all repositories destroyed" do
-      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, exists: false))
-      expect(github_installation).to receive(:repositories_dataset).and_return(instance_double(Sequel::Dataset, exists: true))
+      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, empty?: true))
+      expect(github_installation).to receive(:repositories_dataset).and_return(instance_double(Sequel::Dataset, empty?: false))
       expect { dgi.destroy }.to nap(10)
     end
 
     it "deletes resource and pops" do
-      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, exists: false))
-      expect(github_installation).to receive(:repositories_dataset).and_return(instance_double(Sequel::Dataset, exists: false))
+      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, empty?: true))
+      expect(github_installation).to receive(:repositories_dataset).and_return(instance_double(Sequel::Dataset, empty?: true))
       expect(github_installation).to receive(:destroy)
       expect { dgi.destroy }.to exit({"msg" => "github installation destroyed"})
     end


### PR DESCRIPTION
We ensure that the installation has no repositories or runners before destroy it.

I attempted to handle this check on the query side and used `.exists` with the dataset. However, it doesn't work as expected. Instead of returning a boolean, it returns `Sequel::SQL::PlaceholderLiteralString`. The `if` statement always evaluates as true because it's an object. I replaced it with `empty?`.