### PR TITLE
Use official cache action packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,13 @@ jobs:
         fi
 
     - name: Set up Ruby
-      uses: ubicloud/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: .tool-versions
         bundler-cache: true
 
     - name: Set up Node.js
-      uses: ubicloud/setup-node@v4
+      uses: actions/setup-node@v4
       with:
          node-version: "22"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Cache ngrok binary
       id: cache-ngrok
-      uses: ubicloud/cache@v4
+      uses: actions/cache@v4
       with:
         path: /usr/local/bin/ngrok
         key: ngrok-binary


### PR DESCRIPTION
We began testing our transparent cache implementation. With this new feature, customers can now use Ubicloud Cache even with official cache action packages, eliminating the need for our forked packages.