### PR TITLE
VM Recreate

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -25,7 +25,7 @@ class Vm < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
-  semaphore :restart, :stop
+  semaphore :restart, :stop, :can_recreate, :recreate
 
   include Authorization::HyperTagMethods
 


### PR DESCRIPTION
This pr adds a new logic to Vm::Nexus to be able to recreate a VM. For
now, this is only available to the on-call. In case we realize the VM is
stuck in the provisioning path, the on-call may simply incr_recreate and
force the VM to be recreated including new storage entities, ip
configuration, etc. In future, we may automate this process further and
even add features like excluding the previously tried host. For now,
this is a very basic implementation.