### PR TITLE
Include model annotations at the bottom of all model files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,20 @@ jobs:
     - name: Run linter:openapi
       run: bundle exec rake linter:openapi
 
-    - name: Check that source code formatters make no changes
-      run: git diff --stat --exit-code
-
     - name: Apply migrations
       env:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: bundle exec rake _test_up
+
+    - name: Run annotate
+      env:
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+        CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
+        CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
+      run: bundle exec rake annotate
+
+    - name: Check that source code formatters and annotations make no changes
+      run: git diff --stat --exit-code
 
     - name: Check production puma loads
       env:

--- a/Rakefile
+++ b/Rakefile
@@ -58,10 +58,10 @@ SQL
 end
 
 desc "Migrate test database to latest version"
-task test_up: [:_test_up, :refresh_sequel_caches]
+task test_up: [:_test_up, :refresh_sequel_caches, :annotate]
 
 desc "Migrate test database down. If VERSION isn't given, migrates to all the way down."
-task test_down: [:_test_down, :refresh_sequel_caches]
+task test_down: [:_test_down, :refresh_sequel_caches, :annotate]
 
 # rubocop:disable Rake/Desc
 task :_test_up do

--- a/model/access_policy.rb
+++ b/model/access_policy.rb
@@ -11,3 +11,17 @@ end
 # We need to unrestrict primary key so project.add_access_policy works
 # in model/account.rb.
 AccessPolicy.unrestrict_primary_key
+
+# Table: access_policy
+# Columns:
+#  id         | uuid                     | PRIMARY KEY
+#  project_id | uuid                     | NOT NULL
+#  name       | text                     | NOT NULL
+#  body       | jsonb                    | NOT NULL
+#  created_at | timestamp with time zone | NOT NULL DEFAULT now()
+#  managed    | boolean                  | NOT NULL DEFAULT false
+# Indexes:
+#  access_policy_pkey                  | PRIMARY KEY btree (id)
+#  access_policy_project_id_name_index | UNIQUE btree (project_id, name)
+# Foreign key constraints:
+#  access_policy_project_id_fkey | (project_id) REFERENCES project(id)

--- a/model/access_tag.rb
+++ b/model/access_tag.rb
@@ -10,3 +10,20 @@ class AccessTag < Sequel::Model
 
   include ResourceMethods
 end
+
+# Table: access_tag
+# Columns:
+#  id              | uuid                     | PRIMARY KEY
+#  project_id      | uuid                     | NOT NULL
+#  hyper_tag_id    | uuid                     |
+#  hyper_tag_table | text                     | NOT NULL
+#  name            | text                     | NOT NULL
+#  created_at      | timestamp with time zone | NOT NULL DEFAULT now()
+# Indexes:
+#  access_tag_pkey                          | PRIMARY KEY btree (id)
+#  access_tag_project_id_hyper_tag_id_index | UNIQUE btree (project_id, hyper_tag_id)
+#  access_tag_project_id_name_index         | UNIQUE btree (project_id, name)
+# Foreign key constraints:
+#  access_tag_project_id_fkey | (project_id) REFERENCES project(id)
+# Referenced By:
+#  applied_tag | applied_tag_access_tag_id_fkey | (access_tag_id) REFERENCES access_tag(id)

--- a/model/account.rb
+++ b/model/account.rb
@@ -27,3 +27,41 @@ class Account < Sequel::Model(:accounts)
     projects.each { _1.billing_info&.payment_methods_dataset&.update(fraud: true) }
   end
 end
+
+# Table: accounts
+# Columns:
+#  id           | uuid                     | PRIMARY KEY
+#  status_id    | integer                  | NOT NULL DEFAULT 1
+#  email        | citext                   | NOT NULL
+#  name         | text                     |
+#  created_at   | timestamp with time zone | NOT NULL DEFAULT now()
+#  suspended_at | timestamp with time zone |
+# Indexes:
+#  accounts_pkey        | PRIMARY KEY btree (id)
+#  accounts_email_index | UNIQUE btree (email) WHERE status_id = ANY (ARRAY[1, 2])
+# Check constraints:
+#  valid_email | (email ~ '^[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+$'::citext)
+# Foreign key constraints:
+#  accounts_status_id_fkey | (status_id) REFERENCES account_statuses(id)
+# Referenced By:
+#  account_active_session_keys       | account_active_session_keys_account_id_fkey       | (account_id) REFERENCES accounts(id)
+#  account_activity_times            | account_activity_times_id_fkey                    | (id) REFERENCES accounts(id)
+#  account_authentication_audit_logs | account_authentication_audit_logs_account_id_fkey | (account_id) REFERENCES accounts(id)
+#  account_email_auth_keys           | account_email_auth_keys_id_fkey                   | (id) REFERENCES accounts(id)
+#  account_jwt_refresh_keys          | account_jwt_refresh_keys_account_id_fkey          | (account_id) REFERENCES accounts(id)
+#  account_lockouts                  | account_lockouts_id_fkey                          | (id) REFERENCES accounts(id)
+#  account_login_change_keys         | account_login_change_keys_id_fkey                 | (id) REFERENCES accounts(id)
+#  account_login_failures            | account_login_failures_id_fkey                    | (id) REFERENCES accounts(id)
+#  account_otp_keys                  | account_otp_keys_id_fkey                          | (id) REFERENCES accounts(id)
+#  account_password_change_times     | account_password_change_times_id_fkey             | (id) REFERENCES accounts(id)
+#  account_password_hashes           | account_password_hashes_id_fkey                   | (id) REFERENCES accounts(id)
+#  account_password_reset_keys       | account_password_reset_keys_id_fkey               | (id) REFERENCES accounts(id)
+#  account_previous_password_hashes  | account_previous_password_hashes_account_id_fkey  | (account_id) REFERENCES accounts(id)
+#  account_recovery_codes            | account_recovery_codes_id_fkey                    | (id) REFERENCES accounts(id)
+#  account_remember_keys             | account_remember_keys_id_fkey                     | (id) REFERENCES accounts(id)
+#  account_session_keys              | account_session_keys_id_fkey                      | (id) REFERENCES accounts(id)
+#  account_sms_codes                 | account_sms_codes_id_fkey                         | (id) REFERENCES accounts(id)
+#  account_verification_keys         | account_verification_keys_id_fkey                 | (id) REFERENCES accounts(id)
+#  account_webauthn_keys             | account_webauthn_keys_account_id_fkey             | (account_id) REFERENCES accounts(id)
+#  account_webauthn_user_ids         | account_webauthn_user_ids_id_fkey                 | (id) REFERENCES accounts(id)
+#  usage_alert                       | usage_alert_user_id_fkey                          | (user_id) REFERENCES accounts(id)

--- a/model/address.rb
+++ b/model/address.rb
@@ -8,3 +8,18 @@ class Address < Sequel::Model
 
   include ResourceMethods
 end
+
+# Table: address
+# Columns:
+#  id                | uuid    | PRIMARY KEY
+#  cidr              | cidr    | NOT NULL
+#  is_failover_ip    | boolean | NOT NULL DEFAULT false
+#  routed_to_host_id | uuid    | NOT NULL
+# Indexes:
+#  address_pkey     | PRIMARY KEY btree (id)
+#  address_cidr_key | UNIQUE btree (cidr)
+# Foreign key constraints:
+#  address_routed_to_host_id_fkey | (routed_to_host_id) REFERENCES vm_host(id)
+# Referenced By:
+#  assigned_host_address | assigned_host_address_address_id_fkey | (address_id) REFERENCES address(id)
+#  assigned_vm_address   | assigned_vm_address_address_id_fkey   | (address_id) REFERENCES address(id)

--- a/model/ai/inference_endpoint.rb
+++ b/model/ai/inference_endpoint.rb
@@ -51,3 +51,32 @@ class InferenceEndpoint < Sequel::Model
     http.request(req)
   end
 end
+
+# Table: inference_endpoint
+# Columns:
+#  id                | uuid                     | PRIMARY KEY
+#  created_at        | timestamp with time zone | NOT NULL DEFAULT now()
+#  updated_at        | timestamp with time zone | NOT NULL DEFAULT now()
+#  is_public         | boolean                  | NOT NULL DEFAULT false
+#  visible           | boolean                  | NOT NULL DEFAULT true
+#  location          | text                     | NOT NULL
+#  boot_image        | text                     | NOT NULL
+#  name              | text                     | NOT NULL
+#  vm_size           | text                     | NOT NULL
+#  model_name        | text                     | NOT NULL
+#  storage_volumes   | jsonb                    | NOT NULL
+#  engine            | text                     | NOT NULL
+#  engine_params     | text                     | NOT NULL
+#  replica_count     | integer                  | NOT NULL
+#  project_id        | uuid                     | NOT NULL
+#  load_balancer_id  | uuid                     | NOT NULL
+#  private_subnet_id | uuid                     | NOT NULL
+#  gpu_count         | integer                  | NOT NULL DEFAULT 1
+# Indexes:
+#  inference_endpoint_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  inference_endpoint_load_balancer_id_fkey  | (load_balancer_id) REFERENCES load_balancer(id)
+#  inference_endpoint_private_subnet_id_fkey | (private_subnet_id) REFERENCES private_subnet(id)
+#  inference_endpoint_project_id_fkey        | (project_id) REFERENCES project(id)
+# Referenced By:
+#  inference_endpoint_replica | inference_endpoint_replica_inference_endpoint_id_fkey | (inference_endpoint_id) REFERENCES inference_endpoint(id)

