### PR TITLE
Use require instead of autoload in production and when running all specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,10 +127,17 @@ end
 # Specs
 begin
   require "rspec/core/rake_task"
-  ENV["RACK_ENV"] = "test"
-  RSpec::Core::RakeTask.new(:spec)
-  task default: :spec
+  RSpec::Core::RakeTask.new(:_spec)
+  Rake::Task["_spec"].clear_comments
 rescue LoadError
+else
+  desc "Run specs"
+  task "spec" do
+    ENV["RACK_ENV"] = "test"
+    ENV["FORCE_AUTOLOAD"] = "1"
+    Rake::Task["_spec"].invoke
+  end
+  task default: :spec
 end
 
 desc "Run specs in parallel using turbo_tests"
@@ -139,7 +146,7 @@ task "pspec" do
   nproc = `(nproc 2> /dev/null) || sysctl -n hw.logicalcpu`.to_i
 
   # Limit to 6 processes, as higher number results in more time
-  system("bundle", "exec", "turbo_tests", "-n", nproc.clamp(1, 6).to_s)
+  system({"FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "turbo_tests", "-n", nproc.clamp(1, 6).to_s)
 end
 
 # Other

--- a/Rakefile
+++ b/Rakefile
@@ -151,6 +151,12 @@ end
 
 # Other
 
+desc "Check that model files work when required separately"
+task "check_separate_requires" do
+  require "rbconfig"
+  system({"RACK_ENV" => "test", "LOAD_FILES_SEPARATELY_CHECK" => "1"}, RbConfig.ruby, "-r", "./loader", "-e", "")
+end
+
 desc "Annotate Sequel models"
 task "annotate" do
   ENV["RACK_ENV"] = "development"

--- a/Rakefile
+++ b/Rakefile
@@ -157,6 +157,22 @@ task "check_separate_requires" do
   system({"RACK_ENV" => "test", "LOAD_FILES_SEPARATELY_CHECK" => "1"}, RbConfig.ruby, "-r", "./loader", "-e", "")
 end
 
+desc "Run each spec file in a separate process"
+task :spec_separate do
+  require "rbconfig"
+
+  failures = []
+  Dir["spec/**/*_spec.rb"].each do |file|
+    failures << file unless system(RbConfig.ruby, "-S", "rspec", file)
+  end
+
+  if failures.empty?
+    puts "All files passed"
+  else
+    puts "Failures in:", failures
+  end
+end
+
 desc "Annotate Sequel models"
 task "annotate" do
   ENV["RACK_ENV"] = "development"

--- a/clover_api.rb
+++ b/clover_api.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "roda"
+require_relative "model"
+
 class CloverApi < Roda
   include CloverBase
 

--- a/clover_runtime.rb
+++ b/clover_runtime.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "jwt"
+require "roda"
 
 class CloverRuntime < Roda
   include CloverBase

--- a/clover_web.rb
+++ b/clover_web.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require "roda"
 require "tilt"
 require "tilt/erubi"
+
+require_relative "model"
 
 class CloverWeb < Roda
   include CloverBase

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -111,7 +111,7 @@ module Authorization
   module HyperTagMethods
     def self.included(base)
       base.class_eval do
-        many_to_many :projects, join_table: AccessTag.table_name, left_key: :hyper_tag_id, right_key: :project_id
+        many_to_many :projects, join_table: :access_tag, left_key: :hyper_tag_id, right_key: :project_id
       end
     end
 
@@ -154,7 +154,7 @@ module Authorization
   module TaggableMethods
     def self.included(base)
       base.class_eval do
-        many_to_many :applied_access_tags, class: AccessTag, join_table: AppliedTag.table_name, left_key: :tagged_id, right_key: :access_tag_id
+        many_to_many :applied_access_tags, class: :AccessTag, join_table: :applied_tag, left_key: :tagged_id, right_key: :access_tag_id
       end
     end
 

--- a/loader.rb
+++ b/loader.rb
@@ -89,6 +89,20 @@ if Config.production?
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
 end
 
+unless Unreloader.autoload?
+  # If not autoloading, all classes are already available, so speed up
+  # UBID.class_for_ubid using hash of prefixes to class objects
+  class UBID
+    TYPE2CLASS = TYPE2CLASSNAME.transform_values { Object.const_get(_1) }.freeze
+    private_constant :TYPE2CLASS
+
+    singleton_class.remove_method(:class_for_ubid)
+    def self.class_for_ubid(str)
+      TYPE2CLASS[str[..1]]
+    end
+  end
+end
+
 case Config.mail_driver
 when :smtp
   ::Mail.defaults do

--- a/loader.rb
+++ b/loader.rb
@@ -17,6 +17,7 @@ require "rack/unreloader"
 REPL = false unless defined? REPL
 Warning.ignore(/To use (retry|multipart) middleware with Faraday v2\.0\+, install `faraday-(retry|multipart)` gem/)
 
+force_autoload = Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
 Unreloader = Rack::Unreloader.new(reload: Config.development?, autoload: true) { Clover }
 
 Unreloader.autoload("#{__dir__}/db.rb") { "DB" }
@@ -41,7 +42,6 @@ autoload_normal = ->(subdirectory, include_first: false, flat: false) do
     # "/home/myuser/..."
     Regexp.new('\A' + Regexp.escape((File.file?(absolute) ? File.dirname(absolute) : absolute) + "/") + '(.*)\.rb\z')
   end
-  last_namespace = nil
 
   # Copied from sequel/model/inflections.rb's camelize, to convert
   # file paths into module and class names.
@@ -51,33 +51,41 @@ autoload_normal = ->(subdirectory, include_first: false, flat: false) do
 
   Unreloader.autoload(absolute) do |f|
     full_name = camelize.call((include_first ? subdirectory + File::SEPARATOR : "") + rgx.match(f)[1])
-    parts = full_name.split("::")
-    namespace = parts[0..-2].freeze
-
-    # Skip namespace traversal if the last namespace handled has the
-    # same components, forming a fast-path that works well when output
-    # is the result of a depth-first traversal of the file system, as
-    # is normally the case.
-    unless namespace == last_namespace
-      scope = Object
-      namespace.each { |nested|
-        scope = if scope.const_defined?(nested, false)
-          scope.const_get(nested, false)
-        else
-          Module.new.tap { scope.const_set(nested, _1) }
-        end
-      }
-      last_namespace = namespace
-    end
-
-    # Reloading re-executes this block, which will crash on the
-    # subsequently frozen AUTOLOAD_CONSTANTS.  It's also undesirable
-    # to have re-additions to the array.
     AUTOLOAD_CONSTANTS << full_name unless AUTOLOAD_CONSTANTS.frozen?
-
     full_name
   end
 end
+
+# Define empty modules instead of trying to have autoload_normal create them via metaprogramming
+module Hosting; end
+
+module Minio; end
+
+module Prog; end
+
+module Prog::Ai; end
+
+module Prog::DnsZone; end
+
+module Prog::Github; end
+
+module Prog::Minio; end
+
+module Prog::Postgres; end
+
+module Prog::Storage; end
+
+module Prog::Vm; end
+
+module Prog::Vnet; end
+
+module Scheduling; end
+
+module Serializers; end
+
+module Routes; end
+
+module Routes::Common; end
 
 autoload_normal.call("model", flat: true)
 %w[lib clover.rb clover_web.rb clover_api.rb clover_runtime.rb routes/clover_base.rb routes/clover_error.rb].each { autoload_normal.call(_1) }
@@ -85,13 +93,11 @@ autoload_normal.call("model", flat: true)
 
 AUTOLOAD_CONSTANTS.freeze
 
-if Config.production?
+if force_autoload
   AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
-end
 
-unless Unreloader.autoload?
-  # If not autoloading, all classes are already available, so speed up
-  # UBID.class_for_ubid using hash of prefixes to class objects
+  # All classes are already available, so speed up UBID.class_for_ubid using
+  # hash of prefixes to class objects
   class UBID
     TYPE2CLASS = TYPE2CLASSNAME.transform_values { Object.const_get(_1) }.freeze
     private_constant :TYPE2CLASS

--- a/model/cert.rb
+++ b/model/cert.rb
@@ -4,7 +4,7 @@ require_relative "../model"
 
 class Cert < Sequel::Model
   one_through_one :load_balancer, join_table: :certs_load_balancers, left_key: :cert_id, right_key: :load_balancer_id
-  one_to_one :certs_load_balancers, key: :cert_id, class: CertsLoadBalancers
+  one_to_one :certs_load_balancers, key: :cert_id, class: :CertsLoadBalancers
   one_to_one :strand, key: :id
 
   plugin :association_dependencies, certs_load_balancers: :destroy

--- a/model/ipsec_tunnel.rb
+++ b/model/ipsec_tunnel.rb
@@ -3,8 +3,8 @@
 require_relative "../model"
 
 class IpsecTunnel < Sequel::Model
-  many_to_one :src_nic, key: :src_nic_id, class: Nic
-  many_to_one :dst_nic, key: :dst_nic_id, class: Nic
+  many_to_one :src_nic, key: :src_nic_id, class: :Nic
+  many_to_one :dst_nic, key: :dst_nic_id, class: :Nic
 
   include ResourceMethods
 

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -9,10 +9,10 @@ class LoadBalancer < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :private_subnet
   one_to_many :projects, through: :private_subnet
-  one_to_many :load_balancers_vms, key: :load_balancer_id, class: LoadBalancersVms
+  one_to_many :load_balancers_vms, key: :load_balancer_id, class: :LoadBalancersVms
   many_to_many :certs, join_table: :certs_load_balancers, left_key: :load_balancer_id, right_key: :cert_id
-  one_to_many :certs_load_balancers, key: :load_balancer_id, class: CertsLoadBalancers
-  many_to_one :custom_hostname_dns_zone, class: DnsZone, key: :custom_hostname_dns_zone_id
+  one_to_many :certs_load_balancers, key: :load_balancer_id, class: :CertsLoadBalancers
+  many_to_one :custom_hostname_dns_zone, class: :DnsZone, key: :custom_hostname_dns_zone_id
 
   plugin :association_dependencies, load_balancers_vms: :destroy, certs_load_balancers: :destroy
 

--- a/model/nic.rb
+++ b/model/nic.rb
@@ -5,9 +5,9 @@ require_relative "../model"
 class Nic < Sequel::Model
   many_to_one :private_subnet
   many_to_one :vm
-  one_to_many :src_ipsec_tunnels, key: :src_nic_id, class: IpsecTunnel
-  one_to_many :dst_ipsec_tunnels, key: :dst_nic_id, class: IpsecTunnel
-  one_to_one :strand, key: :id, class: Strand
+  one_to_many :src_ipsec_tunnels, key: :src_nic_id, class: :IpsecTunnel
+  one_to_many :dst_ipsec_tunnels, key: :dst_nic_id, class: :IpsecTunnel
+  one_to_one :strand, key: :id
   plugin :association_dependencies, src_ipsec_tunnels: :destroy, dst_ipsec_tunnels: :destroy
 
   include ResourceMethods

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -7,11 +7,11 @@ class PostgresResource < Sequel::Model
   many_to_one :project
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
   many_to_one :parent, key: :parent_id, class: self
-  one_to_many :servers, class: PostgresServer, key: :resource_id
-  one_to_one :representative_server, class: PostgresServer, key: :resource_id, conditions: Sequel.~(representative_at: nil)
-  one_through_one :timeline, class: PostgresTimeline, join_table: :postgres_server, left_key: :resource_id, right_key: :timeline_id
-  one_to_many :firewall_rules, class: PostgresFirewallRule, key: :postgres_resource_id
-  one_to_many :metric_destinations, class: PostgresMetricDestination, key: :postgres_resource_id
+  one_to_many :servers, class: :PostgresServer, key: :resource_id
+  one_to_one :representative_server, class: :PostgresServer, key: :resource_id, conditions: Sequel.~(representative_at: nil)
+  one_through_one :timeline, class: :PostgresTimeline, join_table: :postgres_server, left_key: :resource_id, right_key: :timeline_id
+  one_to_many :firewall_rules, class: :PostgresFirewallRule, key: :postgres_resource_id
+  one_to_many :metric_destinations, class: :PostgresMetricDestination, key: :postgres_resource_id
   many_to_one :private_subnet
 
   plugin :association_dependencies, firewall_rules: :destroy, metric_destinations: :destroy

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -5,10 +5,10 @@ require_relative "../../model"
 
 class PostgresServer < Sequel::Model
   one_to_one :strand, key: :id
-  many_to_one :resource, class: PostgresResource, key: :resource_id
-  many_to_one :timeline, class: PostgresTimeline, key: :timeline_id
+  many_to_one :resource, class: :PostgresResource, key: :resource_id
+  many_to_one :timeline, class: :PostgresTimeline, key: :timeline_id
   one_to_one :vm, key: :id, primary_key: :vm_id
-  one_to_one :lsn_monitor, class: PostgresLsnMonitor, key: :postgres_server_id
+  one_to_one :lsn_monitor, class: :PostgresLsnMonitor, key: :postgres_server_id
 
   plugin :association_dependencies, lsn_monitor: :destroy
 

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -5,7 +5,7 @@ require_relative "../../model"
 class PostgresTimeline < Sequel::Model
   one_to_one :strand, key: :id
   one_to_one :parent, key: :parent_id, class: self
-  one_to_one :leader, class: PostgresServer, key: :timeline_id, conditions: {timeline_access: "push"}
+  one_to_one :leader, class: :PostgresServer, key: :timeline_id, conditions: {timeline_access: "push"}
 
   include ResourceMethods
   include SemaphoreMethods

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -3,7 +3,7 @@
 require_relative "../model"
 
 class PrivateSubnet < Sequel::Model
-  many_to_many :vms, join_table: Nic.table_name, left_key: :private_subnet_id, right_key: :vm_id
+  many_to_many :vms, join_table: :nic, left_key: :private_subnet_id, right_key: :vm_id
   one_to_many :nics, key: :private_subnet_id
   one_to_one :strand, key: :id
   many_to_many :firewalls

--- a/model/project.rb
+++ b/model/project.rb
@@ -9,18 +9,18 @@ class Project < Sequel::Model
   one_to_many :usage_alerts
   one_to_many :github_installations
 
-  many_to_many :accounts, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
-  many_to_many :vms, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
-  many_to_many :minio_clusters, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
-  many_to_many :private_subnets, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
-  many_to_many :postgres_resources, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
-  many_to_many :firewalls, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
-  many_to_many :load_balancers, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
-  many_to_many :inference_endpoints, join_table: AccessTag.table_name, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :accounts, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :vms, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :minio_clusters, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :private_subnets, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :postgres_resources, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :firewalls, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :load_balancers, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :inference_endpoints, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
 
   one_to_many :invoices, order: Sequel.desc(:created_at)
-  one_to_many :quotas, class: ProjectQuota, key: :project_id
-  one_to_many :invitations, class: ProjectInvitation, key: :project_id
+  one_to_many :quotas, class: :ProjectQuota, key: :project_id
+  one_to_many :invitations, class: :ProjectInvitation, key: :project_id
   one_to_many :api_keys, key: :owner_id, class: :ApiKey, conditions: {owner_table: "project"}
 
   dataset_module Authorization::Dataset

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -7,14 +7,14 @@ class Vm < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :vm_host
   one_to_many :nics, key: :vm_id, class: :Nic
-  many_to_many :private_subnets, join_table: Nic.table_name, left_key: :vm_id, right_key: :private_subnet_id
+  many_to_many :private_subnets, join_table: :nic, left_key: :vm_id, right_key: :private_subnet_id
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
   one_to_many :vm_storage_volumes, key: :vm_id, order: Sequel.desc(:boot)
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
   one_to_many :pci_devices, key: :vm_id, class: :PciDevice
   one_through_one :load_balancer, left_key: :vm_id, right_key: :load_balancer_id, join_table: :load_balancers_vms
-  one_to_one :load_balancers_vms, key: :vm_id, class: LoadBalancersVms
+  one_to_one :load_balancers_vms, key: :vm_id, class: :LoadBalancersVms
 
   plugin :association_dependencies, sshable: :destroy, assigned_vm_address: :destroy, vm_storage_volumes: :destroy, load_balancers_vms: :destroy
 

--- a/spec/model/resource_methods_spec.rb
+++ b/spec/model/resource_methods_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../spec_helper"
+require_relative "spec_helper"
 
 RSpec.describe ResourceMethods do
   it "hides sensitive and long columns" do

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../model"
+
 RSpec.describe ResourceMethods do
   let(:sa) { Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair) }
 

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "stripe"
 require_relative "../spec_helper"
 
 RSpec.describe Clover, "github" do

--- a/ubid.rb
+++ b/ubid.rb
@@ -103,13 +103,22 @@ class UBID
     s.delete_prefix("TYPE").split("_").map(&:capitalize).join
   end
 
-  TYPE2CLASS = constants.select { _1.start_with?("TYPE_") }.reject { _1.to_s == "TYPE_ETC" }
-    .map { [const_get(_1), Object.const_get(camelize(_1.to_s).to_s)] }.to_h
+  # Map of prefixes to class name symbols, to avoid autoloading
+  # classes until they are referenced by class_for_ubid
+  TYPE2CLASSNAME = constants.select { _1.start_with?("TYPE_") }.reject { _1.to_s == "TYPE_ETC" }
+    .map { [const_get(_1), camelize(_1.to_s).to_sym] }.to_h.freeze
+  private_constant :TYPE2CLASSNAME
+
+  def self.class_for_ubid(str)
+    if (sym = TYPE2CLASSNAME[str[..1]])
+      Object.const_get(sym)
+    end
+  end
 
   def self.decode(ubid)
     ubid_str = ubid.to_s
     uuid = UBID.parse(ubid_str).to_uuid
-    klass = TYPE2CLASS[ubid_str[..1]]
+    klass = class_for_ubid(ubid)
     fail "Couldn't decode ubid: #{ubid_str}" if klass.nil?
 
     klass[uuid]
@@ -194,7 +203,7 @@ class UBID
   end
 
   def inspect
-    "#<UBID:#{TYPE2CLASS[to_s[..1]] || "Unknown"} @ubid=#{to_s.inspect} @uuid=#{to_uuid.inspect}>"
+    "#<UBID:#{TYPE2CLASSNAME[to_s[..1]] || "Unknown"} @ubid=#{to_s.inspect} @uuid=#{to_uuid.inspect}>"
   end
 
   #

--- a/ubid.rb
+++ b/ubid.rb
@@ -110,9 +110,12 @@ class UBID
   private_constant :TYPE2CLASSNAME
 
   def self.class_for_ubid(str)
+    # :nocov:
+    # Overridden in production and when forcing autoloads in tests
     if (sym = TYPE2CLASSNAME[str[..1]])
       Object.const_get(sym)
     end
+    # :nocov:
   end
 
   def self.decode(ubid)


### PR DESCRIPTION
This makes `rake spec` operate more similarly to the production environment,
loading all files up front.  Instead of using autoload, this uses require
to load all files in that case.  Using require is simpler than using
autoload, keeping an array of autoloaded constants, and then referencing
each autoloaded constant to force the loading. 

This required some changes:

* Use of `require_relative` in a number of files to specify dependencies
  explicitly instead of relying on autoload to load the dependency
  implicitly.

* Defining empty modules in loader.rb, instead of having loader.rb
  automatically define empty modules via metaprogramming.

* In Sequel models, reference other classes by name, avoiding
  unnecessary autoloads and stale references when Unreloader reloads
  dependencies.

This also changes ubid.rb so it doesn't load every class that can have a ubid.
It has ubid.rb keep a hash of prefixes to class names, and maps to
classes inside a method.  To avoid the performance hit in production
and when you are loading all classes anyway, this has loader.rb
switch back to the previous approach of mapping prefixes to classes,
since you know the classes will no longer change in that case.

This adds a couple rake tasks:

* spec_separate: Run all spec files in separate processes, to check
  that each spec file passes in isolation, and that there are no
  dependencies between the spec files.

* check_separate_requires: Check that each file that can be
  autoloaded by loader.rb can be required separately without
  relying on other autoloaded files already being loaded.

These rake tasks both found issues with missing requires.

Not using autoload when testing and in production is how roda-sequel-stack
is designed to work by default (since https://github.com/jeremyevans/roda-sequel-stack/commit/faf3844bc0982eac8cda4db5786bc2256bff6a53).

Note that this continues to use `Unreloader.autoload`, but if you initialize
`Unreloader` with `autoload: false`, then calls to `Unreloader.autoload`
actually call `require` instead of `autoload` (see https://github.com/jeremyevans/rack-unreloader?tab=readme-ov-file#label-Autoload).

See individual commits for more detail.