### PR TITLE
Generate model uuid automatically before saving it for new model instances

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -59,6 +59,16 @@ module ResourceMethods
     ubid if id
   end
 
+  def before_validation
+    set_uuid
+    super
+  end
+
+  def set_uuid
+    self.id ||= self.class.generate_uuid if new?
+    self
+  end
+
   INSPECT_CONVERTERS = {
     "uuid" => lambda { |v| UBID.from_uuidish(v).to_s },
     "cidr" => :to_s.to_proc,
@@ -144,12 +154,12 @@ module ResourceMethods
       generate_ubid.to_uuid
     end
 
-    def new_with_id(*, **)
-      new(*, **) { _1.id = generate_uuid }
+    def new_with_id(...)
+      new(...).set_uuid
     end
 
-    def create_with_id(*, **)
-      create(*, **) { _1.id = generate_uuid }
+    def create_with_id(...)
+      create(...)
     end
 
     def redacted_columns


### PR DESCRIPTION
This allows the use of normal new/create instead of new_with_id and create_with_id.  The only difference is if you plan to use the id before saving the object, then you would still want to use new_with_id (or you could switch to using the new #set_uuid method). We have no production code that calls new_with_id and then access the id before saving the model.  Only a single spec does so.

This doesn't change all existing new_with_id and model_with_id calls, that can be done in a later commit.