### PR TITLE
Support testing with frozen Database and models

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -135,9 +135,9 @@ else
     sh({"RACK_ENV" => "test", "COVERAGE" => "1", "FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "rspec", "spec")
   end
 
-  desc "Run specs with frozen environment (similar to production)"
+  desc "Run specs with frozen core (similar to production)"
   task "frozen_spec" do
-    sh({"RACK_ENV" => "test", "CLOVER_FREEZE" => "1", "FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "rspec", "spec")
+    sh({"RACK_ENV" => "test", "CLOVER_FREEZE_CORE" => "1", "FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "rspec", "spec")
   end
 
   desc "Run specs in with coverage in unfrozen mode, and without coverage in frozen mode"
@@ -154,9 +154,9 @@ task "pspec" do
   system({"FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "turbo_tests", "-n", nproc.call)
 end
 
-desc "Run parallel specs with frozen environment (similar to production)"
+desc "Run parallel specs with frozen core (similar to production)"
 task "frozen_pspec" do
-  sh({"CLOVER_FREEZE" => "1", "FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "turbo_tests", "-n", nproc.call)
+  sh({"CLOVER_FREEZE_CORE" => "1", "FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "turbo_tests", "-n", nproc.call)
 end
 
 # Other

--- a/clover.rb
+++ b/clover.rb
@@ -7,7 +7,7 @@ require "roda"
 class Clover < Roda
   def self.freeze
     # :nocov:
-    if Config.test?
+    if Config.test? && ENV["CLOVER_FREEZE_MODELS"] != "1"
       Sequel::Model.descendants.each(&:finalize_associations)
     else
       Sequel::Model.freeze_descendants

--- a/loader.rb
+++ b/loader.rb
@@ -147,7 +147,7 @@ when :test
 end
 
 def clover_freeze
-  return unless Config.production? || ENV["CLOVER_FREEZE"] == "1"
+  return unless Config.production? || ENV["CLOVER_FREEZE_CORE"] == "1"
   require "refrigerator"
 
   # Take care of library dependencies that modify core classes.

--- a/loader.rb
+++ b/loader.rb
@@ -147,7 +147,7 @@ when :test
 end
 
 def clover_freeze
-  return unless Config.production? || ENV["CLOVER_FREEZE_CORE"] == "1"
+  return unless Config.production?
   require "refrigerator"
 
   # Take care of library dependencies that modify core classes.

--- a/model/page.rb
+++ b/model/page.rb
@@ -12,6 +12,14 @@ class Page < Sequel::Model
     end
   end
 
+  # This cannot be covered, as the current coverage tests run without freezing models.
+  # :nocov:
+  def self.freeze
+    new.pagerduty_client
+    super
+  end
+  # :nocov:
+
   include SemaphoreMethods
   include ResourceMethods
   semaphore :resolve

--- a/spec/lib/sem_snap_spec.rb
+++ b/spec/lib/sem_snap_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe SemSnap do
   end
 
   it "operates immediately by default in non-block form" do
+    skip_if_frozen_models
     snap = described_class.new(st.id)
     snap.incr(:test)
     delete_set = instance_double(Sequel::Model::DatasetMethods)

--- a/spec/model/boot_image_spec.rb
+++ b/spec/model/boot_image_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe BootImage do
 
   describe "#remove_boot_image" do
     it "creates a strand to delete boot image" do
+      skip_if_frozen_models
       expect(Strand).to receive(:create_with_id) do |args|
         expect(args[:prog]).to eq("RemoveBootImage")
         expect(args[:label]).to eq("start")

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe GithubRunner do
   end
 
   it "can log duration when it's from a vm pool" do
+    skip_if_frozen_models
     expect(VmPool).to receive(:[]).with("pool-id").and_return(instance_double(VmPool, ubid: "pool-ubid"))
     expect(Clog).to receive(:emit).with("runner_tested").and_call_original
     github_runner.log_duration("runner_tested", 10)

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -229,6 +229,7 @@ RSpec.describe PostgresServer do
   end
 
   it "catches Sequel::Error if updating PostgresLsnMonitor fails" do
+    skip_if_frozen_models
     lsn_monitor = instance_double(PostgresLsnMonitor, last_known_lsn: "1/5")
     expect(PostgresLsnMonitor).to receive(:new).and_return(lsn_monitor)
     expect(lsn_monitor).to receive(:insert_conflict).and_return(lsn_monitor)

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -137,11 +137,13 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns blob storage endpoint" do
+    skip_if_frozen_models
     expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
     expect(postgres_timeline.blob_storage_endpoint).to eq("https://blob-endpoint")
   end
 
   it "returns blob storage client from cache" do
+    skip_if_frozen_models
     expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, root_certs: "certs")).once
     expect(Minio::Client).to receive(:new).and_return("dummy-client").once

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe PrivateSubnet do
 
   describe "destroy" do
     it "destroys firewalls private subnets" do
+      skip_if_frozen_models
       ps = described_class.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       fwps = instance_double(FirewallsPrivateSubnets)
       expect(FirewallsPrivateSubnets).to receive(:where).with(private_subnet_id: ps.id).and_return(instance_double(Sequel::Dataset, all: [fwps]))

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Project do
     end
 
     it "sets and gets feature flags" do
+      skip_if_frozen_models
       described_class.feature_flag(:dummy_flag)
       project = described_class.create_with_id(name: "dummy-name")
 

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Strand do
     end
 
     it "does an integrity check that deleted records are gone" do
+      skip_if_frozen_models
       st.label = "hop_exit"
       st.save_changes
       original = DB.method(:[])
@@ -39,6 +40,7 @@ RSpec.describe Strand do
     end
 
     it "does an integrity check that the lease was modified as expected" do
+      skip_if_frozen_models
       st.label = "napper"
       st.save_changes
       original = DB.method(:[])

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to install Rhizome" do
+    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     expect(Strand).to receive(:create) do |args|
       expect(args[:prog]).to eq("InstallRhizome")
@@ -98,6 +99,7 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new boot image" do
+    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     expect(Strand).to receive(:create) do |args|
       expect(args[:prog]).to eq("DownloadBootImage")
@@ -107,6 +109,7 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new firmware for x64" do
+    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "x64"
     expect(Strand).to receive(:create) do |args|
@@ -117,6 +120,7 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new firmware for arm64" do
+    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "arm64"
     expect(Strand).to receive(:create) do |args|
@@ -136,6 +140,7 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new version of cloud hypervisor for x64" do
+    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "x64"
     expect(Strand).to receive(:create) do |args|
@@ -146,6 +151,7 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new version of cloud hypervisor for arm64" do
+    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "arm64"
     expect(Strand).to receive(:create) do |args|
@@ -205,6 +211,7 @@ RSpec.describe VmHost do
   end
 
   it "hetznerifies a host" do
+    skip_if_frozen_models
     expect(vh).to receive(:create_addresses).at_least(:once)
     expect(HetznerHost).to receive(:create).with(server_identifier: "12").and_return(true)
 
@@ -280,6 +287,7 @@ RSpec.describe VmHost do
   end
 
   it "updates the routed_to_host_id if the address is reassigned to another host and there is no vm using the ip range" do
+    skip_if_frozen_models
     hetzner_ips = [
       Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)
     ]
@@ -301,6 +309,7 @@ RSpec.describe VmHost do
   end
 
   it "fails if the ip range is already assigned to a vm" do
+    skip_if_frozen_models
     hetzner_ips = [
       Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)
     ]

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe VmPool do
     }
 
     it "returns the vm if there is one in running state" do
+      skip_if_frozen_models
       locking_vms = class_double(Vm)
       expect(pool).to receive(:vms_dataset).and_return(locking_vms).at_least(:once)
       expect(locking_vms).to receive_message_chain(:for_update, :all).and_return([])  # rubocop:disable RSpec/MessageChain

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -220,6 +220,7 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     p1 = Project.create_with_id(name: "default")
 
     it "updates billing records" do
+      skip_if_frozen_models
       expect(Project).to receive(:from_ubid).with(p1.ubid).and_return(p1).twice
       expect(BillingRecord.count).to eq(0)
       nx.update_billing_records([{"ubid" => p1.ubid, "request_count" => 1, "prompt_token_count" => 10, "completion_token_count" => 20}])
@@ -248,6 +249,7 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     end
 
     it "failure in updating single record doesn't impact others" do
+      skip_if_frozen_models
       p2 = Project.create_with_id(name: "default")
       expect(Project).to receive(:from_ubid).with(p1.ubid).and_return(p1)
       expect(Project).to receive(:from_ubid).with(p2.ubid).and_return(p2)

--- a/spec/prog/check_usage_alerts_spec.rb
+++ b/spec/prog/check_usage_alerts_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Prog::CheckUsageAlerts do
 
   describe "#wait" do
     it "triggers alerts if usage is exceeded given threshold" do
+      skip_if_frozen_models
       exceeded = instance_double(UsageAlert, limit: 100, project: instance_double(Project, current_invoice: instance_double(Invoice, content: {"cost" => 1000})))
       not_exceeded = instance_double(UsageAlert, limit: 100, project: instance_double(Project, current_invoice: instance_double(Invoice, content: {"cost" => 10})))
       expect(UsageAlert).to receive(:where).and_return([exceeded, not_exceeded])

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -209,6 +209,7 @@ RSpec.describe Prog::DownloadBootImage do
 
   describe "#activate_boot_image" do
     it "activates the boot image" do
+      skip_if_frozen_models
       dataset = instance_double(Sequel::Dataset)
       expect(BootImage).to receive(:where).with(vm_host_id: vm_host.id, name: "my-image", version: "20230303").and_return(dataset)
       expect(dataset).to receive(:update) do |args|

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Prog::Heartbeat do
     before { allow(Config).to receive(:heartbeat_url).and_return("http://localhost:3000") }
 
     it "fails if it can't connect to the database" do
+      skip_if_frozen_models
       expect(DB).to receive(:[]).with(described_class::CONNECTED_APPLICATION_QUERY).and_raise(Sequel::DatabaseConnectionError)
 
       expect { hb.wait }.to raise_error Sequel::DatabaseConnectionError

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -98,6 +98,7 @@ ECHO
     }
 
     before do
+      skip_if_frozen_models
       allow(DnsZone).to receive(:where).and_return([instance_double(DnsZone, name: "minio.ubicloud.com")])
     end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     let(:postgres_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
     it "validates input" do
+      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       expect {
@@ -85,6 +86,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "does not allow giving different version than parent for restore" do
+      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128, version: "16").subject
       expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
@@ -94,6 +96,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "validates storage size during restore if the storage size is different from the parent" do
+      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
       parent.update(target_storage_size_gib: 1024)
@@ -111,6 +114,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "passes timeline of parent resource if parent is passed" do
+      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
@@ -271,6 +275,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
   describe "#create_billing_record" do
     it "creates billing record for cores and storage then hops" do
+      skip_if_frozen_models
       expect(postgres_resource).to receive(:required_standby_count).and_return(1)
       expect(postgres_resource).to receive(:flavor).and_return("standard").at_least(:once)
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "picks correct base image for Lantern" do
+      skip_if_frozen_models
       expect(PostgresResource).to receive(:[]).and_return(postgres_resource)
       expect(postgres_resource).to receive(:flavor).and_return(PostgresResource::Flavor::LANTERN).at_least(:once)
       expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).with(anything, anything, hash_including(boot_image: "postgres16-lantern-ubuntu-2204")).and_return(instance_double(Strand, id: "62c62ddb-5b5a-4e9e-b534-e73c16f86bcb"))
@@ -85,6 +86,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "errors out for unknown flavor" do
+      skip_if_frozen_models
       expect(PostgresResource).to receive(:[]).and_return(postgres_resource)
       expect(postgres_resource).to receive(:flavor).and_return("boring_flavor").at_least(:once)
       expect {

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
 
     it "resolves the missing page if last completed backup is more recent than 2 days" do
       skip_if_frozen
+      skip_if_frozen_models
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
       stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([instance_double(Backup, last_modified: Time.now - 1 * 24 * 60 * 60)])

--- a/spec/prog/rotate_storage_kek_spec.rb
+++ b/spec/prog/rotate_storage_kek_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Prog::RotateStorageKek do
 
   describe "#start" do
     it "creates a key & hops to install" do
+      skip_if_frozen_models
       expect(StorageKeyEncryptionKey).to receive(:create).and_return(current_kek)
       expect(volume).to receive(:update).with({key_encryption_key_2_id: current_kek.id})
       expect { rsk.start }.to hop("install")

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Prog::Test::GithubRunner do
 
   describe "#wait_vm_pool_to_be_ready" do
     it "hops to trigger_test_runs when the pool is ready" do
+      skip_if_frozen_models
       pool = instance_double(VmPool, size: 1)
       expect(VmPool).to receive(:[]).and_return(pool)
       expect(pool).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, exclude: [instance_double(Vm)]))
@@ -59,6 +60,7 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "naps if the vm in the pool not provisioned yet" do
+      skip_if_frozen_models
       pool = instance_double(VmPool, size: 1)
       expect(VmPool).to receive(:[]).and_return(pool)
       expect(pool).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, exclude: []))
@@ -127,6 +129,7 @@ RSpec.describe Prog::Test::GithubRunner do
 
   describe "#clean_resources" do
     it "not clean with github exists" do
+      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
@@ -136,6 +139,7 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop finish" do
+      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
@@ -147,6 +151,7 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop failed" do
+      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
@@ -159,6 +164,7 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources already cancelled" do
+      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe Prog::Test::HetznerServer do
 
   describe "#vm_host" do
     it "returns the vm_host" do
+      skip_if_frozen_models
       prg = described_class.new(Strand.new(stack: [{"vm_host_id" => "123"}]))
       vmh = instance_double(VmHost)
       expect(VmHost).to receive(:[]).with("123").and_return(vmh)

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -20,12 +20,14 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#wait_vms" do
     it "hops to verify_vms if vms are ready" do
+      skip_if_frozen_models
       expect(vg_test).to receive(:frame).and_return({"vms" => ["111"]})
       expect(Vm).to receive(:[]).with("111").and_return(instance_double(Vm, display_state: "running"))
       expect { vg_test.wait_vms }.to hop("verify_vms")
     end
 
     it "naps if vms are not running" do
+      skip_if_frozen_models
       expect(vg_test).to receive(:frame).and_return({"vms" => ["111"]})
       expect(Vm).to receive(:[]).with("111").and_return(instance_double(Vm, display_state: "creating"))
       expect { vg_test.wait_vms }.to nap(10)
@@ -81,6 +83,7 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#destroy_resources" do
     it "hops to wait_resources_destroyed" do
+      skip_if_frozen_models
       allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
       expect(Vm).to receive(:[]).with("vm_id").and_return(instance_double(Vm, incr_destroy: nil))
       expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(instance_double(PrivateSubnet, incr_destroy: nil))
@@ -90,6 +93,7 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#wait_resources_destroyed" do
     it "hops to finish if all resources are destroyed" do
+      skip_if_frozen_models
       allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
       expect(Vm).to receive(:[]).with("vm_id").and_return(nil)
       expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(nil)
@@ -98,6 +102,7 @@ RSpec.describe Prog::Test::VmGroup do
     end
 
     it "naps if all resources are not destroyed yet" do
+      skip_if_frozen_models
       allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
       expect(Vm).to receive(:[]).with("vm_id").and_return(instance_double(Vm))
       expect { vg_test.wait_resources_destroyed }.to nap(5)

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "provisions a VM if the pool is not existing" do
+      skip_if_frozen_models
       expect(VmPool).to receive(:where).and_return([])
       expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
       expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
@@ -83,6 +84,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "provisions a new vm if pool is valid but there is no vm" do
+      skip_if_frozen_models
       git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150, arch: "x64")
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
@@ -100,6 +102,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses the existing vm if pool can pick one" do
+      skip_if_frozen_models
       git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150, arch: "arm64")
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
@@ -139,6 +142,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "creates new billing record when no daily record" do
       skip_if_frozen
+      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -152,6 +156,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "uses separate billing rate for arm64 runners" do
       skip_if_frozen
+      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:label).and_return("ubicloud-arm").at_least(:once)
@@ -167,6 +172,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "uses separate billing rate for gpu runners" do
       skip_if_frozen
