### PR TITLE
Use the custom_block_results Roda plugin to handle integer block results

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -35,6 +35,12 @@ class Clover < Roda
       scope.web?
     end
 
+  plugin :custom_block_results
+  handle_block_result Integer do |status_code|
+    response.status = status_code
+    nil
+  end
+
   plugin :route_csrf do |token|
     flash["error"] = "An invalid security token submitted with this request, please try again"
     response.status = 400

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -41,8 +41,7 @@ class Clover
       @project = nil unless @project&.visible
 
       unless @project
-        response.status = r.delete? ? 204 : 404
-        r.halt
+        next(r.delete? ? 204 : 404)
       end
 
       if @project.accounts_dataset.where(Sequel[:accounts][:id] => current_account_id).empty?
@@ -79,8 +78,7 @@ class Clover
 
         @project.soft_delete
 
-        response.status = 204
-        r.halt
+        204
       end
 
       if web?

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -40,9 +40,7 @@ class Clover
       @project = Project.from_ubid(project_ubid)
       @project = nil unless @project&.visible
 
-      unless @project
-        next(r.delete? ? 204 : 404)
-      end
+      next(r.delete? ? 204 : 404) unless @project
 
       if @project.accounts_dataset.where(Sequel[:accounts][:id] => current_account_id).empty?
         fail Authorization::Unauthorized

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -139,7 +139,7 @@ class Clover
 
             payment_method.destroy
 
-            {message: "Deleting #{payment_method.ubid}"}
+            204
           end
         end
       end

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -115,10 +115,7 @@ class Clover
 
       r.on "payment-method" do
         r.get "create" do
-          unless (billing_info = @project.billing_info)
-            response.status = 404
-            r.halt
-          end
+          next unless (billing_info = @project.billing_info)
 
           checkout = Stripe::Checkout::Session.create(
             payment_method_types: ["card"],
@@ -132,12 +129,7 @@ class Clover
         end
 
         r.is String do |pm_ubid|
-          payment_method = PaymentMethod.from_ubid(pm_ubid)
-
-          unless payment_method
-            response.status = 404
-            r.halt
-          end
+          next unless (payment_method = PaymentMethod.from_ubid(pm_ubid))
 
           r.delete true do
             unless payment_method.billing_info.payment_methods.count > 1
@@ -156,10 +148,7 @@ class Clover
         r.is String do |invoice_ubid|
           invoice = (invoice_ubid == "current") ? @project.current_invoice : Invoice.from_ubid(invoice_ubid)
 
-          unless invoice
-            response.status = 404
-            r.halt
-          end
+          next unless invoice
 
           r.get true do
             @invoice_data = Serializers::Invoice.serialize(invoice, {detailed: true})

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -8,7 +8,7 @@ class Clover
     r.on web? do
       unless (Stripe.api_key = Config.stripe_secret_key)
         response.status = 501
-        return "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
+        next "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
       end
 
       authorize("Project:billing", @project.id)
@@ -44,7 +44,7 @@ class Clover
             }
           })
 
