### PR TITLE
Use parallel var instead of raw arg in the setup_database rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,7 +130,7 @@ task :setup_database, [:env, :parallel] do |_, args|
   database_count.times do |i|
     threads << Thread.new do
       puts "Creating database #{i}..."
-      database_name = "clover_#{args[:env]}#{args[:parallel] ? (i + 1) : ""}"
+      database_name = "clover_#{args[:env]}#{parallel ? (i + 1) : ""}"
       sh "dropdb --if-exists -U postgres #{database_name}"
       sh "createdb -U postgres -O clover #{database_name}"
       sh "psql -U postgres -c 'CREATE EXTENSION citext; CREATE EXTENSION btree_gist;' #{database_name}"


### PR DESCRIPTION
We added a `false` option for `parallel` in
b9fa15e069fc7e825c3508f5cc823183c1e3ae78, but it seems we aren't using it everywhere. This causes `clover_test1` to be created instead of `clover_test` when running `rake setup_database\[test,false\]`