### PR TITLE
AI Inference UI

### DIFF
--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -103,7 +103,7 @@ module Authorization
     end
 
     Admin = ManagedPolicyClass.new("admin", ["*"])
-    Member = ManagedPolicyClass.new("member", ["Vm:*", "PrivateSubnet:*", "Firewall:*", "Postgres:*", "Project:view", "Project:github"])
+    Member = ManagedPolicyClass.new("member", ["Vm:*", "PrivateSubnet:*", "Firewall:*", "Postgres:*", "Project:view", "Project:github", "InferenceEndpoint:view"])
 
     def self.from_name(name)
       ManagedPolicy.const_get(name.to_s.capitalize)

--- a/model/ai/inference_endpoint.rb
+++ b/model/ai/inference_endpoint.rb
@@ -8,9 +8,7 @@ class InferenceEndpoint < Sequel::Model
   one_to_many :replicas, class: :InferenceEndpointReplica, key: :inference_endpoint_id
   one_to_one :load_balancer, key: :id, primary_key: :load_balancer_id
   one_to_one :private_subnet, key: :id, primary_key: :private_subnet_id
-  one_to_many :api_keys, key: :owner_id, class: :ApiKey, conditions: {owner_table: "inference_endpoint", used_for: "inference_endpoint"}
 
-  plugin :association_dependencies, api_keys: :destroy
   dataset_module Authorization::Dataset
   dataset_module Pagination
 

--- a/model/ai/inference_endpoint.rb
+++ b/model/ai/inference_endpoint.rb
@@ -48,6 +48,16 @@ class InferenceEndpoint < Sequel::Model
     req.body = {model: model_name, messages: [{role: "user", content: content}]}.to_json
     http.request(req)
   end
+
+  def model_type
+    if model_name == "e5-mistral-7b-it"
+      :embedding
+    elsif model_name.start_with? "llama-guard"
+      :guard
+    else
+      :text_generation
+    end
+  end
 end
 
 # Table: inference_endpoint

--- a/model/api_key.rb
+++ b/model/api_key.rb
@@ -10,6 +10,8 @@ class ApiKey < Sequel::Model
   one_to_many :access_tags, key: :hyper_tag_id
   plugin :association_dependencies, access_tags: :destroy
 
+  dataset_module Authorization::Dataset
+
   plugin :column_encryption do |enc|
     enc.column :key
   end
@@ -26,6 +28,12 @@ class ApiKey < Sequel::Model
     pat = create_with_id(owner_table: "accounts", owner_id: account.id, used_for: "api")
     pat.associate_with_project(project) if project
     pat
+  end
+
+  def self.create_inference_token(project)
+    token = ApiKey.create_with_id(owner_table: "project", owner_id: project.id, used_for: "inference_endpoint")
+    token.associate_with_project(project)
+    token
   end
 
   def self.create_with_id(owner_table:, owner_id:, used_for:)

--- a/model/project.rb
+++ b/model/project.rb
@@ -144,7 +144,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :inference_ui
 end
 
 # Table: project

--- a/model/project.rb
+++ b/model/project.rb
@@ -117,10 +117,6 @@ class Project < Sequel::Model
     effective_quota_value(resource_type) >= current_resource_usage(resource_type) + requested_additional_usage
   end
 
-  def create_api_key(used_for: "inference_endpoint")
-    ApiKey.create_with_id(owner_table: Project.table_name, owner_id: id, used_for: used_for)
-  end
-
   def validate
     super
     if new? || changed_columns.include?(:name)

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -70,7 +70,6 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
         load_balancer_id: lb_s.id, private_subnet_id: subnet_s.id, gpu_count: gpu_count
       ) { _1.id = ubid.to_uuid }
       inference_endpoint.associate_with_project(project)
-      ApiKey.create_with_id(owner_id: inference_endpoint.id, owner_table: "inference_endpoint", used_for: "inference_endpoint")
       Prog::Ai::InferenceEndpointReplicaNexus.assemble(inference_endpoint.id)
       Strand.create(prog: "Ai::InferenceEndpointNexus", label: "start") { _1.id = inference_endpoint.id }
     end

