### PR TITLE
Add default image version for ParadeDB

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -150,6 +150,7 @@ module Config
   override :github_ubuntu_2204_version, "20240818.1.0", string
   override :github_ubuntu_2004_version, "20240818.1.0", string
   override :postgres_ubuntu_2204_version, "20240702.3.0", string
+  override :postgres_paradedb_ubuntu_2204_version, "20240926.1.0", string
   override :github_gpu_ubuntu_2204_version, "20240818.1.0", string
   override :ai_ubuntu_2404_nvidia_version, "20241008.1.0", string
 

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -37,6 +37,8 @@ class Prog::DownloadBootImage < Prog::Base
       Config.github_gpu_ubuntu_2204_version
     when "postgres-ubuntu-2204"
       Config.postgres_ubuntu_2204_version
+    when "postgres-paradedb-ubuntu-2204"
+      Config.postgres_paradedb_ubuntu_2204_version
     when "ai-ubuntu-2404-nvidia"
       Config.ai_ubuntu_2404_nvidia_version
     else

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dbi.default_boot_image_version("github-ubuntu-2004")).to eq(Config.github_ubuntu_2004_version)
       expect(dbi.default_boot_image_version("github-gpu-ubuntu-2204")).to eq(Config.github_gpu_ubuntu_2204_version)
       expect(dbi.default_boot_image_version("postgres-ubuntu-2204")).to eq(Config.postgres_ubuntu_2204_version)
+      expect(dbi.default_boot_image_version("postgres-paradedb-ubuntu-2204")).to eq(Config.postgres_paradedb_ubuntu_2204_version)
       expect(dbi.default_boot_image_version("ai-ubuntu-2404-nvidia")).to eq(Config.ai_ubuntu_2404_nvidia_version)
     end
 


### PR DESCRIPTION
This makes it easier to download new boot images to hosts for ParadeDB.