### PR TITLE
Enable Postgres 17 for Lantern

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -95,9 +95,7 @@ class Clover
       storage_size.to_i >= lower_limit && storage_size.to_i <= upper_limit
     end
 
-    options.add_option(name: "version", values: ["16", "17"], parent: "flavor") do |flavor, version|
-      flavor != PostgresResource::Flavor::LANTERN || version == "16"
-    end
+    options.add_option(name: "version", values: ["16", "17"], parent: "flavor")
 
     options.add_option(name: "ha_type", values: ["none", "async", "sync"], parent: "storage_size")
     options.serialize

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -50,10 +50,6 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         [parent.superuser_password, parent.timeline.id, "fetch", parent.version]
       end
 
-      if flavor == PostgresResource::Flavor::LANTERN && version == "17"
-        fail Validation::ValidationFailed.new({version: "Lantern flavor is not supported with version 17"})
-      end
-
       postgres_resource = PostgresResource.create_with_id(
         project_id: project_id, location: location, name: name,
         target_vm_size: target_vm_size, target_storage_size_gib: target_storage_size_gib,

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -78,10 +78,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         expect(PostgresResource).to receive(:[]).with(parent.id).and_return(parent)
         described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: parent.id, restore_target: Time.now)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: restore_target"
-
-      expect {
-        described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128, version: "17", flavor: "lantern")
-      }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: version"
     end
 
     it "does not allow giving different version than parent for restore" do


### PR DESCRIPTION
Lantern now supports Postgres 17, so we are enabling it in our platform as well.