--- a/routes/project/inference_endpoint.rb
+++ b/routes/project/inference_endpoint.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Clover
+  hash_branch(:project_prefix, "inference-endpoint") do |r|
+    r.on web? do
+      next unless @project.get_ff_inference_ui
+
+      r.get true do
+        dataset_private = dataset_authorize(@project.inference_endpoints_dataset, "InferenceEndpoint:view")
+        dataset_public = InferenceEndpoint.where(is_public: true)
+
+        dataset = dataset_private.union(dataset_public)
+        dataset = dataset.where(visible: true)
+        dataset = dataset.order(:model_name)
+        dataset = dataset.eager(:load_balancer)
+
+        @inference_endpoints = Serializers::InferenceEndpoint.serialize(dataset.all)
+        view "inference/endpoint/index"
+      end
+    end
+  end
+end

--- a/routes/project/inference_token.rb
+++ b/routes/project/inference_token.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Clover
+  hash_branch(:project_prefix, "inference-token") do |r|
+    r.on web? do
+      next unless @project.get_ff_inference_ui
+
+      r.get true do
+        dataset = dataset_authorize(@project.api_keys_dataset.where(used_for: "inference_endpoint"), "InferenceToken:view")
+        dataset = dataset.where(is_valid: true)
+        dataset = dataset.order(:created_at)
+        @inference_tokens = Serializers::InferenceToken.serialize(dataset.all)
+        view "inference/token/index"
+      end
+
+      r.post true do
+        authorize("InferenceToken:create", @project.id)
+        it = DB.transaction { ApiKey.create_inference_token(@project) }
+        flash["notice"] = "Created inference token with id #{it.ubid}"
+        r.redirect "#{@project.path}/inference-token"
+      end
+
+      r.delete String do |ubid|
+        if (it = ApiKey.from_ubid(ubid))
+          authorize("InferenceToken:delete", it.id)
+          it.destroy
+          flash["notice"] = "Inference token deleted successfully"
+        end
+        204
+      end
+    end
+  end
+end

--- a/serializers/inference_endpoint.rb
+++ b/serializers/inference_endpoint.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Serializers::InferenceEndpoint < Serializers::Base
+  def self.serialize_internal(ie, options = {})
+    {
+      id: ie.ubid,
+      name: ie.name,
+      model_name: ie.model_name,
+      model_type: ie.model_type,
+      url: "#{ie.load_balancer.health_check_protocol}://#{ie.load_balancer.hostname}",
+      is_public: ie.is_public,
+      location: ie.display_location,
+      price_million_tokens: (BillingRate.from_resource_properties("InferenceTokens", ie.model_name, "global")["unit_price"] * 1000000).round(2),
+      path: ie.path
+    }
+  end
+end

--- a/serializers/inference_token.rb
+++ b/serializers/inference_token.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Serializers::InferenceToken < Serializers::Base
+  def self.serialize_internal(it, options = {})
+    {
+      id: it.ubid,
+      key: it.key,
+      created_at: it.created_at,
+      path: "/inference-token/#{it.ubid}"
+    }
+  end
+end

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Authorization do
       described_class::ManagedPolicy::Member.apply(projects[0], [users[0], nil, users[1]])
       acl = AccessPolicy[project_id: projects[0].id, name: "member", managed: true].body["acls"].first
       expect(acl["subjects"]).to contain_exactly(users[0].hyper_tag_name)
-      expect(acl["actions"]).to eq(["Vm:*", "PrivateSubnet:*", "Firewall:*", "Postgres:*", "Project:view", "Project:github"])
+      expect(acl["actions"]).to eq(["Vm:*", "PrivateSubnet:*", "Firewall:*", "Postgres:*", "Project:view", "Project:github", "InferenceEndpoint:view"])
       expect(acl["objects"]).to eq(["project/#{projects[0].ubid}"])
       users[1].associate_with_project(projects[0])
       described_class::ManagedPolicy::Member.apply(projects[0], [users[1]], append: true)

--- a/spec/model/ai/inference_endpoint_spec.rb
+++ b/spec/model/ai/inference_endpoint_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe InferenceEndpoint do
     end
   end
 
+  describe "#model_type" do
+    it "embedding" do
+      inference_endpoint.model_name = "e5-mistral-7b-it"
+      expect(inference_endpoint.model_type).to eq(:embedding)
+    end
+
+    it "guard" do
+      inference_endpoint.model_name = "llama-guard-abc"
+      expect(inference_endpoint.model_type).to eq(:guard)
+    end
+
+    it "text generation" do
+      expect(inference_endpoint.model_type).to eq(:text_generation)
+    end
+  end
+
   shared_examples "chat completion request" do |development|
     let(:http) { instance_double(Net::HTTP, read_timeout: 30) }
     let(:load_balancer) { instance_double(LoadBalancer, health_check_protocol: "https") }

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -152,13 +152,4 @@ RSpec.describe Project do
     expect(project.quota_available?("VmCores", 5)).to be true
     expect(project.quota_available?("VmCores", 20)).to be false
   end
