### PR TITLE
Support running specs with frozen environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
         CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
         CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
-      run: COVERAGE=1 bundle exec rspec
+      run: bundle exec rake
 
     - name: Run dataplane tests
       run: bundle exec rspec -O /dev/null rhizome

--- a/loader.rb
+++ b/loader.rb
@@ -147,7 +147,7 @@ when :test
 end
 
 def clover_freeze
-  return unless Config.production?
+  return unless Config.production? || ENV["CLOVER_FREEZE"] == "1"
   require "refrigerator"
 
   # Take care of library dependencies that modify core classes.

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Clog do
   let(:now) { Time.parse("2023-01-17 12:10:54 -0800") }
 
   before do
+    skip_if_frozen
     allow(Config).to receive(:test?).and_return(false)
     allow(Time).to receive(:now).and_return(now)
   end

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Minio::Client do
   let(:minio_client) { described_class.new(endpoint: endpoint, access_key: "minioadmin", secret_key: "minioadminpw", ssl_ca_file_data: "data") }
 
   it "can use ssl_ca_file_data" do
+    skip_if_frozen
     ssl_ca_file_name = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7"
     expect(File).to receive(:exist?).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")).and_return(false)
     expect(FileUtils).to receive(:mkdir_p).with(File.dirname(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")))

--- a/spec/lib/minio/header_signer_spec.rb
+++ b/spec/lib/minio/header_signer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Minio::HeaderSigner do
 
   describe "build_headers" do
     it "can build headers and sign with and without Content-Md5" do
+      skip_if_frozen
       method = "PUT"
       uri = URI.parse("http://localhost:9000/test")
       body = "test"

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe MonitorableResource do
     end
 
     it "returns if session is nil or resource does not need event loop" do
+      skip_if_frozen
       expect(Thread).not_to receive(:new)
 
       # session is nil
@@ -56,6 +57,7 @@ RSpec.describe MonitorableResource do
     end
 
     it "creates a new thread and runs the event loop" do
+      skip_if_frozen
       session = {ssh_session: instance_double(Net::SSH::Connection::Session)}
       r_w_event_loop.instance_variable_set(:@session, session)
       expect(Thread).to receive(:new).and_yield
@@ -64,6 +66,7 @@ RSpec.describe MonitorableResource do
     end
 
     it "swallows exception and logs it if event loop fails" do
+      skip_if_frozen
       session = {ssh_session: instance_double(Net::SSH::Connection::Session)}
       r_w_event_loop.instance_variable_set(:@session, session)
       expect(Thread).to receive(:new).and_yield
@@ -132,6 +135,7 @@ RSpec.describe MonitorableResource do
 
   describe "#force_stop_if_stuck" do
     it "does nothing if pulse check is not stuck" do
+      skip_if_frozen
       expect(Kernel).not_to receive(:exit!)
 
       # not locked

--- a/spec/lib/thread_printer_spec.rb
+++ b/spec/lib/thread_printer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ThreadPrinter do
     end
 
     it "can handle threads with a nil backtrace" do
+      skip_if_frozen
       # The documentation calls out that the backtrace is an array or
       # nil.
       expect(described_class).to receive(:puts).with(/Thread: #<InstanceDouble.*>/)

--- a/spec/model/ai/inference_endpoint_spec.rb
+++ b/spec/model/ai/inference_endpoint_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe InferenceEndpoint do
     end
 
     it "sends the request correctly" do
+      skip_if_frozen
       if development
         allow(Config).to receive(:development?).and_return(true)
         allow(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Invoice do
 
   describe ".charge" do
     it "not charge if Stripe not enabled" do
+      skip_if_frozen
       allow(Config).to receive(:stripe_secret_key).and_return(nil)
       expect(Clog).to receive(:emit).with("Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing.").and_call_original
       expect(invoice.charge).to be true

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -80,6 +80,7 @@ PGHOST=/var/run/postgresql
 
   describe "#latest_backup_label_before_target" do
     it "returns most recent backup before given target" do
+      skip_if_frozen
       stub_const("Backup", Struct.new(:last_modified))
       most_recent_backup_time = Time.now
       expect(postgres_timeline).to receive(:backups).and_return(
@@ -94,6 +95,7 @@ PGHOST=/var/run/postgresql
     end
 
     it "raises error if no backups before given target" do
+      skip_if_frozen
       stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([])
 
@@ -123,6 +125,7 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns list of backups" do
+    skip_if_frozen
     stub_const("Backup", Struct.new(:key))
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
 

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe Sshable do
     end
 
     it "can run a command" do
+      skip_if_frozen
       [false, true].each do |repl_value|
         [false, true].each do |log_value|
           stub_const("REPL", repl_value)

--- a/spec/model/usage_alert_spec.rb
+++ b/spec/model/usage_alert_spec.rb
@@ -4,6 +4,7 @@ require_relative "spec_helper"
 
 RSpec.describe UsageAlert do
   it "trigger sends email and updates last_triggered_at" do
+    skip_if_frozen
     alert = described_class.new
     expect(alert).to receive(:user).and_return(instance_double(Account, name: "dummy-name", email: "dummy-email")).at_least(:once)
     expect(alert).to receive(:project).and_return(instance_double(Project, name: "dummy-name", ubid: "dummy-ubid", path: "dummy-path", current_invoice: instance_double(Invoice, content: {"cost" => "dummy-cost"}))).at_least(:once)

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
 
   describe ".assemble" do
     it "creates github repository or updates last_job_at if the repository exists" do
+      skip_if_frozen
       project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
 
@@ -74,6 +75,7 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
     end
 
     it "naps until the resets_at if remaining quota is low" do
+      skip_if_frozen
       expect(client).to receive(:repository_workflow_runs).and_return({workflow_runs: []})
       now = Time.now
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 8, limit: 100, resets_at: now + 8 * 60)).at_least(:once)

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
     end
 
     it "moves root_cert_2 to root_cert_1 and creates new root_cert_2 if root_cert_1 is about to expire, also updates server_cert" do
+      skip_if_frozen
       rc2 = nx.minio_cluster.root_cert_2
       rck2 = nx.minio_cluster.root_cert_key_2
       certificate_last_checked_at = nx.minio_cluster.certificate_last_checked_at

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -289,6 +289,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     end
 
     it "creates new certificates from root_cert_2 if root_cert_1 is about to expire" do
+      skip_if_frozen
       expect(Time).to receive(:now).and_return(Time.now + 60 * 60 * 24 * 365 * 4 + 1).at_least(:once)
       cert = nx.minio_server.cert
       cert_key = nx.minio_server.cert_key

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "creates a missing backup page if last completed backup is older than 2 days" do
+      skip_if_frozen
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
       stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([instance_double(Backup, last_modified: Time.now - 3 * 24 * 60 * 60)])
@@ -124,6 +125,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "resolves the missing page if last completed backup is more recent than 2 days" do
+      skip_if_frozen
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
       stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([instance_double(Backup, last_modified: Time.now - 1 * 24 * 60 * 60)])
@@ -136,6 +138,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "naps if there is nothing to do" do
+      skip_if_frozen
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
       stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([instance_double(Backup, last_modified: Time.now - 1 * 24 * 60 * 60)])

--- a/spec/prog/redeliver_github_failures_spec.rb
+++ b/spec/prog/redeliver_github_failures_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Prog::RedeliverGithubFailures do
 
   describe "#wait" do
     it "redelivers failed deliveries and naps" do
+      skip_if_frozen
       expect(Time).to receive(:now).and_return("2023-10-19 23:27:47 +0000").at_least(:once)
       expect(Github).to receive(:redeliver_failed_deliveries).with(Time.parse("2023-10-19 22:27:47 +0000"))
       expect(rgf.strand).to receive(:save_changes)

--- a/spec/prog/resolve_globally_blocked_dnsnames_spec.rb
+++ b/spec/prog/resolve_globally_blocked_dnsnames_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Prog::ResolveGloballyBlockedDnsnames do
     end
 
     it "resolves dnsnames to ip addresses and updates records" do
+      skip_if_frozen
       expect(Socket).to receive(:getaddrinfo).with("example.com", nil).and_return([[nil, nil, nil, "1.1.1.1"], [nil, nil, nil, "2a00:1450:400e:811::200e"], [nil, nil, nil, "1.1.1.1"]])
       expect(Time).to receive(:now).and_return(Time.new("2023-10-19 23:27:47 +0000")).at_least(:once)
       expect { rgbd.wait }.to nap(60 * 60)
@@ -23,6 +24,7 @@ RSpec.describe Prog::ResolveGloballyBlockedDnsnames do
     end
 
     it "skips if socket fails" do
+      skip_if_frozen
       expect(Socket).to receive(:getaddrinfo).with("example.com", nil).and_raise(SocketError)
       expect { rgbd.wait }.to nap(60 * 60)
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "creates new billing record when no daily record" do
+      skip_if_frozen
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -150,6 +151,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses separate billing rate for arm64 runners" do
+      skip_if_frozen
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:label).and_return("ubicloud-arm").at_least(:once)
@@ -164,6 +166,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses separate billing rate for gpu runners" do
+      skip_if_frozen
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:label).and_return("ubicloud-gpu").at_least(:once)
@@ -178,6 +181,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "updates the amount of existing billing record" do
+      skip_if_frozen
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -190,6 +194,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "create a new record for a new day" do
+      skip_if_frozen
       today = Time.now
       tomorrow = today + 24 * 60 * 60
       expect(Time).to receive(:now).and_return(today).exactly(5)
@@ -209,6 +214,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "tries 3 times and creates single billing record" do
+      skip_if_frozen
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -221,6 +227,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "tries 4 times and fails" do
+      skip_if_frozen
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -471,6 +478,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#wait" do
     it "does not destroy runner if it does not pick a job in five minutes, and busy" do
+      skip_if_frozen
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
       expect(client).to receive(:get).and_return({busy: true})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
@@ -480,6 +488,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "destroys runner if it does not pick a job in five minutes and not busy" do
+      skip_if_frozen
       expect(github_runner).to receive(:workflow_job).and_return(nil)
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
       expect(client).to receive(:get).and_return({busy: false})
@@ -491,6 +500,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "does not destroy runner if it doesn not pick a job but two minutes not pass yet" do
+      skip_if_frozen
       expect(github_runner).to receive(:workflow_job).and_return(nil)
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 1 * 60)
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -522,6 +522,7 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe "#create_billing_record" do
     before do