--- a/model/ai/inference_endpoint_replica.rb
+++ b/model/ai/inference_endpoint_replica.rb
@@ -12,3 +12,16 @@ class InferenceEndpointReplica < Sequel::Model
 
   semaphore :destroy
 end
+
+# Table: inference_endpoint_replica
+# Columns:
+#  id                    | uuid                     | PRIMARY KEY
+#  created_at            | timestamp with time zone | NOT NULL DEFAULT now()
+#  inference_endpoint_id | uuid                     | NOT NULL
+#  vm_id                 | uuid                     | NOT NULL
+# Indexes:
+#  inference_endpoint_replica_pkey      | PRIMARY KEY btree (id)
+#  inference_endpoint_replica_vm_id_key | UNIQUE btree (vm_id)
+# Foreign key constraints:
+#  inference_endpoint_replica_inference_endpoint_id_fkey | (inference_endpoint_id) REFERENCES inference_endpoint(id)
+#  inference_endpoint_replica_vm_id_fkey                 | (vm_id) REFERENCES vm(id)

--- a/model/api_key.rb
+++ b/model/api_key.rb
@@ -27,3 +27,17 @@ class ApiKey < Sequel::Model
     update(key: new_key, updated_at: Time.now)
   end
 end
+
+# Table: api_key
+# Columns:
+#  id          | uuid                     | PRIMARY KEY
+#  created_at  | timestamp with time zone | NOT NULL DEFAULT now()
+#  updated_at  | timestamp with time zone | NOT NULL DEFAULT now()
+#  owner_table | text                     | NOT NULL
+#  owner_id    | uuid                     | NOT NULL
+#  used_for    | text                     | NOT NULL
+#  key         | text                     | NOT NULL
+#  is_valid    | boolean                  | NOT NULL DEFAULT true
+# Indexes:
+#  api_key_pkey                       | PRIMARY KEY btree (id)
+#  api_key_owner_table_owner_id_index | btree (owner_table, owner_id)

--- a/model/applied_tag.rb
+++ b/model/applied_tag.rb
@@ -7,3 +7,15 @@ class AppliedTag < Sequel::Model
 end
 
 AppliedTag.unrestrict_primary_key
+
+# Table: applied_tag
+# Primary Key: (access_tag_id, tagged_id)
+# Columns:
+#  access_tag_id | uuid |
+#  tagged_id     | uuid |
+#  tagged_table  | text | NOT NULL
+# Indexes:
+#  applied_tag_pkey            | PRIMARY KEY btree (access_tag_id, tagged_id)
+#  applied_tag_tagged_id_index | btree (tagged_id)
+# Foreign key constraints:
+#  applied_tag_access_tag_id_fkey | (access_tag_id) REFERENCES access_tag(id)

--- a/model/assigned_host_address.rb
+++ b/model/assigned_host_address.rb
@@ -8,3 +8,16 @@ class AssignedHostAddress < Sequel::Model
 
   include ResourceMethods
 end
+
+# Table: assigned_host_address
+# Columns:
+#  id         | uuid | PRIMARY KEY
+#  ip         | cidr | NOT NULL
+#  address_id | uuid | NOT NULL
+#  host_id    | uuid | NOT NULL
+# Indexes:
+#  assigned_host_address_pkey   | PRIMARY KEY btree (id)
+#  assigned_host_address_ip_key | UNIQUE btree (ip)
+# Foreign key constraints:
+#  assigned_host_address_address_id_fkey | (address_id) REFERENCES address(id)
+#  assigned_host_address_host_id_fkey    | (host_id) REFERENCES vm_host(id)

--- a/model/assigned_vm_address.rb
+++ b/model/assigned_vm_address.rb
@@ -9,3 +9,16 @@ class AssignedVmAddress < Sequel::Model
 
   include ResourceMethods
 end
+
+# Table: assigned_vm_address
+# Columns:
+#  id         | uuid | PRIMARY KEY
+#  ip         | cidr | NOT NULL
+#  address_id | uuid | NOT NULL
+#  dst_vm_id  | uuid | NOT NULL
+# Indexes:
+#  assigned_vm_address_pkey   | PRIMARY KEY btree (id)
+#  assigned_vm_address_ip_key | UNIQUE btree (ip)
+# Foreign key constraints:
+#  assigned_vm_address_address_id_fkey | (address_id) REFERENCES address(id)
+#  assigned_vm_address_dst_vm_id_fkey  | (dst_vm_id) REFERENCES vm(id)

--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -22,3 +22,15 @@ class BillingInfo < Sequel::Model
     super
   end
 end
+
+# Table: billing_info
+# Columns:
+#  id         | uuid                     | PRIMARY KEY
+#  stripe_id  | text                     | NOT NULL
+#  created_at | timestamp with time zone | NOT NULL DEFAULT now()
+# Indexes:
+#  billing_info_pkey          | PRIMARY KEY btree (id)
+#  billing_info_stripe_id_key | UNIQUE btree (stripe_id)
+# Referenced By:
+#  payment_method | payment_method_billing_info_id_fkey | (billing_info_id) REFERENCES billing_info(id)
+#  project        | project_billing_info_id_fkey        | (billing_info_id) REFERENCES billing_info(id)

--- a/model/billing_record.rb
+++ b/model/billing_record.rb
@@ -43,3 +43,18 @@ class BillingRecord < Sequel::Model
     @billing_rate ||= BillingRate.from_id(billing_rate_id)
   end
 end
+
+# Table: billing_record
+# Columns:
+#  id              | uuid      | PRIMARY KEY
+#  project_id      | uuid      | NOT NULL
+#  resource_id     | uuid      | NOT NULL
+#  resource_name   | text      | NOT NULL
+#  span            | tstzrange | NOT NULL DEFAULT tstzrange(now(), NULL::timestamp with time zone, '[)'::text)
+#  amount          | numeric   | NOT NULL
+#  billing_rate_id | uuid      | NOT NULL
+# Indexes:
+#  billing_record_pkey              | PRIMARY KEY btree (id)
+#  billing_record_project_id_index  | btree (project_id)
+#  billing_record_resource_id_index | btree (resource_id)
+#  billing_record_span_index        | gist (span)

--- a/model/boot_image.rb
+++ b/model/boot_image.rb
@@ -23,3 +23,20 @@ class BootImage < Sequel::Model
         "/var/storage/images/#{name}.raw"
   end
 end
+
+# Table: boot_image
+# Columns:
+#  id           | uuid                     | PRIMARY KEY
+#  vm_host_id   | uuid                     | NOT NULL
+#  name         | text                     | NOT NULL
+#  version      | text                     |
+#  created_at   | timestamp with time zone | NOT NULL DEFAULT now()
+#  activated_at | timestamp with time zone |
+#  size_gib     | integer                  | NOT NULL
+# Indexes:
+#  boot_image_pkey                        | PRIMARY KEY btree (id)
+#  boot_image_vm_host_id_name_version_key | UNIQUE btree (vm_host_id, name, version)
+# Foreign key constraints:
+#  boot_image_vm_host_id_fkey | (vm_host_id) REFERENCES vm_host(id)
+# Referenced By:
+#  vm_storage_volume | vm_storage_volume_boot_image_id_fkey | (boot_image_id) REFERENCES boot_image(id)

--- a/model/cert.rb
+++ b/model/cert.rb
@@ -22,3 +22,21 @@ class Cert < Sequel::Model
     super + [:cert]
   end
 end
+
+# Table: cert
+# Columns:
+#  id          | uuid                        | PRIMARY KEY
+#  hostname    | text                        | NOT NULL
+#  dns_zone_id | uuid                        |
+#  created_at  | timestamp without time zone | NOT NULL DEFAULT now()
+#  cert        | text                        |
+#  account_key | text                        |
+#  kid         | text                        |
+#  order_url   | text                        |
+#  csr_key     | text                        |
+# Indexes:
+#  cert_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  cert_dns_zone_id_fkey | (dns_zone_id) REFERENCES dns_zone(id)
+# Referenced By:
+#  certs_load_balancers | certs_load_balancers_cert_id_fkey | (cert_id) REFERENCES cert(id)

