### PR TITLE
Remove Authorization.authorized_resources

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -25,10 +25,6 @@ module Authorization
     matched_policies_dataset(subject_id, actions).select(Sequel[:applied_tag][:tagged_id])
   end
 
-  def self.authorized_resources(subject_id, actions)
-    matched_policies_dataset(subject_id, actions).select_map(Sequel[:applied_tag][:tagged_id])
-  end
-
   def self.expand_actions(actions)
     extended_actions = Set["*"]
     Array(actions).each do |action|

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -92,15 +92,15 @@ RSpec.describe Authorization do
     end
   end
 
-  describe "#authorized_resources" do
+  describe "#authorized_resources_dataset" do
     it "returns resource ids when has matched policies" do
       ids = [vms[0].id, vms[1].id, projects[0].id, users[0].id, vms[0].private_subnets[0].id, vms[1].private_subnets[0].id, vms[0].firewalls[0].id, vms[1].firewalls[0].id]
-      expect(described_class.authorized_resources(users[0].id, "Vm:view").sort).to eq(ids.sort)
+      expect(described_class.authorized_resources_dataset(users[0].id, "Vm:view").map(:tagged_id).sort).to eq(ids.sort)
     end
 
     it "returns no resource ids when has no matched policies" do
       access_policy.update(body: [])
-      expect(described_class.authorized_resources(users[0].id, "Vm:view")).to eq([])
+      expect(described_class.authorized_resources_dataset(users[0].id, "Vm:view")).to be_empty
     end
   end
 


### PR DESCRIPTION
This is unused since d632ec9d245fa14bb5fcef7bfe693cfdbd7ddb9b. Switch the specs to use authorized_resources_dataset.