### PR TITLE
Disable 4x Storage option for PostgreSQL databases in the US

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -251,13 +251,17 @@ function setupLocationBasedOptions() {
   $(".location-based-option").hide().prop('disabled', true).prop('checked', false).prop('selected', false);
   if (selectedLocation) {
     $(`.location-based-option.${selectedLocation}`).show().prop('disabled', false);
+    if($(`.location-based-option.${selectedLocation}:last input[type=radio]`).length > 0 && $(`.location-based-option.${selectedLocation} input[type=radio]:checked`).length == 0){
+      $(`.location-based-option.${selectedLocation}:last input[type=radio]`).get(0).checked = true;
+    }
   }
 }
 
 function setupInstanceSizeBasedOptions() {
   $(".instance-size-based-storage-sizes").each(function() {
+    let selectedLocation = $("input[name=location]:checked").val();
     resource_family = $("input[name=size]:checked").data("resource-family");
-    storage_size_options = $("input[name=size]:checked").data("storage-size-options");
+    storage_size_options = $("input[name=size]:checked").data("storage-size-options")[selectedLocation];
     storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
     storage_size_index = 0;
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -58,16 +58,16 @@ module Option
     VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, (_1 * 5.34).to_i, [_1 * 30], false, true)
   }).freeze
 
-  PostgresSize = Struct.new(:name, :vm_size, :family, :vcpu, :memory, :storage_size_options) do
+  PostgresSize = Struct.new(:location, :name, :vm_size, :family, :vcpu, :memory, :storage_size_options) do
     alias_method :display_name, :name
   end
