### PR TITLE
Fix arguments for UI components

### DIFF
--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -1,9 +1,9 @@
-<% type = (defined?(type) && type) ? type : "primary" %>
-<% link = (defined?(link) && link) ? link : nil %>
-<% icon = (defined?(icon) && icon) ? icon : nil %>
-<% extra_class = defined?(extra_class) ? extra_class : nil %>
-<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
-<% right_icon = (defined?(right_icon) && right_icon) ? right_icon : nil %>
+<% type ||= "primary"
+link ||= nil
+icon ||= nil
+extra_class ||= nil
+attributes ||= {}
+right_icon ||= nil %>
 
 <% case type %>
 <% when "primary" %>

--- a/views/components/copieble_content.erb
+++ b/views/components/copieble_content.erb
@@ -1,4 +1,4 @@
-<% revealable = defined?(revealable) ? revealable : false %>
+<% revealable ||= false %>
 
 <span class="copieble-content inline-flex items-center" data-content="<%= content %>" data-message="<%= message %>">
   <% if revealable %>

--- a/views/components/delete_button.erb
+++ b/views/components/delete_button.erb
@@ -1,10 +1,10 @@
-<% url = (defined?(url) && url) ? url : request.path %>
-<% csrf_url = (defined?(csrf_url) && csrf_url) ? csrf_url : url %>
-<% text = (defined?(text) && text) ? text : "Delete" %>
-<% confirmation = (defined?(confirmation) && confirmation) ? confirmation : nil %>
-<% confirmation_message = (defined?(confirmation_message) && confirmation_message) ? confirmation_message : nil %>
-<% redirect = (defined?(redirect) && redirect) ? redirect : request.path %>
-<% method = (defined?(method) && method) ? method : "DELETE" %>
+<% url ||= request.path
+csrf_url ||= url
+text ||= "Delete"
+confirmation ||= nil
+confirmation_message ||= nil
+redirect ||= request.path
+method ||= "DELETE" %>
 
 <%== render(
   "components/button",

--- a/views/components/empty_state.erb
+++ b/views/components/empty_state.erb
@@ -1,6 +1,6 @@
-<% description = (defined?(description) && description) ? description : nil %>
-<% button_link = (defined?(button_link) && button_link) ? button_link : nil %>
-<% button_title = (defined?(button_title) && button_title) ? button_title : nil %>
+<% description ||= nil
+button_link ||= nil
+button_title ||= nil %>
 
 <div class="text-center">
   <%== render("components/icon", locals: { name: icon, classes: "mx-auto h-12 w-12 text-gray-400" }) %>

--- a/views/components/form/checkbox.erb
+++ b/views/components/form/checkbox.erb
@@ -1,10 +1,10 @@
-<% name = defined?(name) ? name : nil %>
-<% label = defined?(label) ? label : nil %>
-<% options = (defined?(options) && options) ? options : {} %>
-<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
-<% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
-<% description = (defined?(description) && description) ? description : nil %>
-<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
+<% name ||= nil
+label ||= nil
+options ||= {}
+selected = flash.dig("old", name) || selected
+error ||= rodauth.field_error(name) || flash.dig("errors", name)
+description ||= nil
+attributes ||= {} %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>

--- a/views/components/form/country_select.erb
+++ b/views/components/form/country_select.erb
@@ -1,9 +1,8 @@
-<% name = (defined?(name) && name) ? name : "country" %>
-<% label = (defined?(label) && label) ? label : "Country" %>
-<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
-<% error = defined?(error) ? error : flash.dig("errors", name) %>
-<% description = defined?(description) ? description : nil %>
-<% attributes = defined?(attributes) ? attributes : {} %>
+<% name ||= "country"
+label ||= "Country"
+selected = flash.dig("old", name) || selected
+description ||= nil
+attributes ||= {} %>
 
 <%== render(
   "components/form/select",
@@ -19,7 +18,6 @@
         .sort_by(&:common_name)
         .map { |c| [c.alpha2, c.common_name] }
         .to_h,
-    error: error,
     description: description,
     attributes: attributes
   }

--- a/views/components/form/datepicker.erb
+++ b/views/components/form/datepicker.erb
@@ -1,10 +1,10 @@
 <% @enable_datepicker = true %>
 
-<% name = defined?(name) ? name : nil %>
-<% label = defined?(label) ? label : nil %>
-<% default_date = defined?(default_date) ? default_date : nil %>
-<% min_date = defined?(min_date) ? min_date : nil %>
-<% max_date = defined?(max_date) ? max_date : nil %>
+<% name ||= nil
+label ||= nil
+default_date ||= nil
+min_date ||= nil
+max_date ||= nil %>
 
 <%== render(
   "components/form/text",

--- a/views/components/form/policy_select.erb
+++ b/views/components/form/policy_select.erb
@@ -1,5 +1,5 @@
-<% name = defined?(name) ? name : nil %>
-<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
+<% name ||= nil
+selected = flash.dig("old", name) || selected %>
 
 <div class="">
   <%== render(

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -1,10 +1,10 @@
-<% name = defined?(name) ? name : nil %>
-<% label = defined?(label) ? label : nil %>
-<% options = (defined?(options) && options) ? options : {} %>
-<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
-<% error = defined?(error) ? error : flash.dig("errors", name) %>
-<% description = defined?(description) ? description : nil %>
-<% attributes = defined?(attributes) ? attributes : {} %>
+<% name ||= nil
+label ||= nil
+options ||= {}
+selected = flash.dig("old", name) || selected
+error ||= flash.dig("errors", name)
+description ||= nil
+attributes ||= {} %>
 
 <div class="space-y-2">
   <label for="<%= name %>" class="text-sm font-medium leading-6 text-gray-900"><%= label %></label>

--- a/views/components/form/range_slider.erb
+++ b/views/components/form/range_slider.erb
@@ -1,11 +1,11 @@
-<% name = defined?(name) ? name : nil %>
-<% label = defined?(label) ? label : nil %>
-<% range_labels = (defined?(range_labels) && range_labels) ? range_labels : {} %>
-<% value = flash.dig("old", name) || ((defined?(value) && value) ? value : 0) %>
-<% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
-<% description = (defined?(description) && description) ? description : nil %>
-<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
-<% extra_class = (defined?(extra_class) && extra_class) ? extra_class : {} %>
+<% name ||= nil
+label ||= nil
+range_labels ||= {}
+value = flash.dig("old", name) || value || 0
+error ||= rodauth.field_error(name) || flash.dig("errors", name)
+description ||= nil
+attributes ||= {}
+extra_class ||= {} %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>

--- a/views/components/form/select.erb
+++ b/views/components/form/select.erb
@@ -1,11 +1,11 @@
-<% name = defined?(name) ? name : nil %>
-<% label = defined?(label) ? label : nil %>
-<% options = (defined?(options) && options) ? options : {} %>
-<% selected = flash.dig("old", name) || (defined?(selected) ? selected : nil) %>
-<% placeholder = defined?(placeholder) ? placeholder : nil %>
-<% error = defined?(error) ? error : flash.dig("errors", name) %>
-<% description = defined?(description) ? description : nil %>
-<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
+<% name ||= nil
+label ||= nil
+options ||= {}
+selected = flash.dig("old", name) || selected
+placeholder ||= nil
+error ||= flash.dig("errors", name)
+description ||= nil
+attributes ||= {} %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>

--- a/views/components/form/submit_button.erb
+++ b/views/components/form/submit_button.erb
@@ -1,5 +1,5 @@
-<% name = defined?(name) ? name : nil %>
-<% extra_class = defined?(extra_class) ? extra_class : nil %>
+<% name ||= nil
+extra_class ||= nil %>
 
 <%== render(
   "components/button",

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -1,12 +1,12 @@
-<% name = defined?(name) ? name : nil %>
-<% label = defined?(label) ? label : nil %>
-<% type = (defined?(type) && type) ? type : "text" %>
-<% value = flash.dig("old", name) || ((defined?(value) && value) ? value : nil) %>
-<% error = (defined?(error) && error) ? error : rodauth.field_error(name) || flash.dig("errors", name) %>
-<% description = (defined?(description) && description) ? description : nil %>
-<% attributes = (defined?(attributes) && attributes) ? attributes : {} %>
-<% extra_class = defined?(extra_class) ? extra_class : nil %>
-<% button_title = defined?(button_title) ? button_title : nil %>
+<% name ||= nil
+label ||= nil
+type ||= "text"
+value = flash.dig("old", name) || value
+error ||= rodauth.field_error(name) || flash.dig("errors", name)
+description ||= nil
+attributes ||= {}
+extra_class ||= nil
+button_title ||= nil %>
 
 <div class="space-y-2 text-gray-900">
   <% if label %>

--- a/views/components/form/textarea.erb
+++ b/views/components/form/textarea.erb
@@ -1,9 +1,9 @@
-<% name = defined?(name) ? name : nil %>
-<% value = flash.dig("old", name) || (defined?(value) ? value : nil) %>
-<% label = defined?(label) ? label : nil %>
-<% error = defined?(error) ? error : flash.dig("errors", name) %>
-<% description = defined?(description) ? description : nil %>
-<% attributes = defined?(attributes) ? attributes : {} %>
+<% name ||= nil
+value = flash.dig("old", name) || value
+label ||= nil
+error ||= flash.dig("errors", name)
+description ||= nil
+attributes ||= {} %>
 
 <div class="space-y-2">
   <% if label %>

--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -1,4 +1,4 @@
-<% classes = (defined?(classes) && !classes.nil?) ? classes : "w-6 h-6" %>
+<% classes ||= "w-6 h-6" %>
 <% case name %>
 <% when "hero-arrow-up-right" %>
   <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="<%= classes %>">
@@ -126,5 +126,3 @@
 <% else %>
   <p>Not found icon</p>
 <% end %>
-
-

--- a/views/components/pg_state_label.erb
+++ b/views/components/pg_state_label.erb
@@ -8,7 +8,7 @@
 <% else %>
   <% color = "bg-slate-100 text-slate-800" %>
 <% end %>
-<% extra_class = defined?(extra_class) ? extra_class : nil %>
+<% extra_class ||= nil %>
 
 <span
   class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>"

--- a/views/components/progress_bar.erb
+++ b/views/components/progress_bar.erb
@@ -1,5 +1,6 @@
-<% progress = [100, 100 * numerator / denominator].min %>
-<% color = (progress < 60) ? "bg-blue-500" : (progress < 80) ? "bg-yellow-500" : "bg-red-500" %>
+<% progress = [100, 100 * numerator / denominator].min
+color = (progress < 60) ? "bg-blue-500" : (progress < 80) ? "bg-yellow-500" : "bg-red-500" %>
+
 <div class="flex justify-between mb-1">
   <span class="text-base font-medium"><%= title %></span>
   <span class="text-sm font-medium"><%= numerator %>/<%= denominator %>

--- a/views/components/ps_state_label.erb
+++ b/views/components/ps_state_label.erb
@@ -4,7 +4,7 @@
 <% else %>
   <% color = "bg-yellow-100 text-yellow-800" %>
 <% end %>
-<% extra_class = defined?(extra_class) ? extra_class : nil %>
+<% extra_class ||= nil %>
 
 <span
   class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>"

--- a/views/components/rodauth/login_field.erb
+++ b/views/components/rodauth/login_field.erb
@@ -1,4 +1,4 @@
-<% label = (defined?(label) && label) ? label : "#{rodauth.login_label}#{rodauth.input_field_label_suffix}" %>
+<% label ||= "#{rodauth.login_label}#{rodauth.input_field_label_suffix}" %>
 
 <%== render(
   "components/form/text",

--- a/views/components/rodauth/password_field.erb
+++ b/views/components/rodauth/password_field.erb
@@ -1,13 +1,13 @@
-<% confirm = defined?(confirm) ? confirm : false %>
-<% if confirm %>
-  <% label = (defined?(label) && label) ? label : "#{rodauth.password_confirm_label}#{rodauth.input_field_label_suffix}" %>
-  <% name = (defined?(name) && name) ? name : rodauth.password_confirm_param %>
-  <% autocomplete = (defined?(autocomplete) && autocomplete) ? autocomplete : "new-password" %>
-<% else %>
-  <% label = (defined?(label) && label) ? label : "#{rodauth.password_label}#{rodauth.input_field_label_suffix}" %>
-  <% name = (defined?(name) && name) ? name : rodauth.password_param %>
-  <% autocomplete = (defined?(autocomplete) && autocomplete) ? autocomplete : rodauth.password_field_autocomplete_value %>
-<% end %>
+<% confirm ||= false
+if confirm
+  label ||= "#{rodauth.password_confirm_label}#{rodauth.input_field_label_suffix}"
+  name ||= rodauth.password_confirm_param
+  autocomplete ||= "new-password"
+else
+  label ||= "#{rodauth.password_label}#{rodauth.input_field_label_suffix}"
+  name ||= rodauth.password_param
+  autocomplete ||= rodauth.password_field_autocomplete_value
+end %>
 
 <%== render(
   "components/form/text",

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -8,7 +8,7 @@
 <% else %>
   <% color = "bg-slate-100 text-slate-800" %>
 <% end %>
-<% extra_class = defined?(extra_class) ? extra_class : nil %>
+<% extra_class ||= nil %>
 
 <span
   class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>"


### PR DESCRIPTION
Some arguments for UI components are optional, so we don't have to provide all of them when using them. I had added a `defined?(name)` check to use default values when an argument is not provided.

Jeremy pointed out that it was working by accident. In the code `name = defined?(name)`, `defined?(name)` always returns `local-variable` because it’s on the right-hand side of the assignment, while the local variable is on the left-hand side.

When we remove the `defined?` calls, the remaining code is equivalent to `||=`.