### PR TITLE
Avoid /api/ path mangling for testing purposes

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -476,18 +476,6 @@ class Clover < Roda
     if api?
       response.json = true
       response.skip_content_security_policy!
-      # To make test and development easier
-      # :nocov:
-      unless Config.production?
-        r.on("api") do
-          r.rodauth
-          rodauth.check_active_session
-          rodauth.require_authentication
-          r.hash_branches("")
-        end
-      end
-      # :nocov:
-
       r.rodauth
     else
       r.on "runtime" do

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -164,18 +164,18 @@ RSpec.describe PrivateSubnet do
     }
 
     let(:ps1) {
-      Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps1", location: "hetzner-hel1").subject
+      Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps1", location: "hetzner-fsn1").subject
     }
 
     it ".connected_subnets" do
-      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location: "hetzner-hel1").subject
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location: "hetzner-fsn1").subject
       expect(ps1.connected_subnets).to eq []
 
       ps1.connect_subnet(ps2)
       expect(ps1.connected_subnets.map(&:id)).to eq [ps2.id]
       expect(ps2.connected_subnets.map(&:id)).to eq [ps1.id]
 
-      ps3 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps3", location: "hetzner-hel1").subject
+      ps3 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps3", location: "hetzner-fsn1").subject
       ps2.connect_subnet(ps3)
       expect(ps1.connected_subnets.map(&:id)).to eq [ps2.id]
       expect(ps2.connected_subnets.map(&:id).sort).to eq [ps1.id, ps3.id].sort
@@ -188,7 +188,7 @@ RSpec.describe PrivateSubnet do
     end
 
     it ".all_nics" do
-      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location: "hetzner-hel1").subject
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location: "hetzner-fsn1").subject
 
       ps1_nic = Prog::Vnet::NicNexus.assemble(ps1.id, name: "test-ps1-nic1").subject
       ps2_nic = Prog::Vnet::NicNexus.assemble(ps2.id, name: "test-ps2-nic1").subject
@@ -206,7 +206,7 @@ RSpec.describe PrivateSubnet do
     end
 
     it "disconnect_subnet does not destroy in subnet tunnels" do
-      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location: "hetzner-hel1").subject
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location: "hetzner-fsn1").subject
       ps1_nic = Prog::Vnet::NicNexus.assemble(ps1.id, name: "test-ps1-nic1").subject
       ps1_nic2 = Prog::Vnet::NicNexus.assemble(ps1.id, name: "test-ps1-nic2").subject
       ps1.create_tunnels([ps1_nic], ps1_nic2)

--- a/spec/prog/test/connected_subnets_spec.rb
+++ b/spec/prog/test/connected_subnets_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Prog::Test::ConnectedSubnets do
   }
 
   let(:ps_multiple) {
-    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-multiple", location: "hetzner-hel1").subject
+    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-multiple", location: "hetzner-fsn1").subject
   }
 
   let(:ps_single) {
-    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-single", location: "hetzner-hel1").subject
+    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-single", location: "hetzner-fsn1").subject
   }
 
   let(:project) {

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe Prog::Test::VmGroup do
     it "runs tests for the first connected subnet" do
       prj = Project.create_with_id(name: "project 1")
       prj.associate_with_project(prj)
-      ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-hel1").subject
-      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-hel1").subject
+      ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-fsn1").subject
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-fsn1").subject
       expect(vg_test).to receive(:frame).and_return({"subnets" => [ps1.id, ps2.id]}).at_least(:once)
       expect { vg_test.verify_connected_subnets }.to hop("start", "Test::ConnectedSubnets")
     end
@@ -76,9 +76,9 @@ RSpec.describe Prog::Test::VmGroup do
     it "runs tests for the second connected subnet" do
       prj = Project.create_with_id(name: "project 1")
       prj.associate_with_project(prj)
-      ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-hel1").subject
+      ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-fsn1").subject
       expect(ps1).to receive(:vms).and_return([instance_double(Vm, id: "vm1"), instance_double(Vm, id: "vm2")]).at_least(:once)
-      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-hel1").subject
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-fsn1").subject
       expect(PrivateSubnet).to receive(:[]).and_return(ps1, ps2)
       expect(vg_test).to receive(:frame).and_return({"subnets" => [ps1.id, ps2.id]}).at_least(:once)
       expect { vg_test.verify_connected_subnets }.to hop("start", "Test::ConnectedSubnets")

--- a/spec/routes/api/auth_spec.rb
+++ b/spec/routes/api/auth_spec.rb
@@ -6,26 +6,26 @@ RSpec.describe Clover, "auth" do
   let(:user) { create_account }
 
   it "wrong email" do
-    post "/api/login?login=wrong_mail&password=#{TEST_USER_PASSWORD}", nil, {"CONTENT_TYPE" => "application/json"}
+    post "/login?login=wrong_mail&password=#{TEST_USER_PASSWORD}", nil, {"CONTENT_TYPE" => "application/json"}
 
     expect(last_response).to have_api_error(401, "There was an error logging in")
   end
 
   it "wrong password" do
-    post "/api/login?login=#{TEST_USER_EMAIL}&password=wrongpassword", nil, {"CONTENT_TYPE" => "application/json"}
+    post "/login?login=#{TEST_USER_EMAIL}&password=wrongpassword", nil, {"CONTENT_TYPE" => "application/json"}
 
     expect(last_response).to have_api_error(401, "There was an error logging in")
   end
 
   it "wrong jwt" do
     header "Authorization", "Bearer wrongjwt"
-    get "/api/project"
+    get "/project"
 
     expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "no login" do
-    get "/api/project"
+    get "/project"
 
     expect(last_response).to have_api_error(401, "Please login to continue")
   end

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe Clover, "firewall" do
 
   describe "unauthenticated" do
     it "not post" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule"
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
-      delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
@@ -37,7 +37,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "create firewall rule" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
         cidr: "0.0.0.0/0",
         port_range: "100..101"
       }.to_json
