### PR TITLE
Run all specs in frozen mode - Phase 3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -177,17 +177,7 @@ task "coverage" => [:coverage_spec]
 
   desc "Run specs#{desc_suffix} with frozen core, Database, and models (similar to production)"
   task "frozen_#{task_suffix}" do
-    block.call("CLOVER_FREEZE_CORE" => "1", "CLOVER_FREEZE_MODELS" => "1")
-  end
-
-  desc "Run specs#{desc_suffix} with frozen core"
-  task "frozen_core_#{task_suffix}" do
-    block.call("CLOVER_FREEZE_CORE" => "1")
-  end
-
-  desc "Run specs#{desc_suffix} with frozen Database and models"
-  task "frozen_db_model_#{task_suffix}" do
-    block.call("CLOVER_FREEZE_MODELS" => "1")
+    block.call("CLOVER_FREEZE" => "1")
   end
 
   desc "Run specs#{desc_suffix} with coverage"

--- a/clover.rb
+++ b/clover.rb
@@ -7,7 +7,7 @@ require "roda"
 class Clover < Roda
   def self.freeze
     # :nocov:
-    if Config.test? && ENV["CLOVER_FREEZE_MODELS"] != "1"
+    if Config.test? && ENV["CLOVER_FREEZE"] != "1"
       Sequel::Model.descendants.each(&:finalize_associations)
     else
       Sequel::Model.freeze_descendants

--- a/loader.rb
+++ b/loader.rb
@@ -109,7 +109,7 @@ end
 AUTOLOAD_CONSTANTS.freeze
 
 if force_autoload
-  AUTOLOAD_CONSTANTS.each { Object.const_get(_1) }
+  AUTOLOAD_CONSTANT_VALUES = AUTOLOAD_CONSTANTS.map { Object.const_get(_1) }.freeze
 
   # All classes are already available, so speed up UBID.class_for_ubid using
   # hash of prefixes to class objects
@@ -175,6 +175,10 @@ def clover_freeze
   # a side effect.  We encountered it when using rubygems for its tar
   # file writing.
   Gem.source_date_epoch
+
+  # Freeze all constants that are autoloaded
+  Sequel::Model.freeze_descendants
+  AUTOLOAD_CONSTANT_VALUES.each(&:freeze)
 
   Refrigerator.freeze_core
 end

--- a/loader.rb
+++ b/loader.rb
@@ -147,7 +147,7 @@ when :test
 end
 
 def clover_freeze
-  return unless Config.production? || ENV["CLOVER_FREEZE_CORE"] == "1"
+  return unless Config.production? || ENV["CLOVER_FREEZE"] == "1"
   require "refrigerator"
 
   # Take care of library dependencies that modify core classes.

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Clog do
   let(:now) { Time.parse("2023-01-17 12:10:54 -0800") }
 
   before do
-    skip_if_frozen
     allow(Config).to receive(:test?).and_return(false)
     allow(Time).to receive(:now).and_return(now)
   end

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Minio::Client do
   let(:minio_client) { described_class.new(endpoint: endpoint, access_key: "minioadmin", secret_key: "minioadminpw", ssl_ca_file_data: "data") }
 
   it "can use ssl_ca_file_data" do
