### PR TITLE
Get semaphores from the subject of prog

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -28,7 +28,12 @@ module SemaphoreMethods
   end
 
   module ClassMethods
+    def semaphore_names
+      @semaphore_names || []
+    end
+
     def semaphore(*names)
+      (@semaphore_names ||= []).concat(names)
       names.each do |sym|
         name = sym.name
         define_method :"incr_#{name}" do

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -10,8 +10,6 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
   extend Forwardable
   def_delegators :inference_endpoint, :replicas, :load_balancer, :private_subnet, :project
 
-  semaphore :destroy
-
   def self.model_for_id(model_id)
     Option::AI_MODELS.detect { _1["id"] == model_id }
   end

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -10,8 +10,6 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
   extend Forwardable
   def_delegators :inference_endpoint_replica, :vm, :inference_endpoint, :load_balancers_vm
 
-  semaphore :destroy
-
   def self.assemble(inference_endpoint_id)
     DB.transaction do
       ubid = InferenceEndpointReplica.generate_ubid

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -16,6 +16,10 @@ def #{name}
   @#{name} ||= #{camelize(name.to_s)}[@subject_id]
 end
 ), __FILE__, __LINE__ - 4
+      subject_class = Object.const_get(camelize(name.to_s))
+      if subject_class.respond_to?(:semaphore_names)
+        semaphore(*subject_class.semaphore_names)
+      end
     end
   end
 

--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -5,8 +5,6 @@ require_relative "../../lib/util"
 class Prog::DnsZone::DnsZoneNexus < Prog::Base
   subject_is :dns_zone
 
-  semaphore :refresh_dns_servers
-
   label def wait
     if dns_zone.last_purged_at < Time.now - 60 * 60 * 1 # ~1 hour
       register_deadline("wait", 5 * 60)

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -5,8 +5,6 @@ require_relative "../../lib/util"
 class Prog::Github::GithubRepositoryNexus < Prog::Base
   subject_is :github_repository
 
-  semaphore :destroy
-
   def self.assemble(installation, name, default_branch)
     DB.transaction do
       repository = GithubRepository.new_with_id(installation_id: installation.id, name: name)

--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -5,8 +5,6 @@ require_relative "../../lib/util"
 class Prog::Minio::MinioClusterNexus < Prog::Base
   subject_is :minio_cluster
 
-  semaphore :destroy, :reconfigure
-
   def self.assemble(project_id, cluster_name, location, admin_user,
     storage_size_gib, pool_count, server_count, drive_count, vm_size)
     unless (project = Project[project_id])

--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -5,8 +5,6 @@ require_relative "../../lib/util"
 class Prog::Minio::MinioPoolNexus < Prog::Base
   subject_is :minio_pool
 
-  semaphore :destroy, :add_additional_pool
-
   def self.assemble(cluster_id, start_index, server_count, drive_count, storage_size_gib, vm_size)
     unless MinioCluster[cluster_id]
       fail "No existing cluster"

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -10,8 +10,6 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   extend Forwardable
   def_delegators :minio_server, :vm
 
-  semaphore :checkup, :destroy, :restart, :reconfigure, :refresh_certificates, :initial_provisioning
-
   def self.assemble(minio_pool_id, index)
     unless (minio_pool = MinioPool[minio_pool_id])
       fail "No existing pool"

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -2,7 +2,6 @@
 
 class Prog::PageNexus < Prog::Base
   subject_is :page
-  semaphore :resolve
 
   def self.assemble(summary, tag_parts, related_resources, severity: "error", extra_data: {})
     DB.transaction do

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -10,8 +10,6 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   extend Forwardable
   def_delegators :postgres_resource, :servers, :representative_server
 
-  semaphore :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :destroy
-
   def self.assemble(project_id:, location:, name:, target_vm_size:, target_storage_size_gib:,
     version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
     ha_type: PostgresResource::HaType::NONE, parent_id: nil, restore_target: nil)

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -10,9 +10,6 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   extend Forwardable
   def_delegators :postgres_server, :vm
 
-  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
-  semaphore :restart, :configure, :take_over, :configure_prometheus, :destroy
-
   def self.assemble(resource_id:, timeline_id:, timeline_access:, representative_at: nil, exclude_host_ids: [])
     DB.transaction do
       ubid = PostgresServer.generate_ubid

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -8,8 +8,6 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   extend Forwardable
   def_delegators :postgres_timeline, :blob_storage_client
 
-  semaphore :destroy
-
   def self.assemble(parent_id: nil, location: nil)
     if parent_id && (PostgresTimeline[parent_id]).nil?
       fail "No existing parent"

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -5,8 +5,6 @@ require "net/ssh"
 class Prog::Vm::GithubRunner < Prog::Base
   subject_is :github_runner
 
-  semaphore :destroy, :skip_deregistration
-
   def self.assemble(installation, repository_name:, label:, default_branch: nil)
     unless Github.runner_labels[label]
       fail "Invalid GitHub runner label: #{label}"

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -2,7 +2,6 @@
 
 class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
-  semaphore :checkup, :reboot, :destroy
 
   def self.assemble(sshable_hostname, location: "hetzner-fsn1", net6: nil, ndp_needed: false, provider: nil, hetzner_server_identifier: nil, spdk_version: Config.spdk_version, default_boot_images: [])
     DB.transaction do

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -8,8 +8,6 @@ require "base64"
 
 class Prog::Vm::Nexus < Prog::Base
   subject_is :vm
-  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
-  semaphore :restart
 
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-fsn1", boot_image: Config.default_boot_image_name,

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -5,8 +5,6 @@ require "net/ssh"
 class Prog::Vm::VmPool < Prog::Base
   subject_is :vm_pool
 
-  semaphore :destroy
-
   def self.assemble(size:, vm_size:, boot_image:, location:, storage_size_gib:,
     storage_encrypted:, storage_skip_sync:, arch:)
     DB.transaction do

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -5,7 +5,6 @@ require "openssl"
 
 class Prog::Vnet::CertNexus < Prog::Base
   subject_is :cert
-  semaphore :destroy
 
   REVOKE_REASON = "cessationOfOperation"
 

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -5,7 +5,6 @@ require "openssl"
 
 class Prog::Vnet::LoadBalancerNexus < Prog::Base
   subject_is :load_balancer
-  semaphore :destroy, :update_load_balancer, :rewrite_dns_records, :refresh_cert
 
   def self.assemble(private_subnet_id, name: nil, algorithm: "round_robin", src_port: nil, dst_port: nil,
     health_check_endpoint: "/up", health_check_interval: 30, health_check_timeout: 15,

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -2,7 +2,6 @@
 
 class Prog::Vnet::NicNexus < Prog::Base
   subject_is :nic
-  semaphore :destroy, :start_rekey, :trigger_outbound_update, :old_state_drop_trigger, :setup_nic, :repopulate
 
   def self.assemble(private_subnet_id, name: nil, ipv6_addr: nil, ipv4_addr: nil)
     unless (subnet = PrivateSubnet[private_subnet_id])

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -2,7 +2,6 @@
 
 class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
-  semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
 
   def self.assemble(project_id, name: nil, location: "hetzner-fsn1", ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil)
     unless (project = Project[project_id])


### PR DESCRIPTION
Right now, we define semaphores in both the model and prog, but they are generally the same. We can retrieve the list of semaphores from the subject in prog.

We can still define semaphores in prog if it doesn't have a subject, like in Prog::Test::HetznerServer.