### PR TITLE
Log web exceptions with Clog

### DIFF
--- a/routes/clover_base.rb
+++ b/routes/clover_base.rb
@@ -37,8 +37,7 @@ module CloverBase
       message = e.message
       details = e.details
     else
-      $stderr.print "#{e.class}: #{e.message}\n"
-      warn e.backtrace
+      Clog.emit("route exception") { Util.exception_to_hash(e) }
 
       code = 500
       type = "UnexceptedError"

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Clover do
   end
 
   it "handles unexpected errors" do
-    expect { visit "/webhook/test-error" }.to output(/RuntimeError.*/).to_stderr
+    expect(Clog).to receive(:emit).with("route exception").and_call_original
+
+    visit "/webhook/test-error"
+
     expect(page.title).to eq("Ubicloud - UnexceptedError")
   end
 end


### PR DESCRIPTION
When we encounter unexpected errors in our web application, we simply print the stack trace to stderr. This makes it challenging to investigate the error cause, as our log service can only parse JSON logs. Thus, we can log the exceptions with Clog, similar to how we handle exceptions in the respirate.