### PR TITLE
Openapi responses components

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -209,11 +209,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -228,7 +224,7 @@ paths:
       summary: Delete a specific firewall rule
       responses:
         '204':
-          description: Firewall rule deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -238,11 +234,7 @@ paths:
       summary: Get details of a firewall rule
       responses:
         '200':
-          description: Details of the firewall rule
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -430,7 +422,7 @@ paths:
       summary: Delete a specific firewall
       responses:
         '204':
-          description: Firewall deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -475,11 +467,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -495,7 +483,7 @@ paths:
       summary: Delete a specific firewall rule
       responses:
         '204':
-          description: Firewall rule deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -505,11 +493,7 @@ paths:
       summary: Get details of a firewall rule
       responses:
         '200':
-          description: Details of the firewall rule
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -539,11 +523,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -628,11 +608,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -648,7 +624,7 @@ paths:
       summary: Delete a specific firewall rule
       responses:
         '204':
-          description: Firewall rule deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -658,11 +634,7 @@ paths:
       summary: Get details of a firewall rule
       responses:
         '200':
-          description: Details of the firewall rule
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -692,11 +664,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallRule'
+          $ref: '#/components/responses/FirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1307,7 +1275,7 @@ paths:
       summary: Delete a specific firewall rule
       responses:
         '204':
-          description: Firewall rule deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -2337,6 +2305,12 @@ components:
             required:
               - count
               - items
+    FirewallRule:
+      description: A Firewall Rule
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/FirewallRule'
     Project:
       description: A Project
       content:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -62,22 +62,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: Return the list of all projects visible to the logged in user
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Project'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/Projects'
         default:
           $ref: '#/components/responses/Error'
       security:
@@ -102,11 +87,7 @@ paths:
                 - name
       responses:
         '200':
-          description: Project is created successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Project'
+          $ref: '#/components/responses/Project'
         default:
           $ref: '#/components/responses/Error'
       security:
@@ -121,7 +102,7 @@ paths:
       summary: Delete a project
       responses:
         '204':
-          description: Project deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -131,11 +112,7 @@ paths:
       summary: Retrieve a project
       responses:
         '200':
-          description: Retrieved project
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Project'
+          $ref: '#/components/responses/Project'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -2375,12 +2352,37 @@ components:
             - subnet
             - unix_user
   responses:
+    Delete:
+      description: An empty response after successful resource delete
     Error:
-      description: an error response
+      description: An error response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+    Project:
+      description: A Project
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Project'
+    Projects:
+      description: A list of Projects
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+            additionalProperties: false
+            required:
+              - count
+              - items
   securitySchemes:
     BearerAuth:
       bearerFormat: JWT

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1257,22 +1257,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of Private Subnets in a location
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PrivateSubnet'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/PrivateSubnets'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1287,7 +1272,7 @@ paths:
       summary: Delete a specific Private Subnet with ID
       responses:
         '204':
-          description: Private Subnet is deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1297,11 +1282,7 @@ paths:
       summary: Get details of a specific Private Subnet in a location with ID
       responses:
         '200':
-          description: Details of the private subnet
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PrivateSubnet'
+          $ref: '#/components/responses/PrivateSubnet'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1316,7 +1297,7 @@ paths:
       summary: Delete a specific Private Subnet
       responses:
         '204':
-          description: Private Subnet is deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1326,11 +1307,7 @@ paths:
       summary: Get details of a specific Private Subnet in a location
       responses:
         '200':
-          description: Details of the private subnet
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PrivateSubnet'
+          $ref: '#/components/responses/PrivateSubnet'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1350,11 +1327,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
-          description: Private subnet is created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PrivateSubnet'
+          $ref: '#/components/responses/PrivateSubnet'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1521,22 +1494,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of private subnets
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PrivateSubnet'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/PrivateSubnets'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -2205,6 +2163,29 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/PostgresFirewallRule'
+            additionalProperties: false
+            required:
+              - count
+              - items
+    PrivateSubnet:
+      description: A Private Subnet
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PrivateSubnet'
+    PrivateSubnets:
+      description: A list of Private Subnets
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PrivateSubnet'
             additionalProperties: false
             required:
               - count

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1344,22 +1344,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of VMs
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Vm'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/Vms'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1374,7 +1359,7 @@ paths:
       summary: Delete a specific VM with ID
       responses:
         '204':
