### PR TITLE
Add a "playground" to the AI Inference section of the web console

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,4 @@
-$(function() {
+$(function () {
   setupPolicyEditor();
   setupAutoRefresh();
   setupDatePicker();
@@ -6,17 +6,17 @@ $(function() {
 });
 
 $(".toggle-mobile-menu").on("click", function (event) {
-    let menu = $("#mobile-menu")
-    if (menu.is(":hidden")) {
-        menu.show(0, function () {
-            menu.toggleClass("mobile-menu-open")
-        });
-    } else {
-        menu.toggleClass("mobile-menu-open")
-        setTimeout(function () {
-            menu.hide();
-        }, 300);
-    }
+  let menu = $("#mobile-menu")
+  if (menu.is(":hidden")) {
+    menu.show(0, function () {
+      menu.toggleClass("mobile-menu-open")
+    });
+  } else {
+    menu.toggleClass("mobile-menu-open")
+    setTimeout(function () {
+      menu.hide();
+    }, 300);
+  }
 });
 
 $(".cache-group-row").on("click", function (event) {
@@ -26,7 +26,7 @@ $(".cache-group-row").on("click", function (event) {
 });
 
 
-$(document).click(function(){
+$(document).click(function () {
   $(".dropdown").removeClass("active");
 });
 
@@ -40,46 +40,46 @@ $(".sidebar-group-btn").on("click", function (event) {
 });
 
 $(".delete-btn").on("click", function (event) {
-    event.preventDefault();
-    let url = $(this).data("url");
-    let csrf = $(this).data("csrf");
-    let confirmation = $(this).data("confirmation");
-    let confirmationMessage = $(this).data("confirmation-message");
-    let redirect = $(this).data("redirect");
-    let method = $(this).data("method");
+  event.preventDefault();
+  let url = $(this).data("url");
+  let csrf = $(this).data("csrf");
+  let confirmation = $(this).data("confirmation");
+  let confirmationMessage = $(this).data("confirmation-message");
+  let redirect = $(this).data("redirect");
+  let method = $(this).data("method");
 
-    if (!confirm(confirmationMessage || "Are you sure to delete?")) {
+  if (!confirm(confirmationMessage || "Are you sure to delete?")) {
+    return;
+  }
+
+  if (confirmation && prompt(`Please type "${confirmation}" to confirm deletion`, "") != confirmation) {
+    alert("Could not confirm resource name");
+    return;
+  }
+
+  $.ajax({
+    url: url,
+    type: method || "DELETE",
+    data: { "_csrf": csrf },
+    dataType: "json",
+    headers: { "Accept": "application/json" },
+    success: function (result) {
+      window.location.href = redirect;
+    },
+    error: function (xhr, ajaxOptions, thrownError) {
+      if (xhr.status == 404) {
+        window.location.href = redirect;
         return;
+      }
+
+      let message = thrownError;
+      try {
+        response = JSON.parse(xhr.responseText);
+        message = response.error?.message
+      } catch { };
+      alert(`Error: ${message}`);
     }
-
-    if (confirmation && prompt(`Please type "${confirmation}" to confirm deletion`, "") != confirmation) {
-        alert("Could not confirm resource name");
-        return;
-    }
-
-    $.ajax({
-        url: url,
-        type: method || "DELETE",
-        data: { "_csrf": csrf },
-        dataType : "json",
-        headers: {"Accept": "application/json"},
-        success: function (result) {
-            window.location.href = redirect;
-        },
-        error: function (xhr, ajaxOptions, thrownError) {
-          if(xhr.status == 404){
-            window.location.href = redirect;
-            return;
-          }
-
-          let message = thrownError;
-          try {
-            response = JSON.parse(xhr.responseText);
-            message = response.error?.message
-          } catch {};
-          alert(`Error: ${message}`);
-        }
-    });
+  });
 });
 
 $(".restart-btn").on("click", function (event) {
@@ -95,7 +95,7 @@ $(".copyable-content").on("click", ".copy-button", function (event) {
   navigator.clipboard.writeText(content);
 
   if (message) {
-      notification(message);
+    notification(message);
   }
 })
 
@@ -110,27 +110,27 @@ $(".revealable-content").on("click", ".hide-button", function (event) {
 })
 
 $(".back-btn").on("click", function (event) {
-    event.preventDefault();
-    history.back();
+  event.preventDefault();
+  history.back();
 })
 
 function notification(message) {
-    let container = $("#notification-template").parent();
-    let newNotification = $("#notification-template").clone();
-    newNotification.find("p").text(message);
-    newNotification.appendTo(container).show(0, function () {
-        $(this)
-            .removeClass("translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2")
-            .addClass("translate-y-0 opacity-100 sm:translate-x-0");
-    });
+  let container = $("#notification-template").parent();
+  let newNotification = $("#notification-template").clone();
+  newNotification.find("p").text(message);
+  newNotification.appendTo(container).show(0, function () {
+    $(this)
+      .removeClass("translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2")
+      .addClass("translate-y-0 opacity-100 sm:translate-x-0");
+  });
 
-    setTimeout(function () {
-        newNotification.remove();
-    }, 2000);
+  setTimeout(function () {
+    newNotification.remove();
+  }, 2000);
 }
 
 function setupPolicyEditor() {
-  $(".policy-editor").each(function() {
+  $(".policy-editor").each(function () {
     let pre = $(this).find("pre");
     let textarea = $(this).find("textarea");
     pre.html(jsonHighlight(DOMPurify.sanitize(pre.text())));
@@ -156,26 +156,26 @@ function jsonHighlight(str) {
 
   json = json.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
-      var cls = 'text-orange-700'; // number
-      if (/^"/.test(match)) {
-          if (/:$/.test(match)) {
-              cls = 'text-rose-700 font-medium'; // key
-          } else {
-              cls = 'text-green-700'; // string
-          }
-      } else if (/true|false/.test(match)) {
-          cls = 'text-blue-700'; // boolean
-      } else if (/null/.test(match)) {
-          cls = 'text-pink-700'; // null
+    var cls = 'text-orange-700'; // number
+    if (/^"/.test(match)) {
+      if (/:$/.test(match)) {
+        cls = 'text-rose-700 font-medium'; // key
+      } else {
+        cls = 'text-green-700'; // string
       }
-      return '<span class="' + cls + '">' + match + '</span>';
+    } else if (/true|false/.test(match)) {
+      cls = 'text-blue-700'; // boolean
+    } else if (/null/.test(match)) {
+      cls = 'text-pink-700'; // null
+    }
+    return '<span class="' + cls + '">' + match + '</span>';
   });
 }
 
 function setupAutoRefresh() {
-  $("div.auto-refresh").each(function() {
+  $("div.auto-refresh").each(function () {
     const interval = $(this).data("interval");
-    setTimeout(function() {
+    setTimeout(function () {
       location.reload();
     }, interval * 1000);
   });
@@ -184,7 +184,7 @@ function setupAutoRefresh() {
 function setupDatePicker() {
   if (!$.prototype.flatpickr) { return; }
 
-  $(".datepicker").each(function() {
+  $(".datepicker").each(function () {
     let options = {
       enableTime: true,
       time_24hr: true,
@@ -216,7 +216,7 @@ function setupDatePicker() {
 }
 
 function setupFormOptionUpdates() {
-  $('#creation-form').on('change', 'input', function() {
+  $('#creation-form').on('change', 'input', function () {
     let name = $(this).attr('name');
     option_dirty[name] = $(this).val();
 
@@ -227,32 +227,32 @@ function setupFormOptionUpdates() {
   });
 }
 
-function redrawChildOptions(name){
-  if(option_children[name]) {
+function redrawChildOptions(name) {
+  if (option_children[name]) {
     let value = $("input[name=" + name + "]:checked").val();
     let classes = $("input[name=" + name + "]:checked").parent().attr('class');
     classes = classes ? classes.split(" ") : [];
     classes = "." + classes.concat("form_" + name, "form_" + name + "_" + value).join('.');
 
-    option_children[name].forEach(function(child_name){
+    option_children[name].forEach(function (child_name) {
       let child_type = document.getElementsByName(child_name)[0].nodeName.toLowerCase();
-      if(child_type == "input"){
+      if (child_type == "input") {
         child_type = "input_" + document.getElementsByName(child_name)[0].type.toLowerCase();
       }
 
       let elements2select = [];
-      switch(child_type){
+      switch (child_type) {
         case "input_radio":
           $("input[name=" + child_name + "]").parent().hide()
           $("input[name=" + child_name + "]").prop('disabled', true).prop('checked', false).prop('selected', false);
           $("input[name=" + child_name + "]").parent(classes).show()
           $("input[name=" + child_name + "]").parent(classes).children("input[name=" + child_name + "]").prop('disabled', false);
 
-          if(option_dirty[child_name]){
+          if (option_dirty[child_name]) {
             elements2select = $("input[name=" + child_name + "][value=" + option_dirty[child_name] + "]").parent(classes);
           }
 
-          if(elements2select.length == 0){
+          if (elements2select.length == 0) {
             option_dirty[child_name] = null;
             elements2select = $("input[name=" + child_name + "]").parent(classes);
           }
@@ -266,11 +266,11 @@ function redrawChildOptions(name){
           $("select[name=" + child_name + "]").children().hide().prop('disabled', true).prop('checked', false).prop('selected', false);
           $("select[name=" + child_name + "]").children(".always-visible, " + classes).show().prop('disabled', false);
 
-          if(option_dirty[child_name]){
+          if (option_dirty[child_name]) {
             elements2select = $("select[name=" + child_name + "]").children(classes + "[value=" + option_dirty[child_name] + "]");
           }
 
-          if(elements2select.length == 0){
+          if (elements2select.length == 0) {
             option_dirty[child_name] = null;
             elements2select = $("select[name=" + child_name + "]").children(".always-visible, " + classes);
           }

--- a/clover.rb
+++ b/clover.rb
@@ -94,7 +94,7 @@ class Clover < Roda
     csp.form_action :self, "https://checkout.stripe.com", "https://github.com/login/oauth/authorize", "https://accounts.google.com/o/oauth2/auth"
     csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js", "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js", "https://challenges.cloudflare.com/turnstile/v0/api.js"
     csp.frame_src :self, "https://challenges.cloudflare.com"
-    csp.connect_src :self
+    csp.connect_src :self, "https://*.ubicloud.com"
     csp.base_uri :none
     csp.frame_ancestors :none
   end

--- a/helpers/inference.rb
+++ b/helpers/inference.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Clover
+  def inference_endpoint_ds
+    dataset_private = dataset_authorize(@project.inference_endpoints_dataset, "InferenceEndpoint:view")
+    dataset_public = InferenceEndpoint.where(is_public: true)
+
+    dataset = dataset_private.union(dataset_public)
+    dataset = dataset.where(visible: true)
+    dataset = dataset.order(:model_name)
+    dataset.eager(:load_balancer)
+  end
+
+  def inference_token_ds
+    dataset = dataset_authorize(@project.api_keys_dataset.where(used_for: "inference_endpoint"), "InferenceToken:view")
+    dataset = dataset.where(is_valid: true)
+    dataset.order(:created_at)
+  end
+end

--- a/routes/project/inference_endpoint.rb
+++ b/routes/project/inference_endpoint.rb
@@ -6,15 +6,7 @@ class Clover
       next unless @project.get_ff_inference_ui
 
       r.get true do
-        dataset_private = dataset_authorize(@project.inference_endpoints_dataset, "InferenceEndpoint:view")
-        dataset_public = InferenceEndpoint.where(is_public: true)
-
-        dataset = dataset_private.union(dataset_public)
-        dataset = dataset.where(visible: true)
-        dataset = dataset.order(:model_name)
-        dataset = dataset.eager(:load_balancer)
-
-        @inference_endpoints = Serializers::InferenceEndpoint.serialize(dataset.all)
+        @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.all)
         view "inference/endpoint/index"
       end
     end

--- a/routes/project/inference_playground.rb
+++ b/routes/project/inference_playground.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Clover
+  hash_branch(:project_prefix, "inference-playground") do |r|
+    r.on web? do
+      next unless @project.get_ff_inference_ui
+
+      r.get true do
+        @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.reject { _1.model_type == :embedding })
+        @inference_tokens = Serializers::InferenceToken.serialize(inference_token_ds.all)
+        view "inference/endpoint/playground"
+      end
+    end
+  end
+end

--- a/routes/project/inference_token.rb
+++ b/routes/project/inference_token.rb
@@ -6,10 +6,7 @@ class Clover
       next unless @project.get_ff_inference_ui
 
       r.get true do
-        dataset = dataset_authorize(@project.api_keys_dataset.where(used_for: "inference_endpoint"), "InferenceToken:view")
-        dataset = dataset.where(is_valid: true)
-        dataset = dataset.order(:created_at)
-        @inference_tokens = Serializers::InferenceToken.serialize(dataset.all)
+        @inference_tokens = Serializers::InferenceToken.serialize(inference_token_ds.all)
         view "inference/token/index"
       end
 

--- a/spec/routes/web/inference_playground_spec.rb
+++ b/spec/routes/web/inference_playground_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Clover, "inference-playground" do
+  let(:user) { create_account }
+
+  let(:project) { user.create_project_with_default_policy("project-1") }
+  let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", default_policy: nil) }
+
+  describe "feature enabled" do
+    before do
+      project.set_ff_inference_ui(true)
+      project_wo_permissions.set_ff_inference_ui(true)
+      login
+    end
+
+    it "can handle empty list of inference endpoints" do
+      visit "#{project.path}/inference-playground"
+
+      expect(page.title).to eq("Ubicloud - Playground")
+    end
+
+    it "gives choice of inference endpoints" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
+      lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up")
+      lb2 = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-2", src_port: 80, dst_port: 80, health_check_endpoint: "/up")
+      [
+        ["ie1", "e5-mistral-7b-it", project_wo_permissions.id, true, true, lb.id],
+        ["ie2", "e5-mistral-8b-it", project_wo_permissions.id, true, false, lb.id],
+        ["ie3", "llama-guard-3-8b", project_wo_permissions.id, false, true, lb.id],
+        ["ie4", "llama-3-1-405b-it", project.id, false, true, lb2.id],
+        ["ie5", "llama-3-2-3b-it", project.id, false, true, lb.id],
+        ["ie6", "test-model", project_wo_permissions.id, true, true, lb.id]
+      ].each do |name, model_name, project_id, is_public, visible, load_balancer_id|
+        InferenceEndpoint.create_with_id(name:, model_name:, project_id:, is_public:, visible:, load_balancer_id:, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id)
+      end
+      InferenceEndpoint.first(name: "ie4").associate_with_project(project)
+      visit "#{project.path}/inference-playground"
+
+      expect(page.title).to eq("Ubicloud - Playground")
+      expect(page).to have_no_content("e5-mistral-7b-it")
+      expect(page).to have_no_content("e5-mistral-8b-it")
+      expect(page).to have_no_content("llama-guard-3-8b")
+      expect(page).to have_no_content("llama-3-2-3b-it")
+      expect(page).to have_select("inference_endpoint", selected: "llama-3-1-405b-it", with_options: ["llama-3-1-405b-it", "test-model"])
+    end
+
+    it "gives choice of inference tokens" do
+      visit "#{project.path}/inference-token"
+      expect(ApiKey.all).to be_empty
+      click_button "Create Token"
+
+      visit "#{project.path}/inference-playground"
+
+      expect(page.title).to eq("Ubicloud - Playground")
+      expect(page).to have_select("inference_token", selected: ApiKey.first.ubid)
+    end
+  end
+
+  describe "feature disabled" do
+    it "inference playground page is not accessible" do
+      project.set_ff_inference_ui(false)
+      login
+      visit "#{project.path}/inference-playground"
+      expect(page.status_code).to eq(404)
+    end
+  end
+
+  describe "unauthenticated" do
+    it "inference endpoint page is not accessible" do
+      visit "/inference-playground"
+
+      expect(page.title).to eq("Ubicloud - Login")
+    end
+  end
+end

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -1,0 +1,57 @@
+<% @page_title = "Playground" %>
+<%== render("inference/tabbar") %>
+<div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div class="flex space-x-4">
+    <div class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+      <%== render(
+        "components/form/select",
+        locals: {
+          name: "inference_endpoint",
+          label: "Inference Endpoint",
+          placeholder: "Pick an endpoint",
+          options: @inference_endpoints.map { |ie| [ie[:url], ie[:model_name]] },
+          selected: @inference_endpoints.any? ? @inference_endpoints.first[:url] : nil
+        }
+      ) %>
+    </div>
+    <div class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+      <%== render(
+        "components/form/select",
+        locals: {
+          name: "inference_token",
+          label: "Inference Token",
+          placeholder: "Pick a token",
+          options: @inference_tokens.map { |it| [it[:key], it[:id]] },
+          selected: @inference_tokens.any? ? @inference_tokens.first[:key] : nil
+        }
+      ) %>
+    </div>
+  </div>
+  <div class="shadow-md rounded-lg p-2 ml-2 mr-2 mb-2 bg-gray-50">
+    <%== render(
+      "components/form/textarea",
+      locals: {
+        name: "inference_prompt",
+        attributes: {
+          "autofocus" => true,
+          "placeholder" => "User prompt to be submitted to the inference endpoint"
+        }
+      }
+    ) %>
+    <%== render(
+      "components/button",
+      locals: {
+        text: "Submit",
+        attributes: {
+          "name" => "inference_submit",
+          "id" => "inference_submit",
+          "type" => "button"
+        },
+        extra_class: "mt-2"
+      }
+    ) %>
+  </div>
+  <div class="mt-4 ml-2 mr-2 text-sm text-gray-900">
+    <span id="inference_response" class="overflow-auto min-h-48 whitespace-pre-line"></span>
+  </div>
+</div>

--- a/views/inference/tabbar.erb
+++ b/views/inference/tabbar.erb
@@ -3,7 +3,8 @@
   locals: {
     tabs: [
       ["Inference Endpoints", @project_data[:path] + "/inference-endpoint"],
-      ["Inference Tokens", @project_data[:path] + "/inference-token"]
+      ["Inference Tokens", @project_data[:path] + "/inference-token"],
+      ["Playground", @project_data[:path] + "/inference-playground"]
     ]
   }
 ) %>


### PR DESCRIPTION
Add a simple `playground` to the AI inference section of our web console. It allows users to test available models directly within the console. 

Users can pick available inference endpoints (models) and inference tokens from a dropdown, put their prompt in a text box, and submit the prompt to the model by clicking on `Submit`. The response is directly shown in the playground. 

![image](https://github.com/user-attachments/assets/91c1a3a1-d515-400c-9da3-7648c5df5480)
