### PR TITLE
Automatically use parallel testing in Rakefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /demo/.env
 /var/*
 /tmp/*
+/.auto-parallel-tests
 
 # Used by rake by
 /bin/by

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@
 
 require "sequel"
 
+auto_parallel_tests = nil
+auto_parallel_tests_file = ".auto-parallel-tests"
+
 # Migrate
 migrate = lambda do |env, version, db: nil|
   ENV["RACK_ENV"] = env
@@ -74,12 +77,19 @@ task :prod_up do
 end
 
 # Database setup
+
+nproc = lambda do
+  # Limit to 6 processes, as higher number results in more time
+  `(nproc 2> /dev/null) || sysctl -n hw.logicalcpu`.to_i.clamp(1, 6).to_s
+end
+
 desc "Setup database"
 task :setup_database, [:env, :parallel] do |_, args|
   raise "env must be test or dev" if !["test", "development"].include?(args[:env])
   raise "parallel can only be used in test" if args[:parallel] && args[:env] != "test"
+  File.binwrite(auto_parallel_tests_file, "1") if args[:parallel] && !File.file?(auto_parallel_tests_file)
 
-  database_count = args[:parallel] ? `nproc`.to_i : 1
+  database_count = args[:parallel] ? nproc.call.to_i : 1
   threads = []
   database_count.times do |i|
     threads << Thread.new do
@@ -117,74 +127,59 @@ ENVRB
 end
 
 # Specs
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:_spec)
-  Rake::Task["_spec"].clear_comments
-rescue LoadError
-else
-  desc "Run specs"
-  task "spec" do
-    ENV["RACK_ENV"] = "test"
-    ENV["FORCE_AUTOLOAD"] = "1"
-    Rake::Task["_spec"].invoke
-  end
 
-  rspec = lambda do |env|
-    sh(env.merge("RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "rspec", "spec")
-  end
+desc "Run specs in with coverage in unfrozen mode, and without coverage in frozen mode"
+task default: [:coverage, :frozen_spec]
 
-  desc "Run specs with coverage"
-  task "coverage" do
-    rspec.call("COVERAGE" => "1")
-  end
-
-  desc "Run specs with frozen core, Database, and models (similar to production)"
-  task "frozen_spec" do
-    rspec.call("CLOVER_FREEZE_CORE" => "1", "CLOVER_FREEZE_MODELS" => "1")
-  end
-
-  desc "Run specs with frozen core"
-  task "frozen_core_spec" do
-    rspec.call("CLOVER_FREEZE_CORE" => "1")
-  end
-
-  desc "Run specs with frozen Database and models"
-  task "frozen_db_model_spec" do
-    rspec.call("CLOVER_FREEZE_MODELS" => "1")
-  end
-
-  desc "Run specs in with coverage in unfrozen mode, and without coverage in frozen mode"
-  task default: [:coverage, :frozen_spec]
-end
-
-nproc = lambda do
-  # Limit to 6 processes, as higher number results in more time
-  `(nproc 2> /dev/null) || sysctl -n hw.logicalcpu`.to_i.clamp(1, 6).to_s
+rspec = lambda do |env|
+  sh(env.merge("RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "rspec", "spec")
 end
 
 turbo_tests = lambda do |env|
   sh(env.merge("RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "turbo_tests", "-r", "./spec/suppress_pending", "-n", nproc.call)
 end
 
-desc "Run specs in parallel using turbo_tests"
-task "pspec" do
-  turbo_tests.call({})
+spec = lambda do |env|
+  if auto_parallel_tests.nil?
+    auto_parallel_tests = File.file?(auto_parallel_tests_file) && File.binread(auto_parallel_tests_file) == "1"
+  end
+
+  block = auto_parallel_tests ? turbo_tests : rspec
+  block.call(env)
 end
 
-desc "Run parallel specs with frozen core, Database, and models (similar to production)"
-task "frozen_pspec" do
-  turbo_tests.call("CLOVER_FREEZE_CORE" => "1", "CLOVER_FREEZE_MODELS" => "1")
-end
+desc "Run specs with coverage"
+task "coverage" => [:coverage_spec]
 
-desc "Run parallel specs with frozen core"
-task "frozen_core_pspec" do
-  turbo_tests.call("CLOVER_FREEZE_CORE" => "1")
-end
+{
+  "sspec" => [" in serial", rspec],
+  "pspec" => [" in parallel", turbo_tests],
+  "spec" => ["", spec]
+}.each do |task_suffix, (desc_suffix, block)|
+  desc "Run specs#{desc_suffix}"
+  task task_suffix do
+    block.call({})
+  end
 
-desc "Run parallel specs with frozen Database and models"
-task "frozen_db_model_pspec" do
-  turbo_tests.call("CLOVER_FREEZE_MODELS" => "1")
+  desc "Run specs#{desc_suffix} with frozen core, Database, and models (similar to production)"
+  task "frozen_#{task_suffix}" do
+    block.call("CLOVER_FREEZE_CORE" => "1", "CLOVER_FREEZE_MODELS" => "1")
+  end
+
+  desc "Run specs#{desc_suffix} with frozen core"
+  task "frozen_core_#{task_suffix}" do
+    block.call("CLOVER_FREEZE_CORE" => "1")
+  end
+
+  desc "Run specs#{desc_suffix} with frozen Database and models"
+  task "frozen_db_model_#{task_suffix}" do
+    block.call("CLOVER_FREEZE_MODELS" => "1")
+  end
+
+  desc "Run specs#{desc_suffix} with coverage"
+  task "coverage_#{task_suffix}" do
+    block.call("COVERAGE" => "1")
+  end
 end
 
 # Other


### PR DESCRIPTION
If a developer runs `rake setup_database[test,1]`, create a `.auto-parallel-tests` file to let the Rakefile know to use parallel testing by default.

Create *sspec tasks for every *pspec task.  The *sspec tasks force serial execution (rspec instead of turbo_tests), and are useful for debugging parallel testing issues.  The *pspec tasks force parallel execution, and will fail if the parallel test databases have not been setup.  The *spec tasks check for the `.auto-parallel-tests` file, and run in parallel mode if it is present and has content "1", and in serial mode otherwise.

Fix setup_database to clamp the number of created databases to 6, since the parallel tests are clamped to 6 processes.

To force serial mode always, even when using
`rake setup_database[test,1]`, manually modify the `.auto-parallel-tests` file to have content other than "1".