### PR TITLE
Show total cache quota on the UI

### DIFF
--- a/routes/web/project/github.rb
+++ b/routes/web/project/github.rb
@@ -45,6 +45,7 @@ class CloverWeb
         repository_id_q = @project.github_installations_dataset.join(:github_repository, installation_id: :id).select(Sequel[:github_repository][:id])
         @entries = Serializers::GithubCacheEntry.serialize(GithubCacheEntry.where(repository_id: repository_id_q).exclude(committed_at: nil).eager(:repository).order(Sequel.desc(:created_at)).all)
         @total_usage = Serializers::GithubCacheEntry.humanize_size(@entries.filter_map { _1[:size] }.sum)
+        @total_quota = "#{@project.effective_quota_value("GithubRunnerCacheStorage")} GB"
 
         view "github/cache"
       end

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -20,7 +20,7 @@
         <thead class="bg-gray-50 whitespace-nowrap">
           <tr>
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6" colspan="2"><%= @entries.count %> cache entries</th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6" colspan="3"><%= @total_usage %> used</th>
+            <th scope="col" class="relative py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6" colspan="3"><%= @total_usage %> used of <%= @total_quota %></th>
           </tr>
         </thead>
       <% end %>

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -16,12 +16,14 @@
 <div class="grid gap-6">
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <table class="min-w-full divide-y divide-gray-300">
-      <thead class="bg-gray-50 whitespace-nowrap">
-        <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6" colspan="2"><%= @entries.count %> cache entries</th>
-          <th scope="col" class="relative py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6" colspan="3"><%= @total_usage %> used</th>
-        </tr>
-      </thead>
+      <% if @total_usage %>
+        <thead class="bg-gray-50 whitespace-nowrap">
+          <tr>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6" colspan="2"><%= @entries.count %> cache entries</th>
+            <th scope="col" class="relative py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6" colspan="3"><%= @total_usage %> used</th>
+          </tr>
+        </thead>
+      <% end %>
       <tbody class="divide-y divide-gray-200 bg-white">
         <% if @entries.count > 0 %>
           <% @entries.each do |entry| %>


### PR DESCRIPTION
### **Remove leftover text on the UI when no cache entries are available**

  When the project doesn't have any cache entries, the UI was showing a
  "used" text. I fixed this by hiding the header when there are no cache
  entries available.
  
| Before | After |
|--------|-------|
| <img width="1510" alt="Screenshot 2024-10-30 at 05 48 25" src="https://github.com/user-attachments/assets/ad1c033e-6a3e-4d0e-9c81-531eba5d5e69"> | <img width="1512" alt="Screenshot 2024-10-30 at 05 49 59" src="https://github.com/user-attachments/assets/9f2a37dc-f597-4957-93b6-e14be3f5d563"> |


### **Show total cache quota on the UI**

  Currently, we display the total cache usage on the UI, but not the total
  cache quota. This leaves users uncertain about the remaining cache
  storage. Therefore, I've added the effective cache quota to the UI.

<img width="1512" alt="Screenshot 2024-10-30 at 05 56 29" src="https://github.com/user-attachments/assets/b785ad3b-4a04-4de2-b95c-6d87b1184e8f">

  