-    skip_if_frozen
     ssl_ca_file_name = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7"
     expect(File).to receive(:exist?).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")).and_return(false)
     expect(FileUtils).to receive(:mkdir_p).with(File.dirname(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")))

--- a/spec/lib/minio/header_signer_spec.rb
+++ b/spec/lib/minio/header_signer_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Minio::HeaderSigner do
 
   describe "build_headers" do
     it "can build headers and sign with and without Content-Md5" do
-      skip_if_frozen
       method = "PUT"
       uri = URI.parse("http://localhost:9000/test")
       body = "test"

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe MonitorableResource do
     end
 
     it "returns if session is nil or resource does not need event loop" do
-      skip_if_frozen
       expect(Thread).not_to receive(:new)
 
       # session is nil
@@ -57,7 +56,6 @@ RSpec.describe MonitorableResource do
     end
 
     it "creates a new thread and runs the event loop" do
-      skip_if_frozen
       session = {ssh_session: instance_double(Net::SSH::Connection::Session)}
       r_w_event_loop.instance_variable_set(:@session, session)
       expect(Thread).to receive(:new).and_yield
@@ -66,7 +64,6 @@ RSpec.describe MonitorableResource do
     end
 
     it "swallows exception and logs it if event loop fails" do
-      skip_if_frozen
       session = {ssh_session: instance_double(Net::SSH::Connection::Session)}
       r_w_event_loop.instance_variable_set(:@session, session)
       expect(Thread).to receive(:new).and_yield
@@ -135,7 +132,6 @@ RSpec.describe MonitorableResource do
 
   describe "#force_stop_if_stuck" do
     it "does nothing if pulse check is not stuck" do
-      skip_if_frozen
       expect(Kernel).not_to receive(:exit!)
 
       # not locked

--- a/spec/lib/sem_snap_spec.rb
+++ b/spec/lib/sem_snap_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe SemSnap do
   end
 
   it "operates immediately by default in non-block form" do
-    skip_if_frozen_models
     snap = described_class.new(st.id)
     snap.incr(:test)
     delete_set = instance_double(Sequel::Model::DatasetMethods)

--- a/spec/lib/thread_printer_spec.rb
+++ b/spec/lib/thread_printer_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ThreadPrinter do
     end
 
     it "can handle threads with a nil backtrace" do
-      skip_if_frozen
       # The documentation calls out that the backtrace is an array or
       # nil.
       expect(described_class).to receive(:puts).with(/Thread: #<InstanceDouble.*>/)

--- a/spec/model/ai/inference_endpoint_spec.rb
+++ b/spec/model/ai/inference_endpoint_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe InferenceEndpoint do
     end
 
     it "sends the request correctly" do
-      skip_if_frozen
       if development
         allow(Config).to receive(:development?).and_return(true)
         allow(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)

--- a/spec/model/boot_image_spec.rb
+++ b/spec/model/boot_image_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe BootImage do
 
   describe "#remove_boot_image" do
     it "creates a strand to delete boot image" do
-      skip_if_frozen_models
       expect(Strand).to receive(:create_with_id) do |args|
         expect(args[:prog]).to eq("RemoveBootImage")
         expect(args[:label]).to eq("start")

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe GithubRunner do
   end
 
   it "can log duration when it's from a vm pool" do
-    skip_if_frozen_models
     expect(VmPool).to receive(:[]).with("pool-id").and_return(instance_double(VmPool, ubid: "pool-ubid"))
     expect(Clog).to receive(:emit).with("runner_tested").and_call_original
     github_runner.log_duration("runner_tested", 10)

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Invoice do
 
   describe ".charge" do
     it "not charge if Stripe not enabled" do
-      skip_if_frozen
       allow(Config).to receive(:stripe_secret_key).and_return(nil)
       expect(Clog).to receive(:emit).with("Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing.").and_call_original
       expect(invoice.charge).to be true

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -229,7 +229,6 @@ RSpec.describe PostgresServer do
   end
 
   it "catches Sequel::Error if updating PostgresLsnMonitor fails" do
-    skip_if_frozen_models
     lsn_monitor = instance_double(PostgresLsnMonitor, last_known_lsn: "1/5")
     expect(PostgresLsnMonitor).to receive(:new).and_return(lsn_monitor)
     expect(lsn_monitor).to receive(:insert_conflict).and_return(lsn_monitor)

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -80,7 +80,6 @@ PGHOST=/var/run/postgresql
 
   describe "#latest_backup_label_before_target" do
     it "returns most recent backup before given target" do
-      skip_if_frozen
       most_recent_backup_time = Time.now
       expect(postgres_timeline).to receive(:backups).and_return(
         [
@@ -94,7 +93,6 @@ PGHOST=/var/run/postgresql
     end
 
     it "raises error if no backups before given target" do
-      skip_if_frozen
       expect(postgres_timeline).to receive(:backups).and_return([])
 
       expect { postgres_timeline.latest_backup_label_before_target(target: Time.now) }.to raise_error RuntimeError, "BUG: no backup found"
@@ -123,7 +121,6 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns list of backups" do
-    skip_if_frozen
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
 
     minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key", ssl_ca_file_data: "data")
@@ -134,13 +131,11 @@ PGHOST=/var/run/postgresql
   end
 
   it "returns blob storage endpoint" do
-    skip_if_frozen_models
     expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
     expect(postgres_timeline.blob_storage_endpoint).to eq("https://blob-endpoint")
   end
 
   it "returns blob storage client from cache" do
-    skip_if_frozen_models
     expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, root_certs: "certs")).once
     expect(Minio::Client).to receive(:new).and_return("dummy-client").once

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -117,7 +117,6 @@ RSpec.describe PrivateSubnet do
 
   describe "destroy" do
     it "destroys firewalls private subnets" do
-      skip_if_frozen_models
       ps = described_class.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       fwps = instance_double(FirewallsPrivateSubnets)
       expect(FirewallsPrivateSubnets).to receive(:where).with(private_subnet_id: ps.id).and_return(instance_double(Sequel::Dataset, all: [fwps]))

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Project do
     end
 
     it "sets and gets feature flags" do
-      skip_if_frozen_models
       mod = Module.new
       described_class.feature_flag(:dummy_flag, into: mod)
       project = described_class.create_with_id(name: "dummy-name")

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe Sshable do
     end
 
     it "can run a command" do
-      skip_if_frozen
       [false, true].each do |repl_value|
         [false, true].each do |log_value|
           allow(described_class).to receive(:repl?).and_return(repl_value)

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Strand do
     end
 
     it "does an integrity check that deleted records are gone" do
-      skip_if_frozen_models
       st.label = "hop_exit"
       st.save_changes
       original = DB.method(:[])
@@ -41,7 +40,6 @@ RSpec.describe Strand do
     end
 
     it "does an integrity check that the lease was modified as expected" do
-      skip_if_frozen_models
       st.label = "napper"
       st.save_changes
       original = DB.method(:[])

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Strand do
       st.label = "hop_exit"
       st.save_changes
       original = DB.method(:[])
+      original = original.super_method unless original.owner == Sequel::Database
       expect(DB).to receive(:[]) do |*args, **kwargs|
         case args
         when ["SELECT FROM strand WHERE id = ?", st.id]
@@ -44,6 +45,7 @@ RSpec.describe Strand do
       st.label = "napper"
       st.save_changes
       original = DB.method(:[])
+      original = original.super_method unless original.owner == Sequel::Database
       expect(DB).to receive(:[]) do |*args, **kwargs|
         case args[0]
         when <<SQL

--- a/spec/model/usage_alert_spec.rb
+++ b/spec/model/usage_alert_spec.rb
@@ -4,7 +4,6 @@ require_relative "spec_helper"
 
 RSpec.describe UsageAlert do
   it "trigger sends email and updates last_triggered_at" do
-    skip_if_frozen
     alert = described_class.new
     expect(alert).to receive(:user).and_return(instance_double(Account, name: "dummy-name", email: "dummy-email")).at_least(:once)
     expect(alert).to receive(:project).and_return(instance_double(Project, name: "dummy-name", ubid: "dummy-ubid", path: "dummy-path", current_invoice: instance_double(Invoice, content: {"cost" => "dummy-cost"}))).at_least(:once)

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to install Rhizome" do
-    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     expect(Strand).to receive(:create) do |args|
       expect(args[:prog]).to eq("InstallRhizome")
@@ -99,7 +98,6 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new boot image" do
-    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     expect(Strand).to receive(:create) do |args|
       expect(args[:prog]).to eq("DownloadBootImage")
@@ -109,7 +107,6 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new firmware for x64" do
-    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "x64"
     expect(Strand).to receive(:create) do |args|
@@ -120,7 +117,6 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new firmware for arm64" do
-    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "arm64"
     expect(Strand).to receive(:create) do |args|
@@ -140,7 +136,6 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new version of cloud hypervisor for x64" do
-    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "x64"
     expect(Strand).to receive(:create) do |args|
@@ -151,7 +146,6 @@ RSpec.describe VmHost do
   end
 
   it "has a shortcut to download a new version of cloud hypervisor for arm64" do
-    skip_if_frozen_models
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     vh.arch = "arm64"
     expect(Strand).to receive(:create) do |args|
@@ -211,7 +205,6 @@ RSpec.describe VmHost do
   end
 
   it "hetznerifies a host" do
-    skip_if_frozen_models
     expect(vh).to receive(:create_addresses).at_least(:once)
     expect(HetznerHost).to receive(:create).with(server_identifier: "12").and_return(true)
 
@@ -287,7 +280,6 @@ RSpec.describe VmHost do
   end
 
   it "updates the routed_to_host_id if the address is reassigned to another host and there is no vm using the ip range" do
-    skip_if_frozen_models
     hetzner_ips = [
       Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)
     ]
@@ -309,7 +301,6 @@ RSpec.describe VmHost do
   end
 
   it "fails if the ip range is already assigned to a vm" do
-    skip_if_frozen_models
     hetzner_ips = [
       Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)
     ]

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe VmPool do
     }
 
     it "returns the vm if there is one in running state" do
