### PR TITLE
Remove explicit calls to Clover.freeze

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,6 @@ require_relative "loader"
 
 clover_freeze
 
-run(Config.development? ? Unreloader : Clover.freeze.app)
+run(Config.development? ? Unreloader : Clover.app)
 
 Tilt.finalize! unless Config.development?

--- a/routes/helpers/general.rb
+++ b/routes/helpers/general.rb
@@ -1,19 +1,6 @@
 # frozen_string_literal: true
 
 class Clover < Roda
-  def self.freeze
-    if Config.test? && ENV["CLOVER_FREEZE"] != "1"
-      Sequel::Model.descendants.each(&:finalize_associations)
-    # :nocov:
-    else
-      Sequel::Model.freeze_descendants
-      DB.freeze
-    end
-    return self if frozen? # XXX: Remove after Roda 3.86.0
-    # :nocov:
-    super
-  end
-
   # rubocop:disable Style/OptionalArguments
   def self.autoload_routes(namespace = "", route)
     # rubocop:enable Style/OptionalArguments # different indents required by Rubocop

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -10,7 +10,6 @@ require "capybara/rspec"
 
 Gem.suffix_pattern
 
-Clover.freeze if ENV["FORCE_AUTOLOAD"] == "1"
 Capybara.app = Clover.app
 Capybara.exact = true
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,6 @@ Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
 RSpec.configure do |config|
   config.before(:suite) do
     clover_freeze
-    Clover.freeze if ENV["CLOVER_FREEZE"] == "1"
   end
 
   config.around do |example|


### PR DESCRIPTION
In production mode and when running the frozen specs, clover_freeze now calls freeze on all autoloaded constants, and Clover is an autoloaded constant. Both the specs and config.ru call clover_freeze unconditionally.

This also removes the override of Clover.freeze.  In production and when running the frozen specs, it would call
Sequel::Model.freeze_descendants and DB.freeze.  The freezing of all autoloaded constants handles DB.freeze, and clover_freeze calls Sequel::Model.freeze_descendants before freezing all autoloaded constants.

This does remove the
`Sequel::Model.descendants.each(&:finalize_associations)` when running non-frozen specs, but that's solely an optimization and I don't think it is worth the complexity.

The `return self if frozen?` code was added to work around a bug in autoload_hash_branches, where Roda.freeze would break if you called it the second time on the same object. Now that Clover.freeze is only called once, it is not needed.