### PR TITLE
Remove use of Helsinki as default

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -868,7 +868,7 @@ components:
       required: true
       schema:
         type: string
-        example: eu-north-h1
+        example: eu-central-h1
     order_column:
       description: Pagination - Order column
       in: query
@@ -1130,7 +1130,7 @@ components:
         location:
           description: Location of the VM
           type: string
-          example: eu-north-h1
+          example: eu-central-h1
         name:
           description: Name of the VM
           type: string

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -24,11 +24,11 @@ class Prog::Test::VmGroup < Prog::Test::Base
     project.associate_with_project(project)
 
     subnet1_s = Prog::Vnet::SubnetNexus.assemble(
-      project.id, name: "the-first-subnet", location: "hetzner-hel1"
+      project.id, name: "the-first-subnet", location: "hetzner-fsn1"
     )
 
     subnet2_s = Prog::Vnet::SubnetNexus.assemble(
-      project.id, name: "the-second-subnet", location: "hetzner-hel1"
+      project.id, name: "the-second-subnet", location: "hetzner-fsn1"
     )
 
     storage_encrypted = frame.fetch("storage_encrypted", true)

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -4,7 +4,7 @@ class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
   semaphore :checkup, :reboot, :destroy
 
-  def self.assemble(sshable_hostname, location: "hetzner-hel1", net6: nil, ndp_needed: false, provider: nil, hetzner_server_identifier: nil, spdk_version: Config.spdk_version, default_boot_images: [])
+  def self.assemble(sshable_hostname, location: "hetzner-fsn1", net6: nil, ndp_needed: false, provider: nil, hetzner_server_identifier: nil, spdk_version: Config.spdk_version, default_boot_images: [])
     DB.transaction do
       ubid = VmHost.generate_ubid
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -11,7 +11,7 @@ class Prog::Vm::Nexus < Prog::Base
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
 
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
-    unix_user: "ubi", location: "hetzner-hel1", boot_image: Config.default_boot_image_name,
+    unix_user: "ubi", location: "hetzner-fsn1", boot_image: Config.default_boot_image_name,
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
     enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil,
     distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [], gpu_count: 0)
@@ -176,7 +176,7 @@ class Prog::Vm::Nexus < Prog::Base
         if frame["force_host_id"]
           [[], [], [], [frame["force_host_id"]]]
         elsif vm.location == "github-runners"
-          runner_locations = (vm.cores == 30) ? [] : ["github-runners", "hetzner-fsn1", "hetzner-hel1"]
+          runner_locations = (vm.cores == 30) ? [] : ["github-runners", "hetzner-fsn1"]
           [["accepting"], runner_locations, ["github-runners"], []]
         else
           [["accepting"], [vm.location], [], []]

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -4,7 +4,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
   semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
 
-  def self.assemble(project_id, name: nil, location: "hetzner-hel1", ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil)
+  def self.assemble(project_id, name: nil, location: "hetzner-fsn1", ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil)
     unless (project = Project[project_id])
       fail "No existing project"
     end

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Authorization do
     it "hyper_tag_name" do
       expect(users[0].hyper_tag_name).to eq("user/auth1@example.com")
       p = vms[0].projects.first
-      expect(vms[0].hyper_tag_name(p)).to eq("project/#{p.ubid}/location/eu-north-h1/vm/vm0")
+      expect(vms[0].hyper_tag_name(p)).to eq("project/#{p.ubid}/location/eu-central-h1/vm/vm0")
       expect(projects[0].hyper_tag_name).to eq("project/#{projects[0].ubid}")
     end
 

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe Validation do
     describe "#validate_location" do
       it "valid locations" do
         [
-          "hetzner-hel1",
           "hetzner-fsn1",
           "github-runners"
         ].each do |location|

--- a/spec/model/firewall_rule_spec.rb
+++ b/spec/model/firewall_rule_spec.rb
@@ -5,7 +5,7 @@ require_relative "spec_helper"
 RSpec.describe FirewallRule do
   describe "FirewallRule" do
     let(:fw) {
-      Firewall.create_with_id(location: "hetzner-hel1")
+      Firewall.create_with_id(location: "hetzner-fsn1")
     }
 
     it "returns ip6? properly" do

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -5,7 +5,7 @@ require_relative "spec_helper"
 RSpec.describe Firewall do
   describe "Firewall" do
     let(:fw) {
-      described_class.create_with_id(name: "test-fw", description: "test fw desc", location: "hetzner-hel1")
+      described_class.create_with_id(name: "test-fw", description: "test fw desc", location: "hetzner-fsn1")
     }
 
     it "inserts firewall rules" do
@@ -33,7 +33,7 @@ RSpec.describe Firewall do
     end
 
     it "associates with a private subnet" do
-      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(ps).to receive(:incr_update_firewall_rules)
       fw.associate_with_private_subnet(ps)
 
@@ -42,7 +42,7 @@ RSpec.describe Firewall do
     end
 
     it "disassociates from a private subnet" do
-      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       fw.associate_with_private_subnet(ps, apply_firewalls: false)
       expect(fw.private_subnets.count).to eq(1)
 
@@ -53,7 +53,7 @@ RSpec.describe Firewall do
     end
 
     it "disassociates from a private subnet without applying firewalls" do
-      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       fw.associate_with_private_subnet(ps, apply_firewalls: false)
       expect(fw.private_subnets.count).to eq(1)
 
@@ -64,7 +64,7 @@ RSpec.describe Firewall do
     end
 
     it "destroys firewall" do
