### PR TITLE
Fix nondeterministic test when using invalid flavor

### DIFF
--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -115,6 +115,9 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can not open create page with invalid flavor" do
+        default_project = Project[name: "Default"]
+        url = "#{default_project.path}/dashboard"
+        Capybara.current_session.driver.header "Referer", url
         visit "#{project.path}/postgres/create?flavor=invalid"
 
         expect(page.title).to eq("Ubicloud - Default Dashboard")


### PR DESCRIPTION
This spec has failed twice on GitHub Actions when submitting PRs, and once when I was doing parallel testing.

Reading through the code, the problem is Clover is redirecting based on the Referer header, but I think Referer header state may be leaking between test runs.  I'm not sure how to fix that, but this works around the problem by setting a specific Referer header in the spec.

Example failure: https://github.com/ubicloud/ubicloud/actions/runs/11368240212/job/31622834684?pr=2074#step:15:18