-  PostgresSizes = [2, 4, 8, 16, 30, 60].flat_map {
-    storage_size_options = [_1 * 64, _1 * 128, _1 * 256]
-    storage_size_options = [1024, 2048, 4096] if [30, 60].include?(_1)
+  PostgresSizes = Option.postgres_locations.product([2, 4, 8, 16, 30, 60]).flat_map {
+    storage_size_options = [_2 * 64, _2 * 128, _2 * 256]
+    storage_size_options = [1024, 2048, 4096] if [30, 60].include?(_2)
     [
-      PostgresSize.new("standard-#{_1}", "standard-#{_1}", PostgresResource::Flavor::STANDARD, _1, _1 * 4, storage_size_options),
-      PostgresSize.new("standard-#{_1}", "standard-#{_1}", PostgresResource::Flavor::PARADEDB, _1, _1 * 4, storage_size_options),
-      PostgresSize.new("standard-#{_1}", "standard-#{_1}", PostgresResource::Flavor::LANTERN, _1, _1 * 4, storage_size_options)
+      PostgresSize.new(_1.name, "standard-#{_2}", "standard-#{_2}", PostgresResource::Flavor::STANDARD, _2, _2 * 4, storage_size_options),
+      PostgresSize.new(_1.name, "standard-#{_2}", "standard-#{_2}", PostgresResource::Flavor::PARADEDB, _2, _2 * 4, storage_size_options),
+      PostgresSize.new(_1.name, "standard-#{_2}", "standard-#{_2}", PostgresResource::Flavor::LANTERN, _2, _2 * 4, storage_size_options)
     ]
   }.freeze
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -63,7 +63,12 @@ module Option
   end
   PostgresSizes = Option.postgres_locations.product([2, 4, 8, 16, 30, 60]).flat_map {
     storage_size_options = [_2 * 64, _2 * 128, _2 * 256]
-    storage_size_options = [1024, 2048, 4096] if [30, 60].include?(_2)
+    storage_size_options.map! { |size| size / 15 * 16 } if [30, 60].include?(_2)
+
+    storage_size_options.pop if _1.name == "leaseweb-wdc02"
+
+    storage_size_limiter = [4096, storage_size_options.last].min.fdiv(storage_size_options.last)
+    storage_size_options.map! { |size| size * storage_size_limiter }
     [
       PostgresSize.new(_1.name, "standard-#{_2}", "standard-#{_2}", PostgresResource::Flavor::STANDARD, _2, _2 * 4, storage_size_options),
       PostgresSize.new(_1.name, "standard-#{_2}", "standard-#{_2}", PostgresResource::Flavor::PARADEDB, _2, _2 * 4, storage_size_options),

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -112,16 +112,16 @@ module Validation
     }
   end
 
-  def self.validate_postgres_size(size)
-    unless (postgres_size = Option::PostgresSizes.find { _1.name == size })
+  def self.validate_postgres_size(location, size)
+    unless (postgres_size = Option::PostgresSizes.find { _1.location == location && _1.name == size })
       fail ValidationFailed.new({size: "\"#{size}\" is not a valid PostgreSQL database size. Available sizes: #{Option::PostgresSizes.map(&:name)}"})
     end
     postgres_size
   end
 
-  def self.validate_postgres_storage_size(size, storage_size)
+  def self.validate_postgres_storage_size(location, size, storage_size)
     storage_size = storage_size.to_i
-    pg_size = validate_postgres_size(size)
+    pg_size = validate_postgres_size(location, size)
     fail ValidationFailed.new({storage_size: "Storage size must be one of the following: #{pg_size.storage_size_options.join(", ")}"}) unless pg_size.storage_size_options.include?(storage_size)
     storage_size
   end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -24,7 +24,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
     DB.transaction do
       superuser_password, timeline_id, timeline_access = if parent_id.nil?
-        target_storage_size_gib = Validation.validate_postgres_storage_size(target_vm_size, target_storage_size_gib)
+        target_storage_size_gib = Validation.validate_postgres_storage_size(location, target_vm_size, target_storage_size_gib)
         [SecureRandom.urlsafe_base64(15), Prog::Postgres::PostgresTimelineNexus.assemble(location: location).id, "push"]
       else
         unless (parent = PostgresResource[parent_id])
@@ -32,7 +32,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         end
 
         if target_storage_size_gib != parent.target_storage_size_gib
-          target_storage_size_gib = Validation.validate_postgres_storage_size(target_vm_size, target_storage_size_gib)
+          target_storage_size_gib = Validation.validate_postgres_storage_size(location, target_vm_size, target_storage_size_gib)
         end
 
         restore_target = Validation.validate_date(restore_target, "restore_target")

--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -32,7 +32,7 @@ class Routes::Common::PostgresHelper < Routes::Common::Base
     required_parameters << "name" << "location" if @mode == AppMode::WEB
     allowed_optional_parameters = ["storage_size", "ha_type", "flavor"]
     request_body_params = Validation.validate_request_body(params, required_parameters, allowed_optional_parameters)
-    parsed_size = Validation.validate_postgres_size(request_body_params["size"])
+    parsed_size = Validation.validate_postgres_size(@location, request_body_params["size"])
 
     ha_type = request_body_params["ha_type"] || PostgresResource::HaType::NONE
     requested_standby_count = case ha_type

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -169,35 +169,38 @@ RSpec.describe Validation do
 
     describe "#validate_postgres_size" do
       it "valid postgres size" do
-        expect(described_class.validate_postgres_size("standard-2").name).to eq("standard-2")
+        expect(described_class.validate_postgres_size("hetzner-fsn1", "standard-2").name).to eq("standard-2")
       end
 
       it "invalid postgres size" do
-        expect { described_class.validate_postgres_size("standard-3") }.to raise_error described_class::ValidationFailed
+        expect { described_class.validate_postgres_size("hetzner-fsn1", "standard-3") }.to raise_error described_class::ValidationFailed
       end
     end
 
     describe "#validate_postgres_storage_size" do
       it "valid postgres storage sizes" do
         [
-          ["standard-2", "128"],
-          ["standard-2", "256"],
-          ["standard-4", "1024"]
-        ].each do |pg_size, storage_size|
-          expect(described_class.validate_postgres_storage_size(pg_size, storage_size)).to eq(storage_size.to_f)
+          ["hetzner-fsn1", "standard-2", "128"],
+          ["hetzner-fsn1", "standard-2", "256"],
+          ["hetzner-fsn1", "standard-4", "1024"],
+          ["hetzner-fsn1", "standard-4", "1024"],
+          ["leaseweb-wdc02", "standard-4", "512"]
+        ].each do |location, pg_size, storage_size|
+          expect(described_class.validate_postgres_storage_size(location, pg_size, storage_size)).to eq(storage_size.to_f)
         end
       end
 
       it "invalid postgres storage sizes" do
         [
-          ["standard-2", "1024"],
-          ["standard-2", "37.4"],
-          ["standard-2", ""],
-          ["standard-2", nil],
-          ["standard-5", "128"],
-          [nil, "128"]
-        ].each do |pg_size, storage_size|
-          expect { described_class.validate_postgres_storage_size(pg_size, storage_size) }.to raise_error described_class::ValidationFailed
+          ["hetzner-fsn1", "standard-2", "1024"],
+          ["hetzner-fsn1", "standard-2", "37.4"],
+          ["hetzner-fsn1", "standard-2", ""],
+          ["hetzner-fsn1", "standard-2", nil],
+          ["hetzner-fsn1", "standard-5", "128"],
+          ["leaseweb-wdc02,", "standard-4", "1024"],
+          ["hetzner-fsn1", nil, "128"]
+        ].each do |location, pg_size, storage_size|
+          expect { described_class.validate_postgres_storage_size(location, pg_size, storage_size) }.to raise_error described_class::ValidationFailed
         end
       end
     end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       expect {
-        described_class.assemble(project_id: "26820e05-562a-4e25-a51b-de5f78bd00af", location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128)
+        described_class.assemble(project_id: "26820e05-562a-4e25-a51b-de5f78bd00af", location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128)
       }.to raise_error RuntimeError, "No existing project"
 
       expect {
@@ -58,55 +58,55 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: provider"
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg/server/name", target_vm_size: "standard-2", target_storage_size_gib: 128)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg/server/name", target_vm_size: "standard-2", target_storage_size_gib: 128)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-128", target_storage_size_gib: 128)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-128", target_storage_size_gib: 128)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: size"
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128)
       }.not_to raise_error
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b")
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b")
       }.to raise_error RuntimeError, "No existing parent"
 
       expect {
-        parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
+        parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
         expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: Time.now)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: Time.now)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: restore_target"
     end
 
     it "validates storage size during restore if the storage size is different from the parent" do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
