### PR TITLE
Ankush Disk Monitoring

### DIFF
--- a/migrate/20241028_add_blk_dev_in_storage_devices.rb
+++ b/migrate/20241028_add_blk_dev_in_storage_devices.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:storage_device) do
+      add_column :blk_dev_serial_number, "text[]"
+    end
+  end
+
+  down do
+    alter_table(:storage_device) do
+      drop_column :blk_dev_serial_number
+    end
+  end
+end

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -3,11 +3,42 @@
 require_relative "../model"
 
 class StorageDevice < Sequel::Model
+  many_to_one :vm_host
+  one_to_many :vm_storage_volumes
+
   include ResourceMethods
 
-  many_to_one :vm_host
+  DEFAULT_NAME = "DEFAULT"
 
   def self.ubid_type
     UBID::TYPE_ETC
+  end
+
+  def blk_dev_serial_number
+    super || populate_blk_dev_serial_number
+  end
+
+  def populate_blk_dev_serial_number
+    lsblk_output = JSON.parse(vm_host.sshable.cmd("lsblk -Jno NAME,MOUNTPOINTS,SERIAL"))
+    fail "Expected blockdevices in lsblk output" unless lsblk_output.key?("blockdevices")
+    devices = []
+
+    lsblk_output["blockdevices"].each do |bdev|
+      raise "Expected non-empty serial number in lsblk command while fetching data for vm_host #{vm_host.id}" unless bdev.key?("serial") && !bdev["serial"].to_s.strip.empty?
+      devices << bdev["serial"] if has_mount_point?(bdev)
+    end
+    devices.uniq!
+    update(blk_dev_serial_number: devices)
+    devices
+  end
+
+  private
+
+  def mount_point = (name == DEFAULT_NAME) ? "/" : "/var/storage/devices/#{name}"
+
+  # Recursively checks if the json object has mount_point in the mountpoints list.
+  # Expected structure: type x = {"mountpoints": []string, "children": []x}
+  def has_mount_point?(jobj)
+    jobj.fetch("mountpoints", []).any?(mount_point) || jobj.fetch("children", []).any? { |child| has_mount_point?(child) }
   end
 end

--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../model/storage_device"
+
 class Prog::LearnStorage < Prog::Base
   subject_is :sshable, :vm_host
 
@@ -28,7 +30,7 @@ class Prog::LearnStorage < Prog::Base
     devices = DfRecord.parse_all(sshable.cmd(df_command))
     rec = DfRecord.parse_all(sshable.cmd(df_command("/var/storage"))).first
     sds = [StorageDevice.new_with_id(
-      vm_host_id: vm_host.id, name: "DEFAULT",
+      vm_host_id: vm_host.id, name: StorageDevice::DEFAULT_NAME,
       # reserve 5G the host.
       available_storage_gib: [rec.avail_gib - 5, 0].max,
       total_storage_gib: rec.size_gib
@@ -55,6 +57,7 @@ class Prog::LearnStorage < Prog::Base
             available_storage_gib: Sequel[:excluded][:available_storage_gib]
           }).save_changes
       end
+      sd.populate_blk_dev_serial_number
     end
 
     pop("created StorageDevice records")

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -245,8 +245,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   def available?
-    sshable.cmd("true")
-    true
+    vm_host.run_health_checks({ssh_session: sshable.connect})
   rescue
     false
   end

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -89,6 +89,7 @@ r "apt-get -y install qemu-utils mtools acl"
 # debugging crashes.
 r "apt-get -y install nvme-cli systemd-coredump" if is_prod_env
 
+r "apt-get update && apt-get -y install smartmontools"
 SpdkSetup.prep
 
 # cron job to store serial.log files

