### PR TITLE
Fix suspend bypass via remember token

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -147,14 +147,15 @@ class CloverWeb < Roda
     already_logged_in { redirect login_redirect }
     after_login { remember_login if request.params["remember-me"] == "on" }
 
-    before_login do
-      if Account[account_id].suspended_at
+    update_session do
+      if Account[account_session_value].suspended_at
         flash["error"] = "Your account has been suspended. " \
           "If you believe there's a mistake, or if you need further assistance, " \
           "please reach out to our support team at support@ubicloud.com."
-
+        forget_login
         redirect login_route
       end
+      super()
     end
 
     create_account_view { view "auth/create_account", "Create Account" }

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -166,6 +166,23 @@ RSpec.describe Clover, "auth" do
     expect(page).to have_content("Your account has been suspended")
   end
 
+  it "can not login if the account is suspended via remember token" do
+    account = create_account
+
+    visit "/login"
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    fill_in "Password", with: TEST_USER_PASSWORD
+    check "Remember me"
+    click_button "Sign in"
+
+    expect(page.title).to eq("Ubicloud - #{account.projects.first.name} Dashboard")
+    page.driver.browser.rack_mock_session.cookie_jar.delete("_Clover.session")
+    account.suspend
+    # page.refresh does not work, sends deleted _Clover.session cookie
+    visit page.current_path
+    expect(page.title).to eq("Ubicloud - Login")
+  end
+
   it "redirects to otp page if the otp is only 2FA method" do
     create_account(enable_otp: true)
 


### PR DESCRIPTION
When we suspend an account, we set the `suspended_at` value and check it in the `before_login` method. However, the remember plugin doesn't go through this method, allowing the account to log in with the remember token even if it is suspended. @jeremyevans suggested using the `update_session` method so that every plugin eventually hits this method for login.

We call the `forget_login` method to remove the remember token; otherwise, Rodauth will keep redirecting back to the same page due to the remember token.