-          description: VM deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1384,11 +1369,7 @@ paths:
       summary: Get details of a specific VM in a location with ID
       responses:
         '200':
-          description: Details of the VM
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VmDetailed'
+          $ref: '#/components/responses/Vm'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1403,7 +1384,7 @@ paths:
       summary: Delete a specific VM
       responses:
         '204':
-          description: VM deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1413,11 +1394,7 @@ paths:
       summary: Get details of a specific VM in a location
       responses:
         '200':
-          description: Details of the VM
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VmDetailed'
+          $ref: '#/components/responses/Vm'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1458,11 +1435,7 @@ paths:
                 - public_key
       responses:
         '200':
-          description: Virtual machine created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VmDetailed'
+          $ref: '#/components/responses/Vm'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1510,22 +1483,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: Return the list of all VMs visible created under the given project and visible to the logged in user
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Vm'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/Vms'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1961,38 +1919,6 @@ components:
         - state
         - storage_size_gib
         - unix_user
-    VmDetailed:
-      type: object
-      additionalProperties: false
-      allOf:
-        - $ref: '#/components/schemas/Vm'
-        - additionalProperties: false
-          properties:
-            firewalls:
-              description: List of firewalls
-              type: array
-              items:
-                $ref: '#/components/schemas/Firewall'
-            private_ipv4:
-              description: Private IPv4 address
-              type: string
-              format: ipv4
-            private_ipv6:
-              description: Private IPv6 address
-              type: string
-              format: ipv6
-            subnet:
-              description: Subnet of the VM
-              type: string
-            unix_user:
-              description: Unix user of the VM
-              type: string
-          required:
-            - firewalls
-            - private_ipv4
-            - private_ipv6
-            - subnet
-            - unix_user
   responses:
     Delete:
       description: An empty response after successful resource delete
@@ -2209,6 +2135,59 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/Project'
+            additionalProperties: false
+            required:
+              - count
+              - items
+    Vm:
+      description: A VM
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            allOf:
+              - $ref: '#/components/schemas/Vm'
+              - additionalProperties: false
+                properties:
+                  firewalls:
+                    description: List of firewalls
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Firewall'
+                  private_ipv4:
+                    description: Private IPv4 address
+                    type: string
+                    format: ipv4
+                  private_ipv6:
+                    description: Private IPv6 address
+                    type: string
+                    format: ipv6
+                  subnet:
+                    description: Subnet of the VM
+                    type: string
+                  unix_user:
+                    description: Unix user of the VM
+                    type: string
+                required:
+                  - firewalls
+                  - private_ipv4
+                  - private_ipv6
+                  - subnet
+                  - unix_user
+    Vms:
+      description: A list of VMs
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vm'
             additionalProperties: false
             required:
               - count

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -125,22 +125,7 @@ paths:
       summary: Return the list of firewalls in the project
       responses:
         '200':
-          description: Firewall list retrieved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Firewall'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/Firewalls'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -166,11 +151,7 @@ paths:
                 - name
       responses:
         '200':
-          description: Firewall created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Firewall'
+          $ref: '#/components/responses/Firewall'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -194,11 +175,7 @@ paths:
       summary: Get details of a specific firewall
       responses:
         '200':
-          description: Details of the firewall
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Firewall'
+          $ref: '#/components/responses/Firewall'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -374,22 +351,7 @@ paths:
       summary: Return the list of firewalls in the project and location
       responses:
         '200':
-          description: Firewall list retrieved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Firewall'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/Firewalls'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -478,11 +440,7 @@ paths:
       summary: Get details of a specific firewall
       responses:
         '200':
-          description: Details of the firewall
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Firewall'
+          $ref: '#/components/responses/Firewall'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -635,11 +593,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
-          description: Firewall created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Firewall'
+          $ref: '#/components/responses/Firewall'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -2360,6 +2314,29 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+    Firewall:
+      description: A Firewall
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Firewall'
+    Firewalls:
+      description: A list of Firewalls
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Firewall'
+            additionalProperties: false
+            required:
+              - count
+              - items
     Project:
       description: A Project
       content:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -165,7 +165,7 @@ paths:
       summary: Delete a specific firewall
       responses:
         '204':
