### PR TITLE
Runners DNS related fixups

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -201,6 +201,10 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def setup_environment
+    docker_daemon_json = JSON.generate({
+      "experimental" => false,
+      "dns-opts" => ["timeout:2", "attempts:3"]
+    })
     command = <<~COMMAND
       # To make sure the script errors out if any command fails
       set -ueo pipefail
@@ -220,6 +224,10 @@ class Prog::Vm::GithubRunner < Prog::Base
       # ubicloud/cache package which forked from the official actions/cache package, sends requests to UBICLOUD_CACHE_URL using this token.
       echo "UBICLOUD_RUNTIME_TOKEN=#{vm.runtime_token}
       UBICLOUD_CACHE_URL=#{Config.base_url}/runtime/github/" | sudo tee -a /etc/environment
+
+      # We need to configure Docker to work with IPv6 properly. If the docker daemon config file exists, we append the new configuration to it.
+      ([ -f "/etc/docker/daemon.json" ] && sudo cat /etc/docker/daemon.json || echo '{}') | jq '. += #{docker_daemon_json}' | sudo tee /etc/docker/daemon.json
+      sudo systemctl restart docker
     COMMAND
 
     if github_runner.installation.cache_enabled

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -441,12 +441,15 @@ DHCP
     interfaces = nics.map { "interface=#{_1.tap}" }.join("\n")
     dnsmasq_address_ip6 = NetAddr::IPv6.parse("fd00:0b1c:100d:53::")
     runner_config = if boot_image.include?("github")
-      <<~ADDRESSES
+      <<~ADDITIONAL_RUNNER_CONFIG
       address=/ubicloudhostplaceholder.blob.core.windows.net/#{nics.first.net4.split("/").first}
       address=/.docker.io/::
-      ADDRESSES
+      dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},6h
+      ADDITIONAL_RUNNER_CONFIG
     else
-      ""
+      <<~ADDITIONAL_CONFIG
+      dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
+      ADDITIONAL_CONFIG
     end
     vp.write_dnsmasq_conf(<<DNSMASQ_CONF)
 pid-file=
@@ -458,7 +461,6 @@ bogus-priv
 no-resolv
 #{raparams}
 #{interfaces}
-dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
 #{private_ip_dhcp}
 server=9.9.9.9@#{dns_ipv4}
 server=149.112.112.112@#{dns_ipv4}

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe VmSetup do
       }
       expect(vs).to receive(:setup_taps_6).with(gua, [], "10.0.0.2")
       expect(vs).to receive(:routes4).with(ip4, "local_ip4", [])
-      expect(vs).to receive(:write_nftables_conf).with(ip4, gua, [])
+      expect(vs).to receive(:write_nftables_conf).with(ip4, gua, [], "10.0.0.2")
       expect(vs).to receive(:forwarding)
 
       expect(vps).to receive(:write_guest_ephemeral).with(guest_ephemeral.to_s)
@@ -287,12 +287,14 @@ table ip6 nat_metadata_endpoint {
 table ip nat {
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
+    ip daddr 123.123.123.123 ip saddr == {9.9.9.9, 149.112.112.112} dnat to 10.0.0.2
     ip daddr 123.123.123.123 dnat to 192.168.5.50
   }
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
     ip saddr 192.168.5.50 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 123.123.123.123
+    ip saddr 10.0.0.2 ip daddr == {9.9.9.9, 149.112.112.112} snat to 123.123.123.123
     ip saddr 192.168.5.50 ip daddr 192.168.5.50 snat to 123.123.123.123
   }
 }
@@ -306,7 +308,7 @@ table inet fw_table {
 }
 NFTABLES_CONF
       expect(vs).to receive(:apply_nftables)
-      vs.write_nftables_conf(ip4, gua, nics)
+      vs.write_nftables_conf(ip4, gua, nics, "10.0.0.2")
     end
   end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -394,6 +394,8 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
+        ([ -f "/etc/docker/daemon.json" ] && sudo cat /etc/docker/daemon.json || echo '{}') | jq '. += #{JSON.generate({"experimental" => false, "dns-opts" => ["timeout:2", "attempts:3"]})}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")
@@ -412,6 +414,8 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
+        ([ -f "/etc/docker/daemon.json" ] && sudo cat /etc/docker/daemon.json || echo '{}') | jq '. += #{JSON.generate({"experimental" => false, "dns-opts" => ["timeout:2", "attempts:3"]})}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
       COMMAND
 


