### PR TITLE
Add rhizome side of SliceSetup.

### DIFF
--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -24,9 +24,9 @@ class FsyncFail < Exception
 end
 # rubocop:enable Lint/InheritException
 
-def r(commandline, stdin: "")
+def r(commandline, stdin: "", expect: [0])
   stdout, stderr, status = Open3.capture3(commandline, stdin_data: stdin)
-  fail CommandFail.new("command failed: " + commandline, stdout, stderr) unless status.success?
+  fail CommandFail.new("command failed: " + commandline, stdout, stderr) unless expect.include?(status.exitstatus)
   stdout
 end
 

--- a/rhizome/host/bin/setup-slice
+++ b/rhizome/host/bin/setup-slice
@@ -1,0 +1,42 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/slice_setup"
+
+unless (action = ARGV.shift)
+  puts "expected action as argument"
+  exit 1
+end
+
+unless (slice_name = ARGV.shift)
+  puts "expected slice name as argument"
+  exit 1
+end
+
+slice_setup = SliceSetup.new(slice_name)
+
+case action
+when "delete"
+  slice_setup.purge
+
+when "prep"
+  unless (allowed_cpus = ARGV.shift)
+    puts "expected list of allowed cpus as argument"
+    exit 1
+  end
+  slice_setup.prep(allowed_cpus)
+
+when "recreate-unpersisted"
+  slice_setup.start_systemd_unit
+
+when "reinstall-systemd-units"
+  unless (allowed_cpus = ARGV.shift)
+    puts "expected list of allowed cpus as argument"
+    exit 1
+  end
+  slice_setup.install_systemd_unit(allowed_cpus)
+
+else
+  puts "Invalid action #{action}"
+  exit 1
+end

--- a/rhizome/host/e2e/slice_setup_e2e_spec.rb
+++ b/rhizome/host/e2e/slice_setup_e2e_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "../lib/slice_setup"
+require_relative "../../common/lib/util"
+require "fileutils"
+
+return if ENV["RUN_E2E_TESTS"] != "1"
+return if r("uname -r").to_i < 6
+
+RSpec.describe SliceSetup do
+  subject(:slice_setup) { described_class.new(slice_name) }
+
+  let(:slice_name) { "slice_name.slice" }
+
+  it "can prepare and purge a slice" do
+    cpuset = "3-4"
+    slice_setup.prep(cpuset)
+    expect(File.exist?(slice_setup.systemd_service)).to be true
+
+    # check that the slice is started
+    expect(r("systemctl show -p ActiveState --value #{slice_name}")).to eq("active\n")
+
+    # check that the cpuset.cpus.partition file contains "root"
+    expect(File.read("/sys/fs/cgroup/#{slice_name}/cpuset.cpus.partition")).to eq("root\n")
+
+    # check allowed cpus
+    expect(File.read("/sys/fs/cgroup/#{slice_name}/cpuset.cpus")).to eq("#{cpuset}\n")
+
+    slice_setup.purge
+
+    # check that the slice is stopped & deleted
+    expect(r("systemctl show -p ActiveState --value #{slice_name}")).to eq("inactive\n")
+    expect(File.exist?(slice_setup.systemd_service)).to be false
+  end
+
+  it "doesn't fail if the slice doesn't exist" do
+    slice_setup = described_class.new("nonexistent.slice")
+    expect { slice_setup.purge }.not_to raise_error
+  end
+end

--- a/rhizome/host/lib/slice_setup.rb
+++ b/rhizome/host/lib/slice_setup.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+
+class SliceSetup
+  def initialize(slice_name)
+    @slice_name = slice_name
+  end
+
+  def systemd_service
+    @systemd_service ||= File.join("/etc/systemd/system", @slice_name)
+  end
+
+  def prep(allowed_cpus)
+    fail "BUG: invalid cpuset" unless valid_cpuset?(allowed_cpus)
+    install_systemd_unit(allowed_cpus)
+    start_systemd_unit
+  end
+
+  def purge
+    r("systemctl stop #{@slice_name.shellescape}", expect: [0, 5])
+    rm_if_exists systemd_service
+    r "systemctl daemon-reload"
+  end
+
+  def install_systemd_unit(allowed_cpus)
+    fail "BUG: unit name must not be empty" if @slice_name.empty?
+    fail "BUG: we cannot create system units" if @slice_name == "system.slice" || @slice_name == "user.slice"
+    fail "BUG: unit name cannot contain a dash" if @slice_name.include?("-")
+    fail "BUG: invalid allowed_cpus" if !valid_cpuset?(allowed_cpus)
+
+    # Only proceed if the slice has not yet been setup
+    unless File.exist? systemd_service
+      safe_write_to_file(systemd_service, <<SLICE_CONFIG)
+[Unit]
+Description=Restricting resouces for virtual machines
+Before=slices.target
+[Slice]
+AllowedCPUs=#{allowed_cpus}
+SLICE_CONFIG
+
+      r "systemctl daemon-reload"
+    end
+  end
+
+  def start_systemd_unit
+    r "systemctl start #{@slice_name}"
+    cpuset_path = File.join("/sys/fs/cgroup", @slice_name, "cpuset.cpus.partition")
+    File.write(cpuset_path, "root")
+  end
+
+  def valid_cpuset?(str)
+    return false if str.nil? || str.empty?
+    str.split(",").all? do |part|
+      if part.include?("-")
+        r = part.split("-")
+        r.size == 2 && r.all? { _1.to_i.to_s == _1 } && r[0].to_i <= r[1].to_i
+      else
+        part.to_i.to_s == part
+      end
+    end
+  end
+end

