### PR TITLE
Log the system's overall utilization every minute

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -25,6 +25,10 @@ Strand.dataset.insert_conflict.insert(id: "645cc9ff-7954-1f3a-fa82-ec6b3ffffff5"
 
 # We always insert this strand using the same UBID ("stexp1repr0ject1nv1tat10na")
 Strand.dataset.insert_conflict.insert(id: "776c1c3a-d804-9f3a-6683-5d874ad04155", prog: "ExpireProjectInvitations", label: "wait")
+
+# We always insert this strand using the same UBID ("st10g0vmh0st0vt111zat10nzz")
+Strand.dataset.insert_conflict.insert(id: "08200dd2-20ce-833a-de82-10fd5a082bff", prog: "LogVmHostUtilizations", label: "wait")
+
 clover_freeze
 
 loop do

--- a/prog/log_vm_host_utilizations.rb
+++ b/prog/log_vm_host_utilizations.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Prog::LogVmHostUtilizations < Prog::Base
+  label def wait
+    rows = VmHost.where { (total_cores > 0) & (total_hugepages_1g > 0) }.select {
+      [
+        :allocation_state, :location, :arch,
+        count(:id).as(:host_count),
+        sum(:used_cores).as(:used_cores),
+        sum(:total_cores).as(:total_cores),
+        round((sum(:used_cores) * 100.0 / sum(:total_cores)), 2).cast(:float).as(:core_utilization),
+        sum(:used_hugepages_1g).as(:used_hugepages_1g),
+        sum(:total_hugepages_1g).as(:total_hugepages_1g),
+        round((sum(:used_hugepages_1g) * 100.0 / sum(:total_hugepages_1g)), 2).cast(:float).as(:hugepage_utilization)
+      ]
+    }.group(:allocation_state, :location, :arch).all
+
+    rows.each { |row| Clog.emit("location utilization") { {location_utilization: row.values} } }
+
+    rows.select { |row| row[:allocation_state] == "accepting" }.group_by(&:arch).each do |arch, arch_rows|
+      values = arch_rows.each_with_object(Hash.new(0)) do |row, totals|
+        totals[:host_count] += row[:host_count]
+        totals[:used_cores] += row[:used_cores]
+        totals[:total_cores] += row[:total_cores]
+        totals[:used_hugepages_1g] += row[:used_hugepages_1g]
+        totals[:total_hugepages_1g] += row[:total_hugepages_1g]
+      end
+      values[:arch] = arch
+      values[:core_utilization] = (values[:used_cores] * 100.0 / values[:total_cores]).round(2)
+      values[:hugepage_utilization] = (values[:used_hugepages_1g] * 100.0 / values[:total_hugepages_1g]).round(2)
+
+      Clog.emit("arch utilization") { {arch_utilization: values} }
+    end
+
+    nap 60
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -208,8 +208,6 @@ class Prog::Vm::HostNexus < Prog::Base
       decr_checkup
     end
 
-    Clog.emit("vm host utilization") { {vm_host_utilization: vm_host.values.slice(:location, :arch, :total_cores, :used_cores, :total_hugepages_1g, :used_hugepages_1g, :total_storage_gib, :available_storage_gib).merge({vms_count: vm_host.vms_dataset.count})} }
-
     nap 30
   end
 

--- a/spec/prog/log_vm_host_utilizations_spec.rb
+++ b/spec/prog/log_vm_host_utilizations_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::LogVmHostUtilizations do
+  subject(:lvmhu) { described_class.new(Strand.new(prog: "LogVmHostUtilizations")) }
+
+  describe "#wait" do
+    it "logs vm host utilizations every minute" do
+      [
+        ["1.1.1.1", "hetzner-fsn1", "x64", "accepting", 3, 10, 20, 80],
+        ["2.2.2.2", "hetzner-fsn1", "x64", "draining", 5, 20, 50, 150],
+        ["3.3.3.3", "hetzner-fsn1", "arm64", "accepting", 10, 80, 30, 200],
+        ["4.4.4.4", "hetzner-hel1", "x64", "accepting", 2, 10, 20, 100],
+        ["5.5.5.5", "hetzner-hel1", "x64", "accepting", 0, nil, 0, 0]
+      ].each do |host, location, arch, allocation_state, used_cores, total_cores, used_hugepages_1g, total_hugepages_1g|
+        sshable = Sshable.create_with_id(host:)
+        VmHost.create(location:, arch:, allocation_state:, used_cores:, total_cores:, used_hugepages_1g:, total_hugepages_1g:) { _1.id = sshable.id }
+      end
+
+      expect(Clog).to receive(:emit).with("location utilization") do |&blk|
+        dat = blk.call[:location_utilization]
+        if dat[:location] == "hetzner-fsn1" && dat[:arch] == "x64" && dat[:allocation_state] == "accepting"
+          expect(dat[:core_utilization]).to eq(30.0)
+          expect(dat[:hugepage_utilization]).to eq(25.0)
+        elsif dat[:location] == "hetzner-fsn1" && dat[:arch] == "x64" && dat[:allocation_state] == "draining"
+          expect(dat[:core_utilization]).to eq(25.0)
+          expect(dat[:hugepage_utilization]).to eq(33.33)
+        end
+      end.at_least(:once)
+
+      expect(Clog).to receive(:emit).with("arch utilization") do |&blk|
+        dat = blk.call[:arch_utilization]
+        if dat[:arch] == "x64"
+          expect(dat[:core_utilization]).to eq(25.0)
+          expect(dat[:hugepage_utilization]).to eq(22.22)
+        elsif dat[:arch] == "arm64"
+          expect(dat[:core_utilization]).to eq(12.5)
+          expect(dat[:hugepage_utilization]).to eq(15.0)
+        end
+      end.at_least(:once)
+
+      expect { lvmhu.wait }.to nap(60)
+    end
+  end
+end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -213,8 +213,6 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#wait" do
     it "naps" do
-      expect(vm_host).to receive(:values).and_return({location: "hetzner-fsn1", arch: "x64", total_cores: 4})
-      expect(vm_host).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, count: 2))
       expect { nx.wait }.to nap(30)
     end
 