-      skip_if_frozen_models
       locking_vms = class_double(Vm)
       expect(pool).to receive(:vms_dataset).and_return(locking_vms).at_least(:once)
       expect(locking_vms).to receive_message_chain(:for_update, :all).and_return([])  # rubocop:disable RSpec/MessageChain

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -220,7 +220,6 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     p1 = Project.create_with_id(name: "default")
 
     it "updates billing records" do
-      skip_if_frozen_models
       expect(Project).to receive(:from_ubid).with(p1.ubid).and_return(p1).twice
       expect(BillingRecord.count).to eq(0)
       nx.update_billing_records([{"ubid" => p1.ubid, "request_count" => 1, "prompt_token_count" => 10, "completion_token_count" => 20}])
@@ -249,7 +248,6 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     end
 
     it "failure in updating single record doesn't impact others" do
-      skip_if_frozen_models
       p2 = Project.create_with_id(name: "default")
       expect(Project).to receive(:from_ubid).with(p1.ubid).and_return(p1)
       expect(Project).to receive(:from_ubid).with(p2.ubid).and_return(p2)

--- a/spec/prog/check_usage_alerts_spec.rb
+++ b/spec/prog/check_usage_alerts_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Prog::CheckUsageAlerts do
 
   describe "#wait" do
     it "triggers alerts if usage is exceeded given threshold" do
-      skip_if_frozen_models
       exceeded = instance_double(UsageAlert, limit: 100, project: instance_double(Project, current_invoice: instance_double(Invoice, content: {"cost" => 1000})))
       not_exceeded = instance_double(UsageAlert, limit: 100, project: instance_double(Project, current_invoice: instance_double(Invoice, content: {"cost" => 10})))
       expect(UsageAlert).to receive(:where).and_return([exceeded, not_exceeded])

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -209,7 +209,6 @@ RSpec.describe Prog::DownloadBootImage do
 
   describe "#activate_boot_image" do
     it "activates the boot image" do
-      skip_if_frozen_models
       dataset = instance_double(Sequel::Dataset)
       expect(BootImage).to receive(:where).with(vm_host_id: vm_host.id, name: "my-image", version: "20230303").and_return(dataset)
       expect(dataset).to receive(:update) do |args|

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
 
   describe ".assemble" do
     it "creates github repository or updates last_job_at if the repository exists" do
-      skip_if_frozen
       project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
 
@@ -75,7 +74,6 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
     end
 
     it "naps until the resets_at if remaining quota is low" do
-      skip_if_frozen
       expect(client).to receive(:repository_workflow_runs).and_return({workflow_runs: []})
       now = Time.now
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 8, limit: 100, resets_at: now + 8 * 60)).at_least(:once)

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Prog::Heartbeat do
     before { allow(Config).to receive(:heartbeat_url).and_return("http://localhost:3000") }
 
     it "fails if it can't connect to the database" do
-      skip_if_frozen_models
       expect(DB).to receive(:[]).with(described_class::CONNECTED_APPLICATION_QUERY).and_raise(Sequel::DatabaseConnectionError)
 
       expect { hb.wait }.to raise_error Sequel::DatabaseConnectionError

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
     end
 
     it "moves root_cert_2 to root_cert_1 and creates new root_cert_2 if root_cert_1 is about to expire, also updates server_cert" do
-      skip_if_frozen
       rc2 = nx.minio_cluster.root_cert_2
       rck2 = nx.minio_cluster.root_cert_key_2
       certificate_last_checked_at = nx.minio_cluster.certificate_last_checked_at

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -289,7 +289,6 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     end
 
     it "creates new certificates from root_cert_2 if root_cert_1 is about to expire" do
-      skip_if_frozen
       expect(Time).to receive(:now).and_return(Time.now + 60 * 60 * 24 * 365 * 4 + 1).at_least(:once)
       cert = nx.minio_server.cert
       cert_key = nx.minio_server.cert_key

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -98,7 +98,6 @@ ECHO
     }
 
     before do
-      skip_if_frozen_models
       allow(DnsZone).to receive(:where).and_return([instance_double(DnsZone, name: "minio.ubicloud.com")])
     end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     let(:postgres_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
 
     it "validates input" do
-      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       expect {
@@ -86,7 +85,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "does not allow giving different version than parent for restore" do
-      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128, version: "16").subject
       expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
@@ -96,7 +94,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "validates storage size during restore if the storage size is different from the parent" do
-      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-parent-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
       parent.update(target_storage_size_gib: 1024)
@@ -114,7 +111,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "passes timeline of parent resource if parent is passed" do
-      skip_if_frozen_models
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       parent = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
@@ -275,7 +271,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
   describe "#create_billing_record" do
     it "creates billing record for cores and storage then hops" do
-      skip_if_frozen_models
       expect(postgres_resource).to receive(:required_standby_count).and_return(1)
       expect(postgres_resource).to receive(:flavor).and_return("standard").at_least(:once)
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "picks correct base image for Lantern" do
-      skip_if_frozen_models
       expect(PostgresResource).to receive(:[]).and_return(postgres_resource)
       expect(postgres_resource).to receive(:flavor).and_return(PostgresResource::Flavor::LANTERN).at_least(:once)
       expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).with(anything, anything, hash_including(boot_image: "postgres16-lantern-ubuntu-2204")).and_return(instance_double(Strand, id: "62c62ddb-5b5a-4e9e-b534-e73c16f86bcb"))
