### PR TITLE
Rename current_user to current_account

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -365,7 +365,7 @@ class CloverWeb < Roda
   end
 
   hash_branch("after-login") do |r|
-    if (project = current_user.projects_dataset.order(:created_at).first)
+    if (project = current_account.projects_dataset.order(:created_at).first)
       r.redirect "#{project.path}/dashboard"
     else
       r.redirect "/project"

--- a/routes/api/project.rb
+++ b/routes/api/project.rb
@@ -3,7 +3,7 @@
 class CloverApi
   hash_branch("project") do |r|
     r.get true do
-      result = Project.authorized(current_user.id, "Project:view").where(visible: true).paginated_result(
+      result = Project.authorized(current_account.id, "Project:view").where(visible: true).paginated_result(
         start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
@@ -20,7 +20,7 @@ class CloverApi
 
       request_body_params = Validation.validate_request_body(r.body.read, required_parameters)
 
-      project = current_user.create_project_with_default_policy(request_body_params["name"])
+      project = current_account.create_project_with_default_policy(request_body_params["name"])
 
       Serializers::Project.serialize(project)
     end
@@ -34,12 +34,12 @@ class CloverApi
         r.halt
       end
 
-      unless @project.accounts.any? { _1.id == current_user.id }
+      unless @project.accounts.any? { _1.id == current_account.id }
         fail Authorization::Unauthorized
       end
 
       r.delete true do
-        Authorization.authorize(current_user.id, "Project:delete", @project.id)
+        Authorization.authorize(current_account.id, "Project:delete", @project.id)
 
         # If it has some resources, do not allow to delete it.
         if @project.has_resources
@@ -53,7 +53,7 @@ class CloverApi
       end
 
       r.get true do
-        Authorization.authorize(current_user.id, "Project:view", @project.id)
+        Authorization.authorize(current_account.id, "Project:view", @project.id)
 
         Serializers::Project.serialize(@project)
       end

--- a/routes/api/project/firewall.rb
+++ b/routes/api/project/firewall.rb
@@ -3,7 +3,7 @@
 class CloverApi
   hash_branch(:project_prefix, "firewall") do |r|
     r.get true do
-      result = @project.firewalls_dataset.authorized(current_user.id, "Firewall:view").eager(:firewall_rules).paginated_result(
+      result = @project.firewalls_dataset.authorized(current_account.id, "Firewall:view").eager(:firewall_rules).paginated_result(
         start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]

--- a/routes/api/project/load_balancer.rb
+++ b/routes/api/project/load_balancer.rb
@@ -2,7 +2,7 @@
 
 class CloverApi
   hash_branch(:project_prefix, "load-balancer") do |r|
-    load_balancer_endpoint_helper = Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    load_balancer_endpoint_helper = Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       load_balancer_endpoint_helper.list

--- a/routes/api/project/location/firewall.rb
+++ b/routes/api/project/location/firewall.rb
@@ -3,7 +3,7 @@
 class CloverApi
   hash_branch(:project_location_prefix, "firewall") do |r|
     r.get true do
-      result = @project.firewalls_dataset.where(location: @location).authorized(current_user.id, "Firewall:view").eager(:firewall_rules).paginated_result(
+      result = @project.firewalls_dataset.where(location: @location).authorized(current_account.id, "Firewall:view").eager(:firewall_rules).paginated_result(
         start_after: r.params["start_after"],
         page_size: r.params["page_size"],
         order_column: r.params["order_column"]
@@ -18,7 +18,7 @@ class CloverApi
     r.on NAME_OR_UBID do |firewall_name, firewall_id|
       if firewall_name
         r.post true do
-          Authorization.authorize(current_user.id, "Firewall:create", @project.id)
+          Authorization.authorize(current_account.id, "Firewall:create", @project.id)
 
           allowed_optional_parameters = ["description"]
           request_body_params = Validation.validate_request_body(r.body.read, [], allowed_optional_parameters)
@@ -37,7 +37,7 @@ class CloverApi
 
       filter[:location] = @location
       @firewall = @project.firewalls_dataset.first(filter)
-      handle_firewall_requests(current_user, @firewall, @location)
+      handle_firewall_requests(current_account, @firewall, @location)
     end
 
     # 204 response for invalid names
@@ -91,7 +91,7 @@ class CloverApi
     end
 
     request.post "detach-subnet" do
-      Authorization.authorize(current_user.id, "PrivateSubnet:edit", @project.id)
+      Authorization.authorize(current_account.id, "PrivateSubnet:edit", @project.id)
 
       required_parameters = ["private_subnet_id"]
       request_body_params = Validation.validate_request_body(request.body.read, required_parameters)

--- a/routes/api/project/location/firewall/firewall_rule.rb
+++ b/routes/api/project/location/firewall/firewall_rule.rb
@@ -3,7 +3,7 @@
 class CloverApi
   hash_branch(:project_location_firewall_prefix, "firewall-rule") do |r|
     r.post true do
-      Authorization.authorize(current_user.id, "Firewall:edit", @firewall.id)
+      Authorization.authorize(current_account.id, "Firewall:edit", @firewall.id)
 
       required_parameters = ["cidr"]
       allowed_optional_parameters = ["port_range"]
@@ -29,7 +29,7 @@ class CloverApi
 
       request.delete true do
         if firewall_rule
-          Authorization.authorize(current_user.id, "Firewall:edit", @firewall.id)
+          Authorization.authorize(current_account.id, "Firewall:edit", @firewall.id)
           @firewall.remove_firewall_rule(firewall_rule)
         end
 
@@ -39,7 +39,7 @@ class CloverApi
 
       request.get true do
         if firewall_rule
-          Authorization.authorize(current_user.id, "Firewall:view", @firewall.id)
+          Authorization.authorize(current_account.id, "Firewall:view", @firewall.id)
           Serializers::FirewallRule.serialize(firewall_rule)
         end
       end

--- a/routes/api/project/location/load_balancer.rb
+++ b/routes/api/project/location/load_balancer.rb
@@ -3,7 +3,7 @@
 class CloverApi
   hash_branch(:project_location_prefix, "load-balancer") do |r|
     r.get true do
-      Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_user, location: @location, resource: nil).list
+      Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_account, location: @location, resource: nil).list
     end
 
     r.on NAME_OR_UBID do |lb_name, lb_id|
@@ -15,7 +15,7 @@ class CloverApi
 
       filter[:private_subnet_id] = @project.private_subnets_dataset.where(location: @location).select(Sequel[:private_subnet][:id])
       lb = LoadBalancer.first(filter)
-      handle_lb_requests(current_user, lb)
+      handle_lb_requests(current_account, lb)
     end
   end
 

--- a/routes/api/project/location/postgres.rb
+++ b/routes/api/project/location/postgres.rb
@@ -2,7 +2,7 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "postgres") do |r|
-    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_user, location: @location, resource: nil)
+    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_account, location: @location, resource: nil)
 
     r.get true do
       pg_endpoint_helper.list

