### PR TITLE
Switch from pem to der encoding in cert_nexus development path

### DIFF
--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -32,7 +32,7 @@ class Prog::Vnet::CertNexus < Prog::Base
 
     if Config.development? && cert.dns_zone_id.nil?
       crt, key = Util.create_certificate(subject: "/CN=" + cert.hostname, duration: 60 * 60 * 24 * 30 * 3)
-      cert.update(cert: crt, csr_key: key.to_pem)
+      cert.update(cert: crt, csr_key: key.to_der)
       hop_wait
     end
 


### PR DESCRIPTION
The production path that integrates against an ACME service was already serializing as `der`.  So this makes the development path closer.

A `pem` is 1.87x bigger than `der`, and the impact is amplified further since the `column_encryption` Sequel plugin does another round of base64.