### PR DESCRIPTION
## NAT Dnsmasq IPv4 address properly
We use the 2nd address from the subnet to serve Dnsmasq for IPv4 dns
queries. The problem is, dnsmasq also uses that address to communicate
with the upstream dns servers. That results in a packet with a source
address as the private ip (2nd address of the subnet) AND we were not
NATting it. Therefore, we never got the response back when we use the
IPv4 Upstream DNS server. This was not visible to the VM because it was
querying dnsmasq in parallel for all the available addresses AND Dnsmasq
was responding them, whichever comes first, was accepted.

Now, we start to properly NAT the DNS queries as well, this way, dnsmasq
can properly communicate with upstream dns servers.

## Add additional Docker dns timeout and attempt parameters
On a failed job I have these docker logs;
```
Dec 03 13:45:47 vm7k0rew dockerd[1417]:
time="2024-12-03T13:45:47.038177306Z" level=error msg="[resolver] failed
to query external DNS server" client-addr="udp:172.18.0.2:46693"
dns-server="udp:172.29.239.130:53" error="read udp
172.18.0.2:46693->172.29.239.130:53: i/o timeout"
question=";yum.oracle.com.\tIN\t A" spanID=b5ad3b36d022195b
traceID=617475c6cb9b88190b48e60db9633404
Dec 03 13:45:47 vm7k0rew dockerd[1417]:
time="2024-12-03T13:45:47.038427798Z" level=error msg="[resolver] failed
to query external DNS server" client-addr="udp:172.18.0.2:37673"
dns-server="udp:172.29.239.130:53" error="read udp
172.18.0.2:37673->172.29.239.130:53: i/o timeout"
question=";yum.oracle.com.\tIN\t A" spanID=f88426217d618b04
traceID=7fa35406d60eacd7303bafa762e46a94
Dec 03 13:45:47 vm7k0rew dockerd[1417]:
time="2024-12-03T13:45:47.038604388Z" level=warning msg="[resolver]
connect failed" error="dial udp [fd00:b1c:100d:53::]:53: connect:
network is unreachable" spanID=bb71e837e560dfcf
traceID=7fa35406d60eacd7303bafa762e46a94
Dec 03 13:45:47 vm7k0rew dockerd[1417]:
time="2024-12-03T13:45:47.038769085Z" level=warning msg="[resolver]
connect failed" error="dial udp [fd00:b1c:100d:53::]:53: connect:
network is unreachable" spanID=2316ffb49742a91c
traceID=617475c6cb9b88190b48e60db9633404
Dec 03 13:45:47 vm7k0rew dockerd[1417]:
time="2024-12-03T13:45:47.038814336Z" level=error msg="[resolver] failed
to query external DNS server" client-addr="udp:172.18.0.2:46888"
dns-server="udp:172.29.239.130:53" error="read udp
172.18.0.2:46888->172.29.239.130:53: i/o timeout"
question=";yum.oracle.com.\tIN\t A" spanID=588581a12a0e6fbc
traceID=7bd41c6847bb4873a25807f551d92e16
Dec 03 13:45:47 vm7k0rew dockerd[1417]:
time="2024-12-03T13:45:47.038889982Z" level=warning msg="[resolver]
connect failed" error="dial udp [fd00:b1c:100d:53::]:53: connect:
network is unreachable" spanID=428d41cb63ec9634
traceID=7bd41c6847bb4873a25807f551d92e16
Dec 03 13:45:48 vm7k0rew dockerd[1417]:
time="2024-12-03T13:45:48.017542149Z" level=info msg="ignoring event"
container=6f49ff59382dc50e042aec9b6580efacd3ac49824144c5a98e295ccd17877923
module=libcontainerd namespace=moby topic=/tasks/delete
type="*events.TaskDelete"
```

