### PR TITLE
Anchor gitignore entries at the root of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,29 @@
-.env.rb
-coverage
-spec/examples.txt
-demo/.env
-var/*
-tmp/*
+/.env.rb
+/coverage
+/spec/examples.txt
+/demo/.env
+/var/*
+/tmp/*
 
 # Used by rake by
 /bin/by
 
 # rhizome/Gemfile is combination of all Gemfiles in subdirectories, so does rhizome/Gemfile.lock
-rhizome/*/Gemfile.lock
+/rhizome/*/Gemfile.lock
 
 # Frontend
-node_modules
+/node_modules
 
 # vscode: https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Global/VisualStudioCode.gitignore
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+/.vscode/*
+!/.vscode/settings.json
+!/.vscode/tasks.json
+!/.vscode/launch.json
+!/.vscode/extensions.json
+!/.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
-.history/
+/.history/
 
 # Built Visual Studio Code Extensions
-*.vsix
+/*.vsix


### PR DESCRIPTION
If you do not prefix gitignore entries by a slash, then such files are ignored in any directory.  I think these ignores are designed to apply only at the repository root, so this adds slashes for them.  However, I could be wrong.  Maybe the *.vsix files can occur in subdirectories?