@@ -46,7 +46,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "can not create same firewall rule" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
         cidr: firewall_rule.cidr,
         port_range: "80..5432"
       }.to_json
@@ -55,7 +55,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "firewall rule no port range" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
         cidr: "0.0.0.0/1"
       }.to_json
 
@@ -63,7 +63,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "firewall rule single port" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
         cidr: "0.0.0.0/1",
         port_range: "11111"
       }.to_json
@@ -72,23 +72,23 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "firewall rule delete" do
-      delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
       expect(last_response.status).to eq(204)
     end
 
     it "firewall rule delete does not exist" do
-      delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/fooubid"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/fooubid"
       expect(last_response.status).to eq(204)
     end
 
     it "success get firewall rule" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
       expect(last_response.status).to eq(200)
     end
 
     it "get does not exist" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/fooubid"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/fooubid"
 
       expect(last_response.content_type).to eq("application/json")
       expect(last_response).to have_api_error(404)

--- a/spec/routes/api/project/firewall_spec.rb
+++ b/spec/routes/api/project/firewall_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Clover, "firewall" do
 
   describe "unauthenticated" do
     it "not list" do
-      get "/api/project/#{project.ubid}/firewall"
+      get "/project/#{project.ubid}/firewall"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not create" do
-      post "/api/project/#{project.ubid}/firewall"
+      post "/project/#{project.ubid}/firewall"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
@@ -31,7 +31,7 @@ RSpec.describe Clover, "firewall" do
     it "success get all firewalls" do
       Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1").associate_with_project(project)
 
-      get "/api/project/#{project.ubid}/firewall"
+      get "/project/#{project.ubid}/firewall"
 
       expect(last_response.status).to eq(200)
       expect(JSON.parse(last_response.body)["items"].length).to eq(2)

--- a/spec/routes/api/project/load_balancer_spec.rb
+++ b/spec/routes/api/project/load_balancer_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Clover, "vm" do
 
   let(:project) { user.create_project_with_default_policy("project-1") }
 
+  describe "unauthenticated" do
+    it "not list" do
+      get "/project/#{project.ubid}/load-balancer"
+
+      expect(last_response).to have_api_error(401, "Please login to continue")
+    end
+  end
+
   describe "authenticated" do
     before do
       login_api(user.email)
@@ -18,7 +26,7 @@ RSpec.describe Clover, "vm" do
       ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-fsn1")
       Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "lb-1", src_port: 80, dst_port: 80)
       Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "lb-2", src_port: 80, dst_port: 80)
-      get "/api/project/#{project.ubid}/load-balancer"
+      get "/project/#{project.ubid}/load-balancer"
 
       expect(last_response.status).to eq(200)
       expect(JSON.parse(last_response.body)["items"].length).to eq(2)

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -11,25 +11,25 @@ RSpec.describe Clover, "firewall" do
 
   describe "unauthenticated" do
     it "not delete" do
-      delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not associate" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}/attach-subnet"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}/attach-subnet"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not dissociate" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}/detach-subnet"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}/detach-subnet"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
@@ -43,32 +43,32 @@ RSpec.describe Clover, "firewall" do
     it "success get all location firewalls" do
       Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1").associate_with_project(project)
 
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall"
 
       expect(last_response.status).to eq(200)
       expect(JSON.parse(last_response.body)["items"].length).to eq(2)
     end
 
     it "success get firewall" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
 
       expect(last_response.status).to eq(200)
     end
 
     it "get does not exist for invalid name" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/foo_name"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/foo_name"
 
       expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
     end
 
     it "get does not exist for valid name" do
-      get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/fooname"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/fooname"
 
       expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
     end
 
     it "success post" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/foo-name", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/foo-name", {
         description: "Firewall description"
       }.to_json
 
@@ -76,7 +76,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "failure post" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/FooName", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/FooName", {
         description: "Firewall description"
       }.to_json
 
@@ -84,19 +84,19 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "success delete" do
-      delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}"
 
       expect(last_response.status).to eq(204)
     end
 
     it "delete not exist for valid ubid format" do
