### PR TITLE
Have invalid project name error message explain why

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -124,7 +124,7 @@ class Project < Sequel::Model
   def validate
     super
     if new? || changed_columns.include?(:name)
-      validates_format(%r{\A[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\z}i, :name)
+      validates_format(%r{\A[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\z}i, :name, message: "must only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
     end
   end
 

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -7,28 +7,30 @@ RSpec.describe Project do
   subject(:project) { described_class.create_with_id(name: "test") }
 
   describe "#validate" do
+    invalid_name = "must only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number"
+
     it "validates that name for new object is not empty and has correct format" do
       project = described_class.new
       expect(project.valid?).to be false
-      expect(project.errors[:name]).to eq(["is not present", "is invalid"])
+      expect(project.errors[:name]).to eq(["is not present", invalid_name])
 
       project.name = "@"
       expect(project.valid?).to be false
-      expect(project.errors[:name]).to eq(["is invalid"])
+      expect(project.errors[:name]).to eq([invalid_name])
 
       project.name = "a"
       expect(project.valid?).to be true
 
       project.name = "a-"
       expect(project.valid?).to be false
-      expect(project.errors[:name]).to eq(["is invalid"])
+      expect(project.errors[:name]).to eq([invalid_name])
 
       project.name = "a-b"
       expect(project.valid?).to be true
 
       project.name = "a-#{"b" * 63}"
       expect(project.valid?).to be false
-      expect(project.errors[:name]).to eq(["is invalid"])
+      expect(project.errors[:name]).to eq([invalid_name])
     end
 
     it "validates that name for existing object is valid if the name has changed" do
@@ -36,14 +38,14 @@ RSpec.describe Project do
 
       project.name = "-"
       expect(project.valid?).to be false
-      expect(project.errors[:name]).to eq(["is invalid"])
+      expect(project.errors[:name]).to eq([invalid_name])
 
       project.name = "a"
       expect(project.valid?).to be true
 
       project.name = "@"
       expect(project.valid?).to be false
-      expect(project.errors[:name]).to eq(["is invalid"])
+      expect(project.errors[:name]).to eq([invalid_name])
     end
   end
 


### PR DESCRIPTION
Currently, the error message is the default "is invalid", which isn't that helpful to the user.

This is a bit explicit and technical, in that it mentions ASCII, but without ASCII, it implies that non-ASCII letters would be acceptable, which is incorrect.  I would guess that our users are technical enough to understand this message.