### PR TITLE
Avoid checking CSRF token twice for Rodauth routes

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -376,10 +376,11 @@ class CloverWeb < Roda
     r.on "webhook" do
       r.hash_branches(:webhook_prefix)
     end
-    check_csrf!
 
     @current_user = Account[rodauth.session_value]
     r.rodauth
+
+    check_csrf!
     rodauth.load_memory
     rodauth.check_active_session
 


### PR DESCRIPTION
Rodauth has checked CSRF tokens by default since Rodauth 2.  We could modify the Rodauth configuration to not check CSRF, but moving the check_csrf! call accomplishes the same thing without changing the Rodauth configuration.

No automated test for this change, but I tested in a browser by deleting the _csrf input using DevTools before submitting, and still received the "An invalid security token submitted with this request, please try again" error.