### PR TITLE
Introduce new project dashboard

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -8,6 +8,7 @@ class Project < Sequel::Model
   one_to_one :billing_info, key: :id, primary_key: :billing_info_id
   one_to_many :usage_alerts
   one_to_many :github_installations
+  many_through_many :github_runners, [[:github_installation, :project_id, :id], [:github_runner, :installation_id, :id]]
 
   many_to_many :accounts, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
   many_to_many :vms, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -18,7 +18,7 @@ class Clover
       end
 
       r.get "runner" do
-        @runners = Serializers::GithubRunner.serialize(@project.github_installations_dataset.eager(runners: [:vm, :strand]).flat_map(&:runners).sort_by(&:created_at).reverse)
+        @runners = Serializers::GithubRunner.serialize(@project.github_runners_dataset.eager(:vm, :strand).reverse(:created_at).all)
 
         view "github/runner"
       end

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -121,19 +121,13 @@ RSpec.describe Clover, "github" do
   describe "runner" do
     it "can list active runners" do
       runner_deleted = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").update(label: "wait_vm_destroy")
-      runner_with_job = GithubRunner.create_with_id(
-        installation_id: installation.id,
-        label: "ubicloud",
-        repository_name: "my-repo",
-        runner_id: 2,
-        workflow_job: {
-          "id" => 123,
-          "name" => "test-job",
-          "run_id" => 456,
-          "workflow_name" => "test-workflow"
-        },
-        vm_id: Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "runner-vm").id
-      )
+      runner_with_job = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").update(label: "wait").subject
+      runner_with_job.update(runner_id: 2, vm_id: Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "runner-vm").id, workflow_job: {
+        "id" => 123,
+        "name" => "test-job",
+        "run_id" => 456,
+        "workflow_name" => "test-workflow"
+      })
       runner_not_created = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo")
       runner_concurrency_limit = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").update(label: "wait_concurrency_limit")
       runner_wo_strand = GithubRunner.create_with_id(installation_id: installation.id, label: "ubicloud", repository_name: "my-repo")

--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -121,8 +121,10 @@
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
     <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
   </svg>
-
-
+<% when "hero-document-text" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+  </svg>
 <% else %>
   <p>Not found icon</p>
 <% end %>

--- a/views/project/dashboard.erb
+++ b/views/project/dashboard.erb
@@ -6,31 +6,66 @@
 </div>
 
 <div class="grid gap-6">
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 lg:gap-10">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 lg:gap-8">
+    <div class="overflow-hidden rounded-lg bg-white p-4 relative shadow md:col-span-2 lg:col-span-3 xl:col-span-2">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        <% [
+            ["hero-server-stack", "Virtual Machines", @project.vms_dataset.count, "#{@project_data[:path]}/vm"],
+            ["hero-circle-stack", "PostgreSQL Databases", @project.postgres_resources_dataset.count, "#{@project_data[:path]}/postgres"],
+            ["hero-arrows-pointing-out", "Load Balancers", @project.load_balancers_dataset.count, "#{@project_data[:path]}/load-balancer"],
+            ["hero-firewall", "Firewalls", @project.firewalls_dataset.count, "#{@project_data[:path]}/firewall"],
+            ["github", "GitHub Runners", @project.github_runners_dataset.count, "#{@project_data[:path]}/github"],
+            ["hero-users", "Users", @project.accounts_dataset.count, "#{@project_data[:path]}/user"]
+          ].each do |icon, title, count, link| %>
+          <a href="<%= link %>">
+            <dl class="px-2 py-1">
+              <dt>
+                <div class="absolute rounded-md bg-orange-50 text-orange-700 p-3">
+                  <%== render("components/icon", locals: { name: icon, classes: "size-6" }) %>
+                </div>
+                <p class="ml-16 truncate text-sm font-medium text-gray-500"><%= title %></p>
+              </dt>
+              <dd class="ml-16 flex items-baseline">
+                <p class="text-2xl font-semibold text-gray-900"><%= count %></p>
+              </dd>
+            </dl>
+          </a>
+        <% end %>
+      </div>
+    </div>
+
     <% [
       [
-        "hero-folder-open", "bg-teal-50 text-teal-700", "Create Virtual Machine",
+        "hero-server-stack", "Create Virtual Machine",
         "Linux-based virtual machines that run on top of virtualized hardware. Comprehensive, cost-effective cloud computing.",
         "#{@project_data[:path]}/vm/create"
       ], [
-        "hero-users", "bg-purple-50 text-purple-700", "Add User to Project",
-        "Projects are the central point for working with others within Ubicloud. Get started by adding others to your project to be able to share access and collaborate.",
+        "github", "Use GitHub Runners",
+        "10x cost-effective managed GitHub Actions runners. Install our GitHub app and change one line in your workflow file.",
+        "#{@project_data[:path]}/github"
+      ], [
+        "hero-circle-stack", "Create Managed Database",
+        "Fully managed PostgreSQL databases. It handles backups, high availability, health monitoring, and many for you.",
+        "#{@project_data[:path]}/postgres"
+      ], [
+        "hero-users", "Add User to Project",
+        "Get started by adding other users to your project to be able to share resources and collaborate with them.",
         "#{@project_data[:path]}/user"
       ], [
-        "hero-key", "bg-sky-50 text-sky-700", "Update Access Policy",
-        "Access policies help to specify who can perform particular actions on your project's resources.",
-        "#{@project_data[:path]}/user/policy"
+        "hero-document-text", "Documentation",
+        "Learn more about our managed services and detailed architecture by exploring our documentation.",
+        "https://www.ubicloud.com/docs"
       ], [
-        "hero-envelope", "bg-yellow-50 text-yellow-700", "Get Support",
+        "hero-envelope", "Get Support",
         "If you need any help with Ubicloud, reach out to our support team for help at support@ubicloud.com.",
-        "mailto:support@ubicloud.com"
+        "https://www.ubicloud.com/docs/about/support"
       ]
-    ].each do |icon, color, title, description, link| %>
+    ].each do |icon, title, description, link| %>
       <div
         class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-orange-600"
       >
         <div>
-          <span class="inline-flex rounded-lg p-3 <%= color %> ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-orange-50 text-orange-700 ring-4 ring-white">
             <%== render("components/icon", locals: { name: icon }) %>
           </span>
         </div>


### PR DESCRIPTION
### Add github_runners association to project

The project has GithubRunner models through GitHubInstallation models.

It couldn't setup it with `one_through_many` association, so I used
`many_through_many`.


### Introduce new project dashboard

The project dashboard is the first thing users see when they create a
new account. It was designed in the early days and hasn't been updated
since.

We've overlooked the dashboard, despite it being one of the most crucial
pages.

Redesigning it with UX principles in mind is a significant task.

I've just introduced the new project dashboard. I haven't spent a lot of
time on it yet, but we can certainly enhance it over time.

Even though it's a preliminary version, I believe it's an improvement
over the previous one and a good starting point.

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/2b3d7977-c92a-45c8-8569-ba3498431170) | ![after](https://github.com/user-attachments/assets/097dc8b6-a4bc-41a4-98e2-746d3d4fd982) |