+      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:label).and_return("ubicloud-gpu").at_least(:once)
@@ -182,6 +188,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "updates the amount of existing billing record" do
       skip_if_frozen
+      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -195,6 +202,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "create a new record for a new day" do
       skip_if_frozen
+      skip_if_frozen_models
       today = Time.now
       tomorrow = today + 24 * 60 * 60
       expect(Time).to receive(:now).and_return(today).exactly(5)
@@ -215,6 +223,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "tries 3 times and creates single billing record" do
       skip_if_frozen
+      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -228,6 +237,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "tries 4 times and fails" do
       skip_if_frozen
+      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -245,6 +245,7 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "resolves the page if host is available" do
+      skip_if_frozen_models
       expect(vm_host).to receive(:ubid).and_return("vhxxxx").at_least(:once)
       expect(Prog::PageNexus).to receive(:assemble)
       pg = instance_double(Page)
@@ -255,6 +256,7 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "does not resolves the page if there is none" do
+      skip_if_frozen_models
       expect(vm_host).to receive(:ubid).and_return("vhxxxx").at_least(:once)
       expect(Prog::PageNexus).to receive(:assemble)
       expect(nx).to receive(:available?).and_return(true)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates Nic if only subnet_id is passed" do
+      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with(ps.id).and_return(ps)
       expect(Prog::Vnet::NicNexus).to receive(:assemble).and_return(nic)
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
@@ -90,6 +91,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "adds the VM to a private subnet if nic_id is passed" do
+      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:private_subnet).and_return(ps).at_least(:once)
       expect(nic).to receive(:update).and_return(nic)
