### PR TITLE
Add Prog to Create a new VM for a DNS Server

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -185,4 +185,7 @@ module Config
 
   # AI
   optional :inference_endpoint_service_project_id, string
+
+  # DNS
+  optional :dns_service_project_id, string
 end

--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -51,6 +51,40 @@ class DnsZone < Sequel::Model
     incr_refresh_dns_servers
   end
 
+  def purge_obsolete_records
+    DB.transaction do
+      # These are the records that are obsoleted by a another record with the
+      # same fields but newer date. We can delete them even if they are not
+      # seen yet.
+      obsoleted_records = records_dataset
+        .join(
+          records_dataset
+            .select_group(:dns_zone_id, :name, :type, :data)
+            .select_append { max(created_at).as(:latest_created_at) }
+            .as(:latest_dns_record),
+          [:dns_zone_id, :name, :type, :data]
+        )
+        .where { dns_record[:created_at] < latest_dns_record[:latest_created_at] }.all
+
+      # These are the tombstoned records, we can only delete them if they are
+      # seen by all DNS servers. We join with seen_dns_records_by_dns_servers
+      # and count the number of DNS servers to ensure that they are seen by all
+      # DNS servers.
+      dns_server_ids = dns_servers.map(&:id)
+      seen_tombstoned_records = records_dataset
+        .select_group(:id)
+        .join(:seen_dns_records_by_dns_servers, dns_record_id: :id, dns_server_id: dns_server_ids)
+        .where(tombstoned: true)
+        .having { count.function.* =~ dns_server_ids.count }.all
+
+      records_to_purge = obsoleted_records + seen_tombstoned_records
+      DB[:seen_dns_records_by_dns_servers].where(dns_record_id: records_to_purge.map(&:id).uniq).delete(force: true)
+      records_to_purge.uniq(&:id).map(&:destroy)
+
+      update(last_purged_at: Time.now)
+    end
+  end
+
   def add_dot_if_missing(record_name)
     (record_name[-1] == ".") ? record_name : record_name + "."
   end

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -139,9 +139,8 @@ class Sshable < Sequel::Model
   end
 
   def available?
-    cmd("true")
-    true
-  rescue
+    cmd("true") && true
+  rescue Net::SSH::Disconnect, Net::SSH::ConnectionTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, IOError
     false
   end
 

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -138,6 +138,13 @@ class Sshable < Sequel::Model
     Thread.current[:clover_ssh_cache]&.delete([host, unix_user])
   end
 
