### PR TITLE
Remove unnecessary to_json calls

### DIFF
--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -64,13 +64,13 @@ class Clover
         # If it has some resources, do not allow to delete it.
         if @project.has_resources
           flash["error"] = "'#{@project.name}' project has some resources. Delete all related resources first."
-          return {message: "'#{@project.name}' project has some resources. Delete all related resources first."}.to_json
+          return {message: "'#{@project.name}' project has some resources. Delete all related resources first."}
         end
 
         @project.soft_delete
 
         flash["notice"] = "'#{@project.name}' project is deleted."
-        return {message: "'#{@project.name}' project is deleted."}.to_json
+        return {message: "'#{@project.name}' project is deleted."}
       end
 
       r.get "dashboard" do

--- a/routes/web/project/billing.rb
+++ b/routes/web/project/billing.rb
@@ -141,12 +141,12 @@ class Clover
         r.delete true do
           unless payment_method.billing_info.payment_methods.count > 1
             response.status = 400
-            return {message: "You can't delete the last payment method of a project."}.to_json
+            return {message: "You can't delete the last payment method of a project."}
           end
 
           payment_method.destroy
 
-          return {message: "Deleting #{payment_method.ubid}"}.to_json
+          return {message: "Deleting #{payment_method.ubid}"}
         end
       end
     end

--- a/routes/web/project/location/firewall.rb
+++ b/routes/web/project/location/firewall.rb
@@ -91,7 +91,7 @@ class Clover
 
             fw.remove_firewall_rule(fwr)
 
-            return {message: "Firewall rule deleted"}.to_json
+            return {message: "Firewall rule deleted"}
           end
         end
       end
@@ -101,7 +101,7 @@ class Clover
         fw.private_subnets.map { Authorization.authorize(current_account.id, "PrivateSubnet:edit", _1.id) }
         fw.destroy
 
-        return {message: "Deleting #{fw.name}"}.to_json
+        return {message: "Deleting #{fw.name}"}
       end
     end
   end

--- a/routes/web/project/usage_alert.rb
+++ b/routes/web/project/usage_alert.rb
@@ -18,12 +18,12 @@ class Clover
       usage_alert = UsageAlert.from_ubid(usage_alert_ubid)
       unless usage_alert
         response.status = 404
-        return {message: "Usage alert is not found."}.to_json
+        return {message: "Usage alert is not found."}
       end
 
       r.delete true do
         usage_alert.destroy
-        return {message: "Usage alert #{usage_alert.name} is deleted."}.to_json
+        return {message: "Usage alert #{usage_alert.name} is deleted."}
       end
     end
   end

--- a/routes/web/project/user.rb
+++ b/routes/web/project/user.rb
@@ -127,7 +127,7 @@ class Clover
       r.delete true do
         unless @project.accounts.count > 1
           response.status = 400
-          return {message: "You can't remove the last user from '#{@project.name}' project. Delete project instead."}.to_json
+          return {message: "You can't remove the last user from '#{@project.name}' project. Delete project instead."}
         end
         hyper_tag = user.hyper_tag_name(@project)
         @project.access_policies_dataset.where(managed: true).each do |policy|
@@ -139,7 +139,7 @@ class Clover
         end
         user.dissociate_with_project(@project)
 
-        return {message: "Removing #{user.email} from #{@project.name}"}.to_json
+        return {message: "Removing #{user.email} from #{@project.name}"}
       end
     end
   end

--- a/routes/web/webhook/github.rb
+++ b/routes/web/webhook/github.rb
@@ -24,11 +24,11 @@ class Clover
   end
 
   def error(msg)
-    {error: {message: msg}}.to_json
+    {error: {message: msg}}
   end
 
   def success(msg)
-    {message: msg}.to_json
+    {message: msg}
   end
 
   def check_signature(signature, body)


### PR DESCRIPTION
Roda's json plugin automatically converts Ruby hashes into `JSON` texts, so
these calls were unnecessary. Also, manually calling `to_json` requires setting
`Content-Type` header manually to `application/json`, which is different than
the default for our web endpoints and easy to forget. However Roda's json  
plugin also correctly sets the headers.