### PR TITLE
Cap the cleanup cache entries at 200 for each run

### DIFF
--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -90,6 +90,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     seven_days_ago = Time.now - 7 * 24 * 60 * 60
     github_repository.cache_entries_dataset
       .where { (last_accessed_at < seven_days_ago) | ((last_accessed_at =~ nil) & (created_at < seven_days_ago)) }
+      .limit(200)
       .destroy
 
     # Destroy oldest cache entries if the total usage exceeds the limit.
@@ -97,7 +98,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     total_usage = dataset.sum(:size).to_i
     storage_limit = github_repository.installation.project.effective_quota_value("GithubRunnerCacheStorage") * 1024 * 1024 * 1024
     if total_usage > storage_limit
-      dataset.order(:created_at).each do |oldest_entry|
+      dataset.order(:created_at).limit(200).each do |oldest_entry|
         break if total_usage <= storage_limit
         oldest_entry.destroy
         total_usage -= oldest_entry.size


### PR DESCRIPTION
While we clean up old cache entries, we also remove them from blob storage, which can take some time.

We have a 2-minute limit in respirate for each run. If it exceeds this limit, respirate considers the run stuck and terminates itself.

We encountered this issue in production when we needed to clean up over 1000 cache entries in one run, which took more than 2 minutes. As a result, respirate crashed multiple times.

Since we run the cleanup job every 5 minutes, we can cap the cleanup cache entries at 200 for each run. This way, we can avoid the respirate crash and also keep the cache clean.