+  def available?
+    cmd("true")
+    true
+  rescue
+    false
+  end
+
   def self.reset_cache
     return [] unless (cache = Thread.current[:clover_ssh_cache])
 

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+class Prog::DnsZone::SetupDnsServerVm < Prog::Base
+  subject_is :vm, :sshable
+
+  def self.assemble(dns_server_id, name: nil, vm_size: "standard-2", storage_size_gib: 30, location: "hetzner-fsn1")
+    unless (dns_server = DnsServer[dns_server_id])
+      fail "No existing Dns Server"
+    end
+
+    unless Project[Config.dns_service_project_id]
+      fail "No existing Project"
+    end
+
+    name ||= "#{dns_server.ubid}-#{SecureRandom.alphanumeric(8).downcase}"
+
+    DB.transaction do
+      vm_st = Prog::Vm::Nexus.assemble_with_sshable(
+        "ubi",
+        Config.dns_service_project_id,
+        location: location,
+        name: name,
+        size: vm_size,
+        storage_volumes: [
+          {encrypted: true, size_gib: storage_size_gib}
+        ],
+        boot_image: "ubuntu-jammy",
+        enable_ip4: true
+      )
+
+      Strand.create_with_id(prog: "DnsZone::SetupDnsServerVm", label: "start", stack: [{subject_id: vm_st.id, dns_server_id: dns_server_id}])
+    end
+  end
+
+  def ds
+    @ds ||= DnsServer[frame["dns_server_id"]]
+  end
+
+  label def start
+    nap 5 unless vm.strand.label == "wait"
+    register_deadline(nil, 15 * 60)
+    hop_prepare
+  end
+
+  label def prepare
+    sshable.cmd <<~SH
+sudo sed -i 's/#DNSStubListener=yes/DNSStubListener=no/' /etc/systemd/resolved.conf
+sudo sed -i ':a;N;$!ba;s/127.0.0.1 localhost\\n\\n#/127.0.0.1 localhost\\n127.0.0.1 #{vm.inhost_name}\\n\\n#/' /etc/hosts
+sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+sudo apt-get update
+sudo apt-get -y install apt-transport-https ca-certificates wget
+sudo wget -O /usr/share/keyrings/cznic-labs-pkg.gpg https://pkg.labs.nic.cz/gpg
+echo "deb [signed-by=/usr/share/keyrings/cznic-labs-pkg.gpg] https://pkg.labs.nic.cz/knot-dns jammy main" | sudo tee /etc/apt/sources.list.d/cznic-labs-knot-dns.list
+sudo apt-get update
+sudo systemctl reboot
+    SH
+
+    hop_setup_knot
+  end
+
+  label def setup_knot
+    nap 5 unless sshable.available?
+
+    sshable.cmd <<~SH
+sudo apt-get -y install knot
+echo "KNOTD_ARGS="-C /var/lib/knot/confdb"" | sudo tee -a /etc/default/knot
+    SH
+
+    knot_config = <<-CONF
+server:
+    rundir: "/run/knot"
+    user: "knot:knot"
+    listen: [ "0.0.0.0@53", "::@53" ]
+
+log:
+  - target: "syslog"
+    any: "info"
+
+database:
+    storage: "/var/lib/knot"
+
+acl:
+  - id: "allow_dynamic_updates"
+    address: "127.0.0.1/32"
+    action: "update"
+
+template:
+  - id: "default"
+    storage: "/var/lib/knot"
+    file: "%s.zone"
+    acl: "allow_dynamic_updates"
+    zonefile-sync: "60"
+    zonefile-load: "difference"
+    journal-content: "all"
+
+
+zone:
+  #{ds.dns_zones.map { |dz| "- domain: \"#{dz.name}.\"" }.join("\n  ")}
+    CONF
+
+    sshable.cmd("sudo tee /etc/knot/knot.conf > /dev/null", stdin: knot_config)
+
+    hop_sync_zones
+  end
+
+  label def sync_zones
+    nap 5 if ds.dns_zones.any?(&:refresh_dns_servers_set?)
+
+    ds.dns_zones.each do |dz|
+      zone_config = <<-CONF
+#{dz.name}.          3600    SOA     ns.#{dz.name}. #{dz.name}. 37 86400 7200 1209600 3600
+#{dz.name}.          3600    NS      #{ds.name}.
+      CONF
+      sshable.cmd("sudo -u knot tee /var/lib/knot/#{dz.name}.zone > /dev/null", stdin: zone_config)
+    end
+
+    sshable.cmd "sudo systemctl restart knot"
+
+    ds.dns_zones.each(&:purge_obsolete_records)
+
+    commands = ds.dns_zones.flat_map do |dz|
+      ["zone-abort #{dz.name}", "zone-begin #{dz.name}"] +
+        dz.records.map do |r|
+          "zone-set #{dz.name} #{r.name} #{r.ttl} #{r.type} #{r.data}"
+        end + ["zone-commit #{dz.name}", "zone-flush #{dz.name}"]
+    end
+
+    # Put records
+    sshable.cmd("sudo -u knot knotc", stdin: commands.join("\n"))
+
+    hop_validate
+  end
+
+  label def validate
+    outputs = (ds.vms + [vm]).map do |vm|
+      vm.sshable.cmd("sudo -u knot knotc", stdin: "zone-read --").split("\n").to_set
+    end
+
+    hop_sync_zones unless outputs.uniq.count == 1
+
+    ds.add_vm vm unless ds.vms.map(&:id).include? vm.id
+    pop "created VM for DnsServer"
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -141,12 +141,10 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def reboot
-    begin
-      q_last_boot_id = vm_host.last_boot_id.shellescape
-      new_boot_id = sshable.cmd("sudo host/bin/reboot-host #{q_last_boot_id}").strip
-    rescue Net::SSH::Disconnect, Net::SSH::ConnectionTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, IOError
-      nap 30
-    end
+    nap 30 unless sshable.available?
+
+    q_last_boot_id = vm_host.last_boot_id.shellescape
+    new_boot_id = sshable.cmd("sudo host/bin/reboot-host #{q_last_boot_id}").strip
 
     # If we didn't get a valid new boot id, nap. This can happen if reboot-host
     # issues a reboot and returns without closing the ssh connection.

