### PR TITLE
Refactor Authorization.matched_policies

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -31,7 +31,7 @@ end
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic
 DB.extension :pg_array, :pg_json, :pg_auto_parameterize, :pg_timestamptz, :pg_range
-Sequel.extension :pg_range_ops
+Sequel.extension :pg_range_ops, :pg_json_ops
 
 DB.extension :pg_schema_caching
 DB.extension :index_caching

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -35,7 +35,7 @@ module Authorization
     extended_actions.to_a
   end
 
-  def self.matched_policies(subject_id, actions = nil, object_id = nil)
+  def self.matched_policies_dataset(subject_id, actions = nil, object_id = nil)
     subject_dataset = DB[:access_tag]
       .select(:project_id)
       .join(:applied_tag, access_tag_id: :id)
@@ -66,7 +66,11 @@ module Authorization
       dataset = dataset.where(Sequel.pg_jsonb_op(:actions).contain_any(Sequel.pg_array(expand_actions(actions))))
     end
 
-    dataset.all
+    dataset
+  end
+
+  def self.matched_policies(subject_id, actions = nil, object_id = nil)
+    matched_policies_dataset(subject_id, actions, object_id).all
   end
 
   module ManagedPolicy

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -22,7 +22,7 @@ module Authorization
   end
 
   def self.authorized_resources(subject_id, actions)
-    matched_policies(subject_id, actions).map { _1[:tagged_id] }
+    matched_policies_dataset(subject_id, actions).select_map(:tagged_id)
   end
 
   def self.expand_actions(actions)

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -38,10 +38,14 @@ module Authorization
   def self.matched_policies(subject_id, actions = nil, object_id = nil)
     object_filter = if object_id
       begin
-        Sequel.lit("AND object_applied_tags.tagged_id = ?", UBID.parse(object_id).to_uuid)
+        ubid = UBID.parse(object_id)
       rescue UBIDParseError
-        Sequel.lit("AND object_applied_tags.tagged_id = ?", object_id)
+        # nothing
+      else
+        object_id = ubid.to_uuid
       end
+
+      Sequel.lit("AND object_applied_tags.tagged_id = ?", object_id)
     else
       Sequel.lit("")
     end

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -58,14 +58,13 @@ module Authorization
 
     DB[<<~SQL, {subject_id: subject_id, actions_filter: actions_filter, object_filter: object_filter}].all
       SELECT object_applied_tags.tagged_id, object_applied_tags.tagged_table, subjects, actions, objects
-      FROM accounts AS subject
-        JOIN applied_tag AS subject_applied_tags ON subject.id = subject_applied_tags.tagged_id
+      FROM applied_tag AS subject_applied_tags
           JOIN access_tag AS subject_access_tags ON subject_applied_tags.access_tag_id = subject_access_tags.id
           JOIN access_policy AS acl ON subject_access_tags.project_id = acl.project_id
           JOIN jsonb_to_recordset(acl.body->'acls') as items(subjects JSONB, actions JSONB, objects JSONB) ON TRUE
           JOIN access_tag AS object_access_tags ON subject_access_tags.project_id = object_access_tags.project_id
           JOIN applied_tag AS object_applied_tags ON object_access_tags.id = object_applied_tags.access_tag_id AND objects ? object_access_tags."name"
-      WHERE subject.id = :subject_id
+      WHERE subject_applied_tags.tagged_id = :subject_id
         AND subjects ? subject_access_tags."name"
         :actions_filter
         :object_filter

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -18,7 +18,7 @@ module Authorization
   end
 
   def self.all_permissions(subject_id, object_id)
-    matched_policies(subject_id, nil, object_id).flat_map { _1[:actions] }
+    matched_policies_dataset(subject_id, nil, object_id).select_map(:actions).tap(&:flatten!)
   end
 
   def self.authorized_resources_dataset(subject_id, actions)

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -21,6 +21,10 @@ module Authorization
     matched_policies(subject_id, nil, object_id).flat_map { _1[:actions] }
   end
 
+  def self.authorized_resources_dataset(subject_id, actions)
+    matched_policies_dataset(subject_id, actions).select(:tagged_id)
+  end
+
   def self.authorized_resources(subject_id, actions)
     matched_policies_dataset(subject_id, actions).select_map(:tagged_id)
   end
@@ -109,7 +113,7 @@ module Authorization
       # We need to determine table of id explicitly.
       # @opts is the hash of options for this dataset, and introduced at Sequel::Dataset.
       from = @opts[:from].first
-      where { {Sequel[from][:id] => Authorization.authorized_resources(subject_id, actions)} }
+      where { {Sequel[from][:id] => Authorization.authorized_resources_dataset(subject_id, actions)} }
     end
   end
 

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -8,7 +8,7 @@ module Authorization
   end
 
   def self.has_permission?(subject_id, actions, object_id)
-    !matched_policies(subject_id, actions, object_id).empty?
+    !matched_policies_dataset(subject_id, actions, object_id).empty?
   end
 
   def self.authorize(subject_id, actions, object_id)


### PR DESCRIPTION
This series of commits will make it easier for us to support api key specific access policies.  It changes the SQL-based query to a Sequel-based query, and then speeds up other methods by calling dataset methods, instead of calling methods on array returned by `matched_policies`.