-      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       fw.associate_with_private_subnet(ps, apply_firewalls: false)
       expect(fw.reload.private_subnets.count).to eq(1)
       expect(fw.private_subnets).to receive(:each).and_return([ps])

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LoadBalancer do
 
     it "returns hyper_tag_name" do
       prj = lb.private_subnet.projects.first
-      expect(lb.hyper_tag_name(prj)).to eq("project/#{prj.ubid}/location/eu-north-h1/load-balancer/test-lb")
+      expect(lb.hyper_tag_name(prj)).to eq("project/#{prj.ubid}/location/eu-central-h1/load-balancer/test-lb")
     end
 
     it "returns hostname" do

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 RSpec.describe MinioCluster do
   subject(:mc) {
     mc = described_class.create_with_id(
-      location: "hetzner-hel1",
+      location: "hetzner-fsn1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",
@@ -61,6 +61,6 @@ RSpec.describe MinioCluster do
 
   it "returns hyper tag name properly" do
     project = instance_double(Project, ubid: "project-ubid")
-    expect(mc.hyper_tag_name(project)).to eq("project/project-ubid/location/eu-north-h1/minio-cluster/minio-cluster-name")
+    expect(mc.hyper_tag_name(project)).to eq("project/project-ubid/location/eu-central-h1/minio-cluster/minio-cluster-name")
   end
 end

--- a/spec/model/minio/minio_pool_spec.rb
+++ b/spec/model/minio/minio_pool_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 RSpec.describe MinioPool do
   subject(:mp) {
     mc = MinioCluster.create_with_id(
-      location: "hetzner-hel1",
+      location: "hetzner-fsn1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 RSpec.describe MinioServer do
   subject(:ms) {
     mc = MinioCluster.create_with_id(
-      location: "hetzner-hel1",
+      location: "hetzner-fsn1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PrivateSubnet do
     described_class.new(
       net6: NetAddr.parse_net("fd1b:9793:dcef:cd0a::/64"),
       net4: NetAddr.parse_net("10.9.39.0/26"),
-      location: "hetzner-hel1",
+      location: "hetzner-fsn1",
       state: "waiting",
       name: "ps"
     )
@@ -79,11 +79,11 @@ RSpec.describe PrivateSubnet do
     it "includes ubid if id is available" do
       ubid = described_class.generate_ubid
       uuid = private_subnet.id = ubid.to_uuid.to_s
-      expect(private_subnet.inspect).to eq "#<PrivateSubnet[\"#{ubid}\"] @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location=>\"hetzner-hel1\", :state=>\"waiting\", :name=>\"ps\", :id=>\"#{uuid}\"}>"
+      expect(private_subnet.inspect).to eq "#<PrivateSubnet[\"#{ubid}\"] @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location=>\"hetzner-fsn1\", :state=>\"waiting\", :name=>\"ps\", :id=>\"#{uuid}\"}>"
     end
 
     it "does not includes ubid if id is missing" do
-      expect(private_subnet.inspect).to eq "#<PrivateSubnet @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location=>\"hetzner-hel1\", :state=>\"waiting\", :name=>\"ps\"}>"
+      expect(private_subnet.inspect).to eq "#<PrivateSubnet @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location=>\"hetzner-fsn1\", :state=>\"waiting\", :name=>\"ps\"}>"
     end
   end
 
@@ -95,12 +95,12 @@ RSpec.describe PrivateSubnet do
 
   describe "ui utility methods" do
     it "returns path" do
-      expect(private_subnet.path).to eq "/location/eu-north-h1/private-subnet/ps"
+      expect(private_subnet.path).to eq "/location/eu-central-h1/private-subnet/ps"
     end
 
     it "returns tag name" do
       pr = instance_double(Project, ubid: "prjubid")
-      expect(private_subnet.hyper_tag_name(pr)).to eq "project/prjubid/location/eu-north-h1/private-subnet/ps"
+      expect(private_subnet.hyper_tag_name(pr)).to eq "project/prjubid/location/eu-central-h1/private-subnet/ps"
     end
   end
 
@@ -117,7 +117,7 @@ RSpec.describe PrivateSubnet do
 
   describe "destroy" do
     it "destroys firewalls private subnets" do
-      ps = described_class.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = described_class.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       fwps = instance_double(FirewallsPrivateSubnets)
       expect(FirewallsPrivateSubnets).to receive(:where).with(private_subnet_id: ps.id).and_return(instance_double(Sequel::Dataset, all: [fwps]))
       expect(fwps).to receive(:destroy).once

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Project do
   describe ".default_location" do
     it "returns the location with the highest available core capacity" do
       VmHost.create(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3) { _1.id = Sshable.create_with_id.id }
-      VmHost.create(allocation_state: "accepting", location: "hetzner-hel1", total_cores: 10, used_cores: 3) { _1.id = Sshable.create_with_id.id }
-      VmHost.create(allocation_state: "accepting", location: "hetzner-hel1", total_cores: 10, used_cores: 1) { _1.id = Sshable.create_with_id.id }
+      VmHost.create(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3) { _1.id = Sshable.create_with_id.id }
+      VmHost.create(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 1) { _1.id = Sshable.create_with_id.id }
       VmHost.create(allocation_state: "accepting", location: "leaseweb-wdc02", total_cores: 100, used_cores: 99) { _1.id = Sshable.create_with_id.id }
       VmHost.create(allocation_state: "draining", location: "location-4", total_cores: 100, used_cores: 0) { _1.id = Sshable.create_with_id.id }
       VmHost.create(allocation_state: "accepting", location: "github-runners", total_cores: 100, used_cores: 0) { _1.id = Sshable.create_with_id.id }
 
-      expect(project.default_location).to eq("hetzner-hel1")
+      expect(project.default_location).to eq("hetzner-fsn1")
     end
 
     it "provides first location when location with highest available core capacity cannot be determined" do

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
       }.to raise_error("Invalid replica count")
 
       expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-hel1", boot_image: "ai-ubuntu-2404-nvidia", name: "test-endpoint", vm_size: "standard-gpu-6", storage_volumes: [{encrypted: true, size_gib: 80}], model_name: "llama-3-1-8b-it", engine: "vllm", engine_params: "", replica_count: 1, is_public: false, gpu_count: 1)
-      }.to raise_error("No firewall named 'inference-endpoint-firewall' configured for inference endpoints in hetzner-hel1")
+        described_class.assemble(project_id: customer_project.id, location: "leaseweb-wdc02", boot_image: "ai-ubuntu-2404-nvidia", name: "test-endpoint", vm_size: "standard-gpu-6", storage_volumes: [{encrypted: true, size_gib: 80}], model_name: "llama-3-1-8b-it", engine: "vllm", engine_params: "", replica_count: 1, is_public: false, gpu_count: 1)
+      }.to raise_error("No firewall named 'inference-endpoint-firewall' configured for inference endpoints in leaseweb-wdc02")
 
       expect {
         st = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", boot_image: "ai-ubuntu-2404-nvidia", name: "test-endpoint", vm_size: "standard-gpu-6", storage_volumes: [{encrypted: true, size_gib: 80}], model_name: "llama-3-1-8b-it", engine: "vllm", engine_params: "", replica_count: 1, is_public: false, gpu_count: 1)

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::DownloadBootImage do
   let(:dbi_with_version_nil) { described_class.new(Strand.new(stack: [{"image_name" => "my-image", "version" => nil, "custom_url" => "https://example.com/my-image.raw"}])) }
 
   let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-hel1", arch: "x64") { _1.id = sshable.id } }
+  let(:vm_host) { VmHost.create(location: "hetzner-fsn1", arch: "x64") { _1.id = sshable.id } }
 
   before do
     allow(dbi).to receive_messages(sshable: sshable, vm_host: vm_host)

--- a/spec/prog/download_cloud_hypervisor_spec.rb
+++ b/spec/prog/download_cloud_hypervisor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::DownloadCloudHypervisor do
   subject(:df) { described_class.new(Strand.new(stack: [{"version" => "35.1", "sha256_ch_bin" => "thesha", "sha256_ch_remote" => "anothersha"}])) }
 
   let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-hel1", arch: "x64") { _1.id = sshable.id } }
+  let(:vm_host) { VmHost.create(location: "hetzner-fsn1", arch: "x64") { _1.id = sshable.id } }
 
   before do
     allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)

--- a/spec/prog/download_firmware_spec.rb
+++ b/spec/prog/download_firmware_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::DownloadFirmware do
   subject(:df) { described_class.new(Strand.new(stack: [{"version" => "202405", "sha256" => "thesha"}])) }
 
   let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-hel1", arch: "x64") { _1.id = sshable.id } }
+  let(:vm_host) { VmHost.create(location: "hetzner-fsn1", arch: "x64") { _1.id = sshable.id } }
 
   before do
     allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
     expect(Config).to receive(:minio_service_project_id).and_return(minio_project.id).at_least(:once)
     described_class.new(
       described_class.assemble(
-        minio_project.id, "minio", "hetzner-hel1", "minio-admin", 100, 1, 1, 1, "standard-2"
+        minio_project.id, "minio", "hetzner-fsn1", "minio-admin", 100, 1, 1, 1, "standard-2"
       )
     )
   }
@@ -21,7 +21,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
 
     it "validates input" do
       expect {
-        described_class.assemble(SecureRandom.uuid, "minio", "hetzner-hel1", "minio-admin", 100, 1, 1, 1, "standard-2")
+        described_class.assemble(SecureRandom.uuid, "minio", "hetzner-fsn1", "minio-admin", 100, 1, 1, 1, "standard-2")
       }.to raise_error RuntimeError, "No existing project"
 
       expect {
@@ -29,20 +29,20 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: provider"
 
       expect {
-        described_class.assemble(minio_project.id, "minio/name", "hetzner-hel1", "minio-admin", 100, 1, 1, 1, "standard-2")
+        described_class.assemble(minio_project.id, "minio/name", "hetzner-fsn1", "minio-admin", 100, 1, 1, 1, "standard-2")
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
 
       expect {
-        described_class.assemble(minio_project.id, "minio", "hetzner-hel1", "mu", 100, 1, 1, 1, "standard-2")
+        described_class.assemble(minio_project.id, "minio", "hetzner-fsn1", "mu", 100, 1, 1, 1, "standard-2")
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: username"
     end
 
     it "creates a minio cluster" do
-      described_class.assemble(minio_project.id, "minio2", "hetzner-hel1", "minio-admin", 100, 1, 1, 1, "standard-2")
+      described_class.assemble(minio_project.id, "minio2", "hetzner-fsn1", "minio-admin", 100, 1, 1, 1, "standard-2")
 
       expect(MinioCluster.count).to eq 1
       expect(MinioCluster.first.name).to eq "minio2"
-      expect(MinioCluster.first.location).to eq "hetzner-hel1"
+      expect(MinioCluster.first.location).to eq "hetzner-fsn1"
       expect(MinioCluster.first.admin_user).to eq "minio-admin"
       expect(MinioCluster.first.admin_password).to match(/^[A-Za-z0-9_-]{20}$/)
       expect(MinioCluster.first.storage_size_gib).to eq 100

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
 
   let(:minio_cluster) {
     MinioCluster.create_with_id(
-      location: "hetzner-hel1",
+      location: "hetzner-fsn1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       minio_project.id, name: "minio-cluster-name"
     )
     mc = MinioCluster.create_with_id(
-      location: "hetzner-hel1",
+      location: "hetzner-fsn1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Prog::Minio::SetupMinio do
     )
 
     mc = MinioCluster.create_with_id(
-      location: "hetzner-hel1",
+      location: "hetzner-fsn1",
       name: "minio-cluster-name",
       admin_user: "minio-admin",
       admin_password: "dummy-password",

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     let(:postgres_resource) {
       PostgresResource.create_with_id(
         project_id: user_project.id,
-        location: "hetzner-hel1",
+        location: "hetzner-fsn1",
         name: "pg-name",
         target_vm_size: "standard-2",
         target_storage_size_gib: 128,

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       project = Project.create_with_id(name: "mc-project").tap { _1.associate_with_project(_1) }
       expect(Config).to receive(:minio_service_project_id).and_return(project.id).at_least(:once)
       expect(Config).to receive(:postgres_service_project_id).and_return(project.id)
-      mc = Prog::Minio::MinioClusterNexus.assemble(project.id, "minio", "hetzner-hel1", "minio-admin", 100, 1, 1, 1, "standard-2").subject
+      mc = Prog::Minio::MinioClusterNexus.assemble(project.id, "minio", "hetzner-fsn1", "minio-admin", 100, 1, 1, 1, "standard-2").subject
 
-      st = described_class.assemble(location: "hetzner-hel1")
+      st = described_class.assemble(location: "hetzner-fsn1")
 
       postgres_timeline = PostgresTimeline[st.id]
       expect(postgres_timeline.blob_storage_id).to eq(mc.id)

--- a/spec/prog/remove_boot_image_spec.rb
+++ b/spec/prog/remove_boot_image_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::RemoveBootImage do
   subject(:rbi) { described_class.new(Strand.new(stack: [{}])) }
 
   let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-hel1") { _1.id = sshable.id } }
+  let(:vm_host) { VmHost.create(location: "hetzner-fsn1") { _1.id = sshable.id } }
   let(:boot_image) { BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vm_host.id, size_gib: 14) }
 
   before do

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#wait_concurrency_limit" do
     before do
-      [["hetzner-hel1", "x64"], ["github-runners", "x64"], ["github-runners", "arm64"]].each_with_index do |(location, arch), i|
+      [["hetzner-fsn1", "x64"], ["github-runners", "x64"], ["github-runners", "arm64"]].each_with_index do |(location, arch), i|
         ssh = Sshable.create_with_id(host: "0.0.0.#{i}")
         VmHost.create(location: location, allocation_state: "accepting", arch: arch, total_cores: 16, used_cores: 16) { _1.id = ssh.id }
       end
@@ -374,23 +374,23 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe ".setup_info" do
     it "returns setup info with vm pool ubid" do
       expect(vm).to receive(:pool_id).and_return("ccd51c1e-2c78-8f76-b182-467e6cdc51f0").at_least(:once)
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
+      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-fsn1", data_center: "FSN1-DC8")).at_least(:once)
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
 
-      expect(nx.setup_info[:detail]).to eq("Name: #{github_runner.ubid}\nLabel: ubicloud-standard-4\nArch: \nImage: \nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\nVM Pool: vpskahr7hcf26p614czkcvh8z1\nLocation: hetzner-hel1\nDatacenter: FSN1-DC8\nProject: pjwnadpt27b21p81d7334f11rx\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github")
+      expect(nx.setup_info[:detail]).to eq("Name: #{github_runner.ubid}\nLabel: ubicloud-standard-4\nArch: \nImage: \nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\nVM Pool: vpskahr7hcf26p614czkcvh8z1\nLocation: hetzner-fsn1\nDatacenter: FSN1-DC8\nProject: pjwnadpt27b21p81d7334f11rx\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github")
     end
   end
 
   describe "#setup_environment" do
     it "hops to register_runner" do
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
+      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-fsn1", data_center: "FSN1-DC8")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx", get_ff_transparent_cache: false)).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
       COMMAND
@@ -399,7 +399,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "hops to stop_service with after enabling transparent cache" do
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-hel1", data_center: "FSN1-DC8")).at_least(:once)
+      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-fsn1", data_center: "FSN1-DC8")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx", get_ff_transparent_cache: true)).at_least(:once)
       expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
@@ -407,7 +407,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-hel1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#wait" do
     it "naps" do
-      expect(vm_host).to receive(:values).and_return({location: "hetzner-hel1", arch: "x64", total_cores: 4})
+      expect(vm_host).to receive(:values).and_return({location: "hetzner-fsn1", arch: "x64", total_cores: 4})
       expect(vm_host).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, count: 2))
       expect { nx.wait }.to nap(30)
     end
@@ -228,7 +228,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.wait }.to hop("unavailable")
 
-      expect(vm_host).to receive(:values).and_return({location: "hetzner-hel1", arch: "x64", total_cores: 4})
+      expect(vm_host).to receive(:values).and_return({location: "hetzner-fsn1", arch: "x64", total_cores: 4})
       expect(vm_host).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, count: 2))
       expect(nx).to receive(:when_checkup_set?).and_yield
       expect(nx).to receive(:available?).and_return(true)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Prog::Vm::Nexus do
     disk_2.spdk_installation = si
     disk_2.storage_device = dev2
     disk_2.boot_image = bi
