### PR TITLE
Remove hash_branch_view_subdir plugin usage

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -47,7 +47,6 @@ class Clover < Roda
   plugin :flash
   plugin :h
   plugin :hash_branches
-  plugin :hash_branch_view_subdir
   plugin :hooks
   plugin :Integer_matcher_max
   plugin :json


### PR DESCRIPTION
We don't appear to use this.  At least, the specs pass when it is removed.  From what I've seen, most view generation uses slashes for the rendered files, and when slashes are used, the view subdir is ignored.