--- a/spec/prog/dns_zone/dns_zone_nexus_spec.rb
+++ b/spec/prog/dns_zone/dns_zone_nexus_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Prog::DnsZone::DnsZoneNexus do
       expect { nx.wait }.to hop("refresh_dns_servers")
     end
 
-    it "hops to purge_dns_records if if last purge happened more than 1 hour ago" do
+    it "hops to purge_obsolete_records if if last purge happened more than 1 hour ago" do
       expect(dns_zone).to receive(:last_purged_at).and_return(Time.now - 60 * 60 * 2)
-      expect { nx.wait }.to hop("purge_dns_records")
+      expect { nx.wait }.to hop("purge_obsolete_records")
     end
 
     it "naps if there is nothing to do" do
@@ -80,7 +80,7 @@ COMMANDS
     end
   end
 
-  describe "#purge_dns_records" do
+  describe "#purge_obsolete_records" do
     it "deletes obsoleted records, seen or unseen" do
       r1 = DnsRecord.create_with_id(created_at: Time.now - 1, name: "test-pg-1", type: "A", ttl: 10, data: "1.2.3.4")
       r2 = DnsRecord.create_with_id(created_at: Time.now, name: "test-pg-1", type: "A", ttl: 10, data: "1.2.3.4")
@@ -93,7 +93,7 @@ COMMANDS
       DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r1.id}', '#{dns_server.id}')"].insert
       DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r3.id}', '#{dns_server.id}')"].insert
 
-      expect { nx.purge_dns_records }.to hop("wait")
+      expect { nx.purge_obsolete_records }.to hop("wait")
       expect(dns_zone.reload.records.count).to eq(1)
       expect(DB[:seen_dns_records_by_dns_servers].all.count).to eq(1)
     end
@@ -110,7 +110,7 @@ COMMANDS
       DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r1.id}', '#{dns_server.id}')"].insert
       DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r2.id}', '#{dns_server.id}')"].insert
 
