### PR TITLE
 Disable Rhizome Validation Temporarily

### DIFF
--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -50,7 +50,7 @@ class Prog::InstallRhizome < Prog::Base
   end
 
   label def validate
-    sshable.cmd("common/bin/validate")
+    # sshable.cmd("common/bin/validate")
 
     pop "installed rhizome"
   end

--- a/rhizome/common/bin/validate
+++ b/rhizome/common/bin/validate
@@ -12,7 +12,7 @@ hashes.each do |filename, expected_hash|
   calculated_hash = Digest::SHA384.file(filename).hexdigest
   next if calculated_hash == expected_hash
 
-  violations << {name: file, expected: expected_hash, calculated: calculated_hash}
+  violations << {name: filename, expected: expected_hash, calculated: calculated_hash}
 end
 
 puts violations

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Prog::InstallRhizome do
 
   describe "#validate" do
     it "runs the validate script" do
-      expect(sshable).to receive(:cmd).with("common/bin/validate")
+      # expect(sshable).to receive(:cmd).with("common/bin/validate")
       expect { ir.validate }.to exit({"msg" => "installed rhizome"})
     end
   end


### PR DESCRIPTION
Possibly, we broke the VM provisioning with the Rhizome validation change, so let's skip this step for now, while investigating further.