--- a/model/certs_load_balancers.rb
+++ b/model/certs_load_balancers.rb
@@ -13,3 +13,14 @@ class CertsLoadBalancers < Sequel::Model
     end
   end
 end
+
+# Table: certs_load_balancers
+# Primary Key: (load_balancer_id, cert_id)
+# Columns:
+#  load_balancer_id | uuid |
+#  cert_id          | uuid |
+# Indexes:
+#  certs_load_balancers_pkey | PRIMARY KEY btree (load_balancer_id, cert_id)
+# Foreign key constraints:
+#  certs_load_balancers_cert_id_fkey          | (cert_id) REFERENCES cert(id)
+#  certs_load_balancers_load_balancer_id_fkey | (load_balancer_id) REFERENCES load_balancer(id)

--- a/model/connected_subnet.rb
+++ b/model/connected_subnet.rb
@@ -9,3 +9,18 @@ class ConnectedSubnet < Sequel::Model
     UBID::TYPE_ETC
   end
 end
+
+# Table: connected_subnet
+# Columns:
+#  id          | uuid | PRIMARY KEY
+#  subnet_id_1 | uuid | NOT NULL
+#  subnet_id_2 | uuid | NOT NULL
+# Indexes:
+#  connected_subnet_pkey                        | PRIMARY KEY btree (id)
+#  connected_subnet_subnet_id_1_subnet_id_2_key | UNIQUE btree (subnet_id_1, subnet_id_2)
+#  connected_subnet_subnet_id_2_index           | btree (subnet_id_2)
+# Check constraints:
+#  unique_subnet_pair | (subnet_id_1 < subnet_id_2)
+# Foreign key constraints:
+#  connected_subnet_subnet_id_1_fkey | (subnet_id_1) REFERENCES private_subnet(id)
+#  connected_subnet_subnet_id_2_fkey | (subnet_id_2) REFERENCES private_subnet(id)

--- a/model/deleted_record.rb
+++ b/model/deleted_record.rb
@@ -4,3 +4,12 @@ require_relative "../model"
 
 class DeletedRecord < Sequel::Model
 end
+
+# Table: deleted_record
+# Columns:
+#  id           | uuid                     | PRIMARY KEY DEFAULT gen_random_uuid()
+#  deleted_at   | timestamp with time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  model_name   | text                     | NOT NULL
+#  model_values | jsonb                    | NOT NULL DEFAULT '{}'::jsonb
+# Indexes:
+#  deleted_record_pkey | PRIMARY KEY btree (id)

--- a/model/dns_zone/dns_record.rb
+++ b/model/dns_zone/dns_record.rb
@@ -5,3 +5,21 @@ require_relative "../../model"
 class DnsRecord < Sequel::Model
   include ResourceMethods
 end
+
+# Table: dns_record
+# Columns:
+#  id          | uuid                     | PRIMARY KEY
+#  dns_zone_id | uuid                     |
+#  name        | text                     | NOT NULL
+#  type        | text                     | NOT NULL
+#  ttl         | bigint                   | NOT NULL
+#  data        | text                     | NOT NULL
+#  tombstoned  | boolean                  | NOT NULL DEFAULT false
+#  created_at  | timestamp with time zone | NOT NULL DEFAULT now()
+# Indexes:
+#  dns_record_pkey                             | PRIMARY KEY btree (id)
+#  dns_record_dns_zone_id_name_type_data_index | btree (dns_zone_id, name, type, data)
+# Foreign key constraints:
+#  dns_record_dns_zone_id_fkey | (dns_zone_id) REFERENCES dns_zone(id)
+# Referenced By:
+#  seen_dns_records_by_dns_servers | seen_dns_records_by_dns_servers_dns_record_id_fkey | (dns_record_id) REFERENCES dns_record(id)

--- a/model/dns_zone/dns_server.rb
+++ b/model/dns_zone/dns_server.rb
@@ -28,3 +28,16 @@ class DnsServer < Sequel::Model
     end
   end
 end
+
+# Table: dns_server
+# Columns:
+#  id         | uuid                     | PRIMARY KEY
+#  created_at | timestamp with time zone | NOT NULL DEFAULT now()
+#  name       | text                     | NOT NULL
+# Indexes:
+#  dns_server_pkey     | PRIMARY KEY btree (id)
+#  dns_server_name_key | UNIQUE btree (name)
+# Referenced By:
+#  dns_servers_dns_zones           | dns_servers_dns_zones_dns_server_id_fkey           | (dns_server_id) REFERENCES dns_server(id)
+#  dns_servers_vms                 | dns_servers_vms_dns_server_id_fkey                 | (dns_server_id) REFERENCES dns_server(id)
+#  seen_dns_records_by_dns_servers | seen_dns_records_by_dns_servers_dns_server_id_fkey | (dns_server_id) REFERENCES dns_server(id)

--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -56,3 +56,18 @@ class DnsZone < Sequel::Model
     (record_name[-1] == ".") ? record_name : record_name + "."
   end
 end
+
+# Table: dns_zone
+# Columns:
+#  id             | uuid                     | PRIMARY KEY
+#  created_at     | timestamp with time zone | NOT NULL DEFAULT now()
+#  project_id     | uuid                     | NOT NULL
+#  name           | text                     | NOT NULL
+#  last_purged_at | timestamp with time zone | NOT NULL DEFAULT now()
+# Indexes:
+#  dns_zone_pkey | PRIMARY KEY btree (id)
+# Referenced By:
+#  cert                  | cert_dns_zone_id_fkey                          | (dns_zone_id) REFERENCES dns_zone(id)
+#  dns_record            | dns_record_dns_zone_id_fkey                    | (dns_zone_id) REFERENCES dns_zone(id)
+#  dns_servers_dns_zones | dns_servers_dns_zones_dns_zone_id_fkey         | (dns_zone_id) REFERENCES dns_zone(id)
+#  load_balancer         | load_balancer_custom_hostname_dns_zone_id_fkey | (custom_hostname_dns_zone_id) REFERENCES dns_zone(id)

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -78,3 +78,16 @@ class Firewall < Sequel::Model
     private_subnet.incr_update_firewall_rules if apply_firewalls
   end
 end
+
+# Table: firewall
+# Columns:
+#  id          | uuid                        | PRIMARY KEY
+#  name        | text                        | NOT NULL DEFAULT 'Default'::text
+#  description | text                        | NOT NULL DEFAULT 'Default firewall'::text
+#  created_at  | timestamp without time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  location    | text                        | NOT NULL
+# Indexes:
+#  firewall_pkey | PRIMARY KEY btree (id)
+# Referenced By:
+#  firewall_rule             | firewall_rule_firewall_id_fkey             | (firewall_id) REFERENCES firewall(id)
+#  firewalls_private_subnets | firewalls_private_subnets_firewall_id_fkey | (firewall_id) REFERENCES firewall(id)

--- a/model/firewall_rule.rb
+++ b/model/firewall_rule.rb
@@ -11,3 +11,17 @@ class FirewallRule < Sequel::Model
     cidr.to_s.include?(":")
   end
 end
+
+# Table: firewall_rule
+# Columns:
+#  id          | uuid      | PRIMARY KEY
+#  cidr        | cidr      |
+#  port_range  | int4range | DEFAULT '[0,65536)'::int4range
+#  firewall_id | uuid      | NOT NULL
+# Indexes:
+#  firewall_rule_pkey                            | PRIMARY KEY btree (id)
+#  firewall_rule_cidr_port_range_firewall_id_key | UNIQUE btree (cidr, port_range, firewall_id)
+# Check constraints:
+#  port_range_min_max | (lower(port_range) >= 0 AND upper(port_range) <= 65536)
+# Foreign key constraints:
+#  firewall_rule_firewall_id_fkey | (firewall_id) REFERENCES firewall(id)

--- a/model/firewalls_private_subnets.rb
+++ b/model/firewalls_private_subnets.rb
@@ -5,3 +5,14 @@ require_relative "../model"
 class FirewallsPrivateSubnets < Sequel::Model
   include ResourceMethods
 end
+
+# Table: firewalls_private_subnets
+# Primary Key: (private_subnet_id, firewall_id)
+# Columns:
+#  private_subnet_id | uuid |
+#  firewall_id       | uuid |
+# Indexes:
+#  firewalls_private_subnets_pkey | PRIMARY KEY btree (private_subnet_id, firewall_id)
+# Foreign key constraints:
+#  firewalls_private_subnets_firewall_id_fkey       | (firewall_id) REFERENCES firewall(id)
+#  firewalls_private_subnets_private_subnet_id_fkey | (private_subnet_id) REFERENCES private_subnet(id)

--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -32,3 +32,24 @@ class GithubCacheEntry < Sequel::Model
     end
   end
 end
