### PR TITLE
Fix rake overwrite_envrb to correctly support parallel testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,7 +114,7 @@ task :overwrite_envrb do
 case ENV["RACK_ENV"] ||= "development"
 when "test"
   ENV["CLOVER_SESSION_SECRET"] ||= "#{SecureRandom.base64(64)}"
-  ENV["CLOVER_DATABASE_URL"] ||= 'postgres:///clover_test#{ENV["TEST_ENV_NUMBER"]}?user=clover'
+  ENV["CLOVER_DATABASE_URL"] ||= "postgres:///clover_test\#{ENV["TEST_ENV_NUMBER"]}?user=clover"
   ENV["CLOVER_COLUMN_ENCRYPTION_KEY"] ||= "#{SecureRandom.base64(32)}"
 else
   ENV["CLOVER_SESSION_SECRET"] ||= "#{SecureRandom.base64(64)}"

--- a/Rakefile
+++ b/Rakefile
@@ -133,6 +133,15 @@ begin
 rescue LoadError
 end
 
+desc "Run specs in parallel using turbo_tests"
+task "pspec" do
+  # Try to detect number of CPUs on both Linux and Mac
+  nproc = `(nproc 2> /dev/null) || sysctl -n hw.logicalcpu`.to_i
+
+  # Limit to 6 processes, as higher number results in more time
+  system("bundle", "exec", "turbo_tests", "-n", nproc.clamp(1, 6).to_s)
+end
+
 # Other
 
 desc "Annotate Sequel models"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -131,8 +131,9 @@ RSpec.configure do |config|
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
+  # particularly slow.  However, avoid printing when parallel testing,
+  # to avoid output from every process.
+  config.profile_examples = 10 unless ENV["TEST_ENV_NUMBER"]
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
This was attempting to support parallel testing, but it was eagerly evaluating the ENV["TEST_ENV_NUMBER"] code, instead of placing the #{ENV["TEST_ENV_NUMBER"]} inside env.rb.