### PR TITLE
Only serialize feature flags in the web serialization

### DIFF
--- a/routes/project.rb
+++ b/routes/project.rb
@@ -17,7 +17,7 @@ class Clover
           count: result[:count]
         }
       else
-        @projects = Serializers::Project.serialize(dataset.all, {include_path: true})
+        @projects = Serializers::Project.serialize(dataset.all, {include_path: true, web: true})
         view "project/index"
       end
     end
@@ -49,7 +49,7 @@ class Clover
         fail Authorization::Unauthorized
       end
 
-      @project_data = Serializers::Project.serialize(@project, {include_path: true})
+      @project_data = Serializers::Project.serialize(@project, {include_path: true, web: true})
       @project_permissions = all_permissions(@project.id)
 
       r.get true do

--- a/serializers/project.rb
+++ b/serializers/project.rb
@@ -6,12 +6,15 @@ class Serializers::Project < Serializers::Base
       id: p.ubid,
       name: p.name,
       credit: p.credit.to_f,
-      discount: p.discount,
-      feature_flags: p.feature_flags
+      discount: p.discount
     }
 
     if options[:include_path]
       base[:path] = p.path
+    end
+
+    if options[:web]
+      base[:feature_flags] = p.feature_flags
     end
 
     base


### PR DESCRIPTION
An opaque hash of feature flags is awkward to type in openapi schema, and was only used in the web views.  So limit it only to a "web" variant of the serializer, and leave it out of the API.

It raises at least one question: is what's going on for the web views in fact a "serialization" at all?