### PR TITLE
Disable ipv6 dns runners

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -437,10 +437,10 @@ DHCP
     raparams = nics.map { "ra-param=#{_1.tap}" }.join("\n")
     interfaces = nics.map { "interface=#{_1.tap}" }.join("\n")
     dnsmasq_address_ip6 = NetAddr::IPv6.parse("fd00:0b1c:100d:53::")
-    address_mapping = if boot_image.include?("github")
+    runner_config = if boot_image.include?("github")
       <<~ADDRESSES
       address=/ubicloudhostplaceholder.blob.core.windows.net/#{nics.first.net4.split("/").first}
-      address=/.docker.io/::
+      filter-AAAA
       ADDRESSES
     else
       ""
@@ -467,7 +467,7 @@ listen-address=#{dnsmasq_address_ip6}
 listen-address=#{dns_ipv4}
 dhcp-option=26,1400
 bind-interfaces
-#{address_mapping}
+#{runner_config}
 dhcp-option=54,#{dns_ipv4}
 dns-forward-max=10000
 DNSMASQ_CONF

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -469,6 +469,7 @@ dhcp-option=26,1400
 bind-interfaces
 #{address_mapping}
 dhcp-option=54,#{dns_ipv4}
+dns-forward-max=10000
 DNSMASQ_CONF
 
     ethernets = nics.map do |nic|


### PR DESCRIPTION
## Increase parallel dns query count to 10000
This is set to 150 by default according to dnsmasq manual. When we do
not increase, we may see failures like;
Resolving yum.oracle.com (yum.oracle.com)... failed: Name or service not
known.
wget: unable to resolve host address 'yum.oracle.com'

The theory is that during the setup of runners, many customers install
packages from many different repositories and it is causing dnsmasq to
halt some of these requests.

## Disable IPv6 address resolution for runners
Using dnsmasq's filter-AAAA config, we simply filter out any ipv6
addresses for runners. This is helpful because docker has a poor IPv6
support. The internal dns server of docker that is responsible from
sending requests upstream and returning information fails to properly
handle ipv6 addresses. Looking into some of the failures in detail, we
realized that whenever dnsmasq returns an IPv6 address, we observe a
SERVFAIL package from the internal dns server of docker. Here is an
example package;

{
  "_path": "dns",
  "ts": "2024-11-15T14:53:39.612371Z",
  "uid": "C6TGh23NBSGqa7ECu9",
  "id": {
    "orig_h": "127.0.0.1",
    "orig_p": 54643,
    "resp_h": "127.0.0.11",
    "resp_p": 53
  },
  "proto": "udp",
  "trans_id": 2448,
  "rtt": null,
  "query": null,
  "qclass": null,
  "qclass_name": null,
  "qtype": null,
  "qtype_name": null,
  "rcode": 2,
  "rcode_name": "SERVFAIL",
  "AA": false,
  "TC": false,
  "RD": false,
  "RA": false,
  "Z": 0,
  "answers": null,
  "TTLs": null,
  "rejected": true
}

The address 127.0.0.11 belongs to docker's internal dns service. This
happens just after the dnsmasq resolved one of the crates.io sub
hostnames to "2a04:4e42:8e::649". Testing things further, I have seen
that simply filtering out ipv6 addresses, we can resolve the issue.