### PR TITLE
Small fixes for Inference Endpoint UI

### DIFF
--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -31,7 +31,7 @@ MSG
   
 
   curl_snippet = <<-CURL
-curl #{ie[:url]}#{path}  \\
+curl #{ie[:url]}#{path} \\
  -H <span class="text-green-400">"Content-Type: application/json"</span> \\
  -H <span class="text-green-400">"Authorization: Bearer <span class="text-orange-500">$INFERENCE_TOKEN</span>"</span> \\
  -d <span class="text-green-400">'{

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -24,7 +24,7 @@ MSG
 MSG
       ]
     when :embedding
-      ["/v1/embeddings", "Embedding", "document-arrow-down", "\"input\": \"embed me!\"\n"]
+      ["/v1/embeddings", "Embedding", "hero-document-arrow-down", "\"input\": \"embed me!\"\n"]
     else
       fail "Unknown model type"
   end

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -24,7 +24,7 @@ MSG
 MSG
       ]
     when :embedding
-      ["/v1/chat/embeddings", "Embedding", "document-arrow-down", "\"input\": \"embed me!\"\n"]
+      ["/v1/embeddings", "Embedding", "document-arrow-down", "\"input\": \"embed me!\"\n"]
     else
       fail "Unknown model type"
   end


### PR DESCRIPTION
**Fix typo on UI for embeddings models**

For embedding models, we currently show `/v1/chat/embeddings` as part of the CURL usage example on the inference endpoints index page, while it should be `/v1/embeddings`.

**Show correct icon for embedding models**

**Remove unnecessary blank space on inference UI**
Remove one of the two spaces after the curl path of the multi-line example usage command, i.e., `curl path  \` -> `curl path \`.

