### PR TITLE
Add vm restart to the UI

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -61,6 +61,7 @@ class Vm < Sequel::Model
 
   def display_state
     return "deleting" if destroy_set? || strand&.label == "destroy"
+    return "restarting" if restart_set? || strand&.label == "restart"
     if waiting_for_capacity_set?
       return "no capacity available" if Time.now - created_at > 15 * 60
       return "waiting for capacity"

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -25,6 +25,7 @@ class Vm < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
+  semaphore :restart
 
   include Authorization::HyperTagMethods
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -9,6 +9,7 @@ require "base64"
 class Prog::Vm::Nexus < Prog::Base
   subject_is :vm
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
+  semaphore :restart
 
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-fsn1", boot_image: Config.default_boot_image_name,
@@ -323,6 +324,11 @@ class Prog::Vm::Nexus < Prog::Base
       hop_update_spdk_dependency
     end
 
+    when_restart_set? do
+      register_deadline(:wait, 5 * 60)
+      hop_restart
+    end
+
     when_checkup_set? do
       hop_unavailable if !available?
       decr_checkup
@@ -348,6 +354,12 @@ class Prog::Vm::Nexus < Prog::Base
     decr_update_spdk_dependency
     write_params_json
     host.sshable.cmd("sudo host/bin/setup-vm reinstall-systemd-units #{q_vm}")
+    hop_wait
+  end
+
+  label def restart
+    decr_restart
+    host.sshable.cmd("sudo systemctl restart #{vm.inhost_name}")
     hop_wait
   end
 

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -24,7 +24,7 @@ class Clover
 
       r.get true do
         authorize("Vm:view", vm.id)
-        @vm = Serializers::Vm.serialize(vm, {detailed: true})
+        @vm = Serializers::Vm.serialize(vm, {detailed: true, include_path: web?})
         api? ? @vm : view("vm/show")
       end
 
@@ -32,6 +32,13 @@ class Clover
         authorize("Vm:delete", vm.id)
         vm.incr_destroy
         204
+      end
+
+      r.post web?, "restart" do
+        authorize("Vm:edit", vm.id)
+        vm.incr_restart
+        flash["notice"] = "'#{vm.name}' will be restarted in a few seconds"
+        r.redirect "#{@project.path}#{vm.path}"
       end
     end
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -7,18 +7,23 @@ RSpec.describe Vm do
 
   describe "#display_state" do
     it "returns deleting if destroy semaphore increased" do
-      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "destroy")])
+      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "destroy")]).at_least(:once)
       expect(vm.display_state).to eq("deleting")
     end
 
+    it "returns restarting if restart semaphore increased" do
+      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "restart")]).at_least(:once)
+      expect(vm.display_state).to eq("restarting")
+    end
+
     it "returns waiting for capacity if semaphore increased" do
-      expect(vm).to receive(:semaphores).twice.and_return([instance_double(Semaphore, name: "waiting_for_capacity")])
+      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "waiting_for_capacity")]).at_least(:once)
       expect(vm.display_state).to eq("waiting for capacity")
     end
 
     it "returns no capacity available if it's waiting capacity more than 15 minutes" do
       expect(vm).to receive(:created_at).and_return(Time.now - 16 * 60)
-      expect(vm).to receive(:semaphores).twice.and_return([instance_double(Semaphore, name: "waiting_for_capacity")])
+      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "waiting_for_capacity")]).at_least(:once)
       expect(vm.display_state).to eq("no capacity available")
     end
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -298,5 +298,16 @@ RSpec.describe Clover, "vm" do
         expect { find ".delete-btn" }.to raise_error Capybara::ElementNotFound
       end
     end
+
+    describe "restart" do
+      it "can restart vm" do
+        visit "#{project.path}#{vm.path}"
+        expect(page).to have_content "Restart"
+        click_button "Restart"
+
+        expect(page.status_code).to eq(200)
+        expect(vm.restart_set?).to be true
+      end
+    end
   end
 end

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -1,7 +1,7 @@
 <% case state %>
 <% when "running" %>
   <% color = "bg-green-100 text-green-800" %>
-<% when "creating", "rebooting", "starting", "waiting for capacity" %>
+<% when "creating", "rebooting", "starting", "waiting for capacity", "restarting" %>
   <% color = "bg-yellow-100 text-yellow-800" %>
 <% when "deleting", "deleted" %>
   <% color = "bg-red-100 text-red-800" %>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -152,54 +152,6 @@
       </div>
     </div>
   <% end %>