+      skip_if_frozen
       now = Time.now
       expect(Time).to receive(:now).and_return(now).at_least(:once)
       expect(vm).to receive(:update).with(display_state: "running", provisioned_at: now).and_return(true)

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe Prog::Vnet::CertNexus do
     end
 
     it "updates the certificate when certificate is valid" do
+      skip_if_frozen
       expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name"))
       expect(acme_order).to receive(:status).and_return("valid")
       expect(acme_order).to receive(:certificate).and_return("test-certificate")
@@ -172,12 +173,14 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   describe "#wait" do
     it "waits for 1 month" do
+      skip_if_frozen
       expect(cert).to receive(:created_at).and_return(Time.new(2021, 4, 1, 0, 0, 0))
       expect(Time).to receive(:now).and_return(Time.new(2021, 4, 1, 0, 0, 0))
       expect { nx.wait }.to nap(60 * 60 * 24 * 30 * 1)
     end
 
     it "destroys the certificate after 3 months" do
+      skip_if_frozen
       created_at = Time.new(2021, 1, 1, 0, 0, 0)
       expect(cert).to receive(:created_at).and_return(created_at)
       expect(Time).to receive(:now).and_return(created_at + 60 * 60 * 24 * 30 * 3 + 1)

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -268,6 +268,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "hops to wait if all is done" do
+      skip_if_frozen
       t = Time.now
       expect(Time).to receive(:now).and_return(t)
       expect(nic.strand).to receive(:label).and_return("wait")
