### PR TITLE
Use Cache-Control:no-store for sensitive data

### DIFF
--- a/routes/common/postgres_helper.rb
+++ b/routes/common/postgres_helper.rb
@@ -66,6 +66,8 @@ class Routes::Common::PostgresHelper < Routes::Common::Base
 
   def get
     Authorization.authorize(@user.id, "Postgres:view", @resource.id)
+    response.headers["Cache-Control"] = "no-store"
+
     if @mode == AppMode::API
       Serializers::Postgres.serialize(@resource, {detailed: true})
     else


### PR DESCRIPTION
PostgreSQL get endpoint returns connection string with password in it. Clients can cache the result and store in the client machine, which in turn can be read by unauthorized people. We are setting `Cache-Control: no-store` to let clients know that the response should not be cached. There is also another header that we can set; `Pragma: no-cache`, however `Pragma` is deprecated and it is only used by HTTP/1.0 clients, thus I don't think we need to set it.