### PR TITLE
Unify ajax errors and dependency errors

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -87,8 +87,8 @@ $(".delete-btn").on("click", function (event) {
 
           let message = thrownError;
           try {
-            err = JSON.parse(xhr.responseText);
-            message = err.message
+            response = JSON.parse(xhr.responseText);
+            message = response.error?.message
           } catch {};
           alert(`Error: ${message}`);
         }

--- a/clover.rb
+++ b/clover.rb
@@ -98,7 +98,7 @@ class Clover < Roda
 
     if error[:code] == 204
       # nothing
-    elsif api? || runtime?
+    elsif api? || runtime? || request.headers["Accept"] == "application/json"
       {error: error}
     else
       @error = error

--- a/clover.rb
+++ b/clover.rb
@@ -104,7 +104,7 @@ class Clover < Roda
       @error = error
 
       case e
-      when Sequel::ValidationFailed
+      when Sequel::ValidationFailed, DependencyError
         flash["error"] = @error[:message]
         return redirect_back_with_inputs
       when Validation::ValidationFailed
@@ -324,8 +324,7 @@ class Clover < Roda
       # Do not allow to close account if the project has resources and
       # the account is the only user
       if (project = account.projects.find { _1.accounts.count == 1 && _1.has_resources })
-        flash["error"] = "'#{project.name}' project has some resources. Delete all related resources first."
-        redirect "/project"
+        fail DependencyError.new("'#{project.name}' project has some resources. Delete all related resources first.")
       end
     end
 

--- a/routes/clover_error.rb
+++ b/routes/clover_error.rb
@@ -12,8 +12,6 @@ class CloverError < StandardError
   end
 end
 
-# Add here instead of routes/project.rb as it will be used by other APIs as well
-# TODO: Remove the comment once another API use it
 class DependencyError < CloverError
   def initialize(message)
     super(409, "DependencyError", message)

--- a/routes/merged/project/location/private_subnet.rb
+++ b/routes/merged/project/location/private_subnet.rb
@@ -65,12 +65,7 @@ class Clover
       request.delete true do
         Authorization.authorize(current_account.id, "PrivateSubnet:delete", ps.id)
         unless ps.vms_dataset.empty?
-          if api?
-            fail DependencyError.new("Private subnet '#{ps.name}' has VMs attached, first, delete them.")
-          else
-            response.status = 400
-            next {message: "Private subnet has VMs attached, first, delete them."}
-          end
+          fail DependencyError.new("Private subnet '#{ps.name}' has VMs attached, first, delete them.")
         end
 
         ps.incr_destroy

--- a/routes/web/project.rb
+++ b/routes/web/project.rb
@@ -63,8 +63,7 @@ class Clover
 
         # If it has some resources, do not allow to delete it.
         if @project.has_resources
-          flash["error"] = "'#{@project.name}' project has some resources. Delete all related resources first."
-          return {message: "'#{@project.name}' project has some resources. Delete all related resources first."}
+          fail DependencyError.new("'#{@project.name}' project has some resources. Delete all related resources first.")
         end
 
         @project.soft_delete

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe Clover, "auth" do
 
       click_button "Close Account"
 
-      expect(page.title).to eq("Ubicloud - Projects")
+      expect(page.title).to eq("Ubicloud - Close Account")
       expect(page).to have_content("project has some resources. Delete all related resources first")
     end
   end

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -222,8 +222,9 @@ RSpec.describe Clover, "private subnet" do
 
         visit "#{project.path}#{private_subnet.path}"
         btn = find ".delete-btn"
-        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
-        expect(page.body).to eq({message: "Private subnet has VMs attached, first, delete them."}.to_json)
+        Capybara.current_session.driver.header "Accept", "application/json"
+        response = page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+        expect(response).to have_api_error(409, "Private subnet '#{private_subnet.name}' has VMs attached, first, delete them.")
       end
     end
   end

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -439,9 +439,9 @@ RSpec.describe Clover, "project" do
         # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
         # UI tests run without a JavaScript enginer.
         btn = find ".delete-btn"
-        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
-
-        expect(page.body).to eq({message: "'#{project.name}' project has some resources. Delete all related resources first."}.to_json)
+        Capybara.current_session.driver.header "Accept", "application/json"
+        response = page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+        expect(response).to have_api_error(409, "'#{project.name}' project has some resources. Delete all related resources first.")
 
         visit "/project"
 


### PR DESCRIPTION
- **Return error as json if json requests**
  Our frontend sends a few ajax requests to backend. So even if it's a
  web? route, we need to return exception as json instead of html page if
  json requested.
  

- **Use DependencyError for all similar cases**
  We use DependencyError when a resource can't be deleted due to dependent
  resources. We don't use it in every situation, but it helps us eliminate
  api/web branches.
  