@@ -86,7 +85,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "errors out for unknown flavor" do
-      skip_if_frozen_models
       expect(PostgresResource).to receive(:[]).and_return(postgres_resource)
       expect(postgres_resource).to receive(:flavor).and_return("boring_flavor").at_least(:once)
       expect {

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -115,7 +115,6 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "creates a missing backup page if last completed backup is older than 2 days" do
-      skip_if_frozen
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
       backup = Struct.new(:last_modified)
       expect(postgres_timeline).to receive(:backups).and_return([instance_double(backup, last_modified: Time.now - 3 * 24 * 60 * 60)])
@@ -125,8 +124,6 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "resolves the missing page if last completed backup is more recent than 2 days" do
-      skip_if_frozen
-      skip_if_frozen_models
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
       backup = Struct.new(:last_modified)
       expect(postgres_timeline).to receive(:backups).and_return([instance_double(backup, last_modified: Time.now - 1 * 24 * 60 * 60)])
@@ -139,7 +136,6 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "naps if there is nothing to do" do
-      skip_if_frozen
       expect(postgres_timeline).to receive(:need_backup?).and_return(false)
       backup = Struct.new(:last_modified)
       expect(postgres_timeline).to receive(:backups).and_return([instance_double(backup, last_modified: Time.now - 1 * 24 * 60 * 60)])

--- a/spec/prog/redeliver_github_failures_spec.rb
+++ b/spec/prog/redeliver_github_failures_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Prog::RedeliverGithubFailures do
 
   describe "#wait" do
     it "redelivers failed deliveries and naps" do
-      skip_if_frozen
       expect(Time).to receive(:now).and_return("2023-10-19 23:27:47 +0000").at_least(:once)
       expect(Github).to receive(:redeliver_failed_deliveries).with(Time.parse("2023-10-19 22:27:47 +0000"))
       expect(rgf.strand).to receive(:save_changes)

--- a/spec/prog/resolve_globally_blocked_dnsnames_spec.rb
+++ b/spec/prog/resolve_globally_blocked_dnsnames_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Prog::ResolveGloballyBlockedDnsnames do
     end
 
     it "resolves dnsnames to ip addresses and updates records" do
-      skip_if_frozen
       expect(Socket).to receive(:getaddrinfo).with("example.com", nil).and_return([[nil, nil, nil, "1.1.1.1"], [nil, nil, nil, "2a00:1450:400e:811::200e"], [nil, nil, nil, "1.1.1.1"]])
       expect(Time).to receive(:now).and_return(Time.new("2023-10-19 23:27:47 +0000")).at_least(:once)
       expect { rgbd.wait }.to nap(60 * 60)
@@ -24,7 +23,6 @@ RSpec.describe Prog::ResolveGloballyBlockedDnsnames do
     end
 
     it "skips if socket fails" do
-      skip_if_frozen
       expect(Socket).to receive(:getaddrinfo).with("example.com", nil).and_raise(SocketError)
       expect { rgbd.wait }.to nap(60 * 60)
 

--- a/spec/prog/rotate_storage_kek_spec.rb
+++ b/spec/prog/rotate_storage_kek_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe Prog::RotateStorageKek do
 
   describe "#start" do
     it "creates a key & hops to install" do
-      skip_if_frozen_models
       expect(StorageKeyEncryptionKey).to receive(:create).and_return(current_kek)
       expect(volume).to receive(:update).with({key_encryption_key_2_id: current_kek.id})
       expect { rsk.start }.to hop("install")

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Prog::Test::GithubRunner do
 
   describe "#wait_vm_pool_to_be_ready" do
     it "hops to trigger_test_runs when the pool is ready" do
-      skip_if_frozen_models
       pool = instance_double(VmPool, size: 1)
       expect(VmPool).to receive(:[]).and_return(pool)
       expect(pool).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, exclude: [instance_double(Vm)]))
@@ -60,7 +59,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "naps if the vm in the pool not provisioned yet" do
-      skip_if_frozen_models
       pool = instance_double(VmPool, size: 1)
       expect(VmPool).to receive(:[]).and_return(pool)
       expect(pool).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, exclude: []))
@@ -129,7 +127,6 @@ RSpec.describe Prog::Test::GithubRunner do
 
   describe "#clean_resources" do
     it "not clean with github exists" do
-      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
@@ -139,7 +136,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop finish" do
-      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
@@ -151,7 +147,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop failed" do
-      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
@@ -164,7 +159,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources already cancelled" do
-      skip_if_frozen_models
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -190,7 +190,6 @@ RSpec.describe Prog::Test::HetznerServer do
 
   describe "#vm_host" do
     it "returns the vm_host" do
-      skip_if_frozen_models
       prg = described_class.new(Strand.new(stack: [{"vm_host_id" => "123"}]))
       vmh = instance_double(VmHost)
       expect(VmHost).to receive(:[]).with("123").and_return(vmh)

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -20,14 +20,12 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#wait_vms" do
     it "hops to verify_vms if vms are ready" do
-      skip_if_frozen_models
       expect(vg_test).to receive(:frame).and_return({"vms" => ["111"]})
       expect(Vm).to receive(:[]).with("111").and_return(instance_double(Vm, display_state: "running"))
       expect { vg_test.wait_vms }.to hop("verify_vms")
     end
 
     it "naps if vms are not running" do
-      skip_if_frozen_models
       expect(vg_test).to receive(:frame).and_return({"vms" => ["111"]})
       expect(Vm).to receive(:[]).with("111").and_return(instance_double(Vm, display_state: "creating"))
       expect { vg_test.wait_vms }.to nap(10)
@@ -83,7 +81,6 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#destroy_resources" do
     it "hops to wait_resources_destroyed" do
-      skip_if_frozen_models
       allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
       expect(Vm).to receive(:[]).with("vm_id").and_return(instance_double(Vm, incr_destroy: nil))
       expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(instance_double(PrivateSubnet, incr_destroy: nil))
@@ -93,7 +90,6 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#wait_resources_destroyed" do
     it "hops to finish if all resources are destroyed" do
-      skip_if_frozen_models
       allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
       expect(Vm).to receive(:[]).with("vm_id").and_return(nil)
       expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(nil)
@@ -102,7 +98,6 @@ RSpec.describe Prog::Test::VmGroup do
     end
 
     it "naps if all resources are not destroyed yet" do
-      skip_if_frozen_models
       allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
       expect(Vm).to receive(:[]).with("vm_id").and_return(instance_double(Vm))
       expect { vg_test.wait_resources_destroyed }.to nap(5)

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "provisions a VM if the pool is not existing" do
-      skip_if_frozen_models
       expect(VmPool).to receive(:where).and_return([])
       expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
       expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
@@ -84,7 +83,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "provisions a new vm if pool is valid but there is no vm" do
-      skip_if_frozen_models
       git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150, arch: "x64")
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
@@ -102,7 +100,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses the existing vm if pool can pick one" do
-      skip_if_frozen_models
       git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners", storage_size_gib: 150, arch: "arm64")
       expect(VmPool).to receive(:where).with(
         vm_size: "standard-4", boot_image: "github-ubuntu-2204", location: "github-runners",
@@ -141,8 +138,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "creates new billing record when no daily record" do
-      skip_if_frozen
-      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -155,8 +150,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses separate billing rate for arm64 runners" do
-      skip_if_frozen
-      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:label).and_return("ubicloud-arm").at_least(:once)
@@ -171,8 +164,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses separate billing rate for gpu runners" do
-      skip_if_frozen
-      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:label).and_return("ubicloud-gpu").at_least(:once)
@@ -187,8 +178,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "updates the amount of existing billing record" do
-      skip_if_frozen
-      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -201,8 +190,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "create a new record for a new day" do
-      skip_if_frozen
-      skip_if_frozen_models
       today = Time.now
       tomorrow = today + 24 * 60 * 60
       expect(Time).to receive(:now).and_return(today).exactly(5)
