### PR TITLE
Fix Clover.freeze not returning Clover if already frozen

### DIFF
--- a/routes/helpers/general.rb
+++ b/routes/helpers/general.rb
@@ -9,7 +9,7 @@ class Clover < Roda
       Sequel::Model.freeze_descendants
       DB.freeze
     end
-    return if frozen? # XXX: Remove after Roda 3.86.0
+    return self if frozen? # XXX: Remove after Roda 3.86.0
     # :nocov:
     super
   end


### PR DESCRIPTION
Why Clover.freeze is called twice I'm not yet sure.  I added this to work around an issue with the autoload_hash_branches plugin (which I fixed upstream).