### PR TITLE
Update address for blob storage cache

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -437,7 +437,7 @@ DHCP
     interfaces = nics.map { "interface=#{_1.tap}" }.join("\n")
     dnsmasq_address_ip6 = NetAddr::IPv6.parse("fd00:0b1c:100d:53::")
     address_mapping = boot_image.include?("github") ?
-      "address=/localhost.blob.core.windows.net/#{nics.first.net4.split("/").first}" :
+      "address=/ubicloudhostplaceholder.blob.core.windows.net/#{nics.first.net4.split("/").first}" :
       ""
     vp.write_dnsmasq_conf(<<DNSMASQ_CONF)
 pid-file=


### PR DESCRIPTION
While restoring a cache, we were using localhost.blob.core.windows.net to be able to concurrently download files. Though, with it's latest version, actions/cache repo adds a special check to hosts including `localhost` https://github.com/actions/cache/pull/1474/files and it broke our logic. To fix it and not face with a similar issue again updating address name.