-    vm = Vm.new(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "hetzner-hel1", created_at: Time.now).tap {
+    vm = Vm.new(family: "standard", cores: 1, name: "dummy-vm", arch: "x64", location: "hetzner-fsn1", created_at: Time.now).tap {
       _1.id = "2464de61-7501-8374-9ab0-416caebe31da"
       _1.vm_storage_volumes.append(disk_1)
       _1.vm_storage_volumes.append(disk_2)
@@ -47,7 +47,7 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe ".assemble" do
     let(:ps) {
-      PrivateSubnet.create(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
+      PrivateSubnet.create(name: "ps", location: "hetzner-fsn1", net6: "fd10:9b0b:6b4b:8fbb::/64",
         net4: "1.1.1.0/26", state: "waiting") { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
     }
     let(:nic) {
@@ -97,7 +97,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(Prog::Vnet::NicNexus).not_to receive(:assemble)
       expect(Project).to receive(:[]).with(prj.id).and_return(prj)
       expect(prj.private_subnets).to receive(:any?).and_return(true)
-      described_class.assemble("some_ssh_key", prj.id, nic_id: nic.id, location: "hetzner-hel1")
+      described_class.assemble("some_ssh_key", prj.id, nic_id: nic.id, location: "hetzner-fsn1")
     end
 
     def requested_disk_size(st)
@@ -243,7 +243,7 @@ RSpec.describe Prog::Vm::Nexus do
       vm.unix_user = "test_user"
       vm.public_key = "test_ssh_key"
       vm.local_vetho_ip = "169.254.0.0"
-      ps = instance_double(PrivateSubnet, location: "hetzner-hel1", net4: NetAddr::IPv4Net.parse("10.0.0.0/26"))
+      ps = instance_double(PrivateSubnet, location: "hetzner-fsn1", net4: NetAddr::IPv4Net.parse("10.0.0.0/26"))
       nic = Nic.new(private_ipv6: "fd10:9b0b:6b4b:8fbb::/64", private_ipv4: "10.0.0.3/32", mac: "5a:0f:75:80:c3:64")
       pci = PciDevice.new(slot: "01:00.0", iommu_group: 23)
       expect(nic).to receive(:ubid_to_tap_name).and_return("tap4ncdd56m")
@@ -367,7 +367,7 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [],
         host_exclusion_filter: [],
-        location_filter: ["hetzner-hel1"],
+        location_filter: ["hetzner-fsn1"],
         location_preference: [],
         gpu_count: 0
       )
@@ -382,7 +382,7 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [],
         host_exclusion_filter: [],
-        location_filter: ["github-runners", "hetzner-fsn1", "hetzner-hel1"],
+        location_filter: ["github-runners", "hetzner-fsn1"],
         location_preference: ["github-runners"],
         gpu_count: 0
       )
@@ -436,7 +436,7 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [],
         host_exclusion_filter: [:vm_host_id, "another-vm-host-id"],
-        location_filter: ["hetzner-hel1"],
+        location_filter: ["hetzner-fsn1"],
         location_preference: [],
         gpu_count: 0
       )
@@ -462,7 +462,7 @@ RSpec.describe Prog::Vm::Nexus do
         allocation_state_filter: ["accepting"],
         distinct_storage_devices: true,
         host_filter: [],
-        location_filter: ["hetzner-hel1"],
+        location_filter: ["hetzner-fsn1"],
         host_exclusion_filter: [],
         location_preference: [],
         gpu_count: 0
@@ -482,7 +482,7 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [],
         host_exclusion_filter: [],
-        location_filter: ["hetzner-hel1"],
+        location_filter: ["hetzner-fsn1"],
         location_preference: [],
         gpu_count: 3
       )

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   let(:st) { Strand.new }
   let(:ps) {
-    PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
+    PrivateSubnet.create_with_id(name: "ps", location: "hetzner-fsn1", net6: "fd10:9b0b:6b4b:8fbb::/64",
       net4: "10.0.0.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
   }
 
@@ -66,7 +66,7 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#wait_vm" do
     let(:ps) {
-      PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
+      PrivateSubnet.create_with_id(name: "ps", location: "hetzner-fsn1", net6: "fd10:9b0b:6b4b:8fbb::/64",
         net4: "1.1.1.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
     }
     let(:nic) {
@@ -213,7 +213,7 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#destroy" do
     let(:ps) {
-      PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
+      PrivateSubnet.create_with_id(name: "ps", location: "hetzner-fsn1", net6: "fd10:9b0b:6b4b:8fbb::/64",
         net4: "1.1.1.0/26", state: "waiting").tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
     }
     let(:nic) {

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
 
   let(:st) { Strand.new }
   let(:ps) {
-    PrivateSubnet.create_with_id(name: "ps", location: "hetzner-hel1", net6: "fd10:9b0b:6b4b:8fbb::/64",
+    PrivateSubnet.create_with_id(name: "ps", location: "hetzner-fsn1", net6: "fd10:9b0b:6b4b:8fbb::/64",
       net4: "1.1.1.0/26", state: "waiting")
   }
   let(:tunnel) {

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Clover, "firewall" do
 
   let(:project) { user.create_project_with_default_policy("project-1") }
 
-  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-hel1").tap { _1.associate_with_project(project) } }
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1").tap { _1.associate_with_project(project) } }
 
   let(:firewall_rule) { FirewallRule.create_with_id(firewall_id: firewall.id, cidr: "0.0.0.0/0", port_range: Sequel.pg_range(80..5432)) }
 

--- a/spec/routes/api/project/firewall_spec.rb
+++ b/spec/routes/api/project/firewall_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Clover, "firewall" do
 
   let(:project) { user.create_project_with_default_policy("project-1") }
 
-  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-hel1").tap { _1.associate_with_project(project) } }
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1").tap { _1.associate_with_project(project) } }
 
   describe "unauthenticated" do
     it "not list" do
@@ -29,7 +29,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "success get all firewalls" do
-      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-hel1").associate_with_project(project)
+      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1").associate_with_project(project)
 
       get "/api/project/#{project.ubid}/firewall"
 

--- a/spec/routes/api/project/load_balancer_spec.rb
+++ b/spec/routes/api/project/load_balancer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Clover, "vm" do
     end
 
     it "success all load balancers" do
-      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-hel1")
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-fsn1")
       Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "lb-1", src_port: 80, dst_port: 80)
       Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "lb-2", src_port: 80, dst_port: 80)
       get "/api/project/#{project.ubid}/load-balancer"

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Clover, "firewall" do
 
   let(:project) { user.create_project_with_default_policy("project-1") }
 
-  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-hel1").tap { _1.associate_with_project(project) } }
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1").tap { _1.associate_with_project(project) } }
 
   describe "unauthenticated" do
     it "not delete" do
@@ -41,7 +41,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "success get all location firewalls" do
-      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-hel1").associate_with_project(project)
+      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1").associate_with_project(project)
 
       get "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall"
 
@@ -102,7 +102,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach to subnet" do
-      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
 
@@ -124,7 +124,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "detach from subnet" do
-      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
 
@@ -144,7 +144,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach and detach" do
-      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
+      ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps).twice
       expect(ps).to receive(:incr_update_firewall_rules).twice
 

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Clover, "load-balancer" do
   let(:project) { user.create_project_with_default_policy("project-1") }
 
   let(:lb) do
-    ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-hel1")
+    ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-fsn1")
     dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
     cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
     lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "lb-1", src_port: 80, dst_port: 80).subject
@@ -43,7 +43,7 @@ RSpec.describe Clover, "load-balancer" do
 
     describe "list" do
       it "empty" do
-        get "/api/project/#{project.ubid}/location/eu-north-h1/load-balancer"
+        get "/api/project/#{project.ubid}/location/eu-central-h1/load-balancer"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"]).to eq([])
@@ -52,7 +52,7 @@ RSpec.describe Clover, "load-balancer" do
       it "success single" do
         lb
 
-        get "/api/project/#{project.ubid}/location/eu-north-h1/load-balancer"
+        get "/api/project/#{project.ubid}/location/eu-central-h1/load-balancer"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(1)
@@ -62,7 +62,7 @@ RSpec.describe Clover, "load-balancer" do
         lb
         Prog::Vnet::LoadBalancerNexus.assemble(lb.private_subnet.id, name: "lb-2", src_port: 80, dst_port: 80).subject
 
-        get "/api/project/#{project.ubid}/location/eu-north-h1/load-balancer"
+        get "/api/project/#{project.ubid}/location/eu-central-h1/load-balancer"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"].length).to eq(2)
@@ -86,7 +86,7 @@ RSpec.describe Clover, "load-balancer" do
 
     describe "create" do
       it "success" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-fsn1").subject
         post "/api/project/#{project.ubid}/load-balancer/lb1", {
           private_subnet_id: ps.ubid,
           src_port: "80", dst_port: "80",

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Clover, "private_subnet" do
       end
 
       it "with valid firewall" do
-        fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-hel1").tap { _1.associate_with_project(project) }
+        fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1").tap { _1.associate_with_project(project) }
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: fw.ubid}.to_json
 
         expect(last_response.status).to eq(200)
@@ -116,7 +116,7 @@ RSpec.describe Clover, "private_subnet" do
       it "with invalid firewall id" do
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: "invalidid"}.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: firewall_id", {"firewall_id" => "Firewall with id \"invalidid\" and location \"hetzner-hel1\" is not found"})
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: firewall_id", {"firewall_id" => "Firewall with id \"invalidid\" and location \"hetzner-fsn1\" is not found"})
       end
 
       it "with empty body" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Clover, "vm" do
       it "success multiple location with pagination" do
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-2")
         Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-3")