--- a/routes/api/project/location/private_subnet.rb
+++ b/routes/api/project/location/private_subnet.rb
@@ -2,7 +2,7 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "private-subnet") do |r|
-    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_user, location: @location, resource: nil)
+    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_account, location: @location, resource: nil)
 
     r.get true do
       ps_endpoint_helper.list

--- a/routes/api/project/location/vm.rb
+++ b/routes/api/project/location/vm.rb
@@ -2,7 +2,7 @@
 
 class CloverApi
   hash_branch(:project_location_prefix, "vm") do |r|
-    vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_user, location: @location, resource: nil)
+    vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_account, location: @location, resource: nil)
 
     r.get true do
       vm_endpoint_helper.list

--- a/routes/api/project/postgres.rb
+++ b/routes/api/project/postgres.rb
@@ -2,7 +2,7 @@
 
 class CloverApi
   hash_branch(:project_prefix, "postgres") do |r|
-    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       pg_endpoint_helper.list

--- a/routes/api/project/private_subnet.rb
+++ b/routes/api/project/private_subnet.rb
@@ -2,7 +2,7 @@
 
 class CloverApi
   hash_branch(:project_prefix, "private-subnet") do |r|
-    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       ps_endpoint_helper.list

--- a/routes/api/project/vm.rb
+++ b/routes/api/project/vm.rb
@@ -2,7 +2,7 @@
 
 class CloverApi
   hash_branch(:project_prefix, "vm") do |r|
-    vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       vm_endpoint_helper.list

--- a/routes/clover_base.rb
+++ b/routes/clover_base.rb
@@ -19,9 +19,9 @@ module CloverBase
     base.plugin :common_logger, logger
   end
 
-  def current_user
-    return @current_user if defined?(@current_user)
-    @current_user = Account[rodauth.session_value]
+  def current_account
+    return @current_account if defined?(@current_account)
+    @current_account = Account[rodauth.session_value]
   end
 
   # Assign some HTTP response codes to common exceptions.

