### PR TITLE
Double production_check timeout, and increase output

### DIFF
--- a/bin/production_check
+++ b/bin/production_check
@@ -25,6 +25,7 @@ Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma") do |stdin, 
       case line
       when /\A\* Listening on /
         works = true
+        puts line
         queue.push(true)
         Process.kill(:TERM, pid)
         break
@@ -34,6 +35,8 @@ Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma") do |stdin, 
         queue.push(true)
         Process.kill(:TERM, pid)
         break
+      else
+        puts line
       end
     end
   end

--- a/bin/production_check
+++ b/bin/production_check
@@ -13,7 +13,7 @@ Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma") do |stdin, 
   pid = wait_thr.pid
 
   timer_thread = Thread.new do
-    queue.pop(timeout: 3)
+    queue.pop(timeout: 6)
     if works.nil?
       error = "Timeout"
       Process.kill(:KILL, pid)


### PR DESCRIPTION
We had a timeout failure in the Ruby arm CI for production_check.  This doubles the timeout, and makes it print the stdout received (stderr was already printed), to ease debugging.