### PR TITLE
Remove allow_only_ssh from Vm nexus

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -38,7 +38,6 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         boot_image: postgres_resource.project.get_ff_postgresql_base_image || boot_image,
         private_subnet_id: postgres_resource.private_subnet_id,
         enable_ip4: true,
-        allow_only_ssh: true,
         exclude_host_ids: exclude_host_ids
       )
 

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -57,7 +57,6 @@ class Prog::Vm::GithubRunner < Prog::Base
       storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true, skip_sync: skip_sync}],
       enable_ip4: true,
       arch: label_data["arch"],
-      allow_only_ssh: true,
       swap_size_bytes: 4294963200, # ~4096MB, the same value with GitHub hosted runners
       private_subnet_id: ps.id
     )

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -14,7 +14,7 @@ class Prog::Vm::Nexus < Prog::Base
   def self.assemble(public_key, project_id, name: nil, size: "standard-2",
     unix_user: "ubi", location: "hetzner-fsn1", boot_image: Config.default_boot_image_name,
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
-    enable_ip4: false, pool_id: nil, arch: "x64", allow_only_ssh: false, swap_size_bytes: nil,
+    enable_ip4: false, pool_id: nil, arch: "x64", swap_size_bytes: nil,
     distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [], gpu_count: 0)
 
     unless (project = Project[project_id])

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -54,7 +54,6 @@ class Prog::Vm::VmPool < Prog::Base
       enable_ip4: true,
       pool_id: vm_pool.id,
       arch: vm_pool.arch,
-      allow_only_ssh: true,
       swap_size_bytes: 4294963200,
       private_subnet_id: ps.id
     )


### PR DESCRIPTION
We have the `allow_only_ssh` parameter in the VM nexus to pass the `Private Subnet` nexus.

It's used by GitHubRunner and PostgresResource. Since we moved to the default location subnets and these resources now pass the private subnet explicitly, we no longer need this parameter.