-      delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{"0" * 26}"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{"0" * 26}"
 
       expect(last_response.status).to eq(204)
     end
 
     it "delete not exist for invalid ubid format" do
-      delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_foo_ubid"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_foo_ubid"
 
       expect(last_response.status).to eq(204)
     end
@@ -106,7 +106,7 @@ RSpec.describe Clover, "firewall" do
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
 
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 
@@ -116,7 +116,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach to subnet not exist" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
         private_subnet_id: "fooubid"
       }.to_json
 
@@ -128,7 +128,7 @@ RSpec.describe Clover, "firewall" do
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
 
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 
@@ -136,7 +136,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "detach from subnet not exist" do
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
         private_subnet_id: "fooubid"
       }.to_json
 
@@ -148,13 +148,13 @@ RSpec.describe Clover, "firewall" do
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps).twice
       expect(ps).to receive(:incr_update_firewall_rules).twice
 
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 
       expect(firewall.private_subnets.count).to eq(1)
 
-      post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Clover, "load-balancer" do
   describe "unauthenticated" do
     it "cannot perform authenticated operations" do
       [
-        [:get, "/api/project/#{project.ubid}/load-balancer"],
-        [:post, "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb-1"],
-        [:delete, "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"],
-        [:get, "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"],
-        [:post, "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: "vm-1"}],
-        [:post, "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: "vm-1"}],
-        [:get, "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_#{lb.ubid}"]
+        [:get, "/project/#{project.ubid}/load-balancer"],
+        [:post, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb-1"],
+        [:delete, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"],
+        [:get, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"],
+        [:post, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: "vm-1"}],
+        [:post, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: "vm-1"}],
+        [:get, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_#{lb.ubid}"]
       ].each do |method, path, body|
         send(method, path, body)
 
@@ -43,7 +43,7 @@ RSpec.describe Clover, "load-balancer" do
 
     describe "list" do
       it "empty" do
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"]).to eq([])
@@ -52,7 +52,7 @@ RSpec.describe Clover, "load-balancer" do
       it "success single" do
         lb
 
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(1)
@@ -62,7 +62,7 @@ RSpec.describe Clover, "load-balancer" do
         lb
         Prog::Vnet::LoadBalancerNexus.assemble(lb.private_subnet.id, name: "lb-2", src_port: 80, dst_port: 80).subject
 
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(2)
@@ -71,14 +71,14 @@ RSpec.describe Clover, "load-balancer" do
 
     describe "id" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_#{lb.ubid}"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_#{lb.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("lb-1")
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_invalid"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_invalid"
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
@@ -87,7 +87,7 @@ RSpec.describe Clover, "load-balancer" do
     describe "create" do
       it "success" do
         ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-fsn1").subject
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {
           private_subnet_id: ps.ubid,
           src_port: "80", dst_port: "80",
           health_check_endpoint: "/up", algorithm: "round_robin",
@@ -99,13 +99,13 @@ RSpec.describe Clover, "load-balancer" do
       end
 
       it "missing required parameters" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {}.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
       end
 
       it "invalid private_subnet_id" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {
           private_subnet_id: "invalid",
           src_port: "80", dst_port: "80",
           health_check_endpoint: "/up", algorithm: "round_robin",
@@ -116,7 +116,7 @@ RSpec.describe Clover, "load-balancer" do
       end
 
       it "invalid name" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid_name", {}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid_name", {}.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
       end
@@ -124,13 +124,13 @@ RSpec.describe Clover, "load-balancer" do
 
     describe "delete" do
       it "success" do
-        delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"
+        delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "not found" do
-        delete "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid_name"
+        delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid_name"
 
         expect(last_response.status).to eq(204)
       end
@@ -138,14 +138,14 @@ RSpec.describe Clover, "load-balancer" do
 
     describe "get" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("lb-1")
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid"
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
@@ -161,7 +161,7 @@ RSpec.describe Clover, "load-balancer" do
       }
 
       it "success" do
-        patch "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
+        patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
           src_port: "80", dst_port: "80",
           health_check_endpoint: "/up", algorithm: "round_robin", vms: []
         }.to_json
@@ -171,7 +171,7 @@ RSpec.describe Clover, "load-balancer" do
       end
 
       it "not found" do
-        patch "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid", {
+        patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid", {
           src_port: "80", dst_port: "80",
           health_check_endpoint: "/up", algorithm: "round_robin", vms: []
         }.to_json
@@ -180,13 +180,13 @@ RSpec.describe Clover, "load-balancer" do
       end
 
       it "missing required parameters" do
-        patch "/api/project/#{project.ubid}/location/#{lb.private_subnet.display_location}/load-balancer/#{lb.name}", {}.to_json
+        patch "/project/#{project.ubid}/location/#{lb.private_subnet.display_location}/load-balancer/#{lb.name}", {}.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
       end
 
       it "updates vms" do
-        patch "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
+        patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
           src_port: "80", dst_port: "80", health_check_endpoint: "/up", algorithm: "round_robin", vms: [vm.ubid]
         }.to_json
 
@@ -197,7 +197,7 @@ RSpec.describe Clover, "load-balancer" do
       it "detaches vms" do
         lb.add_vm(vm)
 
-        patch "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
+        patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
           src_port: "80", dst_port: "80", health_check_endpoint: "/up", algorithm: "round_robin", vms: []
         }.to_json
 
@@ -207,7 +207,7 @@ RSpec.describe Clover, "load-balancer" do
       end
 
       it "invalid vm" do
-        patch "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
+        patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
           src_port: "80", dst_port: "80", health_check_endpoint: "/up", algorithm: "round_robin", vms: ["invalid"]
         }.to_json
 
@@ -221,7 +221,7 @@ RSpec.describe Clover, "load-balancer" do
         lb2.add_cert(cert)
         lb2.add_vm(vm)
 
-        patch "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
+        patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
           src_port: "80", dst_port: "80", health_check_endpoint: "/up", algorithm: "round_robin", vms: [vm.ubid]
         }.to_json
 
