### PR TITLE
Fix scan order indeterminacy in test

### DIFF
--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Clover, "github" do
 
         response = JSON.parse(last_response.body)
         expect(response["totalCount"]).to eq(1)
-        expect(response["artifactCaches"].map { [_1["cacheKey"], _1["cacheVersion"]] }).to eq([["k1", "v2"]])
+        expect(response["artifactCaches"].sort.map { [_1["cacheKey"], _1["cacheVersion"]] }).to eq([["k1", "v2"]])
       end
     end
   end


### PR DESCRIPTION
This failed for me once with the two records swapped.