@@ -222,8 +209,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "tries 3 times and creates single billing record" do
-      skip_if_frozen
-      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -236,8 +221,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "tries 4 times and fails" do
-      skip_if_frozen
-      skip_if_frozen_models
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
@@ -522,7 +505,6 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#wait" do
     it "does not destroy runner if it does not pick a job in five minutes, and busy" do
-      skip_if_frozen
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
       expect(client).to receive(:get).and_return({busy: true})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
@@ -532,7 +514,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "destroys runner if it does not pick a job in five minutes and not busy" do
-      skip_if_frozen
       expect(github_runner).to receive(:workflow_job).and_return(nil)
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
       expect(client).to receive(:get).and_return({busy: false})
@@ -544,7 +525,6 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "does not destroy runner if it doesn not pick a job but two minutes not pass yet" do
-      skip_if_frozen
       expect(github_runner).to receive(:workflow_job).and_return(nil)
       expect(Time).to receive(:now).and_return(github_runner.ready_at + 1 * 60)
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -245,7 +245,6 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "resolves the page if host is available" do
-      skip_if_frozen_models
       expect(vm_host).to receive(:ubid).and_return("vhxxxx").at_least(:once)
       expect(Prog::PageNexus).to receive(:assemble)
       pg = instance_double(Page)
@@ -256,7 +255,6 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "does not resolves the page if there is none" do
-      skip_if_frozen_models
       expect(vm_host).to receive(:ubid).and_return("vhxxxx").at_least(:once)
       expect(Prog::PageNexus).to receive(:assemble)
       expect(nx).to receive(:available?).and_return(true)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates Nic if only subnet_id is passed" do
-      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with(ps.id).and_return(ps)
       expect(Prog::Vnet::NicNexus).to receive(:assemble).and_return(nic)
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
@@ -91,7 +90,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "adds the VM to a private subnet if nic_id is passed" do
-      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:private_subnet).and_return(ps).at_least(:once)
       expect(nic).to receive(:update).and_return(nic)
@@ -129,7 +127,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if nic is assigned to a different vm" do
-      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:vm_id).and_return("57afa8a7-2357-4012-9632-07fbe13a3133")
       expect {
@@ -138,7 +135,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if nic subnet is in another location" do
-      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(ps).to receive(:location).and_return("hel2")
@@ -148,7 +144,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if subnet of nic belongs to another project" do
-      skip_if_frozen_models
       expect(Nic).to receive(:[]).with(nic.id).and_return(nic)
       expect(nic).to receive(:private_subnet).and_return(ps)
       expect(Project).to receive(:[]).with(prj.id).and_return(prj)
@@ -160,7 +155,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "fails if subnet belongs to another project" do
-      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with(ps.id).and_return(ps)
       expect(Project).to receive(:[]).with(prj.id).and_return(prj)
       expect(prj).to receive(:private_subnets).and_return([ps]).at_least(:once)
@@ -180,7 +174,6 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe ".assemble_with_sshable" do
     it "calls .assemble with generated ssh key" do
-      skip_if_frozen_models
       st_id = "eb3dbcb3-2c90-8b74-8fb4-d62a244d7ae5"
       expect(SshKey).to receive(:generate).and_return(instance_double(SshKey, public_key: "public", keypair: "pair"))
       expect(described_class).to receive(:assemble) do |public_key, project_id, **kwargs|
@@ -529,7 +522,6 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe "#create_billing_record" do
     before do
-      skip_if_frozen
       now = Time.now
       expect(Time).to receive(:now).and_return(now).at_least(:once)
       expect(vm).to receive(:update).with(display_state: "running", provisioned_at: now).and_return(true)
@@ -537,7 +529,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates billing records when ip4 is enabled" do
-      skip_if_frozen_models
       vm_addr = instance_double(AssignedVmAddress, id: "46ca6ded-b056-4723-bd91-612959f52f6f", ip: NetAddr::IPv4Net.parse("10.0.0.1"))
       expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)
       expect(vm).to receive(:ip4_enabled).and_return(true)
@@ -547,7 +538,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "creates billing records when ip4 is not enabled" do
-      skip_if_frozen_models
       expect(vm).to receive(:ip4_enabled).and_return(false)
       expect(BillingRecord).to receive(:create_with_id).exactly(3).times
       expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
@@ -555,7 +545,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "not create billing records when the project is not billable" do
-      skip_if_frozen_models
       expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
       expect(prj).to receive(:billable).and_return(false)
       expect(BillingRecord).not_to receive(:create_with_id)
@@ -678,7 +667,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "resolves the page if vm is available" do
-      skip_if_frozen_models
       pg = instance_double(Page)
       expect(pg).to receive(:incr_resolve)
       expect(nx).to receive(:available?).and_return(true)
@@ -687,7 +675,6 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "does not resolves the page if there is none" do
-      skip_if_frozen_models
       expect(nx).to receive(:available?).and_return(true)
       expect(Page).to receive(:from_tag_parts).and_return(nil)
       expect { nx.unavailable }.to hop("wait")

--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
   end
 
   it "returns vm_host" do
-    skip_if_frozen_models
     expect(VmHost).to receive(:[]).with(1).and_return(vm_host)
     expect(pr.vm_host).to eq(vm_host)
   end

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe Prog::Vm::VmPool do
     end
 
     it "waits even if the vm count is less when there are waiting GithubRunners" do
-      skip_if_frozen_models
       pool.update(size: 1)
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       expect(GithubRunner).to receive_message_chain(:join, :where, :count).and_return(1) # rubocop:disable RSpec/MessageChain

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   describe "#wait_dns_update" do
     it "waits for dns_record to be seen by all servers" do
-      skip_if_frozen_models
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name", record_content: "content")).at_least(:once)
       dns_record = instance_double(DnsRecord, id: SecureRandom.uuid)
@@ -160,7 +159,6 @@ RSpec.describe Prog::Vnet::CertNexus do
     end
 
     it "updates the certificate when certificate is valid" do