-      expect { nx.purge_dns_records }.to hop("wait")
+      expect { nx.purge_obsolete_records }.to hop("wait")
       expect(dns_zone.reload.records.count).to eq(2)
       expect(DB[:seen_dns_records_by_dns_servers].all.count).to eq(1)
     end

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::DnsZone::SetupDnsServerVm do
+  subject(:prog) {
+    st = described_class.assemble(ds.id)
+    described_class.new(st)
+  }
+
+  before do
+    allow(Config).to receive(:dns_service_project_id).and_return(project.id)
+  end
+
+  let(:ds) { DnsServer.create_with_id(name: "toruk") }
+  let(:dzs) do
+    (1..2).map do |i|
+      dz = DnsZone.create_with_id(project_id: project.id, name: "zone#{i}.domain.io", last_purged_at: Time.now)
+      Strand.create(prog: "DnsZone::DnsZoneNexus", label: "wait") { _1.id = dz.id }
+
+      dz.add_dns_server ds
+      (1..3).map { SecureRandom.alphanumeric(6) }.each do |r|
+        dz.insert_record(record_name: "#{r}.#{dz.name}", type: "A", ttl: 10, data: IPAddr.new(rand(2**32), Socket::AF_INET).to_s)
+      end
+      dz
+    end
+  end
+  let(:project) { Project.create_with_id(name: "ubicloud_dns").tap { _1.associate_with_project(_1) } }
+
+  describe ".assemble" do
+    it "validates input" do
+      expect {
+        described_class.assemble(SecureRandom.uuid)
+      }.to raise_error RuntimeError, "No existing Dns Server"
+
+      expect {
+        described_class.assemble(ds.id, name: "InVaLidNAME")
+      }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
+
+      expect(described_class.assemble(ds.id)).to be_a Strand
+
+      expect(Vm.count).to eq 1
+      expect(Vm.first.unix_user).to eq "ubi"
+    end
+
+    it "errors out if the dns service project id is not put into config properly" do
+      expect(Config).to receive(:dns_service_project_id).and_return(nil)
+      expect {
+        described_class.assemble(ds.id)
+      }.to raise_error RuntimeError, "No existing Project"
+    end
+  end
+
+  describe "#start" do
+    it "naps if vm is not ready" do
+      expect(prog.vm.strand.label).not_to be "wait"
+      expect { prog.start }.to nap(5)
+    end
+
+    it "hops to prepare when VM is ready" do
+      prog.vm.strand.update(label: "wait")
+      expect(prog.strand.stack.first["deadline_at"]).to be_nil
+      expect { prog.start }.to hop("prepare")
+      expect(prog.strand.stack.first["deadline_at"]).not_to be_nil
+    end
+  end
+
+  describe "#prepare" do
+    it "runs some commands to prepare vm for knot installation and restarts" do
+      prog.vm.strand.update(label: "wait")
+
+      expect(prog.sshable).to receive(:cmd).with(/sudo ln -sf \/run\/systemd\/resolve\/resolv.conf \/etc\/resolv.conf[\S\s]*sudo systemctl reboot/)
+
+      expect { prog.prepare }.to hop("setup_knot")
+    end
+  end
+
+  describe "#setup_knot" do
+    it "waits until the vm is ready to accept commands again" do
+      expect(prog.sshable).to receive(:cmd).and_raise
+      expect { prog.setup_knot }.to nap(5)
+    end
+
+    it "runs some commands to install and configure knot on the vm" do
+      expect(prog.sshable).to receive(:cmd).with("true").and_return(true)
+
+      zone_conf = <<-CONF
+  - domain: "zone1.domain.io."
+  - domain: "zone2.domain.io."
+      CONF
+
+      expect(prog.ds).to receive(:dns_zones).and_return(dzs) # To ensure the order
+      expect(prog.sshable).to receive(:cmd).with(/sudo apt-get -y install knot/)
+      expect(prog.sshable).to receive(:cmd).with("sudo tee /etc/knot/knot.conf > /dev/null", stdin: /#{zone_conf}/)
+
+      expect { prog.setup_knot }.to hop("sync_zones")
+    end
+  end
+
+  describe "#sync_zones" do
+    it "naps if any pending dns refresh semaphore is set" do
+      dzs.first.incr_refresh_dns_servers
+      expect { prog.sync_zones }.to nap(5)
+    end
+
+    it "writes knot zone template for each zone" do
+      expect(dzs[0]).to receive(:refresh_dns_servers_set?).and_return(false)
+      expect(dzs[1]).to receive(:refresh_dns_servers_set?).and_return(false)
+      f1 = <<-CONF
+zone1.domain.io.          3600    SOA     ns.zone1.domain.io. zone1.domain.io. 37 86400 7200 1209600 3600
+zone1.domain.io.          3600    NS      toruk.
+      CONF
+      f2 = <<-CONF
+zone2.domain.io.          3600    SOA     ns.zone2.domain.io. zone2.domain.io. 37 86400 7200 1209600 3600
+zone2.domain.io.          3600    NS      toruk.
+      CONF
+      expect(prog.sshable).to receive(:cmd).with("sudo -u knot tee /var/lib/knot/zone1.domain.io.zone > /dev/null", stdin: f1)
+      expect(prog.sshable).to receive(:cmd).with("sudo -u knot tee /var/lib/knot/zone2.domain.io.zone > /dev/null", stdin: f2)
+
+      expect(prog.sshable).to receive(:cmd).with("sudo systemctl restart knot")
+      expect(dzs[0]).to receive(:purge_obsolete_records)
+      expect(dzs[1]).to receive(:purge_obsolete_records)
+
+      knotc_input = <<-INPUT
+zone-abort zone1.domain.io
+zone-begin zone1.domain.io
+zone-set zone1.domain.io #{dzs[0].records.first.name} 10 A #{dzs[0].records.first.data}
+[\\S\\s]*
+zone-commit zone1.domain.io
+zone-flush zone1.domain.io
+zone-abort zone2.domain.io
+zone-begin zone2.domain.io
+zone-set zone2.domain.io #{dzs[1].records.first.name} 10 A #{dzs[1].records.first.data}
+[\\S\\s]*
+zone-commit zone2.domain.io
+zone-flush zone2.domain.io
+      INPUT
+      expect(prog.sshable).to receive(:cmd).with("sudo -u knot knotc", stdin: /#{knotc_input.strip}/)
+
+      expect(prog.ds).to receive(:dns_zones).at_least(:once).and_return(dzs) # To ensure the order
+      expect { prog.sync_zones }.to hop("validate")
+    end
+  end
+
+  describe "#validate" do
+    it "validates the setup by checking outputs from different vms" do
+      dummy_vm = instance_double(Vm, id: Vm.generate_uuid)
+      dummy_sshable = instance_double(Sshable)
+      expect(prog.ds).to receive(:vms).thrice.and_return([dummy_vm])
+      expect(dummy_vm).to receive(:sshable).twice.and_return(dummy_sshable)
+
+      expect(prog.vm.sshable).to receive(:cmd).twice
+        .with("sudo -u knot knotc", stdin: "zone-read --")
+        .and_return("line1\nline2")
+
+      expect(dummy_sshable).to receive(:cmd)
+        .with("sudo -u knot knotc", stdin: "zone-read --")
+        .and_return("line1\nline3")
+
+      # Different outputs
+      expect { prog.validate }.to hop("sync_zones")
+
+      expect(dummy_sshable).to receive(:cmd)
+        .with("sudo -u knot knotc", stdin: "zone-read --")
+        .and_return("line2\nline1")
+
+      expect(prog.ds).to receive(:add_vm)
+
+      # Same output but different order, doesn't matter
+      expect { prog.validate }.to exit({"msg" => "created VM for DnsServer"})
+    end
+
+    it "doesn't add the same VM twice" do
+      dummy_vm = instance_double(Vm, id: Vm.generate_uuid)
+      dummy_sshable = instance_double(Sshable)
+      expect(prog.ds).to receive(:vms).twice.and_return([dummy_vm, prog.vm])
+      expect(dummy_vm).to receive(:sshable).and_return(dummy_sshable)
+
+      expect(prog.vm.sshable).to receive(:cmd).at_least(:once).and_return("l1\nl2")
+      expect(dummy_sshable).to receive(:cmd).and_return("l1\nl2")
+
+      expect(prog.ds).not_to receive(:add_vm)
+
+      expect { prog.validate }.to exit({"msg" => "created VM for DnsServer"})
+    end
+  end
+end

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
 
   describe "#setup_knot" do
     it "waits until the vm is ready to accept commands again" do
-      expect(prog.sshable).to receive(:cmd).and_raise
+      expect(prog.sshable).to receive(:cmd).and_raise(IOError)
       expect { prog.setup_knot }.to nap(5)
     end
 

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       dz
     end
   end
-  let(:project) { Project.create_with_id(name: "ubicloud_dns").tap { _1.associate_with_project(_1) } }
+  let(:project) { Project.create_with_id(name: "ubicloud-dns").tap { _1.associate_with_project(_1) } }
 
   describe ".assemble" do
     it "validates input" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -300,14 +300,14 @@ RSpec.describe Prog::Vm::HostNexus do
       expect { nx.prep_reboot }.to hop("reboot")
     end
 
-    it "reboot naps if reboot-host fails causes IOError" do
-      expect(vm_host).to receive(:last_boot_id).and_return("xyz")
-      expect(sshable).to receive(:cmd).with("sudo host/bin/reboot-host xyz").and_raise(IOError)
+    it "reboot naps if host sshable is not available" do
+      expect(sshable).to receive(:available?).and_return(false)
 
       expect { nx.reboot }.to nap(30)
     end
 
     it "reboot naps if reboot-host returns empty string" do
+      expect(sshable).to receive(:available?).and_return(true)
       expect(vm_host).to receive(:last_boot_id).and_return("xyz")
       expect(sshable).to receive(:cmd).with("sudo host/bin/reboot-host xyz").and_return ""
 
@@ -315,6 +315,7 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "reboot updates last_boot_id and hops to verify_spdk" do
+      expect(sshable).to receive(:available?).and_return(true)
       expect(vm_host).to receive(:last_boot_id).and_return("xyz")
       expect(sshable).to receive(:cmd).with("sudo host/bin/reboot-host xyz").and_return "pqr\n"
       expect(vm_host).to receive(:update).with(last_boot_id: "pqr")

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -70,7 +70,7 @@ module ThawedMock
   allow_mocking(PostgresMetricDestination, :from_ubid)
   allow_mocking(PostgresResource, :[])
   allow_mocking(PostgresServer, :create, :run_query)
-  allow_mocking(Project, :[], :from_ubid)
+  allow_mocking(Project, :[], :from_ubid, :order_by)
   allow_mocking(Semaphore, :where)
   allow_mocking(Sshable, :create, :repl?)
   allow_mocking(StorageKeyEncryptionKey, :create)


### PR DESCRIPTION
Add Prog to Create a new VM for a DNS Server

We didn't have any automation for creation of VMs to server DNS servers
and the process consisted of many manual error-prone steps.

In this change, we introduce SetupDnsServerVM prog, which makes it
straightforward to create fully-functional DNS servers from scratch
(which could be useful for development environments for now and prod in
the future) as well as adding VMs to existing DNS servers.

While working on this, I noticed that we don't have a config variable
for the project holding the DNS service resources we use in prod, so I
created that. You also need to populate that in the dev env. DnsServer
class itself doesn't hold that value (but DnsZone does) so that addition
could be another beginner-friendly task.

Usage is like this:
```ruby
# Get or create a DNS server
ds = DnsServer.first || DnsServer.create_with_id(name: "elephant")

# Create some zones if not exists
dz1 = DnsZone.create_with_id(
    project_id: Config.dns_service_project_id,
    name: "test1.ubicloud.com",
    last_purged_at: Time.now
)
dz2 = DnsZone.create_with_id(
    project_id: Config.dns_service_project_id,
    name: "test2.ubicloud.com",
    last_purged_at: Time.now
)

# Create corresponding DNS Zone Nexus Strands
Strand.create(prog: "DnsZone::DnsZoneNexus", label: "wait") { _1.id = dz1.id }
Strand.create(prog: "DnsZone::DnsZoneNexus", label: "wait") { _1.id = dz2.id }

# Associate the zones we have to the VM
dz1.add_dns_server DnsServer.first
dz2.add_dns_server DnsServer.first

# Create a few Records in each
["hebele", "hubele", "asdasd-asdasd-asd", "123123"].each do |r|
dz1.insert_record(record_name: "#{r}.#{dz1.name}", type: "A", ttl:10, data: "0.1.1.0")
dz2.insert_record(record_name: "#{r}.#{dz2.name}", type: "A", ttl:10, data: "0.1.1.0")
end

# Watch the VM getting created
st = Prog::DnsZone::SetupDnsServerVm.assemble(DnsServer.first.id)

# Validate after VM is created
`nslookup hebele.test1.ubicloud.com #{st.reload.vm.sshable.host}`

```

Note that concurrency between the VM creation, zone operations and
records are not handled in the best way. So it's advised to double-check
the results after the VM is created in prod environment.

We have a ton more to do for a proper DNS service lifecycle. A few
ideas:
- Health check for DNS servers and VMs
- Check-ups for consistency among the VMs of a DNS server
- Ability to add/remove DNS zones
- More validation about multiple DNS servers
- DnsServer belongs to a project

While working on this task, I thought that as we build more capabilities around DNS service, we will need the
purge logic to be called from various places, just to be sure
we can get the latest clean snapshot of the records.