### PR TITLE
Create pages for unavailable inference endpoints

### DIFF
--- a/model/ai/inference_endpoint.rb
+++ b/model/ai/inference_endpoint.rb
@@ -19,7 +19,7 @@ class InferenceEndpoint < Sequel::Model
   include Authorization::HyperTagMethods
   include Authorization::TaggableMethods
 
-  semaphore :destroy
+  semaphore :destroy, :maintenance
 
   def display_location
     LocationNameConverter.to_display_name(location)

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -61,7 +61,7 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
       custom_hostname_prefix = if custom_dns_zone
         name + (is_public ? "" : "-#{ubid.to_s[-5...]}")
       end
-      lb_s = Prog::Vnet::LoadBalancerNexus.assemble(subnet_s.id, name: ubid.to_s, src_port: 443, dst_port: 8443, health_check_endpoint: "/up", health_check_protocol: "https",
+      lb_s = Prog::Vnet::LoadBalancerNexus.assemble(subnet_s.id, name: ubid.to_s, src_port: 443, dst_port: 8443, health_check_endpoint: "/health", health_check_protocol: "https",
         custom_hostname_prefix: custom_hostname_prefix, custom_hostname_dns_zone_id: custom_dns_zone&.id, stack: "ipv4")
 
       inference_endpoint = InferenceEndpoint.create(


### PR DESCRIPTION
**Improved health checks for inference endpoints**
The latest version of AI base images support a new `/health` endpoint. In
contrast to the `/up` endpoint, which succeeds if the inference gateway is
operational, the `/health` endpoint performs more thorough checks and
fails if either inference gateway or inference engine are not available.

This commit switches inference endpoint load balancers from the `/up`
to the `/health` endpoint.


**Create pages for unavailable inference endpoints**
A new label `unavailable` is added the the inference endpoint replica nexus.
When a replica becomes unavailable, it is moved to that label. In that state,
a page is created and the prog checks the replica's availability status more
frequently. When the replica becomes available again, it hops out of
`unavailable` and resolves the page.

An operator can set the `maintenance` semaphore on an inference endpoint,
which suppresses paging on replica unavailability.