-      skip_if_frozen
       expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name"))
       expect(acme_order).to receive(:status).and_return("valid")
       expect(acme_order).to receive(:certificate).and_return("test-certificate")
@@ -174,14 +172,12 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   describe "#wait" do
     it "waits for 1 month" do
-      skip_if_frozen
       expect(cert).to receive(:created_at).and_return(Time.new(2021, 4, 1, 0, 0, 0))
       expect(Time).to receive(:now).and_return(Time.new(2021, 4, 1, 0, 0, 0))
       expect { nx.wait }.to nap(60 * 60 * 24 * 30 * 1)
     end
 
     it "destroys the certificate after 3 months" do
-      skip_if_frozen
       created_at = Time.new(2021, 1, 1, 0, 0, 0)
       expect(cert).to receive(:created_at).and_return(created_at)
       expect(Time).to receive(:now).and_return(created_at + 60 * 60 * 24 * 30 * 3 + 1)
@@ -289,7 +285,6 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   describe "#dns_zone" do
     it "returns the dns zone" do
-      skip_if_frozen_models
       expect(DnsZone).to receive(:[]).with(cert.dns_zone_id).and_return("dns-zone")
       expect(nx.dns_zone).to eq "dns-zone"
     end

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Prog::Vnet::CertServer do
   }
 
   before do
-    skip_if_frozen_models
     allow(lb).to receive(:active_cert).and_return(lb.certs.first)
     allow(Vm).to receive(:[]).and_return(vm)
   end

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
     }
 
     before do
-      skip_if_frozen_models
       allow(vm).to receive(:vm_host).and_return(vmh)
       lb.add_vm(vm)
       lb.load_balancers_vms_dataset.update(state: "up")

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -223,7 +223,6 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
     end
 
     it "does not rewrite dns records if no dns zone" do
-      skip_if_frozen_models
       vms = [instance_double(Vm, ephemeral_net4: NetAddr::IPv4Net.parse("192.168.1.0"), ephemeral_net6: NetAddr::IPv6Net.parse("fd10:9b0b:6b4b:8fb0::"))]
       expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
       expect(DnsRecord).not_to receive(:create)

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "uses ipv6_addr if passed" do
-      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with("57afa8a7-2357-4012-9632-07fbe13a3133").and_return(ps)
       expect(ps).to receive(:random_private_ipv4).and_return("10.0.0.12/32")
       expect(ps).not_to receive(:random_private_ipv6)
@@ -36,7 +35,6 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "uses ipv4_addr if passed" do
-      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:[]).with("57afa8a7-2357-4012-9632-07fbe13a3133").and_return(ps)
       expect(ps).to receive(:random_private_ipv6).and_return("fd10:9b0b:6b4b:8fbb::/128")
       expect(ps).not_to receive(:random_private_ipv4)

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -268,7 +268,6 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "hops to wait if all is done" do
-      skip_if_frozen
       t = Time.now
       expect(Time).to receive(:now).and_return(t)
       expect(nic.strand).to receive(:label).and_return("wait")
@@ -280,7 +279,6 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "doesn't decrement refresh_keys if there are missed nics" do
-      skip_if_frozen
       t = Time.now
       expect(Time).to receive(:now).and_return(t)
       expect(nic.strand).to receive(:label).and_return("wait")
@@ -298,7 +296,6 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "finds a new subnet if the one it found is taken" do
-      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:random_subnet).and_return("10.0.0.0/8").at_least(:once)
       project = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
       described_class.assemble(project.id, location: "hetzner-hel1", name: "test-subnet", ipv4_range: "10.0.0.128/26")
@@ -307,7 +304,6 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "finds a new subnet if the one it found is banned" do
-      skip_if_frozen_models
       expect(PrivateSubnet).to receive(:random_subnet).and_return("172.16.0.0/16", "10.0.0.0/8")
       project = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
       allow(SecureRandom).to receive(:random_number).with(2**(26 - 16) - 1).and_return(1)
@@ -338,14 +334,12 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     }
 
     it "creates tunnels if not existing" do
-      skip_if_frozen_models
       expect(IpsecTunnel).to receive(:create).with(src_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b", dst_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d").and_return(true)
       expect(IpsecTunnel).to receive(:create).with(src_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d", dst_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b").and_return(true)
       nx.create_tunnels([src_nic, dst_nic], dst_nic)
     end
 
     it "skips existing tunnels" do
-      skip_if_frozen_models
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b", dst_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d").and_return(true)
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d", dst_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b").and_return(false)
 
@@ -354,7 +348,6 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "skips existing tunnels - 2" do
-      skip_if_frozen_models
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b", dst_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d").and_return(false)
       expect(IpsecTunnel).to receive(:[]).with(src_nic_id: "6a187cc1-291b-8eac-bdfc-96801fa3118d", dst_nic_id: "8ce8a85c-c3d6-86ac-bfdf-022bad69440b").and_return(true)
 

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe ResourceMethods do
   end
 
   it "archives scrubbed version of the model when deleted" do
-    skip_if_frozen_models
     scrubbed_values_hash = sa.values.merge(model_name: "Sshable")
     scrubbed_values_hash.delete(:raw_private_key_1)
     scrubbed_values_hash.delete(:raw_private_key_2)

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach to subnet" do
-      skip_if_frozen_models
       ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
@@ -125,7 +124,6 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "detach from subnet" do
-      skip_if_frozen_models
       ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
@@ -146,7 +144,6 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach and detach" do
-      skip_if_frozen_models
       ps = PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-hel1", net6: "2001:db8::/64", net4: "10.0.0.0/24")
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps).twice
       expect(ps).to receive(:incr_update_firewall_rules).twice

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -208,8 +208,6 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "restore" do
-        skip_if_frozen
-        skip_if_frozen_models
         backup = Struct.new(:key, :last_modified)
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
@@ -268,7 +266,6 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "failover" do
-        skip_if_frozen_models
         project.set_ff_postgresql_base_image(true)
         pg.save_changes
         rs = pg.representative_server

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Clover, "github" do
   end
 
   it "setups blob storage if no access key" do
-    skip_if_frozen_models
     vm = create_vm
     login_runtime(vm)
     repository = instance_double(GithubRepository, access_key: nil)

--- a/spec/routes/web/github_spec.rb
+++ b/spec/routes/web/github_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Clover, "github" do
   end
 
   it "raises forbidden when does not have permissions to the project in session" do
-    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
     project.access_policies.first.update(body: {})
@@ -61,7 +60,6 @@ RSpec.describe Clover, "github" do
   end
 
   it "redirects to user management page if it requires approval" do