@@ -231,7 +231,7 @@ RSpec.describe Clover, "load-balancer" do
       it "vm already attached to the same load balancer" do
         lb.add_vm(vm)
 
-        patch "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
+        patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}", {
           src_port: "80", dst_port: "80", health_check_endpoint: "/up", algorithm: "round_robin", vms: [vm.ubid]
         }.to_json
 
@@ -249,13 +249,13 @@ RSpec.describe Clover, "load-balancer" do
 
       it "success" do
         vm.associate_with_project(project)
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: vm.ubid}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: vm.ubid}.to_json
 
         expect(last_response.status).to eq(200)
       end
 
       it "not existing vm" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: "invalid"}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: "invalid"}.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: vm_id")
       end
@@ -273,13 +273,13 @@ RSpec.describe Clover, "load-balancer" do
         vm.associate_with_project(project)
         lb.add_vm(vm)
 
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: vm.ubid}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: vm.ubid}.to_json
 
         expect(last_response.status).to eq(200)
       end
 
       it "not existing vm" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: "invalid"}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: "invalid"}.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: vm_id")
       end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -23,19 +23,19 @@ RSpec.describe Clover, "postgres" do
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
 
       [
-        [:get, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"],
-        [:post, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/test-postgres"],
-        [:delete, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"],
-        [:delete, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"],
-        [:get, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"],
-        [:get, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"],
-        [:post, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule"],
-        [:delete, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"],
-        [:post, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore"],
-        [:post, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/restore"],
-        [:post, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password"],
-        [:post, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/reset-superuser-password"],
-        [:post, "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"]
+        [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/test-postgres"],
+        [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"],
+        [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"],
+        [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"],
+        [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule"],
+        [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/restore"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/reset-superuser-password"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"]
       ].each do |method, path|
         send method, path
 
@@ -53,14 +53,14 @@ RSpec.describe Clover, "postgres" do
 
     describe "list" do
       it "empty" do
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"]).to eq([])
       end
 
       it "success single" do
-        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(1)
@@ -75,7 +75,7 @@ RSpec.describe Clover, "postgres" do
           target_storage_size_gib: 128
         )
 
-        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(2)
@@ -84,7 +84,7 @@ RSpec.describe Clover, "postgres" do
 
     describe "create" do
       it "success" do
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-no-ha", {
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-no-ha", {
           size: "standard-2",
           ha_type: "none"
         }.to_json
@@ -92,7 +92,7 @@ RSpec.describe Clover, "postgres" do
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres-no-ha")
 
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-async", {
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-async", {
           size: "standard-2",
           ha_type: "async"
         }.to_json
@@ -100,7 +100,7 @@ RSpec.describe Clover, "postgres" do
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres-async")
 
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-sync", {
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-sync", {
           size: "standard-2",
           ha_type: "sync"
         }.to_json
@@ -113,7 +113,7 @@ RSpec.describe Clover, "postgres" do
         expect(Config).to receive(:postgres_paradedb_notification_email).and_return("dummy@mail.com")
         expect(Util).to receive(:send_email)
 
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-no-ha", {
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-no-ha", {
           size: "standard-2",
           flavor: "paradedb"
         }.to_json
@@ -122,7 +122,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "invalid location" do
-        post "/api/project/#{project.ubid}/location/eu-north-h1/postgres/test-postgres", {
+        post "/project/#{project.ubid}/location/eu-north-h1/postgres/test-postgres", {
           size: "standard-2",
           ha_type: "sync"
         }.to_json
@@ -131,7 +131,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "invalid name" do
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/INVALIDNAME", {
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/INVALIDNAME", {
           size: "standard-2",
           ha_type: "sync"
         }.to_json
@@ -140,13 +140,13 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "invalid body" do
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", "invalid_body"
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", "invalid_body"
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body isn't a valid JSON object."})
       end
 
       it "missing required key" do
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
           unix_user: "ha_type"
         }.to_json
 
@@ -154,7 +154,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "non allowed key" do
-        post "/api/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
           size: "standard-2",
           foo_key: "foo_val"
         }.to_json
@@ -163,7 +163,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule", {
           cidr: "0.0.0.0/24"
         }.to_json
 
@@ -171,7 +171,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule pg ubid" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule", {
           cidr: "0.0.0.0/24"
         }.to_json
 
@@ -179,7 +179,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule invalid cidr" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule", {
           cidr: "0.0.0"
         }.to_json
 
@@ -187,7 +187,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "metric-destination" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination", {
           url: "https://example.com",
           username: "username",
           password: "password"
@@ -197,7 +197,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "metric-destination invalid url" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination", {
           url: "-",
           username: "username",
           password: "password"
@@ -213,7 +213,7 @@ RSpec.describe Clover, "postgres" do
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
         expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, list_objects: [backup.new("basebackups_005/backup_stop_sentinel.json", restore_target - 10 * 60)])).at_least(:once)
 
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg",
           restore_target: restore_target
 
@@ -223,7 +223,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "restore invalid target" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg",
           restore_target: Time.now.utc
         }.to_json
@@ -232,7 +232,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "reset password" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -242,7 +242,7 @@ RSpec.describe Clover, "postgres" do
       it "reset password invalid restore" do
         pg.representative_server.update(timeline_access: "fetch")
 
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -250,7 +250,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "invalid password" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
           password: "dummy"
         }.to_json
 
@@ -258,7 +258,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "reset password ubid" do
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/reset-superuser-password", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -274,7 +274,7 @@ RSpec.describe Clover, "postgres" do
         st.update(label: "wait")
         expect(PostgresServer).to receive(:run_query).and_return "16/B374D848"
 
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
 
         expect(last_response.status).to eq(200)
       end
@@ -283,7 +283,7 @@ RSpec.describe Clover, "postgres" do
         pg.save_changes
         pg.representative_server.update(timeline_access: "fetch")
 
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
 
         expect(last_response).to have_api_error(400, "Failover cannot be triggered during restore!")
       end
@@ -291,7 +291,7 @@ RSpec.describe Clover, "postgres" do
       it "failover no ff base image" do
         pg.save_changes
 
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
 
         expect(last_response).to have_api_error(400, "Failover cannot be triggered for this resource!")
       end
@@ -300,7 +300,7 @@ RSpec.describe Clover, "postgres" do
         project.set_ff_postgresql_base_image(true)
         pg.save_changes
 
-        post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
 
         expect(last_response).to have_api_error(400, "There is not a suitable standby server to failover!")
       end
@@ -308,7 +308,7 @@ RSpec.describe Clover, "postgres" do
       it "invalid payment" do
         expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
 
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres/test-postgres", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/postgres/test-postgres", {
           size: "standard-2",
           ha_type: "sync"
         }.to_json
@@ -319,27 +319,27 @@ RSpec.describe Clover, "postgres" do
 
     describe "show" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(pg.name)
       end
 
       it "success ubid" do
-        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(pg.name)
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/not-exists-pg"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/not-exists-pg"
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "show firewall" do
-        get "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)[0]["cidr"]).to eq("0.0.0.0/0")
@@ -348,54 +348,54 @@ RSpec.describe Clover, "postgres" do
 
     describe "delete" do
       it "success" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
       end
 
       it "success ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
       end
 
       it "not exist" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/foo_name"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/foo_name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 
       it "not exist ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_fooubid"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_fooubid"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 
       it "not exist ubid in location" do
-        delete "/api/project/#{project.ubid}/location/foo_location/postgres/_#{pg.ubid}"
+        delete "/project/#{project.ubid}/location/foo_location/postgres/_#{pg.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 
       it "firewall-rule" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "firewall-rule ubid" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "firewall-rule not exist" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"
 
         expect(last_response.status).to eq(204)
       end
@@ -407,13 +407,13 @@ RSpec.describe Clover, "postgres" do
           username: "username",
           password: "password"
         )
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination/#{pg.metric_destinations.first.ubid}"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination/#{pg.metric_destinations.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end
 
       it "metric-destination not exist" do
-        delete "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination/foo_ubid"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination/foo_ubid"
 
         expect(last_response.status).to eq(204)
       end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Clover, "private_subnet" do
   describe "unauthenticated" do
     it "cannot perform authenticated operations" do
       [
-        [:get, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"],
-        [:post, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"],
-        [:delete, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
-        [:delete, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"],
-        [:get, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
-        [:get, "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"]
+        [:get, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"],
+        [:post, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"],
+        [:delete, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
+        [:delete, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"],
+        [:get, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
+        [:get, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"]
       ].each do |method, path|
         send method, path
 
@@ -37,14 +37,14 @@ RSpec.describe Clover, "private_subnet" do
 
     describe "list" do
       it "empty" do
-        get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"]).to eq([])
       end
 
       it "success single" do
-        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(1)
@@ -53,7 +53,7 @@ RSpec.describe Clover, "private_subnet" do
       it "success multiple" do
         Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2")
 
-        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(2)
@@ -66,7 +66,7 @@ RSpec.describe Clover, "private_subnet" do
 
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, private_subnet_id: ps.id, nic_id: nic.id, name: "dummy-vm-2")
 
-        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
       end
@@ -76,7 +76,7 @@ RSpec.describe Clover, "private_subnet" do
           ipv6_addr: "fd38:5c12:20bf:67d4:919e::/79",
           ipv4_addr: "172.17.226.186/32")
 
-        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"
 
         expect(last_response.status).to eq(200)
       end
@@ -84,20 +84,20 @@ RSpec.describe Clover, "private_subnet" do
 
     describe "create" do
       it "success" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps"
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-ps")
       end
 
       it "invalid name" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/invalid_name"
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/invalid_name"
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: name", {"name" => "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."})
       end
 
       it "not authorized" do
-        post "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/foo_subnet"
+        post "/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/foo_subnet"
 
         expect(last_response.content_type).to eq("application/json")
         expect(last_response).to have_api_error(403)
@@ -105,7 +105,7 @@ RSpec.describe Clover, "private_subnet" do
 
       it "with valid firewall" do
         fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1").tap { _1.associate_with_project(project) }
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: fw.ubid}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: fw.ubid}.to_json
 
         expect(last_response.status).to eq(200)
         resp_body = JSON.parse(last_response.body)
@@ -114,13 +114,13 @@ RSpec.describe Clover, "private_subnet" do
       end
 
       it "with invalid firewall id" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: "invalidid"}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: "invalidid"}.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: firewall_id", {"firewall_id" => "Firewall with id \"invalidid\" and location \"hetzner-fsn1\" is not found"})
       end
 
       it "with empty body" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {}.to_json
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {}.to_json
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-ps")
@@ -129,27 +129,27 @@ RSpec.describe Clover, "private_subnet" do
 
     describe "show" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
       end
 
       it "success id" do
-        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/not-exists-ps"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/not-exists-ps"
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
 
       it "not authorized" do
-        get "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
+        get "/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
 
         expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end
@@ -157,28 +157,28 @@ RSpec.describe Clover, "private_subnet" do
 
     describe "delete" do
       it "success" do
-        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
+        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
       end
 
       it "success id" do
-        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"
+        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
       end
 
       it "not exist ubid in location" do
-        delete "/api/project/#{project.ubid}/location/foo_location/private-subnet/_#{ps.ubid}"
+        delete "/project/#{project.ubid}/location/foo_location/private-subnet/_#{ps.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be false
       end
 
       it "not exist ubid" do
-        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_foo_ubid"
+        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_foo_ubid"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be false
@@ -187,20 +187,20 @@ RSpec.describe Clover, "private_subnet" do
       it "dependent vm failure" do
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, private_subnet_id: ps.id, name: "dummy-vm-2")
 
-        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
+        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"
 
         expect(last_response).to have_api_error(409, "Private subnet 'dummy-ps-1' has VMs attached, first, delete them.")
       end
 
       it "not exist" do
-        delete "/api/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"
+        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be false
       end
 
       it "not authorized" do
-        delete "/api/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
+        delete "/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/#{ps_wo_permission.name}"
 
         expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Clover, "vm" do
   describe "unauthenticated" do
     it "cannot perform authenticated operations" do
       [
-        [:get, "/api/project/#{project.ubid}/location/#{vm.display_location}/vm"],
-        [:post, "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"],
-        [:delete, "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"],
-        [:delete, "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"],
-        [:get, "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"],
-        [:get, "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"]
+        [:get, "/project/#{project.ubid}/location/#{vm.display_location}/vm"],
+        [:post, "/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"],
+        [:delete, "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"],
+        [:delete, "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"],
+        [:get, "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"],
+        [:get, "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"]
       ].each do |method, path|
         send method, path
 
@@ -39,7 +39,7 @@ RSpec.describe Clover, "vm" do
       it "success multiple" do
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-2")
 
-        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm"
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm"
 
         expect(last_response.status).to eq(200)
         parsed_body = JSON.parse(last_response.body)
@@ -52,7 +52,7 @@ RSpec.describe Clover, "vm" do
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-3")
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-4", location: "leaseweb-wdc02")
 
-        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm", {
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm", {
           order_column: "name",
           start_after: "dummy-vm-1"
         }
@@ -64,7 +64,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "ubid not exist" do
-        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/_foo_ubid"
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/_foo_ubid"
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
@@ -72,7 +72,7 @@ RSpec.describe Clover, "vm" do
 
     describe "create" do
       it "success" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -87,7 +87,7 @@ RSpec.describe Clover, "vm" do
       it "success with private subnet" do
         ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").ubid
 
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -102,7 +102,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success with storage size" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -115,7 +115,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "boot image doesn't passed" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -126,7 +126,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "invalid name" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/MyVM", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/MyVM", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -137,7 +137,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "invalid boot image" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -149,7 +149,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "invalid vm size" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-gpu-6",
@@ -160,7 +160,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success without vm_size" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           boot_image: "ubuntu-jammy",
@@ -171,7 +171,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "invalid ps id" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -185,7 +185,7 @@ RSpec.describe Clover, "vm" do
 
       it "invalid ps id in other location" do
         ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "leaseweb-wdc02").ubid
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
           size: "standard-2",
@@ -198,13 +198,13 @@ RSpec.describe Clover, "vm" do
       end
 
       it "invalid body" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", "invalid_body"
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", "invalid_body"
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body isn't a valid JSON object."})
       end
 
       it "missing required key" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           unix_user: "ubi"
         }.to_json
 
@@ -212,7 +212,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "non allowed key" do
-        post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           foo_key: "foo_val"
         }.to_json
@@ -223,21 +223,21 @@ RSpec.describe Clover, "vm" do
 
     describe "show" do
       it "success" do
-        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(vm.name)
       end
 
       it "success ubid" do
-        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(vm.name)
       end
 
       it "not found" do
-        get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/not-exists-vm"
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/not-exists-vm"
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
@@ -245,35 +245,35 @@ RSpec.describe Clover, "vm" do
 
     describe "delete" do
       it "success" do
-        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
+        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be true
       end
 
       it "success ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"
+        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be true
       end
 
       it "not exist" do
-        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"
+        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
       end
 
       it "not exist ubid" do
-        delete "/api/project/#{project.ubid}/location/#{vm.display_location}/vm/_foo_ubid"
+        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/_foo_ubid"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
       end
 
       it "not exist ubid in location" do
-        delete "/api/project/#{project.ubid}/location/foo_location/vm/_#{vm.ubid}"
+        delete "/project/#{project.ubid}/location/foo_location/vm/_#{vm.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Clover, "vm" do
 
   describe "unauthenticated" do
     it "not list" do
-      get "/api/project/#{project.ubid}/pg"
+      get "/project/#{project.ubid}/pg"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
@@ -39,7 +39,7 @@ RSpec.describe Clover, "vm" do
         target_storage_size_gib: 128
       )
 
-      get "/api/project/#{project.ubid}/postgres"
+      get "/project/#{project.ubid}/postgres"
 
       expect(last_response.status).to eq(200)
       expect(JSON.parse(last_response.body)["items"].length).to eq(2)

--- a/spec/routes/api/project/private_subnet_spec.rb
+++ b/spec/routes/api/project/private_subnet_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Clover, "private_subnet" do
 
   describe "unauthenticated" do
     it "not list" do
-      get "/api/project/#{project.ubid}/private-subnet"
+      get "/project/#{project.ubid}/private-subnet"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
@@ -24,7 +24,7 @@ RSpec.describe Clover, "private_subnet" do
       Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-fsn1")
       Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-3", location: "hetzner-fsn1")
 
-      get "/api/project/#{project.ubid}/private-subnet"
+      get "/project/#{project.ubid}/private-subnet"
 
       expect(last_response.status).to eq(200)
       expect(JSON.parse(last_response.body)["items"].length).to eq(2)

--- a/spec/routes/api/project/vm_spec.rb
+++ b/spec/routes/api/project/vm_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Clover, "vm" do
 
   describe "unauthenticated" do
     it "not list" do
-      get "/api/project/#{project.ubid}/vm"
+      get "/project/#{project.ubid}/vm"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
@@ -26,7 +26,7 @@ RSpec.describe Clover, "vm" do
       Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-2", location: "hetzner-fsn1")
       Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-3", location: vm.location)
 
-      get "/api/project/#{project.ubid}/vm"
+      get "/project/#{project.ubid}/vm"
 
       expect(last_response.status).to eq(200)
       expect(JSON.parse(last_response.body)["items"].length).to eq(3)

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Clover, "project" do
   describe "unauthenticated" do
     it "cannot perform authenticated operations" do
       [
-        [:get, "/api/project"],
-        [:post, "/api/project", {name: "p-1"}],
-        [:delete, "/api/project/#{project.ubid}"]
+        [:get, "/project"],
+        [:post, "/project", {name: "p-1"}],
+        [:delete, "/project/#{project.ubid}"]
       ].each do |method, path, body|
         send(method, path, body)
 
@@ -29,16 +29,6 @@ RSpec.describe Clover, "project" do
     describe "list" do
       it "success" do
         project
-        get "/api/project"
-
-        expect(last_response.status).to eq(200)
-        parsed_body = JSON.parse(last_response.body)
-        expect(parsed_body["count"]).to eq(2)
-      end
-
-      it "success with api subdomain" do
-        project
-        header "Host", "api.ubicloud.com"
         get "/project"
 
         expect(last_response.status).to eq(200)
@@ -48,14 +38,14 @@ RSpec.describe Clover, "project" do
 
       it "invalid order column" do
         project
-        get "/api/project?order_column=name"
+        get "/project?order_column=name"
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: order_column")
       end
 
       it "invalid id" do
         project
-        get "/api/project?start_after=invalid_id"
+        get "/project?start_after=invalid_id"
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: start_after")
       end
@@ -63,7 +53,7 @@ RSpec.describe Clover, "project" do
 
     describe "create" do
       it "success" do
-        post "/api/project", {
+        post "/project", {
           name: "test-project"
         }.to_json
 
@@ -72,7 +62,7 @@ RSpec.describe Clover, "project" do
       end
 
       it "missing parameter" do
-        post "/api/project", {}.to_json
+        post "/project", {}.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
       end
@@ -80,7 +70,7 @@ RSpec.describe Clover, "project" do
 
     describe "delete" do
       it "success" do
-        delete "api/project/#{project.ubid}"
+        delete "/project/#{project.ubid}"
 
         expect(last_response.status).to eq(204)
 
@@ -90,7 +80,7 @@ RSpec.describe Clover, "project" do
       end
 
       it "success with non-existing project" do
-        delete "api/project/non_existing_id"
+        delete "/project/non_existing_id"
 
         expect(last_response.status).to eq(204)
       end
@@ -98,7 +88,7 @@ RSpec.describe Clover, "project" do
       it "can not delete project when it has resources" do
         Prog::Vm::Nexus.assemble("key", project.id, name: "vm1")
 
-        delete "api/project/#{project.ubid}"
+        delete "/project/#{project.ubid}"
 
         expect(last_response).to have_api_error(409, "'#{project.name}' project has some resources. Delete all related resources first.")
       end
@@ -106,7 +96,7 @@ RSpec.describe Clover, "project" do
       it "not authorized" do
         u = create_account("test@test.com")
         p = u.create_project_with_default_policy("project-1")
-        delete "api/project/#{p.ubid}"
+        delete "/project/#{p.ubid}"
 
         expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end
@@ -114,14 +104,14 @@ RSpec.describe Clover, "project" do
 
     describe "show" do
       it "success" do
-        get "/api/project/#{project.ubid}"
+        get "/project/#{project.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(project.name)
       end
 
       it "not found" do
-        get "/api/project/08s56d4kaj94xsmrnf5v5m3mav"
+        get "/project/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
@@ -129,7 +119,7 @@ RSpec.describe Clover, "project" do
       it "not authorized" do
         u = create_account("test@test.com")
         p = u.create_project_with_default_policy("project-1")
-        get "/api/project/#{p.ubid}"
+        get "/project/#{p.ubid}"
 
         expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end

--- a/spec/routes/api/show_errors_spec.rb
+++ b/spec/routes/api/show_errors_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe Clover do
   end
 
   it "supports SHOW_ERRORS environment variable when testing" do
-    expect { post "/api/project", {}.to_json }.to raise_error Validation::ValidationFailed
+    expect { post "/project", {}.to_json }.to raise_error Validation::ValidationFailed
   end
 end

--- a/spec/routes/api/spec_helper.rb
+++ b/spec/routes/api/spec_helper.rb
@@ -3,7 +3,7 @@
 require_relative "../spec_helper"
 
 def login_api(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
-  post "/api/login", JSON.generate(login: email, password: password), {"CONTENT_TYPE" => "application/json"}
+  post "/login", JSON.generate(login: email, password: password), {"CONTENT_TYPE" => "application/json"}
   expect(last_response.status).to eq(200)
   header "Authorization", "Bearer #{last_response.headers["authorization"]}"
 end
@@ -15,6 +15,7 @@ RSpec.configure do |config|
 
   config.before do |example|
     next unless example.metadata[:clover_api]
+    header "Host", "api.ubicloud.com"
     header "Content-Type", "application/json"
     header "Accept", "application/json"
   end

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Clover, "private subnet" do
     describe "connected subnets" do
       it "can show connected subnets" do
         private_subnet
-        ps2 = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-hel1").subject
+        ps2 = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-fsn1").subject
         private_subnet.connect_subnet(ps2)
 
         visit "#{project.path}#{private_subnet.path}"
@@ -162,7 +162,7 @@ RSpec.describe Clover, "private subnet" do
 
       it "can disconnect connected subnet" do
         private_subnet
-        ps2 = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-hel1").subject
+        ps2 = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-fsn1").subject
         private_subnet.connect_subnet(ps2)
 
         visit "#{project.path}#{private_subnet.path}"
@@ -177,7 +177,7 @@ RSpec.describe Clover, "private subnet" do
 
       it "can connect to a subnet" do
         private_subnet
-        ps2 = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-hel1").subject
+        ps2 = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-fsn1").subject
         expect(private_subnet.connected_subnets.count).to eq(0)
         visit "#{project.path}#{private_subnet.path}"
 


### PR DESCRIPTION
This makes test and production more similar.  By piggybacking on the existing rspec metadata used to add other common headers, it's possible to likewise set the Host header by default.

Most of the bulk of this patch is from running `sed`, but the interesting hunks are in:

* clover.rb: eliminate a branch to add `/api/` mangling

* routes/api/spec_helper.rb: add the Host header by default

* routes/api/project_spec.rb: remove a special test for the host calling convention, as it's now used in every test.

The motivation for this was to make the program easier to validate with OpenAPI and `committee`, where having two calling conventions (even for the one test that set `Host`) would need more workarounds.