### PR TITLE
Selected Github Runners switch to Cloudflare and Google DNS and add all-servers to Dnsmasq

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -65,6 +65,17 @@ class GithubRunner < Sequel::Model
     aggregate_readings(previous_pulse: previous_pulse, reading: reading, data: {available_memory: available_memory})
   end
 
+  def generate_cf_google_dns_dnsmasq_config
+    <<~COMMAND
+      sudo sed -i 's/^server=9.9.9.9@.*/server=2606:4700:4700::1111/' /vm/#{vm.inhost_name}/dnsmasq.conf
+      sudo sed -i 's/^server=149.112.112.112@.*//' /vm/#{vm.inhost_name}/dnsmasq.conf
+      sudo sed -i 's/^server=2620:fe::fe//' /vm/#{vm.inhost_name}/dnsmasq.conf
+      sudo sed -i 's/^server=2620:fe::9/server=2001:4860:4860::8888/' /vm/#{vm.inhost_name}/dnsmasq.conf
+      echo "all-servers" | sudo tee -a /vm/#{vm.inhost_name}/dnsmasq.conf
+      sudo systemctl restart #{vm.inhost_name}-dnsmasq
+    COMMAND
+  end
+
   def self.redacted_columns
     super + [:workflow_job]
   end

--- a/model/project.rb
+++ b/model/project.rb
@@ -144,7 +144,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :inference_ui
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :inference_ui, :all_servers_dnsmasq
 end
 
 # Table: project

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -247,6 +247,8 @@ class Prog::Vm::GithubRunner < Prog::Base
     # Remove comments and empty lines before sending them to the machine
     vm.sshable.cmd(command.gsub(/^(\s*# .*)?\n/, ""))
 
+    vm.vm_host.sshable.cmd(github_runner.generate_cf_google_dns_dnsmasq_config) if github_runner.installation.project.get_ff_all_servers_dnsmasq
+
     hop_register_runner
   end
 

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe GithubRunner do
     }
   }
 
-  let(:vm) { instance_double(Vm, sshable: instance_double(Sshable), cores: 2) }
+  let(:vm) {
+    instance_double(Vm, sshable: instance_double(Sshable), cores: 2, arch: "x64", ubid: "vm-ubid", pool_id: "pool-id", vm_host: instance_double(VmHost, ubid: "host-ubid"))
+  }
 
   before do
-    allow(github_runner).to receive_messages(installation: instance_double(GithubInstallation), vm: instance_double(Vm, arch: "x64", cores: 2, ubid: "vm-ubid", pool_id: "pool-id"))
-    allow(github_runner.vm).to receive_messages(sshable: instance_double(Sshable), vm_host: instance_double(VmHost, ubid: "host-ubid"))
+    allow(github_runner).to receive_messages(installation: instance_double(GithubInstallation), vm: vm)
   end
 
   it "can log duration when it's from a vm pool" do

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to register_runner" do
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-fsn1", data_center: "FSN1-DC8")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
+      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx", get_ff_all_servers_dnsmasq: false)).at_least(:once)
       expect(github_runner.installation).to receive(:cache_enabled).and_return(false)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
@@ -405,7 +405,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "hops to register_runner with after enabling transparent cache" do
       expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location: "hetzner-fsn1", data_center: "FSN1-DC8")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
+      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx", get_ff_all_servers_dnsmasq: true)).at_least(:once)
       expect(github_runner.installation).to receive(:cache_enabled).and_return(true)
       expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
@@ -419,6 +419,9 @@ RSpec.describe Prog::Vm::GithubRunner do
         sudo systemctl restart docker
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
       COMMAND
+
+      expect(vm.vm_host).to receive(:sshable).and_return(sshable)
+      expect(sshable).to receive(:cmd).with(github_runner.generate_cf_google_dns_dnsmasq_config)
 
       expect { nx.setup_environment }.to hop("register_runner")
     end


### PR DESCRIPTION
## Add feature flag to use all-server param for dnsmasq
We are enabling this in a controlled manner because all-servers
parameter will essentially amplify the number of dns queries we make.
That should not be a big problem since only the non-cached dns queries
will be sent out but still it is better to roll-out in a controlled
manner.

## Set all-servers and use Cloudflare and Google DNS for selected runners