--- a/routes/web/github.rb
+++ b/routes/web/github.rb
@@ -9,41 +9,41 @@ class CloverWeb
       code_response = Github.oauth_client.exchange_code_for_token(oauth_code)
 
       if (installation = GithubInstallation[installation_id: installation_id])
-        Authorization.authorize(current_user.id, "Project:github", installation.project.id)
+        Authorization.authorize(current_account.id, "Project:github", installation.project.id)
         flash["notice"] = "GitHub runner integration is already enabled for #{installation.project.name} project."
-        Clog.emit("GitHub installation already exists") { {installation_failed: {id: installation_id, account_ubid: current_user.ubid}} }
+        Clog.emit("GitHub installation already exists") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{installation.project.path}/github"
       end
 
       unless (project = Project[session.delete("github_installation_project_id")])
         flash["error"] = "You should initiate the GitHub App installation request from the project's GitHub runner integration page."
-        Clog.emit("GitHub callback failed due to lack of project in the session") { {installation_failed: {id: installation_id, account_ubid: current_user.ubid}} }
+        Clog.emit("GitHub callback failed due to lack of project in the session") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "/dashboard"
       end
 
-      Authorization.authorize(current_user.id, "Project:github", project.id)
+      Authorization.authorize(current_account.id, "Project:github", project.id)
 
       if setup_action == "request"
         flash["notice"] = "The GitHub App installation request is awaiting approval from the GitHub organization's administrator. As GitHub will redirect your admin back to the Ubicloud console, the admin needs to have an Ubicloud account with the necessary permissions to finalize the installation. Please invite the admin to your project if they don't have an account yet."
-        Clog.emit("GitHub installation initiated by non-admin user") { {installation_failed: {id: installation_id, account_ubid: current_user.ubid}} }
+        Clog.emit("GitHub installation initiated by non-admin user") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{project.path}/user"
       end
 
       unless (access_token = code_response[:access_token])
         flash["error"] = "GitHub App installation failed. For any questions or assistance, reach out to our team at support@ubicloud.com"
-        Clog.emit("GitHub callback failed due to lack of permission") { {installation_failed: {id: installation_id, account_ubid: current_user.ubid}} }
+        Clog.emit("GitHub callback failed due to lack of permission") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{project.path}/github"
       end
 
       unless (installation_response = Octokit::Client.new(access_token: access_token).get("/user/installations")[:installations].find { _1[:id].to_s == installation_id })
         flash["error"] = "GitHub App installation failed. For any questions or assistance, reach out to our team at support@ubicloud.com"
-        Clog.emit("GitHub callback failed due to lack of installation") { {installation_failed: {id: installation_id, account_ubid: current_user.ubid}} }
+        Clog.emit("GitHub callback failed due to lack of installation") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{project.path}/github"
       end
 
-      if current_user.suspended_at
+      if current_account.suspended_at
         flash["error"] = "GitHub runner integration is not allowed for suspended accounts."
-        Clog.emit("GitHub callback failed due to suspended account") { {installation_failed: {id: installation_id, account_ubid: current_user.ubid}} }
+        Clog.emit("GitHub callback failed due to suspended account") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{project.path}/dashboard"
       end
 

--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -10,7 +10,7 @@ class CloverWeb
       return "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
     end
 
-    Authorization.authorize(current_user.id, "Project:billing", @project.id)
+    Authorization.authorize(current_account.id, "Project:billing", @project.id)
 
     r.get true do
       if (billing_info = @project.billing_info)

--- a/routes/web/project/firewall.rb
+++ b/routes/web/project/firewall.rb
@@ -3,7 +3,7 @@
 class CloverWeb
   hash_branch(:project_prefix, "firewall") do |r|
     r.get true do
-      authorized_firewalls = @project.firewalls_dataset.authorized(current_user.id, "Firewall:view").all
+      authorized_firewalls = @project.firewalls_dataset.authorized(current_account.id, "Firewall:view").all
       @firewalls = Serializers::Firewall.serialize(authorized_firewalls, {include_path: true})
 
       view "networking/firewall/index"
@@ -11,8 +11,8 @@ class CloverWeb
 
     r.on "create" do
       r.get true do
