### PR TITLE
Enable committee openapi schema checking in test and production

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,9 @@ Layout/SpaceInsideHashLiteralBraces:
   Exclude:
     - 'views/**/*.erb'
 
+RSpec/AnyInstance:
+  Enabled: false
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 ruby "3.2.6"
 
 gem "argon2"
+gem "committee"
 gem "nokogiri"
 gem "bcrypt_pbkdf"
 gem "ed25519"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
     cbor (0.5.9.8)
     chunky_png (1.4.0)
     coderay (1.1.3)
+    committee (5.3.0)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (~> 2.0)
+      rack (>= 1.5)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     cose (1.3.1)
@@ -140,6 +144,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.8.2)
+    json_schema (0.21.0)
+      base64
     jwt (2.9.3)
       base64
     language_server-protocol (3.17.0.3)
@@ -182,6 +188,7 @@ GEM
     octokit (9.2.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    openapi_parser (2.2.1)
     openssl (3.2.0)
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
@@ -378,6 +385,7 @@ DEPENDENCIES
   brakeman
   by (>= 1.1.0)
   capybara
+  committee
   countries
   cuprite
   ed25519

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -69,11 +69,7 @@ class Clover < Roda
 
   def validate_request_params(required_keys, allowed_optional_keys = [])
     params = if api?
-      begin
-        request.params
-      rescue Roda::RodaPlugins::InvalidRequestBody::Error
-        raise Validation::ValidationFailed.new({body: "Request body isn't a valid JSON object."})
-      end
+      request.params
     else
       request.params.reject { _1 == "_csrf" }
     end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -386,6 +386,12 @@ RSpec.describe Validation do
     end
   end
 
+  describe "#validate_request_params" do
+    it "rejects requests without required params" do
+      expect { described_class.validate_request_params({extra: true}, []) }.to raise_error described_class::ValidationFailed
+    end
+  end
+
   describe "#validate_url" do
     it "valid account names" do
       [

--- a/spec/routes/api/committee_spec.rb
+++ b/spec/routes/api/committee_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "committee infrastructure" do
+  let(:user) { create_account }
+  let(:project) { user.create_project_with_default_policy("project-1") }
+
+  before do
+    login_api(user.email)
+  end
+
+  it "serializes unexpected nested errors that cannot be converted" do
+    ex = Class.new(Committee::BadRequest) do
+      def self.name
+        "CommitteeTestNestedException"
+      end
+
+      def original_error
+        Exception.new("unaddressed error value")
+      end
+    end.new("testing conversion of unenumerated nested exceptions")
+
+    allow_any_instance_of(Committee::SchemaValidator::OpenAPI3).to receive(:request_validate) do
+      raise ex
+    end
+
+    expect {
+      post "/project/#{UBID.generate(UBID::TYPE_PROJECT)}/location/#{TEST_LOCATION}/vm/test-vm"
+    }.to raise_error ex
+  end
+
+  it "rejects paths that cannot be found in the schema" do
+    post "/not-a-prefix/"
+    expect(JSON.parse(last_response.body).dig("error", "message")).to eq("Sorry, we couldn’t find the resource you’re looking for.")
+  end
+
+  it "fails when the request has unparsable json" do
+    expect {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", "this is not json"
+    }.to raise_error Committee::InvalidRequest, "Request body wasn't valid JSON."
+  end
+
+  it "fails when response has invalid structure" do
+    expect(Serializers::Vm).to receive(:serialize_internal).and_return({totally_not_correct: true})
+    expect {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        public_key: "ssh key",
+        unix_user: "ubi",
+        size: "standard-2",
+        boot_image: "ubuntu-jammy",
+        storage_size: "40"
+      }.to_json
+    }.to raise_error Committee::InvalidResponse, %r{#/components/schemas/Vm missing required parameters: .*}
+  end
+
+  it "fails when request is missing required keys" do
+    expect {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {}.to_json
+    }.to raise_error Committee::InvalidRequest, /missing required parameters: public_key/
+  end
+
+  it "fails when request has extra unexpected keys" do
+    expect {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {missing_stuff: true}.to_json
+    }.to raise_error Committee::InvalidRequest, /schema does not define properties: missing_stuff/
+  end
+
+  it "reports if response body is not valid JSON" do
+    allow_any_instance_of(Committee::SchemaValidator::OpenAPI3).to receive(:response_validate) do
+      raise JSON::ParserError.new("injected parser error")
+    end
+
+    expect {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+        public_key: "ssh key",
+        unix_user: "ubi",
+        size: "standard-2",
+        boot_image: "ubuntu-jammy",
+        storage_size: "40"
+      }.to_json
+    }.to raise_error Committee::InvalidResponse, "Response body wasn't valid JSON."
+  end
+end

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -98,12 +98,6 @@ RSpec.describe Clover, "load-balancer" do
         expect(JSON.parse(last_response.body)["name"]).to eq("lb1")
       end
 
-      it "missing required parameters" do
-        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {}.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
-      end
-
       it "invalid private_subnet_id" do
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {
           private_subnet_id: "invalid",
@@ -113,12 +107,6 @@ RSpec.describe Clover, "load-balancer" do
         }.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id")
-      end
-
-      it "invalid name" do
-        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/invalid_name", {}.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
       end
     end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -139,29 +139,6 @@ RSpec.describe Clover, "postgres" do
         expect(last_response).to have_api_error(400, "Validation failed for following fields: name", {"name" => "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."})
       end
 
-      it "invalid body" do
-        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", "invalid_body"
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body isn't a valid JSON object."})
-      end
-
-      it "missing required key" do
-        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
-          unix_user: "ha_type"
-        }.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body must include required parameters: size"})
-      end
-
-      it "non allowed key" do
-        post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-pg", {
-          size: "standard-2",
-          foo_key: "foo_val"
-        }.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Only following parameters are allowed: size, storage_size, ha_type, version, flavor"})
-      end
-
       it "firewall-rule" do
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule", {
           cidr: "0.0.0.0/24"

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -196,29 +196,6 @@ RSpec.describe Clover, "vm" do
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: private_subnet_id", {"private_subnet_id" => "Private subnet with the given id \"#{ps_id}\" is not found in the location \"eu-central-h1\""})
       end
