### PR TITLE
Location specific default subnets

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -128,6 +128,12 @@ class Project < Sequel::Model
     end
   end
 
+  def default_private_subnet(location)
+    name = "default-#{LocationNameConverter.to_display_name(location)}"
+    ps = private_subnets_dataset.first(:location => location, Sequel[:private_subnet][:name] => name)
+    ps || Prog::Vnet::SubnetNexus.assemble(id, name: name, location: location).subject
+  end
+
   def self.feature_flag(*flags, into: self)
     flags.map(&:to_s).each do |flag|
       into.module_eval do

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -41,6 +41,12 @@ class Prog::Vm::GithubRunner < Prog::Base
       return picked_vm
     end
 
+    ps = Prog::Vnet::SubnetNexus.assemble(
+      Config.github_runner_service_project_id,
+      location: label_data["location"],
+      allow_only_ssh: true
+    ).subject
+
     vm_st = Prog::Vm::Nexus.assemble_with_sshable(
       "runneradmin",
       Config.github_runner_service_project_id,
@@ -52,7 +58,8 @@ class Prog::Vm::GithubRunner < Prog::Base
       enable_ip4: true,
       arch: label_data["arch"],
       allow_only_ssh: true,
-      swap_size_bytes: 4294963200 # ~4096MB, the same value with GitHub hosted runners
+      swap_size_bytes: 4294963200, # ~4096MB, the same value with GitHub hosted runners
+      private_subnet_id: ps.id
     )
 
     vm_st.subject

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -81,8 +81,7 @@ class Prog::Vm::Nexus < Prog::Base
           raise "Given subnet is not available in the given project" unless project.private_subnets.any? { |ps| ps.id == subnet.id }
           subnet
         else
-          subnet = Prog::Vnet::SubnetNexus.assemble(project_id, name: "#{name}-subnet", location: location, allow_only_ssh: allow_only_ssh).subject
-          PrivateSubnet[subnet.id]
+          project.default_private_subnet(location)
         end
         nic = Prog::Vnet::NicNexus.assemble(subnet.id, name: "#{name}-nic").subject
       end

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -38,6 +38,12 @@ class Prog::Vm::VmPool < Prog::Base
       encrypted: vm_pool.storage_encrypted,
       skip_sync: vm_pool.storage_skip_sync
     }
+    ps = Prog::Vnet::SubnetNexus.assemble(
+      Config.vm_pool_project_id,
+      location: vm_pool.location,
+      allow_only_ssh: true
+    ).subject
+
     Prog::Vm::Nexus.assemble_with_sshable(
       "runneradmin",
       Config.vm_pool_project_id,
@@ -49,7 +55,8 @@ class Prog::Vm::VmPool < Prog::Base
       pool_id: vm_pool.id,
       arch: vm_pool.arch,
       allow_only_ssh: true,
-      swap_size_bytes: 4294963200
+      swap_size_bytes: 4294963200,
+      private_subnet_id: ps.id
     )
 
     hop_wait

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe Authorization do
     ]
   }
   let(:projects) { (0..1).map { users[_1].create_project_with_default_policy("project-#{_1}") } }
-  let(:vms) { (0..3).map { Prog::Vm::Nexus.assemble("key", projects[_1 / 2].id, name: "vm#{_1}") }.map(&:subject) }
+  let(:vms) {
+    (0..3).map do |index|
+      ps = Prog::Vnet::SubnetNexus.assemble(projects[index / 2].id, name: "vm#{index}-ps", location: "hetzner-fsn1").subject
+      Prog::Vm::Nexus.assemble("key", projects[index / 2].id, name: "vm#{index}", private_subnet_id: ps.id)
+    end.map(&:subject)
+  }
   let(:pg) {
     Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: projects[0].id, location: "hetzner-fsn1", name: "pg0", target_vm_size: "standard-2", target_storage_size_gib: 128

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Pagination do
 
       it "big page size" do
         101.times do |index|
-          Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "additional-vm-#{index}").subject
+          ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "additional-ps-#{index}", location: "hetzner-fsn1").subject
+          Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "additional-vm-#{index}", private_subnet_id: ps.id).subject
         end
 
         result = project.vms_dataset.paginated_result(page_size: 1000)

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "provisions a VM if the pool is not existing" do
       expect(VmPool).to receive(:where).and_return([])
+      expect(Prog::Vnet::SubnetNexus).to receive(:assemble).and_call_original
       expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
       expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
       vm = nx.pick_vm

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Prog::Vm::VmPool do
     }
 
     it "creates a new vm and hops to wait" do
-      expect(Config).to receive(:vm_pool_project_id).and_return(prj.id)
+      expect(Config).to receive(:vm_pool_project_id).and_return(prj.id).at_least(:once)
       st = described_class.assemble(
         size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1",
         storage_size_gib: 86, storage_encrypted: true,

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -67,10 +67,18 @@
                   locals: {
                     name: "private_subnet_id",
                     label: "Private Subnet",
-                    placeholder: "Create new subnet",
+                    placeholder: "Default",
                     options: @subnets.map { |s| [s[:id], s[:name], "location-based-option #{s[:location]}"] }
                   }
                 ) %>
+                <p class="mt-1 text-sm leading-6 text-gray-600">
+                  We recommend using the default subnet for most use-cases. If
+                  you'd like to learn more about private subnets, please visit
+                  <a href="<%=
+                  "https://www.ubicloud.com/docs/networking/private-subnet" %>"
+                  class="text-orange-600 hover:text-orange-700">Private
+                  Subnets</a> page.
+                </p>
               </div>
               <div class="col-span-full">
                 <%== render(


### PR DESCRIPTION
## Introduce location specific default subnets
This way, customers will simply use their default subnet in that region
unless they choose otherwise. This will simply make the experience
easier for the most basic customer. Nothing changes for the ones who
care about proper grouping of resources in different subnets.

## Github Runners force different subnet usage
This is important because Github Runners simply live in the same project
and they leave private subnet provisioning to the Vm::Nexus.assemble
function. To make sure every runner is provisioned in a different
subnet, we pass the foce_new_subnet flag.

This is not a problem for the other services because they create their
individual subnets and pass their id.