-  <!-- Reset password -->
-  <% if @pg[:primary] %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-      <div class="px-4 py-5 sm:p-6">
-        <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/reset-superuser-password" %>" role="form" method="POST">
-          <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/reset-superuser-password") %>
-          <div class="space-y-4">
-            <div>
-              <h2 class="text-lg font-medium leading-6 text-gray-900">Reset superuser password</h2>
-            </div>
-            <div class="grid grid-cols-12 gap-6">
-              <div class="col-span-12 sm:col-span-5">
-                <%== render(
-                  "components/form/text",
-                  locals: {
-                    label: "New password",
-                    name: "password",
-                    type: "password",
-                    attributes: {
-                      required: true
-                    },
-                    extra_class: "reset-superuser-password-new-password"
-                  }
-                ) %>
-              </div>
-              <div class="col-span-12 sm:col-span-5">
-                <%== render(
-                  "components/form/text",
-                  locals: {
-                    label: "New password (repeat)",
-                    name: "repeat_password",
-                    type: "password",
-                    attributes: {
-                      required: true
-                    },
-                    extra_class: "reset-superuser-password-new-password-repeat"
-                  }
-                ) %>
-              </div>
-              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                <%== render("components/form/submit_button", locals: { text: "Reset" }) %>
-              </div>
-            </div>
-          </div>
-        </form>
-      </div>
-    </div>
-  <% end %>
   <!-- Firewall Rules Card -->
   <% if has_permission?("Postgres:Firewall:view", @pg[:id]) %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
@@ -336,46 +288,102 @@
       </table>
     </div>
   <% end %>
-  <% if has_permission?(["Postgres:edit", "Postgres:delete"], @pg[:id]) %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-      <!-- Restart Card -->
-      <% if has_permission?("Postgres:edit", @pg[:id]) %>
-        <div class="px-4 py-5 sm:p-6">
-          <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restart" %>" role="form" method="POST">
-            <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restart") %>
+  <!-- Danger Zone -->
+  <% if has_permission?(["Postgres:view", "Postgres:edit", "Postgres:delete"], @pg[:id]) || @pg[:primary] %>
+    <div>
+      <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+        <div class="min-w-0 flex-1">
+          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+            Danger Zone
+          </h3>
+        </div>
+      </div>
+      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+        <!-- Reset password -->
+        <% if @pg[:primary] %>
+          <div class="px-4 py-5 sm:p-6">
+            <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/reset-superuser-password" %>" role="form" method="POST">
+              <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/reset-superuser-password") %>
+              <div class="space-y-4">
+                <div>
+                  <h3 class="text-base font-semibold leading-6 text-gray-900">Reset superuser password</h3>
+                </div>
+                <div class="grid grid-cols-12 gap-6">
+                  <div class="col-span-12 sm:col-span-5">
+                    <%== render(
+                      "components/form/text",
+                      locals: {
+                        label: "New password",
+                        name: "password",
+                        type: "password",
+                        attributes: {
+                          required: true
+                        },
+                        extra_class: "reset-superuser-password-new-password"
+                      }
+                    ) %>
+                  </div>
+                  <div class="col-span-12 sm:col-span-5">
+                    <%== render(
+                      "components/form/text",
+                      locals: {
+                        label: "New password (repeat)",
+                        name: "repeat_password",
+                        type: "password",
+                        attributes: {
+                          required: true
+                        },
+                        extra_class: "reset-superuser-password-new-password-repeat"
+                      }
+                    ) %>
+                  </div>
+                  <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                    <%== render("components/form/submit_button", locals: { text: "Reset" }) %>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        <% end %>
+        <!-- Restart Card -->
+        <% if has_permission?("Postgres:edit", @pg[:id]) %>
+          <div class="px-4 py-5 sm:p-6">
+            <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restart" %>" role="form" method="POST">
+              <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restart") %>
+              <div class="sm:flex sm:items-center sm:justify-between">
+                <div>
+                  <h3 class="text-base font-semibold leading-6 text-gray-900">Restart PostgreSQL database</h3>
+                  <div class="mt-2 text-sm text-gray-500">
+                    <p>This action will restart the PostgreSQL database. The database will be offline momentarily, and
+                      all connections will be dropped.</p>
+                  </div>
+                </div>
+                <div id="postgres-restart-<%=@pg[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                  <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                    <%== render("components/form/submit_button", locals: { text: "Restart", extra_class: "restart-btn" }) %>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        <% end %>
+        <!-- Delete Card -->
+        <% if has_permission?("Postgres:delete", @pg[:id]) %>
+          <div class="px-4 py-5 sm:p-6">
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Restart PostgreSQL database</h3>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">Delete PostgreSQL database</h3>
                 <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will restart the PostgreSQL database. The database will be offline momentarily, and all
