### PR TITLE
Run all specs in frozen mode - Phase 2

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -121,14 +121,16 @@ class Project < Sequel::Model
     ApiKey.create_with_id(owner_table: Project.table_name, owner_id: id, used_for: used_for)
   end
 
-  def self.feature_flag(*flags)
+  def self.feature_flag(*flags, into: self)
     flags.map(&:to_s).each do |flag|
-      define_method :"set_ff_#{flag}" do |value|
-        update(feature_flags: feature_flags.merge({flag => value}))
-      end
+      into.module_eval do
+        define_method :"set_ff_#{flag}" do |value|
+          update(feature_flags: feature_flags.merge({flag => value}))
+        end
 
-      define_method :"get_ff_#{flag}" do
-        feature_flags[flag]
+        define_method :"get_ff_#{flag}" do
+          feature_flags[flag]
+        end
       end
     end
   end

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -29,6 +29,14 @@ class Sshable < Sequel::Model
     }
   end
 
+  def self.repl?
+    REPL
+  end
+
+  def repl?
+    self.class.repl?
+  end
+
   def cmd(cmd, stdin: nil, log: true)
     start = Time.now
     stdout = StringIO.new
@@ -42,12 +50,12 @@ class Sshable < Sequel::Model
         channel_duration = Time.now - start
         ch.exec(cmd) do |ch, success|
           ch.on_data do |ch, data|
-            $stderr.write(data) if REPL
+            $stderr.write(data) if repl?
             stdout.write(data)
           end
 
           ch.on_extended_data do |ch, type, data|
-            $stderr.write(data) if REPL
+            $stderr.write(data) if repl?
             stderr.write(data)
           end
 
@@ -84,7 +92,7 @@ class Sshable < Sequel::Model
         # real time to $stderr could be removed, but when supervising
         # a tty, I've found it can be useful to see data arrive in
         # real time from SSH.
-        unless REPL
+        unless repl?
           embed[:stderr] = stderr_str
           embed[:stdout] = stdout_str
         end

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -12,9 +12,13 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
 
   semaphore :destroy
 
+  def self.model_for_id(model_id)
+    Option::AI_MODELS.detect { _1["id"] == model_id }
+  end
+
   def self.assemble_with_model(project_id:, location:, name:, model_id:,
     replica_count: 1, is_public: false)
-    model = Option::AI_MODELS.detect { _1["id"] == model_id }
+    model = model_for_id(model_id)
 
     fail "Model with id #{model_id} not found" unless model
 

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -81,13 +81,12 @@ PGHOST=/var/run/postgresql
   describe "#latest_backup_label_before_target" do
     it "returns most recent backup before given target" do
       skip_if_frozen
