### PR TITLE
Avoid 4 allocations for every request

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -16,8 +16,7 @@ class Clover < Roda
   end
 
   route do |r|
-    subdomain = r.host.split(".").first
-    if subdomain == "api"
+    if r.host.start_with?("api.")
       r.run CloverApi
     end
 


### PR DESCRIPTION
Instead of splitting the host, just check it starts with `api.`. The four allocations come from:

* 1 array allocation
* 3 string allocations (potentially more or less depending on the number of `.` in the Host header)