### PR TITLE
Fix E2E tests when they select Debian

### DIFF
--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -22,7 +22,7 @@ class Prog::Test::Vm < Prog::Test::Base
   end
 
   label def install_packages
-    if vm.boot_image.start_with?("ubuntu")
+    if /ubuntu|debian/.match?(vm.boot_image)
       sshable.cmd("sudo apt update")
       sshable.cmd("sudo apt install -y build-essential")
     elsif vm.boot_image.start_with?("almalinux")

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -84,6 +84,13 @@ RSpec.describe Prog::Test::Vm do
       expect { vm_test.install_packages }.to hop("verify_extra_disks")
     end
 
+    it "installs packages for debian images and hops to next step" do
+      expect(vm_test).to receive(:vm).and_return(instance_double(Vm, boot_image: "debian-12")).at_least(:once)
+      expect(sshable).to receive(:cmd).with("sudo apt update")
+      expect(sshable).to receive(:cmd).with("sudo apt install -y build-essential")
+      expect { vm_test.install_packages }.to hop("verify_extra_disks")
+    end
+
     it "installs packages for almalinux images and hops to next step" do
       expect(vm_test).to receive(:vm).and_return(instance_double(Vm, boot_image: "almalinux-9")).at_least(:once)
       expect(sshable).to receive(:cmd).with("sudo dnf check-update || [ $? -eq 100 ]")


### PR DESCRIPTION
Otherwise, the `else` case will trigger a failure, creating a log that looks like this:

    2024-10-28T22:17:14.9503517Z 22:17:14 respirate.1 | {"strand":{"id":"0192d531-ec76-8f3a-9ee1-58b64e8681b4","parent_id":null,"schedule":"2024-10-28 22:17:08 +0000","lease":"2024-10-28 22:19:07 +0000","prog":"Test::Vm","label":"failed","stack":[{"link":["Test::VmGroup","verify_vms"],"subject_id":"58b27234-2601-8f74-8f76-5b35f625135e","last_label_changed_at":"2024-10-28 22:17:14 +0000"},{"vms":["58b27234-2601-8f74-8f76-5b35f625135e","d66e75c7-d28e-8374-81e6-2d1327508a33","7cfb89be-ba0e-8374-843d-71d775e3cf08"],"subnets":["6c09c1ac-c39f-8ad9-b8d1-fd0f707cf9ae","178597d1-2e89-86d9-ae8f-22868f01ec3c"],"project_id":"a0a6365a-fc07-8ad2-92e3-41948e3e801e","test_reboot":true,"storage_encrypted":true,"last_label_changed_at":"2024-10-28 22:17:06 +0000"}],"exitval":{"msg":"unexpected boot image: debian-12"},"retval":null,"try":0},"strand_started":{"prog_label":"Test::Vm.failed"},"message":"starting strand","time":"2024-10-28 22:17:14 +0000","thread":"st069dacfcet7kvgnhdjegt0v8"}
    2024-10-28T22:17:21.9881320Z 22:17:21 e2e.1       | 2024-10-28T22:17:21Z | 0192d531-ec76-8f3a-9ee1-58b64e8681b4 | Test::Vm.failed | FAILED: unexpected boot image: debian-12 | Vm.wait
    2024-10-28T22:17:22.5582252Z 22:17:22 e2e.1       | exited with code 1
    2024-10-28T22:17:22.5584121Z 22:17:22 system      | sending SIGTERM to all processes
    2024-10-28T22:17:22.9722774Z 22:17:22 web.1       | terminated by SIGTERM
    2024-10-28T22:17:22.9724525Z 22:17:22 respirate.1 | terminated by SIGTERM
    2024-10-28T22:17:22.9726165Z 22:17:22 monitor.1   | terminated by SIGTERM
    2024-10-28T22:17:22.9763138Z ##[error]Process completed with exit code 1.