### PR TITLE
Add Clover instance methods related to authorization

### DIFF
--- a/routes/helpers/firewall.rb
+++ b/routes/helpers/firewall.rb
@@ -20,7 +20,7 @@ class Clover
   end
 
   def firewall_post(firewall_name)
-    Authorization.authorize(current_account.id, "Firewall:create", @project.id)
+    authorize("Firewall:create", @project.id)
     Validation.validate_name(firewall_name)
 
     optional_parameters = %w[description]

--- a/routes/helpers/firewall.rb
+++ b/routes/helpers/firewall.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def firewall_list_dataset
-    @project.firewalls_dataset.authorized(current_account.id, "Firewall:view")
+    dataset_authorize(@project.firewalls_dataset, "Firewall:view")
   end
 
   def firewall_list_api_response(dataset)

--- a/routes/helpers/general.rb
+++ b/routes/helpers/general.rb
@@ -72,6 +72,10 @@ class Clover < Roda
     @is_web = !api? && !runtime?
   end
 
+  def authorize(actions, object_id)
+    Authorization.authorize(rodauth.session_value, actions, object_id)
+  end
+
   def has_project_permission(actions)
     @project_permissions.intersection(Authorization.expand_actions(actions)).any?
   end

--- a/routes/helpers/general.rb
+++ b/routes/helpers/general.rb
@@ -80,6 +80,10 @@ class Clover < Roda
     Authorization.has_permission?(rodauth.session_value, actions, object_id)
   end
 
+  def all_permissions(actions)
+    Authorization.all_permissions(rodauth.session_value, actions)
+  end
+
   def has_project_permission(actions)
     @project_permissions.intersection(Authorization.expand_actions(actions)).any?
   end

--- a/routes/helpers/general.rb
+++ b/routes/helpers/general.rb
@@ -72,20 +72,24 @@ class Clover < Roda
     @is_web = !api? && !runtime?
   end
 
+  def current_account_id
+    rodauth.session_value
+  end
+
   def authorize(actions, object_id)
-    Authorization.authorize(rodauth.session_value, actions, object_id)
+    Authorization.authorize(current_account_id, actions, object_id)
   end
 
   def has_permission?(actions, object_id)
-    Authorization.has_permission?(rodauth.session_value, actions, object_id)
+    Authorization.has_permission?(current_account_id, actions, object_id)
   end
 
   def all_permissions(actions)
-    Authorization.all_permissions(rodauth.session_value, actions)
+    Authorization.all_permissions(current_account_id, actions)
   end
 
   def dataset_authorize(ds, actions)
-    ds.authorized(rodauth.session_value, actions)
+    ds.authorized(current_account_id, actions)
   end
 
   def has_project_permission(actions)

--- a/routes/helpers/general.rb
+++ b/routes/helpers/general.rb
@@ -76,6 +76,10 @@ class Clover < Roda
     Authorization.authorize(rodauth.session_value, actions, object_id)
   end
 
+  def has_permission?(actions, object_id)
+    Authorization.has_permission?(rodauth.session_value, actions, object_id)
+  end
+
   def has_project_permission(actions)
     @project_permissions.intersection(Authorization.expand_actions(actions)).any?
   end

--- a/routes/helpers/general.rb
+++ b/routes/helpers/general.rb
@@ -84,6 +84,10 @@ class Clover < Roda
     Authorization.all_permissions(rodauth.session_value, actions)
   end
 
+  def dataset_authorize(ds, actions)
+    ds.authorized(rodauth.session_value, actions)
+  end
+
   def has_project_permission(actions)
     @project_permissions.intersection(Authorization.expand_actions(actions)).any?
   end

--- a/routes/helpers/load_balancer.rb
+++ b/routes/helpers/load_balancer.rb
@@ -2,8 +2,7 @@
 
 class Clover
   def load_balancer_list
