### PR TITLE
Add flash-notice/flash-error id attributes

### DIFF
--- a/views/components/flash_message.erb
+++ b/views/components/flash_message.erb
@@ -5,7 +5,7 @@
         <%== render("components/icon", locals: { name: "hero-check-circle-mini", classes: "h-5 w-5 text-green-400" }) %>
       </div>
       <div class="ml-3">
-        <h3 class="text-sm font-medium text-green-800"><%= flash["notice"] %></h3>
+        <h3 id="flash-notice" class="text-sm font-medium text-green-800"><%= flash["notice"] %></h3>
       </div>
     </div>
   </div>
@@ -17,7 +17,7 @@
         <%== render("components/icon", locals: { name: "hero-x-circle-mini", classes: "h-5 w-5 text-red-400" }) %>
       </div>
       <div class="ml-3">
-        <h3 class="text-sm font-medium text-red-800"><%= flash["error"] %></h3>
+        <h3 id="flash-error" class="text-sm font-medium text-red-800"><%= flash["error"] %></h3>
       </div>
     </div>
   </div>


### PR DESCRIPTION
After we add these, we can update the specs to use them instead of using `have_content`.  `have_content` checks for content anywhere in the page, and the specs should be checking for error/notice messages in a specific place.

This also makes it easier to debug failing specs, since you can more easily see what the flash notice/error being displayed is.