### PR TITLE
Dhcp fix for IPv4

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -441,15 +441,12 @@ DHCP
     interfaces = nics.map { "interface=#{_1.tap}" }.join("\n")
     dnsmasq_address_ip6 = NetAddr::IPv6.parse("fd00:0b1c:100d:53::")
     runner_config = if boot_image.include?("github")
-      <<~ADDITIONAL_RUNNER_CONFIG
+      <<~ADDRESSES
       address=/ubicloudhostplaceholder.blob.core.windows.net/#{nics.first.net4.split("/").first}
       address=/.docker.io/::
-      dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},6h
-      ADDITIONAL_RUNNER_CONFIG
+      ADDRESSES
     else
-      <<~ADDITIONAL_CONFIG
-      dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
-      ADDITIONAL_CONFIG
+      ""
     end
     vp.write_dnsmasq_conf(<<DNSMASQ_CONF)
 pid-file=
@@ -461,6 +458,7 @@ bogus-priv
 no-resolv
 #{raparams}
 #{interfaces}
+dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
 #{private_ip_dhcp}
 server=9.9.9.9@#{dns_ipv4}
 server=149.112.112.112@#{dns_ipv4}

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -432,7 +432,7 @@ EOS
       vm_sub_6 = NetAddr::IPv6Net.parse(nic.net6)
       vm_sub_4 = NetAddr::IPv4Net.parse(nic.net4)
       <<DHCP
-dhcp-range=#{nic.tap},#{vm_sub_4.nth(0)},#{vm_sub_4.nth(0)},#{vm_sub_4.netmask.prefix_len}
+dhcp-range=#{nic.tap},#{vm_sub_4.nth(0)},#{vm_sub_4.nth(0)},6h
 dhcp-range=#{nic.tap},#{vm_sub_6.nth(2)},#{vm_sub_6.nth(2)},#{vm_sub_6.netmask.prefix_len}
 DHCP
     end.join("\n")


### PR DESCRIPTION
## Revert "Lease DHCP4 for 6 hours"
This reverts commit cb833fd0cc57901c16abccbbe67239def89b7562.

## Fix DHCPv4 Lease Time (Really set it to 6h)
The previous commit made a mistake and it was not setting the right dhcp
lease. It was setting it for IPv6, this one sets it really for IPv4.