### PR TITLE
Set longer deadlines for restore operations

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -90,8 +90,12 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     nap 5 unless representative_server.vm.strand.label == "wait"
 
     postgres_resource.incr_initial_provisioning
-    register_deadline(:wait, 10 * 60)
-    bud self.class, frame, :trigger_pg_current_xact_id_on_parent if postgres_resource.parent
+    if postgres_resource.parent
+      bud self.class, frame, :trigger_pg_current_xact_id_on_parent
+      register_deadline(:wait, 120 * 60)
+    else
+      register_deadline(:wait, 10 * 60)
+    end
     hop_refresh_dns_record
   end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -74,7 +74,11 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   end
 
   label def bootstrap_rhizome
-    register_deadline(:wait, 10 * 60)
+    if postgres_server.primary?
+      register_deadline(:wait, 10 * 60)
+    else
+      register_deadline(:wait, 120 * 60)
+    end
 
     bud Prog::BootstrapRhizome, {"target_folder" => "postgres", "subject_id" => vm.id, "user" => "ubi"}
     hop_wait_bootstrap_rhizome

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -128,7 +128,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#bootstrap_rhizome" do
     it "buds a bootstrap rhizome process" do
+      expect(postgres_server).to receive(:primary?).and_return(true)
       expect(nx).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "postgres", "subject_id" => postgres_server.vm.id, "user" => "ubi"})
+      expect { nx.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
+    end
+
+    it "sets longer deadline for non-primary servers" do
+      expect(postgres_server).to receive(:primary?).and_return(false)
+      expect(nx).to receive(:register_deadline).with(:wait, 120 * 60)
       expect { nx.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
     end
   end


### PR DESCRIPTION
Normally we set 10 minute deadline for PostgreSQL databases to be ready, but in case of restore, it takes more time until the database is ready. This commit increases the deadline to 2 hours for restore operations, which would be enough for most cases.