### PR TITLE
Enable Helsinki region for runners

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -176,7 +176,7 @@ class Prog::Vm::Nexus < Prog::Base
         if frame["force_host_id"]
           [[], [], [], [frame["force_host_id"]]]
         elsif vm.location == "github-runners"
-          runner_locations = (vm.cores == 30) ? [] : ["github-runners", "hetzner-fsn1"]
+          runner_locations = (vm.cores == 30) ? [] : ["github-runners", "hetzner-fsn1", "hetzner-hel1"]
           [["accepting"], runner_locations, ["github-runners"], []]
         else
           [["accepting"], [vm.location], [], []]

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe Prog::Vm::Nexus do
         distinct_storage_devices: false,
         host_filter: [],
         host_exclusion_filter: [],
-        location_filter: ["github-runners", "hetzner-fsn1"],
+        location_filter: ["github-runners", "hetzner-fsn1", "hetzner-hel1"],
         location_preference: ["github-runners"],
         gpu_count: 0
       )


### PR DESCRIPTION
Half of our fleet is still located in Helsinki, so it makes sense to use the Helsinki region for runners. Once we replace all our hosts with those from Germany, we can remove it.