@@ -127,6 +129,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if nic is assigned to a different vm" do
+      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:vm_id).and_return("57afa8a7-2357-4012-9632-07fbe13a3133")
       expect {
@@ -135,6 +138,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if nic subnet is in another location" do
+      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(ps).to receive(:location).and_return("hel2")
@@ -144,6 +148,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if subnet of nic belongs to another project" do
+      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(Project).to receive(:[]).with(prj.id).and_return(prj)
@@ -155,6 +160,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if subnet belongs to another project" do
+      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with(ps.id).and_return(ps)
       expect(Project).to receive(:[]).with(prj.id).and_return(prj)
       expect(prj).to receive(:private_subnets).and_return([ps]).at_least(:once)
@@ -174,6 +180,7 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe ".assemble_with_sshable" do
     it "calls .assemble with generated ssh key" do
+      skip_if_frozen_models
       st_id = "eb3dbcb3-2c90-8b74-8fb4-d62a244d7ae5"
       expect(SshKey).to receive(:generate).and_return(instance_double(SshKey, public_key: "public", keypair: "pair"))
       expect(described_class).to receive(:assemble) do |public_key, project_id, **kwargs|
@@ -530,6 +537,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates billing records when ip4 is enabled" do
+      skip_if_frozen_models
       vm_addr = instance_double(AssignedVmAddress, id: "46ca6ded-b056-4723-bd91-612959f52f6f", ip: NetAddr::IPv4Net.parse("10.0.0.1"))
       expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)
       expect(vm).to receive(:ip4_enabled).and_return(true)
