### PR TITLE
Add the amount of money saved compare to default runners to invoice emails

### DIFF
--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe Invoice do
 
     it "can charge from a correct payment method even some of them are not working" do
       invoice.content["billing_info"] = {"id" => billing_info.id, "email" => "customer@example.com"}
+      invoice.content["resources"] = [{"cost" => 4.3384, "line_items" => [{"cost" => 4.3384, "amount" => 5423.0, "duration" => 1, "location" => "global", "description" => "standard-2 GitHub Runner", "resource_type" => "GitHubRunnerMinutes", "resource_family" => "standard-2"}], "resource_id" => "ed0b26bf-53c4-82d2-9a00-21e5f05dc364", "resource_name" => "Daily Usage 2024-02-26"}]
       payment_method1 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_1", order: 1)
       payment_method2 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_2", order: 2)
       payment_method3 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_3", order: 3)


### PR DESCRIPTION
Our managed GitHub Actions runners are 10x cost-effective than GitHub-hosted runners. We decided to share the amount of money saved by just using our runners with customers in the invoice emails.

<img width="905" alt="Screenshot 2024-10-31 at 17 57 27" src="https://github.com/user-attachments/assets/7a150440-259e-47cb-b160-d0a8a046e74e">
