### PR TITLE
Switch to using a released version of by

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "argon2-kdf"
 group :development do
   gem "awesome_print"
   gem "brakeman"
-  gem "by", github: "jeremyevans/by", ref: "f022615e367da3a23f012c3ab06ff664fe3776d3"
+  gem "by", ">= 1.1.0"
   gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "a9ff0001a1eb028e2186b222aeb02b07c04f9808"
   gem "foreman"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/jeremyevans/by.git
-  revision: f022615e367da3a23f012c3ab06ff664fe3776d3
-  ref: f022615e367da3a23f012c3ab06ff664fe3776d3
-  specs:
-    by (1.0.1)
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: a9ff0001a1eb028e2186b222aeb02b07c04f9808
   ref: a9ff0001a1eb028e2186b222aeb02b07c04f9808
@@ -83,6 +76,7 @@ GEM
     brakeman (6.2.2)
       racc
     builder (3.3.0)
+    by (1.1.0)
     byebug (11.1.3)
     capybara (3.40.0)
       addressable
@@ -383,7 +377,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.169)
   bcrypt_pbkdf
   brakeman
-  by!
+  by (>= 1.1.0)
   capybara
   countries
   cuprite


### PR DESCRIPTION
This was previously using the main branch on GitHub, because the rspec support wasn't in a released version.