### PR TITLE
Make clog.rb require sequel/model

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "sequel/model"
 
 class Clog
   MUTEX = Mutex.new


### PR DESCRIPTION
It uses Sequel::Model internally, and without this require, spec/lib/clog_spec.rb fails if run in isolation.  Found by the spec_separate rake task.