-    dataset = @project.load_balancers_dataset
-    dataset = dataset.authorized(current_account.id, "LoadBalancer:view")
+    dataset = dataset_authorize(@project.load_balancers_dataset, "LoadBalancer:view")
     dataset = dataset.join(:private_subnet, id: Sequel[:load_balancer][:private_subnet_id]).where(location: @location).select_all(:load_balancer) if @location
     if api?
       result = dataset.paginated_result(

--- a/routes/helpers/load_balancer.rb
+++ b/routes/helpers/load_balancer.rb
@@ -23,7 +23,7 @@ class Clover
   end
 
   def load_balancer_post(name)
-    Authorization.authorize(current_account.id, "LoadBalancer:create", @project.id)
+    authorize("LoadBalancer:create", @project.id)
 
     required_parameters = %w[private_subnet_id algorithm src_port dst_port health_check_protocol]
     required_parameters << "name" if web?
@@ -33,7 +33,7 @@ class Clover
     unless (ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"]))
       fail Validation::ValidationFailed.new("private_subnet_id" => "Private subnet not found")
     end
-    Authorization.authorize(current_account.id, "PrivateSubnet:view", ps.id)
+    authorize("PrivateSubnet:view", ps.id)
 
     lb = Prog::Vnet::LoadBalancerNexus.assemble(
       ps.id,

--- a/routes/helpers/postgres.rb
+++ b/routes/helpers/postgres.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def postgres_post(name)
-    Authorization.authorize(current_account.id, "Postgres:create", @project.id)
+    authorize("Postgres:create", @project.id)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
     Validation.validate_postgres_location(@location)

--- a/routes/helpers/postgres.rb
+++ b/routes/helpers/postgres.rb
@@ -44,7 +44,7 @@ class Clover
   end
 
   def postgres_list
-    dataset = @project.postgres_resources_dataset.authorized(current_account.id, "Postgres:view").eager(:semaphores, :strand)
+    dataset = dataset_authorize(@project.postgres_resources_dataset, "Postgres:view").eager(:semaphores, :strand)
     if api?
       dataset = dataset.where(location: @location) if @location
       result = dataset.paginated_result(

--- a/routes/helpers/private_subnet.rb
+++ b/routes/helpers/private_subnet.rb
@@ -23,7 +23,7 @@ class Clover
   end
 
   def private_subnet_post(name)
-    Authorization.authorize(current_account.id, "PrivateSubnet:create", @project.id)
+    authorize("PrivateSubnet:create", @project.id)
 
     params = json_params
     unless params.empty?
@@ -35,7 +35,7 @@ class Clover
         unless fw && fw.location == @location
           fail Validation::ValidationFailed.new(firewall_id: "Firewall with id \"#{request_body_params["firewall_id"]}\" and location \"#{@location}\" is not found")
         end
-        Authorization.authorize(current_account.id, "Firewall:view", fw.id)
+        authorize("Firewall:view", fw.id)
         fw.id
       end
     end

--- a/routes/helpers/private_subnet.rb
+++ b/routes/helpers/private_subnet.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def private_subnet_list
-    dataset = @project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:view")
+    dataset = dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view")
 
     if api?
       dataset = dataset.where(location: @location) if @location

--- a/routes/helpers/vm.rb
+++ b/routes/helpers/vm.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def vm_list_dataset
-    @project.vms_dataset.authorized(current_account.id, "Vm:view")
+    dataset_authorize(@project.vms_dataset, "Vm:view")
   end
 
   def vm_list_api_response(dataset)

--- a/routes/helpers/vm.rb
+++ b/routes/helpers/vm.rb
@@ -21,7 +21,7 @@ class Clover
 
   def vm_post(name)
     project = @project
-    Authorization.authorize(current_account.id, "Vm:create", project.id)
+    authorize("Vm:create", project.id)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless project.has_valid_payment_method?
 
     required_parameters = ["public_key"]
@@ -55,7 +55,7 @@ class Clover
       if !ps || ps.location != @location
         fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{assemble_params["private_subnet_id"]}\" is not found in the location \"#{LocationNameConverter.to_display_name(@location)}\""})
       end
-      Authorization.authorize(current_account.id, "PrivateSubnet:view", ps.id)
+      authorize("PrivateSubnet:view", ps.id)
     end
     assemble_params["private_subnet_id"] = ps&.id
 

--- a/routes/merged/github.rb
+++ b/routes/merged/github.rb
@@ -9,7 +9,7 @@ class Clover
       code_response = Github.oauth_client.exchange_code_for_token(oauth_code)
 
       if (installation = GithubInstallation[installation_id: installation_id])
-        Authorization.authorize(current_account.id, "Project:github", installation.project.id)
+        authorize("Project:github", installation.project.id)
         flash["notice"] = "GitHub runner integration is already enabled for #{installation.project.name} project."
         Clog.emit("GitHub installation already exists") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{installation.project.path}/github"
@@ -21,7 +21,7 @@ class Clover
         r.redirect "/dashboard"
       end
 
-      Authorization.authorize(current_account.id, "Project:github", project.id)
+      authorize("Project:github", project.id)
 
       if setup_action == "request"
         flash["notice"] = "The GitHub App installation request is awaiting approval from the GitHub organization's administrator. As GitHub will redirect your admin back to the Ubicloud console, the admin needs to have an Ubicloud account with the necessary permissions to finalize the installation. Please invite the admin to your project if they don't have an account yet."

--- a/routes/merged/project.rb
+++ b/routes/merged/project.rb
@@ -53,7 +53,7 @@ class Clover
       @project_permissions = Authorization.all_permissions(current_account.id, @project.id)
 
       r.get true do
-        Authorization.authorize(current_account.id, "Project:view", @project.id)
+        authorize("Project:view", @project.id)
 
         if api?
           Serializers::Project.serialize(@project)
@@ -71,7 +71,7 @@ class Clover
       end
 
       r.delete true do
-        Authorization.authorize(current_account.id, "Project:delete", @project.id)
+        authorize("Project:delete", @project.id)
 
         if @project.has_resources
           fail DependencyError.new("'#{@project.name}' project has some resources. Delete all related resources first.")
@@ -87,7 +87,7 @@ class Clover
         r.get("dashboard") { view("project/dashboard") }
 
         r.post true do
-          Authorization.authorize(current_account.id, "Project:edit", @project.id)
+          authorize("Project:edit", @project.id)
           @project.update(name: r.params["name"])
 
           flash["notice"] = "The project name is updated to '#{@project.name}'."

--- a/routes/merged/project.rb
+++ b/routes/merged/project.rb
@@ -45,7 +45,7 @@ class Clover
         r.halt
       end
 
-      if @project.accounts_dataset.where(Sequel[:accounts][:id] => current_account.id).empty?
+      if @project.accounts_dataset.where(Sequel[:accounts][:id] => current_account_id).empty?
         fail Authorization::Unauthorized
       end
 

--- a/routes/merged/project.rb
+++ b/routes/merged/project.rb
@@ -50,7 +50,7 @@ class Clover
       end
 
       @project_data = Serializers::Project.serialize(@project, {include_path: true})
-      @project_permissions = Authorization.all_permissions(current_account.id, @project.id)
+      @project_permissions = all_permissions(@project.id)
 
       r.get true do
         authorize("Project:view", @project.id)

--- a/routes/merged/project/billing.rb
+++ b/routes/merged/project/billing.rb
@@ -11,7 +11,7 @@ class Clover
         return "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
       end
 
-      Authorization.authorize(current_account.id, "Project:billing", @project.id)
+      authorize("Project:billing", @project.id)
 
       r.get true do
         if (billing_info = @project.billing_info)

--- a/routes/merged/project/firewall.rb
+++ b/routes/merged/project/firewall.rb
@@ -17,7 +17,7 @@ class Clover
 
     r.on web? do
       r.get "create" do
-        Authorization.authorize(current_account.id, "Firewall:create", @project.id)
+        authorize("Firewall:create", @project.id)
         authorized_subnets = @project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:edit").all
         @subnets = Serializers::PrivateSubnet.serialize(authorized_subnets)
         @default_location = @project.default_location

--- a/routes/merged/project/firewall.rb
+++ b/routes/merged/project/firewall.rb
@@ -18,7 +18,7 @@ class Clover
     r.on web? do
       r.get "create" do
         authorize("Firewall:create", @project.id)
-        authorized_subnets = @project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:edit").all
+        authorized_subnets = dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:edit").all
         @subnets = Serializers::PrivateSubnet.serialize(authorized_subnets)
         @default_location = @project.default_location
         view "networking/firewall/create"

--- a/routes/merged/project/github.rb
+++ b/routes/merged/project/github.rb
@@ -8,7 +8,7 @@ class Clover
         return "GitHub Action Runner integration is not enabled. Set GITHUB_APP_NAME to enable it."
       end
 
-      Authorization.authorize(current_account.id, "Project:github", @project.id)
+      authorize("Project:github", @project.id)
 
       r.get true do
         if @project.github_installations.empty?

--- a/routes/merged/project/load_balancer.rb
+++ b/routes/merged/project/load_balancer.rb
@@ -12,7 +12,7 @@ class Clover
       end
 
       r.get "create" do
-        Authorization.authorize(current_account.id, "LoadBalancer:create", @project.id)
+        authorize("LoadBalancer:create", @project.id)
         authorized_subnets = @project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:view").all
         @subnets = Serializers::PrivateSubnet.serialize(authorized_subnets)
         view "networking/load_balancer/create"

--- a/routes/merged/project/load_balancer.rb
+++ b/routes/merged/project/load_balancer.rb
@@ -13,7 +13,7 @@ class Clover
 
       r.get "create" do
         authorize("LoadBalancer:create", @project.id)
-        authorized_subnets = @project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:view").all
+        authorized_subnets = dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").all
         @subnets = Serializers::PrivateSubnet.serialize(authorized_subnets)
         view "networking/load_balancer/create"
       end

--- a/routes/merged/project/location/firewall.rb
+++ b/routes/merged/project/location/firewall.rb
@@ -45,7 +45,7 @@ class Clover
         if api?
           @firewall
         else
-          project_subnets = @project.private_subnets_dataset.where(location: @location).authorized(current_account.id, "PrivateSubnet:view").all
+          project_subnets = dataset_authorize(@project.private_subnets_dataset.where(location: @location), "PrivateSubnet:view").all
           attached_subnets = firewall.private_subnets_dataset.all
           @attachable_subnets = Serializers::PrivateSubnet.serialize(project_subnets.reject { |ps| attached_subnets.find { |as| as.id == ps.id } })
 

--- a/routes/merged/project/location/firewall.rb
+++ b/routes/merged/project/location/firewall.rb
@@ -26,8 +26,8 @@ class Clover
       end
 
       r.delete true do
-        Authorization.authorize(current_account.id, "Firewall:delete", firewall.id)
-        firewall.private_subnets.map { Authorization.authorize(current_account.id, "PrivateSubnet:edit", _1.id) }
+        authorize("Firewall:delete", firewall.id)
+        firewall.private_subnets.map { authorize("PrivateSubnet:edit", _1.id) }
         firewall.destroy
 
         if api?
@@ -39,7 +39,7 @@ class Clover
       end
 
       r.get true do
-        Authorization.authorize(current_account.id, "Firewall:view", firewall.id)
+        authorize("Firewall:view", firewall.id)
         @firewall = Serializers::Firewall.serialize(firewall, {detailed: true})
 
         if api?
@@ -54,7 +54,7 @@ class Clover
       end
 
       r.post %w[attach-subnet detach-subnet] do |action|
-        Authorization.authorize(current_account.id, "Firewall:view", firewall.id)
+        authorize("Firewall:view", firewall.id)
 
         private_subnet_id = Validation.validate_request_body(json_params, ["private_subnet_id"])["private_subnet_id"]
         private_subnet = PrivateSubnet.from_ubid(private_subnet_id)
@@ -68,7 +68,7 @@ class Clover
           end
         end
 
-        Authorization.authorize(current_account.id, "PrivateSubnet:edit", private_subnet.id)
+        authorize("PrivateSubnet:edit", private_subnet.id)
 
         if action == "attach-subnet"
           firewall.associate_with_private_subnet(private_subnet)
@@ -93,7 +93,7 @@ class Clover
 
       r.on "firewall-rule" do
         r.post true do
-          Authorization.authorize(current_account.id, "Firewall:edit", firewall.id)
+          authorize("Firewall:edit", firewall.id)
 
           port_range = if r.params["port_range"].empty?
             [0, 65535]
@@ -111,7 +111,7 @@ class Clover
         end
 
         r.delete String do |firewall_rule_ubid|
-          Authorization.authorize(current_account.id, "Firewall:edit", firewall.id)
+          authorize("Firewall:edit", firewall.id)
           fwr = FirewallRule.from_ubid(firewall_rule_ubid)
           unless fwr
             response.status = 204

--- a/routes/merged/project/location/firewall/firewall_rule.rb
+++ b/routes/merged/project/location/firewall/firewall_rule.rb
@@ -5,7 +5,7 @@ class Clover
     # This is api-only, but is only called from an r.on api? branch, so no check is needed here
 
     r.post true do
-      Authorization.authorize(current_account.id, "Firewall:edit", @firewall.id)
+      authorize("Firewall:edit", @firewall.id)
 
       required_parameters = ["cidr"]
       allowed_optional_parameters = ["port_range"]
@@ -31,7 +31,7 @@ class Clover
 
       request.delete true do
         if firewall_rule
-          Authorization.authorize(current_account.id, "Firewall:edit", @firewall.id)
+          authorize("Firewall:edit", @firewall.id)
           @firewall.remove_firewall_rule(firewall_rule)
         end
 
@@ -41,7 +41,7 @@ class Clover
 
       request.get true do
         if firewall_rule
-          Authorization.authorize(current_account.id, "Firewall:view", @firewall.id)
+          authorize("Firewall:view", @firewall.id)
           Serializers::FirewallRule.serialize(firewall_rule)
         end
       end

--- a/routes/merged/project/location/load_balancer.rb
+++ b/routes/merged/project/location/load_balancer.rb
@@ -26,7 +26,7 @@ class Clover
       end
 
       r.post %w[attach-vm detach-vm] do |action|
-        Authorization.authorize(current_account.id, "LoadBalancer:edit", lb.id)
+        authorize("LoadBalancer:edit", lb.id)
         required_parameters = %w[vm_id]
         request_body_params = Validation.validate_request_body(json_params, required_parameters)
 
@@ -34,7 +34,7 @@ class Clover
           fail Validation::ValidationFailed.new("vm_id" => "VM not found")
         end
 
-        Authorization.authorize(current_account.id, "Vm:view", vm.id)
+        authorize("Vm:view", vm.id)
 
         if action == "attach-vm"
           if vm.load_balancer
@@ -56,7 +56,7 @@ class Clover
       end
 
       r.get true do
-        Authorization.authorize(current_account.id, "LoadBalancer:view", lb.id)
+        authorize("LoadBalancer:view", lb.id)
         @lb = Serializers::LoadBalancer.serialize(lb, {detailed: true, vms_serialized: !api?})
         if api?
           @lb
@@ -69,14 +69,14 @@ class Clover
       end
 
       r.delete true do
-        Authorization.authorize(current_account.id, "LoadBalancer:delete", lb.id)
+        authorize("LoadBalancer:delete", lb.id)
         lb.incr_destroy
         response.status = 204
         r.halt
       end
 
       r.patch api? do
-        Authorization.authorize(current_account.id, "LoadBalancer:edit", lb.id)
+        authorize("LoadBalancer:edit", lb.id)
         request_body_params = Validation.validate_request_body(json_params, %w[algorithm src_port dst_port health_check_endpoint vms])
         lb.update(
           algorithm: request_body_params["algorithm"],
@@ -91,7 +91,7 @@ class Clover
             fail Validation::ValidationFailed.new("vms" => "VM not found")
           end
 
-          Authorization.authorize(current_account.id, "Vm:view", vm.id)
+          authorize("Vm:view", vm.id)
           if vm.load_balancer
             next if vm.load_balancer.id == lb.id
             fail Validation::ValidationFailed.new("vms" => "VM is already attached to a load balancer")

--- a/routes/merged/project/location/load_balancer.rb
+++ b/routes/merged/project/location/load_balancer.rb
@@ -61,7 +61,7 @@ class Clover
         if api?
           @lb
         else
-          vms = lb.private_subnet.vms_dataset.authorized(current_account.id, "Vm:view").exclude(Sequel[:vm][:id] => lb.vms_dataset.select(Sequel[:vm][:id])).all
+          vms = dataset_authorize(lb.private_subnet.vms_dataset, "Vm:view").exclude(Sequel[:vm][:id] => lb.vms_dataset.select(Sequel[:vm][:id])).all
           @attachable_vms = Serializers::Vm.serialize(vms)
 
           view "networking/load_balancer/show"

--- a/routes/merged/project/location/private_subnet.rb
+++ b/routes/merged/project/location/private_subnet.rb
@@ -27,18 +27,18 @@ class Clover
 
       if web?
         r.post "connect" do
-          Authorization.authorize(current_account.id, "PrivateSubnet:connect", ps.id)
+          authorize("PrivateSubnet:connect", ps.id)
           subnet = PrivateSubnet.from_ubid(r.params["connected-subnet-ubid"])
-          Authorization.authorize(current_account.id, "PrivateSubnet:connect", subnet.id)
+          authorize("PrivateSubnet:connect", subnet.id)
           ps.connect_subnet(subnet)
           flash["notice"] = "#{subnet.name} will be connected in a few seconds"
           r.redirect "#{@project.path}#{ps.path}"
         end
 
         r.post "disconnect", String do |disconnecting_ps_ubid|
-          Authorization.authorize(current_account.id, "PrivateSubnet:disconnect", ps.id)
+          authorize("PrivateSubnet:disconnect", ps.id)
           subnet = PrivateSubnet.from_ubid(disconnecting_ps_ubid)
-          Authorization.authorize(current_account.id, "PrivateSubnet:disconnect", subnet.id)
+          authorize("PrivateSubnet:disconnect", subnet.id)
           ps.disconnect_subnet(subnet)
           flash["notice"] = "#{subnet.name} will be disconnected in a few seconds"
           ""
@@ -46,7 +46,7 @@ class Clover
       end
 
       request.get true do
-        Authorization.authorize(current_account.id, "PrivateSubnet:view", ps.id)
+        authorize("PrivateSubnet:view", ps.id)
         @ps = Serializers::PrivateSubnet.serialize(ps)
         if api?
           @ps
@@ -63,7 +63,7 @@ class Clover
       end
 
       request.delete true do
-        Authorization.authorize(current_account.id, "PrivateSubnet:delete", ps.id)
+        authorize("PrivateSubnet:delete", ps.id)
         unless ps.vms_dataset.empty?
           fail DependencyError.new("Private subnet '#{ps.name}' has VMs attached, first, delete them.")
         end

--- a/routes/merged/project/location/vm.rb
+++ b/routes/merged/project/location/vm.rb
@@ -26,13 +26,13 @@ class Clover
       end
 
       r.get true do
-        Authorization.authorize(current_account.id, "Vm:view", vm.id)
+        authorize("Vm:view", vm.id)
         @vm = Serializers::Vm.serialize(vm, {detailed: true})
         api? ? @vm : view("vm/show")
       end
 
       r.delete true do
-        Authorization.authorize(current_account.id, "Vm:delete", vm.id)
+        authorize("Vm:delete", vm.id)
         vm.incr_destroy
         response.status = 204
         nil

--- a/routes/merged/project/postgres.rb
+++ b/routes/merged/project/postgres.rb
@@ -13,7 +13,7 @@ class Clover
       end
 
       r.get "create" do
-        Authorization.authorize(current_account.id, "Postgres:create", @project.id)
+        authorize("Postgres:create", @project.id)
 
         flavor = r.params["flavor"] || PostgresResource::Flavor::STANDARD
         Validation.validate_postgres_flavor(flavor)

--- a/routes/merged/project/private_subnet.rb
+++ b/routes/merged/project/private_subnet.rb
@@ -13,7 +13,7 @@ class Clover
       end
 
       r.get "create" do
-        Authorization.authorize(current_account.id, "PrivateSubnet:create", @project.id)
+        authorize("PrivateSubnet:create", @project.id)
         view "networking/private_subnet/create"
       end
     end

--- a/routes/merged/project/usage_alert.rb
+++ b/routes/merged/project/usage_alert.rb
@@ -3,7 +3,7 @@
 class Clover
   hash_branch(:project_prefix, "usage-alert") do |r|
     r.on web? do
-      Authorization.authorize(current_account.id, "Project:billing", @project.id)
+      authorize("Project:billing", @project.id)
 
       r.post true do
         name = r.params["alert_name"]

--- a/routes/merged/project/usage_alert.rb
+++ b/routes/merged/project/usage_alert.rb
@@ -10,7 +10,7 @@ class Clover
         Validation.validate_short_text(name, "name")
         limit = Validation.validate_usage_limit(r.params["limit"])
 
-        UsageAlert.create_with_id(project_id: @project.id, user_id: current_account.id, name: name, limit: limit)
+        UsageAlert.create_with_id(project_id: @project.id, user_id: current_account_id, name: name, limit: limit)
 
         r.redirect "#{@project.path}/billing"
       end

--- a/routes/merged/project/user.rb
+++ b/routes/merged/project/user.rb
@@ -3,7 +3,7 @@
 class Clover
   hash_branch(:project_prefix, "user") do |r|
     r.on web? do
-      Authorization.authorize(current_account.id, "Project:user", @project.id)
+      authorize("Project:user", @project.id)
 
       r.get true do
         @user_policies = @project.access_policies_dataset.where(managed: true).flat_map do |policy|

--- a/routes/merged/project/user.rb
+++ b/routes/merged/project/user.rb
@@ -49,7 +49,7 @@ class Clover
             button_title: "Join Project",
             button_link: "#{Config.base_url}#{@project.path}/dashboard")
         else
-          @project.add_invitation(email: email, policy: policy, inviter_id: current_account.id, expires_at: Time.now + 7 * 24 * 60 * 60)
+          @project.add_invitation(email: email, policy: policy, inviter_id: current_account_id, expires_at: Time.now + 7 * 24 * 60 * 60)
           Util.send_email(email, "Invitation to Join '#{@project.name}' Project on Ubicloud",
             greeting: "Hello,",
             body: ["You're invited by '#{current_account.name}' to join the '#{@project.name}' project on Ubicloud.",

--- a/routes/merged/project/vm.rb
+++ b/routes/merged/project/vm.rb
@@ -21,7 +21,7 @@ class Clover
 
       r.get "create" do
         authorize("Vm:create", @project.id)
-        @subnets = Serializers::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:view").all)
+        @subnets = Serializers::PrivateSubnet.serialize(dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").all)
         @prices = fetch_location_based_prices("VmCores", "VmStorage", "IPAddress")
         @has_valid_payment_method = @project.has_valid_payment_method?
         @default_location = @project.default_location

--- a/routes/merged/project/vm.rb
+++ b/routes/merged/project/vm.rb
@@ -20,7 +20,7 @@ class Clover
       end
 
       r.get "create" do
-        Authorization.authorize(current_account.id, "Vm:create", @project.id)
+        authorize("Vm:create", @project.id)
         @subnets = Serializers::PrivateSubnet.serialize(@project.private_subnets_dataset.authorized(current_account.id, "PrivateSubnet:view").all)
         @prices = fetch_location_based_prices("VmCores", "VmStorage", "IPAddress")
         @has_valid_payment_method = @project.has_valid_payment_method?

--- a/views/networking/firewall/index.erb
+++ b/views/networking/firewall/index.erb
@@ -19,7 +19,7 @@
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
               text-gray-900 sm:pl-6" scope="row">
-                <% if Authorization.has_permission?(current_account.id, "Firewall:view", fw[:id]) %>
+                <% if has_permission?("Firewall:view", fw[:id]) %>
                   <a href="<%= @project_data[:path] %><%= fw[:path] %>"
                   class="text-orange-600 hover:text-orange-700"><%= fw[:name]
                   %></a>

--- a/views/networking/firewall/show.erb
+++ b/views/networking/firewall/show.erb
@@ -41,7 +41,7 @@
         <tr>
           <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
           <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Port range</th>
-          <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
+          <% if has_permission?("Firewall:edit", @firewall[:id]) %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           <% end %>
         </tr>
@@ -51,7 +51,7 @@
           <tr>
             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:port_range] %></td>
-            <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
+            <% if has_permission?("Firewall:edit", @firewall[:id]) %>
               <td
                 id="fwr-delete-<%=fwr[:id]%>"
                 class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
@@ -61,7 +61,7 @@
             <% end %>
           </tr>
         <% end %>
-        <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
+        <% if has_permission?("Firewall:edit", @firewall[:id]) %>
           <tr>
             <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST">
               <%== csrf_tag("#{request.path}/firewall-rule") %>
@@ -102,7 +102,7 @@
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-          <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
+          <% if has_permission?("Firewall:edit", @firewall[:id]) %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           <% end %>
         </tr>
@@ -125,7 +125,7 @@
             </form>
           </tr>
         <% end %>
-        <% if Authorization.has_permission?(current_account.id, "Firewall:edit", @firewall[:id]) %>
+        <% if has_permission?("Firewall:edit", @firewall[:id]) %>
           <tr>
             <form action="<%= "#{request.path}/attach-subnet" %>" role="form" method="POST">
               <%== csrf_tag("#{request.path}/attach-subnet") %>
@@ -152,7 +152,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_account.id, "Firewall:delete", @firewall[:id]) %>
+  <% if has_permission?("Firewall:delete", @firewall[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/networking/load_balancer/show.erb
+++ b/views/networking/load_balancer/show.erb
@@ -49,7 +49,7 @@
         <tr>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">VM</th>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Application State</th>
-          <% if Authorization.has_permission?(current_account.id, "LoadBalancer:edit", @lb[:id]) %>
+          <% if has_permission?("LoadBalancer:edit", @lb[:id]) %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           <% end %>
         </tr>
@@ -75,7 +75,7 @@
             </form>
           </tr>
         <% end %>
-        <% if Authorization.has_permission?(current_account.id, "LoadBalancer:edit", @lb[:id]) %>
+        <% if has_permission?("LoadBalancer:edit", @lb[:id]) %>
           <tr>
             <form action="<%= "#{request.path}/attach-vm" %>" role="form" method="POST">
               <%== csrf_tag("#{request.path}/attach-vm") %>
@@ -104,7 +104,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_account.id, "LoadBalancer:delete", @lb[:id]) %>
+  <% if has_permission?("LoadBalancer:delete", @lb[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -95,7 +95,7 @@
         <% @ps[:firewalls].each do |fw| %>
           <tr>
             <td class="whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-              <% if Authorization.has_permission?(current_account.id, "Firewall:view", fw[:id]) %>
+              <% if has_permission?("Firewall:view", fw[:id]) %>
                 <a
                   href="<%= "#{@project_data[:path]}/location/#{fw[:location]}/firewall/#{fw[:name]}" %>"
                   class="text-orange-600 hover:text-orange-700"
@@ -130,7 +130,7 @@
         <% @connected_subnets.each do |subnet| %>
           <tr>
             <td class="whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-              <% if Authorization.has_permission?(current_account.id, "PrivateSubnet:view", subnet[:id]) %>
+              <% if has_permission?("PrivateSubnet:view", subnet[:id]) %>
                 <a
                   href="<%= "#{@project_data[:path]}/location/#{subnet[:location]}/private-subnet/#{subnet[:name]}" %>"
                   class="text-orange-600 hover:text-orange-700"
@@ -179,7 +179,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_account.id, "PrivateSubnet:delete", @ps[:id]) %>
+  <% if has_permission?("PrivateSubnet:delete", @ps[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -203,7 +203,7 @@
     </div>
   <% end %>
   <!-- Firewall Rules Card -->
-  <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:view", @pg[:id]) %>
+  <% if has_permission?("Postgres:Firewall:view", @pg[:id]) %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
         <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
@@ -217,7 +217,7 @@
           <tr>
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Port Range</th>
-            <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:edit", @pg[:id]) %>
+            <% if has_permission?("Postgres:Firewall:edit", @pg[:id]) %>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
             <% end %>
           </tr>
@@ -227,7 +227,7 @@
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432</td>
-              <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:edit", @pg[:id]) %>
+              <% if has_permission?("Postgres:Firewall:edit", @pg[:id]) %>
                 <td
                   id="fwr-delete-<%=fwr[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
@@ -237,7 +237,7 @@
               <% end %>
             </tr>
           <% end %>
-          <% if Authorization.has_permission?(current_account.id, "Postgres:Firewall:edit", @pg[:id]) %>
+          <% if has_permission?("Postgres:Firewall:edit", @pg[:id]) %>
             <tr>
               <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST">
                 <%== csrf_tag("#{request.path}/firewall-rule") %>
@@ -268,7 +268,7 @@
     </div>
   <% end %>
   <!-- Metric Destination Card -->
-  <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
+  <% if has_permission?("Postgres:edit", @pg[:id]) %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
         <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
@@ -283,7 +283,7 @@
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">URL</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Username</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Password</th>
-            <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
+            <% if has_permission?("Postgres:edit", @pg[:id]) %>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
             <% end %>
           </tr>
@@ -294,7 +294,7 @@
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= md[:url] %></td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= md[:username] %></td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">●●●●●●</td>
-              <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
+              <% if has_permission?("Postgres:edit", @pg[:id]) %>
                 <td
                   id="md-delete-<%=md[:id]%>"
                   class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
@@ -304,7 +304,7 @@
               <% end %>
             </tr>
           <% end %>
-          <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
+          <% if has_permission?("Postgres:edit", @pg[:id]) %>
             <tr>
               <form action="<%= "#{request.path}/metric-destination" %>" role="form" method="POST">
                 <%== csrf_tag("#{request.path}/metric-destination") %>
@@ -338,10 +338,10 @@
       </table>
     </div>
   <% end %>
-  <% if Authorization.has_permission?(current_account.id, ["Postgres:edit", "Postgres:delete"], @pg[:id]) %>
+  <% if has_permission?(["Postgres:edit", "Postgres:delete"], @pg[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <!-- Restart Card -->
-      <% if Authorization.has_permission?(current_account.id, "Postgres:edit", @pg[:id]) %>
+      <% if has_permission?("Postgres:edit", @pg[:id]) %>
         <div class="px-4 py-5 sm:p-6">
           <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restart" %>" role="form" method="POST">
             <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restart") %>
@@ -363,7 +363,7 @@
         </div>
       <% end %>
       <!-- Delete Card -->
-      <% if Authorization.has_permission?(current_account.id, "Postgres:delete", @pg[:id]) %>
+      <% if has_permission?("Postgres:delete", @pg[:id]) %>
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -22,7 +22,7 @@
         data: [
           ["ID", @project_data[:id]],
           (
-            if Authorization.has_permission?(current_account.id, "Project:edit", @project_data[:id])
+            if has_permission?("Project:edit", @project_data[:id])
               [
                 "Name",
                 render(
@@ -73,7 +73,7 @@
 
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_account.id, "Project:delete", @project_data[:id]) %>
+  <% if has_permission?("Project:delete", @project_data[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -74,7 +74,7 @@
           <% fw[:firewall_rules].each do |fwr| %>
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-                <% if Authorization.has_permission?(current_account.id, "Firewall:view", fw[:id]) %>
+                <% if has_permission?("Firewall:view", fw[:id]) %>
                   <a
                     href="<%= "#{@project_data[:path]}/location/#{fw[:location]}/firewall/#{fw[:name]}" %>"
                     class="text-orange-600 hover:text-orange-700"
@@ -92,7 +92,7 @@
     </table>
   </div>
   <!-- Delete Card -->
-  <% if Authorization.has_permission?(current_account.id, "Vm:delete", @vm[:id]) %>
+  <% if has_permission?("Vm:delete", @vm[:id]) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">


### PR DESCRIPTION
These have the following advantages:

* DRYs up code in all of the routes
* Improves performance by not loading current_account unnecessarily
  (if only the id is needed, no reason to load the Account from the 
  database)
* Will allow transparent support for personal access token
  authorization when that is added.

Submitting as a draft, as this depends on #2277.  Will rebase and switch to non-draft after #2277 is merged.