### PR TITLE
Increase default cache storage limit to 30GB

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -1,4 +1,4 @@
 - { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmCores,                  new_value: 16,  verified_value: 128 }
 - { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerCores,        new_value: 150, verified_value: 150 }
-- { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, new_value: 10,  verified_value: 10 }
+- { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, new_value: 30,  verified_value: 30 }
 - { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresCores,            new_value: 64,  verified_value: 128 }

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -122,19 +122,19 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
     end
 
     it "deletes oldest cache entries if the total usage exceeds the default limit" do
-      nine_gib_cache = create_cache_entry(created_at: Time.now - 10 * 60, size: 9 * 1024 * 1024 * 1024)
+      twenty_nine_gib_cache = create_cache_entry(created_at: Time.now - 10 * 60, size: 29 * 1024 * 1024 * 1024)
       two_gib_cache = create_cache_entry(created_at: Time.now - 11 * 60, size: 2 * 1024 * 1024 * 1024)
       three_gib_cache = create_cache_entry(created_at: Time.now - 12 * 60, size: 3 * 1024 * 1024 * 1024)
-      expect(blob_storage_client).not_to receive(:delete_object).with(bucket: github_repository.bucket_name, key: nine_gib_cache.blob_key)
+      expect(blob_storage_client).not_to receive(:delete_object).with(bucket: github_repository.bucket_name, key: twenty_nine_gib_cache.blob_key)
       expect(blob_storage_client).to receive(:delete_object).with(bucket: github_repository.bucket_name, key: two_gib_cache.blob_key)
       expect(blob_storage_client).to receive(:delete_object).with(bucket: github_repository.bucket_name, key: three_gib_cache.blob_key)
       nx.cleanup_cache
     end
 
     it "excludes uncommitted cache entries" do
-      twelve_gib_cache = create_cache_entry(created_at: Time.now - 10 * 60, size: 12 * 1024 * 1024 * 1024)
+      thirty_two_gib_cache = create_cache_entry(created_at: Time.now - 10 * 60, size: 32 * 1024 * 1024 * 1024)
       create_cache_entry(created_at: Time.now - 13 * 60, size: nil)
-      expect(blob_storage_client).to receive(:delete_object).with(bucket: github_repository.bucket_name, key: twelve_gib_cache.blob_key)
+      expect(blob_storage_client).to receive(:delete_object).with(bucket: github_repository.bucket_name, key: thirty_two_gib_cache.blob_key)
       nx.cleanup_cache
     end
 


### PR DESCRIPTION
We decided to increase free storage limit of Ubicloud Cache to 30GB after launching transparent cache feature.