### PR TITLE
Exclude more lines from runner script logs

### DIFF
--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).to receive(:private_subnets).and_return([ps])
       expect(vm).to receive(:vm_host).and_return(vm_host).at_least(:once)
       expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
+      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
       expect(vm).to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")
@@ -573,7 +573,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       vm_host = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vm_host).at_least(:once)
       expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
+      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
       expect(vm).to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")
@@ -601,7 +601,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
       expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"}).at_least(:once)
       expect(sshable).not_to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).not_to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -v -e Started -e sudo")
+      expect(sshable).not_to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -e run-withenv -e systemd | grep -v -e Started")
       expect(vm).to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")


### PR DESCRIPTION
When a job fails, we log the runner script's output for any necessary further investigation. We have excluded the JIT token line and sudo lines.

But other logs include outputs from subprocesses like php, sudo, etc., which could contain sensitive data. `run-withenv` is the main process, while `systemd` lines provide valuable insights into the lifecycle of the runner script, including OOM issues. We exclude the 'Started' line to avoid exposing the JIT token.