-          description: Firewall deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -348,11 +348,7 @@ paths:
                 - private_subnet_id
       responses:
         '200':
-          description: Subnet attached successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallDetailed'
+          $ref: '#/components/responses/FirewallDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -380,11 +376,7 @@ paths:
                 - private_subnet_id
       responses:
         '200':
-          description: Subnet detached successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallDetailed'
+          $ref: '#/components/responses/FirewallDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -515,7 +507,7 @@ paths:
       summary: Delete a specific firewall
       responses:
         '204':
-          description: Firewall deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -525,11 +517,7 @@ paths:
       summary: Get details of a specific firewall
       responses:
         '200':
-          description: Details of the firewall
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FirewallDetailed'
+          $ref: '#/components/responses/FirewallDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1762,20 +1750,6 @@ components:
         - id
         - location
         - name
-    FirewallDetailed:
-      type: object
-      additionalProperties: false
-      allOf:
-        - $ref: '#/components/schemas/Firewall'
-        - properties:
-            private_subnets:
-              description: List of private subnets
-              type: array
-              items:
-                type: string
-          additionalProperties: false
-          required:
-            - private_subnets
     FirewallRule:
       type: object
       properties:
@@ -2076,6 +2050,24 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Firewall'
+    FirewallDetailed:
+      description: A Firewall (detailed)
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            allOf:
+              - $ref: '#/components/schemas/Firewall'
+              - properties:
+                  private_subnets:
+                    description: List of private subnets
+                    type: array
+                    items:
+                      type: string
+                additionalProperties: false
+                required:
+                  - private_subnets
     Firewalls:
       description: A list of Firewalls
       content:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -858,22 +858,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of Postgres Databases in a specific location of a project
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PostgresDatabase'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/PostgresDatabases'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -888,11 +873,7 @@ paths:
       summary: Failover a specific Postgres Database with ID
       responses:
         '200':
-          description: Details of the failed over Postgres Databases in a location
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -964,7 +945,7 @@ paths:
       summary: Delete a specific Postgres Database with ID
       responses:
         '204':
-          description: Postgres Database is deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -974,11 +955,7 @@ paths:
       summary: Get details of a specific Postgres Database in a location with ID
       responses:
         '200':
-          description: Details of the Postgres Databases in a location
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1062,11 +1039,7 @@ paths:
                 - password
       responses:
         '200':
-          description: Superuser password is updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1096,11 +1069,7 @@ paths:
                 - restore_target
       responses:
         '200':
-          description: Postgres Database is restored successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabase'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1115,7 +1084,7 @@ paths:
       summary: Delete a specific Postgres Database
       responses:
         '204':
-          description: Postgres database is deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1125,11 +1094,7 @@ paths:
       summary: Get details of a specific Postgres database in a location
       responses:
         '200':
-          description: Details of the Postgres Database
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1161,11 +1126,7 @@ paths:
                 - size
       responses:
         '200':
-          description: Postgres Database is created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1249,11 +1210,7 @@ paths:
                 - username
       responses:
         '200':
-          description: Postgres Metric Destiantion created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1269,7 +1226,7 @@ paths:
       summary: Delete a specific Metric Destination
       responses:
         '204':
-          description: Metric Destination deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1296,11 +1253,7 @@ paths:
                 - password
       responses:
         '200':
-          description: Superuser password is updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1330,11 +1283,7 @@ paths:
                 - restore_target
       responses:
         '200':
-          description: Postgres database is restored successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresDatabaseDetailed'
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1599,22 +1548,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of Postgres Databases
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PostgresDatabase'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/PostgresDatabases'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1996,38 +1930,6 @@ components:
         - storage_size_gib
         - version
         - vm_size
-    PostgresDatabaseDetailed:
-      type: object
-      additionalProperties: false
-      allOf:
-        - $ref: '#/components/schemas/PostgresDatabase'
-        - additionalProperties: false
-          properties:
-            connection_string:
-              description: Connection string to the Postgres database
-              type: string
-              nullable: true
-            earliest_restore_time:
-              description: Earliest restore time (if primary)
-              type: string
-              nullable: true
-            firewall_rules:
-              description: List of Postgres firewall rules
-              type: array
-              items:
-                $ref: '#/components/schemas/PostgresFirewallRule'
-            latest_restore_time:
-              description: Latest restore time (if primary)"
-              type: string
-            primary:
-              description: Is the database primary
-              type: boolean
-          required:
-            - connection_string
-            - earliest_restore_time
-            - firewall_rules
-            - latest_restore_time
-            - primary
     PostgresFirewallRule:
       type: object
       properties:
