### PR TITLE
Make coverage_pspec rake task exit 1 if there are failures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -218,6 +218,7 @@ task "coverage_pspec" do
     warn "SimpleCov failed with exit 2 due to a coverage related error"
     exit(2)
   end
+  exit(1) if command_output.include?("\nFailures:\n")
 ensure
   File.delete(output_file) if File.file?(output_file)
 end


### PR DESCRIPTION
It's possible to have 100% coverage, but still have failing tests. Use exit code 1 in this situation, to make it obvious there is an error.