### PR TITLE
Avoid serializing and then deserializing params to JSON in web routes

### DIFF
--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -25,7 +25,7 @@ class Clover
 
     optional_parameters = %w[description]
     optional_parameters.concat(%w[name location private_subnet_id]) if web?
-    description = Validation.validate_request_body(json_params, [], optional_parameters)["description"] || ""
+    description = validate_request_params([], optional_parameters)["description"] || ""
 
     firewall = Firewall.create_with_id(
       name: firewall_name,

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -27,7 +27,7 @@ class Clover
     required_parameters = %w[private_subnet_id algorithm src_port dst_port health_check_protocol]
     required_parameters << "name" if web?
     optional_parameters = %w[health_check_endpoint]
-    request_body_params = Validation.validate_request_body(json_params, required_parameters, optional_parameters)
+    request_body_params = validate_request_params(required_parameters, optional_parameters)
 
     unless (ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"]))
       fail Validation::ValidationFailed.new("private_subnet_id" => "Private subnet not found")

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -10,7 +10,7 @@ class Clover
     required_parameters = ["size"]
     required_parameters << "name" << "location" if web?
     allowed_optional_parameters = ["storage_size", "ha_type", "version", "flavor"]
-    request_body_params = Validation.validate_request_body(json_params, required_parameters, allowed_optional_parameters)
+    request_body_params = validate_request_params(required_parameters, allowed_optional_parameters)
     parsed_size = Validation.validate_postgres_size(@location, request_body_params["size"])
 
     ha_type = request_body_params["ha_type"] || PostgresResource::HaType::NONE

--- a/helpers/private_subnet.rb
+++ b/helpers/private_subnet.rb
@@ -25,19 +25,16 @@ class Clover
   def private_subnet_post(name)
     authorize("PrivateSubnet:create", @project.id)
 
-    params = json_params
-    unless params.empty?
-      required_parameters = []
-      required_parameters << "name" << "location" if web?
-      request_body_params = Validation.validate_request_body(params, required_parameters, ["firewall_id"])
-      firewall_id = if request_body_params["firewall_id"]
-        fw = Firewall.from_ubid(request_body_params["firewall_id"])
-        unless fw && fw.location == @location
-          fail Validation::ValidationFailed.new(firewall_id: "Firewall with id \"#{request_body_params["firewall_id"]}\" and location \"#{@location}\" is not found")
-        end
-        authorize("Firewall:view", fw.id)
-        fw.id
+    required_parameters = []
+    required_parameters << "name" << "location" if web?
+    request_body_params = validate_request_params(required_parameters, ["firewall_id"])
+    firewall_id = if request_body_params["firewall_id"]
+      fw = Firewall.from_ubid(request_body_params["firewall_id"])
+      unless fw && fw.location == @location
+        fail Validation::ValidationFailed.new(firewall_id: "Firewall with id \"#{request_body_params["firewall_id"]}\" and location \"#{@location}\" is not found")
       end
+      authorize("Firewall:view", fw.id)
+      fw.id
     end
 
     st = Prog::Vnet::SubnetNexus.assemble(

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -27,7 +27,7 @@ class Clover
     required_parameters = ["public_key"]
     required_parameters << "name" << "location" if web?
     allowed_optional_parameters = ["size", "storage_size", "unix_user", "boot_image", "enable_ip4", "private_subnet_id"]
-    request_body_params = Validation.validate_request_body(json_params, required_parameters, allowed_optional_parameters)
+    request_body_params = validate_request_params(required_parameters, allowed_optional_parameters)
     assemble_params = request_body_params.slice(*allowed_optional_parameters).compact
 
     # Generally parameter validation is handled in progs while creating resources.

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -196,13 +196,7 @@ module Validation
     port.to_i
   end
 
-  def self.validate_request_body(request_body, required_keys, allowed_optional_keys = [])
-    begin
-      request_body_params = JSON.parse(request_body)
-    rescue JSON::ParserError
-      fail ValidationFailed.new({body: "Request body isn't a valid JSON object."})
-    end
-
+  def self.validate_request_params(request_body_params, required_keys, allowed_optional_keys = [])
     missing_required_keys = required_keys - request_body_params.keys
     unless missing_required_keys.empty?
       fail ValidationFailed.new({body: "Request body must include required parameters: #{missing_required_keys.join(", ")}"})

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -24,7 +24,7 @@ class Clover
 
     r.post true do
       required_parameters = ["name"]
-      request_body_params = Validation.validate_request_body(json_params, required_parameters)
+      request_body_params = validate_request_params(required_parameters)
       project = current_account.create_project_with_default_policy(request_body_params["name"])
 
       if api?

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -56,7 +56,7 @@ class Clover
       r.post %w[attach-subnet detach-subnet] do |action|
         authorize("Firewall:view", firewall.id)
 
-        private_subnet_id = Validation.validate_request_body(json_params, ["private_subnet_id"])["private_subnet_id"]
+        private_subnet_id = validate_request_params(["private_subnet_id"])["private_subnet_id"]
         private_subnet = PrivateSubnet.from_ubid(private_subnet_id)
 
         unless private_subnet && private_subnet.location == @location

--- a/routes/project/location/firewall/firewall_rule.rb
+++ b/routes/project/location/firewall/firewall_rule.rb
@@ -10,7 +10,7 @@ class Clover
       required_parameters = ["cidr"]
       allowed_optional_parameters = ["port_range"]
 
-      request_body_params = Validation.validate_request_body(request.body.read, required_parameters, allowed_optional_parameters)
+      request_body_params = validate_request_params(required_parameters, allowed_optional_parameters)
 
       parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
       port_range = if request_body_params["port_range"].nil?

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -28,7 +28,7 @@ class Clover
       r.post %w[attach-vm detach-vm] do |action|
         authorize("LoadBalancer:edit", lb.id)
         required_parameters = %w[vm_id]
-        request_body_params = Validation.validate_request_body(json_params, required_parameters)
+        request_body_params = validate_request_params(required_parameters)
 
         unless (vm = Vm.from_ubid(request_body_params["vm_id"]))
           fail Validation::ValidationFailed.new("vm_id" => "VM not found")
@@ -77,7 +77,7 @@ class Clover
 
       r.patch api? do
         authorize("LoadBalancer:edit", lb.id)
-        request_body_params = Validation.validate_request_body(json_params, %w[algorithm src_port dst_port health_check_endpoint vms])
+        request_body_params = validate_request_params(%w[algorithm src_port dst_port health_check_endpoint vms])
         lb.update(
           algorithm: request_body_params["algorithm"],
           src_port: Validation.validate_port(:src_port, request_body_params["src_port"]),

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -84,7 +84,7 @@ class Clover
           authorize("Postgres:Firewall:edit", pg.id)
 
           required_parameters = ["cidr"]
-          request_body_params = Validation.validate_request_body(json_params, required_parameters)
+          request_body_params = validate_request_params(required_parameters)
           parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
 
           firewall_rule = DB.transaction do
@@ -122,7 +122,7 @@ class Clover
           authorize("Postgres:edit", pg.id)
 
           required_parameters = ["url", "username", "password"]
-          request_body_params = Validation.validate_request_body(json_params, required_parameters)
+          request_body_params = validate_request_params(required_parameters)
 
           Validation.validate_url(request_body_params["url"])
 
@@ -164,7 +164,7 @@ class Clover
         authorize("Postgres:view", pg.id)
 
         required_parameters = ["name", "restore_target"]
-        request_body_params = Validation.validate_request_body(json_params, required_parameters)
+        request_body_params = validate_request_params(required_parameters)
 
         st = Prog::Postgres::PostgresResourceNexus.assemble(
           project_id: @project.id,
@@ -200,7 +200,7 @@ class Clover
         end
 
         required_parameters = api? ? ["password"] : ["password", "repeat_password"]
-        request_body_params = Validation.validate_request_body(json_params, required_parameters)
+        request_body_params = validate_request_params(required_parameters)
         Validation.validate_postgres_superuser_password(request_body_params["password"], request_body_params["repeat_password"])
 
         DB.transaction do


### PR DESCRIPTION
Previously, Validation.validate_request_body was used in many routes. This expected a JSON string as input, which was reasonable for api requests, but counterproductive for web requests, because it required taking the already deserialized params, reserializing them to JSON, and then have the method deserialize the JSON representation.

Replace Validation.validate_request_body with
Validation.validate_request_params, which takes deserialized params. Introduce Clover#validate_request_params, which calls Validation.validate_request_params with the appropriate params. This DRYs up callers in all routes. Clover#validate_request_params relies on the json_parser Roda plugin to parse the request body to parameters.

Delete Clover#json_params, which only had one caller after this. In the private subnet route that was using it, just drop the call, and always do appropriate validation. The previous code did not validate the name and location parameters in the web case, which I think was a mistake.