### PR TITLE
Display the list of fields that failed validation at the top

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -78,6 +78,7 @@ class CloverWeb < Roda
       flash["error"] = @error[:message]
       return redirect_back_with_inputs
     when Validation::ValidationFailed
+      flash["error"] = @error[:message]
       flash["errors"] = (flash["errors"] || {}).merge(@error[:details])
       return redirect_back_with_inputs
     end


### PR DESCRIPTION
When a field in a form fails validation, we display the error at the bottom of the relevant field. However, this requires the customer to scroll down, which can be inconvenient for long pages. To improve this, I've added a list of failed fields to the top of the page in the error view. This way, customers can quickly see the names of the fields that failed at a glance.

<img width="1512" alt="Screenshot 2024-10-31 at 18 21 37" src="https://github.com/user-attachments/assets/95e03204-9ac9-47f1-96b8-376adeb437d0">