-        Authorization.authorize(current_user.id, "Firewall:create", @project.id)
-        authorized_subnets = @project.private_subnets_dataset.authorized(current_user.id, "PrivateSubnet:edit").all
+        Authorization.authorize(current_account.id, "Firewall:create", @project.id)
+        authorized_subnets = @project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:edit").all
         @subnets = Serializers::PrivateSubnet.serialize(authorized_subnets)
         @default_location = @project.default_location
         view "networking/firewall/create"
@@ -20,7 +20,7 @@ class CloverWeb
     end
 
     r.post true do
-      Authorization.authorize(current_user.id, "Firewall:create", @project.id)
+      Authorization.authorize(current_account.id, "Firewall:create", @project.id)
       Validation.validate_name(r.params["name"])
       location = LocationNameConverter.to_internal_name(r.params["location"])
 

--- a/routes/web/project/github.rb
+++ b/routes/web/project/github.rb
@@ -7,7 +7,7 @@ class CloverWeb
       return "GitHub Action Runner integration is not enabled. Set GITHUB_APP_NAME to enable it."
     end
 
-    Authorization.authorize(current_user.id, "Project:github", @project.id)
+    Authorization.authorize(current_account.id, "Project:github", @project.id)
 
     r.get true do
       if @project.github_installations.empty?

--- a/routes/web/project/load_balancer.rb
+++ b/routes/web/project/load_balancer.rb
@@ -2,7 +2,7 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "load-balancer") do |r|
-    load_balancer_endpoint_helper = Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    load_balancer_endpoint_helper = Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       load_balancer_endpoint_helper.list

--- a/routes/web/project/location/firewall.rb
+++ b/routes/web/project/location/firewall.rb
@@ -13,7 +13,7 @@ class CloverWeb
 
       r.on "attach-subnet" do
         r.post true do
-          Authorization.authorize(current_user.id, "Firewall:view", fw.id)
+          Authorization.authorize(current_account.id, "Firewall:view", fw.id)
           ps = PrivateSubnet.from_ubid(r.params["private-subnet-id"])
           unless ps && ps.location == @location
             flash["error"] = "Private subnet not found"
@@ -21,7 +21,7 @@ class CloverWeb
             r.redirect "#{@project.path}#{fw.path}"
           end
 
-          Authorization.authorize(current_user.id, "PrivateSubnet:edit", ps.id)
+          Authorization.authorize(current_account.id, "PrivateSubnet:edit", ps.id)
 
           fw.associate_with_private_subnet(ps)
 
@@ -33,7 +33,7 @@ class CloverWeb
 
       r.on "detach-subnet" do
         r.post true do
-          Authorization.authorize(current_user.id, "Firewall:view", fw.id)
+          Authorization.authorize(current_account.id, "Firewall:view", fw.id)
           ps = PrivateSubnet.from_ubid(r.params["private-subnet-id"])
           unless ps && ps.location == @location
             flash["error"] = "Private subnet not found"
@@ -41,7 +41,7 @@ class CloverWeb
             r.redirect "#{@project.path}#{fw.path}"
           end
 
-          Authorization.authorize(current_user.id, "PrivateSubnet:edit", ps.id)
+          Authorization.authorize(current_account.id, "PrivateSubnet:edit", ps.id)
 
           fw.disassociate_from_private_subnet(ps)
 
@@ -52,8 +52,8 @@ class CloverWeb
       end
 
       r.get true do
-        Authorization.authorize(current_user.id, "Firewall:view", fw.id)
-        project_subnets = @project.private_subnets_dataset.where(location: @location).authorized(current_user.id, "PrivateSubnet:view").all
+        Authorization.authorize(current_account.id, "Firewall:view", fw.id)
+        project_subnets = @project.private_subnets_dataset.where(location: @location).authorized(current_account.id, "PrivateSubnet:view").all
         attached_subnets = fw.private_subnets_dataset.all
         @attachable_subnets = Serializers::PrivateSubnet.serialize(project_subnets.reject { |ps| attached_subnets.map(&:id).include?(ps.id) })
         @firewall = Serializers::Firewall.serialize(fw, {detailed: true})
@@ -63,7 +63,7 @@ class CloverWeb
 
       r.on "firewall-rule" do
         r.post true do
-          Authorization.authorize(current_user.id, "Firewall:edit", fw.id)
+          Authorization.authorize(current_account.id, "Firewall:edit", fw.id)
 
           port_range = if r.params["port_range"].empty?
             [0, 65535]
@@ -82,7 +82,7 @@ class CloverWeb
 
         r.is String do |firewall_rule_ubid|
           r.delete true do
