### PR TITLE
Remove hard dependency to MinIO connection in Postgres serializer

### DIFF
--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -27,7 +27,11 @@ class Serializers::Postgres < Serializers::Base
       )
 
       if pg.timeline && pg.representative_server&.primary?
-        base[:earliest_restore_time] = pg.timeline.earliest_restore_time&.utc&.iso8601
+        begin
+          base[:earliest_restore_time] = pg.timeline.earliest_restore_time&.utc&.iso8601
+        rescue => ex
+          Clog.emit("Failed to get earliest restore time") { Util.exception_to_hash(ex) }
+        end
         base[:latest_restore_time] = pg.timeline.latest_restore_time&.utc&.iso8601
       end
     end

--- a/spec/serializers/postgres_spec.rb
+++ b/spec/serializers/postgres_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe Serializers::Postgres do
     expect(data[:latest_restore_time]).to be_nil
   end
 
+  it "can serialize when earliest_restore_time calculation raises an exception" do
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, latest_restore_time: nil)).exactly(4)
+    expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
+    expect(pg.timeline).to receive(:earliest_restore_time).and_raise("error")
+    data = described_class.serialize(pg, {detailed: true})
+    expect(data[:earliest_restore_time]).to be_nil
+    expect(data[:latest_restore_time]).to be_nil
+  end
+
   it "can serialize when have earliest/latest restore times" do
     time = Time.now
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)


### PR DESCRIPTION
We need to connect to MinIO cluster to calculate earliest restore time, however this is not always possible and can error out due to various reasons. In such cases, instead of returning 500, it is better to just hide restore UI. This commit does that by surrounding the code that tries to connect MinIO with a rescue block.