### PR TITLE
Avoid private subnet conflicts at the project level, add dns ipv4 to the dhcp payload and remove static dns conf, add weighted subnet picking and ban some ranges

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -179,7 +179,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
     selected_addr = addr.nth_subnet(26, SecureRandom.random_number(2**(26 - addr.netmask.prefix_len) - 1).to_i + 1)
 
-    selected_addr = random_private_ipv4(location, project) if banned_subnets.any? { _1.rel(selected_addr) } || project.private_subnets_dataset[Sequel[:net4] => selected_addr.to_s, :location => location]
+    selected_addr = random_private_ipv4(location, project) if PrivateSubnet::BANNED_IPV4_SUBNETS.any? { _1.rel(selected_addr) } || project.private_subnets_dataset[Sequel[:net4] => selected_addr.to_s, :location => location]
 
     selected_addr
   end

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -456,6 +456,7 @@ server=9.9.9.9
 server=2620:fe::fe
 server=2620:fe::9
 dhcp-option=option6:dns-server,#{dnsmasq_address_ip6}
+dhcp-option=6,#{dns_ipv4}
 listen-address=#{dnsmasq_address_ip6}
 listen-address=#{dns_ipv4}
 dhcp-option=26,1400
@@ -470,10 +471,6 @@ DNSMASQ_CONF
       macaddress: "#{nic.mac}"
     dhcp6: true
     dhcp4: true
-    nameservers:
-      addresses:
-        - "fd00:0b1c:100d:53::"
-        - #{dns_ipv4}
 ETHERNETS
     end.join("\n")
 


### PR DESCRIPTION
## Avoid private subnet conflicts at the project level
We used to enforce subnet uniqueness at the location level. That's not
really necessary and there may be conflicts for subnets in different
projects. This opens up the possibility of conflicts for the subnet
peering but a pretty low possibility. We'll attack the conflict problem
later.

## Add dns ipv4 to the dhcp payload and remove static dns conf
This is necessary because if we don't add the ipv4 address to the dhcp
payload, systemd-resolved kind of resolves it from the interface it gets
the dhcp packs from and adds the first address from the subnet as the
dns ipv4 address because the first address is added to the tap device.

We also remove the static dns configuration because that's unnecessary,
the dns addresses must be configured as part of dhcp.

## Add weighted subnet picking and ban some ranges
This commit adds weighted private ipv4 class picking depending on the
size of the subnet. In addition, we ban 172.16.0.0/16, 172.17.0.0/16,
and 172.18.0.0/16 because these are commonly used by docker and
kubernetes networks.