### PR TITLE
Group cache entries by repository on UI

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,6 +22,13 @@ $(".toggle-mobile-menu").on("click", function (event) {
     }
 });
 
+$(".cache-group-row").on("click", function (event) {
+  let repository = $(this).data("repository");
+  $(this).toggleClass("active");
+  $(".cache-group-" + repository).toggleClass("hidden");
+});
+
+
 $(document).click(function(){
   $(".dropdown").removeClass("active");
 });

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -44,9 +44,9 @@ class Clover
       r.on "cache" do
         r.get true do
           repository_id_q = @project.github_installations_dataset.join(:github_repository, installation_id: :id).select(Sequel[:github_repository][:id])
-          @entries = Serializers::GithubCacheEntry.serialize(GithubCacheEntry.where(repository_id: repository_id_q).exclude(committed_at: nil).eager(:repository).order(Sequel.desc(:created_at)).all)
-          @total_usage = Serializers::GithubCacheEntry.humanize_size(@entries.filter_map { _1[:size] }.sum)
-          @total_quota = "#{@project.effective_quota_value("GithubRunnerCacheStorage")} GB"
+          entries = GithubCacheEntry.where(repository_id: repository_id_q).exclude(committed_at: nil).eager(:repository).reverse(:created_at).all
+          @entries_by_repo = Serializers::GithubCacheEntry.serialize(entries).group_by { _1[:repository][:id] }
+          @quota_per_repo = "#{@project.effective_quota_value("GithubRunnerCacheStorage")} GB"
 
           view "github/cache"
         end

--- a/serializers/github_cache_entry.rb
+++ b/serializers/github_cache_entry.rb
@@ -5,7 +5,10 @@ class Serializers::GithubCacheEntry < Serializers::Base
     {
       id: entry.ubid,
       key: entry.key,
-      repository_name: entry.repository.name,
+      repository: {
+        id: entry.repository.ubid,
+        name: entry.repository.name
+      },
       scope: entry.scope,
       created_at: entry.created_at.strftime("%Y-%m-%d %H:%M UTC"),
       created_at_human: humanize_time(entry.created_at),

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -16,49 +16,56 @@
 <div class="grid gap-6">
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <table class="min-w-full divide-y divide-gray-300">
-      <% if @total_usage %>
-        <thead class="bg-gray-50 whitespace-nowrap">
-          <tr>
-            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6" colspan="2"><%= @entries.count %> cache entries</th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6" colspan="3"><%= @total_usage %> used of <%= @total_quota %></th>
-          </tr>
-        </thead>
-      <% end %>
       <tbody class="divide-y divide-gray-200 bg-white">
-        <% if @entries.count > 0 %>
-          <% @entries.each do |entry| %>
-            <tr id="entry-<%= entry[:id]%>">
-              <td class="py-3 pl-4 pr-3 text-sm sm:pl-6" scope="row">
-                <div class="font-medium text-gray-900"><%= entry[:key] %></div>
-                <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry[:created_at] %>"><%= entry[:created_at_human] %></span></div>
-              </td>
-              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
-                <div><%= entry[:scope] %></div>
-                <div class="mt-1 text-gray-500 text-xs"><%= entry[:repository_name] %></div>
-              </td>
-              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
-                <div class="inline-flex items-baseline rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800" title="<%= entry[:size] %> bytes">
-                  <%= entry[:size_human] %>
+        <% if @entries_by_repo.count > 0 %>
+          <% @entries_by_repo.each do |repository_id, entries| %>
+            <tr class="cache-group-row cursor-pointer group" data-repository="<%= repository_id %>">
+              <th scope="colgroup" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 w-full group-[.active]:bg-gray-50">
+                <div class="flex">
+                  <%== render("components/icon", locals: { name: "hero-chevron-right", classes: "w-5 h-5 group-[.active]:rotate-90" }) %>
+                  <%= entries.first[:repository][:name] %>
                 </div>
-              </td>
-              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
-                <% if entry[:last_accessed_at] %>
-                  <div>Last used</div>
-                  <div title="<%= entry[:last_accessed_at] %>"> <%= entry[:last_accessed_at_human] %></div>
-                <% else %>
-                  <div>Never used</div>
-                <% end %>
-              </td>
-              <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
-                <%== render(
-                  "components/delete_button",
-                  locals: {
-                    url: "#{@project_data[:path]}/github/cache/#{entry[:id]}",
-                    text: ""
-                  }
-                ) %>
-              </td>
+              </th>
+              <th scope="colgroup" class="py-3.5 pl-3 pr-3 text-right text-sm font-semibold text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50" colspan="2">
+                <%= entries.count %> cache entries
+              </th>
+              <th scope="colgroup" class="py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50" colspan="2">
+                <%= Serializers::GithubCacheEntry.humanize_size(entries.sum { _1[:size].to_i }) %> used of <%= @quota_per_repo %>
+              </th>
             </tr>
+            <% entries.each do |entry| %>
+              <tr id="entry-<%= entry[:id]%>" class="hidden cache-group-<%= repository_id %>">
+                <td class="py-3 pl-4 pr-3 text-sm sm:pl-6 w-full" scope="row">
+                  <div class="font-medium text-gray-900"><%= entry[:key] %></div>
+                  <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry[:created_at] %>"><%= entry[:created_at_human] %></span></div>
+                </td>
+                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                  <div><%= entry[:scope] %></div>
+                </td>
+                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                  <div class="inline-flex items-baseline rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800" title="<%= entry[:size] %> bytes">
+                    <%= entry[:size_human] %>
+                  </div>
+                </td>
+                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                  <% if entry[:last_accessed_at] %>
+                    <div>Last used</div>
+                    <div title="<%= entry[:last_accessed_at] %>"> <%= entry[:last_accessed_at_human] %></div>
+                  <% else %>
+                    <div>Never used</div>
+                  <% end %>
+                </td>
+                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
+                  <%== render(
+                    "components/delete_button",
+                    locals: {
+                      url: "#{@project_data[:path]}/github/cache/#{entry[:id]}",
+                      text: ""
+                    }
+                  ) %>
+                </td>
+              </tr>
+            <% end %>
           <% end %>
         <% else %>
           <tr>


### PR DESCRIPTION
We apply the cache storage quota to each repository. Displaying all cache entries and total usage can lead to confusion, as it's the total usage per repository that matters most.

To clarify this, I grouped cache entries by repository in the UI. I also made these groups collapsible, allowing users to easily view cache entries for a specific repository. This feature is especially useful when a repository has many cache entries, making it difficult to find a specific one.

![cache-ui](https://github.com/user-attachments/assets/ea690a5a-6e07-413b-836a-b79bd46234db)
