### PR TITLE
Upload coverage report with different artifact names in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,5 +101,5 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: code-coverage-report
+        name: code-coverage-report-${{ matrix.runs-on }}
         path: coverage/


### PR DESCRIPTION
When the CI fails, we upload the coverage report as an artifact.

Previously, `actions/upload-artifact` allowed uploading artifacts with the same name in different jobs in v3, but v4 doesn't allow this [^1]. We need to upload artifacts with different names; otherwise, it fails with a 409 error. It seems we overlooked this change when upgrading from v3 to v4.

[^1]: https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact