### PR TITLE
Apply firewall rules to private subnet addresses as well

### DIFF
--- a/prog/test/firewall_rules.rb
+++ b/prog/test/firewall_rules.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+class Prog::Test::FirewallRules < Prog::Test::Base
+  subject_is :firewall
+
+  label def start
+    vms = [vm1, vm2, vm_outside]
+    vms.each do |vm|
+      vm.sshable.cmd("sudo yum install -y nc") if vm.boot_image.include?("almalinux")
+      vm.sshable.cmd("sudo apt-get update && sudo apt-get install -y netcat-openbsd") if vm.boot_image.include?("debian")
+    end
+
+    vm1.sshable.cmd("echo '[Unit]
+Description=A lightweight port 8080 listener
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/nc -l 8080
+' | sudo tee /etc/systemd/system/listening_ipv4.service > /dev/null")
+
+    vm1.sshable.cmd("echo '[Unit]
+Description=A lightweight port 8080 listener
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=nc -l 8080 -6
+' | sudo tee /etc/systemd/system/listening_ipv6.service > /dev/null")
+
+    vm1.sshable.cmd("sudo systemctl daemon-reload")
+    vm1.sshable.cmd("sudo systemctl enable listening_ipv4.service")
+    vm1.sshable.cmd("sudo systemctl enable listening_ipv6.service")
+
+    hop_perform_tests_none
+  end
+
+  label def perform_tests_none
+    update_firewall_rules(config: :perform_tests_none) unless frame["firewalls"] == "none"
+
+    update_stack({
+      "firewalls" => "none"
+    })
+
+    if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
+      nap 5
+    end
+
+    vm1.sshable.cmd("true")
+    vm2.sshable.cmd("true")
+    vm1.sshable.cmd("ping -c 2 google.com")
+    vm2.sshable.cmd("ping -c 2 google.com")
+
+    vm1.sshable.cmd("sudo systemctl start listening_ipv4.service")
+    test_connection(vm1.ephemeral_net4, vm2, should_fail: true, ipv4: true, hop_method_symbol: :hop_perform_tests_public_ipv4)
+    fail_test "#{vm2.inhost_name} should not be able to connect to #{vm1.inhost_name} on port 8080"
+  end
+
+  label def perform_tests_public_ipv4
+    update_firewall_rules(config: :perform_tests_public_ipv4) unless frame["firewalls"] == "public_ipv4"
+
+    update_stack({
+      "firewalls" => "public_ipv4"
+    })
+    if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
+      nap 5
+    end
+
+    test_connection(vm1.ephemeral_net4, vm2, should_fail: false, ipv4: true, hop_method_symbol: nil)
+    test_connection(vm1.ephemeral_net4, vm_outside, should_fail: true, ipv4: true, hop_method_symbol: :hop_perform_tests_public_ipv6)
+
+    fail_test "#{vm_outside.inhost_name} should not be able to connect to #{vm1.inhost_name} on port 8080"
+  end
+
+  label def perform_tests_public_ipv6
+    update_firewall_rules(config: :perform_tests_public_ipv6) unless frame["firewalls"] == "public_ipv6"
+
+    update_stack({
+      "firewalls" => "public_ipv6"
+    })
+    if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
+      nap 5
+    end
+
+    vm1.sshable.cmd("sudo systemctl stop listening_ipv4.service")
+    vm1.sshable.cmd("sudo systemctl start listening_ipv6.service")
+    test_connection(vm1.ephemeral_net6.nth(2), vm2, should_fail: false, ipv4: false, hop_method_symbol: nil)
+    test_connection(vm1.ephemeral_net6.nth(2), vm_outside, should_fail: true, ipv4: false, hop_method_symbol: :hop_perform_tests_private_ipv4)
+    fail_test "#{vm_outside.inhost_name} should not be able to connect to #{vm1.ephemeral_net6.nth(2)} on port 8080"
+  end
+
+  label def perform_tests_private_ipv4
+    update_firewall_rules(config: :perform_tests_private_ipv4) unless frame["firewalls"] == "private_ipv4"
+
+    update_stack({
+      "firewalls" => "private_ipv4"
+    })
+    if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
+      nap 5
+    end
+
+    vm1.sshable.cmd("sudo systemctl stop listening_ipv6.service")
+    vm1.sshable.cmd("sudo systemctl start listening_ipv4.service")
+    test_connection(vm1.nics.first.private_ipv4.nth(0), vm2, should_fail: false, ipv4: true, hop_method_symbol: nil)
+    test_connection(vm1.ephemeral_net4, vm_outside, should_fail: true, ipv4: true, hop_method_symbol: :hop_perform_tests_private_ipv6)
+    fail_test "#{vm_outside.inhost_name} should not be able to connect to #{vm1.nics.first.private_ipv4.nth(0)} on port 8080"
+  end
+
+  label def perform_tests_private_ipv6
+    update_firewall_rules(config: :perform_tests_private_ipv6) unless frame["firewalls"] == "private_ipv6"
+
+    update_stack({
+      "firewalls" => "private_ipv6"
+    })
+    if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
+      nap 5
+    end
+
+    vm1.sshable.cmd("sudo systemctl stop listening_ipv4.service")
+    vm1.sshable.cmd("sudo systemctl start listening_ipv6.service")
+    test_connection(vm1.nics.first.private_ipv6.nth(2), vm2, should_fail: false, ipv4: false, hop_method_symbol: nil)
+    test_connection(vm1.ephemeral_net6.nth(2), vm2, should_fail: true, ipv4: false, hop_method_symbol: :hop_finish)
+    fail_test "#{vm2.inhost_name} should not be able to connect to #{vm1.ephemeral_net6.nth(2)} on port 8080"
+  end
+
+  label def finish
+    pop "Verified Firewall Rules!"
+  end
+
+  label def failed
+    nap 15
+  end
+
+  def update_firewall_rules(config: nil)
+    uri = URI("https://api.ipify.org")
+    my_ip = Net::HTTP.get(uri)
+    firewall_rules = [
+      {cidr: "#{my_ip}/32", port_range: Sequel.pg_range(22..22)}
+    ]
+    firewall_rules << case config
+    when :perform_tests_none
+      nil
+    when :perform_tests_public_ipv4
+      {cidr: vm2.ephemeral_net4.to_s, port_range: Sequel.pg_range(8080..8080)}
+    when :perform_tests_public_ipv6
+      {cidr: vm2.ephemeral_net6.nth(2).to_s, port_range: Sequel.pg_range(8080..8080)}
+    when :perform_tests_private_ipv4
+      {cidr: vm2.nics.first.private_ipv4.to_s, port_range: Sequel.pg_range(8080..8080)}
+    when :perform_tests_private_ipv6
+      {cidr: vm2.nics.first.private_ipv6.nth(2).to_s, port_range: Sequel.pg_range(8080..8080)}
+    else
+      raise "Unknown config: #{config}"
+    end
+
+    firewall.replace_firewall_rules(firewall_rules.compact)
+  end
+
+  def vm1
+    @vm1 ||= firewall.private_subnets.first.vms.first
+  end
+
+  def vm2
+    @vm2 ||= firewall.private_subnets.first.vms.reject { _1.id == vm1.id }.first
+  end
+
+  def vm_outside
+    @vm_outside ||= PrivateSubnet.find { |ps| ps.id != vm1.private_subnets.first.id }.vms.first
+  end
+
+  def test_connection(to_connect_ip, connecting, should_fail: false, ipv4: true, hop_method_symbol: nil)
+    test_version_arg = ipv4 ? "" : "-6"
+    connecting.sshable.cmd("nc -zvw 1 #{to_connect_ip} 8080 #{test_version_arg}")
+  rescue
+    send(hop_method_symbol) if should_fail
+    fail_test "#{connecting.inhost_name} should be able to connect to #{to_connect_ip} on port 8080"
+  end
+end

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -76,6 +76,14 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def verify_vms
     if retval&.dig("msg") == "Verified VM!"
+      hop_verify_firewall_rules
+    end
+
+    push Prog::Test::Vm, {subject_id: frame["vms"].first}
+  end
+
+  label def verify_firewall_rules
+    if retval&.dig("msg") == "Verified Firewall Rules!"
       if frame["test_reboot"]
         hop_test_reboot
       else
@@ -83,7 +91,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
       end
     end
 
-    push Prog::Test::Vm, {subject_id: frame["vms"].first}
+    push Prog::Test::FirewallRules, {subject_id: PrivateSubnet[frame["subnets"].first].firewalls.first.id}
   end
 
   label def test_reboot

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -210,11 +210,11 @@ TEMPLATE
   end
 
   def generate_private_ip4_list
-    vm.nics.map { NetAddr::IPv4Net.parse(_1.private_ipv4.network.to_s + "/26").to_s }.join(",")
+    vm.nics.map { _1.private_ipv4.to_s }.join(",")
   end
 
   def generate_private_ip6_list
-    vm.nics.map { NetAddr::IPv6Net.parse(_1.private_ipv6.network.to_s + "/64").to_s }.join(",")
+    vm.nics.map { _1.private_ipv6.to_s }.join(",")
   end
 
   def subdivide_network(net)

--- a/spec/prog/test/firewall_rules_spec.rb
+++ b/spec/prog/test/firewall_rules_spec.rb
@@ -1,0 +1,511 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+require "netaddr"
+
+RSpec.describe Prog::Test::FirewallRules do
+  subject(:firewall_test) {
+    described_class.new(Strand.new(prog: "Test::FirewallRules"))
+  }
+
+  let(:sshable) {
+    instance_double(Sshable)
+  }
+
+  let(:private_subnet_1) {
+    nic = instance_double(Nic, private_ipv6: NetAddr::IPv6Net.parse("fd01:0db8:85a1::/64"), private_ipv4: NetAddr::IPv4Net.parse("192.168.0.1/32"))
+    vm_1 = instance_double(Vm, id: "vm_1", sshable: sshable, boot_image: "ubuntu-noble", ephemeral_net4: "1.1.1.1", ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a1::/64"), inhost_name: "vm1", nics: [nic])
+    vm_2 = instance_double(Vm, id: "vm_2", sshable: sshable, boot_image: "almalinux-9", ephemeral_net4: "1.1.1.2", ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a2::/64"), inhost_name: "vm2", nics: [nic])
+    instance_double(PrivateSubnet, id: "subnet_1", vms: [vm_1, vm_2])
+  }
+
+  let(:vm_outside) {
+    instance_double(Vm, id: "vm_outside", sshable: sshable, boot_image: "debian-12", ephemeral_net4: "1.1.1.3", ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a3::/64"), inhost_name: "vm_outside")
+  }
+
+  before do
+    fw = instance_double(Firewall, id: "fw_id", private_subnets: [private_subnet_1])
+    allow(firewall_test).to receive(:firewall).and_return(fw)
+  end
+
+  describe "#start" do
+    it "installs nc and sets up services" do
+      ps = instance_double(PrivateSubnet, id: "ps2", vms: [vm_outside])
+      expect(firewall_test).to receive(:vm1).and_return(private_subnet_1.vms.first).at_least(:once)
+      expect(firewall_test).to receive(:vm2).and_return(private_subnet_1.vms.last).at_least(:once)
+      expect(firewall_test).to receive(:vm_outside).and_return(ps.vms.first).at_least(:once)
+      expect(sshable).to receive(:cmd).with("sudo yum install -y nc")
+      expect(sshable).to receive(:cmd).with("sudo apt-get update && sudo apt-get install -y netcat-openbsd")
+      expect(sshable).to receive(:cmd).with("echo '[Unit]
+Description=A lightweight port 8080 listener
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/nc -l 8080
+' | sudo tee /etc/systemd/system/listening_ipv4.service > /dev/null")
+      expect(sshable).to receive(:cmd).with("echo '[Unit]
+Description=A lightweight port 8080 listener
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=nc -l 8080 -6
+' | sudo tee /etc/systemd/system/listening_ipv6.service > /dev/null")
+      expect(sshable).to receive(:cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv6.service")
+
+      expect { firewall_test.start }.to hop("perform_tests_none")
+    end
+
+    it "installs nc to other vms too" do
+      ps = instance_double(PrivateSubnet, id: "ps2", vms: [vm_outside])
+      expect(firewall_test).to receive(:vm1).and_return(private_subnet_1.vms.first).at_least(:once)
+      expect(firewall_test).to receive(:vm2).and_return(private_subnet_1.vms.last).at_least(:once)
+      expect(firewall_test).to receive(:vm_outside).and_return(ps.vms.first).at_least(:once)
+
+      expect(firewall_test.vm1).to receive(:boot_image).and_return("almalinux-8")
+      expect(firewall_test.vm2).to receive(:boot_image).and_return("ubuntu-jammy")
+      expect(sshable).to receive(:cmd).with("sudo yum install -y nc")
+      expect(sshable).to receive(:cmd).with("sudo apt-get update && sudo apt-get install -y netcat-openbsd")
+
+      expect(sshable).to receive(:cmd).with("echo '[Unit]
+Description=A lightweight port 8080 listener
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/nc -l 8080
+' | sudo tee /etc/systemd/system/listening_ipv4.service > /dev/null")
+      expect(sshable).to receive(:cmd).with("echo '[Unit]
+Description=A lightweight port 8080 listener
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=nc -l 8080 -6
+' | sudo tee /etc/systemd/system/listening_ipv6.service > /dev/null")
+      expect(sshable).to receive(:cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv6.service")
+
+      expect { firewall_test.start }.to hop("perform_tests_none")
+    end
+  end
+
+  describe "#perform_tests_none" do
+    it "updates firewall rules when the frame is not set to none and naps if firewall rules are not updated" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => nil})
+      expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_none)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_none }.to nap(5)
+    end
+
+    it "doesn't update firewall rules when the frame is set to none and naps if firewall rules are not updated" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_none }.to nap(5)
+    end
+
+    it "doesn't update firewall rules and tests connectivity and hops when the fw update is done" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("true").twice
+      expect(sshable).to receive(:cmd).with("ping -c 2 google.com").twice
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
+
+      expect { firewall_test.perform_tests_none }.to hop("perform_tests_public_ipv4")
+    end
+
+    it "updates firewall rules and tests connectivity and fails when the fw update is done" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("true").twice
+      expect(sshable).to receive(:cmd).with("ping -c 2 google.com").twice
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_return("success!")
+
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should not be able to connect to vm1 on port 8080"})
+      expect { firewall_test.perform_tests_none }.to hop("failed")
+    end
+  end
+
+  describe "#perform_tests_public_ipv4" do
+    it "updates firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_public_ipv4 }.to nap(5)
+    end
+
+    it "does not update firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_public_ipv4 }.to nap(5)
+    end
+
+    it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to 1.1.1.1 on port 8080"})
+      expect { firewall_test.perform_tests_public_ipv4 }.to hop("failed")
+    end
+
+    it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_return("success!").at_least(:once)
+
+      vm_outside = instance_double(Vm, ephemeral_net4: "1.1.1.3", inhost_name: "vm_outside", sshable: sshable)
+      expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm_outside should not be able to connect to vm1 on port 8080"})
+      expect { firewall_test.perform_tests_public_ipv4 }.to hop("failed")
+    end
+
+    it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_return("success!").once
+
+      vm_outside = instance_double(Vm, ephemeral_net4: "1.1.1.3", inhost_name: "vm_outside", sshable: sshable)
+      expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
+
+      expect { firewall_test.perform_tests_public_ipv4 }.to hop("perform_tests_public_ipv6")
+    end
+  end
+
+  describe "#perform_tests_public_ipv6" do
+    it "updates firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_public_ipv6 }.to nap(5)
+    end
+
+    it "does not update firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_public_ipv6 }.to nap(5)
+    end
+
+    it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 2001:db8:85a1::2 8080 -6").and_raise("nc: connect to 2001:db8:85a1::/64 port 8080 (tcp) timed out")
+
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to 2001:db8:85a1::2 on port 8080"})
+      expect { firewall_test.perform_tests_public_ipv6 }.to hop("failed")
+    end
+
+    it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv6.service")
+
+      vm_outside = instance_double(Vm, inhost_name: "vm_outside", sshable: sshable)
+      expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 2001:db8:85a1::2 8080 -6").and_return("success!").at_least(:once)
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm_outside should not be able to connect to 2001:db8:85a1::2 on port 8080"})
+      expect { firewall_test.perform_tests_public_ipv6 }.to hop("failed")
+    end
+
+    it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 2001:db8:85a1::2 8080 -6").and_return("success!").once
+
+      vm_outside = instance_double(Vm, inhost_name: "vm_outside", sshable: sshable)
+      expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 2001:db8:85a1::2 8080 -6").and_raise("nc: connect to 2001:db8:85a1::/64 port 8080 (tcp) timed out")
+      expect { firewall_test.perform_tests_public_ipv6 }.to hop("perform_tests_private_ipv4")
+    end
+  end
+
+  describe "#perform_tests_private_ipv4" do
+    it "updates firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_private_ipv4 }.to nap(5)
+    end
+
+    it "does not update firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_private_ipv4 }.to nap(5)
+    end
+
+    it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 192.168.0.1 8080 ").and_raise("nc: connect to 192.168.0.1 port 8080 (tcp) timed out")
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to 192.168.0.1 on port 8080"})
+      expect { firewall_test.perform_tests_private_ipv4 }.to hop("failed")
+    end
+
+    it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 192.168.0.1 8080 ").and_return("success!").once
+
+      vm_outside = instance_double(Vm, ephemeral_net4: "1.1.1.3", inhost_name: "vm_outside", sshable: sshable)
+      expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
+      expect { firewall_test.perform_tests_private_ipv4 }.to hop("perform_tests_private_ipv6")
+    end
+
+    it "does not update firewall rules and tests connectivity and fails when the vm_outside can connect to VM1 publicly" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 192.168.0.1 8080 ").and_return("success!").once
+
+      vm_outside = instance_double(Vm, ephemeral_net4: "1.1.1.3", inhost_name: "vm_outside", sshable: sshable)
+      expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 1.1.1.1 8080 ").and_return("success!").once
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm_outside should not be able to connect to 192.168.0.1 on port 8080"})
+      expect { firewall_test.perform_tests_private_ipv4 }.to hop("failed")
+    end
+  end
+
+  describe "#perform_tests_private_ipv6" do
+    it "updates firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_private_ipv6 }.to nap(5)
+    end
+
+    it "does not update firewall rules and naps when the fw update is not done yet" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
+      expect { firewall_test.perform_tests_private_ipv6 }.to nap(5)
+    end
+
+    it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_raise("nc: connect to fd01:0db8:85a1::2 port 8080 (tcp) timed out")
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to fd01:db8:85a1::2 on port 8080"})
+      expect { firewall_test.perform_tests_private_ipv6 }.to hop("failed")
+    end
+
+    it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_return("success!").once
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 2001:db8:85a1::2 8080 -6").and_raise("nc: connect to 2001:db8:85a1::2 port 8080 (tcp) timed out")
+      expect { firewall_test.perform_tests_private_ipv6 }.to hop("finish")
+    end
+
+    it "does not update firewall rules and tests connectivity and fails when the vm2 can connect to VM1 publicly" do
+      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
+      expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
+      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
+
+      expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
+      expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
+
+      expect(sshable).to receive(:cmd).with("sudo systemctl stop listening_ipv4.service")
+      expect(sshable).to receive(:cmd).with("sudo systemctl start listening_ipv6.service")
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_return("success!").once
+      expect(sshable).to receive(:cmd).with("nc -zvw 1 2001:db8:85a1::2 8080 -6").and_return("success!").once
+      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should not be able to connect to 2001:db8:85a1::2 on port 8080"})
+      expect { firewall_test.perform_tests_private_ipv6 }.to hop("failed")
+    end
+  end
+
+  describe "#finish" do
+    it "pops the message" do
+      expect(firewall_test).to receive(:pop).with("Verified Firewall Rules!")
+      firewall_test.finish
+    end
+  end
+
+  describe "#failed" do
+    it "naps for 15 seconds" do
+      expect(firewall_test).to receive(:nap).with(15)
+      firewall_test.failed
+    end
+  end
+
+  describe ".update_firewall_rules" do
+    it "updates the firewall rules for different configurations" do
+      expect(Sequel).to receive(:pg_range).with(22..22).and_return("22..22").at_least(:once)
+      expect(Sequel).to receive(:pg_range).with(8080..8080).and_return("8080..8080").at_least(:once)
+      expect(Net::HTTP).to receive(:get).with(URI("https://api.ipify.org")).and_return("100.100.100.100").at_least(:once)
+      expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}])
+      firewall_test.update_firewall_rules(config: :perform_tests_none)
+
+      expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}, {cidr: "1.1.1.2", port_range: "8080..8080"}])
+      firewall_test.update_firewall_rules(config: :perform_tests_public_ipv4)
+
+      expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}, {cidr: "2001:db8:85a2::2", port_range: "8080..8080"}])
+      firewall_test.update_firewall_rules(config: :perform_tests_public_ipv6)
+
+      expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}, {cidr: "192.168.0.1/32", port_range: "8080..8080"}])
+      firewall_test.update_firewall_rules(config: :perform_tests_private_ipv4)
+
+      expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}, {cidr: "fd01:db8:85a1::2", port_range: "8080..8080"}])
+      firewall_test.update_firewall_rules(config: :perform_tests_private_ipv6)
+
+      expect { firewall_test.update_firewall_rules(config: :unknown) }.to raise_error("Unknown config: unknown")
+    end
+  end
+
+  describe ".vm1" do
+    it "returns the first vm" do
+      expect(firewall_test.vm1).to eq(firewall_test.firewall.private_subnets.first.vms.first)
+    end
+  end
+
+  describe ".vm2" do
+    it "returns the second vm" do
+      expect(firewall_test.vm2).to eq(firewall_test.firewall.private_subnets.first.vms.last)
+    end
+  end
+
+  describe ".vm_outside" do
+    it "returns the vm outside" do
+      expect(firewall_test.vm1).to receive(:private_subnets).and_return([instance_double(PrivateSubnet, id: "ps1", vms: [instance_double(Vm, inhost_name: "vm1")])])
+      prj = Project.create_with_id(name: "project1")
+      prj.associate_with_project(prj)
+      ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-fsn1").subject
+      Prog::Vm::Nexus.assemble("", prj.id, name: "vm-outside", location: "hetzner-fsn1", private_subnet_id: ps.id).subject
+      expect(firewall_test.vm_outside.name).to eq("vm-outside")
+    end
+  end
+end

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -67,14 +67,14 @@ elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
     type ipv4_addr;
     flags interval;
     elements = {
-      10.0.0.0/26
+      10.0.0.0/32
     }
   }
 
   set private_ipv6_cidrs {
     type ipv6_addr
     flags interval
-    elements = { fd00::/64 }
+    elements = { fd00::1/128 }
   }
 
   set globally_blocked_ipv4s {
@@ -164,14 +164,14 @@ table inet fw_table {
     type ipv4_addr;
     flags interval;
     elements = {
-      10.0.0.0/26
+      10.0.0.0/32
     }
   }
 
   set private_ipv6_cidrs {
     type ipv6_addr
     flags interval
-    elements = { fd00::/64 }
+    elements = { fd00::1/128 }
   }
 
   set globally_blocked_ipv4s {


### PR DESCRIPTION
## Limit private_ipX_cidrs to the specific private ips of the resource
We were previously generating the private ip ranges of the whole subnet
for both ipv4 and ipv6. Using these sets later in the rules, we were hot
wiring all of the private subnet and avoiding them to get filtered by
firewall rules.

## Apply firewall rules to the private subnet as well
This commit makes 2 main modifications to apply firewall rules to the
private subnet ranges as well. Together with the previous commit, we are
reorganizing firewall rules to support that.
1. We add new set of rules that would allow connections for the same
lists in the previous commit but this time, when they are used in daddr.
2. Lastly, we get the clover_ephemeral address and apply new rules to
allow everything for them as very first rules.

## Additional reorganization and testing changes for FirewallRules
Here, we make further modifications to reorganize and clean-up the
firewall rules generation file.
1. We remove the sets allowed_ipv4_cidrs/allowed_ipv6_cidrs. These are
not used anymore. Those sets were added with the initial implementation
when our firewall rules did not have ports. However, now, even if we add
a rule without specifying a port, the default behavior is to set all the
ports. Therefore, these sets are not used, the rules that use them are
also removed in the previous commit.
2. We add comments to the necessary places.
3. We further increase the rules to allow pings for all addresses.
4. Modify tests to use the new firewall rules nftables definition.

## Firewalls E2E Tests
Here are the covered scenarios;
- When no firewall rules are set, ipv4 connectivity should fail
- When only public ipv4 of vm2 is allowed:
  - VM2 can connect to VM1
  - VM3 cannot connect to VM1
- When only public ipv6 of vm2 is allowed;
  - VM2 can connect to VM1 using IPv6
  - VM3 cannot connect to VM1 using IPv6
- When only private ipv4 is allowed:
  - VM2 can connect to VM1 using private IPv4
  - VM2 cannot connect to VM1 using public IPv4
- When only private ipv6 of VM2 is allowed:
  - VM2 can connect to VM1 using private IPv6
  - VM2 cannot connect to VM1 using public IPv6

This also includes the unit tests of the E2E tests.