-      parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
+      parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
       parent.update(target_storage_size_gib: 1024)
       expect(parent.timeline).to receive(:earliest_restore_time).and_return(Time.now - 10 * 60)
       expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent).at_least(:once)
       expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_id: parent.timeline.id, timeline_access: "fetch")).and_return(instance_double(Strand, subject: postgres_resource.representative_server))
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 1024, parent_id: parent.id, restore_target: Time.now)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 1024, parent_id: parent.id, restore_target: Time.now)
       }.not_to raise_error
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 2048, parent_id: parent.id, restore_target: Time.now)
+        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 2048, parent_id: parent.id, restore_target: Time.now)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: storage_size"
     end
 
     it "passes timeline of parent resource if parent is passed" do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
-      parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
+      parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
       restore_target = Time.now
       expect(parent.timeline).to receive(:earliest_restore_time).and_return(restore_target - 10 * 60)
       expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
       expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(timeline_id: parent.timeline.id, timeline_access: "fetch")).and_return(instance_double(Strand, subject: postgres_resource.representative_server))
 
-      described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: restore_target)
+      described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name-2", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: restore_target)
     end
   end
 
@@ -184,7 +184,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     it "hops to wait_servers after creating certificates" do
       postgres_resource = PostgresResource.create_with_id(
         project_id: "e3e333dd-bd9a-82d2-acc1-1c7c1ee9781f",
-        location: "hetzner-hel1",
+        location: "hetzner-fsn1",
         name: "pg-name",
         target_vm_size: "standard-2",
         target_storage_size_gib: 128,

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Clover, "vm" do
     it "success all vms" do
       Prog::Postgres::PostgresResourceNexus.assemble(
         project_id: project.id,
-        location: "hetzner-hel1",
+        location: "hetzner-fsn1",
         name: "pg-foo-1",
         target_vm_size: "standard-2",
         target_storage_size_gib: 128

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -80,8 +80,17 @@
                   <fieldset class="radio-small-cards" id="size-radios">
                     <legend class="sr-only">Server size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                      <% Option::PostgresSizes.select { _1.family == @flavor }.each_with_index do |size, idx| %>
-                        <% disabled = !@enabled_postgres_sizes.include?(size.name) %>
+                      <%
+                      selected_location = flash.dig("old", "location") || locations.first[0]
+                      Option::PostgresSizes.select { _1.family == @flavor && _1.location == LocationNameConverter.to_internal_name(selected_location) }.each_with_index do |size, idx|
+                        disabled = !@enabled_postgres_sizes.include?(size.name)
+                        storage_size_options = JSON.generate(
+                          Option::PostgresSizes
+                          .select { _1.family == @flavor && _1.name == size.name }
+                          .map { [LocationNameConverter.to_display_name(_1.location), _1.storage_size_options] }
+                          .to_h
+                          )
+                        %>
                         <label class="size-<%= size.name %>" title="<%= disabled ? "Insufficient quota. You can reach us at support@ubicloud.com to increase your quota." : "" %>">
                           <input
                             type="radio"
@@ -92,7 +101,7 @@
                             data-resource-family="<%= size.family %>"
                             data-amount="<%= size.vcpu / 2 %>"
                             data-storage-resource-type="PostgresStorage"
-                            data-storage-size-options="<%= size.storage_size_options %>"
+                            data-storage-size-options="<%= storage_size_options %>"
                             required
                             <%= (flash.dig("old", "size") == size.name || flash.dig("old", "size").nil? && idx == 0) ? "checked" : "" %>
                             <%= disabled ? "disabled" : "" %>
@@ -132,9 +141,13 @@
                   <fieldset class="radio-small-cards" id="storage-size-radios">
                   <legend class="sr-only">Storage size</legend>
                     <div class="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                      <% size = flash.dig("old", "size") ? Option::PostgresSizes.find { _1.name == flash.dig("old", "size") } : Option::PostgresSizes[0] %>
-                      <% size.storage_size_options.each_with_index do |storage_size, idx| %>
-                        <label class="storage-size storage-size-<%= storage_size %>">
+                      <% size_name = flash.dig("old", "size") || Option::PostgresSizes[0].name
+                      size = Option::PostgresSizes.find { _1.name == size_name }
+                      size.storage_size_options.each_with_index do |storage_size, idx|
+                        all_locations_with_storage_size = Option::PostgresSizes.select { _1.name == size_name && _1.family == @flavor && _1.storage_size_options.include?(storage_size) }.map { "#{LocationNameConverter.to_display_name(_1.location)}" }
+                        location_based_classes = ["location-based-option"] + all_locations_with_storage_size
+                      %>
+                        <label class="storage-size storage-size-<%= storage_size %> <%= location_based_classes.join(" ") %>">
                           <input
                             type="radio"
                             name="storage_size"

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -141,7 +141,7 @@
                             value="<%= storage_size %>"
                             class="peer sr-only"
                             required
-                            <%= (flash.dig("old", "storage_size") == storage_size || flash.dig("old", "storage_size").nil? && idx == 0) ? "checked" : "" %>
+                            <%= (flash.dig("old", "storage_size") == storage_size.to_s || flash.dig("old", "storage_size").nil? && idx == 0) ? "checked" : "" %>
                           >
                           <span
                             class="flex items-center justify-between rounded-md py-4 px-4 sm:flex-1 cursor-pointer focus:outline-none


### PR DESCRIPTION
This PR disables 4x storage option for PostgreSQL resources in US because we have different cost and utilization structures there.

The meat of the PR is in UI changes. Now, not only the values of storage sizes change based on the instance size, we also change the number of storage size options based on selected location. This complex interaction between location, size, storage size, option values and option count made me think that we should invest some time soon to improve general business logic in creation forms.