### PR TITLE
Rewrite port for load balancer when balanced

### DIFF
--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -55,8 +55,8 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
     ipv4_prerouting_rule = load_balancer.ipv4_enabled? ? "ip daddr #{public_ipv4} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to #{balance_mode_ip4} mod #{modulo} map { #{ipv4_map_def} }" : ""
     ipv6_prerouting_rule = load_balancer.ipv6_enabled? ? "ip6 daddr #{public_ipv6} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to #{balance_mode_ip6} mod #{modulo} map { #{ipv6_map_def} }" : ""
 
-    ipv4_postrouting_rule = load_balancer.ipv4_enabled? ? "ip daddr @neighbor_ips_v4 tcp dport #{load_balancer.dst_port} ct state established,related,new counter snat to #{private_ipv4}" : ""
-    ipv6_postrouting_rule = load_balancer.ipv6_enabled? ? "ip6 daddr @neighbor_ips_v6 tcp dport #{load_balancer.dst_port} ct state established,related,new counter snat to #{private_ipv6}" : ""
+    ipv4_postrouting_rule = load_balancer.ipv4_enabled? ? "ip daddr @neighbor_ips_v4 tcp dport #{load_balancer.dst_port} ct state established,related,new counter snat to #{private_ipv4}:#{load_balancer.dst_port}" : ""
+    ipv6_postrouting_rule = load_balancer.ipv6_enabled? ? "ip6 daddr @neighbor_ips_v6 tcp dport #{load_balancer.dst_port} ct state established,related,new counter snat to #{private_ipv6}:#{load_balancer.dst_port}" : ""
     <<TEMPLATE
 table ip nat;
 delete table ip nat;

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -100,8 +100,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
+ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -143,7 +143,7 @@ ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counte
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
+ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
 
 
     # Basic NAT for private IPv4 to public IPv4
@@ -187,8 +187,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
+ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -240,8 +240,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
+ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -283,7 +283,7 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
 
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -324,8 +324,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
+ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -366,8 +366,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
+ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
+ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32


### PR DESCRIPTION
We were not rewriting the port when the load balancer redirects the connection to the neighbor node. This was not an issue with the initial implementation because the private networking was not impacted by firewalls. It is now. Therefore, we must rewrite the port in a firewall suitable way at the postrouting state. This commit adds that.