### PR TITLE
Fix some VM values on UI

### DIFF
--- a/serializers/vm.rb
+++ b/serializers/vm.rb
@@ -11,6 +11,7 @@ class Serializers::Vm < Serializers::Base
       unix_user: vm.unix_user,
       storage_size_gib: vm.storage_size_gib,
       ip6: vm.ephemeral_net6&.nth(2),
+      ip4_enabled: vm.ip4_enabled,
       ip4: vm.ephemeral_net4
     }
 

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -53,8 +53,10 @@
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                 <% if vm[:ip4] %>
                   <%== render("components/copieble_content", locals: { content: vm[:ip4], message: "Copied IPv4" }) %>
-                <% else %>
+                <% elsif vm[:ip6] %>
                   <%== render("components/copieble_content", locals: { content: vm[:ip6], message: "Copied IPv6" }) %>
+                <% else %>
+                  Not assigned yet
                 <% end %>
               </td>
             </tr>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -45,8 +45,9 @@
               </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:location] %></td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:size] %></td>
-              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= vm[:storage_size_gib] %>
-                GB</td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                <%= (vm[:storage_size_gib] > 0) ? "#{vm[:storage_size_gib]} GB" : "-" %>
+              </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                 <%== render("components/vm_state_label", locals: { state: vm[:state] }) %>
               </td>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -35,7 +35,7 @@
         ["Location", @vm[:location]],
         ["Size", @vm[:size]],
         ["Storage", (@vm[:storage_size_gib] > 0) ? "#{@vm[:storage_size_gib]} GB" : nil],
-        ["IPv4", @vm[:ip4], { copieble: true }],
+        ["IPv4", @vm[:ip4_enabled] ? @vm[:ip4] : "Not enabled", { copieble: @vm[:ip4_enabled] }],
         ["IPv6", @vm[:ip6], { copieble: true }],
         [
           "SSH Command",

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -34,7 +34,7 @@
         ["Name", @vm[:name]],
         ["Location", @vm[:location]],
         ["Size", @vm[:size]],
-        ["Storage", "#{@vm[:storage_size_gib]}GB"],
+        ["Storage", (@vm[:storage_size_gib] > 0) ? "#{@vm[:storage_size_gib]} GB" : nil],
         ["IPv4", @vm[:ip4], { copieble: true }],
         ["IPv6", @vm[:ip6], { copieble: true }],
         [


### PR DESCRIPTION
- **Fix IP address value in the VM list if not assigned yet**
  

- **Do not show 0GB storage for virtual machines**
  Until `vm_storage_volumes` are created, `vm.storage_size_gib` returns 0.
  So instead of showing 0GB, we should show nothing.
  

- **Do not show the same value for not enabled or not assigned IPv4 on UI**


| Before | After |
|--------|-------|
| ![CleanShot 2024-11-28 at 21 34 17@2x](https://github.com/user-attachments/assets/8d0d1d0e-72ac-4d4e-b064-28f75e1aee10) | ![CleanShot 2024-11-28 at 21 35 13@2x](https://github.com/user-attachments/assets/527015c6-9237-4bf5-912d-e2e7b5ce3271) |
| ![CleanShot 2024-11-28 at 21 34 44@2x](https://github.com/user-attachments/assets/ab4fea95-2b1e-4440-8929-325eb166a3fb) | ![CleanShot 2024-11-28 at 21 35 02@2x](https://github.com/user-attachments/assets/8bee5ff6-2938-45a3-a8a1-da7f2425142f) |
