### PR TITLE
Improve awesome_print rendering of Sequel

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -9,6 +9,7 @@ require "pry"
 
 if Config.development?
   require "awesome_print"
+  require "awesome_print/ext/sequel"
 end
 
 def dev_project


### PR DESCRIPTION
Because the loader is extremely lazy -- mostly a good thing, for fast test and repl start-up -- the Sequel extension in `awesome_print` will not auto-detect:

https://github.com/awesome-print/awesome_print/blob/8a7ff0aabacbebf694c3e27242809219a96d5a3b/lib/awesome_print.rb#L39

    require 'awesome_print/ext/sequel'         if defined?(Sequel)

Reproduce this in our own loader, and make it unconditional.  I checked that it is still lazy, i.e. does not load Sequel:

    fdr@albatross ~/c/clover ((192f7767))> ./bin/pry
    [1] clover-development(main)> require 'awesome_print/ext/sequel'
    => true
    [2] clover-development(main)> Sequel
    NameError: uninitialized constant Sequel
    from (pry):2:in `__pry__'
    [3] clover-development(main)>

The net result of this change: the unadorned hash of model objects will now carry `inspect` output changes as seen at c7d6d38bff53a09cde084344ee54ba5c050e3f51.

Before:

    [1] clover-development(main)> ap VmHost.first
    {
                        :id => "609bdd6f-ade3-8371-9a2f-7b4f3234ece5",
          :allocation_state => "accepting",
          ...

After:

    [1] clover-development(main)> ap VmHost.first
    VmHost[vhc2dxtvxdwe0k8qqpksj6kpea] {
          :allocation_state => "accepting",
                      :arch => "x64",
                      ...

Note `VmHost[vhc2dxtvxdwe0k8qqpksj6kpea]`.

There are a few other changes that are perhaps not as good, e.g. strict lexical order of columns meaning that `id` does not appear first. It's also perhaps not so good that the rendering loses quotes around the ubid, unlike regular `inspect`, which make it less copy-pastable: `#<VmHost["vhc2dxtvxdwe0k8qqpksj6kpea"] @values={...`

Nevertheless, an improvement.