### PR TITLE
Set load balancer stack for inference endpoints

### DIFF
--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -62,7 +62,7 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
         name + (is_public ? "" : "-#{ubid.to_s[-5...]}")
       end
       lb_s = Prog::Vnet::LoadBalancerNexus.assemble(subnet_s.id, name: ubid.to_s, src_port: 443, dst_port: 8443, health_check_endpoint: "/up", health_check_protocol: "https",
-        custom_hostname_prefix: custom_hostname_prefix, custom_hostname_dns_zone_id: custom_dns_zone&.id)
+        custom_hostname_prefix: custom_hostname_prefix, custom_hostname_dns_zone_id: custom_dns_zone&.id, stack: "ipv4")
 
       inference_endpoint = InferenceEndpoint.create(
         project_id: project_id, location: location, boot_image: boot_image, name: name, vm_size: vm_size, storage_volumes: storage_volumes,

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -86,11 +86,13 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
       expect {
         st = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", boot_image: "ai-ubuntu-2404-nvidia", name: "test-endpoint", vm_size: "standard-gpu-6", storage_volumes: [{encrypted: true, size_gib: 80}], model_name: "llama-3-1-8b-it", engine: "vllm", engine_params: "", replica_count: 1, is_public: false, gpu_count: 1)
         expect(st.subject.load_balancer.hostname).to eq("test-endpoint-#{st.subject.ubid.to_s[-5...]}.ai.ubicloud.com")
+        expect(st.subject.load_balancer.stack).to eq("ipv4")
       }.not_to raise_error
 
       expect {
         st = described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", boot_image: "ai-ubuntu-2404-nvidia", name: "test-endpoint-public", vm_size: "standard-gpu-6", storage_volumes: [{encrypted: true, size_gib: 80}], model_name: "llama-3-1-8b-it", engine: "vllm", engine_params: "", replica_count: 1, is_public: true, gpu_count: 1)
         expect(st.subject.load_balancer.hostname).to eq("test-endpoint-public.ai.ubicloud.com")
+        expect(st.subject.load_balancer.stack).to eq("ipv4")
       }.not_to raise_error
 
       expect {


### PR DESCRIPTION
Inference endpoints currently don't support dual stack ip addresses. Configure the load balancer as ipv4 to make sure clients don't try to connect with ipv6.