-        Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-4", location: "hetzner-fsn1")
+        Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-4", location: "leaseweb-wdc02")
 
         get "/api/project/#{project.ubid}/location/#{vm.display_location}/vm", {
           order_column: "name",
@@ -85,7 +85,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success with private subnet" do
-        ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").ubid
+        ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").ubid
 
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
@@ -180,11 +180,11 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id", {"private_subnet_id" => "Private subnet with the given id \"invalid-ubid\" is not found in the location \"eu-north-h1\""})
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id", {"private_subnet_id" => "Private subnet with the given id \"invalid-ubid\" is not found in the location \"eu-central-h1\""})
       end
 
       it "invalid ps id in other location" do
-        ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").ubid
+        ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "leaseweb-wdc02").ubid
         post "/api/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",
           unix_user: "ubi",
@@ -194,7 +194,7 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id", {"private_subnet_id" => "Private subnet with the given id \"#{ps_id}\" is not found in the location \"eu-north-h1\""})
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id", {"private_subnet_id" => "Private subnet with the given id \"#{ps_id}\" is not found in the location \"eu-central-h1\""})
       end
 
       it "invalid body" do

--- a/spec/routes/api/project/private_subnet_spec.rb
+++ b/spec/routes/api/project/private_subnet_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Clover, "private_subnet" do
 
     it "success all pss" do
       Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location: "hetzner-fsn1")
