### PR TITLE
Pop from DestroyGithubInstallation if installation already destroyed

### DIFF
--- a/prog/github/destroy_github_installation.rb
+++ b/prog/github/destroy_github_installation.rb
@@ -13,6 +13,10 @@ class Prog::Github::DestroyGithubInstallation < Prog::Base
     )
   end
 
+  label def before_run
+    pop "github installation is destroyed" unless github_installation
+  end
+
   label def start
     register_deadline(nil, 10 * 60)
     hop_delete_installation

--- a/spec/prog/github/destroy_github_installation_spec.rb
+++ b/spec/prog/github/destroy_github_installation_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Prog::Github::DestroyGithubInstallation do
     end
   end
 
+  describe ".before_run" do
+    it "pops if installation already deleted" do
+      expect(dgi).to receive(:github_installation).and_return(nil)
+      expect { dgi.before_run }.to exit({"msg" => "github installation is destroyed"})
+    end
+
+    it "no ops if installation exists" do
+      expect(dgi).to receive(:github_installation).and_return(github_installation)
+      dgi.before_run
+    end
+  end
+
   describe "#start" do
     it "hops after registering deadline" do
       expect(dgi).to receive(:register_deadline)


### PR DESCRIPTION
We assemble the DestroyGithubInstallation prog in several places. For instance, if the same webhook is delivered twice, we end up with multiple instances for the same installation.

When the first instance destroys the installation, the second one starts to fail.

We could add a check to ensure only a single instance is running, but the current implementation is more robust and straightforward.

We already have a similar check in place within the Prog::Vnet::CertServer prog.