@@ -2266,6 +2168,59 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/LoadBalancer'
+            additionalProperties: false
+            required:
+              - count
+              - items
+    PostgresDatabase:
+      description: A Postgres Database
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            allOf:
+              - $ref: '#/components/schemas/PostgresDatabase'
+              - additionalProperties: false
+                properties:
+                  connection_string:
+                    description: Connection string to the Postgres database
+                    type: string
+                    nullable: true
+                  earliest_restore_time:
+                    description: Earliest restore time (if primary)
+                    type: string
+                    nullable: true
+                  firewall_rules:
+                    description: List of Postgres firewall rules
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PostgresFirewallRule'
+                  latest_restore_time:
+                    description: Latest restore time (if primary)"
+                    type: string
+                  primary:
+                    description: Is the database primary
+                    type: boolean
+                required:
+                  - connection_string
+                  - earliest_restore_time
+                  - firewall_rules
+                  - latest_restore_time
+                  - primary
+    PostgresDatabases:
+      description: A list of Postgres Databases
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PostgresDatabase'
             additionalProperties: false
             required:
               - count

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -849,7 +849,7 @@ paths:
   '/project/{project_id}/location/{location}/postgres':
     get:
       operationId: listLocationPostgresDatabases
-      summary: List Postgres databases in a specific location of a project
+      summary: List Postgres Databases in a specific location of a project
       parameters:
         - $ref: '#/components/parameters/project_id'
         - $ref: '#/components/parameters/location'
@@ -858,7 +858,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of Postgres databases in a specific location of a project
+          description: A list of Postgres Databases in a specific location of a project
           content:
             application/json:
               schema:
@@ -869,7 +869,7 @@ paths:
                   items:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Postgres'
+                      $ref: '#/components/schemas/PostgresDatabase'
                 additionalProperties: false
                 required:
                   - count
@@ -877,7 +877,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/_{postgres_database_id}/failover':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -885,18 +885,18 @@ paths:
       - $ref: '#/components/parameters/postgres_database_id'
     post:
       operationId: failoverPostgresDatabaseWithID
-      summary: Failover a specific Postgres database with ID
+      summary: Failover a specific Postgres Database with ID
       responses:
         '200':
-          description: Details of the failed over Postgres databases in a location
+          description: Details of the failed over Postgres Databases in a location
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/_{postgres_database_id}/firewall-rule':
     parameters:
       - $ref: '#/components/parameters/location'
@@ -961,28 +961,28 @@ paths:
       - $ref: '#/components/parameters/postgres_database_id'
     delete:
       operationId: deletePostgresDatabaseWithID
-      summary: Delete a specific Postgres database with ID
+      summary: Delete a specific Postgres Database with ID
       responses:
         '204':
-          description: Postgres database is deleted successfully
+          description: Postgres Database is deleted successfully
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
     get:
       operationId: getPostgresDetailsWithId
-      summary: Get details of a specific Postgres database in a location with ID
+      summary: Get details of a specific Postgres Database in a location with ID
       responses:
         '200':
-          description: Details of the Postgres databases in a location
+          description: Details of the Postgres Databases in a location
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/id/{postgres_database_id}/firewall-rule/{firewall_rule_id}':
     parameters:
       - $ref: '#/components/parameters/location'
@@ -1043,7 +1043,7 @@ paths:
   '/project/{project_id}/location/{location}/postgres/id/{postgres_database_id}/reset-superuser-password':
     post:
       operationId: resetSuperuserPasswordWithID
-      summary: Reset super-user password of the Postgres database
+      summary: Reset super-user password of the Postgres Database
       parameters:
         - $ref: '#/components/parameters/project_id'
         - $ref: '#/components/parameters/location'
@@ -1066,15 +1066,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/id/{postgres_database_id}/restore':
     post:
       operationId: restorePostgresDatabaseWithID
-      summary: Restore a new Postgres database in a specific location of a project with ID
+      summary: Restore a new Postgres Database in a specific location of a project with ID
       parameters:
         - $ref: '#/components/parameters/project_id'
         - $ref: '#/components/parameters/location'