+
+# Table: github_cache_entry
+# Columns:
+#  id               | uuid                     | PRIMARY KEY
+#  repository_id    | uuid                     | NOT NULL
+#  key              | text                     | NOT NULL
+#  version          | text                     | NOT NULL
+#  scope            | text                     | NOT NULL
+#  size             | bigint                   |
+#  upload_id        | text                     |
+#  created_at       | timestamp with time zone | NOT NULL DEFAULT now()
+#  created_by       | uuid                     | NOT NULL
+#  last_accessed_at | timestamp with time zone |
+#  last_accessed_by | uuid                     |
+#  committed_at     | timestamp with time zone |
+# Indexes:
+#  github_cache_entry_pkey                                | PRIMARY KEY btree (id)
+#  github_cache_entry_repository_id_scope_key_version_key | UNIQUE btree (repository_id, scope, key, version)
+#  github_cache_entry_upload_id_key                       | UNIQUE btree (upload_id)
+# Foreign key constraints:
+#  github_cache_entry_repository_id_fkey | (repository_id) REFERENCES github_repository(id)

--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -87,3 +87,23 @@ class GithubRepository < Sequel::Model
     end
   end
 end
+
+# Table: github_repository
+# Columns:
+#  id              | uuid                     | PRIMARY KEY
+#  installation_id | uuid                     |
+#  name            | text                     | NOT NULL
+#  created_at      | timestamp with time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  last_job_at     | timestamp with time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  last_check_at   | timestamp with time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  default_branch  | text                     |
+#  access_key      | text                     |
+#  secret_key      | text                     |
+# Indexes:
+#  github_repository_pkey                       | PRIMARY KEY btree (id)
+#  github_repository_installation_id_name_index | UNIQUE btree (installation_id, name)
+# Foreign key constraints:
+#  github_repository_installation_id_fkey | (installation_id) REFERENCES github_installation(id)
+# Referenced By:
+#  github_cache_entry | github_cache_entry_repository_id_fkey | (repository_id) REFERENCES github_repository(id)
+#  github_runner      | github_runner_repository_id_fkey      | (repository_id) REFERENCES github_repository(id)

--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -22,3 +22,18 @@ class GithubInstallation < Sequel::Model
     end
   end
 end
+
+# Table: github_installation
+# Columns:
+#  id              | uuid   | PRIMARY KEY
+#  installation_id | bigint | NOT NULL
+#  name            | text   | NOT NULL
+#  type            | text   | NOT NULL
+#  project_id      | uuid   |
+# Indexes:
+#  github_installation_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  github_installation_project_id_fkey | (project_id) REFERENCES project(id)
+# Referenced By:
+#  github_repository | github_repository_installation_id_fkey | (installation_id) REFERENCES github_installation(id)
+#  github_runner     | github_runner_installation_id_fkey     | (installation_id) REFERENCES github_installation(id)

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -69,3 +69,22 @@ class GithubRunner < Sequel::Model
     super + [:workflow_job]
   end
 end
+
+# Table: github_runner
+# Columns:
+#  id              | uuid                     | PRIMARY KEY
+#  installation_id | uuid                     |
+#  repository_name | text                     | NOT NULL
+#  label           | text                     | NOT NULL
+#  vm_id           | uuid                     |
+#  runner_id       | bigint                   |
+#  created_at      | timestamp with time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  ready_at        | timestamp with time zone |
+#  workflow_job    | jsonb                    |
+#  repository_id   | uuid                     |
+# Indexes:
+#  github_runner_pkey      | PRIMARY KEY btree (id)
+#  github_runner_vm_id_key | UNIQUE btree (vm_id)
+# Foreign key constraints:
+#  github_runner_installation_id_fkey | (installation_id) REFERENCES github_installation(id)
+#  github_runner_repository_id_fkey   | (repository_id) REFERENCES github_repository(id)

--- a/model/globally_blocked_dnsname.rb
+++ b/model/globally_blocked_dnsname.rb
@@ -9,3 +9,13 @@ class GloballyBlockedDnsname < Sequel::Model
     UBID::TYPE_ETC
   end
 end
+
+# Table: globally_blocked_dnsname
+# Columns:
+#  id            | uuid                        | PRIMARY KEY
+#  dns_name      | text                        | NOT NULL
+#  ip_list       | inet[]                      |
+#  last_check_at | timestamp without time zone |
+# Indexes:
+#  globally_blocked_dnsname_pkey         | PRIMARY KEY btree (id)
+#  globally_blocked_dnsname_dns_name_key | UNIQUE btree (dns_name)

--- a/model/hetzner_host.rb
+++ b/model/hetzner_host.rb
@@ -23,3 +23,13 @@ class HetznerHost < Sequel::Model
     Config.hetzner_password
   end
 end
+
+# Table: hetzner_host
+# Columns:
+#  id                | uuid | PRIMARY KEY
+#  server_identifier | text | NOT NULL
+# Indexes:
+#  hetzner_host_pkey                  | PRIMARY KEY btree (id)
+#  hetzner_host_server_identifier_key | UNIQUE btree (server_identifier)
+# Foreign key constraints:
+#  hetzner_host_id_fkey | (id) REFERENCES vm_host(id)

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -230,3 +230,17 @@ class Invoice < Sequel::Model
 end
 
 Invoice.unrestrict_primary_key
+
+# Table: invoice
+# Columns:
+#  id             | uuid                     | PRIMARY KEY
+#  project_id     | uuid                     | NOT NULL
+#  content        | jsonb                    | NOT NULL
+#  created_at     | timestamp with time zone | NOT NULL DEFAULT now()
+#  invoice_number | text                     | NOT NULL
+#  begin_time     | timestamp with time zone | NOT NULL
+#  end_time       | timestamp with time zone | NOT NULL
+#  status         | text                     | NOT NULL DEFAULT 'unpaid'::text
+# Indexes:
+#  invoice_pkey             | PRIMARY KEY btree (id)
+#  invoice_project_id_index | btree (project_id)

--- a/model/ipsec_tunnel.rb
+++ b/model/ipsec_tunnel.rb
@@ -12,3 +12,15 @@ class IpsecTunnel < Sequel::Model
     nic.vm.inhost_name.shellescape
   end
 end
+
+# Table: ipsec_tunnel
+# Columns:
+#  id         | uuid | PRIMARY KEY
+#  src_nic_id | uuid |
+#  dst_nic_id | uuid |
+# Indexes:
+#  ipsec_tunnel_pkey                      | PRIMARY KEY btree (id)
+#  ipsec_tunnel_src_nic_id_dst_nic_id_key | UNIQUE btree (src_nic_id, dst_nic_id)
+# Foreign key constraints:
+#  ipsec_tunnel_dst_nic_id_fkey | (dst_nic_id) REFERENCES nic(id)
+#  ipsec_tunnel_src_nic_id_fkey | (src_nic_id) REFERENCES nic(id)

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -99,3 +99,38 @@ class LoadBalancer < Sequel::Model
     DUAL = "dual"
   end
 end
+
+# Table: load_balancer
+# Columns:
+#  id                          | uuid           | PRIMARY KEY
+#  name                        | text           | NOT NULL
+#  algorithm                   | lb_algorithm   | NOT NULL DEFAULT 'round_robin'::lb_algorithm
+#  src_port                    | integer        | NOT NULL
+#  dst_port                    | integer        | NOT NULL
+#  private_subnet_id           | uuid           | NOT NULL
+#  health_check_endpoint       | text           | NOT NULL
+#  health_check_interval       | integer        | NOT NULL DEFAULT 10
+#  health_check_timeout        | integer        | NOT NULL DEFAULT 5
+#  health_check_up_threshold   | integer        | NOT NULL DEFAULT 5
+#  health_check_down_threshold | integer        | NOT NULL DEFAULT 3
+#  health_check_protocol       | lb_hc_protocol | NOT NULL DEFAULT 'http'::lb_hc_protocol
+#  custom_hostname             | text           |
+#  custom_hostname_dns_zone_id | uuid           |
+#  stack                       | lb_stack       | NOT NULL DEFAULT 'dual'::lb_stack
+# Indexes:
+#  load_balancer_pkey                | PRIMARY KEY btree (id)
+#  load_balancer_custom_hostname_key | UNIQUE btree (custom_hostname)
+# Check constraints:
+#  health_check_down_threshold_gt_0              | (health_check_down_threshold > 0)
+#  health_check_interval_gt_0                    | (health_check_interval > 0)
+#  health_check_interval_lt_600                  | (health_check_interval < 600)
+#  health_check_timeout_gt_0                     | (health_check_timeout > 0)
+#  health_check_timeout_lt_health_check_interval | (health_check_timeout <= health_check_interval)
+#  health_check_up_threshold_gt_0                | (health_check_up_threshold > 0)
+# Foreign key constraints:
+#  load_balancer_custom_hostname_dns_zone_id_fkey | (custom_hostname_dns_zone_id) REFERENCES dns_zone(id)
+#  load_balancer_private_subnet_id_fkey           | (private_subnet_id) REFERENCES private_subnet(id)
+# Referenced By:
+#  certs_load_balancers | certs_load_balancers_load_balancer_id_fkey | (load_balancer_id) REFERENCES load_balancer(id)
+#  inference_endpoint   | inference_endpoint_load_balancer_id_fkey   | (load_balancer_id) REFERENCES load_balancer(id)
+#  load_balancers_vms   | load_balancers_vms_load_balancer_id_fkey   | (load_balancer_id) REFERENCES load_balancer(id)

