### PR TITLE
DRY up r.rodauth call in main route, and move after check_active_session

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -203,6 +203,7 @@ class Clover < Roda
       :otp, :webauthn, :recovery_codes
 
     title_instance_variable :@page_title
+    check_csrf? false
 
     # :nocov:
     unless Config.development?
@@ -496,7 +497,6 @@ class Clover < Roda
     if api?
       response.json = true
       response.skip_content_security_policy!
-      r.rodauth
     else
       r.on "runtime" do
         @is_runtime = true
@@ -517,8 +517,6 @@ class Clover < Roda
         r.hash_branches(:webhook_prefix)
       end
 
-      r.rodauth
-
       check_csrf!
       rodauth.load_memory
 
@@ -527,6 +525,7 @@ class Clover < Roda
       end
     end
 
+    r.rodauth
     rodauth.check_active_session
     rodauth.require_authentication
     r.hash_branches("")

--- a/clover.rb
+++ b/clover.rb
@@ -525,8 +525,8 @@ class Clover < Roda
       end
     end
 
-    r.rodauth
     rodauth.check_active_session
+    r.rodauth
     rodauth.require_authentication
     r.hash_branches("")
   end


### PR DESCRIPTION
This changes where r.rodauth is called for web routes, moving it after check_csrf!, rodauth.load_memory, and the root route.

To avoid double checking CSRF token after moving it after check_csrf!, set check_csrf? false in the Rodauth configuration.

The rodauth.load_memory change is probably better to have before r.rodauth than after, so if they logged in with the remember cookie, the rodauth pages will treat them requested as logged in.

For the root route, it just redirects to the login route, so it doesn't matter if it is before or after r.rodauth.  

For both the web routes and api routes, this moves r.rodauth after rodauth.check_active_session, so that if there is no active session, the rodauth routes will not treat the request as being authenticated.