@@ -1096,15 +1096,15 @@ paths:
                 - restore_target
       responses:
         '200':
-          description: Postgres database is restored successfully
+          description: Postgres Database is restored successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Postgres'
+                $ref: '#/components/schemas/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -1112,31 +1112,31 @@ paths:
       - $ref: '#/components/parameters/postgres_database_name'
     delete:
       operationId: deletePostgresDatabase
-      summary: Delete a specific Postgres database
+      summary: Delete a specific Postgres Database
       responses:
         '204':
           description: Postgres database is deleted successfully
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
     get:
       operationId: getPostgresDatabaseDetails
       summary: Get details of a specific Postgres database in a location
       responses:
         '200':
-          description: Details of the Postgres database
+          description: Details of the Postgres Database
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
     post:
       operationId: createPostgresDatabase
-      summary: Create a new Postgres database in a specific location of a project
+      summary: Create a new Postgres Database in a specific location of a project
       requestBody:
         required: true
         content:
@@ -1161,15 +1161,15 @@ paths:
                 - size
       responses:
         '200':
-          description: Postgres database is created successfully
+          description: Postgres Database is created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/firewall-rule':
     parameters:
       - $ref: '#/components/parameters/location'
@@ -1253,7 +1253,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1300,11 +1300,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/restore':
     post:
       operationId: restorePostgresDatabase
@@ -1334,11 +1334,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostgresDetailed'
+                $ref: '#/components/schemas/PostgresDatabaseDetailed'
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/location/{location}/private-subnet':
     get:
       operationId: listLocationPrivateSubnets
@@ -1591,7 +1591,7 @@ paths:
   '/project/{project_id}/postgres':
     get:
       operationId: listPostgresDatabases
-      summary: List visible Postgres databases
+      summary: List visible Postgres Databases
       parameters:
         - $ref: '#/components/parameters/project_id'
         - $ref: '#/components/parameters/start_after'
@@ -1599,7 +1599,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of Postgres databases
+          description: A list of Postgres Databases
           content:
             application/json:
               schema:
@@ -1610,7 +1610,7 @@ paths:
                   items:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Postgres'
+                      $ref: '#/components/schemas/PostgresDatabase'
                 additionalProperties: false
                 required:
                   - count
@@ -1618,7 +1618,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Postgres
+        - Postgres Database
   '/project/{project_id}/private-subnet':
     get:
       operationId: listPSs
@@ -1955,7 +1955,7 @@ components:
         - private_ipv4
         - private_ipv6
         - vm_name
-    Postgres:
+    PostgresDatabase:
       type: object
       properties:
         flavor:
@@ -1996,11 +1996,11 @@ components:
         - storage_size_gib
         - version
         - vm_size
-    PostgresDetailed:
+    PostgresDatabaseDetailed:
       type: object
       additionalProperties: false
       allOf:
-        - $ref: '#/components/schemas/Postgres'
+        - $ref: '#/components/schemas/PostgresDatabase'
         - additionalProperties: false
           properties:
             connection_string:
@@ -2307,8 +2307,8 @@ tags:
     name: Load Balancer
   - description: Login Operations
     name: Login
-  - description: Postgres Operations
-    name: Postgres
+  - description: Postgres Database Operations
+    name: Postgres Database
   - description: Postgres Firewall Rule Operations
     name: Postgres Firewall Rule
   - description: Postgres Metric Destination

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -250,22 +250,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of Load Balancers in a specific project
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/LoadBalancer'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/LoadBalancers'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -279,11 +264,7 @@ paths:
       summary: Get details of a specific Load Balancer
       responses:
         '200':
-          description: A list of Load Balancers in a specific project
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -325,11 +306,7 @@ paths:
                 - src_port
       responses:
         '200':
-          description: Load Balancer created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -681,22 +658,7 @@ paths:
         - $ref: '#/components/parameters/order_column'
       responses:
         '200':
-          description: A list of Load Balancers in a specific location of a project
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/LoadBalancer'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/LoadBalancers'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -711,7 +673,7 @@ paths:
       summary: Delete a specific Load Balancer with ID
       responses:
         '204':
-          description: Load balancer is deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -721,11 +683,7 @@ paths:
       summary: Get details of a specific Load Balancer in a location with ID
       responses:
         '200':
