### PR TITLE
Destroy account's usage alerts while closing account

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -3,6 +3,10 @@
 require_relative "../model"
 
 class Account < Sequel::Model(:accounts)
+  one_to_many :usage_alerts, key: :user_id
+
+  plugin :association_dependencies, usage_alerts: :destroy
+
   include ResourceMethods
   include Authorization::HyperTagMethods
 

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -315,6 +315,9 @@ RSpec.describe Clover, "auth" do
     end
 
     it "can close account" do
+      account = Account[email: TEST_USER_EMAIL]
+      UsageAlert.create_with_id(project_id: account.projects.first.id, user_id: account.id, name: "test", limit: 100)
+
       visit "/account/close-account"
 
       click_button "Close Account"


### PR DESCRIPTION
If the account has usage alerts, it fails to close the account with the following error:

    Sequel::ForeignKeyConstraintViolation
    #<PG::ForeignKeyViolation:"ERROR:  update or delete on table
    \"accounts\" violates foreign key constraint
    \"usage_alert_user_id_fkey\" on table \"usage_alert\"\nDETAIL:  Key
    (id)=(UUID) is still referenced from table \"usage_alert\".\n">