### PR TITLE
Verify the purge logic in E2E tests.

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -55,7 +55,7 @@ def main(options)
   # No need to make it parallel.
   tests_to_wait.each { |st| wait_until(st) }
 
-  Semaphore.incr(hetzner_server_st.id, "destroy")
+  Semaphore.incr(hetzner_server_st.id, "verify_cleanup_and_destroy")
   wait_until(hetzner_server_st)
 end
 

--- a/rhizome/host/e2e/storage_volume_e2e_spec.rb
+++ b/rhizome/host/e2e/storage_volume_e2e_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe StorageVolume do
 
   after do
     r "sudo userdel --remove #{vm}"
+
+    # YYY: Don't delete manually after moving the storage dir purge logic from
+    # vm_setup.rb to storage_volume.rb.
+    rm_if_exists("/var/storage/#{vm}")
   end
 
   describe "#encrypted_storage_volume" do


### PR DESCRIPTION
In the past, bugs in the purge logic went unnoticed, causing outages. This PR adds a step to the E2E tests to verify that resources are actually purged after VMs are destroyed.