--- a/spec/model/storage_device_spec.rb
+++ b/spec/model/storage_device_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe StorageDevice do
+  subject(:storage_device) { described_class.create_with_id(vm_host: vmh, name: "DEFAULT", available_storage_gib: 100, total_storage_gib: 200) }
+
+  let(:sshable) { instance_double(Sshable) }
+  let(:vmh) { Prog::Vm::HostNexus.assemble("::1").subject }
+  let(:lsblk_output) { <<EOS }
+{
+  "blockdevices": [
+    {
+      "name": "nvme0n1",
+      "serial": "SERIAL2",
+      "mountpoints": [],
+      "children": [
+        {
+          "name": "nvme0n1p1",
+          "mountpoints": ["/mnt/data", "/"],
+          "children": []
+        }
+      ]
+    },
+    {
+      "name": "nvme1n1",
+      "serial": "SERIAL1",
+      "mountpoints": ["/var/storage/devices/test_device"],
+      "children": []
+    },
+    {
+      "name": "nvme2n1",
+      "serial": "SERIAL4",
+      "mountpoints": [],
+      "children": [
+        {
+          "name": "nvme2n1p1",
+          "mountpoints": ["/mnt/data", "/"],
+          "children": []
+        }
+      ]
+    }
+  ]
+}
+EOS
+
+  before do
+    allow(vmh).to receive(:sshable).and_return(sshable)
+  end
+
+  describe "#populate_blk_dev_serial_number" do
+    context "when blk_dev_serial_number has value" do
+      it "do not try to populate again" do
+        sd = described_class.create_with_id(vm_host_id: vmh.id, name: "DEFAULT", blk_dev_serial_number: ["SERIAL2", "SERIAL4"], available_storage_gib: 50, total_storage_gib: 100)
+        expect(sshable).not_to receive(:cmd)
+        expect(sd.blk_dev_serial_number).to eq(["SERIAL2", "SERIAL4"])
+      end
+    end
+
+    context "when blk_dev_serial_number is nil" do
+      it "populates the block device serial number" do
+        expect(sshable).to receive(:cmd).with("lsblk -Jno NAME,MOUNTPOINTS,SERIAL").and_return(lsblk_output)
+        expect(storage_device.populate_blk_dev_serial_number).to eq(["SERIAL2", "SERIAL4"])
+      end
+    end
+
+    it "picks correct serial number for custom storage device name" do
+      sd = described_class.create_with_id(vm_host: vmh, name: "test_device", available_storage_gib: 75, total_storage_gib: 150)
+      expect(sshable).to receive(:cmd).with("lsblk -Jno NAME,MOUNTPOINTS,SERIAL").and_return(lsblk_output)
+      expect(sd.populate_blk_dev_serial_number).to eq(["SERIAL1"])
+    end
+
+    context "when ssh cmd fails" do
+      it "raises an error" do
+        expect(sshable).to receive(:cmd).with("lsblk -Jno NAME,MOUNTPOINTS,SERIAL").and_return("Permission denied")
+        expect { storage_device.populate_blk_dev_serial_number }.to raise_error(JSON::ParserError, "unexpected token at 'Permission denied'")
+      end
+    end
+
+    context "when ssh cmd result does not contain blockdevices" do
+      it "raises an error" do
+        expect(sshable).to receive(:cmd).with("lsblk -Jno NAME,MOUNTPOINTS,SERIAL").and_return("{}")
+        expect { storage_device.populate_blk_dev_serial_number }.to raise_error(RuntimeError, "Expected blockdevices in lsblk output")
+      end
+    end
+
+    context "when ssh cmd result does not contain serial number" do
+      it "raises an error" do
+        expect(sshable).to receive(:cmd).with("lsblk -Jno NAME,MOUNTPOINTS,SERIAL").and_return(<<EOS)
+{
+  "blockdevices": [
+    {
+      "name": "nvme0n1",
+      "mountpoints": [],
+      "children": [
+        {
+          "name": "nvme0n1p1",
+          "mountpoints": ["/mnt/data", "/"],
+          "children": []
+        }
+      ]
+    }
+  ]
+}
+EOS
+        expect { storage_device.populate_blk_dev_serial_number }.to raise_error(RuntimeError, /Expected non-empty serial number in lsblk command/)
+      end
+    end
+  end
+end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -380,10 +380,10 @@ RSpec.describe VmHost do
       reading_rpt: 5,
       reading_chg: Time.now - 30
     }
-    expected_cmd = "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '11110000$') | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'; " \
-                   "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '22220000$') | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'; " \
-                   "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '33330000$') | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'; " \
-                   "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '44440000$') | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'"
+    expected_cmd = "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '11110000$' | head -n1) | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'; " \
+                   "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '22220000$' | head -n1) | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'; " \
+                   "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '33330000$' | head -n1) | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'; " \
+                   "sudo smartctl -H /dev/disk/by-id/$(ls /dev/disk/by-id/ | grep -E '44440000$' | head -n1) | grep -qE 'OK|PASSED' && echo 'up' || echo 'down'"
 
     expect(vh).to receive(:storage_devices).and_return(sds).exactly(3).times
     expect(session[:ssh_session]).to receive(:exec!).with(expected_cmd).and_return("up\nup")

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -4,6 +4,10 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnStorage do
   describe "#start" do
+    before do
+      allow_any_instance_of(StorageDevice).to receive(:populate_blk_dev_serial_number).and_return(nil) # rubocop:disable RSpec/AnyInstance
+    end
+
     it "exits, saving StorageDevice model instances" do
       vmh = Prog::Vm::HostNexus.assemble("::1").subject
       ls = described_class.new(Strand.new(stack: [{"subject_id" => vmh.id}]))

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -385,10 +385,15 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#available?" do
     it "returns the available status" do
-      expect(sshable).to receive(:cmd).and_return("true")
+      expect(sshable).to receive(:connect).and_return(nil)
+      expect(vm_host).to receive(:run_health_checks).and_return(true)
       expect(nx.available?).to be true
 
-      expect(sshable).to receive(:cmd).and_raise Sshable::SshError.new("ssh failed", "", "", nil, nil)
+      expect(sshable).to receive(:connect).and_raise Sshable::SshError.new("ssh failed", "", "", nil, nil)
+      expect(nx.available?).to be false
+
+      expect(sshable).to receive(:connect).and_return(nil)
+      expect(vm_host).to receive(:run_health_checks).and_return(false)
       expect(nx.available?).to be false
     end
   end