-                    connections will be dropped.</p>
+                  <p>This action will permanently delete this PostgreSQL database.</p>
                 </div>
               </div>
-              <div id="postgres-restart-<%=@pg[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                  <%== render("components/form/submit_button", locals: { text: "Restart", extra_class: "restart-btn" }) %>
-                </div>
+              <div id="postgres-delete-<%=@pg[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                <%== render("components/delete_button", locals: { confirmation: @pg[:name], redirect: "#{@project_data[:path]}/postgres" }) %>
               </div>
-            </div>
-          </form>
-        </div>
-      <% end %>
-      <!-- Delete Card -->
-      <% if has_permission?("Postgres:delete", @pg[:id]) %>
-        <div class="px-4 py-5 sm:p-6">
-          <div class="sm:flex sm:items-center sm:justify-between">
-            <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Delete PostgreSQL database</h3>
-              <div class="mt-2 text-sm text-gray-500">
-                <p>This action will permanently delete this PostgreSQL database.</p>
-              </div>
-            </div>
-            <div id="postgres-delete-<%=@pg[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-              <%== render("components/delete_button", locals: { confirmation: @pg[:name], redirect: "#{@project_data[:path]}/postgres" }) %>
             </div>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -89,23 +89,54 @@
       </tbody>
     </table>
   </div>
-  <!-- Delete Card -->
-  <% if has_permission?("Vm:delete", @vm[:id]) %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-      <div class="px-4 py-5 sm:p-6">
-        <div class="sm:flex sm:items-center sm:justify-between">
-          <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete virtual machine</h3>
-            <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this virtual machine. Deleted data cannot be recovered. Use it
-                carefully.</p>
-            </div>
-          </div>
-          <div id="vm-delete-<%=@vm[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-            <%== render("components/delete_button", locals: { confirmation: @vm[:name], redirect: "#{@project_data[:path]}/vm" }) %>
-          </div>
-        </div>
+  <!-- Danger Zone -->
+  <div>
+    <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          Danger Zone
+        </h3>
       </div>
     </div>
-  <% end %>
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <!-- Restart Card -->
+      <% if has_permission?("Vm:edit", @vm[:id]) %>
+        <div class="px-4 py-5 sm:p-6">
+          <form action="<%= "#{@project_data[:path]}#{@vm[:path]}/restart" %>" role="form" method="POST">
+            <%== csrf_tag("#{@project_data[:path]}#{@vm[:path]}/restart") %>
+            <div class="sm:flex sm:items-center sm:justify-between">
+              <div>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">Restart virtual machine</h3>
+                <div class="mt-2 text-sm text-gray-500">
+                  <p>This action will restart the virtual machine, causing it to be temporarily offline.</p>
+                </div>
+              </div>
+              <div id="vm-restart-<%=@vm[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                  <%== render("components/form/submit_button", locals: { text: "Restart", extra_class: "restart-btn" }) %>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      <% end %>
+      <!-- Delete Card -->
+      <% if has_permission?("Vm:delete", @vm[:id]) %>
+        <div class="px-4 py-5 sm:p-6">
+          <div class="sm:flex sm:items-center sm:justify-between">
+            <div>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">Delete virtual machine</h3>
+              <div class="mt-2 text-sm text-gray-500">
+                <p>This action will permanently delete this virtual machine. Deleted data cannot be recovered. Use it
+                  carefully.</p>
+              </div>
+            </div>
+            <div id="vm-delete-<%=@vm[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <%== render("components/delete_button", locals: { confirmation: @vm[:name], redirect: "#{@project_data[:path]}/vm" }) %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
- **Move reset PG superuser password to danger zone**
  I moved dangerous actions to one place and added a title
  
![CleanShot 2024-12-11 at 23 42 12@2x](https://github.com/user-attachments/assets/fca53f3a-2455-4bdf-819e-b9b62cd845f1)


- **Add vm restart semaphore**
  Several customers have already requested a method to force restart their
  VMs. Previously, we handled this through support tickets. However, we
  can easily integrate this functionality into the UI.
  

- **Add vm restart button to the UI**
  I did it very similar to the PostgreSQL restart functionality.
  
![CleanShot 2024-12-11 at 23 42 20@2x](https://github.com/user-attachments/assets/2a5b4373-04c2-4e89-83bb-4a7aea1e3787)

- **Change vm display state while restarting it**
  