### PR TITLE
Increase nap time at GithubRunner.wait

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -306,7 +306,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       end
     end
 
-    nap 15
+    nap 60
   end
 
   label def destroy

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect(github_runner).not_to receive(:incr_destroy)
 
-      expect { nx.wait }.to nap(15)
+      expect { nx.wait }.to nap(60)
     end
 
     it "destroys runner if it does not pick a job in five minutes and not busy" do
@@ -496,7 +496,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect(github_runner).not_to receive(:incr_destroy)
 
-      expect { nx.wait }.to nap(15)
+      expect { nx.wait }.to nap(60)
     end
 
     it "destroys the runner if the runner-script is succeeded" do
@@ -517,7 +517,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(github_runner).to receive(:workflow_job).and_return({"id" => 123})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
 
-      expect { nx.wait }.to nap(15)
+      expect { nx.wait }.to nap(60)
     end
   end
 


### PR DESCRIPTION
In the GitHubRunner.wait method, we check whether the runner script is running or if it has been idle for 5 minutes without picking up a job. We increment the destroy semaphore upon receiving a webhook event from GitHub. Previously, I had set the nap time to 15 seconds because I was unaware that we update the scheduled time when we increase the semaphore. My intention was to deprovision the virtual machine and free up our capacity as quickly as possible. However, since we update the scheduled time when we increase the semaphore, there's no need to run the wait method frequently. As a result, I've increased the nap time to 60 seconds.

Additionally, this method is one of the most time-consuming for respirate. I believe this change will help reduce the overall time.