-            Authorization.authorize(current_user.id, "Firewall:edit", fw.id)
+            Authorization.authorize(current_account.id, "Firewall:edit", fw.id)
             fwr = FirewallRule.from_ubid(firewall_rule_ubid)
             unless fwr
               response.status = 204
@@ -97,8 +97,8 @@ class CloverWeb
       end
 
       r.delete true do
-        Authorization.authorize(current_user.id, "Firewall:delete", fw.id)
-        fw.private_subnets.map { Authorization.authorize(current_user.id, "PrivateSubnet:edit", _1.id) }
+        Authorization.authorize(current_account.id, "Firewall:delete", fw.id)
+        fw.private_subnets.map { Authorization.authorize(current_account.id, "PrivateSubnet:edit", _1.id) }
         fw.destroy
 
         return {message: "Deleting #{fw.name}"}.to_json

--- a/routes/web/project/location/load_balancer.rb
+++ b/routes/web/project/location/load_balancer.rb
@@ -11,7 +11,7 @@ class CloverWeb
         r.halt
       end
 
-      load_balancer_endpoint_helper = Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_user, resource: lb, location: nil)
+      load_balancer_endpoint_helper = Routes::Common::LoadBalancerHelper.new(app: self, request: r, user: current_account, resource: lb, location: nil)
 
       r.get true do
         load_balancer_endpoint_helper.get

--- a/routes/web/project/location/postgres.rb
+++ b/routes/web/project/location/postgres.rb
@@ -10,7 +10,7 @@ class CloverWeb
         r.halt
       end
 
-      pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_user, location: @location, resource: pg)
+      pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_account, location: @location, resource: pg)
 
       r.get true do
         pg_endpoint_helper.get

--- a/routes/web/project/location/private_subnet.rb
+++ b/routes/web/project/location/private_subnet.rb
@@ -8,7 +8,7 @@ class CloverWeb
         r.halt
       end
 
-      ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_user, location: @location, resource: ps)
+      ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_account, location: @location, resource: ps)
 
       r.get true do
         ps_endpoint_helper.get

--- a/routes/web/project/location/vm.rb
+++ b/routes/web/project/location/vm.rb
@@ -8,7 +8,7 @@ class CloverWeb
         r.halt
       end
 
-      vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_user, location: @location, resource: vm)
+      vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_account, location: @location, resource: vm)
 
       r.get true do
         vm_endpoint_helper.get

--- a/routes/web/project/postgres.rb
+++ b/routes/web/project/postgres.rb
@@ -2,7 +2,7 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "postgres") do |r|
-    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    pg_endpoint_helper = Routes::Common::PostgresHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       pg_endpoint_helper.list

--- a/routes/web/project/private_subnet.rb
+++ b/routes/web/project/private_subnet.rb
@@ -2,7 +2,7 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "private-subnet") do |r|
-    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    ps_endpoint_helper = Routes::Common::PrivateSubnetHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       ps_endpoint_helper.list

--- a/routes/web/project/usage_alert.rb
+++ b/routes/web/project/usage_alert.rb
@@ -2,14 +2,14 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "usage-alert") do |r|
-    Authorization.authorize(current_user.id, "Project:billing", @project.id)
+    Authorization.authorize(current_account.id, "Project:billing", @project.id)
 
     r.post true do
       name = r.params["alert_name"]
       Validation.validate_short_text(name, "name")
       limit = Validation.validate_usage_limit(r.params["limit"])
 
-      UsageAlert.create_with_id(project_id: @project.id, user_id: current_user.id, name: name, limit: limit)
+      UsageAlert.create_with_id(project_id: @project.id, user_id: current_account.id, name: name, limit: limit)
 
       r.redirect "#{@project.path}/billing"
     end

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -2,7 +2,7 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "user") do |r|
-    Authorization.authorize(current_user.id, "Project:user", @project.id)
+    Authorization.authorize(current_account.id, "Project:user", @project.id)
 
     r.get true do
       @user_policies = @project.access_policies_dataset.where(managed: true).flat_map do |policy|
