### PR TITLE
Add ruby-lsp to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development do
   gem "rubocop-rake"
   gem "rubocop-rspec"
   gem "rubocop-sequel"
+  gem "ruby-lsp", require: false
   gem "standard", ">= 1.24.3"
   gem "simplecov"
   gem "turbo_tests"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,7 @@ GEM
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
     prettier_print (1.2.1)
+    prism (1.2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -227,6 +228,8 @@ GEM
       nokogiri (~> 1.14)
     rainbow (3.1.1)
     rake (13.2.1)
+    rbs (3.6.1)
+      logger
     refrigerator (1.7.0)
     regexp_parser (2.9.2)
     rexml (3.3.8)
@@ -279,6 +282,11 @@ GEM
       rubocop (~> 1.61)
     rubocop-sequel (0.3.4)
       rubocop (~> 1.0)
+    ruby-lsp (0.20.1)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 4)
+      sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     safety_net_attestation (0.4.0)
@@ -301,6 +309,7 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
+    sorbet-runtime (0.5.11615)
     standard (1.41.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -403,6 +412,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
+  ruby-lsp
   sequel (>= 5.62)
   sequel-annotate
   sequel_pg (>= 1.8)


### PR DESCRIPTION
Will Leinweber told me I was missing out if I wasn't using this.  I gave it a try, unless my previous (few years ago) experiences with lsp servers in emacs for ruby, this one worked immediately, having tested finding declarations and references for a couple of symbols.

So, make it easier for everyone by adding it.