### PR TITLE
Add Disk IO to VM Host Healthchecks

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -245,7 +245,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   def available?
-    sshable.cmd("true")
+    sshable.cmd(VmHost::SSH_HEALTH_CHECK_COMMAND)
     true
   rescue
     false


### PR DESCRIPTION
The health checks in `VmHost#check_pulse` and `HostNexus#available?`
were simple SSH access attempts, but this was not sufficient for
detecting issues in the disks. This change adds a simple disk IO
to the health check commands.

The disk I/O added for the health check is a simple read from
/dev/zero into a random file in /tmp. This would be enough to detect
any obvious failures related to the disks. Note that, in cases of
multiple disks are mounted into the file system (`/`) via raid, this
approach may not detect a single disk failure as long as the system
works.

Note: Through the codebase, health checks for the monitor (`check_pulse`)
and progs (`available?`) are duplicated, which is also the case for
VM host. We can argue about unifying the health check and availability
detection in general as a next step. Still, I wanted to make some
deduplication by extracting the shell command to be used for health
check into a `VmHost` constant.

Future work: While some disk i/o would be enough to check for obvious problems,
as a future work we can consider monitoring SMART bits, preferably
with less frequency and less severity.