-      Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-3", location: "hetzner-hel1")
+      Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-3", location: "hetzner-fsn1")
 
       get "/api/project/#{project.ubid}/private-subnet"
 

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -8,7 +8,7 @@ require "argon2"
 
 TEST_USER_EMAIL = "user@example.com"
 TEST_USER_PASSWORD = "Secret@Password123"
-TEST_LOCATION = "eu-north-h1"
+TEST_LOCATION = "eu-central-h1"
 
 RSpec.configure do |config|
   include Rack::Test::Methods

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Clover, "firewall" do
   let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", default_policy: nil) }
 
   let(:firewall) do
-    fw = Firewall.create_with_id(name: "dummy-fw", description: "dummy-fw", location: "hetzner-hel1")
+    fw = Firewall.create_with_id(name: "dummy-fw", description: "dummy-fw", location: "hetzner-fsn1")
     fw.associate_with_project(project)
     fw
   end
 
   let(:fw_wo_permission) {
-    fw = Firewall.create_with_id(name: "dummy-fw-2", description: "dummy-fw-2", location: "hetzner-hel1")
+    fw = Firewall.create_with_id(name: "dummy-fw-2", description: "dummy-fw-2", location: "hetzner-fsn1")
     fw.associate_with_project(project_wo_permissions)
     fw
   }
