### PR TITLE
Remove exhaustive config name to config value conversion

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -18,38 +18,9 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   def default_boot_image_version(image_name)
-    case image_name
-    when "ubuntu-noble"
-      Config.ubuntu_noble_version
-    when "ubuntu-jammy"
-      Config.ubuntu_jammy_version
-    when "almalinux-9"
-      Config.almalinux_9_version
-    when "almalinux-8"
-      Config.almalinux_8_version
-    when "github-ubuntu-2404"
-      Config.github_ubuntu_2404_version
-    when "github-ubuntu-2204"
-      Config.github_ubuntu_2204_version
-    when "github-ubuntu-2004"
-      Config.github_ubuntu_2004_version
-    when "github-gpu-ubuntu-2204"
-      Config.github_gpu_ubuntu_2204_version
-    when "postgres16-ubuntu-2204"
-      Config.postgres16_ubuntu_2204_version
-    when "postgres17-ubuntu-2204"
-      Config.postgres17_ubuntu_2204_version
-    when "postgres16-paradedb-ubuntu-2204"
-      Config.postgres16_paradedb_ubuntu_2204_version
-    when "postgres17-paradedb-ubuntu-2204"
-      Config.postgres17_paradedb_ubuntu_2204_version
-    when "postgres16-lantern-ubuntu-2204"
-      Config.postgres16_lantern_ubuntu_2204_version
-    when "ai-ubuntu-2404-nvidia"
-      Config.ai_ubuntu_2404_nvidia_version
-    else
-      fail "Unknown boot image: #{image_name}"
-    end
+    config_name = image_name.tr("-", "_") + "_version"
+    fail "Unknown boot image: #{image_name}" unless Config.respond_to?(config_name)
+    Config.send(config_name)
   end
 
   def url

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -39,19 +39,6 @@ RSpec.describe Prog::DownloadBootImage do
   describe "#default_boot_image_version" do
     it "returns the version for the default image" do
       expect(dbi.default_boot_image_version("ubuntu-noble")).to eq(Config.ubuntu_noble_version)
-      expect(dbi.default_boot_image_version("ubuntu-jammy")).to eq(Config.ubuntu_jammy_version)
-      expect(dbi.default_boot_image_version("almalinux-9")).to eq(Config.almalinux_9_version)
-      expect(dbi.default_boot_image_version("almalinux-8")).to eq(Config.almalinux_8_version)
-      expect(dbi.default_boot_image_version("github-ubuntu-2404")).to eq(Config.github_ubuntu_2404_version)
-      expect(dbi.default_boot_image_version("github-ubuntu-2204")).to eq(Config.github_ubuntu_2204_version)
-      expect(dbi.default_boot_image_version("github-ubuntu-2004")).to eq(Config.github_ubuntu_2004_version)
-      expect(dbi.default_boot_image_version("github-gpu-ubuntu-2204")).to eq(Config.github_gpu_ubuntu_2204_version)
-      expect(dbi.default_boot_image_version("postgres16-ubuntu-2204")).to eq(Config.postgres16_ubuntu_2204_version)
-      expect(dbi.default_boot_image_version("postgres17-ubuntu-2204")).to eq(Config.postgres17_ubuntu_2204_version)
-      expect(dbi.default_boot_image_version("postgres16-paradedb-ubuntu-2204")).to eq(Config.postgres16_paradedb_ubuntu_2204_version)
-      expect(dbi.default_boot_image_version("postgres17-paradedb-ubuntu-2204")).to eq(Config.postgres17_paradedb_ubuntu_2204_version)
-      expect(dbi.default_boot_image_version("postgres16-lantern-ubuntu-2204")).to eq(Config.postgres16_lantern_ubuntu_2204_version)
-      expect(dbi.default_boot_image_version("ai-ubuntu-2404-nvidia")).to eq(Config.ai_ubuntu_2404_nvidia_version)
     end
 
     it "fails for unknown images" do


### PR DESCRIPTION
This was OK approach while the number of configs was low, but we added lots of new version configs. This reduces the places we need to update as we add new configs.