### PR TITLE
Add a test for broken links

### DIFF
--- a/views/project/index.erb
+++ b/views/project/index.erb
@@ -5,7 +5,7 @@
     <%== render(
       "components/page_header",
       locals: {
-        right_items: [render("components/button", locals: { text: "Create Project", link: "project/create" })]
+        right_items: [render("components/button", locals: { text: "Create Project", link: "/project/create" })]
       }
     ) %>
   </div>


### PR DESCRIPTION
This implements a simple spider that checks all user accessible links
after login.

This also changes one link from a relative path to an absolute path,
since the simple spider only deals with absolute paths.

This is currently in draft as the test fails, because the "Update
Access Policy" link on the project dashboard is currently a broken
link.