### PR TITLE
User management page improvements

### DIFF
--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -16,8 +16,8 @@ class CloverWeb
           end
         end
       end.compact.to_h
-      @users = Serializers::Account.serialize(@project.accounts)
-      @invitations = Serializers::ProjectInvitation.serialize(@project.invitations)
+      @users = Serializers::Account.serialize(@project.accounts_dataset.order_by(:email).all)
+      @invitations = Serializers::ProjectInvitation.serialize(@project.invitations_dataset.order_by(:email).all)
       @policy = Serializers::AccessPolicy.serialize(@project.access_policies_dataset.where(managed: false).first) || {body: {acls: []}.to_json}
 
       view "project/user"

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -70,6 +70,10 @@ class CloverWeb
         # we clear out any policy that no one is using.
         [Authorization::ManagedPolicy::Admin, Authorization::ManagedPolicy::Member].each do |policy|
           accounts = user_policies.select { _2 == policy.name }.keys.map { Account.from_ubid(_1) }
+          if policy == Authorization::ManagedPolicy::Admin && accounts.empty?
+            flash["error"] = "The project must have at least one admin."
+            return redirect_back_with_inputs
+          end
           policy.apply(@project, accounts)
         end
         invitation_policies = r.params["invitation_policies"] || {}

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -308,6 +308,7 @@ RSpec.describe Clover, "project" do
 
         expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
         expect(project).to receive(:invitations_dataset).and_return(instance_double(Sequel::Dataset, count: 50))
+        expect(project).to receive(:invitations_dataset).and_call_original
 
         fill_in "Email", with: "new@example.com"
         click_button "Invite"

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -271,6 +271,17 @@ RSpec.describe Clover, "project" do
         expect(page).to have_select("user_policies[#{user2.ubid}]", selected: "Admin")
       end
 
+      it "raises bad request when it's the last admin" do
+        visit "#{project.path}/user"
+
+        within "form#managed-policy" do
+          select "Member", from: "user_policies[#{user.ubid}]"
+          click_button "Update"
+        end
+        expect(page).to have_content "The project must have at least one admin"
+        expect(page).to have_select("user_policies[#{user.ubid}]", selected: "Admin")
+      end
+
       it "can remove invited user from project" do
         invited_email = "invited@example.com"
         project.add_invitation(email: invited_email, inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)


### PR DESCRIPTION
### **Order project users by email**

  Currently, users are sorted by scan order since we don't sort
  explicitly. This causes the user list to change each time we refresh the
  page, which is not ideal for user experience. We can sort them by email
  instead.
  
### **Do not allow to remove all admins from project**

  It's possible for a user to remove all of their permissions, leaving the
  project inaccessible. A user might also mistakenly strip away all their
  own permissions, again resulting in an inaccessible project. This new
  condition check prevents the updating of management policies if there's
  no remaining admin in the project.
  