### PR TITLE
Postgres Endpoint Adjustments

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -74,7 +74,10 @@ class Clover
       r.on "firewall-rule" do
         r.get api?, true do
           authorize("Postgres:Firewall:view", pg.id)
-          Serializers::PostgresFirewallRule.serialize(pg.firewall_rules)
+          {
+            items: Serializers::PostgresFirewallRule.serialize(pg.firewall_rules),
+            count: pg.firewall_rules.count
+          }
         end
 
         r.post true do

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -87,16 +87,16 @@ class Clover
           request_body_params = Validation.validate_request_body(json_params, required_parameters)
           parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
 
-          DB.transaction do
+          firewall_rule = DB.transaction do
+            pg.incr_update_firewall_rules
             PostgresFirewallRule.create_with_id(
               postgres_resource_id: pg.id,
               cidr: parsed_cidr.to_s
             )
-            pg.incr_update_firewall_rules
           end
 
           if api?
-            Serializers::Postgres.serialize(pg, {detailed: true})
+            Serializers::PostgresFirewallRule.serialize(firewall_rule, {detailed: true})
           else
             flash["notice"] = "Firewall rule is created"
             r.redirect "#{@project.path}#{pg.path}"

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -342,7 +342,8 @@ RSpec.describe Clover, "postgres" do
         get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule"
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)[0]["cidr"]).to eq("0.0.0.0/0")
+        expect(JSON.parse(last_response.body)["items"][0]["cidr"]).to eq("0.0.0.0/0")
+        expect(JSON.parse(last_response.body)["count"]).to eq(1)
       end
     end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe Clover, "postgres" do
           cidr: "0.0.0.0/24"
         }.to_json
 
+        expect(JSON.parse(last_response.body)["cidr"]).to eq("0.0.0.0/24")
         expect(last_response.status).to eq(200)
       end
 


### PR DESCRIPTION
@geemus found these abnormalities while typing the entire schema in openapi that look like oversights:

```
Serialize the Postgres firewall rule when POSTing to the same

This looks like an oversight, to not return the rule, but the Postgres
resource instance related to the rule.
```

```
Nest postgres firewall rules into "items" key

Other routes use use "items" to list things, so do this here too.
```