### PR TITLE
Run all specs in frozen mode - Phase 1

### DIFF
--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -3,8 +3,15 @@
 require "yaml"
 
 class BillingRate
+  # :nocov:
+  def self.freeze
+    rates
+    super
+  end
+  # :nocov:
+
   def self.rates
-    @@rates ||= YAML.load_file("config/billing_rates.yml", permitted_classes: [Time])
+    @rates ||= YAML.load_file("config/billing_rates.yml", permitted_classes: [Time])
   end
 
   def self.from_resource_properties(resource_type, resource_family, location, active_at = Time.now)

--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -3,7 +3,7 @@
 require "json"
 
 class Clog
-  @@mutex = Mutex.new
+  MUTEX = Mutex.new
 
   def self.emit(message)
     out = if block_given?
@@ -39,7 +39,7 @@ class Clog
     end
 
     raw = (JSON.generate(out) << "\n").freeze
-    @@mutex.synchronize do
+    MUTEX.synchronize do
       $stdout.write(raw)
     end
     nil

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -30,8 +30,15 @@ module Github
     client
   end
 
+  # :nocov:
+  def self.freeze
+    runner_labels
+    super
+  end
+  # :nocov:
+
   def self.runner_labels
-    @@runner_labels ||= YAML.load_file("config/github_runner_labels.yml").to_h { [_1["name"], _1] }
+    @runner_labels ||= YAML.load_file("config/github_runner_labels.yml").to_h { [_1["name"], _1] }
   end
 
   def self.failed_deliveries(since, max_page = 50)

--- a/loader.rb
+++ b/loader.rb
@@ -147,7 +147,7 @@ when :test
 end
 
 def clover_freeze
-  return unless Config.production?
+  return unless Config.production? || ENV["CLOVER_FREEZE_CORE"] == "1"
   require "refrigerator"
 
   # Take care of library dependencies that modify core classes.

--- a/model/page.rb
+++ b/model/page.rb
@@ -15,17 +15,21 @@ class Page < Sequel::Model
   # This cannot be covered, as the current coverage tests run without freezing models.
   # :nocov:
   def self.freeze
-    new.pagerduty_client
+    pagerduty_client
     super
   end
   # :nocov:
+
+  def self.pagerduty_client
+    @pagerduty_client ||= Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2)
+  end
 
   include SemaphoreMethods
   include ResourceMethods
   semaphore :resolve
 
   def pagerduty_client
-    @@pagerduty_client ||= Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2)
+    self.class.pagerduty_client
   end
 
   def trigger

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -204,7 +204,11 @@ class PostgresServer < Sequel::Model
     lsn2int(lsn1) - lsn2int(lsn2)
   end
 
-  def run_query(query)
+  def self.run_query(vm, query)
     vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv", stdin: query).chomp
+  end
+
+  def run_query(query)
+    self.class.run_query(vm, query)
   end
 end

--- a/model/project_quota.rb
+++ b/model/project_quota.rb
@@ -3,9 +3,15 @@
 require_relative "../model"
 
 class ProjectQuota < Sequel::Model
-  @@default_quotas = nil
+  # :nocov:
+  def self.freeze
+    default_quotas
+    super
+  end
+  # :nocov:
+
   def self.default_quotas
-    @@default_quotas ||= YAML.load_file("config/default_quotas.yml").each_with_object({}) do |item, hash|
+    @default_quotas ||= YAML.load_file("config/default_quotas.yml").each_with_object({}) do |item, hash|
       hash[item["resource_type"]] = item
     end
   end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -236,7 +236,14 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     ).map(&:to_pem)
   end
 
+  # :nocov:
+  def self.freeze
+    dns_zone
+    super
+  end
+  # :nocov:
+
   def self.dns_zone
-    @@dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
+    @dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
   end
 end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -244,6 +244,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   # :nocov:
 
   def self.dns_zone
-    @dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
+    return @dns_zone if defined?(@dns_zone)
+    @dns_zone = DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
   end
 end

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 module Scheduling::Allocator
+  # :nocov:
+  def self.freeze
+    target_host_utilization
+    super
+  end
+  # :nocov:
+
   def self.target_host_utilization
-    @@target_host_utilization ||= Config.allocator_target_host_utilization
+    @target_host_utilization ||= Config.allocator_target_host_utilization
   end
 
   def self.allocate(vm, storage_volumes, distinct_storage_devices: false, gpu_enabled: false, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], location_filter: [], location_preference: [])
@@ -37,9 +44,16 @@ module Scheduling::Allocator
   class Allocation
     attr_reader :score
 
+    # :nocov:
+    def self.freeze
+      random_score
+      super
+    end
+    # :nocov:
+
     def self.random_score
-      @@max_random_score ||= Config.allocator_max_random_score
-      rand(0..@@max_random_score)
+      @max_random_score ||= Config.allocator_max_random_score
+      rand(0..@max_random_score)
     end
 
     def self.best_allocation(request)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -275,9 +275,7 @@ RSpec.describe Clover, "postgres" do
         rs.update(timeline_access: "push")
         st = Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: rs.timeline_id, timeline_access: "fetch")
         st.update(label: "wait")
-        # rubocop:disable RSpec/AnyInstance
-        expect_any_instance_of(PostgresServer).to receive(:run_query).and_return "16/B374D848"
-        # rubocop:enable RSpec/AnyInstance
+        expect(PostgresServer).to receive(:run_query).and_return "16/B374D848"
 
         post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
 
 RSpec.configure do |config|
   config.before(:suite) do
-    clover_freeze if ENV["CLOVER_FREEZE_CORE"] == "1"
+    clover_freeze
     Clover.freeze if ENV["CLOVER_FREEZE_MODELS"] == "1"
   end
 


### PR DESCRIPTION
We are going to merge #2154 in phases, and this is the first phase.  This provides some setup:

* Remove all usage of class variables. Switch to class instance variables (or a constant in one case).  Class variables are a Ruby misfeature that should almost never be used.

* When switching away from class variables to class instance variables, add `freeze` methods to the classes that call the methods to set the instance variables, so calling the methods will not raise FrozenError.

* Fix core freezing in tests, which I broke in 66d5d62.

* Remove use of `expect_any_instance_of` in a spec (which I added last week in 0d3702f1), by adding a class method that can be mocked.

* Change Prog::Postgres::PostgresResourceNexus.dns_zone so it caches the value on first call, even if the value is nil.