### PR TITLE
Fix incorrect comparision between symbols and strings in deadlines

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -81,7 +81,7 @@ SQL
     prog_label = "#{prog}.#{label}"
     Clog.emit("starting strand") { [self, {strand_started: {prog_label: prog_label}}] }
 
-    if label == stack.first["deadline_target"].to_s
+    if label == stack.first["deadline_target"]
       if (pg = Page.from_tag_parts("Deadline", id, prog, stack.first["deadline_target"]))
         pg.incr_resolve
       end

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -85,7 +85,7 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
 
   label def start
     reconcile_replicas
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
     hop_wait_replicas
   end
 

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -58,7 +58,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
   end
 
   label def bootstrap_rhizome
-    register_deadline(:wait, 15 * 60)
+    register_deadline("wait", 15 * 60)
 
     bud Prog::BootstrapRhizome, {"target_folder" => "inference_endpoint", "subject_id" => vm.id, "user" => "ubi"}
     hop_wait_bootstrap_rhizome

--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -9,12 +9,12 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
 
   label def wait
     if dns_zone.last_purged_at < Time.now - 60 * 60 * 1 # ~1 hour
-      register_deadline(:wait, 5 * 60)
+      register_deadline("wait", 5 * 60)
       hop_purge_dns_records
     end
 
     when_refresh_dns_servers_set? do
-      register_deadline(:wait, 5 * 60)
+      register_deadline("wait", 5 * 60)
       hop_refresh_dns_servers
     end
 