--- a/model/load_balancers_vms.rb
+++ b/model/load_balancers_vms.rb
@@ -5,3 +5,17 @@ require_relative "../model"
 class LoadBalancersVms < Sequel::Model
   include ResourceMethods
 end
+
+# Table: load_balancers_vms
+# Primary Key: (load_balancer_id, vm_id)
+# Columns:
+#  load_balancer_id | uuid          |
+#  vm_id            | uuid          |
+#  state            | lb_node_state | NOT NULL DEFAULT 'down'::lb_node_state
+#  state_counter    | integer       | NOT NULL DEFAULT 0
+# Indexes:
+#  load_balancers_vms_pkey      | PRIMARY KEY btree (load_balancer_id, vm_id)
+#  load_balancers_vms_vm_id_key | UNIQUE btree (vm_id)
+# Foreign key constraints:
+#  load_balancers_vms_load_balancer_id_fkey | (load_balancer_id) REFERENCES load_balancer(id)
+#  load_balancers_vms_vm_id_fkey            | (vm_id) REFERENCES vm(id)

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -83,3 +83,24 @@ class MinioCluster < Sequel::Model
     super + [:root_cert_1, :root_cert_2]
   end
 end
+
+# Table: minio_cluster
+# Columns:
+#  id                          | uuid                        | PRIMARY KEY
+#  name                        | text                        | NOT NULL
+#  location                    | text                        | NOT NULL
+#  created_at                  | timestamp without time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  admin_user                  | text                        | NOT NULL
+#  admin_password              | text                        | NOT NULL
+#  private_subnet_id           | uuid                        |
+#  root_cert_1                 | text                        |
+#  root_cert_key_1             | text                        |
+#  root_cert_2                 | text                        |
+#  root_cert_key_2             | text                        |
+#  certificate_last_checked_at | timestamp with time zone    | NOT NULL DEFAULT now()
+# Indexes:
+#  minio_cluster_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  minio_cluster_private_subnet_id_fkey | (private_subnet_id) REFERENCES private_subnet(id)
+# Referenced By:
+#  minio_pool | minio_pool_cluster_id_fkey | (cluster_id) REFERENCES minio_cluster(id)

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -34,3 +34,19 @@ class MinioPool < Sequel::Model
     (storage_size_gib / server_count).to_i
   end
 end
+
+# Table: minio_pool
+# Columns:
+#  id               | uuid    | PRIMARY KEY
+#  start_index      | integer | NOT NULL DEFAULT 0
+#  cluster_id       | uuid    | NOT NULL
+#  server_count     | integer |
+#  drive_count      | integer |
+#  storage_size_gib | bigint  |
+#  vm_size          | text    | NOT NULL
+# Indexes:
+#  minio_pool_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  minio_pool_cluster_id_fkey | (cluster_id) REFERENCES minio_cluster(id)
+# Referenced By:
+#  minio_server | minio_server_minio_pool_id_fkey | (minio_pool_id) REFERENCES minio_pool(id)

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -96,3 +96,18 @@ class MinioServer < Sequel::Model
     super + [:cert]
   end
 end
+
+# Table: minio_server
+# Columns:
+#  id                          | uuid                     | PRIMARY KEY
+#  index                       | integer                  | NOT NULL
+#  minio_pool_id               | uuid                     |
+#  vm_id                       | uuid                     | NOT NULL
+#  cert                        | text                     |
+#  cert_key                    | text                     |
+#  certificate_last_checked_at | timestamp with time zone | NOT NULL DEFAULT now()
+# Indexes:
+#  minio_server_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  minio_server_minio_pool_id_fkey | (minio_pool_id) REFERENCES minio_pool(id)
+#  minio_server_vm_id_fkey         | (vm_id) REFERENCES vm(id)

--- a/model/nic.rb
+++ b/model/nic.rb
@@ -36,3 +36,24 @@ class Nic < Sequel::Model
     Semaphore.where(strand_id: strand.id, name: "lock").delete(force: true)
   end
 end
+
+# Table: nic
+# Columns:
+#  id                | uuid                     | PRIMARY KEY
+#  private_subnet_id | uuid                     | NOT NULL
+#  mac               | macaddr                  | NOT NULL
+#  created_at        | timestamp with time zone | NOT NULL DEFAULT now()
+#  private_ipv4      | cidr                     | NOT NULL
+#  private_ipv6      | cidr                     | NOT NULL
+#  vm_id             | uuid                     |
+#  encryption_key    | text                     |
+#  name              | text                     | NOT NULL
+#  rekey_payload     | jsonb                    |
+# Indexes:
+#  nic_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  nic_private_subnet_id_fkey | (private_subnet_id) REFERENCES private_subnet(id)
+#  nic_vm_id_fkey             | (vm_id) REFERENCES vm(id)
+# Referenced By:
+#  ipsec_tunnel | ipsec_tunnel_dst_nic_id_fkey | (dst_nic_id) REFERENCES nic(id)
+#  ipsec_tunnel | ipsec_tunnel_src_nic_id_fkey | (src_nic_id) REFERENCES nic(id)

--- a/model/page.rb
+++ b/model/page.rb
@@ -62,3 +62,16 @@ class Page < Sequel::Model
     Page.active.where(tag: tag).first
   end
 end
+
+# Table: page
+# Columns:
+#  id          | uuid                     | PRIMARY KEY
+#  created_at  | timestamp with time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  resolved_at | timestamp with time zone |
+#  summary     | text                     |
+#  tag         | text                     | NOT NULL
+#  details     | jsonb                    | NOT NULL DEFAULT '{}'::jsonb
+#  severity    | page_severity            | NOT NULL DEFAULT 'error'::page_severity
+# Indexes:
+#  page_pkey      | PRIMARY KEY btree (id)
+#  page_tag_index | UNIQUE btree (tag) WHERE resolved_at IS NULL

--- a/model/payment_method.rb
+++ b/model/payment_method.rb
@@ -21,3 +21,21 @@ class PaymentMethod < Sequel::Model
     super
   end
 end
+
+# Table: payment_method
+# Columns:
+#  id                | uuid                     | PRIMARY KEY
+#  stripe_id         | text                     | NOT NULL
+#  order             | integer                  |
+#  billing_info_id   | uuid                     |
+#  created_at        | timestamp with time zone | NOT NULL DEFAULT now()
+#  card_fingerprint  | text                     |
+#  fraud             | boolean                  | NOT NULL DEFAULT false
+#  preauth_amount    | integer                  |
+#  preauth_intent_id | text                     |
+# Indexes:
+#  payment_method_pkey                  | PRIMARY KEY btree (id)
+#  payment_method_preauth_intent_id_key | UNIQUE btree (preauth_intent_id)
+#  payment_method_stripe_id_key         | UNIQUE btree (stripe_id)
+# Foreign key constraints:
+#  payment_method_billing_info_id_fkey | (billing_info_id) REFERENCES billing_info(id)

--- a/model/pci_device.rb
+++ b/model/pci_device.rb
@@ -16,3 +16,23 @@ class PciDevice < Sequel::Model
     ["0300", "0302"].include? device_class
   end
 end
+
+# Table: pci_device
+# Columns:
+#  id           | uuid    | PRIMARY KEY
+#  slot         | text    | NOT NULL
+#  device_class | text    | NOT NULL
+#  vendor       | text    | NOT NULL
+#  device       | text    | NOT NULL
+#  numa_node    | integer |
+#  iommu_group  | integer | NOT NULL
+#  enabled      | boolean | NOT NULL DEFAULT true
+#  vm_host_id   | uuid    | NOT NULL
+#  vm_id        | uuid    |
+# Indexes:
+#  pci_device_pkey                | PRIMARY KEY btree (id)
+#  pci_device_vm_host_id_slot_key | UNIQUE btree (vm_host_id, slot)
+#  pci_device_vm_id_index         | btree (vm_id)
+# Foreign key constraints:
+#  pci_device_vm_host_id_fkey | (vm_host_id) REFERENCES vm_host(id)
+#  pci_device_vm_id_fkey      | (vm_id) REFERENCES vm(id)

