### PR TITLE
Change "rake" to "bundle exec rake" in the demo docker-compose file.

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       postgres:
         condition: service_healthy
     env_file: .env
-    command: rake dev_up
+    command: bundle exec rake dev_up
 
   app:
     image: ubicloud/ubicloud:latest


### PR DESCRIPTION
When we use GitHub references in the Gemfile, we need to use `bundle exec rake` instead of `rake` to avoid the error `rake aborted! LoadError: cannot load such file`.

Currently, the "sequel" gem is using a GitHub reference in the Gemfile. Since we change references over time, using "bundle exec rake" is a better choice.

Fixes #2325