### PR TITLE
Fix total_active_runner_cores calculation

### DIFF
--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -13,7 +13,7 @@ class GithubInstallation < Sequel::Model
     runner_labels = runners_dataset.left_join(:strand, id: :id).exclude(Sequel[:strand][:label] => "start").exclude(Sequel[:strand][:label] => "wait_concurrency_limit").select_map(Sequel[:github_runner][:label])
     label_record_data_set = runner_labels.map { |label| Github.runner_labels[label] }
     label_record_data_set.sum do |label_record|
-      vcpu = Validation.validate_vm_size(label_record["vm_size"], "x64").vcpus
+      vcpu = Validation.validate_vm_size(label_record["vm_size"], label_record["arch"]).vcpus
       if label_record["arch"] == "arm64"
         vcpu
       else

--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -10,16 +10,14 @@ class GithubInstallation < Sequel::Model
   include ResourceMethods
 
   def total_active_runner_cores
-    runner_labels = runners_dataset.left_join(:strand, id: :id).exclude(Sequel[:strand][:label] => "start").exclude(Sequel[:strand][:label] => "wait_concurrency_limit").select_map(Sequel[:github_runner][:label])
-    label_record_data_set = runner_labels.map { |label| Github.runner_labels[label] }
-    label_record_data_set.sum do |label_record|
-      vcpu = Validation.validate_vm_size(label_record["vm_size"], label_record["arch"]).vcpus
-      if label_record["arch"] == "arm64"
-        vcpu
-      else
-        vcpu / 2
+    runners_dataset
+      .left_join(:strand, id: :id)
+      .exclude(Sequel[:strand][:label] => ["start", "wait_concurrency_limit"])
+      .select_map(Sequel[:github_runner][:label])
+      .sum do
+        label = Github.runner_labels[_1]
+        Validation.validate_vm_size(label["vm_size"], label["arch"]).cores
       end
-    end
   end
 end
 


### PR DESCRIPTION
- **Pass correct arch while calculating total runner cores**
  We start to pass arch values to vm_size validation at a041770b. We
  should pass the arch of label instead of "x64" for all runners.
  

- **Use cores from vm_size option when calculating total active runner cores**
  We start to keep core values at vm_size option. So no need to calculate
  it here anymore.
  