@@ -539,6 +547,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates billing records when ip4 is not enabled" do
+      skip_if_frozen_models
       expect(vm).to receive(:ip4_enabled).and_return(false)
       expect(BillingRecord).to receive(:create_with_id).exactly(3).times
       expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
@@ -546,6 +555,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "not create billing records when the project is not billable" do
+      skip_if_frozen_models
       expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
       expect(prj).to receive(:billable).and_return(false)
       expect(BillingRecord).not_to receive(:create_with_id)
@@ -668,6 +678,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "resolves the page if vm is available" do
+      skip_if_frozen_models
       pg = instance_double(Page)
       expect(pg).to receive(:incr_resolve)
       expect(nx).to receive(:available?).and_return(true)
@@ -676,6 +687,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "does not resolves the page if there is none" do
+      skip_if_frozen_models
       expect(nx).to receive(:available?).and_return(true)
       expect(Page).to receive(:from_tag_parts).and_return(nil)
       expect { nx.unavailable }.to hop("wait")

--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
   end
 
   it "returns vm_host" do
+    skip_if_frozen_models
     expect(VmHost).to receive(:[]).with(1).and_return(vm_host)
     expect(pr.vm_host).to eq(vm_host)
   end

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Prog::Vm::VmPool do
     end
 
     it "waits even if the vm count is less when there are waiting GithubRunners" do