-    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
 
@@ -72,7 +70,6 @@ RSpec.describe Clover, "github" do
   end
 
   it "fails if oauth code is invalid" do
-    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("invalid").and_return({})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
 
@@ -83,7 +80,6 @@ RSpec.describe Clover, "github" do
   end
 
   it "fails if installation not found" do
-    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: []})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
@@ -95,7 +91,6 @@ RSpec.describe Clover, "github" do
   end
 
   it "fails if the current user's account suspended" do
-    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)
@@ -108,7 +103,6 @@ RSpec.describe Clover, "github" do
   end
 
   it "creates installation with project from session" do
-    skip_if_frozen_models
     expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
     expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
     expect(Project).to receive(:[]).and_return(project).at_least(:once)

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Clover, "github" do
     end
 
     it "can not connect GitHub account if project has no valid payment method" do
-      skip_if_frozen_models
       expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 
@@ -61,7 +60,6 @@ RSpec.describe Clover, "github" do
     end
 
     it "shows new billing info button instead of connect account if project has no valid payment method" do
-      skip_if_frozen_models
       expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
       # rubocop:disable RSpec/VerifiedDoubles

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -188,8 +188,6 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can restore PostgreSQL database" do
-        skip_if_frozen
-        skip_if_frozen_models
         backup = Struct.new(:key, :last_modified)
         restore_target = Time.now.utc
         expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
@@ -348,7 +346,6 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "cannot delete metric destination if it is not exist" do
-        skip_if_frozen_models
         md = PostgresMetricDestination.create_with_id(
           postgres_resource_id: pg.id,
           url: "https://example.com",

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Clover, "project" do
 
     describe "list" do
       it "can list no projects" do
-        skip_if_frozen_models
         expect(Account).to receive(:[]).and_return(user).twice
         expect(user).to receive(:projects).and_return([]).at_least(1)
 
@@ -316,7 +315,6 @@ RSpec.describe Clover, "project" do
       end
 
       it "can not have more than 50 pending invitations" do
-        skip_if_frozen_models
         visit "#{project.path}/user"
 
         expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe Clover, "vm" do
 
     describe "create" do
       it "can create new virtual machine" do
-        skip_if_frozen
         project
 
         visit "#{project.path}/vm/create"
@@ -107,7 +106,6 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can create new virtual machine with chosen private subnet" do
-        skip_if_frozen
         project
         ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1").id
         ps = PrivateSubnet[ps_id]
@@ -132,7 +130,6 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can not create virtual machine with invalid name" do
-        skip_if_frozen
         project
         visit "#{project.path}/vm/create"
 
@@ -151,7 +148,6 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can not create virtual machine with same name" do
-        skip_if_frozen
         project
         visit "#{project.path}/vm/create"
 
@@ -169,7 +165,6 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can not create virtual machine if project has no valid payment method" do
-        skip_if_frozen_models
         expect(Project).to receive(:from_ubid).and_return(project).at_least(:once)
         expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe Clover, "github" do
     end
 
     it "updates job details of runner when receive in_progress action" do
-      skip_if_frozen_models
       expect(Clog).to receive(:emit).with("runner_started")
       expect(runner).to receive(:vm).and_return(instance_double(Vm, ubid: "vm-ubid", arch: "x64", cores: 2, vm_host: nil, pool_id: nil)).at_least(:once)
       expect(GithubRunner).to receive(:first).and_return(runner)
@@ -126,7 +125,6 @@ RSpec.describe Clover, "github" do
     end
 
     it "fails if unexpected action" do
-      skip_if_frozen_models
       expect(GithubRunner).to receive(:first).and_return(runner)
       send_webhook("workflow_job", workflow_job_payload(action: "approved"))
 

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -665,7 +665,6 @@ RSpec.describe Al do
     end
 
     it "allocates the vm to a host with IPv4 address" do
-      skip_if_frozen_models
       vm = create_vm
       vmh = VmHost.first
       address = Address.new(cidr: "0.0.0.0/30", routed_to_host_id: vmh.id)

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Scheduling::Dispatcher do
     end
 
     it "exits if all strands have finished when shutting down" do
-      skip_if_frozen
       expect { di.shutdown }.to change(di, :shutting_down).from(false).to(true)
       expect(Kernel).to receive(:exit)
       di.wait_cohort
@@ -99,7 +98,6 @@ RSpec.describe Scheduling::Dispatcher do
     end
 
     it "can trigger thread dumps and exit if the Prog takes too long" do
-      skip_if_frozen
       expect(ThreadPrinter).to receive(:run)
       expect(Kernel).to receive(:exit!)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -214,16 +214,7 @@ RSpec.configure do |config|
     require "diff/lcs"
     require "ripper"
     require "coderay"
-
-    def skip_if_frozen
-      itself # Satisfy Rubocop
-    end
-  else
-    def skip_if_frozen
-    end
   end
-
-  alias_method :skip_if_frozen_models, :skip_if_frozen
 end
 
 def create_vm(**args)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
 RSpec.configure do |config|
   config.before(:suite) do
     clover_freeze
-    Clover.freeze if ENV["CLOVER_FREEZE_MODELS"] == "1"
+    Clover.freeze if ENV["CLOVER_FREEZE"] == "1"
   end
 
   config.around do |example|
@@ -115,10 +115,6 @@ RSpec.configure do |config|
   # particularly slow.  However, avoid printing when parallel testing,
   # to avoid output from every process.
   config.profile_examples = 10 unless ENV["TEST_ENV_NUMBER"]
-
-  if ENV["CLOVER_FREEZE_CORE"] == "1" || ENV["CLOVER_FREEZE_MODELS"] == "1"
-    require_relative "suppress_pending"
-  end
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -211,27 +207,23 @@ RSpec.configure do |config|
     end
   end
 
-  if ENV["CLOVER_FREEZE_CORE"] == "1"
-    # Required by rspec after running examples
+  if ENV["CLOVER_FREEZE"] == "1"
+    require_relative "suppress_pending"
+    require_relative "thawed_mock"
+
+    require "diff/lcs"
     require "ripper"
     require "coderay"
 
     def skip_if_frozen
-      skip("Spec skipped when running with frozen core")
+      itself # Satisfy Rubocop
     end
   else
     def skip_if_frozen
     end
   end
 
-  if ENV["CLOVER_FREEZE_MODELS"] == "1"
-    def skip_if_frozen_models
-      skip("Spec skipped when running with frozen Database/models")
-    end
-  else
-    def skip_if_frozen_models
-    end
-  end
+  alias_method :skip_if_frozen_models, :skip_if_frozen
 end
 
 def create_vm(**args)

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module ThawedMock
+  OBJECTS = {}
+
+  def self.allow_mocking(obj, *methods)
+    mod, mock = OBJECTS[obj]
+    unless mod
+      mod = Module.new
+      mock = Object.new
+
+      obj.singleton_class.prepend(mod)
+      OBJECTS[obj] = [mod, mock].freeze
+    end
+
+    methods.each do |method|
+      original_method = obj.method(method)
+
+      mock.define_singleton_method(method) do |*a, **kw, &b|
+        original_method.call(*a, **kw, &b)
+      end
+
+      mod.define_method(method) do |*a, **kw, &b|
+        mock.send(method, *a, **kw, &b)
+      end
+    end
+  end
+
+  module ExpectOverride
+    [:allow, :expect].each do |method|
+      define_method(method) do |obj = nil, &block|
+        return super(&block) if obj.nil? && block
+
+        _, mock = OBJECTS[obj]
+        super(mock || obj, &block)
+      end
+    end
+  end
+  RSpec::Core::ExampleGroup.prepend(ExpectOverride)
+
+  # Ruby Core Classes
+  allow_mocking(File, :exist?, :open, :rename, :write)
+  allow_mocking(Kernel, :exit, :exit!)
+  allow_mocking(Thread, :new, :list)
+  allow_mocking(Time, :now)
+
+  # Database
+  allow_mocking(DB, :[])
+
+  # Models
+  allow_mocking(Account, :[])
+  allow_mocking(Address, :where)
+  allow_mocking(AssignedVmAddress, :create_with_id)
+  allow_mocking(BillingRecord, :create_with_id)
+  allow_mocking(BootImage, :where)
+  allow_mocking(DeletedRecord, :create)
+  allow_mocking(DnsRecord, :[], :create)
+  allow_mocking(DnsZone, :[], :where)
+  allow_mocking(FirewallsPrivateSubnets, :where)
+  allow_mocking(FirewallRule, :create_with_id)
+  allow_mocking(Github, :app_client, :failed_deliveries, :installation_client, :oauth_client, :redeliver_failed_deliveries)
+  allow_mocking(GithubRunner, :[], :any?, :first, :join)
+  allow_mocking(HetznerHost, :create)
+  allow_mocking(IpsecTunnel, :[], :create)
+  allow_mocking(MinioCluster, :[])
+  allow_mocking(Nic, :[], :create)
+  allow_mocking(Page, :from_tag_parts)
+  allow_mocking(PrivateSubnet, :[], :from_ubid, :random_subnet)
+  allow_mocking(PostgresLsnMonitor, :new)
+  allow_mocking(PostgresMetricDestination, :from_ubid)
+  allow_mocking(PostgresResource, :[])
+  allow_mocking(PostgresServer, :create, :run_query)
+  allow_mocking(Project, :[], :from_ubid)
+  allow_mocking(Semaphore, :where)
+  allow_mocking(Sshable, :create, :repl?)
+  allow_mocking(StorageKeyEncryptionKey, :create)
+  allow_mocking(Strand, :create, :create_with_id)
+  allow_mocking(UsageAlert, :where)
+  allow_mocking(VmHost, :[])
+  allow_mocking(Vm, :[], :where)
+  allow_mocking(VmPool, :[], :where)
+
+  # Progs
+  allow_mocking(Prog::Ai::InferenceEndpointNexus, :assemble, :model_for_id)
+  allow_mocking(Prog::Ai::InferenceEndpointReplicaNexus, :assemble)
+  allow_mocking(Prog::Github::DestroyGithubInstallation, :assemble)
+  allow_mocking(Prog::PageNexus, :assemble)
+  allow_mocking(Prog::Postgres::PostgresResourceNexus, :dns_zone)
+  allow_mocking(Prog::Postgres::PostgresServerNexus, :assemble)
+  allow_mocking(Prog::Postgres::PostgresTimelineNexus, :assemble)
+  allow_mocking(Prog::Vm::GithubRunner, :assemble)
+  allow_mocking(Prog::Vm::HostNexus, :assemble)
+  allow_mocking(Prog::Vm::Nexus, :assemble, :assemble_with_sshable)
+  allow_mocking(Prog::Vm::VmPool, :assemble)
+  allow_mocking(Prog::Vnet::NicNexus, :assemble, :gen_mac, :rand)
+  allow_mocking(Prog::Vnet::SubnetNexus, :assemble, :random_private_ipv4, :random_private_ipv6)
+
+  # Other Classes
+  allow_mocking(BillingRate, :from_resource_properties)
+  allow_mocking(Clog, :emit)
+  allow_mocking(CloudflareClient, :new)
+  allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reset_server)
+  allow_mocking(Minio::Client, :new)
+  allow_mocking(Minio::Crypto, :new)
+  allow_mocking(Scheduling::Allocator, :allocate)
+  allow_mocking(SshKey, :generate)
+  allow_mocking(ThreadPrinter, :puts, :run)
+  allow_mocking(Util, :create_certificate, :create_root_certificate, :rootish_ssh, :send_email)
+end