@@ -81,7 +81,7 @@ RSpec.describe Clover, "firewall" do
       end
 
       it "can create new firewall with private subnet" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
 
         visit "#{project.path}/firewall/create"
 
@@ -153,7 +153,7 @@ RSpec.describe Clover, "firewall" do
       end
 
       it "raises not found when firewall not exists" do
-        visit "#{project.path}/location/hetzner-hel1/firewall/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/hetzner-fsn1/firewall/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
@@ -163,7 +163,7 @@ RSpec.describe Clover, "firewall" do
 
     describe "subnets" do
       it "can show" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         firewall.associate_with_private_subnet(ps)
 
         visit "#{project.path}#{firewall.path}"
@@ -173,7 +173,7 @@ RSpec.describe Clover, "firewall" do
       end
 
       it "can attach subnet" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
 
         visit "#{project.path}#{firewall.path}"
         select ps.name, from: "private-subnet-id"
@@ -191,7 +191,7 @@ RSpec.describe Clover, "firewall" do
       end
 
       it "can not attach subnet when it does not exist" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         visit "#{project.path}#{firewall.path}"
         select "dummy-ps-1", from: "private-subnet-id"
         ps.destroy
@@ -203,7 +203,7 @@ RSpec.describe Clover, "firewall" do
       end
 
       it "can detach subnet" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1111", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1111", location: "hetzner-fsn1").subject
         expect(page).to have_no_content ps.name
 
         firewall.associate_with_private_subnet(ps)
