### PR TITLE
Remove the vcpu count check in Vm::params_json

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -202,7 +202,6 @@ class Vm < Sequel::Model
 
   def params_json(swap_size_bytes)
     topo = cloud_hypervisor_cpu_topology
-    fail "BUG: topology does not match vcpu count" unless topo.max_vcpus == vcpus
 
     project_public_keys = projects.first.get_ff_vm_public_ssh_keys || []
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -135,13 +135,6 @@ RSpec.describe Vm do
     end
   end
 
-  describe "#params_json" do
-    it "fails if topology does not match vcpu count" do
-      expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(1, 1, 1, 1))
-      expect { vm.params_json(0) }.to raise_error RuntimeError, "BUG: topology does not match vcpu count"
-    end
-  end
-
   describe "#utility functions" do
     it "can compute the ipv4 addresses" do
       as_ad = instance_double(AssignedVmAddress, ip: NetAddr::IPv4Net.new(NetAddr.parse_ip("1.1.1.0"), NetAddr::Mask32.new(32)))


### PR DESCRIPTION
We assume in the code that in all x64 hosts `:total_cpus == 2*:total_cores`, but this isnot the case for GEX hosts, which we model as `:total_cores=>14, :total_cpus=>14`.

Because of this, the number of `max_vcpus` that we calculate in `Vm::params_json` is equal to half the number of actual vcpus requested, so the recent consistency check that we added raised an error.

Since the inconsistency is a bug from past, in this PR we remove the check to not raise exceptions in prod (i.e. behaviour will be as it used to be), and then we will fix the actual issue in a future PR.