This makes me think that there is a connection failure to dnsmasq. I
have checked the dnsmasq logs for the same instance and they are as
following;
```
...
...
Dec 03 13:45:43 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
e10877.dscd.akamaiedge.net is 2a02:26f0:de:290::2a7d
Dec 03 13:45:43 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
e10877.dscd.akamaiedge.net is 2a02:26f0:de:2ad::2a7d
Dec 03 13:45:47 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
pipelinesghubeus25.actions.githubusercontent.com from 172.29.239.174
Dec 03 13:45:47 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
pipelinesghubeus25.actions.githubusercontent.com is NODATA-IPv6
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[A]
results-receiver.actions.githubusercontent.com from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: forwarded
results-receiver.actions.githubusercontent.com to 149.112.112.112
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
results-receiver.actions.githubusercontent.com from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: forwarded
results-receiver.actions.githubusercontent.com to 149.112.112.112
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
results-receiver.actions.githubusercontent.com is <CNAME>
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
glb-db52c2cf8be544.github.com is 140.82.112.22
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
results-receiver.actions.githubusercontent.com is <CNAME>
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
glb-db52c2cf8be544.github.com is NODATA-IPv6
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
glb-db52c2cf8be544.github.com from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
glb-db52c2cf8be544.github.com is NODATA-IPv6
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
glb-db52c2cf8be544.github.com from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
glb-db52c2cf8be544.github.com is NODATA-IPv6
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[A]
productionresultssa6.blob.core.windows.net from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: forwarded
productionresultssa6.blob.core.windows.net to 149.112.112.112
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
productionresultssa6.blob.core.windows.net from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: forwarded
productionresultssa6.blob.core.windows.net to 149.112.112.112
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
productionresultssa6.blob.core.windows.net is <CNAME>
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
blob.bn3prdstrz12a.store.core.windows.net is <CNAME>
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
blob.bn3prdstrz12a.trafficmanager.net is NODATA-IPv6
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
blob.bn3prdstrz12a.trafficmanager.net from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
blob.bn3prdstrz12a.trafficmanager.net is NODATA-IPv6
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
productionresultssa6.blob.core.windows.net is <CNAME>
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
blob.bn3prdstrz12a.store.core.windows.net is <CNAME>
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
blob.bn3prdstrz12a.trafficmanager.net is 20.209.112.225
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
blob.bn3prdstrz12a.trafficmanager.net is 20.209.113.193
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: reply
blob.bn3prdstrz12a.trafficmanager.net is 20.209.178.193
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
pipelinesghubeus25.actions.githubusercontent.com from 172.29.239.174
Dec 03 13:45:48 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
pipelinesghubeus25.actions.githubusercontent.com is NODATA-IPv6
Dec 03 13:45:49 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
pipelinesghubeus25.actions.githubusercontent.com from 172.29.239.174
Dec 03 13:45:49 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
pipelinesghubeus25.actions.githubusercontent.com is NODATA-IPv6
Dec 03 13:45:49 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
pipelinesghubeus25.actions.githubusercontent.com from 172.29.239.174
Dec 03 13:45:49 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
pipelinesghubeus25.actions.githubusercontent.com is NODATA-IPv6
Dec 03 13:45:49 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: query[AAAA]
pipelinesghubeus25.actions.githubusercontent.com from 172.29.239.174
Dec 03 13:45:49 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq[308118]: cached
pipelinesghubeus25.actions.githubusercontent.com is NODATA-IPv6
Dec 03 13:46:25 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq-dhcp[308118]:
DHCPREQUEST(ncar5494db) 172.29.239.174 46:de:fc:a9:a7:6a
Dec 03 13:46:25 vhp1hr9mt8gy7hkym0j96mx60n dnsmasq-dhcp[308118]:
DHCPACK(ncar5494db) 172.29.239.174 46:de:fc:a9:a7:6a vm7k0rew
...
...
```

The interesting thing is that from 13:45:49 to 13:46:25, there are no
logs. Dnsmasq did not reboot, too. So, this only makes me think that we
are either congested at the VM or host tap device. There is not much of
a way to understand which one it is. Therefore, I am simply adding retry
attempts in case such a failure happens.

## Lease DHCP4 for 6 hours
The default is 1 hour for dnsmasq per the manual however, as far as I
can see, it is 2 minutes for us. I caught at just at the renewal;
```
runneradmin@vm086b75:/tmp$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc mq state UP
group default qlen 1000
    link/ether 9a:b1:f0:66:29:8a brd ff:ff:ff:ff:ff:ff
    altname enp0s3
inet 10.95.34.36/26 metric 100 brd 10.95.34.63 scope global dynamic
ens3
       valid_lft 120sec preferred_lft 120sec
inet6 2a01:4f8:161:24db:98cc::2/128 scope global dynamic
noprefixroute
       valid_lft 82409sec preferred_lft 82409sec
inet6 fd0d:83f8:ff01:194b:ec40::2/128 scope global dynamic
noprefixroute
       valid_lft 82409sec preferred_lft 82409sec
    inet6 fe80::98b1:f0ff:fe66:298a/64 scope link
       valid_lft forever preferred_lft forever
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue
state DOWN group default
    link/ether 02:42:b6:3a:c0:02 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
```

This doesn't make sense especially for runners because the private ipv4
address of the VM will never change the whole lifetime of the runner.
The timeout limit for github actions runners are 6 hours, so I simply
set it to that value.

dhcp-range parameter of dnsmasq is a little bit weird that if we put
both the mask and lease time, it fails to start. Since the address is
defined from start to end and we put the same address, the prefix len
can be replaced with 6h.