### PR TITLE
Load pg_array extension before other extensions

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -30,7 +30,7 @@ end
 
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic
-DB.extension :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range, :pg_array
+DB.extension :pg_array, :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range
 Sequel.extension :pg_range_ops
 
 DB.extension :schema_caching


### PR DESCRIPTION
As mentioned in the pg_json and pg_range documentation, you should load pg_array first.  I doubt we are using json[], jsonb[], or one of the array range types, but just in case we use array_agg in a query with one of those types, we probably want to get an array-like object back, and not a string.