@@ -220,7 +220,7 @@ RSpec.describe Clover, "firewall" do
       end
 
       it "can not detach subnet when it does not exist" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         visit "#{project.path}#{firewall.path}"
         select "dummy-ps-1", from: "private-subnet-id"
         click_button "Attach"

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Clover, "load balancer" do
   let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", default_policy: nil) }
 
   let(:lb) do
-    ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+    ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
     lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up")
     lb.associate_with_project(project)
     lb
   end
 
   let(:lb_wo_permission) {
-    ps = Prog::Vnet::SubnetNexus.assemble(project_wo_permissions.id, name: "dummy-ps-2", location: "hetzner-hel1").subject
+    ps = Prog::Vnet::SubnetNexus.assemble(project_wo_permissions.id, name: "dummy-ps-2", location: "hetzner-fsn1").subject
     lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-2", src_port: 80, dst_port: 80, health_check_endpoint: "/up")
     lb.associate_with_project(project_wo_permissions)
     lb
@@ -67,7 +67,7 @@ RSpec.describe Clover, "load balancer" do
     describe "create" do
       it "can create new load balancer" do
         project
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         visit "#{project.path}/load-balancer/create"
 
         expect(page.title).to eq("Ubicloud - Create Load Balancer")
@@ -90,7 +90,7 @@ RSpec.describe Clover, "load balancer" do
 
       it "can not create load balancer with invalid name" do
         project
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         visit "#{project.path}/load-balancer/create"
 
         expect(page.title).to eq("Ubicloud - Create Load Balancer")
@@ -111,7 +111,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "can not create load balancer in a project when does not have permissions" do
-        Prog::Vnet::SubnetNexus.assemble(project_wo_permissions.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        Prog::Vnet::SubnetNexus.assemble(project_wo_permissions.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         visit "#{project_wo_permissions.path}/load-balancer/create"
 
         expect(page.title).to eq("Ubicloud - Forbidden")
@@ -121,7 +121,7 @@ RSpec.describe Clover, "load balancer" do
 
       it "can not create load balancer with invalid private subnet" do
         project
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         visit "#{project.path}/load-balancer/create"
 
         expect(page.title).to eq("Ubicloud - Create Load Balancer")
@@ -160,7 +160,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "raises forbidden when does not have permissions" do
-        visit "#{project_wo_permissions.path}/location/eu-north-h1/load-balancer/#{lb_wo_permission.name}"
+        visit "#{project_wo_permissions.path}/location/eu-central-h1/load-balancer/#{lb_wo_permission.name}"
 
         expect(page.title).to eq("Ubicloud - Forbidden")
         expect(page.status_code).to eq(403)
@@ -168,7 +168,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "raises not found when load balancer not exists" do
-        visit "#{project.path}/location/eu-north-h1/load-balancer/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/eu-central-h1/load-balancer/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
@@ -188,7 +188,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "can attach vm" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000, algorithm: "hash_based").subject
         dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
         cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
@@ -214,7 +214,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "can not attach vm when it is already attached to another load balancer" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         lb1 = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
         lb2 = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-4", src_port: 80, dst_port: 8000).subject
         dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
@@ -234,7 +234,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "can not attach vm when it does not exist" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
         vm = Prog::Vm::Nexus.assemble("key", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
 
@@ -250,7 +250,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "can detach vm" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
         dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
         cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
@@ -273,7 +273,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "can not detach vm when it does not exist" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
         dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)
         cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
@@ -300,7 +300,7 @@ RSpec.describe Clover, "load balancer" do
 
     describe "delete" do
       it "can delete load balancer" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
 
         visit "#{project.path}#{lb.path}"
@@ -327,7 +327,7 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "can not delete load balancer when it doesn't exist" do
-        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").subject
+        ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
 
         visit "#{project.path}#{lb.path}"

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Clover, "private subnet" do
   let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", default_policy: nil) }
 
   let(:private_subnet) do
-    ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-hel1").id
+    ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").id
     ps = PrivateSubnet[ps_id]
     ps.update(net6: "2a01:4f8:173:1ed3::/64")
     ps.update(net4: "172.17.226.128/26")
@@ -71,7 +71,7 @@ RSpec.describe Clover, "private subnet" do
         expect(page.title).to eq("Ubicloud - Create Private Subnet")
         name = "dummy-ps"
         fill_in "Name", with: name
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
 
         click_button "Create"
 
@@ -88,7 +88,7 @@ RSpec.describe Clover, "private subnet" do
         expect(page.title).to eq("Ubicloud - Create Private Subnet")
 
         fill_in "Name", with: private_subnet.name
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
 
         click_button "Create"
 
@@ -112,7 +112,7 @@ RSpec.describe Clover, "private subnet" do
       end
 
       it "raises not found when private subnet not exists" do
-        visit "#{project.path}/location/hetzner-hel1/private-subnet/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/hetzner-fsn1/private-subnet/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)
@@ -138,7 +138,7 @@ RSpec.describe Clover, "private subnet" do
     describe "show firewalls" do
       it "can show attached firewalls" do
         private_subnet
-        fw = Firewall.create_with_id(name: "dummy-fw", description: "dummy-fw", location: "hetzner-hel1")
+        fw = Firewall.create_with_id(name: "dummy-fw", description: "dummy-fw", location: "hetzner-fsn1")
         fw.associate_with_private_subnet(private_subnet)
 
         visit "#{project.path}#{private_subnet.path}"

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
         name = "dummy-vm"
         fill_in "Name", with: name
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
         uncheck "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
@@ -90,7 +90,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
         name = "dummy-vm"
         fill_in "Name", with: name
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
         check "Enable Public IPv4"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
@@ -115,7 +115,7 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content "Create new subnet"
         name = "dummy-vm"
         fill_in "Name", with: name
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
         select match: :prefer_exact, text: ps.name
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
@@ -136,7 +136,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
 
         fill_in "Name", with: "invalid name"
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
@@ -154,7 +154,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
 
         fill_in "Name", with: vm.name
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
@@ -174,7 +174,7 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content "Project doesn't have valid billing information"
 
         fill_in "Name", with: "dummy-vm"
-        choose option: "eu-north-h1"
+        choose option: "eu-central-h1"
         choose option: "ubuntu-jammy"
         choose option: "standard-2"
 
@@ -226,7 +226,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "raises not found when virtual machine not exists" do
-        visit "#{project.path}/location/eu-north-h1/vm/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/eu-central-h1/vm/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -218,7 +218,7 @@ RSpec.configure do |config|
 end
 
 def create_vm(**args)
-  defaults = {unix_user: "ubi", public_key: "ssh-ed25519 key", name: "test-vm", family: "standard", cores: 1, arch: "x64", location: "hetzner-hel1", boot_image: "ubuntu-jammy", display_state: "running", ip4_enabled: false, created_at: Time.now}
+  defaults = {unix_user: "ubi", public_key: "ssh-ed25519 key", name: "test-vm", family: "standard", cores: 1, arch: "x64", location: "hetzner-fsn1", boot_image: "ubuntu-jammy", display_state: "running", ip4_enabled: false, created_at: Time.now}
   Vm.create_with_id(**defaults.merge(args))
 end
 


### PR DESCRIPTION
To complete the removal of the Helsinki region, we also need to create a new E2E tests host in hetzner-fsn1. However, it is not urgent as the current host would think that it is in hetzner-fsn1 anyway and continue to work.