### PR TITLE
Relax private subnet deletion check

### DIFF
--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -61,7 +61,7 @@ class Clover
 
       request.delete true do
         authorize("PrivateSubnet:delete", ps.id)
-        unless ps.vms_dataset.empty?
+        unless ps.vms.all? { _1.destroy_set? || _1.strand.nil? || _1.strand.label == "destroy" }
           fail DependencyError.new("Private subnet '#{ps.name}' has VMs attached, first, delete them.")
         end
 


### PR DESCRIPTION
When processing a request to delete a PrivateSubnet, the system currently verifies whether the subnet contains any VMs. If VMs are present, a dependency error is raised. This behavior can lead to unexpected errors if a client deletes all VMs and subsequently attempts to delete the subnet.

To address this, the deletion check is being adjusted to allow the subnet to be deleted even if it still contains VMs, provided all the VMs are already marked for deletion. This ensures the subnet deletion request succeeds in such scenarios.