@@ -279,6 +280,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "doesn't decrement refresh_keys if there are missed nics" do
+      skip_if_frozen
       t = Time.now
       expect(Time).to receive(:now).and_return(t)
       expect(nic.strand).to receive(:label).and_return("wait")

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "restore" do
+        skip_if_frozen
         stub_const("Backup", Struct.new(:key, :last_modified))
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can restore PostgreSQL database" do
+        skip_if_frozen
         stub_const("Backup", Struct.new(:key, :last_modified))
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Clover, "vm" do
 
     describe "create" do
       it "can create new virtual machine" do
+        skip_if_frozen
         project
 
         visit "#{project.path}/vm/create"
@@ -106,6 +107,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can create new virtual machine with chosen private subnet" do
+        skip_if_frozen
         project
         ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1").id
         ps = PrivateSubnet[ps_id]
@@ -130,6 +132,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can not create virtual machine with invalid name" do
+        skip_if_frozen
         project
         visit "#{project.path}/vm/create"
 
@@ -148,6 +151,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can not create virtual machine with same name" do
+        skip_if_frozen
         project
         visit "#{project.path}/vm/create"
 

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Scheduling::Dispatcher do
     end
 
     it "exits if all strands have finished when shutting down" do
+      skip_if_frozen
       expect { di.shutdown }.to change(di, :shutting_down).from(false).to(true)
       expect(Kernel).to receive(:exit)
       di.wait_cohort