+      skip_if_frozen_models
       pool.update(size: 1)
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       expect(GithubRunner).to receive_message_chain(:join, :where, :count).and_return(1) # rubocop:disable RSpec/MessageChain

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   describe "#wait_dns_update" do
     it "waits for dns_record to be seen by all servers" do
+      skip_if_frozen_models
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name", record_content: "content")).at_least(:once)
       dns_record = instance_double(DnsRecord, id: SecureRandom.uuid)
@@ -288,6 +289,7 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   describe "#dns_zone" do
     it "returns the dns zone" do
+      skip_if_frozen_models
       expect(DnsZone).to receive(:[]).with(cert.dns_zone_id).and_return("dns-zone")
       expect(nx.dns_zone).to eq "dns-zone"
     end

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Prog::Vnet::CertServer do
   }
 
   before do
+    skip_if_frozen_models
     allow(lb).to receive(:active_cert).and_return(lb.certs.first)
     allow(Vm).to receive(:[]).and_return(vm)
   end

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
     }
 
     before do
+      skip_if_frozen_models
       allow(vm).to receive(:vm_host).and_return(vmh)
       lb.add_vm(vm)
       lb.load_balancers_vms_dataset.update(state: "up")

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
     end
 
     it "does not rewrite dns records if no dns zone" do
