### PR TITLE
Add bin/production_check for checking app loads in production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,13 @@ jobs:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: bundle exec rake _test_up
 
+    - name: Check production puma loads
+      env:
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+        CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
+        CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
+      run: ruby bin/production_check
+
     - name: Run controlplane tests
       env:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}

--- a/bin/production_check
+++ b/bin/production_check
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+Dir.chdir(File.dirname(__dir__))
+
+require "open3"
+
+works = nil
+error = +""
+queue = Queue.new
+
+Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma") do |stdin, stdout, stderr, wait_thr|
+  pid = wait_thr.pid
+
+  timer_thread = Thread.new do
+    queue.pop(timeout: 3)
+    if works.nil?
+      error = "Timeout"
+      Process.kill(:KILL, pid)
+    end
+  end
+
+  stdout_thread = Thread.new do
+    while (line = stdout.gets)
+      case line
+      when /\A\* Listening on /
+        works = true
+        queue.push(true)
+        Process.kill(:TERM, pid)
+        break
+      when /\A! Unable to load application: /
+        error << line
+        works = false
+        queue.push(true)
+        Process.kill(:TERM, pid)
+        break
+      end
+    end
+  end
+
+  stderr_thread = Thread.new do
+    err = stderr.read(1)
+    if !err.nil?
+      error << err << stderr.read_nonblock(100000)
+      works = false
+      queue.push(true)
+      Process.kill(:TERM, pid)
+    end
+  end
+
+  [stdout_thread, stderr_thread, timer_thread].map(&:join)
+end
+
+unless works
+  warn error
+  exit(1)
+end


### PR DESCRIPTION
This file starts puma, and checks for correct loading or for failure.  It returns 0 on success and 1 on failure, printing the error to stderr in the failure case.

Run this before the control plane tests in CI.  I've tested that this file catches the production issue in my deployment this morning.