### PR DESCRIPTION
This introduces ThawedMock, which allows the specs to work in frozen
mode. With ThawedMock, you register all methods on the frozen objects
you plan to mock, and it redefines the methods to call methods on
an unfrozen mocked object.  That mocked object then calls the super
method of the method on the original object.  When you use:

```ruby
  expect(obj).to receive(:method)
```

ThawedMock replaces obj with the unfrozen mocked object, so it redefines
the method on the mocked object without raising an error.

If you want to mock additional methods on classes, you need to update
spec/thawed_mock.rb to add a line such as:

```
  allow_mocking(Klass, :method1, :method2, ...)
```

If there is already a line for the class, you just add the method as
an additional argument on the line for the class.

Since all specs can now run in frozen mode, there is no point in
having separate rake tasks to run just frozen core specs and with just
frozen Database and models specs.  Remove those, and combine the
CLOVER_FREEZE_CORE and CLOVER_FREEZE_MODELS environment variables
into CLOVER_FREEZE.

I found after doing this that I also needed to require diff/lcs
to avoid rspec breaking in frozen mode.

This needed a small tweak in strand_spec, to get the correct method,
as `DB.method(:[])` now returns the method that delegates to the
mock object, and not the actual implementation.

This removes all skip_if_frozen{,_models} calls in the specs, since they
are no longer necessary.

This also freezes all autoloaded classes in clover_freeze.  Before, just the
core classes, model classes, and DB were frozen.