### PR TITLE
Enable E2E tests for Ubuntu 24 runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2204,github_runner_ubuntu_2004'
+        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,github_runner_ubuntu_2004'
         type: string
 
   schedule:

--- a/config/github_runner_e2e_tests.yml
+++ b/config/github_runner_e2e_tests.yml
@@ -1,2 +1,3 @@
+- {name: github_runner_ubuntu_2404, image_name: github-ubuntu-2404, runs: [{repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2404.yml, branch_name: main}]}
 - {name: github_runner_ubuntu_2204, image_name: github-ubuntu-2204, runs: [{repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2204.yml, branch_name: main}]}
 - {name: github_runner_ubuntu_2004, image_name: github-ubuntu-2004, runs: [{repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2004.yml, branch_name: main}]}


### PR DESCRIPTION
We recently introduced Ubuntu 24 runners, following GitHub's migration to the Ubuntu 24 as their default. At some point, we'll also make Ubuntu 24 our default, making it the majority. Therefore, it's beneficial to have E2E tests for Ubuntu 24 runners.

As we run E2E tests concurrently, the overall pipeline time isn't significantly affected. It only adds a few minutes to the image download process.