-
-      it "invalid body" do
-        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", "invalid_body"
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body isn't a valid JSON object."})
-      end
-
-      it "missing required key" do
-        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
-          unix_user: "ubi"
-        }.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Request body must include required parameters: public_key"})
-      end
-
-      it "non allowed key" do
-        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
-          public_key: "ssh key",
-          foo_key: "foo_val"
-        }.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body", {"body" => "Only following parameters are allowed: public_key, size, storage_size, unix_user, boot_image, enable_ip4, private_subnet_id"})
-      end
     end
 
     describe "show" do

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -60,12 +60,6 @@ RSpec.describe Clover, "project" do
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-project")
       end
-
-      it "missing parameter" do
-        post "/project", {}.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
-      end
     end
 
     describe "delete" do

--- a/spec/routes/api/show_errors_spec.rb
+++ b/spec/routes/api/show_errors_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe Clover do
   end
 
   it "supports SHOW_ERRORS environment variable when testing" do
-    expect { post "/project", {}.to_json }.to raise_error Validation::ValidationFailed
+    expect { post "/project", {}.to_json }.to raise_error Committee::InvalidRequest
   end
 end

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Clover do
   it "raises unexpected errors in test environment" do
     expect(Clog).not_to receive(:emit)
 
-    expect { visit "/webhook/test-error?message=treat+as+unexpected+error" }.to raise_error(RuntimeError)
+    expect { visit "/webhook/test-error?message=treat+as+unexpected+error" }.to raise_error(RuntimeError, "treat as unexpected error")
   end
 
   it "does not have broken links" do

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -106,6 +106,7 @@ module ThawedMock
   allow_mocking(Scheduling::Allocator::Allocation, :best_allocation, :candidate_hosts, :new, :random_score, :update_vm)
   allow_mocking(Scheduling::Allocator::StorageAllocation, :new)
   allow_mocking(Scheduling::Allocator::VmHostAllocation, :new)
+  allow_mocking(Serializers::Vm, :serialize_internal)
   allow_mocking(SshKey, :generate)
   allow_mocking(ThreadPrinter, :puts, :run)
   allow_mocking(Util, :create_certificate, :create_root_certificate, :rootish_ssh, :send_email)


### PR DESCRIPTION
Enable committee openapi schema checking in test and production

Committee is rack middleware that validates requests and responses for
adherence to an openapi specification.  It will limit the kind of
(possibly malicious) input to the API part of the program.  And, it
because it checks the test suite, and we have a 100% branch coverage
policy covering routes, fixing schema problems will keep the openapi
specification up to date as people add features.

committee already detected some mistakes, such as being too relaxed
about content types, in 793b61f260b872f79095ce73d95fd99789d672ad.

Applying committee obsoletes some validation code, but not a lot: at
least some validations are also called from the web application,
rather than the API.  It's not clear to me how well these can be
converged to reduce code.

However, it does obsolete several validation-related API *tests* that
were rolled in with API application testing: now, the entire API is
covered in a consistent way for that kind of thing: parsable JSON,
missing fields, extra fields, etc.

