### PR TITLE
Exclude uncommitted cache entries when cleaning up cache storage

### DIFF
--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -89,10 +89,11 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
       .destroy
 
     # Destroy oldest cache entries if the total usage exceeds the limit.
-    total_usage = github_repository.cache_entries_dataset.sum(:size).to_i
+    dataset = github_repository.cache_entries_dataset.exclude(size: nil)
+    total_usage = dataset.sum(:size).to_i
     storage_limit = github_repository.installation.project.effective_quota_value("GithubRunnerCacheStorage") * 1024 * 1024 * 1024
     if total_usage > storage_limit
-      github_repository.cache_entries_dataset.order(:created_at).each do |oldest_entry|
+      dataset.order(:created_at).each do |oldest_entry|
         break if total_usage <= storage_limit
         oldest_entry.destroy
         total_usage -= oldest_entry.size

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -131,6 +131,13 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       nx.cleanup_cache
     end
 
+    it "excludes uncommitted cache entries" do
+      twelve_gib_cache = create_cache_entry(created_at: Time.now - 10 * 60, size: 12 * 1024 * 1024 * 1024)
+      create_cache_entry(created_at: Time.now - 13 * 60, size: nil)
+      expect(blob_storage_client).to receive(:delete_object).with(bucket: github_repository.bucket_name, key: twelve_gib_cache.blob_key)
+      nx.cleanup_cache
+    end
+
     it "deletes oldest cache entries if the total usage exceeds the custom limit" do
       github_repository.installation.project.add_quota(quota_id: ProjectQuota.default_quotas["GithubRunnerCacheStorage"]["id"], value: 20)
       nine_gib_cache = create_cache_entry(created_at: Time.now - 10 * 60, size: 19 * 1024 * 1024 * 1024)


### PR DESCRIPTION
In the caching workflow, the client first reserves the cache and then commits it.

The size of the cache entry is set when committing the cache in certain cases.

If we clean up the cache storage while a cache entry is reserved but not committed, it fails with the following error because the size is nil:

    TypeError: nil can't be coerced into Integer