### PR TITLE
Escape LIKE metacharacters when doing a prefix match in the runtime route

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -17,7 +17,9 @@ class Clover
       # We prioritize scope over key, returning the cache for the first matching
       # key in the head branch scope, followed by the first matching key in
       # default branch scope.
-      scopes = [runner.workflow_job&.dig("head_branch"), repository.default_branch].compact
+      scopes = [runner.workflow_job&.dig("head_branch"), repository.default_branch]
+      scopes.compact!
+      scopes.uniq!
 
       dataset = repository.cache_entries_dataset
         .exclude(committed_at: nil)

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -35,7 +35,7 @@ class Clover
       if entry.nil?
         entry = repository.cache_entries_dataset
           .exclude(committed_at: nil)
-          .where { keys.map { |key| Sequel.like(:key, "#{key}%") }.reduce(:|) }
+          .where { keys.map { |key| Sequel.like(:key, "#{DB.dataset.escape_like(key)}%") }.reduce(:|) }
           .where(version: version, scope: scopes)
           .order(Sequel.desc(:created_at))
           .first

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -39,8 +39,7 @@ class Clover
       #   for a restore key, the action returns the most recently created cache.
       entry ||= dataset
         .grep(:key, keys.map { |key| "#{DB.dataset.escape_like(key)}%" })
-        .reverse(:created_at)
-        .first
+        .min_by { |e| keys.find_index { |k| e.key.start_with?(k) } + (scopes.index(e.scope) * keys.size) }
 
       fail CloverError.new(204, "NotFound", "No cache entry") if entry.nil?
 

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -235,17 +235,17 @@ RSpec.describe Clover, "github" do
         expect(GithubCacheEntry[key: "k2", version: "v1", scope: "dev"].last_accessed_by).to eq(runner.id)
       end
 
-      it "partially matched key returns the most recently created cache" do
-        GithubCacheEntry.create_with_id(key: "k1234", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 2, created_by: runner.id, committed_at: Time.now)
-        GithubCacheEntry.create_with_id(key: "k12345", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 1, created_by: runner.id, committed_at: Time.now)
-        GithubCacheEntry.create_with_id(key: "k123456", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now, created_by: runner.id, committed_at: Time.now)
+      it "partially matched key returns the cache according to the order of incoming keys" do
+        GithubCacheEntry.create_with_id(key: "mix-dev-123", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 2, created_by: runner.id, committed_at: Time.now)
+        GithubCacheEntry.create_with_id(key: "mix-dev-main-123", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 1, created_by: runner.id, committed_at: Time.now)
+        GithubCacheEntry.create_with_id(key: "mix-prod-123", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now, created_by: runner.id, committed_at: Time.now)
 
         expect(url_presigner).to receive(:presigned_url).with(:get_object, anything).and_return("http://presigned-url")
-        get "/runtime/github/cache", {keys: "k12,k123", version: "v1"}
+        get "/runtime/github/cache", {keys: "mix-dev-main-,mix-dev-,mix-", version: "v1"}
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["k123456", "v1", "main"])
-        expect(GithubCacheEntry[key: "k123456", version: "v1", scope: "main"].last_accessed_by).to eq(runner.id)
+        expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["mix-dev-main-123", "v1", "main"])
+        expect(GithubCacheEntry[key: "mix-dev-main-123", version: "v1", scope: "main"].last_accessed_by).to eq(runner.id)
       end
 
       it "only does a prefix match on key, escapes LIKE metacharacters in submitted keys" do

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -247,6 +247,12 @@ RSpec.describe Clover, "github" do
         expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["k123456", "v1", "main"])
         expect(GithubCacheEntry[key: "k123456", version: "v1", scope: "main"].last_accessed_by).to eq(runner.id)
       end
+
+      it "only does a prefix match on key, escapes LIKE metacharacters in submitted keys" do
+        GithubCacheEntry.create_with_id(key: "k123456", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now, created_by: runner.id, committed_at: Time.now)
+        get "/runtime/github/cache", {keys: "%6", version: "v1"}
+        expect(last_response.status).to eq(204)
+      end
     end
 
     describe "lists cache entries" do


### PR DESCRIPTION
Not escaping LIKE metacharacters means that a prefix match isn't
forced if a user includes LIKE metacharacters in the key, which
can result in the index not being used.

While here, refactor runtime route entry setting:

* Use a dataset variable that can be shared by both cases.
* Switch from if entry.nil? to more idiomatic ||=.
* Use reverse instead of order with Sequel.desc.
* Use Dataset#grep to simplify prefix search.