### PR TITLE
Revert passing credentials to services on CI and E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
     services:
       postgres:
         image: postgres:15.4
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,9 +28,6 @@ jobs:
     services:
       postgres:
         image: postgres:15.4
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}


### PR DESCRIPTION
We started passing credentials to service initiation yesterday to not consume docker hub pull limit for our own repos as we thought that limit was hit due to noisy neighbours. Passing them also allowed us to merge PRs fixing the issue as they expected to pass CI. As we realized that issue was not caused by noisy neighbours and PRs fixing the issue was merged, reverting that change.

By the way, we might keep that for the main repo as it is harmless. Though, since secrets are not accessible via forks, it makes developers life harder if they want to work via their forked repos.