-
-  describe ".create_api_key" do
-    it "creates an api key" do
-      project = described_class.create_with_id(name: "test")
-      expect(project.api_keys.count).to be(0)
-      project.create_api_key
-      expect(project.reload.api_keys.count).to be(1)
-    end
-  end
 end

--- a/spec/routes/web/inference_endpoint_spec.rb
+++ b/spec/routes/web/inference_endpoint_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "inference-endpoint" do
+  let(:user) { create_account }
+
+  let(:project) { user.create_project_with_default_policy("project-1") }
+  let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", default_policy: nil) }
+
+  describe "feature enabled" do
+    before do
+      project.set_ff_inference_ui(true)
+      project_wo_permissions.set_ff_inference_ui(true)
+      login(user.email)
+    end
+
+    it "can handle empty list of inference endpoints" do
+      visit "#{project.path}/inference-endpoint"
+
+      expect(page.title).to eq("Ubicloud - Inference Endpoints")
+    end
+
+    it "shows the right inference endpoints" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
+      lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up")
+      InferenceEndpoint.create_with_id(name: "ie1", model_name: "e5-mistral-7b-it", project_id: project_wo_permissions.id, is_public: true, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
+      InferenceEndpoint.create_with_id(name: "ie2", model_name: "e5-mistral-8b-it", project_id: project_wo_permissions.id, is_public: true, visible: false, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
+      InferenceEndpoint.create_with_id(name: "ie3", model_name: "llama-guard-3-8b", project_id: project_wo_permissions.id, is_public: false, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
+      ie = InferenceEndpoint.create_with_id(name: "ie4", model_name: "llama-3-1-405b-it", project_id: project.id, is_public: false, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
+      ie.associate_with_project(project)
+      InferenceEndpoint.create_with_id(name: "ie5", model_name: "test-model", project_id: project.id, is_public: false, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
+      visit "#{project.path}/inference-endpoint"
+
+      expect(page.title).to eq("Ubicloud - Inference Endpoints")
+      expect(page).to have_content("e5-mistral-7b-it")
+      expect(page).to have_no_content("e5-mistral-8b-it") # not visible
+      expect(page).to have_no_content("llama-guard-3-8b") # private model of another project
+      expect(page).to have_content("llama-3-1-405b-it")
+      expect(page).to have_no_content("test-model") # no permissions
+    end
+
+    it "does not show inference endpoints without permissions" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
+      lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up")
+      ie = InferenceEndpoint.create_with_id(name: "ie1", model_name: "test-model", project_id: project_wo_permissions.id, is_public: true, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
+      ie.associate_with_project(project_wo_permissions)
+      visit "#{project_wo_permissions.path}/inference-endpoint"
+
+      expect(page.title).to eq("Ubicloud - Inference Endpoints")
+      expect(page).to have_no_content("e5-mistral-7b-it")
+    end
+  end
+
+  describe "feature disabled" do
+    before do
+      project.set_ff_inference_ui(false)
+      login(user.email)
+      visit "#{project.path}/inference-endpoint"
+    end
+
+    it "inference endpoint page is not accessible" do
+      expect(page.status_code).to eq(404)
+    end
+  end
+
+  describe "unauthenticated" do
+    it "inference endpoint page is not accessible" do
+      visit "/inference-endpoint"
+
+      expect(page.title).to eq("Ubicloud - Login")
+    end
+  end
+end

--- a/spec/routes/web/inference_token_spec.rb
+++ b/spec/routes/web/inference_token_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "inference-token" do
+  let(:user) { create_account }
+
+  let(:project) { user.create_project_with_default_policy("project-1") }
+
+  describe "feature enabled" do
+    before do
+      project.set_ff_inference_ui(true)
+      login(user.email)
+      visit "#{project.path}/inference-token"
+      expect(ApiKey.all).to be_empty
+      click_button "Create Token"
+      @api_key = ApiKey.first
+    end
+
+    it "inference token page allows creating inference tokens" do
+      expect(find_by_id("flash-notice").text).to include("Created inference token with id ")
+
+      expect(ApiKey.count).to eq(1)
+      expect(@api_key.owner_id).to eq(project.id)
+      expect(@api_key.owner_table).to eq("project")
+      expect(@api_key.projects).to eq([project])
+      expect(@api_key.used_for).to eq("inference_endpoint")
+      expect(@api_key.is_valid).to be(true)
+    end
+
+    it "inference token page allows removing inference tokens" do
+      access_tag_ds = DB[:access_tag].where(hyper_tag_id: @api_key.id)
+      expect(access_tag_ds.all).not_to be_empty
+
+      btn = find(".delete-btn")
+      data_url = btn["data-url"]
+      _csrf = btn["data-csrf"]
+      page.driver.delete data_url, {_csrf:}
+      expect(page.status_code).to eq(204)
+      expect(ApiKey.all).to be_empty
+      expect(access_tag_ds.all).to be_empty
+      visit "#{project.path}/user/token"
+      expect(find_by_id("flash-notice").text).to eq("Inference token deleted successfully")
+
+      page.driver.delete data_url, {_csrf:}
+      expect(page.status_code).to eq(204)
+      visit "#{project.path}/user/token"
+      expect(page.html).not_to include("Inference token deleted successfully")
+    end
+  end
+
+  describe "feature disabled" do
+    before do
+      project.set_ff_inference_ui(false)
+      login(user.email)
+      visit "#{project.path}/inference-token"
+    end
+
+    it "inference token page is not accessible" do
+      expect(page.status_code).to eq(404)
+    end
+  end
+
+  describe "unauthenticated" do
+    it "inference token page is not accessible" do
+      visit "/inference-token"
+
+      expect(page.title).to eq("Ubicloud - Login")
+    end
+  end
+end

--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -121,6 +121,22 @@
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
     <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
   </svg>
+<% when "hero-chat-bubble-bottom-center-text" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+</svg>
+  <% when "hero-shield-check" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+  </svg>
+<% when "hero-document-arrow-down" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+  </svg>
+<% when "tabler-robot" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"  class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M6 4m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z M12 2v2 M9 12v9 M15 12v9 M5 16l4 -2 M15 14l4 2 M9 18h6 M10 8v.01 M14 8v.01" /> 
+  </svg>
 
 
 <% else %>

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -1,0 +1,74 @@
+<% @page_title = "Inference Endpoints" %>
+<%== render("inference/tabbar") %>
+
+<% @inference_endpoints.each_with_index do | ie, index |
+
+  path, model_type, model_icon, curl_message = case ie[:model_type]
+    when :text_generation
+      [
+        "/v1/chat/completions",
+        "Text Generation",
+        "hero-chat-bubble-bottom-center-text",
+      <<-MSG
+"messages": [{"role": "user", "content": "say something"}],
+  "stream": true
+MSG
+      ]
+    when :guard
+      [
+        "/v1/chat/completions",
+        "Guard",
+        "hero-shield-check",
+      <<-MSG
+"messages": [{"role": "user", "content": "is this safe?"}]
+MSG
+      ]
+    when :embedding
+      ["/v1/chat/embeddings", "Embedding", "document-arrow-down", "\"input\": \"embed me!\"\n"]
+    else
+      fail "Unknown model type"
+  end
+  
+
+  curl_snippet = <<-CURL
+curl #{ie[:url]}#{path}  \\
+ -H <span class="text-green-400">"Content-Type: application/json"</span> \\
+ -H <span class="text-green-400">"Authorization: Bearer <span class="text-orange-500">$INFERENCE_TOKEN</span>"</span> \\
+ -d <span class="text-green-400">'{
+  "model": "#{ie[:model_name]}",
+  #{curl_message} }'</span>
+CURL
+%>
+
+<div class="inline-block w-auto bg-white shadow-md rounded-lg p-4 mr-4 <%= (index > 0) ? "mt-6" : "" %>">
+  <h2 class="text-lg font-bold mb-4 text-gray-800"><%= ie[:name] %></h2>
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <div class="mb-4">
+        <h3 class="text-sm font-semibold text-gray-900">Type</h3>
+        <p class="text-gray-500"><%== render("components/icon", locals: { name: model_icon, classes: "inline-block w-5 h-5 flex-shrink-0 text-gray-400" }) %> <%= model_type %></p>
+      </div>
+    </div>
+    <div class="mb-4">
+      <h3 class="text-sm font-semibold text-gray-900">Pricing per million tokens</h3>
+      <p class="text-gray-500">$<%= ie[:price_million_tokens] %></p>
+    </div>
+  </div>
+  <div class="grid grid-cols-1 gap-4">
+    <div class="mb-4">
+      <h3 class="text-sm font-semibold text-gray-900">URL</h3>
+      <p class="text-gray-500"><%== render("components/copyable_content", locals: { content: ie[:url], message: "Copied URL" }) %></p>
+    </div>
+  </div>
+  <div class="grid grid-cols-1 gap-2">
+    <div class="mb-2">
+      <h3 class="text-sm font-semibold text-gray-900">
+        CURL usage example
+      </h3>
+      <div class="mt-2">
+        <pre class="text-sm bg-gray-800 text-white p-1 rounded-lg"><%== curl_snippet %></pre>
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/views/inference/tabbar.erb
+++ b/views/inference/tabbar.erb
@@ -1,0 +1,8 @@
+<%== render(
+  "components/tabbar",
+  locals: {
+    tabs: [
+      ["Inference Endpoints", @project_data[:path] + "/inference-endpoint"]
+    ]
+  }
+) %>

--- a/views/inference/tabbar.erb
+++ b/views/inference/tabbar.erb
@@ -2,7 +2,8 @@
   "components/tabbar",
   locals: {
     tabs: [
-      ["Inference Endpoints", @project_data[:path] + "/inference-endpoint"]
+      ["Inference Endpoints", @project_data[:path] + "/inference-endpoint"],
+      ["Inference Tokens", @project_data[:path] + "/inference-token"]
     ]
   }
 ) %>

--- a/views/inference/token/index.erb
+++ b/views/inference/token/index.erb
@@ -1,0 +1,48 @@
+<% @page_title = "Inference Tokens" %>
+<%== render("inference/tabbar") %>
+
+<div>
+  <% unless @inference_tokens.empty? %>
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">ID</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Token</th>
+            <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold text-gray-900"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @inference_tokens.each do |token| %>
+            <tr id="token-<%= token[:id] %>">
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <%= token[:id] %>
+              </td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                <%== render("components/revealable_content", locals: { content: token[:key] }) %>
+              </td>
+              <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
+                <%== has_project_permission("InferenceToken:delete") ? render(
+                  "components/delete_button",
+                  locals: {
+                    text: "Delete",
+                    url: "#{@project_data[:path]}/inference-token/#{token[:id]}",
+                    confirmation: "delete token"
+                  }
+                ) : "No Permission to delete" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+  <% if has_project_permission("InferenceToken:create") && @inference_tokens.size < 10 %>
+  <div class="flex justify-end space-y-1 mt-6">
+    <form id="create-inference-token" action="<%= "#{@project_data[:path]}/inference-token" %>" role="form" method="POST">
+      <%== csrf_tag("#{@project_data[:path]}/inference-token") %>
+      <%== render("components/form/submit_button", locals: { text: "Create Token" }) %>
+    </form>
+  </div>
+  <% end %>
+</div>

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -48,6 +48,17 @@
                 icon: "hero-circle-stack"
               }
             ) %>
+            <% if @project.get_ff_inference_ui %>
+              <%== render(
+                "layouts/sidebar/item",
+                locals: {
+                  name: "AI Inference",
+                  url: "#{@project_data[:path]}/inference-endpoint",
+                  is_active: request.path.start_with?("#{@project_data[:path]}/inference"),
+                  icon: "tabler-robot"
+                }
+              ) %>
+            <% end %>
           <% else %>
             <%== render(
               "layouts/sidebar/item",


### PR DESCRIPTION
Add a new top-level item, `AI Inference`, to the navigation sidebar. This section contains two tabs:
1. Inference Endpoints: Displays all inference endpoints available to the user. Currently, users cannot create custom inference endpoints. Only public endpoints created by an operator are listed. Each endpoint is presented as a card with relevant details, such as pricing and usage instructions.
2. Inference Tokens: Enables users to create inference tokens. These tokens are required to make requests to the OpenAI-compatible inference endpoint API. Each token is tied to a specific project, and requests made using the token are billed to the associated project.

Access to this feature is controlled by a project-level feature switch, `inference_ui`. The feature is disabled by default and must be explicitly enabled for users to access it.

Navigation
![screenshot nav](https://github.com/user-attachments/assets/e3914b4c-674e-4e23-b46b-765f2bd356b5)

Inference Endpoints
![screenshot ie](https://github.com/user-attachments/assets/513b6aae-2343-4783-a090-d1c53c97f3c7)

Inference Tokens
![image](https://github.com/user-attachments/assets/390c5002-4b5e-4895-8ccc-c84b1e35dfb0)

