### PR TITLE
Run bin/production check on port 8081

### DIFF
--- a/bin/production_check
+++ b/bin/production_check
@@ -9,7 +9,7 @@ works = nil
 error = +""
 queue = Queue.new
 
-Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma") do |stdin, stdout, stderr, wait_thr|
+Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma", "-p", "8081") do |stdin, stdout, stderr, wait_thr|
   pid = wait_thr.pid
 
   timer_thread = Thread.new do


### PR DESCRIPTION
That way it doesn't break if you are currently running puma on the default port of 8080.