### PR TITLE
Revert "Add the implicit_subquery extension"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ migrate = lambda do |env, version, db: nil|
   # migrations.  It's desirable to avoid always connecting to run
   # migrations, since, almost always, there will be nothing to do and
   # it gluts output.
-  case db[<<SQL].single_value
+  case db[<<SQL].get
 SELECT count(*)
 FROM pg_class
 WHERE relnamespace = 'public'::regnamespace AND relname = 'account_password_hashes'
@@ -32,7 +32,7 @@ SQL
 
     # NB: this grant/revoke cannot be transaction-isolated, so, in
     # sensitive settings, it would be good to check role access.
-    db["GRANT CREATE ON SCHEMA public TO ?", ph_user.to_sym].first
+    db["GRANT CREATE ON SCHEMA public TO ?", ph_user.to_sym].get
     Sequel.postgres(**db.opts.merge(user: ph_user)) do |ph_db|
       ph_db.loggers << Logger.new($stdout) if ph_db.loggers.empty?
       Sequel::Migrator.run(ph_db, "migrate/ph", table: "schema_migrations_password")
@@ -41,11 +41,11 @@ SQL
         # User doesn't have permission to run TRUNCATE on password hash tables, so DatabaseCleaner
         # can't clean Rodauth tables between test runs. While running migrations for test database,
         # we allow it, so cleaner can clean them.
-        ph_db["GRANT TRUNCATE ON account_password_hashes TO ?", user.to_sym].first
-        ph_db["GRANT TRUNCATE ON account_previous_password_hashes TO ?", user.to_sym].first
+        ph_db["GRANT TRUNCATE ON account_password_hashes TO ?", user.to_sym].get
+        ph_db["GRANT TRUNCATE ON account_previous_password_hashes TO ?", user.to_sym].get
       end
     end
-    db["REVOKE ALL ON SCHEMA public FROM ?", ph_user.to_sym].first
+    db["REVOKE ALL ON SCHEMA public FROM ?", ph_user.to_sym].get
   when 1
     # Already ran the "ph" migration as the alternate user.  This
     # branch is taken nearly all the time in a production situation.

--- a/db.rb
+++ b/db.rb
@@ -28,5 +28,5 @@ end
 
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic
-DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range, :pg_array, :implicit_subquery
+DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range, :pg_array
 Sequel.extension :pg_range_ops

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -120,7 +120,7 @@ SQL
     rescue Prog::Base::Nap => e
       save_changes
 
-      scheduled = DB[<<SQL, e.seconds, id].single_value
+      scheduled = DB[<<SQL, e.seconds, id].get
 UPDATE strand
 SET try = 0, schedule = now() + (? * '1 second'::interval)
 WHERE id = ?


### PR DESCRIPTION
This reverts commit 0085befc4a41ab8e2a257fbf97fda5813d7d5727.

This commit caused puma to fail to start, breaking production.

You can reproduce it locally by running:

    RACK_ENV=production bundle exec puma -t 5:5 -p ${PORT:-9292} -e ${RACK_ENV:-production}

The head of logs:

    2024-10-17 08:58:08  Starting process with command `bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}`
    2024-10-17 08:58:09  Puma starting in single mode...
    2024-10-17 08:58:09  * Puma version: 6.4.3 (ruby 3.2.5-p208) ("The Eagle of Durango")
    2024-10-17 08:58:09  *  Min threads: 5
    2024-10-17 08:58:09  *  Max threads: 5
    2024-10-17 08:58:09  *  Environment: production
    2024-10-17 08:58:09  *          PID: 2
    2024-10-17 08:58:11  ! Unable to load application: Sequel::DatabaseError: PG::SyntaxError: ERROR:  syntax error at or near ")"
    2024-10-17 08:58:11  LINE 1: ...T NULL AS "v" FROM (SHOW max_prepared_transactions) AS "t1" ...
    2024-10-17 08:58:11  bundler: failed to load command: puma (/app/vendor/bundle/ruby/3.2.0/bin/puma)
    2024-10-17 08:58:11  /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.84.0/lib/sequel/adapters/postgres.rb:171:in `exec': PG::SyntaxError: ERROR:  syntax error at or near ")" (Sequel::DatabaseError)
    2024-10-17 08:58:11  LINE 1: ...T NULL AS "v" FROM (SHOW max_prepared_transactions) AS "t1" ...
    ...
    2024-10-17 08:58:11  	from /app/clover.rb:12:in `freeze'
    2024-10-17 08:58:11  	from config.ru:7:in `block (2 levels) in <top (required)>'
    ...
    2024-10-17 08:58:11  /app/vendor/bundle/ruby/3.2.0/gems/sequel-5.84.0/lib/sequel/adapters/postgres.rb:171:in `exec': ERROR:  syntax error at or near ")" (PG::SyntaxError)
    2024-10-17 08:58:11  LINE 1: ...T NULL AS "v" FROM (SHOW max_prepared_transactions) AS "t1" ...
    ...
    2024-10-17 08:58:11  	from /app/clover.rb:12:in `freeze'
    2024-10-17 08:58:11  	from config.ru:7:in `block (2 levels) in <top (required)>'