### PR TITLE
Remove feature flag for Lantern

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -134,5 +134,4 @@ class Project < Sequel::Model
   end
 
   feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache
-  feature_flag :enable_lantern
 end

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -4,7 +4,7 @@
   flavors = {
     "standard" => ["Ubicloud", "PostgreSQL Database", "Get started by creating a new PostgreSQL database which is managed by Ubicloud team. It's a good choice for general purpose databases."],
     "paradedb" => ["ParadeDB", "ParadeDB PostgreSQL Database", "ParadeDB is an Elasticsearch alternative built on Postgres. ParadeDB instances are managed by the ParadeDB team and are optimal for search and analytics workloads."],
-    "lantern" => (["Lantern", "Lantern PostgreSQL Database", "Lantern is a PostgreSQL-based vector database designed specifically for building AI applications. Lantern instances are managed by the Lantern team and are optimal for AI workloads."] if @project_data[:feature_flags]["enable_lantern"])
+    "lantern" => ["Lantern", "Lantern PostgreSQL Database", "Lantern is a PostgreSQL-based vector database designed specifically for building AI applications. Lantern instances are managed by the Lantern team and are optimal for AI workloads."]
   }.compact
 %>
 


### PR DESCRIPTION
Lantern partnership is publicly announced and it is now available to use by anyone. No need for feature flag.