### PR TITLE
Make setup-vm fail earlier

### DIFF
--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -50,8 +50,8 @@ begin
   storage_volumes = params.fetch("storage_volumes")
   swap_size_bytes = params["swap_size_bytes"]
   pci_devices = params.fetch("pci_devices", [])
-  boot_image = params["boot_image"]
-  dns_ipv4 = params["dns_ipv4"]
+  boot_image = params.fetch("boot_image")
+  dns_ipv4 = params.fetch("dns_ipv4")
 rescue KeyError => e
   puts "Needed #{e.key} in parameters json"
   exit 1


### PR DESCRIPTION
I saw a case of a nil-expansion of `dns_ipv4` causing this error in code that looks like this:

    r "ip -n #{q_vm} addr replace #{dns_ipv4} dev #{nic.tap}"

And has errors like:

    ---STDERR---
    RTNETLINK answers: Operation not supported
            from /home/rhizome/host/lib/vm_setup.rb:271:in `block in setup_taps_6'
            from /home/rhizome/host/lib/vm_setup.rb:268:in `each'
            from /home/rhizome/host/lib/vm_setup.rb:268:in `setup_taps_6'
            from /home/rhizome/host/lib/vm_setup.rb:96:in `setup_networking'
            from /home/rhizome/host/lib/vm_setup.rb:49:in `block in prep'
    /home/rhizome/common/lib/util.rb:29:in `r': command failed: ip -n vmg1x0hy addr replace  dev nc9g0we9s2 (CommandFail)

While this was probably caused by an old running code image, it seems like we can check for the existence of obliged fields in `params.json` as we do all the others, for some reason, a couple got square brackets rather than `.fetch`.