@@ -228,8 +226,6 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.wait }.to hop("unavailable")
 
-      expect(vm_host).to receive(:values).and_return({location: "hetzner-fsn1", arch: "x64", total_cores: 4})
-      expect(vm_host).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, count: 2))
       expect(nx).to receive(:when_checkup_set?).and_yield
       expect(nx).to receive(:available?).and_return(true)
       expect { nx.wait }.to nap(30)


### PR DESCRIPTION
- **Remove vm host based utilization logs**
  We added these logs to monitor our utilization with our monitoring tool,
  but since they are too granular, it’s hard to keep track of them.
  
  Since we don't use them, there's no need to log each VM host every 30
  seconds.
  

- **Log the system's overall utilization every minute**
  Previously, we printed similar logs for each VM host, but they were hard
  to digest.
  
  Aggregated utilization by location, architecture, and allocation state
  is more useful for us.
  
  For utilization grouped by architecture, I log the utilization of
  accepting VM hosts; we don't need to consider draining VM hosts.

```json
{
  "location_utilization": {
    "allocation_state": "accepting",
    "location": "hetzner-fsn1",
    "arch": "x64",
    "host_count": 1,
    "used_cores": 1,
    "total_cores": 32,
    "core_utilization": 3.13,
    "used_hugepages_1g": 2,
    "total_hugepages_1g": 249,
    "hugepage_utilization": 0.8
  },
  "message": "location utilization",
  "time": "2024-12-10 19:47:31 +0000",
  "thread": "st10g0vmh0st0vt111zat10nzz"
}

{
  "arch_utilization": {
    "host_count": 1,
    "used_cores": 1,
    "total_cores": 32,
    "used_hugepages_1g": 2,
    "total_hugepages_1g": 249,
    "arch": "x64",
    "core_utilization": 3.13,
    "hugepage_utilization": 0.8
  },
  "message": "arch utilization",
  "time": "2024-12-10 19:47:31 +0000",
  "thread": "st10g0vmh0st0vt111zat10nzz"
}
```

  