### PR TITLE
Add io_limits to VmSize.

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -48,17 +48,20 @@ module Option
     ["almalinux-9", "AlmaLinux 9"]
   ].map { |args| BootImage.new(*args) }.freeze
 
-  VmSize = Struct.new(:name, :family, :cores, :vcpus, :memory_gib, :storage_size_options, :visible, :gpu, :arch) do
+  IoLimits = Struct.new(:max_ios_per_sec, :max_read_mbytes_per_sec, :max_write_mbytes_per_sec)
+  NO_IO_LIMITS = IoLimits.new(nil, nil, nil).freeze
+
+  VmSize = Struct.new(:name, :family, :cores, :vcpus, :memory_gib, :storage_size_options, :io_limits, :visible, :gpu, :arch) do
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
     storage_size_options = [_1 * 20, _1 * 40]
-    VmSize.new("standard-#{_1}", "standard", _1 / 2, _1, _1 * 4, storage_size_options, true, false, "x64")
+    VmSize.new("standard-#{_1}", "standard", _1 / 2, _1, _1 * 4, storage_size_options, NO_IO_LIMITS, true, false, "x64")
   }.concat([2, 4, 8, 16, 30, 60].map {
     storage_size_options = [_1 * 20, _1 * 40]
-    VmSize.new("standard-#{_1}", "standard", _1, _1, (_1 * 3.2).to_i, storage_size_options, false, false, "arm64")
+    VmSize.new("standard-#{_1}", "standard", _1, _1, (_1 * 3.2).to_i, storage_size_options, NO_IO_LIMITS, false, false, "arm64")
   }).concat([6].map {
-    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1 / 2, _1, (_1 * 5.34).to_i, [_1 * 30], false, true, "x64")
+    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1 / 2, _1, (_1 * 5.34).to_i, [_1 * 30], NO_IO_LIMITS, false, true, "x64")
   }).freeze
 
   PostgresSize = Struct.new(:location, :name, :vm_size, :family, :vcpu, :memory, :storage_size_options) do

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -35,6 +35,9 @@ class Prog::Vm::Nexus < Prog::Base
     storage_volumes.each_with_index do |volume, disk_index|
       volume[:size_gib] ||= vm_size.storage_size_options.first
       volume[:skip_sync] ||= false
+      volume[:max_ios_per_sec] ||= vm_size.io_limits.max_ios_per_sec
+      volume[:max_read_mbytes_per_sec] ||= vm_size.io_limits.max_read_mbytes_per_sec
+      volume[:max_write_mbytes_per_sec] ||= vm_size.io_limits.max_write_mbytes_per_sec
       volume[:encrypted] = true if !volume.has_key? :encrypted
       volume[:boot] = disk_index == boot_disk_index
 

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -39,6 +39,27 @@ RSpec.describe Validation do
       it "invalid vm size" do
         expect { described_class.validate_vm_size("standard-3", "x64") }.to raise_error described_class::ValidationFailed
       end
+
+      it "no IO limits for standard x64" do
+        io_limits = described_class.validate_vm_size("standard-2", "x64").io_limits
+        expect(io_limits.max_ios_per_sec).to be_nil
+        expect(io_limits.max_read_mbytes_per_sec).to be_nil
+        expect(io_limits.max_write_mbytes_per_sec).to be_nil
+      end
+
+      it "no IO limits for standard arm64" do
+        io_limits = described_class.validate_vm_size("standard-2", "arm64").io_limits
+        expect(io_limits.max_ios_per_sec).to be_nil
+        expect(io_limits.max_read_mbytes_per_sec).to be_nil
+        expect(io_limits.max_write_mbytes_per_sec).to be_nil
+      end
+
+      it "no IO limits for standard-gpu" do
+        io_limits = described_class.validate_vm_size("standard-gpu-6", "x64").io_limits
+        expect(io_limits.max_ios_per_sec).to be_nil
+        expect(io_limits.max_read_mbytes_per_sec).to be_nil
+        expect(io_limits.max_write_mbytes_per_sec).to be_nil
+      end
     end
 
     describe "#validate_vm_storage_size" do


### PR DESCRIPTION
We will put limits on IO rate burstable or shared instances can have. This PR prepares for that by adding `io_limits` to VmSize. Currently, IO performance of standard VMs are not limited. We might revisit this in future.