-          description: Details of the Load Balancer in a location
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -740,7 +698,7 @@ paths:
       summary: Delete a specific Load Balancer
       responses:
         '204':
-          description: Load Balancer deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -750,11 +708,7 @@ paths:
       summary: Get details of a specific Load Balancer in a location
       responses:
         '200':
-          description: Details of the LoadBalancer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -789,11 +743,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
-          description: Load Balancer updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -835,11 +785,7 @@ paths:
                 - src_port
       responses:
         '200':
-          description: Load Balancer created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -867,11 +813,7 @@ paths:
                 - vm_id
       responses:
         '200':
-          description: VM attached to Load Balancer successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -899,11 +841,7 @@ paths:
                 - vm_id
       responses:
         '200':
-          description: VM detached from Load Balancer successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoadBalancerDetailed'
+          $ref: '#/components/responses/LoadBalancer'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1989,27 +1927,6 @@ components:
         - id
         - name
         - src_port
-    LoadBalancerDetailed:
-      type: object
-      additionalProperties: false
-      allOf:
-        - $ref: '#/components/schemas/LoadBalancer'
-        - properties:
-            location:
-              description: Location of the Load Balancer
-              type: string
-            subnet:
-              description: Subnet of the Load Balancer
-              type: string
-            vms:
-              type: array
-              items:
-                $ref: '#/components/schemas/Vm'
-          additionalProperties: false
-          required:
-            - location
-            - subnet
-            - vms
     Nic:
       type: object
       properties:
@@ -2311,6 +2228,48 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/FirewallRule'
+    LoadBalancer:
+      description: A Load Balancer
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            allOf:
+              - $ref: '#/components/schemas/LoadBalancer'
+              - properties:
+                  location:
+                    description: Location of the Load Balancer
+                    type: string
+                  subnet:
+                    description: Subnet of the Load Balancer
+                    type: string
+                  vms:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Vm'
+                additionalProperties: false
+                required:
+                  - location
+                  - subnet
+                  - vms
+    LoadBalancers:
+      description: A list of Load Balancers
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LoadBalancer'
+            additionalProperties: false
+            required:
+              - count
+              - items
     Project:
       description: A Project
       content:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -888,22 +888,7 @@ paths:
       summary: List location Postgres firewall rules
       responses:
         '200':
-          description: List of the location Postgres firewall rules
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PostgresFirewallRule'
-                additionalProperties: false
-                required:
-                  - count
-                  - items
+          $ref: '#/components/responses/PostgresFirewallRules'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -926,11 +911,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Postgres firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresFirewallRule'
+          $ref: '#/components/responses/PostgresFirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -971,7 +952,7 @@ paths:
       summary: Delete a specific Postgres firewall rule
       responses:
         '204':
-          description: Postgres firewall rule deleted successfully
+          $ref: '#/components/responses/Delete'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -981,11 +962,7 @@ paths:
       summary: Get details of a Postgres firewall rule
       responses:
         '200':
-          description: Details of the Postgres firewall rule
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresFirewallRule'
+          $ref: '#/components/responses/PostgresFirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1008,11 +985,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Postgres firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresFirewallRule'
+          $ref: '#/components/responses/PostgresFirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1154,11 +1127,7 @@ paths:
                 - cidr
       responses:
         '200':
-          description: Firewall rule created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostgresFirewallRule'
+          $ref: '#/components/responses/PostgresFirewallRule'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -2221,6 +2190,29 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/PostgresDatabase'
+            additionalProperties: false
+            required:
+              - count
+              - items
+    PostgresFirewallRule:
+      description: A Postgres Firewall Rule
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PostgresFirewallRule'
+    PostgresFirewallRules:
+      description: A list of Postgres Firewall Rules
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PostgresFirewallRule'
             additionalProperties: false
             required:
               - count


### PR DESCRIPTION
Consolidate/DRY responses by using components.

This helps to make it more obvious where serializations are being used consistently (or not) and should make it much easier to keep things in sync as things continue to evolve and more details continue to be added (like examples).

I also think, even in cases where responses are not reused (like some lists) it helps communicate intent, keeps similar things together, and helps things be more future proof.

Overall I think this should be a nice quality-of-life improvement, without materially changing how things function. Happy to discuss further or tweak if needed. 