--- a/model/postgres/postgres_firewall_rule.rb
+++ b/model/postgres/postgres_firewall_rule.rb
@@ -8,3 +8,14 @@ class PostgresFirewallRule < Sequel::Model
 
   include ResourceMethods
 end
+
+# Table: postgres_firewall_rule
+# Columns:
+#  id                   | uuid | PRIMARY KEY
+#  cidr                 | cidr | NOT NULL
+#  postgres_resource_id | uuid | NOT NULL
+# Indexes:
+#  postgres_firewall_rule_pkey                          | PRIMARY KEY btree (id)
+#  postgres_firewall_rule_postgres_resource_id_cidr_key | UNIQUE btree (postgres_resource_id, cidr)
+# Foreign key constraints:
+#  postgres_firewall_rule_postgres_resource_id_fkey | (postgres_resource_id) REFERENCES postgres_resource(id)

--- a/model/postgres/postgres_lsn_monitor.rb
+++ b/model/postgres/postgres_lsn_monitor.rb
@@ -4,3 +4,10 @@ require_relative "../../model"
 
 class PostgresLsnMonitor < Sequel::Model(POSTGRES_MONITOR_DB[:postgres_lsn_monitor])
 end
+
+# Table: postgres_lsn_monitor
+# Columns:
+#  postgres_server_id | uuid   | PRIMARY KEY
+#  last_known_lsn     | pg_lsn |
+# Indexes:
+#  postgres_lsn_monitor_pkey | PRIMARY KEY btree (postgres_server_id)

--- a/model/postgres/postgres_metric_destination.rb
+++ b/model/postgres/postgres_metric_destination.rb
@@ -15,3 +15,15 @@ class PostgresMetricDestination < Sequel::Model
     UBID::TYPE_ETC
   end
 end
+
+# Table: postgres_metric_destination
+# Columns:
+#  id                   | uuid | PRIMARY KEY
+#  postgres_resource_id | uuid | NOT NULL
+#  url                  | text | NOT NULL
+#  username             | text | NOT NULL
+#  password             | text | NOT NULL
+# Indexes:
+#  postgres_metric_destination_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  postgres_metric_destination_postgres_resource_id_fkey | (postgres_resource_id) REFERENCES postgres_resource(id)

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -118,3 +118,35 @@ class PostgresResource < Sequel::Model
     super + [:root_cert_1, :root_cert_2, :server_cert]
   end
 end
+
+# Table: postgres_resource
+# Columns:
+#  id                          | uuid                     | PRIMARY KEY
+#  created_at                  | timestamp with time zone | NOT NULL DEFAULT now()
+#  updated_at                  | timestamp with time zone | NOT NULL DEFAULT now()
+#  project_id                  | uuid                     | NOT NULL
+#  location                    | text                     | NOT NULL
+#  name                        | text                     | NOT NULL
+#  target_vm_size              | text                     | NOT NULL
+#  target_storage_size_gib     | bigint                   | NOT NULL
+#  superuser_password          | text                     | NOT NULL
+#  root_cert_1                 | text                     |
+#  root_cert_key_1             | text                     |
+#  server_cert                 | text                     |
+#  server_cert_key             | text                     |
+#  root_cert_2                 | text                     |
+#  root_cert_key_2             | text                     |
+#  certificate_last_checked_at | timestamp with time zone | NOT NULL DEFAULT now()
+#  parent_id                   | uuid                     |
+#  restore_target              | timestamp with time zone |
+#  ha_type                     | ha_type                  | NOT NULL DEFAULT 'none'::ha_type
+#  hostname_version            | hostname_version         | NOT NULL DEFAULT 'v1'::hostname_version
+#  private_subnet_id           | uuid                     |
+#  flavor                      | postgres_flavor          | NOT NULL DEFAULT 'standard'::postgres_flavor
+#  version                     | postgres_version         | NOT NULL DEFAULT '16'::postgres_version
+# Indexes:
+#  postgres_server_pkey            | PRIMARY KEY btree (id)
+#  postgres_server_server_name_key | UNIQUE btree (name)
+# Referenced By:
+#  postgres_firewall_rule      | postgres_firewall_rule_postgres_resource_id_fkey      | (postgres_resource_id) REFERENCES postgres_resource(id)
+#  postgres_metric_destination | postgres_metric_destination_postgres_resource_id_fkey | (postgres_resource_id) REFERENCES postgres_resource(id)

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -212,3 +212,21 @@ class PostgresServer < Sequel::Model
     self.class.run_query(vm, query)
   end
 end
+
+# Table: postgres_server
+# Columns:
+#  id                     | uuid                     | PRIMARY KEY
+#  created_at             | timestamp with time zone | NOT NULL DEFAULT now()
+#  updated_at             | timestamp with time zone | NOT NULL DEFAULT now()
+#  resource_id            | uuid                     | NOT NULL
+#  vm_id                  | uuid                     |
+#  timeline_id            | uuid                     | NOT NULL
+#  timeline_access        | timeline_access          | NOT NULL DEFAULT 'push'::timeline_access
+#  representative_at      | timestamp with time zone |
+#  synchronization_status | synchronization_status   | NOT NULL DEFAULT 'ready'::synchronization_status
+# Indexes:
+#  postgres_server_pkey1             | PRIMARY KEY btree (id)
+#  postgres_server_resource_id_index | UNIQUE btree (resource_id) WHERE representative_at IS NOT NULL
+# Foreign key constraints:
+#  postgres_server_timeline_id_fkey | (timeline_id) REFERENCES postgres_timeline(id)
+#  postgres_server_vm_id_fkey       | (vm_id) REFERENCES vm(id)

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -97,3 +97,18 @@ PGHOST=/var/run/postgresql
     {Version: "2012-10-17", Statement: [{Effect: "Allow", Action: ["s3:*"], Resource: ["arn:aws:s3:::#{ubid}*"]}]}
   end
 end
+
+# Table: postgres_timeline
+# Columns:
+#  id                       | uuid                     | PRIMARY KEY
+#  created_at               | timestamp with time zone | NOT NULL DEFAULT now()
+#  updated_at               | timestamp with time zone | NOT NULL DEFAULT now()
+#  parent_id                | uuid                     |
+#  access_key               | text                     |
+#  secret_key               | text                     |
+#  latest_backup_started_at | timestamp with time zone |
+#  blob_storage_id          | uuid                     |
+# Indexes:
+#  postgres_timeline_pkey | PRIMARY KEY btree (id)
+# Referenced By:
+#  postgres_server | postgres_server_timeline_id_fkey | (timeline_id) REFERENCES postgres_timeline(id)

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -134,3 +134,23 @@ class PrivateSubnet < Sequel::Model
     nics + connected_subnets.select { |subnet| !excluded_private_subnet_ids.include?(subnet.id) }.flat_map { _1.find_all_connected_nics(excluded_private_subnet_ids + [id]) }.uniq
   end
 end
+
+# Table: private_subnet
+# Columns:
+#  id            | uuid                     | PRIMARY KEY
+#  net6          | cidr                     | NOT NULL
+#  net4          | cidr                     | NOT NULL
+#  state         | text                     | NOT NULL DEFAULT 'creating'::text
+#  name          | text                     | NOT NULL
+#  location      | text                     | NOT NULL
+#  last_rekey_at | timestamp with time zone | NOT NULL DEFAULT now()
+# Indexes:
+#  vm_private_subnet_pkey | PRIMARY KEY btree (id)
+# Referenced By:
+#  connected_subnet          | connected_subnet_subnet_id_1_fkey                | (subnet_id_1) REFERENCES private_subnet(id)
+#  connected_subnet          | connected_subnet_subnet_id_2_fkey                | (subnet_id_2) REFERENCES private_subnet(id)
+#  firewalls_private_subnets | firewalls_private_subnets_private_subnet_id_fkey | (private_subnet_id) REFERENCES private_subnet(id)
+#  inference_endpoint        | inference_endpoint_private_subnet_id_fkey        | (private_subnet_id) REFERENCES private_subnet(id)
+#  load_balancer             | load_balancer_private_subnet_id_fkey             | (private_subnet_id) REFERENCES private_subnet(id)
+#  minio_cluster             | minio_cluster_private_subnet_id_fkey             | (private_subnet_id) REFERENCES private_subnet(id)
+#  nic                       | nic_private_subnet_id_fkey                       | (private_subnet_id) REFERENCES private_subnet(id)

--- a/model/project.rb
+++ b/model/project.rb
@@ -137,3 +137,30 @@ class Project < Sequel::Model
 
   feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra
 end
