### PR TITLE
Do not register runners for suspended accounts

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -78,6 +78,10 @@ class Project < Sequel::Model
     end
   end
 
+  def active?
+    visible && accounts_dataset.exclude(suspended_at: nil).empty?
+  end
+
   def current_invoice
     begin_time = invoices.first&.end_time || Time.new(Time.now.year, Time.now.month, 1)
     end_time = Time.now

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -32,6 +32,10 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
   end
 
   def check_queued_jobs
+    unless github_repository.installation.project.active?
+      @polling_interval = 24 * 60 * 60
+      return
+    end
     queued_runs = client.repository_workflow_runs(github_repository.name, {status: "queued"})[:workflow_runs]
     Clog.emit("polled queued runs") { {polled_queued_runs: {repository_name: github_repository.name, count: queued_runs.count}} }
 

--- a/routes/github.rb
+++ b/routes/github.rb
@@ -41,9 +41,9 @@ class Clover
         r.redirect "#{project.path}/github"
       end
 
-      if current_account.suspended_at
-        flash["error"] = "GitHub runner integration is not allowed for suspended accounts."
-        Clog.emit("GitHub callback failed due to suspended account") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
+      unless project.active?
+        flash["error"] = "GitHub runner integration is not allowed for inactive projects"
+        Clog.emit("GitHub callback failed due to inactive project") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{project.path}/dashboard"
       end
 

--- a/spec/routes/web/github_spec.rb
+++ b/spec/routes/web/github_spec.rb
@@ -90,16 +90,16 @@ RSpec.describe Clover, "github" do
     expect(page).to have_content("GitHub App installation failed.")
   end
 
-  it "fails if the current user's account suspended" do
+  it "fails if the project is not active" do
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
-    user.update(suspended_at: Time.now)
+    expect(project).to receive(:active?).and_return(false)
 
     visit "/github/callback?code=123123&installation_id=345"
 
     expect(page.title).to eq("Ubicloud - project-1 Dashboard")
-    expect(page).to have_content("GitHub runner integration is not allowed for suspended accounts.")
+    expect(page).to have_content("GitHub runner integration is not allowed for inactive projects")
   end
 
   it "creates installation with project from session" do


### PR DESCRIPTION
- **Add active? helper to the project**
  We need to determine whether a project is active or not to allow certain
  actions, like installing our GitHub App. This is particularly important
  when we're investigating the project for any fraudulent activity. I've
  added two basic conditions to assess a project's activity status, and we
  can improve this in the future.
  
  At present, if any account within the project is suspended, we consider
  the project inactive. We also soft delete projects, preserving their
  billing information temporarily to finalize the billing. If a project is
  'soft deleted', we classify it as inactive.
  

- **Do not poll jobs if the project is inactive**
  We have a job poller that checks the repository for queued jobs via
  GitHub API, ensuring no webhook events are missed and that a runner is
  provisioned for each one.
  
  However, when we suspend an account, we intentionally avoid provisioning
  runners. Despite this, the poller might misinterpret this as the
  repository lacking runners and provision new ones.
  
  Ideally, we should destroy GithubInstallation when we suspend an account.
  If for some reason this hasn't been done, we shouldn't poll the jobs.
  

- **Do not register runner for inactive projects**
  In the last wave of fraud, we prevented new runner registrations for
  fraudulent accounts using our quota system. However, we can simplify
  this. If the project is inactive, we can terminate the runner prog. A
  project's activity status is determined by suspended accounts and soft
  project deletions. As the job poller also checks project activity, we
  can exit from this prog instead of taking a long nap. The poller will
  not a create new runners.
  