### PR TITLE
Refactor semaphore method

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -27,14 +27,14 @@ module SemaphoreMethods
 
   module ClassMethods
     def semaphore(*names)
-      names.map!(&:intern)
-      names.each do |name|
+      names.each do |sym|
+        name = sym.name
         define_method :"incr_#{name}" do
-          Semaphore.incr(id, name)
+          Semaphore.incr(id, sym)
         end
 
         define_method :"#{name}_set?" do
-          semaphores.any? { |s| s.name == name.to_s }
+          semaphores.any? { |s| s.name == name }
         end
       end
     end


### PR DESCRIPTION
This method is always passed symbol arguments, so the names.map!(&:intern) call is unnecessary. Speed up the generated *_set? methods to avoid a method call and string allocation per loop iteration.

This uses Symbol#name instead of Symbol#to_s, as the resulting string will not be mutated.