--- a/rhizome/host/spec/slice_setup_spec.rb
+++ b/rhizome/host/spec/slice_setup_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative "../lib/slice_setup"
+
+RSpec.describe SliceSetup do
+  subject(:slice_setup) { described_class.new(slice_name) }
+
+  let(:slice_name) { "slice_name.slice" }
+
+  describe "#systemd_service" do
+    it "returns the correct systemd service path" do
+      expect(slice_setup.systemd_service).to eq("/etc/systemd/system/slice_name.slice")
+    end
+  end
+
+  describe "#prep" do
+    it "installs the systemd unit and starts the systemd unit" do
+      cpuset = "3-4"
+      expect(slice_setup).to receive(:install_systemd_unit).with(cpuset)
+      expect(slice_setup).to receive(:start_systemd_unit)
+      slice_setup.prep(cpuset)
+    end
+
+    it "raises an error if the cpuset is invalid" do
+      expect { slice_setup.prep("3-4-5") }.to raise_error("BUG: invalid cpuset")
+    end
+  end
+
+  describe "#purge" do
+    it "stops the systemd unit and removes the systemd service file" do
+      expect(slice_setup).to receive(:r).with("systemctl stop slice_name.slice", expect: [0, 5])
+      expect(slice_setup).to receive(:rm_if_exists).with(slice_setup.systemd_service)
+      expect(slice_setup).to receive(:r).with("systemctl daemon-reload")
+      slice_setup.purge
+    end
+  end
+
+  describe "#install_systemd_unit" do
+    it "writes the slice configuration to the systemd service file" do
+      expect(File).to receive(:exist?).with(slice_setup.systemd_service).and_return(false)
+      expect(slice_setup).to receive(:safe_write_to_file)
+      expect(slice_setup).to receive(:r).with("systemctl daemon-reload")
+      slice_setup.install_systemd_unit("3-4")
+    end
+
+    it "does nothing if the systemd service file already exists" do
+      expect(File).to receive(:exist?).with(slice_setup.systemd_service).and_return(true)
+      slice_setup.install_systemd_unit("3-4")
+    end
+
+    it "raises an error if the slice name is empty" do
+      slice_setup = described_class.new("")
+      expect { slice_setup.install_systemd_unit("3-4") }.to raise_error("BUG: unit name must not be empty")
+    end
+
+    it "raises an error if the slice name is system.slice" do
+      slice_setup = described_class.new("system.slice")
+      expect { slice_setup.install_systemd_unit("3-4") }.to raise_error("BUG: we cannot create system units")
+    end
+
+    it "raises an error if the slice name is user.slice" do
+      slice_setup = described_class.new("user.slice")
+      expect { slice_setup.install_systemd_unit("3-4") }.to raise_error("BUG: we cannot create system units")
+    end
+
+    it "raises an error if allowed_cpus is nil" do
+      expect { slice_setup.install_systemd_unit(nil) }.to raise_error("BUG: invalid allowed_cpus")
+    end
+
+    it "raises an error if allowed_cpus is empty" do
+      expect { slice_setup.install_systemd_unit("") }.to raise_error("BUG: invalid allowed_cpus")
+    end
+  end
+
+  describe "#start_systemd_unit" do
+    it "starts the systemd unit and writes to the cpuset.cpus.partition file" do
+      expect(slice_setup).to receive(:r).with("systemctl start slice_name.slice")
+      expect(File).to receive(:write).with("/sys/fs/cgroup/slice_name.slice/cpuset.cpus.partition", "root")
+      slice_setup.start_systemd_unit
+    end
+  end
+
+  describe "#valid_cpuset?" do
+    it "can handle a valid cpuset" do
+      expect(slice_setup.valid_cpuset?("0-3")).to be(true)
+      expect(slice_setup.valid_cpuset?("0")).to be(true)
+      expect(slice_setup.valid_cpuset?("1,2-3,5-10")).to be(true)
+    end
+
+    it "can handle an invalid cpuset" do
+      expect(slice_setup.valid_cpuset?("0-3-5")).to be(false)
+      expect(slice_setup.valid_cpuset?("0-")).to be(false)
+      expect(slice_setup.valid_cpuset?("1,2-3,5-")).to be(false)
+      expect(slice_setup.valid_cpuset?("a,b,c,d")).to be(false)
+      expect(slice_setup.valid_cpuset?("-1")).to be(false)
+    end
+
+    it "returns false if the cpuset is nil or empty" do
+      expect(slice_setup.valid_cpuset?(nil)).to be(false)
+      expect(slice_setup.valid_cpuset?("")).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
### Expand `r` in `util.rb` to get a list of expected exit statuses
Expand `r` in `util.rb` to get a list of expected exit statuses
    
By default, `r` threw exceptions whenever the exit status was not 0. However, in some scenarios the caller is ok with some exit statuses. For example, when the caller wants to stop a systemd unit if it exists. In which case, it is ok if the exit status is 5.
    
This change adds the `expect:` parameter to `r` to allow for that:
    
```
    def r(commandline, stdin: "", expect: [0])
```

### Add rhizome side of SliceSetup. 

This change introduces the rhizome library and executable to manage the creation and deletion of slices. Slices will form the foundation for controlling VM resource usage in future updates. This functionality will enable support for burstable VM instances.

### Add rspec tests for SliceSetup.
This change make sure we have code coverage SliceSetup.

### Add E2E rspec to actually try SliceSetup.

In this change we add an rspec test to actually try the SliceSetup library & verify that it works. This will be run as part of E2E tests.