### PR TITLE
Check the job scope from the GitHub API if the webhook is delayed

### DIFF
--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -9,4 +9,28 @@ class Clover < Roda
     rescue JWT::DecodeError
     end
   end
+
+  def get_scope_from_github(runner, run_id)
+    log_context = {runner_ubid: runner.ubid, repository_ubid: runner.repository.ubid, run_id: run_id}
+    if run_id.nil? || run_id.empty?
+      Clog.emit("The run_id is blank") { {runner_scope_failure: log_context} }
+      return
+    end
+
+    Clog.emit("Get runner scope from GitHub API") { {get_runner_scope: log_context} }
+    client = Github.installation_client(runner.installation.installation_id)
+    begin
+      jobs = client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
+    rescue Octokit::ClientError => ex
+      log_context[:expection] = Util.exception_to_hash(ex)
+      Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }
+      return
+    end
+    if (job = jobs.find { _1[:runner_name] == runner.ubid })
+      job[:head_branch]
+    else
+      Clog.emit("The workflow run does not have given runner") { {runner_scope_failure: log_context} }
+      nil
+    end
+  end
 end

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -3,6 +3,7 @@
 require_relative "spec_helper"
 
 require "aws-sdk-s3"
+require "octokit"
 
 RSpec.describe Clover, "github" do
   describe "authentication" do
@@ -46,6 +47,7 @@ RSpec.describe Clover, "github" do
 
   describe "cache endpoints" do
     let(:repository) { GithubRepository.create_with_id(name: "test", default_branch: "main", access_key: "123") }
+    let(:installation) { GithubInstallation.create_with_id(installation_id: 123, name: "test-user", type: "User") }
     let(:runner) { GithubRunner.create_with_id(vm_id: create_vm.id, repository_name: "test", label: "ubicloud", repository_id: repository.id, workflow_job: {head_branch: "dev"}) }
     let(:url_presigner) { instance_double(Aws::S3::Presigner, presigned_request: "aa") }
     let(:blob_storage_client) { instance_double(Aws::S3::Client) }
@@ -89,12 +91,26 @@ RSpec.describe Clover, "github" do
         expect(last_response).to have_api_error(409, "A cache entry for dev scope already exists with k1 key and v1 version.")
       end
 
-      it "Rollbacks inconsistent cache entry if a failure occurs in the middle" do
+      it "rollbacks inconsistent cache entry if a failure occurs in the middle" do
         expect(blob_storage_client).to receive(:create_multipart_upload).and_raise(CloverError.new(500, "UnexceptedError", "Sorry, we couldn’t process your request because of an unexpected error."))
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 75 * 1024 * 1024}
 
         expect(last_response).to have_api_error(500, "Sorry, we couldn’t process your request because of an unexpected error.")
         expect(repository.cache_entries).to be_empty
+      end
+
+      it "gets branch from GitHub API if the runner doesn't have a branch info" do
+        runner.update(workflow_job: nil, installation_id: installation.id)
+        client = instance_double(Octokit::Client)
+        allow(Github).to receive(:installation_client).and_return(client)
+        expect(client).to receive(:workflow_run_jobs).and_return({jobs: [{head_branch: "dev", runner_name: runner.ubid}]})
+        expect(blob_storage_client).to receive(:create_multipart_upload).and_return(instance_double(Aws::S3::Types::CreateMultipartUploadOutput, upload_id: "upload-id"))
+        expect(url_presigner).to receive(:presigned_url).with(:upload_part, hash_including(bucket: repository.bucket_name, upload_id: "upload-id"))
+
+        post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100, runId: 123}
+
+        expect(last_response.status).to eq(200)
+        expect(repository.cache_entries.first.scope).to eq("dev")
       end
 
       it "returns presigned urls and upload id for the reserved cache" do
@@ -206,6 +222,41 @@ RSpec.describe Clover, "github" do
         get "/runtime/github/cache", {keys: "k1", version: "v1"}
 
         expect(last_response.status).to eq(204)
+      end
+
+      it "fails to get head branch if runner name not matched" do
+        runner.update(workflow_job: nil, installation_id: installation.id)
+        GithubCacheEntry.create_with_id(key: "k1", version: "v1", scope: "dev", repository_id: repository.id, created_by: runner.id, committed_at: Time.now)
+        client = instance_double(Octokit::Client)
+        allow(Github).to receive(:installation_client).and_return(client)
+        expect(client).to receive(:workflow_run_jobs).and_return({jobs: [{head_branch: "dev", runner_name: "dummy-runner-name"}]})
+        get "/runtime/github/cache", {keys: "k1", version: "v1", runId: 123}
+
+        expect(last_response.status).to eq(204)
+      end
+
+      it "fails to get head branch if GitHub API raises an exception" do
+        runner.update(workflow_job: nil, installation_id: installation.id)
+        GithubCacheEntry.create_with_id(key: "k1", version: "v1", scope: "dev", repository_id: repository.id, created_by: runner.id, committed_at: Time.now)
+        client = instance_double(Octokit::Client)
+        allow(Github).to receive(:installation_client).and_return(client)
+        expect(client).to receive(:workflow_run_jobs).and_raise(Octokit::NotFound)
+        get "/runtime/github/cache", {keys: "k1", version: "v1", runId: 123}
+
+        expect(last_response.status).to eq(204)
+      end
+
+      it "gets branch from GitHub API if the runner doesn't have a branch info" do
+        runner.update(workflow_job: nil, installation_id: installation.id)
+        entry = GithubCacheEntry.create_with_id(key: "k1", version: "v1", scope: "dev", repository_id: repository.id, created_by: runner.id, committed_at: Time.now)
+        client = instance_double(Octokit::Client)
+        allow(Github).to receive(:installation_client).and_return(client)
+        expect(client).to receive(:workflow_run_jobs).and_return({jobs: [{head_branch: "dev", runner_name: runner.ubid}]})
+        expect(url_presigner).to receive(:presigned_url).with(:get_object, hash_including(bucket: repository.bucket_name, key: entry.blob_key)).and_return("http://presigned-url")
+        get "/runtime/github/cache", {keys: "k1", version: "v1", runId: 123}
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["k1", "v1", "dev"])
       end
 
       it "returns a cache from default branch when no branch info" do


### PR DESCRIPTION
We prioritize both cache security and privacy along with the performance. We adhere to the same cache restrictions as the default GitHub Actions Cache [^1].

The endpoint needs to verify the head branch of the workflow job to allow cache access [^2] . The `runner.workflow_job&.dig("head_branch")` property, filled via the webhook payload delivered by GitHub when the job started to run our runners. However, occasional delays in GitHub's delivery of this webhook can cause the job to receive a 'not found' response from the endpoint, as it fails to verify the branch.

Without the webhook details, we only have the self-hosted runner's name. However, the GitHub API doesn’t provide a way to get job details using just the runner name, so we need additional information.

If we have the job ID, we can retrieve job details from the GitHub API. We verify the runner name against the job's runner name; if they match, we can obtain the head branch from the job details.

Unfortunately, the cache client doesn’t have the job ID, but it does have the run ID. This means we can retrieve all jobs from the workflow run instead of just the details for a single job. While it’s still a single API request, it’s slower than getting the details for a single job.

Next, we try to find the correct job details from the list of jobs using the runner name.

This approach adds some latency to the runtime cache endpoints, but it's only for cases where the webhook is delayed, which is rare.

[^1]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
[^2]: https://github.com/ubicloud/ubicloud/blob/main/routes/runtime/github.rb#L24-L28