### PR TITLE
Move nic gateway setting to vm_setup

### DIFF
--- a/model/nic.rb
+++ b/model/nic.rb
@@ -28,6 +28,10 @@ class Nic < Sequel::Model
     ubid.to_s[0..9]
   end
 
+  def private_ipv4_gateway
+    private_subnet.net4.nth(1).to_s + private_subnet.net4.netmask.to_s
+  end
+
   def unlock
     Semaphore.where(strand_id: strand.id, name: "lock").delete(force: true)
   end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -216,7 +216,7 @@ class Vm < Sequel::Model
       "dns_ipv4" => nics.first.private_subnet.net4.nth(2).to_s,
       "unix_user" => unix_user,
       "ssh_public_keys" => [public_key] + project_public_keys,
-      "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac] },
+      "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac, nic.private_ipv4_gateway] },
       "boot_image" => boot_image,
       "max_vcpus" => topo.max_vcpus,
       "cpu_topology" => topo.to_s,

--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -9,12 +9,6 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
     end
   end
 
-  label def add_subnet_addr
-    addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
-    nic.vm.vm_host.sshable.cmd("sudo ip -n #{nic.vm.inhost_name.shellescape} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
-    pop "add_subnet_addr is complete"
-  end
-
   label def setup_inbound
     nic.dst_ipsec_tunnels.each do |tunnel|
       args = tunnel.src_nic.rekey_payload

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -13,7 +13,7 @@ require_relative "cloud_hypervisor"
 require_relative "storage_volume"
 
 class VmSetup
-  Nic = Struct.new(:net6, :net4, :tap, :mac)
+  Nic = Struct.new(:net6, :net4, :tap, :mac, :private_ipv4_gateway)
 
   def initialize(vm_name)
     @vm_name = vm_name
@@ -226,6 +226,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     multiqueue_fragment = multiqueue ? " multi_queue vnet_hdr " : " "
     nics.each do |nic|
       r "ip -n #{q_vm} tuntap add dev #{nic.tap} mode tap user #{q_vm} #{multiqueue_fragment}"
+      r "ip -n #{q_vm} addr replace #{nic.private_ipv4_gateway} dev #{nic.tap}"
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -229,8 +229,6 @@ RSpec.describe Prog::Vm::Nexus do
       sshable = instance_spy(Sshable)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("Succeeded")
       expect(sshable).to receive(:cmd).with(/common\/bin\/daemonizer --clean prep_/)
-      nic = Nic.new(private_ipv6: "fd10:9b0b:6b4b:8fbb::/64", private_ipv4: "10.0.0.3/32", mac: "5a:0f:75:80:c3:64")
-      expect(nic).to receive(:incr_setup_nic)
       vmh = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vmh)
       expect { nx.prep }.to hop("wait_sshable")

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "creates Nic if only subnet_id is passed" do
       expect(PrivateSubnet).to receive(:[]).with(ps.id).and_return(ps)
-      expect(Prog::Vnet::NicNexus).to receive(:assemble).and_return(nic)
-      expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
+      nic_strand = instance_double(Strand, subject: nic)
+      expect(Prog::Vnet::NicNexus).to receive(:assemble).and_return(nic_strand)
       expect(nic).to receive(:update).and_return(nic)
       expect(Project).to receive(:[]).with(prj.id).and_return(prj)
       expect(prj).to receive(:private_subnets).and_return([ps]).at_least(:once)
@@ -230,7 +230,6 @@ RSpec.describe Prog::Vm::Nexus do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("Succeeded")
       expect(sshable).to receive(:cmd).with(/common\/bin\/daemonizer --clean prep_/)
       nic = Nic.new(private_ipv6: "fd10:9b0b:6b4b:8fbb::/64", private_ipv4: "10.0.0.3/32", mac: "5a:0f:75:80:c3:64")
-      expect(vm).to receive(:nics).and_return([nic]).at_least(:once)
       expect(nic).to receive(:incr_setup_nic)
       vmh = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vmh)
@@ -271,7 +270,7 @@ RSpec.describe Prog::Vm::Nexus do
           "cpu_topology" => "1:1:1:1",
           "mem_gib" => 8,
           "local_ipv4" => "169.254.0.0",
-          "nics" => [["fd10:9b0b:6b4b:8fbb::/64", "10.0.0.3/32", "tap4ncdd56m", "5a:0f:75:80:c3:64"]],
+          "nics" => [["fd10:9b0b:6b4b:8fbb::/64", "10.0.0.3/32", "tap4ncdd56m", "5a:0f:75:80:c3:64", "10.0.0.1/26"]],
           "swap_size_bytes" => nil,
           "pci_devices" => [["01:00.0", 23]]
         })

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -50,15 +50,6 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
     end
   end
 
-  describe "#add_subnet_addr" do
-    it "adds the subnet net4 address to the nic" do
-      allow(tunnel.src_nic.vm).to receive_messages(ephemeral_net6: NetAddr.parse_net("2a01:4f8:10a:128b:4919::/80"), inhost_name: "hellovm")
-      expect(tunnel.src_nic).to receive(:ubid_to_tap_name).and_return("ncname")
-      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:cmd).with("sudo ip -n hellovm addr replace 1.1.1.1/26 dev ncname")
-      expect { nx.add_subnet_addr }.to exit({"msg" => "add_subnet_addr is complete"})
-    end
-  end
-
   describe "#setup_inbound" do
     before do
       allow(tunnel.src_nic).to receive(:dst_ipsec_tunnels).and_return([tunnel])


### PR DESCRIPTION
## Move nic gateway setting to vm_setup
Nic gateway setup is the most crucial piece in ipv4 networking setup.
Most of that work already is happenning in vm_setup. Keeping this piece
in controlplane doesn't make sense. Therefore, I am moving it to the
proper place.

With this change, we simplify the controlplane operations for cases of
provisioning a VM and initially setting up its IPv4 networking or
repopulating networking after a host reboot. Without controlplane
intervention, we make sure the private subnet's first IP is added as the
gateway to the tap device during initialization.

This will require migration of prep.json files, which is fine and will
be handled at the time of deployment for existing VMs.

## Vm::Nexus.assemble clean-up for private networking setup
We just in-line some of the variable assignments and clean up some
scopes properly.