### PR TITLE
Update AI base image to 20241128.1.0

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -156,7 +156,7 @@ module Config
   override :postgres17_paradedb_ubuntu_2204_version, "20241025.1.0", string
   override :postgres16_lantern_ubuntu_2204_version, "20241024.1.0", string
   override :github_gpu_ubuntu_2204_version, "20241016.1.0", string
-  override :ai_ubuntu_2404_nvidia_version, "20241127.1.0", string
+  override :ai_ubuntu_2404_nvidia_version, "20241128.1.0", string
 
   # Allocator
   override :allocator_target_host_utilization, 0.55, float

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -93,7 +93,7 @@ class Prog::DownloadBootImage < Prog::Base
       ["postgres16-paradedb-ubuntu-2204", "x64", "20241022.1.0"] => "1256a2e13f059f08747df6a0b2125ecbc756aa34666d7d1d5c86b32f8fe4b4d0",
       ["postgres17-paradedb-ubuntu-2204", "x64", "20241022.1.0"] => "d510cbc817114d424266cfca37deb011ae31b071c52f2013f98af17f6c0b032f",
       ["postgres16-lantern-ubuntu-2204", "x64", "20241010.1.0"] => "608766a3dc4be757c32c2855893ebaf5d92a55675205cd4c9aec1b0a8bc274fb",
-      ["ai-ubuntu-2404-nvidia", "x64", "20241127.1.0"] => "5252fecfaecc186c8f20471c91d78fa5cbafee80fc8e117891af7084a85c87d8",
+      ["ai-ubuntu-2404-nvidia", "x64", "20241128.1.0"] => "6f3904a395572fbda58365afd04de68409091ea5d325d77064e45d3e7b27bc5f",
       ["ai-model-gemma-2-2b-it", "x64", "20240918.1.0"] => "b726ead6d5f48fb8e6de7efb48fb22367c9a7c155cfee71a3a7e5527be5df08e",
       ["ai-model-llama-3-1-405b-it", "x64", "20241029.1.0"] => "54680b8b18ed501956a78c63b94576b7200fbd8fbe025eccb90152d13478882e",
       ["ai-model-llama-3-1-nt-70b-it", "x64", "20241028.1.0"] => "35dafc63fb65d1e5f3aaa309f0775bebe01016179866515dd7ea25d7e525bed7",


### PR DESCRIPTION
Job producing the image:
https://github.com/ubicloud/ai-images/actions/runs/12067035442

The image contains
* Python 3.12
* vLLM: 0.6.4.post1
* inference gateway: 0.1.3