### PR TITLE
Add awesome_print for easier inspection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "octokit"
 gem "argon2-kdf"
 
 group :development do
+  gem "awesome_print"
   gem "brakeman"
   gem "by", github: "jeremyevans/by", ref: "f022615e367da3a23f012c3ab06ff664fe3776d3"
   gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "a9ff0001a1eb028e2186b222aeb02b07c04f9808"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       ffi-compiler (~> 1.0)
     argon2-kdf (0.2.0)
     ast (2.4.2)
+    awesome_print (1.9.2)
     awrence (1.2.1)
     aws-eventstream (1.3.0)
     aws-partitions (1.983.0)
@@ -364,6 +365,7 @@ DEPENDENCIES
   acme-client (~> 2.0)
   argon2
   argon2-kdf
+  awesome_print
   aws-sdk-s3 (~> 1.167)
   bcrypt_pbkdf
   brakeman

--- a/bin/pry
+++ b/bin/pry
@@ -7,6 +7,10 @@ require_relative "../loader"
 
 require "pry"
 
+if Config.development?
+  require "awesome_print"
+end
+
 def dev_project
   return unless Config.development?
   ac = Account[email: "dev@ubicloud.com"] || Account.create_with_id(email: "dev@ubicloud.com")


### PR DESCRIPTION
We used awesome_print gem [1] in predecessors of clover, and it proved a bit useful in inspecting objects in repl. This change adds it here too.

Usage:

```ruby
[9] clover-development(main)> s = Strand.first
=> #<Strand @values={:id=>"fea6d185-f903-82ac-96b7-25f5c833f220", :parent_id=>nil, :schedule=>2024-10-15 16:27:26.148985 +0300, :lease=>nil, :prog=>"Vnet::NicNexus", :label=>"wait", :stack=>[{"last_label_changed_at"=>"2024-10-15 14:50:28 +0300"}], :exitval=>nil, :retval=>nil, :try=>0}>
[10] clover-development(main)> ap s
{
           :id => "fea6d185-f903-82ac-96b7-25f5c833f220",
    :parent_id => nil,
     :schedule => 2024-10-15 16:27:26.148985 +0300,
        :lease => nil,
         :prog => "Vnet::NicNexus",
        :label => "wait",
        :stack => [{"last_label_changed_at"=>"2024-10-15 14:50:28 +0300"}],
      :exitval => nil,
       :retval => nil,
          :try => 0
}
=> nil
```

[1] https://github.com/awesome-print/awesome_print