### PR TITLE
Run finalize_associations on each Sequel::Model class when testing

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -7,8 +7,10 @@ require "roda"
 class Clover < Roda
   def self.freeze
     # :nocov:
-    unless Config.test?
-      Sequel::Model.freeze_descendents
+    if Config.test?
+      Sequel::Model.descendants.each(&:finalize_associations)
+    else
+      Sequel::Model.freeze_descendants
       DB.freeze
     end
     # :nocov:


### PR DESCRIPTION
This is something Sequel::Model.freeze_descendants does, which is what is run in production.  It would be best to be able to use Sequel::Model.freeze_descendants when testing, but due to the extensive use of rspec mocking, that isn't currently possible.  This makes the test environment closer to the production environment, and it speeds up the tests.

While here, change freeze_descendents to freeze_descendants. Both are currently supported, but descendents is a typo, and I plan to remove freeze_descendents in Sequel 6 (see https://github.com/jeremyevans/sequel/commit/185efe54047a6c912555651523726f9929451589)