### PR TITLE
Fix PostgresTimeline destroy when blob storage is missing

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -81,7 +81,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
 
   label def destroy
     decr_destroy
-    destroy_blob_storage if postgres_timeline.blob_storage_endpoint
+    destroy_blob_storage if postgres_timeline.blob_storage
     postgres_timeline.destroy
     pop "postgres timeline is deleted"
   end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     let(:admin_blob_storage_client) { instance_double(Minio::Client) }
 
     it "completes destroy even if dns zone and blob_storage are not configured" do
-      expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return(nil)
+      expect(postgres_timeline).to receive(:blob_storage).and_return(nil)
       expect(postgres_timeline).to receive(:destroy)
       expect { nx.destroy }.to exit({"msg" => "postgres timeline is deleted"})
     end


### PR DESCRIPTION
We already check the existence of blob_storage_endpoint, however generating blob_storage_endpoint requires accessing properties of blob_storage, which might be nil as well. The correct way of handling the nil case would be checking blob_storage directly instead of blob_storage_endpoint.