### PR TITLE
Support SHOW_ERRORS environment variable when testing

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -93,7 +93,10 @@ class Clover < Roda
   end
 
   plugin :error_handler do |e|
-    # raise e
+    if Config.test? && ENV["SHOW_ERRORS"]
+      raise e
+    end
+
     error = parse_error(e)
 
     if error[:code] == 204

--- a/spec/routes/api/show_errors_spec.rb
+++ b/spec/routes/api/show_errors_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover do
+  before do
+    unless (@show_errors = ENV["SHOW_ERRORS"])
+      ENV["SHOW_ERRORS"] = "1"
+    end
+    login_api(create_account.email)
+  end
+
+  after do
+    ENV.delete("SHOW_ERRORS") unless @show_errors
+  end
+
+  it "supports SHOW_ERRORS environment variable when testing" do
+    expect { post "/api/project", {}.to_json }.to raise_error Validation::ValidationFailed
+  end
+end


### PR DESCRIPTION
This environment variable makes the error handler raise the exception instead swallowing it.  This makes debugging issues significantly simpler.