### PR TITLE
Don't have rake by require Sequel threaded connection pool

### DIFF
--- a/.by-session-setup.rb
+++ b/.by-session-setup.rb
@@ -20,7 +20,6 @@ tilt/erubi
 tilt/string
 sequel/adapters/postgres
 sequel/connection_pool/timed_queue
-sequel/connection_pool/threaded
 capybara/dsl
 capybara/rspec
 mail/network/delivery_methods/test_mailer


### PR DESCRIPTION
The timed_queue connection pool is the default connection pool in Sequel starting with 5.85.0, so this file is no longer loaded by ubicloud.