### PR TITLE
Proof of concept that access_tag.hyper_tag_table is not needed

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -62,7 +62,9 @@ class Project < Sequel::Model
   end
 
   def has_resources
-    access_tags_dataset.exclude(hyper_tag_table: [Account.table_name.to_s, Project.table_name.to_s, AccessTag.table_name.to_s]).count > 0 || github_installations.flat_map(&:runners).count > 0
+    hyper_tag_type_number = (Sequel.join(["0x", Sequel.function(:substr, Sequel[:hyper_tag_id].cast(String), 16, 3)]).cast(Float).cast_numeric % 0x400)
+    allowed_hyper_tag_type_numbers = [Account, Project, AccessTag].map { UBID.type_number(_1) }
+    access_tags_dataset.exclude(hyper_tag_type_number => allowed_hyper_tag_type_numbers).count > 0 || github_installations.flat_map(&:runners).count > 0
   end
 
   def soft_delete

--- a/ubid.rb
+++ b/ubid.rb
@@ -214,6 +214,15 @@ class UBID
     "#<UBID:#{TYPE2CLASSNAME[to_s[..1]] || "Unknown"} @ubid=#{to_s.inspect} @uuid=#{to_uuid.inspect}>"
   end
 
+  CLASSNAME2YTPE = TYPE2CLASSNAME.invert.freeze
+  def self.type_number(klass)
+    to_base32_n(CLASSNAME2YTPE[klass.name.to_sym])
+  end
+
+  # def type_number
+  #  UBID.get_bits(@value, 64, 73)
+  # end
+
   #
   # Utility functions
   #


### PR DESCRIPTION
As the uuids encode type information, you can determine the table from the uuid, so the hyper_tag_table column is redundant.

To get the 10-bit type information from the uuid in the database:

* Turn it into a string
* Take characters 16-18 and convert the hex value to integer, modulo 0x400

To get the 10-bit type information from an existing uuid integer:

* Take bits 64-73 (UBID#type_number, though it is commented out)

To get the same 10-bit type information for a class:

* Get base32-encoded 2 byte type prefix from TYPE2CLASSNAME, convert to integer (UBID.type_number)

The hyper_tag_table column appears to be used only in a single place, and this converts that usage to using the hyper_tag_id value instead.

The same is true of applied_tag.tagged_table, as that is not even used (it is returned in an authorization query, but all specs pass when it is removed from the query).