### PR TITLE
Only run E2E GitHub Action when the variable RUN_E2E is set

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   run-ci:
+    if: vars.RUN_E2E == 'true'
     runs-on: ubicloud
     environment: E2E-CI
     timeout-minutes: 45


### PR DESCRIPTION
One (all?) of our contributors got annoying email once an hour on their fork of Ubicloud.

To change the default, while allowing downstream forks to in principle run E2E if they set everything up, I use a "variable" on the repository.  A fork can set the variable at a URL like this:

    https://github.com/$user-name/ubicloud/settings/variables/actions

To enable the hourly E2E runs, assign the text "true" to the `RUN_E2E` variable.