### PR TITLE
Apply order to runtime github/caches route query

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -64,7 +64,8 @@ class Clover
         scopes = [runner.workflow_job&.dig("head_branch"), repository.default_branch].compact
         entries = repository.cache_entries_dataset
           .exclude(committed_at: nil)
-          .where(key: key, scope: scopes).all
+          .where(key: key, scope: scopes)
+          .order(:version).all
 
         {
           totalCount: entries.count,


### PR DESCRIPTION
Fixes nondeterministic test failure:

```
  1) Clover github cache endpoints lists cache entries returns the list of cache entries for the key
     Failure/Error: expect(response["artifactCaches"].map { [_1["cacheKey"], _1["cacheVersion"]] }).to eq([["k1", "v1"], ["k1", "v2"]])

       expected: [["k1", "v1"], ["k1", "v2"]]
            got: [["k1", "v2"], ["k1", "v1"]]
```