### PR TITLE
Add page header and breadcrumb to networking list pages

### DIFF
--- a/views/networking/firewall/index.erb
+++ b/views/networking/firewall/index.erb
@@ -1,5 +1,10 @@
-<% @page_title = "Firewalls" %>
+<% @page_title = "Firewalls"
+@right_items = has_project_permission("Firewall:create") ? [
+  render("components/button", locals: { text: "Create Firewall", link: "#{@project_data[:path]}/firewall/create" })
+] : [] %>
+
 <%== render("networking/tabbar") %>
+
 <% if @firewalls.count > 0 %>
   <div class="grid gap-6">
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
@@ -34,13 +39,6 @@
         </tbody>
       </table>
     </div>
-  </div>
-  <div class="flex justify-end space-y-1 mt-6">
-      <% if has_project_permission("Firewall:create")%>
-      <%== render(
-        "components/button", locals: { text: "Create Firewall", link: "firewall/create" })
-      %>
-      <% end %>
   </div>
 <% else %>
   <div class="mt-6">

--- a/views/networking/load_balancer/index.erb
+++ b/views/networking/load_balancer/index.erb
@@ -1,5 +1,10 @@
-<% @page_title = "Load Balancers" %>
+<% @page_title = "Load Balancers"
+@right_items = has_project_permission("LoadBalancer:create") ? [
+  render("components/button", locals: { text: "Create Load Balancer", link: "#{@project_data[:path]}/load-balancer/create" })
+] : [] %>
+
 <%== render("networking/tabbar") %>
+
 <% if @lbs.count > 0 %>
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <table class="min-w-full divide-y divide-gray-300">
@@ -28,13 +33,6 @@
         <% end %>
       </tbody>
     </table>
-  </div>
-  <div class="flex justify-end space-y-1 mt-6">
-    <% if has_project_permission("LoadBalancer:create")%>
-      <%== render(
-        "components/button", locals: { text: "Create Load Balancer", link: "load-balancer/create" })
-      %>
-    <% end %>
   </div>
 <% else %>
 <div class="mt-6">

--- a/views/networking/private_subnet/index.erb
+++ b/views/networking/private_subnet/index.erb
@@ -1,5 +1,10 @@
-<% @page_title = "Private Subnets" %>
+<% @page_title = "Private Subnets"
+@right_items = has_project_permission("PrivateSubnet:create") ? [
+  render("components/button", locals: { text: "Create Private Subnet", link: "#{@project_data[:path]}/private-subnet/create" })
+] : [] %>
+
 <%== render("networking/tabbar") %>
+
 <% if @pss.count > 0 %>
   <div class="grid gap-6">
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
@@ -28,13 +33,6 @@
         </tbody>
       </table>
     </div>
-  </div>
-  <div class="flex justify-end space-y-1 mt-6">
-    <% if has_project_permission("PrivateSubnet:create")%>
-    <%== render(
-      "components/button", locals: { text: "Create Private Subnet", link: "private-subnet/create" })
-    %>
-    <% end %>
   </div>
 <% else %>
   <div class="mt-6">

--- a/views/networking/tabbar.erb
+++ b/views/networking/tabbar.erb
@@ -1,4 +1,13 @@
 <%== render(
+  "components/page_header",
+  locals: {
+    title: "Networking",
+    breadcrumbs: [%w[Projects /project], [@project_data[:name], @project_data[:path]], [@page_title, "#"]],
+    right_items: @right_items
+  }
+) %>
+
+<%== render(
   "components/tabbar",
   locals: {
     tabs: [


### PR DESCRIPTION
The new version looks more similar to the our other pages.

Also we put create buttons to right of the page header instead of the bottom of the page in the other pages.

When it's at the bottom of the page, it's not visible when the list is long.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/4a83face-1cd3-46a0-be31-a4a16b007fff) | ![After](https://github.com/user-attachments/assets/d8651b38-f871-4676-b561-ec5f37a66b45) |