@@ -42,16 +42,16 @@ class CloverWeb
         end
         Util.send_email(email, "Invitation to Join '#{@project.name}' Project on Ubicloud",
           greeting: "Hello,",
-          body: ["You're invited by '#{current_user.name}' to join the '#{@project.name}' project on Ubicloud.",
+          body: ["You're invited by '#{current_account.name}' to join the '#{@project.name}' project on Ubicloud.",
             "To join project, click the button below.",
             "For any questions or assistance, reach out to our team at support@ubicloud.com."],
           button_title: "Join Project",
           button_link: "#{Config.base_url}#{@project.path}/dashboard")
       else
-        @project.add_invitation(email: email, policy: policy, inviter_id: current_user.id, expires_at: Time.now + 7 * 24 * 60 * 60)
+        @project.add_invitation(email: email, policy: policy, inviter_id: current_account.id, expires_at: Time.now + 7 * 24 * 60 * 60)
         Util.send_email(email, "Invitation to Join '#{@project.name}' Project on Ubicloud",
           greeting: "Hello,",
-          body: ["You're invited by '#{current_user.name}' to join the '#{@project.name}' project on Ubicloud.",
+          body: ["You're invited by '#{current_account.name}' to join the '#{@project.name}' project on Ubicloud.",
             "To join project, you need to create an account on Ubicloud. Once you create an account, you'll be automatically joined to the project.",
             "For any questions or assistance, reach out to our team at support@ubicloud.com."],
           button_title: "Create Account",

--- a/routes/web/project/vm.rb
+++ b/routes/web/project/vm.rb
@@ -2,7 +2,7 @@
 
 class CloverWeb
   hash_branch(:project_prefix, "vm") do |r|
-    vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_user, location: nil, resource: nil)
+    vm_endpoint_helper = Routes::Common::VmHelper.new(app: self, request: r, user: current_account, location: nil, resource: nil)
 
     r.get true do
       vm_endpoint_helper.list

--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -17,7 +17,7 @@
               <%== rodauth.csrf_tag("/" + rodauth.change_login_route) %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
-                  <%== render("components/form/text", locals: {label: "Current Email", value: current_user.email, extra_class: "bg-gray-50 text-gray-500 ring-gray-200 ", attributes: {disabled: true}}) %>
+                  <%== render("components/form/text", locals: {label: "Current Email", value: current_account.email, extra_class: "bg-gray-50 text-gray-500 ring-gray-200 ", attributes: {disabled: true}}) %>
                 </div>
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== render("components/rodauth/login_field", locals: {label: "New Email Address"}) %>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -7,7 +7,7 @@
 <div class="grid gap-6">
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 lg:gap-10">
     <% [
-      if (project = current_user.projects_dataset.order(:created_at).first)
+      if (project = current_account.projects_dataset.order(:created_at).first)
         [
           "hero-server-stack", "bg-teal-50 text-teal-700", "Create Virtual Machine",
           "Linux-based virtual machines that run on top of virtualized hardware. Comprehensive, cost-effective cloud computing.",

--- a/views/layouts/sidebar/project_switcher.erb
+++ b/views/layouts/sidebar/project_switcher.erb
@@ -16,7 +16,7 @@
     tabindex="-1"
   >
     <div class="py-1 max-h-64 overflow-y-auto" role="none">
-      <% current_user.projects.each do |p| %>
+      <% current_account.projects.each do |p| %>
         <a
           href="<%= p.path %>/dashboard"
           class="block px-4 py-2 hover:bg-gray-100 hover:text-gray-900 <% if p.id == @project&.id %> bg-orange-50 text-orange-600 hover:bg-orange-50 hover:text-orange-700 <% end %>"

--- a/views/layouts/topbar.erb
+++ b/views/layouts/topbar.erb
@@ -12,10 +12,10 @@
     <div class="flex items-center gap-x-4 lg:gap-x-6">
       <!-- Profile dropdown -->
       <div class="relative group dropdown text-sm leading-6 text-gray-900">
-        <button type="button" class="-m-1.5 flex items-center p-1.5" title="<%= current_user.email %>">
+        <button type="button" class="-m-1.5 flex items-center p-1.5" title="<%= current_account.email %>">
           <%== render("components/icon", locals: { name: "hero-user-circle", classes: "h-8 w-8 rounded-full bg-gray-50" }) %>
           <span class="hidden lg:flex lg:items-center">
-            <span class="ml-3 font-semibold" aria-hidden="true"><%= current_user.name %></span>
+            <span class="ml-3 font-semibold" aria-hidden="true"><%= current_account.name %></span>
             <%== render("components/icon", locals: { name: "hero-chevron-down", classes: "h-5 w-5 ml-2 text-gray-400" }) %>
           </span>
         </button>
@@ -27,7 +27,7 @@
           <div class="px-3 py-2">
             <p class="text-sm">Signed in as</p>
             <p class="truncate text-sm font-medium text-gray-900">
-              <%= current_user.email %></p>
+              <%= current_account.email %></p>
           </div>
           <div>
             <a href="/account" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">My Account</a>

--- a/views/networking/firewall/index.erb
+++ b/views/networking/firewall/index.erb
@@ -19,7 +19,7 @@
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
               text-gray-900 sm:pl-6" scope="row">
-                <% if Authorization.has_permission?(current_user.id, "Firewall:view", fw[:id]) %>
+                <% if Authorization.has_permission?(current_account.id, "Firewall:view", fw[:id]) %>
                   <a href="<%= @project_data[:path] %><%= fw[:path] %>"
                   class="text-orange-600 hover:text-orange-700"><%= fw[:name]
                   %></a>

--- a/views/networking/firewall/show.erb
+++ b/views/networking/firewall/show.erb
@@ -41,7 +41,7 @@
         <tr>
           <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
           <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Port range</th>
-          <% if Authorization.has_permission?(current_user.id, "Firewall:edit", @firewall[:id]) %>
+          <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           <% end %>
         </tr>
@@ -51,7 +51,7 @@
           <tr>
             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:port_range] %></td>
-            <% if Authorization.has_permission?(current_user.id, "Firewall:edit", @firewall[:id]) %>
+            <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
               <td
                 id="fwr-delete-<%=fwr[:id]%>"
                 class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
@@ -69,7 +69,7 @@
             <% end %>
           </tr>
         <% end %>
-        <% if Authorization.has_permission?(current_user.id, "Firewall:edit", @firewall[:id]) %>
+        <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
           <tr>
             <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST">
               <%== csrf_tag("#{request.path}/firewall-rule") %>
@@ -110,7 +110,7 @@
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-          <% if Authorization.has_permission?(current_user.id, "Firewall:edit", @firewall[:id]) %>
+          <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           <% end %>
         </tr>
@@ -133,7 +133,7 @@
             </form>
           </tr>
         <% end %>
-        <% if Authorization.has_permission?(current_user.id, "Firewall:edit", @firewall[:id]) %>
+        <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
           <tr>
             <form action="<%= "#{request.path}/attach-subnet" %>" role="form" method="POST">
               <%== csrf_tag("#{request.path}/attach-subnet") %>
@@ -160,7 +160,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_user.id, "Firewall:delete", @firewall[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, "Firewall:delete", @firewall[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/networking/load_balancer/show.erb
+++ b/views/networking/load_balancer/show.erb
@@ -49,7 +49,7 @@
         <tr>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">VM</th>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Application State</th>
-          <% if Authorization.has_permission?(current_user.id, "LoadBalancer:edit", @lb[:id]) %>
+          <% if Authorization.has_permission?(current_account.id, "LoadBalancer:edit", @lb[:id]) %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           <% end %>
         </tr>
@@ -75,7 +75,7 @@
             </form>
           </tr>
         <% end %>
-        <% if Authorization.has_permission?(current_user.id, "LoadBalancer:edit", @lb[:id]) %>
+        <% if Authorization.has_permission?(current_account.id, "LoadBalancer:edit", @lb[:id]) %>
           <tr>
             <form action="<%= "#{request.path}/attach-vm" %>" role="form" method="POST">
               <%== csrf_tag("#{request.path}/attach-vm") %>
@@ -104,7 +104,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_user.id, "LoadBalancer:delete", @lb[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, "LoadBalancer:delete", @lb[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -95,7 +95,7 @@
         <% @ps[:firewalls].each do |fw| %>
           <tr>
             <td class="whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-              <% if Authorization.has_permission?(current_user.id, "Firewall:view", fw[:id]) %>
+              <% if Authorization.has_permission?(current_account.id, "Firewall:view", fw[:id]) %>
                 <a
                   href="<%= "#{@project_data[:path]}/location/#{fw[:location]}/firewall/#{fw[:name]}" %>"
                   class="text-orange-600 hover:text-orange-700"
@@ -111,7 +111,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_user.id, "PrivateSubnet:delete", @ps[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, "PrivateSubnet:delete", @ps[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -203,7 +203,7 @@
     </div>
   <% end %>
   <!-- Firewall Rules Card -->
-  <% if Authorization.has_permission?(current_user.id, "Postgres:Firewall:view", @pg[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:view", @pg[:id]) %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
         <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
@@ -217,7 +217,7 @@
           <tr>
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Port Range</th>
-            <% if Authorization.has_permission?(current_user.id, "Postgres:Firewall:edit", @pg[:id]) %>
+            <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:edit", @pg[:id]) %>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
             <% end %>
           </tr>
@@ -227,7 +227,7 @@
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432</td>
-              <% if Authorization.has_permission?(current_user.id, "Postgres:Firewall:edit", @pg[:id]) %>
+              <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:edit", @pg[:id]) %>
                 <td
                   id="fwr-delete-<%=fwr[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
@@ -245,7 +245,7 @@
               <% end %>
             </tr>
           <% end %>
-          <% if Authorization.has_permission?(current_user.id, "Postgres:Firewall:edit", @pg[:id]) %>
+          <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:edit", @pg[:id]) %>
             <tr>
               <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST">
                 <%== csrf_tag("#{request.path}/firewall-rule") %>
@@ -276,7 +276,7 @@
     </div>
   <% end %>
   <!-- Metric Destination Card -->
-  <% if Authorization.has_permission?(current_user.id, "Postgres:edit", @pg[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
         <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
@@ -291,7 +291,7 @@
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">URL</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Username</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Password</th>
-            <% if Authorization.has_permission?(current_user.id, "Postgres:edit", @pg[:id]) %>
+            <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
             <% end %>
           </tr>
@@ -302,7 +302,7 @@
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= md[:url] %></td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= md[:username] %></td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">●●●●●●</td>
-              <% if Authorization.has_permission?(current_user.id, "Postgres:edit", @pg[:id]) %>
+              <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
                 <td
                   id="md-delete-<%=md[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
@@ -320,7 +320,7 @@
               <% end %>
             </tr>
           <% end %>
-          <% if Authorization.has_permission?(current_user.id, "Postgres:edit", @pg[:id]) %>
+          <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
             <tr>
               <form action="<%= "#{request.path}/metric-destination" %>" role="form" method="POST">
                 <%== csrf_tag("#{request.path}/metric-destination") %>
@@ -354,10 +354,10 @@
       </table>
     </div>
   <% end %>
-  <% if Authorization.has_permission?(current_user.id, ["Postgres:edit", "Postgres:delete"], @pg[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, ["Postgres:edit", "Postgres:delete"], @pg[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <!-- Restart Card -->
-      <% if Authorization.has_permission?(current_user.id, "Postgres:edit", @pg[:id]) %>
+      <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
         <div class="px-4 py-5 sm:p-6">
           <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restart" %>" role="form" method="POST">
             <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restart") %>
@@ -379,7 +379,7 @@
         </div>
       <% end %>
       <!-- Delete Card -->
-      <% if Authorization.has_permission?(current_user.id, "Postgres:delete", @pg[:id]) %>
+      <% if Authorization.has_permission?(current_account.id, "Postgres:delete", @pg[:id]) %>
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -22,7 +22,7 @@
         data: [
           ["ID", @project_data[:id]],
           (
-            if Authorization.has_permission?(current_user.id, "Project:edit", @project_data[:id])
+            if Authorization.has_permission?(current_account.id, "Project:edit", @project_data[:id])
               [
                 "Name",
                 render(
@@ -73,7 +73,7 @@
 
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_user.id, "Project:delete", @project_data[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, "Project:delete", @project_data[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -74,7 +74,7 @@
           <% fw[:firewall_rules].each do |fwr| %>
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-                <% if Authorization.has_permission?(current_user.id, "Firewall:view", fw[:id]) %>
+                <% if Authorization.has_permission?(current_account.id, "Firewall:view", fw[:id]) %>
                   <a
                     href="<%= "#{@project_data[:path]}/location/#{fw[:location]}/firewall/#{fw[:name]}" %>"
                     class="text-orange-600 hover:text-orange-700"
@@ -92,7 +92,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_user.id, "Vm:delete", @vm[:id]) %>
+  <% if Authorization.has_permission?(current_account.id, "Vm:delete", @vm[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">


### PR DESCRIPTION
This was recommended by Enes, and is more aligned with the model naming (the model is Account).

This was a completely mechanical change, using the following code:

```
sed -i -e 's/current_user/current_account/' `git grep -l 'current_user' clover*.rb routes/clover_base.rb routes views`
```

This makes some naming more consistent, such as `account_ubid: current_account.ubid`.

This makes some naming less consistent, such as `user: current_account`

We could fix the less consistent naming by changing `Routes::Common::Base#initialize` to use `account` instead of `user` as a keyword argument.  This commit doesn't make that change.  It's likely Routes::Common will go away when merging CloverWeb and CloverApi, so I'm not sure it's worth it.