### PR TITLE
Replace database_cleaner-sequel with call to DB.transaction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :development do
 end
 
 group :test do
-  gem "database_cleaner-sequel"
   gem "capybara"
   gem "rspec"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,10 +103,6 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    database_cleaner-core (2.0.1)
-    database_cleaner-sequel (2.0.2)
-      database_cleaner-core (~> 2.0.0)
-      sequel
     date (3.3.4)
     diff-lcs (1.5.1)
     docile (1.4.1)
@@ -374,7 +370,6 @@ DEPENDENCIES
   by!
   capybara
   countries
-  database_cleaner-sequel
   ed25519
   erb-formatter!
   erubi (>= 1.5)

--- a/Rakefile
+++ b/Rakefile
@@ -36,14 +36,6 @@ SQL
     Sequel.postgres(**db.opts.merge(user: ph_user)) do |ph_db|
       ph_db.loggers << Logger.new($stdout) if ph_db.loggers.empty?
       Sequel::Migrator.run(ph_db, "migrate/ph", table: "schema_migrations_password")
-
-      if Config.test?
-        # User doesn't have permission to run TRUNCATE on password hash tables, so DatabaseCleaner
-        # can't clean Rodauth tables between test runs. While running migrations for test database,
-        # we allow it, so cleaner can clean them.
-        ph_db["GRANT TRUNCATE ON account_password_hashes TO ?", user.to_sym].get
-        ph_db["GRANT TRUNCATE ON account_previous_password_hashes TO ?", user.to_sym].get
-      end
     end
     db["REVOKE ALL ON SCHEMA public FROM ?", ph_user.to_sym].get
   when 1

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# A bit of a hack, to re-use a different spec_helper, but otherwise
-# these tests will crash DatabaseCleaner.
 require_relative "../model/spec_helper"
 
 RSpec.describe Scheduling::Dispatcher do
@@ -93,8 +91,8 @@ RSpec.describe Scheduling::Dispatcher do
         expect(di.notifiers).to be_empty
       ensure
         # Multiple transactions are required for this test across
-        # threads, so we need to clean up differently than
-        # DatabaseCleaner would.
+        # threads, so we need to clean up differently than using
+        # ROLLBACK on the main thread's transaction.
         Strand.truncate(cascade: true)
       end.join
     end


### PR DESCRIPTION
I'm starting work on optimizing running single specs.  The TRUNCATE commands run by database_cleaner-sequel take far longer than the running a single spec.  Using a separate transaction per spec, which is rolled back after the spec completes, is simple to do by calling DB.transaction with the :rollback option.

With this, we can remove the GRANT TRUNCATE in the Rakefile, as well as a substantial amount of setup code in spec/spec_config.

On my laptop, this cuts the time to run a single spec by about 45%, from about 2.5 seconds to about 1.4 seconds (this will hopefully get to about 0.5 seconds with some additional changes).

Unfortunately, rspec does not support a global around(:context), so you cannot do a transaction-per-suite and savepoint-per-spec like you can when using minitest with minitest-hooks.