### PR TITLE
Fix NoMethodError when logging in user via remember token

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -388,6 +388,7 @@ class CloverWeb < Roda
       r.redirect rodauth.login_route
     end
     rodauth.require_authentication
+    @current_user ||= Account[rodauth.session_value]
 
     r.hash_branches("")
   end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -105,6 +105,22 @@ RSpec.describe Clover, "auth" do
     expect(DB[:account_remember_keys].first(id: account.id)).not_to be_nil
   end
 
+  it "has correct current user when logged in via remember token" do
+    account = create_account
+
+    visit "/login"
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Password", with: TEST_USER_PASSWORD
+    check "Remember me"
+    click_button "Sign in"
+
+    expect(page.title).to eq("Ubicloud - #{account.projects.first.name} Dashboard")
+    page.driver.browser.rack_mock_session.cookie_jar.delete("_Clover.session")
+    # page.refresh does not work, sends deleted _Clover.session cookie
+    visit page.current_path
+    expect(page.title).to eq("Ubicloud - #{account.projects.first.name} Dashboard")
+  end
+
   it "can reset password" do
     create_account
 


### PR DESCRIPTION
When a user is logged in via the remember token, @current_user was previously set to nil, because it was set before load_memory, probably to make it available in the rodauth routes (I'm guessing).

If @current_user isn't already set after requiring authentication, then set it at the point so it is available in all of the routes.