### PR TITLE
Fix delete invited user route

### DIFF
--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -107,14 +107,12 @@ class Clover
         end
       end
 
-      r.on "invitation" do
-        r.is String do |email|
-          r.delete true do
-            @project.invitations_dataset.where(email: email).destroy
-            flash["notice"] = "Invitation for '#{email}' is removed successfully."
-            r.halt
-          end
-        end
+      r.delete "invitation", String do |email|
+        @project.invitations_dataset.where(email: email).destroy
+        # Javascript handles redirect
+        flash["notice"] = "Invitation for '#{email}' is removed successfully."
+        response.status = 204
+        nil
       end
 
       r.delete String do |user_ubid|

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -306,6 +306,10 @@ RSpec.describe Clover, "project" do
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
         visit "#{project.path}/user"
+        expect(page.find_by_id("flash-notice").text).to eq("Invitation for '#{invited_email}' is removed successfully.")
+
+        visit "#{project.path}/user"
+        expect(page).to have_no_content invited_email
         expect { find "#invitation-#{invited_email.gsub(/\W+/, "")} .delete-btn" }.to raise_error Capybara::ElementNotFound
       end
 


### PR DESCRIPTION
This does not redirect, so it should not set flash.  Otherwise, the next request the user makes will display the set flash.

For consistency, use a 204 status, similar to other delete routes.

While here, avoid unnecessary nesting.