### PR TITLE
Fix 2 nondeterministic tests by hardcoding expected value

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -366,7 +366,7 @@ class CloverWeb < Roda
   end
 
   hash_branch("after-login") do |r|
-    if (project = current_account.projects_dataset.order(:created_at).first)
+    if (project = current_account.projects_dataset.order(:created_at, :name).first)
       r.redirect "#{project.path}/dashboard"
     else
       r.redirect "/project"

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Clover, "auth" do
     expect(page.title).to eq("Ubicloud - Verify Account")
 
     click_button "Verify Account"
-    expect(page.title).to eq("Ubicloud - #{Account[email: TEST_USER_EMAIL].projects.first.name} Dashboard")
+    expect(page.title).to eq("Ubicloud - Default Dashboard")
 
     visit "#{p.path}/dashboard"
     expect(page.title).to eq("Ubicloud - #{p.name} Dashboard")
@@ -86,7 +86,7 @@ RSpec.describe Clover, "auth" do
     expect(page.title).to eq("Ubicloud - Verify Account")
 
     click_button "Verify Account"
-    expect(page.title).to eq("Ubicloud - #{Account[email: TEST_USER_EMAIL].projects.first.name} Dashboard")
+    expect(page.title).to eq("Ubicloud - Default Dashboard")
 
     visit p.path
     expect(page.title).to eq("Ubicloud - #{p.name}")


### PR DESCRIPTION
Without this change, I see failures such as:

```
Failure/Error: expect(page.title).to eq("Ubicloud - #{Account[email: TEST_USER_EMAIL].projects.first.name} Dashboard")

expected: "Ubicloud - Default Dashboard"
     got: "Ubicloud - Invited project Dashboard"
```

This is because there are multiple projects for the account, and a dataset order was not enforced.  We could enforce a dataset order, but since the value we are expecting is constant, it seems simpler to hardcode it.