### PR TITLE
Add name validation for projects

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -121,6 +121,13 @@ class Project < Sequel::Model
     ApiKey.create_with_id(owner_table: Project.table_name, owner_id: id, used_for: used_for)
   end
 
+  def validate
+    super
+    if new? || changed_columns.include?(:name)
+      validates_format(%r{\A[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\z}i, :name)
+    end
+  end
+
   def self.feature_flag(*flags, into: self)
     flags.map(&:to_s).each do |flag|
       into.module_eval do

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -8,13 +8,13 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   IN_PROGRESS_CONCLUSIONS = ["in_progress", "queued", "requested", "waiting", "pending", "neutral"]
 
   def self.assemble(vm_host_id, test_cases)
-    github_service_project = Project.create(name: "Github Runner Service Project") { _1.id = Config.github_runner_service_project_id }
+    github_service_project = Project.create(name: "Github-Runner-Service-Project") { _1.id = Config.github_runner_service_project_id }
     github_service_project.associate_with_project(github_service_project)
 
-    vm_pool_service_project = Project.create(name: "Vm Pool Service Project") { _1.id = Config.vm_pool_project_id }
+    vm_pool_service_project = Project.create(name: "Vm-Pool-Service-Project") { _1.id = Config.vm_pool_project_id }
     vm_pool_service_project.associate_with_project(vm_pool_service_project)
 
-    github_test_project = Project.create_with_id(name: "Github Runner Test Project")
+    github_test_project = Project.create_with_id(name: "Github-Runner-Test-Project")
     github_test_project.associate_with_project(github_test_project)
     GithubInstallation.create_with_id(
       installation_id: Config.e2e_github_installation_id,

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -20,7 +20,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def setup_vms
-    project = Project.create_with_id(name: "project 1")
+    project = Project.create_with_id(name: "project-1")
     project.associate_with_project(project)
 
     subnet1_s = Prog::Vnet::SubnetNexus.assemble(

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -6,6 +6,47 @@ require "octokit"
 RSpec.describe Project do
   subject(:project) { described_class.create_with_id(name: "test") }
 
+  describe "#validate" do
+    it "validates that name for new object is not empty and has correct format" do
+      project = described_class.new
+      expect(project.valid?).to be false
+      expect(project.errors[:name]).to eq(["is not present", "is invalid"])
+
+      project.name = "@"
+      expect(project.valid?).to be false
+      expect(project.errors[:name]).to eq(["is invalid"])
+
+      project.name = "a"
+      expect(project.valid?).to be true
+
+      project.name = "a-"
+      expect(project.valid?).to be false
+      expect(project.errors[:name]).to eq(["is invalid"])
+
+      project.name = "a-b"
+      expect(project.valid?).to be true
+
+      project.name = "a-#{"b" * 63}"
+      expect(project.valid?).to be false
+      expect(project.errors[:name]).to eq(["is invalid"])
+    end
+
+    it "validates that name for existing object is valid if the name has changed" do
+      expect(project.valid?).to be true
+
+      project.name = "-"
+      expect(project.valid?).to be false
+      expect(project.errors[:name]).to eq(["is invalid"])
+
+      project.name = "a"
+      expect(project.valid?).to be true
+
+      project.name = "@"
+      expect(project.valid?).to be false
+      expect(project.errors[:name]).to eq(["is invalid"])
+    end
+  end
+
   describe ".has_valid_payment_method?" do
     it "returns true when Stripe not enabled" do
       expect(Config).to receive(:stripe_secret_key).and_return(nil)

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Prog::Test::VmGroup do
     end
 
     it "runs tests for the first connected subnet" do
-      prj = Project.create_with_id(name: "project 1")
+      prj = Project.create_with_id(name: "project-1")
       prj.associate_with_project(prj)
       ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-fsn1").subject
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-fsn1").subject
@@ -74,7 +74,7 @@ RSpec.describe Prog::Test::VmGroup do
     end
 
     it "runs tests for the second connected subnet" do
-      prj = Project.create_with_id(name: "project 1")
+      prj = Project.create_with_id(name: "project-1")
       prj.associate_with_project(prj)
       ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-fsn1").subject
       expect(ps1).to receive(:vms).and_return([instance_double(Vm, id: "vm1"), instance_double(Vm, id: "vm2")]).at_least(:once)
@@ -146,7 +146,7 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#finish" do
     it "exits" do
-      project = Project.create_with_id(name: "project 1")
+      project = Project.create_with_id(name: "project-1")
       allow(vg_test).to receive(:frame).and_return({"project_id" => project.id})
       expect { vg_test.finish }.to exit({"msg" => "VmGroup tests finished!"})
     end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Clover, "auth" do
   end
 
   it "can create new account, verify it, and visit project which invited" do
-    p = Project.create_with_id(name: "Invited project").tap { _1.associate_with_project(_1) }
+    p = Project.create_with_id(name: "Invited-project").tap { _1.associate_with_project(_1) }
     p.add_invitation(email: TEST_USER_EMAIL, inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)
 
     visit "/create-account"
@@ -68,7 +68,7 @@ RSpec.describe Clover, "auth" do
   end
 
   it "can create new account, verify it, and visit project which invited with default policy" do
-    p = Project.create_with_id(name: "Invited project").tap { _1.associate_with_project(_1) }
+    p = Project.create_with_id(name: "Invited-project").tap { _1.associate_with_project(_1) }
     p.add_invitation(email: TEST_USER_EMAIL, policy: "admin", inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)
 
     visit "/create-account"

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Clover, "project" do
       end
 
       it "can update the project name" do
-        new_name = "New Project Name"
+        new_name = "New-Project-Name"
         visit project.path
 
         fill_in "name", with: new_name


### PR DESCRIPTION
Currently, even projects with empty names are allowed. The UI tries to avoid this by using a required attribute on the inputs, but it's trivial for users to work around that.

To not break existing projects with invalid names, only validate for new projects, and when the project's name has changed.

For the validation format, use a case-insensitive version of Validation::ALLOWED_NAME_PATTERN.