### PR TITLE
Allow in subnet communication by default for PG

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -95,6 +95,8 @@ class PostgresResource < Sequel::Model
     vm_firewall_rules = firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(5432..5432)} }
     vm_firewall_rules.push({cidr: "0.0.0.0/0", port_range: Sequel.pg_range(22..22)})
     vm_firewall_rules.push({cidr: "::/0", port_range: Sequel.pg_range(22..22)})
+    vm_firewall_rules.push({cidr: private_subnet.net4.to_s, port_range: Sequel.pg_range(5432..5432)})
+    vm_firewall_rules.push({cidr: private_subnet.net6.to_s, port_range: Sequel.pg_range(5432..5432)})
     private_subnet.firewalls.first.replace_firewall_rules(vm_firewall_rules)
   end
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -58,12 +58,14 @@ RSpec.describe PostgresResource do
 
   it "sets firewall rules" do
     firewall = instance_double(Firewall, name: "#{postgres_resource.ubid}-firewall")
-    expect(postgres_resource).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, firewalls: [firewall]))
+    expect(postgres_resource).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, firewalls: [firewall], net4: "10.238.50.0/26", net6: "fd19:9c92:e9b9:a1a::/64")).at_least(:once)
     expect(postgres_resource).to receive(:firewall_rules).and_return([instance_double(PostgresFirewallRule, cidr: "0.0.0.0/0")])
     expect(firewall).to receive(:replace_firewall_rules).with([
       {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(5432..5432)},
       {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(22..22)},
-      {cidr: "::/0", port_range: Sequel.pg_range(22..22)}
+      {cidr: "::/0", port_range: Sequel.pg_range(22..22)},
+      {cidr: "10.238.50.0/26", port_range: Sequel.pg_range(5432..5432)},
+      {cidr: "fd19:9c92:e9b9:a1a::/64", port_range: Sequel.pg_range(5432..5432)}
     ])
     postgres_resource.set_firewall_rules
   end


### PR DESCRIPTION
With https://github.com/ubicloud/ubicloud/pull/2036 we started to apply firewall rules to the in subnet communication as well. This impacts PG because the primary <-> standby communication is through private networking. Therefore, we are adding explicit rules to allow the full subnet range on port 5432 by default.