### PR TITLE
Return cache in incoming key order for partial match

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -39,8 +39,7 @@ class Clover
       #   for a restore key, the action returns the most recently created cache.
       entry ||= dataset
         .grep(:key, keys.map { |key| "#{DB.dataset.escape_like(key)}%" })
-        .reverse(:created_at)
-        .first
+        .min_by { |e| keys.find_index { |k| e.key.start_with?(k) } + (scopes.index(e.scope) * keys.size) }
 
       fail CloverError.new(204, "NotFound", "No cache entry") if entry.nil?
 

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -235,17 +235,17 @@ RSpec.describe Clover, "github" do
         expect(GithubCacheEntry[key: "k2", version: "v1", scope: "dev"].last_accessed_by).to eq(runner.id)
       end
 
-      it "partially matched key returns the most recently created cache" do
-        GithubCacheEntry.create_with_id(key: "k1234", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 2, created_by: runner.id, committed_at: Time.now)
-        GithubCacheEntry.create_with_id(key: "k12345", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 1, created_by: runner.id, committed_at: Time.now)
-        GithubCacheEntry.create_with_id(key: "k123456", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now, created_by: runner.id, committed_at: Time.now)
+      it "partially matched key returns the cache according to the order of incoming keys" do
+        GithubCacheEntry.create_with_id(key: "mix-dev-123", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 2, created_by: runner.id, committed_at: Time.now)
+        GithubCacheEntry.create_with_id(key: "mix-dev-main-123", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now - 1, created_by: runner.id, committed_at: Time.now)
+        GithubCacheEntry.create_with_id(key: "mix-prod-123", version: "v1", scope: "main", repository_id: repository.id, created_at: Time.now, created_by: runner.id, committed_at: Time.now)
 
         expect(url_presigner).to receive(:presigned_url).with(:get_object, anything).and_return("http://presigned-url")
-        get "/runtime/github/cache", {keys: "k12,k123", version: "v1"}
+        get "/runtime/github/cache", {keys: "mix-dev-main-,mix-dev-,mix-", version: "v1"}
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["k123456", "v1", "main"])
-        expect(GithubCacheEntry[key: "k123456", version: "v1", scope: "main"].last_accessed_by).to eq(runner.id)
+        expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["mix-dev-main-123", "v1", "main"])
+        expect(GithubCacheEntry[key: "mix-dev-main-123", version: "v1", scope: "main"].last_accessed_by).to eq(runner.id)
       end
 
       it "only does a prefix match on key, escapes LIKE metacharacters in submitted keys" do


### PR DESCRIPTION
We sorted cache entries according to the order of the incoming keys and returned the first match. However, this only works when the full key is provided. It seems that partial match doesn't follow the same ordering. Instead, it simply orders the entries by their creation time. We should order them by the incoming key order.

I used similar logic to the full match for this. The only difference is that I used `find_index` and `start_with?` instead of `index`.