### PR TITLE
Append docker IPv6 config to daemon.json instead of overwriting it

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -228,7 +228,9 @@ class Prog::Vm::GithubRunner < Prog::Base
       # ubicloud/cache package which forked from the official actions/cache package, sends requests to UBICLOUD_CACHE_URL using this token.
       echo "UBICLOUD_RUNTIME_TOKEN=#{vm.runtime_token}
       UBICLOUD_CACHE_URL=#{Config.base_url}/runtime/github/" | sudo tee -a /etc/environment
-      echo #{docker_daemon_json.shellescape} | sudo tee /etc/docker/daemon.json
+
+      # We need to configure Docker to work with IPv6 properly. If the docker daemon config file exists, we append the new configuration to it.
+      ([ -f "/etc/docker/daemon.json" ] && sudo cat /etc/docker/daemon.json || echo '{}') | jq '. += #{docker_daemon_json}' | sudo tee /etc/docker/daemon.json
       sudo systemctl restart docker
     COMMAND
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
-        echo #{JSON.generate({"ipv6" => true, "fixed-cidr-v6" => "2a01:4f8:10b:1a5f:3444::2:dc/124", "experimental" => false, "dns" => ["10.0.0.2", "fd00:0b1c:100d:53::"], "dns-opts" => ["single-request-reopen"]}).shellescape} | sudo tee /etc/docker/daemon.json
+        ([ -f "/etc/docker/daemon.json" ] && sudo cat /etc/docker/daemon.json || echo '{}') | jq '. += #{JSON.generate({"ipv6" => true, "fixed-cidr-v6" => "2a01:4f8:10b:1a5f:3444::2:dc/124", "experimental" => false, "dns" => ["10.0.0.2", "fd00:0b1c:100d:53::"], "dns-opts" => ["single-request-reopen"]})}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
       COMMAND
 
@@ -417,7 +417,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
-        echo #{JSON.generate({"ipv6" => true, "fixed-cidr-v6" => "2a01:4f8:10b:1a5f:3444::2:dc/124", "experimental" => false, "dns" => ["10.0.0.2", "fd00:0b1c:100d:53::"], "dns-opts" => ["single-request-reopen"]}).shellescape} | sudo tee /etc/docker/daemon.json
+        ([ -f "/etc/docker/daemon.json" ] && sudo cat /etc/docker/daemon.json || echo '{}') | jq '. += #{JSON.generate({"ipv6" => true, "fixed-cidr-v6" => "2a01:4f8:10b:1a5f:3444::2:dc/124", "experimental" => false, "dns" => ["10.0.0.2", "fd00:0b1c:100d:53::"], "dns-opts" => ["single-request-reopen"]})}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
       COMMAND


### PR DESCRIPTION
We found that Docker doesn't work smoothly with IPv6 by default. To address this, we started to configure Docker to work correctly with IPv6 at d98fd5c9.

But it overwrites the existing configuration. This is not good because it may break the existing configuration. For example our GPU runners have an existing configuration for the nvidia runtime.