### PR TITLE
Fix error messages for setup_database with incorrect argument

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -109,7 +109,7 @@ end
 
 desc "Setup database"
 task :setup_database, [:env, :parallel] do |_, args|
-  raise "env must be test or dev" if !["test", "development"].include?(args[:env])
+  raise "env must be test or development" unless ["test", "development"].include?(args[:env])
   raise "parallel can only be used in test" if args[:parallel] && args[:env] != "test"
   File.binwrite(auto_parallel_tests_file, "1") if args[:parallel] && !File.file?(auto_parallel_tests_file)
 


### PR DESCRIPTION
I think the current error message doesn't make sense:

```
$ rake "setup_database[dev]"
rake aborted!
env must be test or dev
```

While here, switch from `if !` to `unless`.