### PR TITLE
Add Cloudflare Turnstile captcha to account creation form

### DIFF
--- a/clover_web.rb
+++ b/clover_web.rb
@@ -27,7 +27,8 @@ class CloverWeb < Roda
     csp.style_src :self, "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css"
     csp.img_src :self, "data: image/svg+xml"
     csp.form_action :self, "https://checkout.stripe.com"
-    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js", "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"
+    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js", "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js", "https://challenges.cloudflare.com/turnstile/v0/api.js"
+    csp.frame_src :self, "https://challenges.cloudflare.com"
     csp.connect_src :self
     csp.base_uri :none
     csp.frame_ancestors :none
@@ -167,6 +168,7 @@ class CloverWeb < Roda
     create_account_set_password? true
     password_confirm_label "Password Confirmation"
     before_create_account do
+      Validation.validate_cloudflare_turnstile(param("cf-turnstile-response"))
       account[:id] = Account.generate_uuid
       account[:name] = param("name")
       Validation.validate_account_name(account[:name])

--- a/config.rb
+++ b/config.rb
@@ -86,6 +86,8 @@ module Config
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)
   override :hetzner_ssh_key, string
   override :minimum_invoice_charge_threshold, 0.5, float
+  optional :cloudflare_turnstile_site_key, string
+  optional :cloudflare_turnstile_secret_key, string
 
   # GitHub Runner App
   optional :github_app_name, string

--- a/views/auth/create_account.erb
+++ b/views/auth/create_account.erb
@@ -28,6 +28,8 @@
     <% end %>
   <% end %>
 
+  <%== render("components/form/cloudflare_turnstile") %>
+
   <div class="flex flex-col text-center">
     <%== render("components/form/submit_button", locals: { text: "Create Account" }) %>
     <a href="/login" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Sign in to existing account</a>

--- a/views/components/form/cloudflare_turnstile.erb
+++ b/views/components/form/cloudflare_turnstile.erb
@@ -1,0 +1,5 @@
+<% @enable_cloudflare_turnstile = Config.cloudflare_turnstile_site_key %>
+
+<% if @enable_cloudflare_turnstile %>
+  <div class="cf-turnstile" data-sitekey="<%= Config.cloudflare_turnstile_site_key %>"></div>
+<% end %>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -31,6 +31,9 @@
         crossorigin="anonymous"
       ></script>
     <% end %>
+    <% if @enable_cloudflare_turnstile %>
+      <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
+    <% end %>
   </head>
 
   <body class="h-full">


### PR DESCRIPTION
Our account creation form is publicly accessible, and open to abuse by spammers. The spam bots enter random email addresses and increase our bounce rate.

We decided to add a captcha to the form to prevent this abuse. I evaluated a few options and decided to use Cloudflare's Turnstile since it's free and privacy-friendly. It's also easy to implement. [^1]

We add their client-side widget to our form. This widget add token input and we use this token to verify the captcha on the server-side.

I added `cloudflare_turnstile.erb` component to add Cloudflare Turnstile to any form easily. External Cloudflare script is loaded only when the component is used.

There are 3 different modes for Turnstile: managed, non-interactive, and invisible [^2]. It's configurable in the Cloudflare UI. I think we can start with the invisible mode and see how it goes.

[^1]: https://developers.cloudflare.com/turnstile/get-started/
[^2]: https://developers.cloudflare.com/turnstile/concepts/widget/