### PR TITLE
Improve awesome_print output for Sequel::Model instances

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -10,6 +10,13 @@ require "pry"
 if Config.development?
   require "awesome_print"
   require "awesome_print/ext/sequel"
+
+  module AwesomePrint::Sequel
+    remove_method(:awesome_sequel_document)
+    def awesome_sequel_document(object)
+      "#{object} #{awesome_hash(object.values)}"
+    end
+  end
 end
 
 def dev_project

--- a/model.rb
+++ b/model.rb
@@ -51,7 +51,7 @@ module ResourceMethods
   end
 
   def to_s
-    "#{self.class.name}[#{ubid}]"
+    "#{self.class.name}[\"#{ubid}\"]"
   end
 
   def inspect

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -152,14 +152,14 @@ RSpec.describe Prog::DownloadBootImage do
     it "waits manual intervation if it's failed in production" do
       expect(Config).to receive(:production?).and_return(true)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image_20230303").and_return("Failed")
-      expect { dbi.download }.to raise_error RuntimeError, "Failed to download 'my-image' image on VmHost[#{vm_host.ubid}]"
+      expect { dbi.download }.to raise_error RuntimeError, "Failed to download 'my-image' image on VmHost[\"#{vm_host.ubid}\"]"
     end
 
     it "retries downloading image if it is failed somewhere other than production" do
       expect(Config).to receive(:production?).and_return(false)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_my-image_20230303").and_return("Failed")
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --clean download_my-image_20230303")
-      expect { dbi.download }.to raise_error RuntimeError, "Failed to download 'my-image' image on VmHost[#{vm_host.ubid}]"
+      expect { dbi.download }.to raise_error RuntimeError, "Failed to download 'my-image' image on VmHost[\"#{vm_host.ubid}\"]"
     end
 
     it "waits for the download to complete" do

--- a/spec/prog/download_cloud_hypervisor_spec.rb
+++ b/spec/prog/download_cloud_hypervisor_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Prog::DownloadCloudHypervisor do
 
     it "waits for manual intervention if failed" do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("Failed")
-      expect { df.download }.to raise_error RuntimeError, "Failed to download cloud hypervisor version 35.1 on VmHost[#{vm_host.ubid}]"
+      expect { df.download }.to raise_error RuntimeError, "Failed to download cloud hypervisor version 35.1 on VmHost[\"#{vm_host.ubid}\"]"
     end
 
     it "waits for the download to complete" do

--- a/spec/prog/download_firmware_spec.rb
+++ b/spec/prog/download_firmware_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Prog::DownloadFirmware do
 
     it "waits for manual intervention if failed" do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check download_firmware_202405").and_return("Failed")
-      expect { df.download }.to raise_error RuntimeError, "Failed to download firmware version 202405 on VmHost[#{vm_host.ubid}]"
+      expect { df.download }.to raise_error RuntimeError, "Failed to download firmware version 202405 on VmHost[\"#{vm_host.ubid}\"]"
     end
 
     it "waits for the download to complete" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Al do
 
     it "fails if no valid allocation is found" do
       expect(Al::Allocation).to receive(:best_allocation).and_return(nil)
-      expect { described_class.allocate(vm, storage_volumes) }.to raise_error RuntimeError, "Vm[#{vm.ubid}] no space left on any eligible host"
+      expect { described_class.allocate(vm, storage_volumes) }.to raise_error RuntimeError, "Vm[\"#{vm.ubid}\"] no space left on any eligible host"
     end
 
     it "persists valid allocation" do


### PR DESCRIPTION
Do not sort columns lexicographically, or include errors.

Modify Model#to_s to include quotes around the UBID.  This also
improves awesome_print output, since awesome_print calls to_s on
the object.