### PR TITLE
Return error json without error key for runtime endpoints

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -193,7 +193,9 @@ class Clover < Roda
 
     error = {code:, type:, message:, details:}
 
-    if api? || runtime? || request.headers["Accept"] == "application/json"
+    if runtime?
+      error
+    elsif api? || request.headers["Accept"] == "application/json"
       {error:}
     else
       @error = error

--- a/spec/routes/runtime/auth_spec.rb
+++ b/spec/routes/runtime/auth_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Clover, "auth" do
   it "no jwt token" do
     get "/runtime"
 
-    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
+    expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "wrong jwt token" do
     header "Authorization", "Bearer wrongjwt"
     get "/runtime"
 
-    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
+    expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "valid jwt token but no active vm" do
@@ -21,7 +21,7 @@ RSpec.describe Clover, "auth" do
     header "Authorization", "Bearer #{vm.runtime_token}"
     get "/runtime"
 
-    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
+    expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "valid jwt token with an active vm" do

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Clover, "github" do
     it "vm has no runner" do
       get "/runtime/github"
 
-      expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
+      expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
     end
 
     it "vm has runner but no repository" do
       GithubRunner.create_with_id(vm_id: vm.id, repository_name: "test", label: "ubicloud")
       get "/runtime/github"
 
-      expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
+      expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
     end
 
     it "vm has runner and repository" do
@@ -42,7 +42,7 @@ RSpec.describe Clover, "github" do
 
     post "/runtime/github/caches"
 
-    expect(last_response).to have_api_error(400, "Wrong parameters")
+    expect(last_response).to have_runtime_error(400, "Wrong parameters")
   end
 
   describe "cache endpoints" do
@@ -67,7 +67,7 @@ RSpec.describe Clover, "github" do
           params = {key: key, version: version}.compact
           post "/runtime/github/caches", params
 
-          expect(last_response).to have_api_error(400, "Wrong parameters")
+          expect(last_response).to have_runtime_error(400, "Wrong parameters")
         end
       end
 
@@ -75,27 +75,27 @@ RSpec.describe Clover, "github" do
         runner.update(workflow_job: nil)
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100}
 
-        expect(last_response).to have_api_error(400, "No workflow job data available")
+        expect(last_response).to have_runtime_error(400, "No workflow job data available")
       end
 
       it "fails if cache is bigger than 10GB" do
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 11 * 1024 * 1024 * 1024}
 
-        expect(last_response).to have_api_error(400, "The cache size is over the 10GB limit")
+        expect(last_response).to have_runtime_error(400, "The cache size is over the 10GB limit")
       end
 
       it "fails if the cache entry already exists" do
         GithubCacheEntry.create_with_id(key: "k1", version: "v1", scope: "dev", repository_id: repository.id, created_by: runner.id, committed_at: Time.now)
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100}
 
-        expect(last_response).to have_api_error(409, "A cache entry for dev scope already exists with k1 key and v1 version.")
+        expect(last_response).to have_runtime_error(409, "A cache entry for dev scope already exists with k1 key and v1 version.")
       end
 
       it "rollbacks inconsistent cache entry if a failure occurs in the middle" do
         expect(blob_storage_client).to receive(:create_multipart_upload).and_raise(CloverError.new(500, "UnexceptedError", "Sorry, we couldn’t process your request because of an unexpected error."))
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 75 * 1024 * 1024}
 
-        expect(last_response).to have_api_error(500, "Sorry, we couldn’t process your request because of an unexpected error.")
+        expect(last_response).to have_runtime_error(500, "Sorry, we couldn’t process your request because of an unexpected error.")
         expect(repository.cache_entries).to be_empty
       end
 
@@ -162,7 +162,7 @@ RSpec.describe Clover, "github" do
           params = {etags: etags, uploadId: upload_id, size: size}.compact
           post "/runtime/github/caches/commit", params
 
-          expect(last_response).to have_api_error(400, "Wrong parameters")
+          expect(last_response).to have_runtime_error(400, "Wrong parameters")
         end
       end
 
@@ -177,7 +177,7 @@ RSpec.describe Clover, "github" do
         expect(blob_storage_client).to receive(:complete_multipart_upload).and_raise(Aws::S3::Errors::NoSuchUpload.new("error", "error"))
         post "/runtime/github/caches/commit", {etags: ["etag-1", "etag-2"], uploadId: "upload-id", size: 100}
 
-        expect(last_response).to have_api_error(400, "Wrong parameters")
+        expect(last_response).to have_runtime_error(400, "Wrong parameters")
       end
 
       it "completes multipart upload" do
@@ -214,7 +214,7 @@ RSpec.describe Clover, "github" do
           params = {keys: keys, version: version}.compact
           get "/runtime/github/cache", params
 
-          expect(last_response).to have_api_error(400, "Wrong parameters")
+          expect(last_response).to have_runtime_error(400, "Wrong parameters")
         end
       end
 


### PR DESCRIPTION
Returning an error json without an error key on top for runtime endpoints. It is required because docker layer caching expects error in this format to skip duplicate cache entries. Passing it in this way works properly with the cache proxy as we directly pass the error to the client without parsing it.