### PR TITLE
Enable Ubuntu 24 runners on arm64

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -30,6 +30,12 @@
 - { name: ubicloud-standard-16-arm,             vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-30-arm,             vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-60-arm,             vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-standard-2-arm-ubuntu-2404,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-4-arm-ubuntu-2404,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-8-arm-ubuntu-2404,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-16-arm-ubuntu-2404, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-30-arm-ubuntu-2404, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2404,     location: github-runners }
+- { name: ubicloud-standard-60-arm-ubuntu-2404, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2404,     location: github-runners }
 - { name: ubicloud-standard-2-arm-ubuntu-2204,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-4-arm-ubuntu-2204,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
 - { name: ubicloud-standard-8-arm-ubuntu-2204,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }


### PR DESCRIPTION
We've added Ubuntu 24 runners for x64 in
d997e64fadc15239ca065c3977071191a86e4d96. Now, with this PR, we're also enabling Ubuntu 24 runners for arm64.