--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -62,7 +62,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
   end
 
   label def wait_pools
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
     if minio_cluster.pools.all? { _1.strand.label == "wait" }
       # Start all the servers now
       minio_cluster.servers.each(&:incr_restart)

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -59,7 +59,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     nap 5 unless vm.strand.label == "wait"
     minio_server.incr_initial_provisioning
 
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
 
     minio_server.cluster.dns_zone&.insert_record(record_name: cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
     cert, cert_key = create_certificate
@@ -165,7 +165,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   end
 
   label def unavailable
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
 
     reap
     nap 5 unless strand.children.select { _1.prog == "Minio::MinioServerNexus" && _1.label == "minio_restart" }.empty?

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -92,9 +92,9 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     postgres_resource.incr_initial_provisioning
     if postgres_resource.parent
       bud self.class, frame, :trigger_pg_current_xact_id_on_parent
-      register_deadline(:wait, 120 * 60)
+      register_deadline("wait", 120 * 60)
     else
-      register_deadline(:wait, 10 * 60)
+      register_deadline("wait", 10 * 60)
     end
     hop_refresh_dns_record
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -75,9 +75,9 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
   label def bootstrap_rhizome
     if postgres_server.primary?
-      register_deadline(:wait, 10 * 60)
+      register_deadline("wait", 10 * 60)
     else
-      register_deadline(:wait, 120 * 60)
+      register_deadline("wait", 120 * 60)
     end
 
     bud Prog::BootstrapRhizome, {"target_folder" => "postgres", "subject_id" => vm.id, "user" => "ubi"}

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -91,12 +91,12 @@ class Prog::Test < Prog::Base
   end
 
   label def set_expired_deadline
-    register_deadline(:pusher2, -1)
+    register_deadline("pusher2", -1)
     hop_pusher1
   end
 
   label def extend_deadline
-    register_deadline(:pusher2, 1, allow_extension: true)
+    register_deadline("pusher2", 1, allow_extension: true)
     hop_pusher1
   end
 
@@ -110,7 +110,7 @@ class Prog::Test < Prog::Base
   end
 
   label def set_popping_deadline2
-    register_deadline(:pusher2, -1)
+    register_deadline("pusher2", -1)
     hop_popper
   end
 

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -173,7 +173,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # definitely more than 13 seconds.
     nap 13 unless vm.allocated_at
     nap 1 unless vm.provisioned_at
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
     hop_setup_environment
   end
 

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -37,7 +37,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def start
-    register_deadline(:download_boot_images, 10 * 60)
+    register_deadline("download_boot_images", 10 * 60)
     hop_prep if retval&.dig("msg") == "rhizome user bootstrapped and source installed"
 
     push Prog::BootstrapRhizome, {"target_folder" => "host"}
@@ -109,7 +109,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def download_boot_images
-    register_deadline(:prep_reboot, 4 * 60 * 60)
+    register_deadline("prep_reboot", 4 * 60 * 60)
     frame["default_boot_images"].each { |image_name|
       bud Prog::DownloadBootImage, {
         "image_name" => image_name
@@ -126,7 +126,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def prep_reboot
-    register_deadline(:wait, 15 * 60)
+    register_deadline("wait", 15 * 60)
     boot_id = get_boot_id
     vm_host.update(last_boot_id: boot_id)
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -201,7 +201,7 @@ class Prog::Vm::Nexus < Prog::Base
       page.incr_resolve
     end
 
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
 
     # We don't need storage_volume info anymore, so delete it before
     # transitioning to the next state.
@@ -310,22 +310,22 @@ class Prog::Vm::Nexus < Prog::Base
 
   label def wait
     when_start_after_host_reboot_set? do
-      register_deadline(:wait, 5 * 60)
+      register_deadline("wait", 5 * 60)
       hop_start_after_host_reboot
     end
 
     when_update_firewall_rules_set? do
-      register_deadline(:wait, 5 * 60)
+      register_deadline("wait", 5 * 60)
       hop_update_firewall_rules
     end
 
     when_update_spdk_dependency_set? do
-      register_deadline(:wait, 5 * 60)
+      register_deadline("wait", 5 * 60)
       hop_update_spdk_dependency
     end
 
     when_restart_set? do
-      register_deadline(:wait, 5 * 60)
+      register_deadline("wait", 5 * 60)
       hop_restart
     end
 
@@ -388,7 +388,7 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   label def prevent_destroy
-    register_deadline(:destroy, 24 * 60 * 60)
+    register_deadline("destroy", 24 * 60 * 60)
     nap 30
   end
 

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -28,7 +28,7 @@ class Prog::Vnet::CertNexus < Prog::Base
   end
 
   label def start
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
 
     if Config.development? && cert.dns_zone_id.nil?
       crt, key = Util.create_certificate(subject: "/CN=" + cert.hostname, duration: 60 * 60 * 24 * 30 * 3)

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -86,7 +86,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
   end
 
   label def add_new_nic
-    register_deadline(:wait, 3 * 60)
+    register_deadline("wait", 3 * 60)
     nics_snap = nics_to_rekey
     nap 10 if nics_snap.any? { |nic| nic.lock_set? }
     nics_snap.each do |nic|

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
   describe "#start" do
     it "reconciles replicas and hops to wait_replicas" do
       expect(nx).to receive(:reconcile_replicas)
-      expect(nx).to receive(:register_deadline).with(:wait, 10 * 60)
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
       expect { nx.start }.to hop("wait_replicas")
     end
   end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Prog::Base do
 
       # register if the target is different
       st.label = :set_expired_deadline
-      st.stack.first["deadline_target"] = :napper
+      st.stack.first["deadline_target"] = "napper"
       expect {
         st.unsynchronized_run
       }.to change { st.stack.first["deadline_at"] }
@@ -174,7 +174,7 @@ RSpec.describe Prog::Base do
       # ignore if new deadline is further in the time and target is same
       st.label = :set_expired_deadline
       st.stack.first["deadline_at"] = Time.now - 60
-      st.stack.first["deadline_target"] = :pusher2
+      st.stack.first["deadline_target"] = "pusher2"
       expect {
         st.unsynchronized_run
       }.not_to change { st.stack.first["deadline_at"] }
@@ -182,7 +182,7 @@ RSpec.describe Prog::Base do
       # allow to explicitly extend deadline
       st.label = :extend_deadline
       st.stack.first["deadline_at"] = Time.now
-      st.stack.first["deadline_target"] = :pusher2
+      st.stack.first["deadline_target"] = "pusher2"
       expect {
         st.unsynchronized_run
       }.to change { st.stack.first["deadline_at"] }
@@ -238,7 +238,7 @@ RSpec.describe Prog::Base do
       st = Strand.create_with_id(prog: "Test", label: :napper)
       page_id = Prog::PageNexus.assemble("dummy-summary", ["Deadline", st.id, st.prog, :napper], st.ubid).id
 
-      st.stack.first["deadline_target"] = :napper
+      st.stack.first["deadline_target"] = "napper"
       st.stack.first["deadline_at"] = Time.now - 1
 
       expect {
@@ -252,7 +252,7 @@ RSpec.describe Prog::Base do
       st = Strand.create_with_id(prog: "Test", label: :start)
       page_id = Prog::PageNexus.assemble("dummy-summary", ["Deadline", st.id, st.prog, :napper], st.ubid).id
 
-      st.stack.first["deadline_target"] = :napper
+      st.stack.first["deadline_target"] = "napper"
       st.stack.first["deadline_at"] = Time.now - 1
 
       st.update(label: :set_popping_deadline2)
@@ -268,7 +268,7 @@ RSpec.describe Prog::Base do
 
     it "deletes the deadline information once the target is reached" do
       st = Strand.create_with_id(prog: "Test", label: :napper)
-      st.stack.first["deadline_target"] = :napper
+      st.stack.first["deadline_target"] = "napper"
       st.stack.first["deadline_at"] = Time.now - 1
 
       expect(st.stack.first).to receive(:delete).with("deadline_target")

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "sets longer deadline for non-primary servers" do
       expect(postgres_server).to receive(:primary?).and_return(false)
-      expect(nx).to receive(:register_deadline).with(:wait, 120 * 60)
+      expect(nx).to receive(:register_deadline).with("wait", 120 * 60)
       expect { nx.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
     end
   end


### PR DESCRIPTION
In register_deadline function, we have a logic where we don't allow extending the deadline if the target is same. However, we were comparing symbols with strings to decide if the target is same, which always results in us deciding the targets are different and extending the deadline. This commit fixes it by using strings for deadline targets.