@@ -98,6 +99,7 @@ RSpec.describe Scheduling::Dispatcher do
     end
 
     it "can trigger thread dumps and exit if the Prog takes too long" do
+      skip_if_frozen
       expect(ThreadPrinter).to receive(:run)
       expect(Kernel).to receive(:exit!)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,10 @@ Warning.ignore([:unused_var], /.*lib\/aws-sdk-(s3|core)\/(endpoint_provider|cbor
 Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    clover_freeze if ENV["CLOVER_FREEZE"] == "1"
+  end
+
   config.around do |example|
     DB.transaction(rollback: :always, auto_savepoint: true) do
       example.run
@@ -199,6 +203,19 @@ RSpec.configure do |config|
     failure_message_when_negated do
       "not expected: ".rjust(16) + "nap" + (expected_seconds.nil? ? "" : " #{expected_seconds} seconds") + "\n" +
         "got: ".rjust(16) + (@nap.nil? ? "not nap" : "nap #{@nap.seconds} seconds") + "\n "
+    end
+  end
+
+  if ENV["CLOVER_FREEZE"] == "1"
+    # Required by rspec after running examples
+    require "ripper"
+    require "coderay"
+
+    def skip_if_frozen
+      skip("Spec skipped when running with frozen environment")
+    end
+  else
+    def skip_if_frozen
     end
   end
 end


### PR DESCRIPTION
This allows for running the specs with a frozen environment that should closely match the production environment.

This adds the following rake tasks:

* coverage: Runs specs in serial with coverage
* frozen_spec: Runs specs in serial in frozen environment
* frozen_pspec: Runs specs in parallel in frozen environment

It changes the default rake task to run both the coverage and frozen_spec tasks.  It also changes the GitHub CI workflow to use the default rake task.

When specs are run in the frozen environment they call clover_freeze before running the specs, after loading all other code.

There are currently 56 specs that do not work in the frozen environment.  They are skipped by including the skip_if_frozen method in each spec.