### PR TITLE
Allow resource creation if the project has credit

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -39,7 +39,7 @@ class Project < Sequel::Model
 
   def has_valid_payment_method?
     return true unless Config.stripe_secret_key
-    !!billing_info&.payment_methods&.any?
+    !!billing_info&.payment_methods&.any? || (!!billing_info && credit > 0)
   end
 
   def default_location

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -4,7 +4,7 @@ require_relative "spec_helper"
 require "octokit"
 
 RSpec.describe Project do
-  subject(:project) { described_class.new }
+  subject(:project) { described_class.create_with_id(name: "test") }
 
   describe ".has_valid_payment_method?" do
     it "returns true when Stripe not enabled" do
@@ -14,22 +14,21 @@ RSpec.describe Project do
 
     it "returns false when no billing info" do
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
-      expect(project).to receive(:billing_info).and_return(nil)
       expect(project.has_valid_payment_method?).to be false
     end
 
     it "returns false when no payment method" do
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
-      bi = instance_double(BillingInfo, payment_methods: [])
-      expect(project).to receive(:billing_info).and_return(bi)
+      bi = BillingInfo.create_with_id(stripe_id: "cus")
+      project.update(billing_info_id: bi.id)
       expect(project.has_valid_payment_method?).to be false
     end
 
     it "returns true when has valid payment method" do
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
-      pm = instance_double(PaymentMethod)
-      bi = instance_double(BillingInfo, payment_methods: [pm])
-      expect(project).to receive(:billing_info).and_return(bi)
+      bi = BillingInfo.create_with_id(stripe_id: "cus123")
+      PaymentMethod.create_with_id(billing_info_id: bi.id, stripe_id: "pm123")
+      project.update(billing_info_id: bi.id)
       expect(project.has_valid_payment_method?).to be true
     end
 

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Project do
       expect(project.has_valid_payment_method?).to be true
     end
 
+    it "returns true when has some credits" do
+      expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      bi = BillingInfo.create_with_id(stripe_id: "cus")
+      project.update(billing_info_id: bi.id, credit: 100)
+      expect(project.has_valid_payment_method?).to be true
+    end
+
     it "sets and gets feature flags" do
       mod = Module.new
       described_class.feature_flag(:dummy_flag, into: mod)


### PR DESCRIPTION
### Do not mock project in model tests

### Allow resource creation if the project has credit

We expect our customers to add a payment method to create resources,
which helps us prevent fraud.

However, sometimes customers want to pay by bank transfer and prefer not
to add a payment method.

We should allow the creation of new resources if the project has credit.
But we need to create billing information for the customer without
payment method since we require it for invoicing.