+
+# Table: project
+# Columns:
+#  id              | uuid                     | PRIMARY KEY
+#  name            | text                     | NOT NULL
+#  visible         | boolean                  | NOT NULL DEFAULT true
+#  billing_info_id | uuid                     |
+#  credit          | numeric                  | NOT NULL DEFAULT 0
+#  discount        | integer                  | NOT NULL DEFAULT 0
+#  created_at      | timestamp with time zone | NOT NULL DEFAULT now()
+#  feature_flags   | jsonb                    | NOT NULL DEFAULT '{}'::jsonb
+#  billable        | boolean                  | NOT NULL DEFAULT true
+#  reputation      | project_reputation       | NOT NULL DEFAULT 'new'::project_reputation
+# Indexes:
+#  project_pkey                      | PRIMARY KEY btree (id)
+#  project_right(id::text, 10)_index | UNIQUE btree ("right"(id::text, 10))
+# Check constraints:
+#  max_discount_amount | (discount <= 100)
+#  min_credit_amount   | (credit >= 0::numeric)
+# Foreign key constraints:
+#  project_billing_info_id_fkey | (billing_info_id) REFERENCES billing_info(id)
+# Referenced By:
+#  access_policy       | access_policy_project_id_fkey       | (project_id) REFERENCES project(id)
+#  access_tag          | access_tag_project_id_fkey          | (project_id) REFERENCES project(id)
+#  github_installation | github_installation_project_id_fkey | (project_id) REFERENCES project(id)
+#  inference_endpoint  | inference_endpoint_project_id_fkey  | (project_id) REFERENCES project(id)
+#  usage_alert         | usage_alert_project_id_fkey         | (project_id) REFERENCES project(id)

--- a/model/project_invitation.rb
+++ b/model/project_invitation.rb
@@ -7,3 +7,14 @@ class ProjectInvitation < Sequel::Model
 end
 
 ProjectInvitation.unrestrict_primary_key
+
+# Table: project_invitation
+# Primary Key: (project_id, email)
+# Columns:
+#  project_id | uuid                        |
+#  email      | citext                      |
+#  inviter_id | uuid                        | NOT NULL
+#  expires_at | timestamp without time zone | NOT NULL
+#  policy     | text                        |
+# Indexes:
+#  project_invitation_pkey | PRIMARY KEY btree (project_id, email)

--- a/model/project_quota.rb
+++ b/model/project_quota.rb
@@ -18,3 +18,12 @@ class ProjectQuota < Sequel::Model
 end
 
 ProjectQuota.unrestrict_primary_key
+
+# Table: project_quota
+# Primary Key: (project_id, quota_id)
+# Columns:
+#  project_id | uuid    |
+#  quota_id   | uuid    |
+#  value      | integer | NOT NULL
+# Indexes:
+#  project_quota_pkey | PRIMARY KEY btree (project_id, quota_id)

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -12,3 +12,14 @@ class Semaphore < Sequel::Model
     end
   end
 end
+
+# Table: semaphore
+# Columns:
+#  id        | uuid | PRIMARY KEY
+#  strand_id | uuid | NOT NULL
+#  name      | text | NOT NULL
+# Indexes:
+#  semaphore_pkey            | PRIMARY KEY btree (id)
+#  semaphore_strand_id_index | btree (strand_id)
+# Foreign key constraints:
+#  semaphore_strand_id_fkey | (strand_id) REFERENCES strand(id)

--- a/model/spdk_installation.rb
+++ b/model/spdk_installation.rb
@@ -16,3 +16,20 @@ class SpdkInstallation < Sequel::Model
     version.match?(/^v[0-9]+\.[0-9]+-ubi-.*/)
   end
 end
+
+# Table: spdk_installation
+# Columns:
+#  id                | uuid                     | PRIMARY KEY
+#  version           | text                     | NOT NULL
+#  allocation_weight | integer                  | NOT NULL
+#  created_at        | timestamp with time zone | NOT NULL DEFAULT now()
+#  vm_host_id        | uuid                     |
+#  cpu_count         | integer                  | NOT NULL DEFAULT 2
+#  hugepages         | integer                  | NOT NULL DEFAULT 2
+# Indexes:
+#  spdk_installation_pkey                   | PRIMARY KEY btree (id)
+#  spdk_installation_vm_host_id_version_key | UNIQUE btree (vm_host_id, version)
+# Foreign key constraints:
+#  spdk_installation_vm_host_id_fkey | (vm_host_id) REFERENCES vm_host(id)
+# Referenced By:
+#  vm_storage_volume | vm_storage_volume_spdk_installation_id_fkey | (spdk_installation_id) REFERENCES spdk_installation(id)

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -155,3 +155,16 @@ end
 # We need to unrestrict primary key so Sshable.new(...).save_changes works
 # in sshable_spec.rb.
 Sshable.unrestrict_primary_key
+
+# Table: sshable
+# Columns:
+#  id                | uuid | PRIMARY KEY
+#  host              | text |
+#  raw_private_key_1 | text |
+#  raw_private_key_2 | text |
+#  unix_user         | text | NOT NULL DEFAULT 'rhizome'::text
+# Indexes:
+#  sshable_pkey     | PRIMARY KEY btree (id)
+#  sshable_host_key | UNIQUE btree (host)
+# Referenced By:
+#  vm_host | vm_host_id_fkey | (id) REFERENCES sshable(id)

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -11,3 +11,22 @@ class StorageDevice < Sequel::Model
     UBID::TYPE_ETC
   end
 end
+
+# Table: storage_device
+# Columns:
+#  id                    | uuid    | PRIMARY KEY
+#  name                  | text    | NOT NULL
+#  total_storage_gib     | integer | NOT NULL
+#  available_storage_gib | integer | NOT NULL
+#  enabled               | boolean | NOT NULL DEFAULT true
+#  vm_host_id            | uuid    |
+# Indexes:
+#  storage_device_pkey                | PRIMARY KEY btree (id)
+#  storage_device_vm_host_id_name_key | UNIQUE btree (vm_host_id, name)
+# Check constraints:
+#  available_storage_gib_less_than_or_equal_to_total | (available_storage_gib <= total_storage_gib)
+#  available_storage_gib_non_negative                | (available_storage_gib >= 0)
+# Foreign key constraints:
+#  storage_device_vm_host_id_fkey | (vm_host_id) REFERENCES vm_host(id)
+# Referenced By:
+#  vm_storage_volume | vm_storage_volume_storage_device_id_fkey | (storage_device_id) REFERENCES storage_device(id)

--- a/model/storage_key_encryption_key.rb
+++ b/model/storage_key_encryption_key.rb
@@ -22,3 +22,17 @@ class StorageKeyEncryptionKey < Sequel::Model
     }
   end
 end
+
+# Table: storage_key_encryption_key
+# Columns:
+#  id          | uuid                     | PRIMARY KEY
+#  algorithm   | text                     | NOT NULL
+#  key         | text                     | NOT NULL
+#  init_vector | text                     | NOT NULL
+#  auth_data   | text                     | NOT NULL
+#  created_at  | timestamp with time zone | NOT NULL DEFAULT now()
+# Indexes:
+#  storage_key_encryption_key_pkey | PRIMARY KEY btree (id)
+# Referenced By:
+#  vm_storage_volume | vm_storage_volume_key_encryption_key_1_id_fkey | (key_encryption_key_1_id) REFERENCES storage_key_encryption_key(id)
+#  vm_storage_volume | vm_storage_volume_key_encryption_key_2_id_fkey | (key_encryption_key_2_id) REFERENCES storage_key_encryption_key(id)

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -180,3 +180,23 @@ end
 
 # We need to unrestrict primary key so strand.add_child works in Prog::Base.
 Strand.unrestrict_primary_key
+
+# Table: strand
+# Columns:
+#  id        | uuid                     | PRIMARY KEY
+#  parent_id | uuid                     |
+#  schedule  | timestamp with time zone | NOT NULL DEFAULT now()
+#  lease     | timestamp with time zone |
+#  prog      | text                     | NOT NULL
+#  label     | text                     | NOT NULL
+#  stack     | jsonb                    | NOT NULL DEFAULT '[{}]'::jsonb
+#  exitval   | jsonb                    |
+#  retval    | jsonb                    |
+#  try       | integer                  | NOT NULL DEFAULT 0
+# Indexes:
+#  strand_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  strand_parent_id_fkey | (parent_id) REFERENCES strand(id)
+# Referenced By:
+#  semaphore | semaphore_strand_id_fkey | (strand_id) REFERENCES strand(id)
+#  strand    | strand_parent_id_fkey    | (parent_id) REFERENCES strand(id)

--- a/model/usage_alert.rb
+++ b/model/usage_alert.rb
@@ -27,3 +27,18 @@ class UsageAlert < Sequel::Model
       button_link: "#{Config.base_url}#{project.path}/billing")
   end
 end