### PR DESCRIPTION
## Migration for block device serail number column in storage_device
The new column `blk_dev_serial_number` would contain the serial number
of the block storage device. The column has type `text[]` and not just
`text` to accomodate RAID setups.

## Populate blk_dev_serial_number in storage_device on vm host prep

## Add disk monitoring in VM host
This commit contains changes for disk monitoring for both RAID and
non-RAID systems, supporting NVME and SCSI storage controller
interfaces. The system is designed to identify and report disk failures
in a pull-based monitoring setup.

Storage Device Model

To identify which disks are down in a pull-based system, we first need
to maintain the record of existing disks. We introduced a column in the
`storage_device` model to store the list of physical disks mapped to
each logical disk.

Note: Entries in the storage_device table do not represent physical
storage. For example, a RAID1 setup would only have a single entry in
the table despite being backed by multiple physical storage devices. Due
to this, the newly added column is a collection, not a single entry.

Device Identification

We decided to store the device's serial number rather than using more
legible device file naming (e.g., /dev/nvme0n1). This choice was made
due to the non-permanent nature of device file naming. Device names tend
to change on reboot or when ports on which they are attached to the
machine are physically swapped.

Mountpoint and Physical Device Association

To find the associated physical device for each storage_device table
entry, we leverage mountpoint information. The mountpoint can be
inferred from the name column of storage_device:
- If the name is `DEFAULT`, the disk is mounted at `/`.
- Otherwise, it is mounted at `/var/storage/devices/<name>`.

Precedence for this can be found [in this
commit](https://github.com/ubicloud/ubicloud/commit/89f9dbd7f2b12c08eb993d947e64003c68c90606#diff-f336d7f0af53644f9dae8673dcebdaab01a2d3173a00ba648fc48d79aee2ba81R19).

After finding the associated mountpoint, we parse lsblk to get the
serial number of the physical device.

Health Check Process

On each check pulse run: 1. We fetch the device file name for each
serial number.  2. We run a health check using smartmontools.  3. If any
device fails, it fails the overall `check_pulse`.

We supplement smartmontools with another check to detect if the OS has
remounted the disk as read-only. This occurs when the OS observes too
many IO failures, among other reasons. To check if the device is
read-only, we rely on the `lsblk` command.

Smartmontools doesn't cache the health check result. It works for both
NVME and SCSI, with differences in output formatting:
- For NVME: We see "PASSED"
- For SCSI: We see "OK"

This is cross-checked from their source code on
[GitHub](https://github.com/smartmontools/smartmontools/blob/65707ca59285a4b2350fb5b30293398f17e868bd/smartmontools/scsiprint.cpp#L402).
Also, smartmontools are not part of linux distributions. It needs to be
installed. We do this in `rhizome/host/bin/prep_host.rb`.

Failure Modes

1. SSH fails:
   - If due to binary not found: The disk on which SSH resides gets
     detached. Systems are expected to survive such events.
   - If due to other reasons (e.g., machine busy or out of resources):
     We fail the check.

2. `smartctl` binary not found:
   - This could be due to disk detachment. We're currently ignoring this
     scenario.
   - Reasoning: The smartctl binary's page should be in memory since we
     run it every 30 seconds. However, we can't make assumptions about
client usage.
   - Potential solution: Pin the page to RAM using `vmtouch`.

3. `smartctl` command fails:
   - We fail the check in this case.

These checks are run per storage as part of the VmHost monitoring,
reusing the strand.

Other Considerations

- Populating serial numbers in the storage_device table:
  - Option 1: Manually run a script at new deployment time. This
    requires considering failure retry mechanisms and handling permanent
failures.
  - Option 2 (Chosen): Anchor population to the users of this column.
    When the storage_device model is asked for a serial number it
doesn't have, it runs an SSH command to find the serial number,
populates the table, and returns to the caller.

- Testing the mountpoint to serial number mapping:
  - We created loopback devices, which added more entries to the lsblk
    output.
  - Running the logic for fetching serial numbers from the control plane
    retrieved the expected serial numbers.
  - The script used to create loopback fs is [mentioned in this commit
    message](https://github.com/ubicloud/ubicloud/commit/89f9dbd7f2b12c08eb993d947e64003c68c90606#diff-f336d7f0af53644f9dae8673dcebdaab01a2d3173a00ba648fc48d79aee2ba81R19).

- LearnStorage update:
  - We updated LearnStorage to populate serial numbers in
    storage_device.
  - LearnStorage runs as part of the PrepHost program, which is executed
    on machine changes like new disk attachments.

- Disk CRUD:
  - Removal of disk and addition of new disk to existing RAID systems is
    still to be determined (TBD).
  - Addition of new disk is handled by `LearnStorage` prog.

- Transaction consideration:
  - A transaction is not required for populating serial numbers in
    storage_device as the race condition is benign.

## Added parallel health check in host_nexus to automatically recover