+      skip_if_frozen_models
       vms = [instance_double(Vm, ephemeral_net4: NetAddr::IPv4Net.parse("192.168.1.0"), ephemeral_net6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fb0::"))]
       expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
       expect(DnsRecord).not_to receive(:create)

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "uses ipv6_addr if passed" do
+      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with("57afa8a7-2357-4012-9632-07fbe13a3133").and_return(ps)
       expect(ps).to receive(:random_private_ipv4).and_return("10.0.0.12/32")
       expect(ps).not_to receive(:random_private_ipv6)
@@ -35,6 +36,7 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "uses ipv4_addr if passed" do
+      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with("57afa8a7-2357-4012-9632-07fbe13a3133").and_return(ps)
       expect(ps).to receive(:random_private_ipv6).and_return("fd10:9b0b:6b4b:8fbb::/128")
       expect(ps).not_to receive(:random_private_ipv4)

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -298,6 +298,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "finds a new subnet if the one it found is taken" do
+      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:random_subnet).and_return("10.0.0.0/8").at_least(:once)
       project = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
       described_class.assemble(project.id, location: "hetzner-hel1", name: "test-subnet", ipv4_range: "10.0.0.128/26")
@@ -306,6 +307,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "finds a new subnet if the one it found is banned" do
+      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:random_subnet).and_return("172.16.0.0/16", "10.0.0.0/8")
       project = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
       allow(SecureRandom).to receive(:random_number).with(2**(26 - 16) - 1).and_return(1)
@@ -336,12 +338,14 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     }
 
     it "creates tunnels if not existing" do
+      skip_if_frozen_models
       expect(IpsecTunnel).to receive(:create).with(src_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b", dst_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d").and_return(true)
       expect(IpsecTunnel).to receive(:create).with(src_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d", dst_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b").and_return(true)
       nx.create_tunnels([src_nic, dst_nic], dst_nic)
     end
 
     it "skips existing tunnels" do
+      skip_if_frozen_models
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b", dst_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d").and_return(true)
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d", dst_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b").and_return(false)
 
@@ -350,6 +354,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "skips existing tunnels - 2" do
+      skip_if_frozen_models
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b", dst_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d").and_return(false)
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d", dst_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b").and_return(true)
 

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ResourceMethods do
   end
 
   it "archives scrubbed version of the model when deleted" do
+    skip_if_frozen_models
     scrubbed_values_hash = sa.values.merge(model_name: "Sshable")
     scrubbed_values_hash.delete(:raw_private_key_1)
     scrubbed_values_hash.delete(:raw_private_key_2)

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach to subnet" do
+      skip_if_frozen_models
       ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
@@ -124,6 +125,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "detach from subnet" do
+      skip_if_frozen_models
       ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