-          return r.redirect @project.path + "/billing"
+          r.redirect @project.path + "/billing"
         end
 
         checkout = Stripe::Checkout::Session.create(
@@ -134,12 +134,12 @@ class Clover
           r.delete true do
             unless payment_method.billing_info.payment_methods.count > 1
               response.status = 400
-              return {message: "You can't delete the last payment method of a project."}
+              next {message: "You can't delete the last payment method of a project."}
             end
 
             payment_method.destroy
 
-            return {message: "Deleting #{payment_method.ubid}"}
+            {message: "Deleting #{payment_method.ubid}"}
           end
         end
       end
@@ -156,7 +156,7 @@ class Clover
             if r.params["pdf"] == "1"
               response["Content-Type"] = "application/pdf"
               response["Content-Disposition"] = "filename=\"#{@invoice_data[:filename]}.pdf\""
-              return invoice.generate_pdf(@invoice_data)
+              next invoice.generate_pdf(@invoice_data)
             end
 
             view "project/invoice"

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -41,11 +41,7 @@ class Clover
         end
 
         r.on String do |installation_id|
-          installation = GithubInstallation.from_ubid(installation_id)
-          unless installation
-            response.status = 404
-            r.halt
-          end
+          next unless (installation = GithubInstallation.from_ubid(installation_id))
 
           r.post true do
             cache_enabled = r.params["cache_enabled"] == "true"
@@ -68,18 +64,12 @@ class Clover
         end
 
         r.is String do |entry_ubid|
-          entry = GithubCacheEntry.from_ubid(entry_ubid)
-
-          unless entry
-            response.status = 404
-            r.halt
-          end
+          next unless (entry = GithubCacheEntry.from_ubid(entry_ubid))
 
           r.delete true do
             entry.destroy
             flash["notice"] = "Cache '#{entry.key}' deleted."
-            response.status = 204
-            request.halt
+            204
           end
         end
       end

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -5,7 +5,7 @@ class Clover
     r.on web? do
       unless Config.github_app_name
         response.status = 501
-        return "GitHub Action Runner integration is not enabled. Set GITHUB_APP_NAME to enable it."
+        next "GitHub Action Runner integration is not enabled. Set GITHUB_APP_NAME to enable it."
       end
 
       authorize("Project:github", @project.id)

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -20,9 +20,7 @@ class Clover
       filter[:location] = @location
       firewall = @project.firewalls_dataset.first(filter)
 
-      unless firewall
-        next (r.delete? ? 204 : 404)
-      end
+      next (r.delete? ? 204 : 404) unless firewall
 
       r.delete true do
         authorize("Firewall:delete", firewall.id)

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -26,12 +26,7 @@ class Clover
         authorize("Firewall:delete", firewall.id)
         firewall.private_subnets.map { authorize("PrivateSubnet:edit", _1.id) }
         firewall.destroy
-
-        if api?
-          204
-        else
-          {message: "Deleting #{firewall.name}"}
-        end
+        204
       end
 
       r.get true do

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -21,8 +21,7 @@ class Clover
       firewall = @project.firewalls_dataset.first(filter)
 
       unless firewall
-        response.status = r.delete? ? 204 : 404
-        next
+        next (r.delete? ? 204 : 404)
       end
 
       r.delete true do
@@ -31,8 +30,7 @@ class Clover
         firewall.destroy
 
         if api?
-          response.status = 204
-          nil
+          204
         else
           {message: "Deleting #{firewall.name}"}
         end
@@ -112,11 +110,7 @@ class Clover
 
         r.delete String do |firewall_rule_ubid|
           authorize("Firewall:edit", firewall.id)
-          fwr = FirewallRule.from_ubid(firewall_rule_ubid)
-          unless fwr
-            response.status = 204
-            next
-          end
+          next 204 unless (fwr = FirewallRule.from_ubid(firewall_rule_ubid))
 
           firewall.remove_firewall_rule(fwr)
 
@@ -132,8 +126,7 @@ class Clover
       end
 
       r.delete do
-        response.status = 204
-        nil
+        204
       end
     end
   end

--- a/routes/project/location/firewall/firewall_rule.rb
+++ b/routes/project/location/firewall/firewall_rule.rb
@@ -35,8 +35,7 @@ class Clover
           @firewall.remove_firewall_rule(firewall_rule)
         end
 
-        response.status = 204
-        r.halt
+        204
       end
 
       request.get true do

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -21,8 +21,7 @@ class Clover
       lb = LoadBalancer.first(filter)
 
       unless lb
-        response.status = request.delete? ? 204 : 404
-        request.halt
+        next (r.delete? ? 204 : 404)
       end
 
       r.post %w[attach-vm detach-vm] do |action|
@@ -71,8 +70,7 @@ class Clover
       r.delete true do
         authorize("LoadBalancer:delete", lb.id)
         lb.incr_destroy
-        response.status = 204
-        r.halt
+        204
       end
 
       r.patch api? do
@@ -115,8 +113,7 @@ class Clover
       r.post { load_balancer_post(lb_name) }
 
       r.delete do
-        response.status = 204
-        nil
+        204
       end
     end
   end

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -20,9 +20,7 @@ class Clover
       filter[:private_subnet_id] = @project.private_subnets_dataset.where(location: @location).select(Sequel[:private_subnet][:id])
       lb = LoadBalancer.first(filter)
 
-      unless lb
-        next (r.delete? ? 204 : 404)
-      end
+      next (r.delete? ? 204 : 404) unless lb
 
       r.post %w[attach-vm detach-vm] do |action|
         authorize("LoadBalancer:edit", lb.id)

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -21,8 +21,7 @@ class Clover
       pg = @project.postgres_resources_dataset.first(filter)
 
       unless pg
-        response.status = r.delete? ? 204 : 404
-        next
+        next (r.delete? ? 204 : 404)
       end
 
       r.get true do
@@ -40,8 +39,7 @@ class Clover
       r.delete true do
         authorize("Postgres:delete", pg.id)
         pg.incr_destroy
-        response.status = 204
-        ""
+        204
       end
 
       r.post web?, "restart" do
@@ -112,8 +110,7 @@ class Clover
               pg.incr_update_firewall_rules
             end
           end
-          response.status = 204
-          ""
+          204
         end
       end
 
@@ -154,8 +151,7 @@ class Clover
             end
           end
 
-          response.status = 204
-          ""
+          204
         end
       end
 
@@ -224,8 +220,7 @@ class Clover
       end
 
       r.delete do
-        response.status = 204
-        nil
+        204
       end
     end
   end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -20,9 +20,7 @@ class Clover
       filter[:location] = @location
       pg = @project.postgres_resources_dataset.first(filter)
 
-      unless pg
-        next (r.delete? ? 204 : 404)
-      end
+      next (r.delete? ? 204 : 404) unless pg
 
       r.get true do
         authorize("Postgres:view", pg.id)

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -20,9 +20,7 @@ class Clover
       filter[:location] = @location
       ps = @project.private_subnets_dataset.first(filter)
 
-      unless ps
-        next (r.delete? ? 204 : 404)
-      end
+      next (r.delete? ? 204 : 404) unless ps
 
       if web?
         r.post "connect" do

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -21,8 +21,7 @@ class Clover
       ps = @project.private_subnets_dataset.first(filter)
 
       unless ps
-        response.status = request.delete? ? 204 : 404
-        next
+        next (r.delete? ? 204 : 404)
       end
 
       if web?
@@ -69,8 +68,7 @@ class Clover
         end
 
         ps.incr_destroy
-        response.status = 204
-        nil
+        204
       end
     end
 
@@ -81,8 +79,7 @@ class Clover
       end
 
       r.delete do
-        response.status = 204
-        nil
+        204
       end
     end
   end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -21,8 +21,7 @@ class Clover
       vm = @project.vms_dataset.first(filter)
 
       unless vm
-        response.status = r.delete? ? 204 : 404
-        r.halt
+        next(r.delete? ? 204 : 404)
       end
 
       r.get true do
@@ -34,8 +33,7 @@ class Clover
       r.delete true do
         authorize("Vm:delete", vm.id)
         vm.incr_destroy
-        response.status = 204
-        nil
+        204
       end
     end
 
@@ -44,8 +42,7 @@ class Clover
       r.post { vm_post(vm_name) }
 
       r.delete do
-        response.status = 204
-        nil
+        204
       end
     end
   end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -20,9 +20,7 @@ class Clover
       filter[:location] = @location
       vm = @project.vms_dataset.first(filter)
 
-      unless vm
-        next(r.delete? ? 204 : 404)
-      end
+      next(r.delete? ? 204 : 404) unless vm
 
       r.get true do
         authorize("Vm:view", vm.id)

--- a/routes/project/usage_alert.rb
+++ b/routes/project/usage_alert.rb
@@ -19,12 +19,12 @@ class Clover
         usage_alert = UsageAlert.from_ubid(usage_alert_ubid)
         unless usage_alert
           response.status = 404
-          return {message: "Usage alert is not found."}
+          next {message: "Usage alert is not found."}
         end
 
         r.delete true do
           usage_alert.destroy
-          return {message: "Usage alert #{usage_alert.name} is deleted."}
+          {message: "Usage alert #{usage_alert.name} is deleted."}
         end
       end
     end

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -111,8 +111,7 @@ class Clover
         @project.invitations_dataset.where(email: email).destroy
         # Javascript handles redirect
         flash["notice"] = "Invitation for '#{email}' is removed successfully."
-        response.status = 204
-        nil
+        204
       end
 
       r.delete String do |user_ubid|
@@ -135,8 +134,7 @@ class Clover
 
         # Javascript refreshes page
         flash["notice"] = "Removed #{user.email} from #{@project.name}"
-        response.status = 204
-        nil
+        204
       end
     end
   end

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -11,12 +11,12 @@ class Clover
       data = JSON.parse(body)
       case r.headers["x-github-event"]
       when "installation"
-        return handle_installation(data)
+        handle_installation(data)
       when "workflow_job"
-        return handle_workflow_job(data)
+        handle_workflow_job(data)
+      else
+        error("Unhandled event")
       end
-
-      return error("Unhandled event")
     end
   end
 

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -4,10 +4,7 @@ class Clover
   hash_branch(:webhook_prefix, "github") do |r|
     r.post true do
       body = r.body.read
-      unless check_signature(r.headers["x-hub-signature-256"], body)
-        response.status = 401
-        r.halt
-      end
+      next 401 unless check_signature(r.headers["x-hub-signature-256"], body)
 
       response.headers["Content-Type"] = "application/json"
 

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -320,7 +320,8 @@ RSpec.describe Clover, "firewall" do
         btn = find ".delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-        expect(page.body).to eq({message: "Deleting #{firewall.name}"}.to_json)
+        expect(page.status_code).to eq(204)
+        expect(page.body).to be_empty
         expect(Firewall.count).to eq(0)
       end
 

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -215,8 +215,8 @@ RSpec.describe Clover, "billing" do
       btn = find "#payment-method-#{payment_method.ubid} .delete-btn"
       page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
-      expect(page.status_code).to eq(200)
-      expect(page.body).to eq({message: "Deleting #{payment_method.ubid}"}.to_json)
+      expect(page.status_code).to eq(204)
+      expect(page.body).to be_empty
       expect(billing_info.reload.payment_methods.count).to eq(1)
     end
 


### PR DESCRIPTION
Treat integer block results as setting the response status code. Use this in the routes to DRY up a lot of code that sets the status and then halts.

 Remove unnecessary return calls.
    
Convert remaining return calls in route blocks to next calls, because return only worked because the route block was converted to a method, and that may change in the future.