### PR TITLE
Re-enable Rhizome Validation

### DIFF
--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -7,6 +7,8 @@ require "digest/sha2"
 class Prog::InstallRhizome < Prog::Base
   subject_is :sshable
 
+  SKIP_VALIDATION = ["Gemfile.lock"]
+
   label def start
     tar = StringIO.new
     file_hash_map = {} # pun intended
@@ -24,7 +26,8 @@ class Prog::InstallRhizome < Prog::Base
               IO.copy_stream(_1, tf)
             end
           end
-          file_hash_map[file] = Digest::SHA384.file(full_path).hexdigest
+
+          file_hash_map[file] = Digest::SHA384.file(full_path).hexdigest unless SKIP_VALIDATION.include?(file)
         else
           # :nocov:
           fail "BUG"
@@ -50,7 +53,7 @@ class Prog::InstallRhizome < Prog::Base
   end
 
   label def validate
-    # sshable.cmd("common/bin/validate")
+    sshable.cmd("common/bin/validate")
 
     pop "installed rhizome"
   end

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Prog::InstallRhizome do
       expect(sshable).to receive(:cmd) do |*args, **kwargs|
         expect(args).to eq ["tar xf -"]
 
+        expect(kwargs[:stdin].scan("Gemfile.lock").count).to be < 2
+
         # Take offset from
         # https://www.gnu.org/software/tar/manual/html_node/Standard.html
         expect(kwargs[:stdin][257..261]).to eq "ustar"
@@ -40,7 +42,7 @@ RSpec.describe Prog::InstallRhizome do
 
   describe "#validate" do
     it "runs the validate script" do
-      # expect(sshable).to receive(:cmd).with("common/bin/validate")
+      expect(sshable).to receive(:cmd).with("common/bin/validate")
       expect { ir.validate }.to exit({"msg" => "installed rhizome"})
     end
   end


### PR DESCRIPTION
Previously, we found that validations failed after the validation changes are deployed. In my tests, I realized that the validations failed due to Gemfile.lock changing after the bundle install step.

I decided to filter out the Gemfile.lock file. Alternatively, we could move the validation step before the gem install step, but making sure that `bundle install` runs before any ruby script is run sounded like a better idea.