### PR TITLE
Add rake by for faster testing of single file or spec

### DIFF
--- a/.by-session-setup.rb
+++ b/.by-session-setup.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+Bundler.require(:default)
+Bundler.require(:test)
+
+<<END.split.each { |f| require f }
+digest/sha2
+open-uri
+unicode_normalize/normalize
+unicode_normalize/tables
+enc/trans/single_byte
+enc/trans/utf_16_32
+enc/utf_16be
+rubygems/openssl
+rubygems/package
+rubygems/security
+webmock/rspec
+tilt/erubi
+tilt/string
+sequel/adapters/postgres
+sequel/connection_pool/timed_queue
+sequel/connection_pool/threaded
+capybara/dsl
+capybara/rspec
+mail/network/delivery_methods/test_mailer
+mail/smtp_envelope
+rack/head
+rack/files
+rack/body_proxy
+rspec/mocks
+rspec/expectations
+rspec/support/fuzzy_matcher
+rspec/support/mutex
+rspec/support/object_formatter
+rspec/core/example_status_persister
+rspec/core/formatters/base_formatter
+rspec/core/formatters/base_text_formatter
+rspec/core/formatters/documentation_formatter
+rspec/core/formatters/profile_formatter
+rspec/core/mocking_adapters/rspec
+rspec/core/profiler
+rspec/matchers/built_in/eq
+rspec/matchers/built_in/start_or_end_with
+rspec/mocks/any_instance
+rspec/mocks/any_instance/chain
+rspec/mocks/any_instance/error_generator
+rspec/mocks/any_instance/expect_chain_chain
+rspec/mocks/any_instance/expectation_chain
+rspec/mocks/any_instance/message_chains
+rspec/mocks/any_instance/proxy
+rspec/mocks/any_instance/recorder
+rspec/mocks/any_instance/stub_chain
+rspec/mocks/any_instance/stub_chain_chain
+rspec/mocks/marshal_extension
+rspec/mocks/matchers/expectation_customization
+rspec/mocks/matchers/receive
+rspec/core/formatters/progress_formatter
+rspec/matchers/built_in/all
+rspec/matchers/built_in/be
+rspec/matchers/built_in/be_instance_of
+rspec/matchers/built_in/be_kind_of
+rspec/matchers/built_in/be_within
+rspec/matchers/built_in/change
+rspec/matchers/built_in/contain_exactly
+rspec/matchers/built_in/count_expectation
+rspec/matchers/built_in/equal
+rspec/matchers/built_in/exist
+rspec/matchers/built_in/has
+rspec/matchers/built_in/include
+rspec/matchers/built_in/match
+rspec/matchers/built_in/output
+rspec/matchers/built_in/raise_error
+rspec/matchers/built_in/yield
+rspec/mocks/matchers/receive_message_chain
+rspec/mocks/matchers/receive_messages
+rspec/mocks/message_chain
+mail/elements/address
+mail/elements/address_list
+mail/elements/content_disposition_element
+mail/elements/content_transfer_encoding_element
+mail/elements/content_type_element
+mail/elements/message_ids_element
+mail/elements/mime_version_element
+mail/parsers/address_lists_parser
+mail/parsers/content_disposition_parser
+mail/parsers/content_transfer_encoding_parser
+mail/parsers/content_type_parser
+mail/parsers/message_ids_parser
+mail/parsers/mime_version_parser
+aws-sdk-s3/client
+aws-sdk-s3/client_api
+aws-sdk-s3/customizations/errors
+aws-sdk-s3/customizations/types/list_object_versions_output
+aws-sdk-s3/customizations/types/permanent_redirect
+aws-sdk-s3/errors
+aws-sdk-s3/plugins/accelerate
+aws-sdk-s3/plugins/access_grants
+aws-sdk-s3/plugins/arn
+aws-sdk-s3/plugins/bucket_dns
+aws-sdk-s3/plugins/bucket_name_restrictions
+aws-sdk-s3/plugins/dualstack
+aws-sdk-s3/plugins/endpoints
+aws-sdk-s3/plugins/expect_100_continue
+aws-sdk-s3/plugins/express_session_auth
+aws-sdk-s3/plugins/get_bucket_location_fix
+aws-sdk-s3/plugins/http_200_errors
+aws-sdk-s3/plugins/iad_regional_endpoint
+aws-sdk-s3/plugins/location_constraint
+aws-sdk-s3/plugins/md5s
+aws-sdk-s3/plugins/redirects
+aws-sdk-s3/plugins/s3_host_id
+aws-sdk-s3/plugins/s3_signer
+aws-sdk-s3/plugins/skip_whole_multipart_get_checksums
+aws-sdk-s3/plugins/sse_cpk
+aws-sdk-s3/plugins/streaming_retry
+aws-sdk-s3/plugins/url_encoded_keys
+aws-sdk-s3/presigner
+aws-sdk-s3/types
+aws-sdk-core/rest/response/headers
+aws-sdk-core/rest/response/parser
+aws-sdk-core/rest/response/status_code
+aws-sdk-core/structure
+aws-sdk-core/telemetry
+aws-sdk-core/telemetry/base
+aws-sdk-core/telemetry/no_op
+aws-sdk-core/telemetry/otel
+aws-sdk-core/telemetry/span_kind
+aws-sdk-core/telemetry/span_status
+aws-sdk-core/xml
+aws-sdk-core/xml/builder
+aws-sdk-core/xml/default_list
+aws-sdk-core/xml/default_map
+aws-sdk-core/xml/doc_builder
+aws-sdk-core/xml/error_handler
+aws-sdk-core/xml/parser
+aws-sdk-core/xml/parser/frame
+aws-sdk-core/xml/parser/nokogiri_engine
+aws-sdk-core/xml/parser/parsing_error
+aws-sdk-core/xml/parser/stack
+argon2/kdf/ffi
+END
+
+<<END.split.each { |f| require "sequel/extensions/#{f}" }
+date_arithmetic
+index_caching
+pg_array
+pg_auto_parameterize
+pg_json
+pg_range
+pg_range_ops
+pg_timestamptz
+schema_caching
+END
+
+<<END.split.each { |f| require "sequel/plugins/#{f}" }
+association_dependencies
+auto_validations
+column_encryption
+defaults_setter
+insert_conflict
+many_through_many
+require_valid_schema
+serialization
+singular_table_names
+subclasses
+validation_helpers
+END
+
+<<END.split.each { |f| require "roda/plugins/#{f}" }
+Integer_matcher_max
+_base64
+_before_hook
+_optimized_matching
+all_verbs
+assets
+autoload_hash_branches
+caching
+common_logger
+content_security_policy
+custom_block_results
+default_headers
+direct_call
+disallow_file_uploads
+error_handler
+flash
+h
+hash_branch_view_subdir
+hash_branches
+json
+json_parser
+not_found
+public
+render
+request_headers
+route_csrf
+sessions
+status_handler
+typecast_params
+typecast_params_sized_integers
+view_options
+rodauth
+END
+
+<<END.split.each { |f| require "rodauth/features/#{f}" }
+active_sessions
+argon2
+base
+change_login
+change_password
+change_password_notify
+close_account
+confirm_password
+create_account
+disallow_common_passwords
+disallow_password_reuse
+email_base
+json
+jwt
+lockout
+login
+login_password_requirements_base
+logout
+otp
+password_grace_period
+recovery_codes
+remember
+reset_password
+two_factor_base
+verify_account
+verify_login_change
+webauthn
+END
+
+lf = $LOADED_FEATURES.dup
+at_exit do
+  loaded_features = $LOADED_FEATURES - lf
+  dir = __dir__
+  loaded_features.reject! { _1.start_with?(dir) }
+
+  unless loaded_features.empty?
+    load_paths = $LOAD_PATH.sort_by { |path| -path.length }
+    loaded_features.map! do |f|
+      f = f.delete_suffix(".rb")
+      catch(:fixed) do
+        load_paths.each do |dir|
+          if f.start_with?(dir)
+            dir += "/" unless dir.end_with?("/")
+            throw :fixed, f.delete_prefix(dir)
+          end
+        end
+        f
+      end
+    end
+
+    puts "Missed preloading, update .by-session-setup.rb to load:"
+    puts loaded_features.sort
+  end
+end

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ demo/.env
 var/*
 tmp/*
 
+# Used by rake by
+/bin/by
+
 # rhizome/Gemfile is combination of all Gemfiles in subdirectories, so does rhizome/Gemfile.lock
 rhizome/*/Gemfile.lock
 

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "argon2-kdf"
 
 group :development do
   gem "brakeman"
