### PR TITLE
Allow access to all caches from all scopes if feature flag enabled

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -149,7 +149,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :inference_ui
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :inference_ui, :access_all_cache_scopes
 end
 
 # Table: project


### PR DESCRIPTION
We aim to maintain the same security measures as the official GitHub Actions runners.

Jobs can only access cache entries from their own branch or the default branch.


> Access restrictions provide cache isolation and security by creating
> a logical boundary between different branches or tags. Workflow runs
> can restore caches created in either the current branch or the
> default branch (usually main) [^1]

Some customers want access to all caches from all scopes. If a customer prefers not to isolate cache entries and accepts the consequences of having no boundaries, this PR will allow that.

I believe it's reasonable not to enforce isolation for private repositories if all contributors are trusted.

If more customers request this feature, we can consider adding a toggle on the settings page.

[^1]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache