### PR TITLE
Migrate adhoc delete buttons to the component

### DIFF
--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -37,7 +37,7 @@
         "components/icon",
         locals: {
           name: icon,
-          classes: "h-5 w-5 #{(text && !text.empty?) ? "ml-0.5 mr-1.5" : "ml-0.5 mr-0.5 "}"
+          classes: "h-5 w-5 #{(text && !text.empty?) ? "ml-0.5 mr-1.5" : "mx-0"}"
         }
       ) %>
     <% end %>

--- a/views/components/delete_button.erb
+++ b/views/components/delete_button.erb
@@ -1,6 +1,7 @@
 <% csrf_url = (defined?(csrf_url) && csrf_url) ? csrf_url : url %>
 <% text = (defined?(text) && text) ? text : "Delete" %>
 <% confirmation = (defined?(confirmation) && confirmation) ? confirmation : nil %>
+<% confirmation_message = (defined?(confirmation_message) && confirmation_message) ? confirmation_message : nil %>
 
 <%== render(
   "components/button",
@@ -13,6 +14,7 @@
       "data-url" => url,
       "data-csrf" => csrf_token(csrf_url, "DELETE"),
       "data-confirmation" => confirmation,
+      "data-confirmation-message" => confirmation_message,
       "data-redirect" => redirect
     }
   }

--- a/views/components/delete_button.erb
+++ b/views/components/delete_button.erb
@@ -1,7 +1,9 @@
+<% url = (defined?(url) && url) ? url : request.path %>
 <% csrf_url = (defined?(csrf_url) && csrf_url) ? csrf_url : url %>
 <% text = (defined?(text) && text) ? text : "Delete" %>
 <% confirmation = (defined?(confirmation) && confirmation) ? confirmation : nil %>
 <% confirmation_message = (defined?(confirmation_message) && confirmation_message) ? confirmation_message : nil %>
+<% redirect = (defined?(redirect) && redirect) ? redirect : request.path %>
 <% method = (defined?(method) && method) ? method : "DELETE" %>
 
 <%== render(

--- a/views/components/delete_button.erb
+++ b/views/components/delete_button.erb
@@ -2,6 +2,7 @@
 <% text = (defined?(text) && text) ? text : "Delete" %>
 <% confirmation = (defined?(confirmation) && confirmation) ? confirmation : nil %>
 <% confirmation_message = (defined?(confirmation_message) && confirmation_message) ? confirmation_message : nil %>
+<% method = (defined?(method) && method) ? method : "DELETE" %>
 
 <%== render(
   "components/button",
@@ -12,10 +13,11 @@
     type: "danger",
     attributes: {
       "data-url" => url,
-      "data-csrf" => csrf_token(csrf_url, "DELETE"),
+      "data-csrf" => csrf_token(csrf_url, method),
       "data-confirmation" => confirmation,
       "data-confirmation-message" => confirmation_message,
-      "data-redirect" => redirect
+      "data-redirect" => redirect,
+      "data-method" => method
     }
   }
 ) %>

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -54,8 +54,7 @@
                   "components/delete_button",
                   locals: {
                     url: "#{@project_data[:path]}/github/cache/#{entry[:id]}",
-                    text: "",
-                    redirect: request.path
+                    text: ""
                   }
                 ) %>
               </td>

--- a/views/networking/firewall/show.erb
+++ b/views/networking/firewall/show.erb
@@ -56,15 +56,14 @@
                 id="fwr-delete-<%=fwr[:id]%>"
                 class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
               >
-                <button
-                  type="button"
-                  data-url="<%= "#{request.path}/firewall-rule/#{fwr[:id]}" %>"
-                  data-csrf="<%= csrf_token("#{request.path}/firewall-rule/#{fwr[:id]}", "DELETE") %>"
-                  data-redirect="<%= request.path.to_s %>"
-                  class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
-                >
-                  <%== render("components/icon", locals: { name: "hero-trash", classes: "h-5 w-5" }) %>
-                </button>
+                <%== render(
+                  "components/delete_button",
+                  locals: {
+                    url: "#{request.path}/firewall-rule/#{fwr[:id]}",
+                    text: "",
+                    redirect: request.path
+                  }
+                ) %>
               </td>
             <% end %>
           </tr>

--- a/views/networking/firewall/show.erb
+++ b/views/networking/firewall/show.erb
@@ -56,14 +56,7 @@
                 id="fwr-delete-<%=fwr[:id]%>"
                 class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
               >
-                <%== render(
-                  "components/delete_button",
-                  locals: {
-                    url: "#{request.path}/firewall-rule/#{fwr[:id]}",
-                    text: "",
-                    redirect: request.path
-                  }
-                ) %>
+                <%== render("components/delete_button", locals: { url: "#{request.path}/firewall-rule/#{fwr[:id]}", text: "" }) %>
               </td>
             <% end %>
           </tr>
@@ -174,7 +167,6 @@
             <%== render(
               "components/delete_button",
               locals: {
-                url: request.path,
                 confirmation: @firewall[:name],
                 redirect: "#{@project_data[:path]}/firewall"
               }

--- a/views/networking/load_balancer/show.erb
+++ b/views/networking/load_balancer/show.erb
@@ -119,7 +119,6 @@
             <%== render(
               "components/delete_button",
               locals: {
-                url: request.path,
                 confirmation: @lb[:name],
                 redirect: "#{@project_data[:path]}/load-balancer"
               }

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -194,7 +194,6 @@
             <%== render(
               "components/delete_button",
               locals: {
-                url: request.path,
                 confirmation: @ps[:name],
                 redirect: "#{@project_data[:path]}/private-subnet"
               }

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -143,17 +143,16 @@
               id="cps-delete-<%=subnet[:id]%>"
               class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
             >
-              <button
-                type="button"
-                data-url="<%= "#{request.path}/disconnect/#{subnet[:id]}" %>"
-                data-csrf="<%= csrf_token("#{request.path}/disconnect/#{subnet[:id]}", "POST") %>"
-                data-redirect="<%= request.path.to_s %>"
-                data-method="POST"
-                data-confirmation-message="Are you sure to disconnect?"
-                class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
-              >
-                <%== render("components/icon", locals: { name: "hero-trash", classes: "h-5 w-5" }) %>
-              </button>
+              <%== render(
+                "components/delete_button",
+                locals: {
+                  url: "#{request.path}/disconnect/#{subnet[:id]}",
+                  confirmation_message: "Are you sure to disconnect?",
+                  redirect: request.path,
+                  method: "POST",
+                  text: ""
+                }
+              ) %>
             </td>
           </tr>
         <% end %>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -232,14 +232,7 @@
                   id="fwr-delete-<%=fwr[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
                 >
-                  <%== render(
-                    "components/delete_button",
-                    locals: {
-                      url: "#{request.path}/firewall-rule/#{fwr[:id]}",
-                      text: "",
-                      redirect: request.path
-                    }
-                  ) %>
+                  <%== render("components/delete_button", locals: { url: "#{request.path}/firewall-rule/#{fwr[:id]}", text: "" }) %>
                 </td>
               <% end %>
             </tr>
@@ -306,14 +299,7 @@
                   id="md-delete-<%=md[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
                 >
-                  <%== render(
-                    "components/delete_button",
-                    locals: {
-                      url: "#{request.path}/metric-destination/#{md[:id]}",
-                      text: "",
-                      redirect: request.path
-                    }
-                  ) %>
+                  <%== render("components/delete_button", locals: { url: "#{request.path}/metric-destination/#{md[:id]}", text: "" }) %>
                 </td>
               <% end %>
             </tr>
@@ -387,14 +373,7 @@
               </div>
             </div>
             <div id="postgres-delete-<%=@pg[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-              <%== render(
-                "components/delete_button",
-                locals: {
-                  url: request.path,
-                  confirmation: @pg[:name],
-                  redirect: "#{@project_data[:path]}/postgres"
-                }
-              ) %>
+              <%== render("components/delete_button", locals: { confirmation: @pg[:name], redirect: "#{@project_data[:path]}/postgres" }) %>
             </div>
           </div>
         </div>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -232,15 +232,14 @@
                   id="fwr-delete-<%=fwr[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
                 >
-                  <button
-                    type="button"
-                    data-url="<%= "#{request.path}/firewall-rule/#{fwr[:id]}" %>"
-                    data-csrf="<%= csrf_token("#{request.path}/firewall-rule/#{fwr[:id]}", "DELETE") %>"
-                    data-redirect="<%= request.path.to_s %>"
-                    class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
-                  >
-                    <%== render("components/icon", locals: { name: "hero-trash", classes: "h-5 w-5" }) %>
-                  </button>
+                  <%== render(
+                    "components/delete_button",
+                    locals: {
+                      url: "#{request.path}/firewall-rule/#{fwr[:id]}",
+                      text: "",
+                      redirect: request.path
+                    }
+                  ) %>
                 </td>
               <% end %>
             </tr>
@@ -307,15 +306,14 @@
                   id="md-delete-<%=md[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
                 >
-                  <button
-                    type="button"
-                    data-url="<%= "#{request.path}/metric-destination/#{md[:id]}" %>"
-                    data-csrf="<%= csrf_token("#{request.path}/metric-destination/#{md[:id]}", "DELETE") %>"
-                    data-redirect="<%= request.path.to_s %>"
-                    class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
-                  >
-                    <%== render("components/icon", locals: { name: "hero-trash", classes: "h-5 w-5" }) %>
-                  </button>
+                  <%== render(
+                    "components/delete_button",
+                    locals: {
+                      url: "#{request.path}/metric-destination/#{md[:id]}",
+                      text: "",
+                      redirect: request.path
+                    }
+                  ) %>
                 </td>
               <% end %>
             </tr>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -217,8 +217,7 @@
                       locals: {
                         url: "#{@project_data[:path]}/billing/payment-method/#{pm[:ubid]}?project_id=#{@project.ubid}",
                         csrf_url: "#{@project_data[:path]}/billing/payment-method/#{pm[:ubid]}",
-                        confirmation: pm[:last4],
-                        redirect: request.path
+                        confirmation: pm[:last4]
                       }
                     ) %>
                   </td>
@@ -396,8 +395,7 @@
                     locals: {
                       text: "Remove",
                       url: "#{@project_data[:path]}/usage-alert/#{alert[:ubid]}",
-                      confirmation: alert[:name],
-                      redirect: "#{@project_data[:path]}/billing"
+                      confirmation: alert[:name]
                     }
                   ) %>
                 </td>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -84,14 +84,7 @@
             </div>
           </div>
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-            <%== render(
-              "components/delete_button",
-              locals: {
-                url: request.path,
-                confirmation: @project_data[:name],
-                redirect: "/project"
-              }
-            ) %>
+            <%== render("components/delete_button", locals: { confirmation: @project_data[:name], redirect: "/project" }) %>
           </div>
         </div>
       </div>

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -102,8 +102,7 @@
                     locals: {
                       text: "Remove",
                       url: "#{@project_data[:path]}/user/#{user[:ubid]}",
-                      confirmation: user[:email],
-                      redirect: "#{@project_data[:path]}/user"
+                      confirmation: user[:email]
                     }
                   ) %>
                 </td>
@@ -136,8 +135,7 @@
                     locals: {
                       text: "Remove",
                       url: "#{@project_data[:path]}/user/invitation/#{invitation[:email]}",
-                      confirmation: invitation[:email],
-                      redirect: "#{@project_data[:path]}/user"
+                      confirmation: invitation[:email]
                     }
                   ) %>
                 </td>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -104,17 +104,14 @@
             </div>
           </div>
           <div id="vm-delete-<%=@vm[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-            <button
-              type="button"
-              data-url="<%= request.path %>"
-              data-csrf="<%= csrf_token(request.path, "DELETE") %>"
-              data-confirmation="<%= @vm[:name] %>"
-              data-redirect="<%= "#{@project_data[:path]}/vm" %>"
-              class="delete-btn inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600"
-            >
-              <%== render("components/icon", locals: { name: "hero-trash", classes: "-ml-0.5 mr-1.5 h-5 w-5" }) %>
-              Delete
-            </button>
+            <%== render(
+              "components/delete_button",
+              locals: {
+                url: request.path,
+                confirmation: @vm[:name],
+                redirect: "#{@project_data[:path]}/vm"
+              }
+            ) %>
           </div>
         </div>
       </div>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -104,14 +104,7 @@
             </div>
           </div>
           <div id="vm-delete-<%=@vm[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-            <%== render(
-              "components/delete_button",
-              locals: {
-                url: request.path,
-                confirmation: @vm[:name],
-                redirect: "#{@project_data[:path]}/vm"
-              }
-            ) %>
+            <%== render("components/delete_button", locals: { confirmation: @vm[:name], redirect: "#{@project_data[:path]}/vm" }) %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- **Add confirmation message argument to delete button component**
  JS code supports `confirmation-message` property for `.delete-btn`
  class.
  

- **Add method argument to delete button component**
  JS code supports `method` property for `.delete-btn` class.
  

- **Migrate all delete button instance to component**
  We have already `delete_button` component. But some delete button
  instances are not using this component. We can migrate all delete button
  instances to this component.
  

- **Add default url values to delete button component**
  Almost half of the `delete_button` instances use `request.path` for
  `url` or `redirect`. By adding default values to them, we can remove
  bunch of lines.
  