### PR TITLE
Add ip4_enabled field to openapi.yml

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -2302,6 +2302,9 @@ components:
           type: string
           format: ipv4
           nullable: true
+        ip4_enabled:
+          description: Whether IPv4 is enabled
+          type: boolean
         ip6:
           description: IPv6 address
           type: string
@@ -2331,6 +2334,7 @@ components:
       required:
         - id
         - ip4
+        - ip4_enabled
         - ip6
         - location
         - name


### PR DESCRIPTION
To track the change in 51973d9b03c897a6591025e904f0c61e6c539191, which theoretically was for the UI, but due to shared code paths, manipulates the API as well. But, perhaps, in this case, that coupling is desirable, the same ambiguities that
51973d9b03c897a6591025e904f0c61e6c539191 may apply to the API as well (alas, the commit does not explain itself)