### PR TITLE
Validate Rhizome after install

### DIFF
--- a/rhizome/common/bin/validate
+++ b/rhizome/common/bin/validate
@@ -1,0 +1,20 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "digest/sha2"
+
+hashes = JSON.load_file("hashes.json")
+
+violations = []
+
+hashes.each do |filename, expected_hash|
+  calculated_hash = Digest::SHA384.file(filename).hexdigest
+  next if calculated_hash == expected_hash
+
+  violations << {name: file, expected: expected_hash, calculated: calculated_hash}
+end
+
+puts violations
+
+fail "Error during rhizome validation: " + violations.to_s if violations.any?

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -33,9 +33,15 @@ RSpec.describe Prog::InstallRhizome do
 
   describe "#install_gems" do
     it "runs some commands and exits" do
-      expect(sshable).to receive(:cmd).with("bundle config set --local path vendor/bundle")
-      expect(sshable).to receive(:cmd).with("bundle install")
-      expect { ir.install_gems }.to exit({"msg" => "installed rhizome"})
+      expect(sshable).to receive(:cmd).with("bundle config set --local path vendor/bundle && bundle install")
+      expect { ir.install_gems }.to hop
+    end
+  end
+
+  describe "#validate" do
+    it "runs the validate script" do
+      expect(sshable).to receive(:cmd).with("common/bin/validate")
+      expect { ir.validate }.to exit({"msg" => "installed rhizome"})
     end
   end
 end


### PR DESCRIPTION
We have seen incidents where some of the files in the rhizome
directory were empty. This is rare but also concerning.
We don't precisely know why that happened,
but it gave us an idea to improve our InstallRhizome prog.

This change adds a validation step to InstallRhizome prog
as a first step, maybe a 20/80 improvement. We checksum all the
files we pack into the rhizome package to be sent to the sshable
and add an extra file to the package with all the file
inventory along the hashes. Then, an additional script within
the package called `validate` is run by the prog, which goes
through the inventory and validates the hashes of all files.
If anything goes wrong, the InstallRhizome prog will fail and
we will know about it sooner so we can investigate more.

Some extra thoughts:
- Tried xxhash for being fast, but that required native compilation
so failed back to built-in md5, then finally SHA384.
- another method _could_ be: hash the tar and retar the untar-ed Rhizome to rehash
- Any harm of validation after the bundle step?
- Constructing the mode of a new file, which is an integer, seemed hard.
When I checked the files, non-executables were 33188 and executables were 33261.
Copied the stats of a non-executable (Gemfile):
`File.stat(base + "/Gemfile").mode == 33188`. Apparently
(thanks @jeremyevans for the pointer), it's the decimal value of the
octal representation 100644 or 100755.
- Ideally we would add the capability of syncing the deleted files as well.
Even better, atomic switch to a newer version of Rhizome folder,
maybe with symlinks. That's a future work.