### PR TITLE
Use the project's `active?` helper in `InferenceEndpointReplicaNexus`

### DIFF
--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -173,8 +173,8 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
     eligible_projects_ds = Project.where(api_key_ds)
     eligible_projects_ds = eligible_projects_ds.where(id: inference_endpoint.project.id) unless inference_endpoint.is_public
 
-    eligible_projects = eligible_projects_ds
-      .reject { |pj| pj.accounts.any? { |ac| !ac.suspended_at.nil? } }
+    eligible_projects = eligible_projects_ds.all
+      .select(&:active?)
       .map do
       {
         ubid: _1.ubid,


### PR DESCRIPTION
I added the `active?` helper to the project in 9779fa83. We can use it to check if the project is active instead of checking its accounts.