### PR TITLE
Make no capacity status more visible

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -60,7 +60,10 @@ class Vm < Sequel::Model
 
   def display_state
     return "deleting" if destroy_set? || strand&.label == "destroy"
-    return "waiting for capacity" if waiting_for_capacity_set?
+    if waiting_for_capacity_set?
+      return "no capacity available" if Time.now - created_at > 15 * 60
+      return "waiting for capacity"
+    end
     super
   end
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -3,7 +3,7 @@
 require_relative "spec_helper"
 
 RSpec.describe Vm do
-  subject(:vm) { described_class.new(display_state: "creating") }
+  subject(:vm) { described_class.new(display_state: "creating", created_at: Time.now) }
 
   describe "#display_state" do
     it "returns deleting if destroy semaphore increased" do
@@ -14,6 +14,12 @@ RSpec.describe Vm do
     it "returns waiting for capacity if semaphore increased" do
       expect(vm).to receive(:semaphores).twice.and_return([instance_double(Semaphore, name: "waiting_for_capacity")])
       expect(vm.display_state).to eq("waiting for capacity")
+    end
+
+    it "returns no capacity available if it's waiting capacity more than 15 minutes" do
+      expect(vm).to receive(:created_at).and_return(Time.now - 16 * 60)
+      expect(vm).to receive(:semaphores).twice.and_return([instance_double(Semaphore, name: "waiting_for_capacity")])
+      expect(vm.display_state).to eq("no capacity available")
     end
 
     it "return same if semaphores not increased" do

--- a/views/components/page_header.erb
+++ b/views/components/page_header.erb
@@ -1,7 +1,12 @@
 <div class="md:flex md:items-center md:justify-between pb-4">
-  <div class="min-w-0 flex-1">
+  <div class="min-w-0">
     <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight"><%= title %></h2>
   </div>
+  <% if defined?(left_items) %>
+    <div class="mt-4 flex md:ml-4 md:mt-0 mr-auto">
+      <%== left_items.join %>
+    </div>
+  <% end %>
   <% if defined?(right_items) %>
     <div class="mt-4 flex md:ml-4 md:mt-0">
       <%== right_items.join %>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -20,7 +20,7 @@
     "components/page_header",
     locals: {
       title: @vm[:name],
-      right_items: [render("components/vm_state_label", locals: { state: @vm[:state], extra_class: "text-md" })]
+      left_items: [render("components/vm_state_label", locals: { state: @vm[:state], extra_class: "text-md" })]
     }
   ) %>
 </div>


### PR DESCRIPTION
### **Show the vm status next to its name in the UI**
  We currently display the VM status to the right of the page in the UI,
  but on larger screens, it's easy to overlook.
  
  Moving the status to the left side of the VM name will make it more
  visible.
  
| Before | After |
|--------|-------|
| <img width="1508" alt="Screenshot 2024-11-20 at 22 37 46" src="https://github.com/user-attachments/assets/8f4b787f-4fdd-48cf-b36b-19e56a75a0fc"> | <img width="1512" alt="Screenshot 2024-11-20 at 22 33 58" src="https://github.com/user-attachments/assets/67432d28-aa3d-4959-8a55-454b04cc9d69"> |

### **Show "no capacity available" as vm status if waiting for capacity for +15m**

<img width="1512" alt="Screenshot 2024-11-20 at 22 33 50" src="https://github.com/user-attachments/assets/253e45fa-9080-4ae4-8264-4a20fd6d978b">
