### PR TITLE
Update github runner spec to receive nics for vm

### DIFF
--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to register_runner" do
       expect(Config).to receive_messages(github_cache_forked_runner_tarball_uri: "https://github.com/foo/tarball")
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
-      expect(vm.nics.first).to receive(:private_ipv4).and_return(NetAddr::IPv4Net.parse("10.0.0.1/32"))
+      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         curl --output actions-runner.tar.gz -L https://github.com/foo/tarball
@@ -450,7 +450,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(Config).to receive_messages(github_cache_forked_runner_tarball_uri_arm64: "https://github.com/foo/tarball")
       expect(github_runner).to receive(:label).and_return("ubicloud-arm").at_least(:once)
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
-      expect(vm.nics.first).to receive(:private_ipv4).and_return(NetAddr::IPv4Net.parse("10.0.0.1/32"))
+      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         curl --output actions-runner.tar.gz -L https://github.com/foo/tarball


### PR DESCRIPTION
It was expected to get private_ipv4 for the first nic of the vm on the test, though it causes a warning since nothing was expected for nics of the vm. Updating test to receive nics and pass expected ipv4 via that.