### PR TITLE
Fix Bundler.setup calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,13 +35,14 @@ gem "argon2-kdf"
 
 group :development do
   gem "awesome_print"
-  gem "brakeman"
   gem "by", ">= 1.1.0"
-  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "a9ff0001a1eb028e2186b222aeb02b07c04f9808"
   gem "foreman"
   gem "pry-byebug"
   gem "rackup"
-  gem "sequel-annotate"
+  gem "cuprite"
+end
+
+group :rubocop do
   gem "rubocop-capybara"
   gem "rubocop-erb"
   gem "rubocop-performance"
@@ -49,9 +50,11 @@ group :development do
   gem "rubocop-rspec"
   gem "rubocop-sequel"
   gem "standard", ">= 1.24.3"
-  gem "simplecov"
-  gem "turbo_tests"
-  gem "cuprite"
+end
+
+group :lint do
+  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "a9ff0001a1eb028e2186b222aeb02b07c04f9808"
+  gem "brakeman"
 end
 
 group :test do
@@ -59,6 +62,12 @@ group :test do
   gem "rspec"
   gem "webmock"
   gem "pdf-reader"
+  gem "turbo_tests"
+  gem "simplecov"
+end
+
+group :test, :development do
+  gem "sequel-annotate"
 end
 
 gem "webauthn", "~> 3.2"

--- a/Rakefile
+++ b/Rakefile
@@ -16,8 +16,8 @@ end
 # Migrate
 migrate = lambda do |env, version, db: nil|
   ENV["RACK_ENV"] = env
-  require "bundler/setup"
-  Bundler.setup
+  require "bundler"
+  Bundler.setup(:default, :development)
   require "logger"
   require_relative "db"
   Sequel.extension :migration
@@ -283,41 +283,39 @@ ensure
   File.delete(by_path) if File.file?(by_path)
 end
 
-begin
-  namespace :linter do
-    # "fdr/erb-formatter" can't be required without bundler setup because of custom repository.
-    require "bundler/setup"
-    Bundler.setup
-
-    require "rubocop/rake_task"
-    desc "Run Rubocop"
-    RuboCop::RakeTask.new
-
-    desc "Run Brakeman"
-    task :brakeman do
-      puts "Running Brakeman..."
-      require "brakeman"
-      Brakeman.run app_path: ".", quiet: true, force_scan: true, print_report: true, run_all_checks: true
-    end
-
-    desc "Run ERB::Formatter"
-    task :erb_formatter do
-      puts "Running ERB::Formatter..."
-      require "erb/formatter/command_line"
-      files = Dir.glob("views/**/[!icon]*.erb").entries
-      ERB::Formatter::CommandLine.new(files + ["--write", "--print-width", "120"]).run
-    end
-
-    desc "Validate, lint, format OpenAPI YAML file"
-    task :openapi do
-      sh "npx redocly lint openapi/openapi.yml --config openapi/redocly.yml"
-      sh "npx @stoplight/spectral-cli lint openapi/openapi.yml --fail-severity=warn --ruleset openapi/.spectral.yml"
-      sh "npx openapi-format openapi/openapi.yml --configFile openapi/openapi_format.yml"
-    end
+namespace :linter do
+  desc "Run Rubocop"
+  task :rubocop do
+    sh "BUNDLE_WITH=rubocop bundle exec rubocop"
   end
 
-  desc "Run all linters"
-  task linter: ["rubocop", "brakeman", "erb_formatter", "openapi"].map { "linter:#{_1}" }
-rescue LoadError => e
-  puts "Could not load dev dependencies: #{e.class}: #{e.message}"
+  desc "Run Brakeman"
+  task :brakeman do
+    require "bundler"
+    Bundler.setup(:lint)
+    puts "Running Brakeman..."
+    require "brakeman"
+    Brakeman.run app_path: ".", quiet: true, force_scan: true, print_report: true, run_all_checks: true
+  end
+
+  desc "Run ERB::Formatter"
+  task :erb_formatter do
+    # "fdr/erb-formatter" can't be required without bundler setup because of custom repository.
+    require "bundler"
+    Bundler.setup(:lint)
+    puts "Running ERB::Formatter..."
+    require "erb/formatter/command_line"
+    files = Dir.glob("views/**/[!icon]*.erb").entries
+    ERB::Formatter::CommandLine.new(files + ["--write", "--print-width", "120"]).run
+  end
+
+  desc "Validate, lint, format OpenAPI YAML file"
+  task :openapi do
+    sh "npx redocly lint openapi/openapi.yml --config openapi/redocly.yml"
+    sh "npx @stoplight/spectral-cli lint openapi/openapi.yml --fail-severity=warn --ruleset openapi/.spectral.yml"
+    sh "npx openapi-format openapi/openapi.yml --configFile openapi/openapi_format.yml"
+  end
 end
+
+desc "Run all linters"
+task linter: ["rubocop", "brakeman", "erb_formatter", "openapi"].map { "linter:#{_1}" }

--- a/loader.rb
+++ b/loader.rb
@@ -6,8 +6,9 @@ Signal.trap("QUIT") do
   Kernel.exit!(Signal.list["QUIT"] + 128)
 end
 
-require "bundler/setup"
-Bundler.setup
+require "bundler"
+rack_env = ENV["RACK_ENV"] || "development"
+Bundler.setup(:default, rack_env.to_sym)
 
 require_relative "config"
 require "mail"


### PR DESCRIPTION
First, Bundler.setup after require "bundler/setup" does nothing.
If you require "bundler/setup", it calls Bundler.setup, and
once Bundler.setup is called once, all future Bundler.setup calls
are ignored.

This switches require "bundler/setup" to require "bundler", and
then updates the Bundler.setup calls to only load the expected
groups.

In the loader, only load the :default and either the :test or
:development groups, depending on the rack environment.

This adds :rubocop and :lint Gemfile groups, to allow only
loading those specific gems, since the related gems are never
loaded directly by our code, only by tools run by the Rakefile.

For the linter:rubocop task, run the rubocop command line tool.
This allows the use of a normal task, and means you don't need
to require rubocop every time you run the Rakefile (and handle
failures).  This runs rubocop with BUNDLE_WITH so it only loads
the rubocop related gems.

Have the brakeman and erb_formatter tasks load only the :lint
group.

Note that I am not that knowledgeable about bundler, so this
should be thoroughly scrutinized. 