### PR TITLE
Check for missing backups before hopping

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -49,10 +49,6 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   label def wait
     nap 20 * 60 if postgres_timeline.blob_storage.nil?
 
-    if postgres_timeline.need_backup?
-      hop_take_backup
-    end
-
     # For the purpose of missing backup pages, we act like the very first backup
     # is taken at the creation, which ensures that we would get a page if and only
     # if no backup is taken for 2 days.
@@ -61,6 +57,10 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid)
     else
       Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
+    end
+
+    if postgres_timeline.need_backup?
+      hop_take_backup
     end
 
     nap 20 * 60

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -111,6 +111,9 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
 
     it "hops to take_backup if backup is needed" do
       expect(postgres_timeline).to receive(:need_backup?).and_return(true)
+      backup = Struct.new(:last_modified)
+      expect(postgres_timeline).to receive(:backups).and_return([instance_double(backup, last_modified: Time.now - 3 * 24 * 60 * 60)])
+      expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer))
       expect { nx.wait }.to hop("take_backup")
     end
 


### PR DESCRIPTION
If take_backup script on the VM fails quickly for some reason, we hop between wait and take_backup labels continuously without having opportunity to create a missing backup page. With this commit, we first check if we need to create a missing backup page before hopping.