@@ -144,6 +146,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach and detach" do
+      skip_if_frozen_models
       ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps).twice
       expect(ps).to receive(:incr_update_firewall_rules).twice

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -209,6 +209,7 @@ RSpec.describe Clover, "postgres" do
 
       it "restore" do
         skip_if_frozen
+        skip_if_frozen_models
         stub_const("Backup", Struct.new(:key, :last_modified))
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
@@ -267,6 +268,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "failover" do
+        skip_if_frozen_models
         project.set_ff_postgresql_base_image(true)
         pg.save_changes
         rs = pg.representative_server

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Clover, "github" do
   end
 
   it "setups blob storage if no access key" do
+    skip_if_frozen_models
     vm = create_vm
     login_runtime(vm)
     repository = instance_double(GithubRepository, access_key: nil)

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Clover do
   end
 
   it "handles unexpected errors" do
+    skip_if_frozen_models
     expect(Account).to receive(:[]).and_raise(RuntimeError)
     expect { visit "/create-account" }.to output(/RuntimeError.*/).to_stderr
     expect(page.title).to eq("Ubicloud - UnexceptedError")

--- a/spec/routes/web/github_spec.rb
+++ b/spec/routes/web/github_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Clover, "github" do
   end
 
   it "raises forbidden when does not have permissions to the project in session" do
+    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
     project.access_policies.first.update(body: {})
@@ -60,6 +61,7 @@ RSpec.describe Clover, "github" do
   end
 
   it "redirects to user management page if it requires approval" do
+    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
 
@@ -70,6 +72,7 @@ RSpec.describe Clover, "github" do
   end
 
   it "fails if oauth code is invalid" do
+    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("invalid").and_return({})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
 
@@ -80,6 +83,7 @@ RSpec.describe Clover, "github" do
   end
 
   it "fails if installation not found" do
+    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: []})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
@@ -91,6 +95,7 @@ RSpec.describe Clover, "github" do
   end
 
   it "fails if the current user's account suspended" do
+    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
@@ -103,6 +108,7 @@ RSpec.describe Clover, "github" do
   end
 
   it "creates installation with project from session" do
+    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "can not connect GitHub account if project has no valid payment method" do
+      skip_if_frozen_models
       expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 
@@ -60,6 +61,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "shows new billing info button instead of connect account if project has no valid payment method" do
+      skip_if_frozen_models
       expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
       # rubocop:disable RSpec/VerifiedDoubles

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe Clover, "postgres" do
 
       it "can restore PostgreSQL database" do
         skip_if_frozen
