### PR TITLE
Fix available storage bug on vm creation page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -261,7 +261,12 @@ function setupInstanceSizeBasedOptions() {
   $(".instance-size-based-storage-sizes").each(function() {
     let selectedLocation = $("input[name=location]:checked").val();
     resource_family = $("input[name=size]:checked").data("resource-family");
-    storage_size_options = $("input[name=size]:checked").data("storage-size-options")[selectedLocation];
+    storage_size_options = $("input[name=size]:checked").data("storage-size-options");
+    // Available storage sizes for postgres depend on location, but this is not
+    // the case for VM. If it's an array, location doesn't matter; otherwise, it does.
+    if (!Array.isArray(storage_size_options)) {
+      storage_size_options = storage_size_options[selectedLocation];
+    }
     storage_resource_type = $("input[name=size]:checked").data("storage-resource-type");
     storage_size_index = 0;
 


### PR DESCRIPTION
We recently started to passing available postgres storage sizes to the frontend with location details at 7b430520. However, we didn't apply this to available VM storage sizes, resulting in them lacking location keys. But they use same JS function, so it broke vm creation page. If the options are a single-dimension array and not a hash, there's no need for selecting by location. But if it's not an array, we should select by location.