+
+# Table: usage_alert
+# Columns:
+#  id                | uuid                     | PRIMARY KEY
+#  project_id        | uuid                     | NOT NULL
+#  name              | text                     | NOT NULL
+#  limit             | integer                  | NOT NULL
+#  user_id           | uuid                     | NOT NULL
+#  last_triggered_at | timestamp with time zone | NOT NULL DEFAULT (now() - '42 days'::interval)
+# Indexes:
+#  usage_alert_pkey                    | PRIMARY KEY btree (id)
+#  usage_alert_last_triggered_at_index | btree (last_triggered_at)
+# Foreign key constraints:
+#  usage_alert_project_id_fkey | (project_id) REFERENCES project(id)
+#  usage_alert_user_id_fkey    | (user_id) REFERENCES accounts(id)

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -255,3 +255,40 @@ class Vm < Sequel::Model
     }.to_h
   end
 end
+
+# Table: vm
+# Columns:
+#  id             | uuid                     | PRIMARY KEY
+#  ephemeral_net6 | cidr                     |
+#  vm_host_id     | uuid                     |
+#  unix_user      | text                     | NOT NULL
+#  public_key     | text                     | NOT NULL
+#  display_state  | vm_display_state         | NOT NULL DEFAULT 'creating'::vm_display_state
+#  name           | text                     | NOT NULL
+#  location       | text                     | NOT NULL
+#  boot_image     | text                     | NOT NULL
+#  local_vetho_ip | text                     |
+#  ip4_enabled    | boolean                  | NOT NULL DEFAULT false
+#  family         | text                     | NOT NULL
+#  cores          | integer                  | NOT NULL
+#  pool_id        | uuid                     |
+#  created_at     | timestamp with time zone | NOT NULL DEFAULT now()
+#  arch           | arch                     | NOT NULL DEFAULT 'x64'::arch
+#  allocated_at   | timestamp with time zone |
+#  provisioned_at | timestamp with time zone |
+# Indexes:
+#  vm_pkey               | PRIMARY KEY btree (id)
+#  vm_ephemeral_net6_key | UNIQUE btree (ephemeral_net6)
+# Foreign key constraints:
+#  vm_pool_id_fkey    | (pool_id) REFERENCES vm_pool(id)
+#  vm_vm_host_id_fkey | (vm_host_id) REFERENCES vm_host(id)
+# Referenced By:
+#  assigned_vm_address        | assigned_vm_address_dst_vm_id_fkey    | (dst_vm_id) REFERENCES vm(id)
+#  dns_servers_vms            | dns_servers_vms_vm_id_fkey            | (vm_id) REFERENCES vm(id)
+#  inference_endpoint_replica | inference_endpoint_replica_vm_id_fkey | (vm_id) REFERENCES vm(id)
+#  load_balancers_vms         | load_balancers_vms_vm_id_fkey         | (vm_id) REFERENCES vm(id)
+#  minio_server               | minio_server_vm_id_fkey               | (vm_id) REFERENCES vm(id)
+#  nic                        | nic_vm_id_fkey                        | (vm_id) REFERENCES vm(id)
+#  pci_device                 | pci_device_vm_id_fkey                 | (vm_id) REFERENCES vm(id)
+#  postgres_server            | postgres_server_vm_id_fkey            | (vm_id) REFERENCES vm(id)
+#  vm_storage_volume          | vm_storage_volume_vm_id_fkey          | (vm_id) REFERENCES vm(id)

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -284,3 +284,43 @@ class VmHost < Sequel::Model
     end
   end
 end
+
+# Table: vm_host
+# Columns:
+#  id                 | uuid                     | PRIMARY KEY
+#  allocation_state   | allocation_state         | NOT NULL DEFAULT 'unprepared'::allocation_state
+#  ip6                | inet                     |
+#  net6               | cidr                     |
+#  location           | text                     | NOT NULL
+#  total_mem_gib      | integer                  |
+#  total_sockets      | integer                  |
+#  total_cores        | integer                  |
+#  total_cpus         | integer                  |
+#  used_cores         | integer                  | NOT NULL DEFAULT 0
+#  ndp_needed         | boolean                  | NOT NULL DEFAULT false
+#  total_hugepages_1g | integer                  | NOT NULL DEFAULT 0
+#  used_hugepages_1g  | integer                  | NOT NULL DEFAULT 0
+#  last_boot_id       | text                     |
+#  created_at         | timestamp with time zone | NOT NULL DEFAULT now()
+#  data_center        | text                     |
+#  arch               | arch                     |
+#  total_dies         | integer                  |
+# Indexes:
+#  vm_host_pkey     | PRIMARY KEY btree (id)
+#  vm_host_ip6_key  | UNIQUE btree (ip6)
+#  vm_host_net6_key | UNIQUE btree (net6)
+# Check constraints:
+#  core_allocation_limit      | (used_cores <= total_cores)
+#  hugepages_allocation_limit | (used_hugepages_1g <= total_hugepages_1g)
+#  used_cores_above_zero      | (used_cores >= 0)
+# Foreign key constraints:
+#  vm_host_id_fkey | (id) REFERENCES sshable(id)
+# Referenced By:
+#  address               | address_routed_to_host_id_fkey     | (routed_to_host_id) REFERENCES vm_host(id)
+#  assigned_host_address | assigned_host_address_host_id_fkey | (host_id) REFERENCES vm_host(id)
+#  boot_image            | boot_image_vm_host_id_fkey         | (vm_host_id) REFERENCES vm_host(id)
+#  hetzner_host          | hetzner_host_id_fkey               | (id) REFERENCES vm_host(id)
+#  pci_device            | pci_device_vm_host_id_fkey         | (vm_host_id) REFERENCES vm_host(id)
+#  spdk_installation     | spdk_installation_vm_host_id_fkey  | (vm_host_id) REFERENCES vm_host(id)
+#  storage_device        | storage_device_vm_host_id_fkey     | (vm_host_id) REFERENCES vm_host(id)
+#  vm                    | vm_vm_host_id_fkey                 | (vm_host_id) REFERENCES vm_host(id)

--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -23,3 +23,19 @@ class VmPool < Sequel::Model
     end
   end
 end
+
+# Table: vm_pool
+# Columns:
+#  id                | uuid    | PRIMARY KEY
+#  size              | integer | NOT NULL
+#  vm_size           | text    | NOT NULL
+#  boot_image        | text    | NOT NULL
+#  location          | text    | NOT NULL
+#  storage_size_gib  | bigint  | NOT NULL
+#  arch              | arch    | NOT NULL DEFAULT 'x64'::arch
+#  storage_encrypted | boolean | NOT NULL DEFAULT true
+#  storage_skip_sync | boolean | NOT NULL DEFAULT false
+# Indexes:
+#  vm_pool_pkey | PRIMARY KEY btree (id)
+# Referenced By:
+#  vm | vm_pool_id_fkey | (pool_id) REFERENCES vm_pool(id)

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -26,3 +26,28 @@ class VmStorageVolume < Sequel::Model
     spdk_installation.version
   end
 end
+
+# Table: vm_storage_volume
+# Columns:
+#  id                      | uuid    | PRIMARY KEY
+#  vm_id                   | uuid    | NOT NULL
+#  boot                    | boolean | NOT NULL
+#  size_gib                | bigint  | NOT NULL
+#  disk_index              | integer | NOT NULL
+#  key_encryption_key_1_id | uuid    |
+#  key_encryption_key_2_id | uuid    |
+#  spdk_installation_id    | uuid    | NOT NULL
+#  use_bdev_ubi            | boolean | NOT NULL DEFAULT false
+#  skip_sync               | boolean | NOT NULL DEFAULT false
+#  storage_device_id       | uuid    | NOT NULL
+#  boot_image_id           | uuid    |
+# Indexes:
+#  vm_storage_volume_pkey                 | PRIMARY KEY btree (id)
+#  vm_storage_volume_vm_id_disk_index_key | UNIQUE btree (vm_id, disk_index)
+# Foreign key constraints:
+#  vm_storage_volume_boot_image_id_fkey           | (boot_image_id) REFERENCES boot_image(id)
+#  vm_storage_volume_key_encryption_key_1_id_fkey | (key_encryption_key_1_id) REFERENCES storage_key_encryption_key(id)
+#  vm_storage_volume_key_encryption_key_2_id_fkey | (key_encryption_key_2_id) REFERENCES storage_key_encryption_key(id)
+#  vm_storage_volume_spdk_installation_id_fkey    | (spdk_installation_id) REFERENCES spdk_installation(id)
+#  vm_storage_volume_storage_device_id_fkey       | (storage_device_id) REFERENCES storage_device(id)
+#  vm_storage_volume_vm_id_fkey                   | (vm_id) REFERENCES vm(id)


### PR DESCRIPTION
This makes it easier for developers new to the codebase to easily get important information on the model's table in the same file as the model code.

To ensure the model annotations stay accurate, run them on test_up/test_down.  In CI, regenerate the annotations, and check for no changes, similar to how the linters work.