### PR TITLE
Fix error handling for delete user

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -73,7 +73,7 @@ class Clover < Roda
       message: "Sorry, we couldn’t find the resource you’re looking for."
     }
 
-    if api?
+    if api? || request.headers["Accept"] == "application/json"
       {error: @error}.to_json
     else
       view "/error"

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -244,7 +244,11 @@ RSpec.describe Clover, "project" do
         btn = find "#user-#{user2.ubid} .delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-        expect(page.body).to eq({message: "Removing #{user2.email} from #{project.name}"}.to_json)
+        expect(page.body).to be_empty
+
+        visit "#{project.path}/user"
+        expect(page).to have_content user.email
+        expect(page.find_by_id("flash-notice").text).to eq("Removed #{user2.email} from #{project.name}")
 
         visit "#{project.path}/user"
         expect(page).to have_content user.email
@@ -335,8 +339,8 @@ RSpec.describe Clover, "project" do
         # UI tests run without a JavaScript enginer.
         btn = find "#user-#{user.ubid} .delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
-
-        expect(page.body).to eq({message: "You can't remove the last user from '#{project.name}' project. Delete project instead."}.to_json)
+        expect(page.status_code).to eq(400)
+        expect(page.body).to eq({error: {message: "You can't remove the last user from '#{project.name}' project. Delete project instead."}}.to_json)
 
         visit "#{project.path}/user"
         expect(page).to have_content user.email


### PR DESCRIPTION
The hash with message key needs to be wrapped in an error key in order for the javascript to handle it.

While here, refactor:

* Only one route in the block, so combine `r.is String` and `r.delete true` to `r.delete String`.

* Use `next` instead of `response.status = 404; r.halt` for early exit.

* Avoid `return`, use `next` for early exit, and just have block return the hash implicitly.