-      stub_const("Backup", Struct.new(:last_modified))
       most_recent_backup_time = Time.now
       expect(postgres_timeline).to receive(:backups).and_return(
         [
-          instance_double(Backup, key: "basebackups_005/0001_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 200),
-          instance_double(Backup, key: "basebackups_005/0002_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 100),
-          instance_double(Backup, key: "basebackups_005/0003_backup_stop_sentinel.json", last_modified: most_recent_backup_time)
+          instance_double(Minio::Client::Blob, key: "basebackups_005/0001_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 200),
+          instance_double(Minio::Client::Blob, key: "basebackups_005/0002_backup_stop_sentinel.json", last_modified: most_recent_backup_time - 100),
+          instance_double(Minio::Client::Blob, key: "basebackups_005/0003_backup_stop_sentinel.json", last_modified: most_recent_backup_time)
         ]
       )
 
@@ -96,7 +95,6 @@ PGHOST=/var/run/postgresql
 
     it "raises error if no backups before given target" do
       skip_if_frozen
-      stub_const("Backup", Struct.new(:last_modified))
       expect(postgres_timeline).to receive(:backups).and_return([])
 
       expect { postgres_timeline.latest_backup_label_before_target(target: Time.now) }.to raise_error RuntimeError, "BUG: no backup found"
@@ -126,11 +124,10 @@ PGHOST=/var/run/postgresql
 
   it "returns list of backups" do
     skip_if_frozen
-    stub_const("Backup", Struct.new(:key))
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
 
     minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key", ssl_ca_file_data: "data")
-    expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/").and_return([instance_double(Backup, key: "backup_stop_sentinel.json"), instance_double(Backup, key: "unrelated_file.txt")])
+    expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/").and_return([instance_double(Minio::Client::Blob, key: "backup_stop_sentinel.json"), instance_double(Minio::Client::Blob, key: "unrelated_file.txt")])
     expect(Minio::Client).to receive(:new).and_return(minio_client)
 
     expect(postgres_timeline.backups.map(&:key)).to eq(["backup_stop_sentinel.json"])

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -35,8 +35,10 @@ RSpec.describe Project do
 
     it "sets and gets feature flags" do
       skip_if_frozen_models
-      described_class.feature_flag(:dummy_flag)
+      mod = Module.new
+      described_class.feature_flag(:dummy_flag, into: mod)
       project = described_class.create_with_id(name: "dummy-name")
+      project.extend(mod)
 
       expect(project.get_ff_dummy_flag).to be_nil
       project.set_ff_dummy_flag("new-value")

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Sshable do
       skip_if_frozen
       [false, true].each do |repl_value|
         [false, true].each do |log_value|
-          stub_const("REPL", repl_value)
+          allow(described_class).to receive(:repl?).and_return(repl_value)
           if repl_value
             # Note that in the REPL, stdout and stderr get multiplexed
             # into stderr in real time, packet by packet.

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -18,11 +18,8 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
   describe ".assemble_with_model" do
     let(:model) { {"id" => "model_id", "boot_image" => "ai-ubuntu-2404-nvidia", "vm_size" => "standard-gpu-6", "storage_volumes" => "storage_volumes", "model_name" => "llama-3-1-8b-it", "engine" => "vllm", "engine_params" => "engine_params"} }
 
-    before do
-      stub_const("Option::AI_MODELS", [model])
-    end
-
     it "assembles with model" do
+      expect(described_class).to receive(:model_for_id).and_return(model)
       expect(described_class).to receive(:assemble).with(
         project_id: 1,
         location: "hetzner-fsn1",
@@ -41,6 +38,7 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
     end
 
     it "raises an error if model is not found" do
+      expect(described_class).to receive(:model_for_id).and_return(nil)
       expect {
         described_class.assemble_with_model(project_id: 1, location: "hetzner-fsn1", name: "test-endpoint", model_id: "invalid_id")
       }.to raise_error("Model with id invalid_id not found")

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -117,8 +117,8 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     it "creates a missing backup page if last completed backup is older than 2 days" do
       skip_if_frozen
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
-      stub_const("Backup", Struct.new(:last_modified))
-      expect(postgres_timeline).to receive(:backups).and_return([instance_double(Backup, last_modified: Time.now - 3 * 24 * 60 * 60)])
+      backup = Struct.new(:last_modified)
+      expect(postgres_timeline).to receive(:backups).and_return([instance_double(backup, last_modified: Time.now - 3 * 24 * 60 * 60)])
       expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer))
       expect { nx.wait }.to nap(20 * 60)
       expect(Page.active.count).to eq(1)
@@ -128,8 +128,8 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       skip_if_frozen
       skip_if_frozen_models
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
-      stub_const("Backup", Struct.new(:last_modified))
-      expect(postgres_timeline).to receive(:backups).and_return([instance_double(Backup, last_modified: Time.now - 1 * 24 * 60 * 60)])
+      backup = Struct.new(:last_modified)
+      expect(postgres_timeline).to receive(:backups).and_return([instance_double(backup, last_modified: Time.now - 1 * 24 * 60 * 60)])
       expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer))
       page = instance_double(Page)
       expect(page).to receive(:incr_resolve)
@@ -141,8 +141,8 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     it "naps if there is nothing to do" do
       skip_if_frozen
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
-      stub_const("Backup", Struct.new(:last_modified))
-      expect(postgres_timeline).to receive(:backups).and_return([instance_double(Backup, last_modified: Time.now - 1 * 24 * 60 * 60)])
+      backup = Struct.new(:last_modified)
+      expect(postgres_timeline).to receive(:backups).and_return([instance_double(backup, last_modified: Time.now - 1 * 24 * 60 * 60)])
       expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer))
 
       expect { nx.wait }.to nap(20 * 60)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -210,10 +210,10 @@ RSpec.describe Clover, "postgres" do
       it "restore" do
         skip_if_frozen
         skip_if_frozen_models
-        stub_const("Backup", Struct.new(:key, :last_modified))
+        backup = Struct.new(:key, :last_modified)
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
-        expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, list_objects: [Backup.new("basebackups_005/backup_stop_sentinel.json", restore_target - 10 * 60)])).at_least(:once)
+        expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, list_objects: [backup.new("basebackups_005/backup_stop_sentinel.json", restore_target - 10 * 60)])).at_least(:once)
 
         post "/api/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg",

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -190,10 +190,10 @@ RSpec.describe Clover, "postgres" do
       it "can restore PostgreSQL database" do
         skip_if_frozen
         skip_if_frozen_models
-        stub_const("Backup", Struct.new(:key, :last_modified))
+        backup = Struct.new(:key, :last_modified)
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
-        expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, list_objects: [Backup.new("basebackups_005/backup_stop_sentinel.json", restore_target - 10 * 60)])).at_least(:once)
+        expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, list_objects: [backup.new("basebackups_005/backup_stop_sentinel.json", restore_target - 10 * 60)])).at_least(:once)
 
         visit "#{project.path}#{pg.path}"
         expect(page).to have_content "Fork PostgreSQL database"


### PR DESCRIPTION
This makes the following changes, which are necessary prerequisites
for running all specs in frozen mode:

* Add Prog::Ai::InferenceEndpointNexus.model_for_id and Sshable{.,#}repl? to avoid need for stub_const.

* Remove remaining uses of stub_const in the specs

* Make Project.feature_flag accept into keyword argument, so it can be tested when Project is frozen.