+  gem "by", github: "jeremyevans/by", ref: "f022615e367da3a23f012c3ab06ff664fe3776d3"
   gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "a9ff0001a1eb028e2186b222aeb02b07c04f9808"
   gem "foreman"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/jeremyevans/by.git
+  revision: f022615e367da3a23f012c3ab06ff664fe3776d3
+  ref: f022615e367da3a23f012c3ab06ff664fe3776d3
+  specs:
+    by (1.0.1)
+
+GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: a9ff0001a1eb028e2186b222aeb02b07c04f9808
   ref: a9ff0001a1eb028e2186b222aeb02b07c04f9808
@@ -364,6 +371,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.167)
   bcrypt_pbkdf
   brakeman
+  by!
   capybara
   countries
   database_cleaner-sequel

--- a/Rakefile
+++ b/Rakefile
@@ -162,6 +162,21 @@ task "assets:precompile" do
   fail unless $?.success?
 end
 
+desc "Open a new shell allowing use of by for speeding up tests"
+task "by" do
+  by_path = "bin/by"
+
+  require "rbconfig"
+
+  by_content = File.binread(Gem.activate_bin_path("by", "by"))
+  by_content.sub!(/\A#!.*/, "#!#{RbConfig.ruby} --disable-gems")
+  File.binwrite(by_path, by_content)
+  ENV["PATH"] = "#{__dir__}/bin:#{ENV["PATH"]}"
+  sh("bundle", "exec", "by-session", "./.by-session-setup.rb")
+ensure
+  File.delete(by_path) if File.file?(by_path)
+end
+
 begin
   namespace :linter do
     # "fdr/erb-formatter" can't be required without bundler setup because of custom repository.


### PR DESCRIPTION
One of the most common developer operations when developing a new feature is running a single test related to that feature.  As ubicloud uses rspec, generally that takes the form of `rspec file:line`. When you run `rspec file:line`, it needs to load all ruby libraries necessary to run that particular spec, which can take much more time than running the spec itself.  For example:

```
$ time rspec spec/model/nic_spec.rb:7
Run options: include {:locations=>{"./spec/model/nic_spec.rb"=>[7]}}

Randomized with seed 54633

Nic
  ubid_to_name
    returns name from ubid

Top 1 slowest examples (0.00289 seconds, 3.5% of total time):
  Nic ubid_to_name returns name from ubid
    0.00289 seconds ./spec/model/nic_spec.rb:7

Finished in 0.08183 seconds (files took 0.90238 seconds to load)
1 example, 0 failures

Randomized with seed 54633

real    0m1.361s
user    0m1.074s
sys     0m0.191s
```

We see here that it takes 1.36 seconds to run this rspec command, of which 0.90 seconds were spent loading files, and only 0.08 seconds were spent running the spec.

Most of the time spent loading files is actually spent loading libraries required by files.  Since those libraries should be unchanged until you have updated your Gemfile, one strategy for speeding up running a single spec is preloading all libraries into a Ruby process, and then using that Ruby process (or a fork of it) to execute the spec.  That approach is implemented by "by".

To speed up the above running of a single spec, you first run `rake by`, which will open up a new shell.  Inside that shell, you then append `by` before rspec:

```
$ time by rspec spec/model/nic_spec.rb:7
Run options: include {:locations=>{"./spec/model/nic_spec.rb"=>[7]}}

Randomized with seed 64910

Nic
  ubid_to_name
    returns name from ubid

Top 1 slowest examples (0.00293 seconds, 4.8% of total time):
  Nic ubid_to_name returns name from ubid
    0.00293 seconds ./spec/model/nic_spec.rb:7

Finished in 0.06144 seconds (files took 0.12752 seconds to load)
1 example, 0 failures

Randomized with seed 64910

real    0m0.579s
user    0m0.275s
sys     0m0.056s
```

You can see that this drops total execution time from 1.36 seconds to 0.58 seconds, because the time to load files drops from 0.90 seconds to 0.13 seconds.

How this works is that `rake by` calls `by-session`.  `by-session` creates a `by-server` process that loads `.by-session-setup.rb`, That file loads all libraries in the Gemfile, as well as as any extensions/plugins/other files used by libraries, which are not loaded by requiring the library itself.  After the `by-server` process is created, `by-session` spawns a shell that supports `by`. Running `by` inside the subshell connects to the server process, providing the arguments, environment, stdin/stdout/stderr, and the current directory.  The server process forks, sets up ENV, reopens stdin/stdout/stderr, changes to the directory in which you called `by`, and operates on the arguments given.  If the first argument to `by` is `rspec`, then `by` will operate similarly to `rspec`.

This currently uses the master branch of `by`, because rspec support was just added to `by` (to support this feature in ubicloud), and is not yet in a released version.

This will require some minor additional maintenance going forward. As there are new files loaded by the specs, beyond what would be loaded by the Gemfile, those will need to be added to `.by-session-setup.rb`.