+        skip_if_frozen_models
         stub_const("Backup", Struct.new(:key, :last_modified))
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
@@ -347,6 +348,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "cannot delete metric destination if it is not exist" do
+        skip_if_frozen_models
         md = PostgresMetricDestination.create_with_id(
           postgres_resource_id: pg.id,
           url: "https://example.com",

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Clover, "project" do
 
     describe "list" do
       it "can list no projects" do
+        skip_if_frozen_models
         expect(Account).to receive(:[]).and_return(user).twice
         expect(user).to receive(:projects).and_return([]).at_least(1)
 
@@ -315,6 +316,7 @@ RSpec.describe Clover, "project" do
       end
 
       it "can not have more than 50 pending invitations" do
+        skip_if_frozen_models
         visit "#{project.path}/user"
 
         expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -7,7 +7,8 @@ require "capybara/rspec"
 
 Gem.suffix_pattern
 
-Capybara.app = Clover.freeze.app
+Clover.freeze if ENV["FORCE_AUTOLOAD"] == "1"
+Capybara.app = Clover.app
 Capybara.exact = true
 
 module RackTestPlus

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can not create virtual machine if project has no valid payment method" do
+        skip_if_frozen_models
         expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
         expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "updates job details of runner when receive in_progress action" do
+      skip_if_frozen_models
       expect(Clog).to receive(:emit).with("runner_started")
       expect(runner).to receive(:vm).and_return(instance_double(Vm, ubid: "vm-ubid", arch: "x64", cores: 2, vm_host: nil, pool_id: nil)).at_least(:once)
       expect(GithubRunner).to receive(:first).and_return(runner)
@@ -125,6 +126,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "fails if unexpected action" do
+      skip_if_frozen_models
       expect(GithubRunner).to receive(:first).and_return(runner)
       send_webhook("workflow_job", workflow_job_payload(action: "approved"))
 

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -665,6 +665,7 @@ RSpec.describe Al do
     end
 
     it "allocates the vm to a host with IPv4 address" do
+      skip_if_frozen_models
       vm = create_vm
       vmh = VmHost.first
       address = Address.new(cidr: "0.0.0.0/30", routed_to_host_id: vmh.id)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
 
 RSpec.configure do |config|
   config.before(:suite) do
-    clover_freeze if ENV["CLOVER_FREEZE"] == "1"
+    clover_freeze if ENV["CLOVER_FREEZE_CORE"] == "1"
   end
 
   config.around do |example|
@@ -206,7 +206,7 @@ RSpec.configure do |config|
     end
   end
 
-  if ENV["CLOVER_FREEZE"] == "1"
+  if ENV["CLOVER_FREEZE_CORE"] == "1"
     # Required by rspec after running examples
     require "ripper"
     require "coderay"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
 RSpec.configure do |config|
   config.before(:suite) do
     clover_freeze if ENV["CLOVER_FREEZE_CORE"] == "1"
+    Clover.freeze if ENV["CLOVER_FREEZE_MODELS"] == "1"
   end
 
   config.around do |example|
@@ -114,6 +115,10 @@ RSpec.configure do |config|
   # particularly slow.  However, avoid printing when parallel testing,
   # to avoid output from every process.
   config.profile_examples = 10 unless ENV["TEST_ENV_NUMBER"]
+
+  if ENV["CLOVER_FREEZE_CORE"] == "1" || ENV["CLOVER_FREEZE_MODELS"] == "1"
+    require_relative "suppress_pending"
+  end
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -212,10 +217,19 @@ RSpec.configure do |config|
     require "coderay"
 
     def skip_if_frozen
-      skip("Spec skipped when running with frozen environment")
+      skip("Spec skipped when running with frozen core")
     end
   else
     def skip_if_frozen
+    end
+  end
+
+  if ENV["CLOVER_FREEZE_MODELS"] == "1"
+    def skip_if_frozen_models
+      skip("Spec skipped when running with frozen Database/models")
+    end
+  else
+    def skip_if_frozen_models
     end
   end
 end

--- a/spec/suppress_pending.rb
+++ b/spec/suppress_pending.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# When running specs with frozen core, Database, or models, do not show
+# all skipped tests after the run. This is the approach recommended by
+# rspec maintainers in
+# https://github.com/rspec/rspec-core/issues/2377#issuecomment-275131981
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides
+RSpec::Core::Formatters::ProgressFormatter.prepend FormatterOverrides


### PR DESCRIPTION
This makes the testing more like the production environment.

This renames the previous frozen_{,p}spec rake task to
frozen_core_{,p}spec, and adds:

* frozen_db_model_{,p}spec for running the specs with just a frozen
  Database and models
* frozen_{,p}spec for running the specs with a frozen core, Database,
  and models (the most similar to the production environment, but
  the most skipped tests).

This adds rspec and turbo_tests lambdas to DRY up the related rake
task code. It sets RAKE_ENV explicitly for turbo_tests, instead
of relying on the Rakefile setting it implicitly due to how the
spec task is currently defined.

This adds a skip_if_frozen_models method to the specs, which does
nothing when running without frozen Database and models, but skips
the spec if running with frozen Database and models.  It then
adds a call to skip_if_frozen_models to all specs that try to mock
DB or the models (109 callsites, 124 specs).

To avoid pages of output of skipped specs, this uses the approach
recommended by the rspec maintainers to suppress skipped specs.
The approach is stored in a separate spec/supress_pending.rb file
so it is usable by both the normal and parallel specs.

I tested this with the implicit_subquery commit
(0085befc4a41ab8e2a257fbf97fda5813d7d5727), and the frozen model
tests fail with it, showing that this approach would have caught
that failure before the change was put into production.

Related changes:

* Eagerly set pagerduty_client when freezing Page.
* Remove duplicate CLOVER_FREEZE_CORE check in clover_freeze.
* Rename CLOVER_FREEZE to CLOVER_FREEZE_CORE