### PR TITLE
Add policy selector to user list

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -5,6 +5,7 @@ require_relative "../model"
 class Account < Sequel::Model(:accounts)
   one_to_many :usage_alerts, key: :user_id
   one_to_many :api_keys, key: :owner_id, conditions: {owner_table: "accounts"}
+  many_to_many :subject_tags, join_table: :applied_subject_tag, left_key: :subject_id, right_key: :tag_id
 
   plugin :association_dependencies, usage_alerts: :destroy
 

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -13,7 +13,7 @@ class Clover
         authorize("Project:user", @project.id)
 
         r.get do
-          @users = Serializers::Account.serialize(@project.accounts_dataset.order_by(:email).all)
+          @users = Serializers::Account.serialize(@project.accounts_dataset.order_by(:email).all, {project_id: @project.id})
           @invitations = Serializers::ProjectInvitation.serialize(@project.invitations_dataset.order_by(:email).all)
           view "project/user"
         end

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -31,6 +31,11 @@ class Clover
           end
 
           tag = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").first(name: policy)
+          unless tag || policy == ""
+            flash["error"] = "You don't have permission to invite users with this subject tag."
+            r.redirect "#{@project_data[:path]}/user"
+          end
+
           if (user = Account.exclude(status_id: 3)[email: email])
             user.associate_with_project(@project)
             tag&.add_subject(user.id)

--- a/serializers/account.rb
+++ b/serializers/account.rb
@@ -2,10 +2,16 @@
 
 class Serializers::Account < Serializers::Base
   def self.serialize_internal(a, options = {})
-    {
+    base = {
       id: a.id,
       ubid: a.ubid,
       email: a.email
     }
+
+    if (project_id = options[:project_id])
+      base[:policies] = a.subject_tags_dataset.where(project_id: project_id).order_by(:name).map(&:name)
+    end
+
+    base
   end
 end

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -514,21 +514,25 @@ RSpec.describe Clover, "project" do
 
         visit "#{project.path}/user"
 
-        expect(page.html).to include "Allowed"
-        expect(page.html).to include "ToBeRemoved"
-        within "form#managed-policy" do
-          select "Allowed", from: "invitation_policies[#{invited_email}]"
-          click_button "Update"
-        end
-        expect(page).to have_select("invitation_policies[#{invited_email}]", selected: "Allowed")
-
-        ace.destroy
         within "form#managed-policy" do
           select "ToBeRemoved", from: "invitation_policies[#{invited_email}]"
           click_button "Update"
         end
         expect(page).to have_select("invitation_policies[#{invited_email}]", selected: "Allowed")
-        expect(page.html).to include "Allowed"
+
+        AccessControlEntry.create_with_id(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["SubjectTag:remove"], object_id: allowed.id)
+        within "form#managed-policy" do
+          select "ToBeRemoved", from: "invitation_policies[#{invited_email}]"
+          ace.destroy
+          click_button "Update"
+        end
+        expect(page).to have_select("invitation_policies[#{invited_email}]", selected: "Allowed")
+
+        within "form#managed-policy" do
+          select "No access", from: "invitation_policies[#{invited_email}]"
+          click_button "Update"
+        end
+        expect(page).to have_select("invitation_policies[#{invited_email}]", selected: nil)
       end
 
       it "can not have more than 50 pending invitations" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -291,14 +291,15 @@ RSpec.describe Clover, "project" do
         AccessControlEntry.create_with_id(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Project:user"])
 
         visit "#{project.path}/user"
-        expect(page.html).not_to include "Allowed"
+        fill_in "Email", with: user2.email
+        select "Allowed", from: "policy"
+        click_button "Invite"
 
-        ace = AccessControlEntry.create_with_id(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["SubjectTag:add"], object_id: allowed.id)
+        expect(page.find_by_id("flash-error").text).to eq("You don't have permission to invite users with this subject tag.")
 
         page.refresh
         fill_in "Email", with: user2.email
-        select "Allowed", from: "policy"
-        ace.destroy
+        select "No access", from: "policy"
         click_button "Invite"
 
         expect(page).to have_content user.email
@@ -329,20 +330,23 @@ RSpec.describe Clover, "project" do
         AccessControlEntry.create_with_id(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Project:user"])
 
         visit "#{project.path}/user"
-        expect(page.html).not_to include "Allowed"
+        fill_in "Email", with: user2.email
+        select "Allowed", from: "policy"
+        click_button "Invite"
 
-        ace = AccessControlEntry.create_with_id(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["SubjectTag:add"], object_id: allowed.id)
+        expect(page.find_by_id("flash-error").text).to eq("You don't have permission to invite users with this subject tag.")
+
+        AccessControlEntry.create_with_id(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["SubjectTag:add"], object_id: allowed.id)
 
         visit "#{project.path}/user"
         new_email = "newUpper@example.com"
         expect(page).to have_content user.email
 
         fill_in "Email", with: new_email
-        select "Allowed", from: "policy"
-        ace.destroy
+        select "No access", from: "policy"
         click_button "Invite"
-        expect(page.find_by_id("flash-notice").text).to eq("Invitation sent successfully to 'newUpper@example.com'.")
 
+        expect(page.find_by_id("flash-notice").text).to eq("Invitation sent successfully to 'newUpper@example.com'.")
         expect(page).to have_content user.email
         expect(page).to have_content new_email
         expect(page).to have_content "Invitation sent successfully to '#{new_email}'."
@@ -525,7 +529,6 @@ RSpec.describe Clover, "project" do
         end
         expect(page).to have_select("invitation_policies[#{invited_email}]", selected: "Allowed")
         expect(page.html).to include "Allowed"
-        expect(page.html).not_to include "ToBeRemoved"
       end
 
       it "can not have more than 50 pending invitations" do

--- a/spec/serializers/account_spec.rb
+++ b/spec/serializers/account_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Serializers::Account do
+  let(:account) { Account.create(email: "user@example.com") }
+
+  it "can serialize without project_id" do
+    data = described_class.serialize(account)
+    expect(data[:policies]).to be_nil
+  end
+end

--- a/views/components/flash_message.erb
+++ b/views/components/flash_message.erb
@@ -1,24 +1,18 @@
-<% if flash["notice"] %>
-  <div class="-mt-6 mb-2 rounded-md bg-green-50 p-4">
-    <div class="flex">
-      <div class="flex-shrink-0">
-        <%== render("components/icon", locals: { name: "hero-check-circle-mini", classes: "h-5 w-5 text-green-400" }) %>
-      </div>
-      <div class="ml-3">
-        <h3 id="flash-notice" class="text-sm font-medium text-green-800"><%= flash["notice"] %></h3>
-      </div>
-    </div>
-  </div>
-<% end %>
-<% if flash["error"] %>
-  <div class="-mt-6 mb-2 rounded-md bg-red-50 p-4">
-    <div class="flex">
-      <div class="flex-shrink-0">
-        <%== render("components/icon", locals: { name: "hero-x-circle-mini", classes: "h-5 w-5 text-red-400" }) %>
-      </div>
-      <div class="ml-3">
-        <h3 id="flash-error" class="text-sm font-medium text-red-800"><%= flash["error"] %></h3>
+<div class="-mt-6 mb-2 space-y-2">
+  <% [
+    ["notice", "hero-check-circle-mini", "bg-green-50", "text-green-800", "text-green-400"],
+    ["error", "hero-x-circle-mini", "bg-red-50", "text-red-800", "text-red-400"]
+  ].each do |type, icon, bg_color, text_color, icon_color| %>
+    <% next unless flash[type] %>
+    <div class="rounded-md <%= bg_color %> p-4">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <%== render("components/icon", locals: { name: icon, classes: "h-5 w-5 #{icon_color}" }) %>
+        </div>
+        <div class="ml-3">
+          <h3 id="flash-<%= type %>" class="text-sm font-medium <%= text_color %>"><%= flash[type] %></h3>
+        </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/views/components/form/policy_select.erb
+++ b/views/components/form/policy_select.erb
@@ -1,5 +1,6 @@
 <% name ||= nil
-selected = flash.dig("old", name) || selected %>
+selected = flash.dig("old", name) || selected
+allowed_add_tags = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").map(&:name) %>
 
 <div class="">
   <%== render(
@@ -7,7 +8,9 @@ selected = flash.dig("old", name) || selected %>
     locals: {
       name: name,
       options: [["", "No access", nil, {}]].concat(
-        dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").map { [_1.name, _1.name, nil, {}] }
+        @project.subject_tags_dataset.map do
+          [_1.name, _1.name, nil, allowed_add_tags.include?(_1.name) ? {} : { disabled: true }]
+        end
       ),
       selected: selected
     }

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -44,7 +44,7 @@
                 ) %>
               </div>
               <div class="col-span-12 sm:col-span-3">
-                <%== render("components/form/policy_select", locals: { name: "policy" }) %>
+                <%== render("components/form/policy_select", locals: { name: "policy", selected: "Member" }) %>
               </div>
               <div class="col-span-3 sm:col-span-2">
                 <%== render("components/form/submit_button", locals: { text: "Invite" }) %>

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -81,7 +81,21 @@
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
                   <%= user[:email] %>
                 </td>
-                <td></td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  <% if user[:policies].length < 2 %>
+                    <%== render(
+                      "components/form/policy_select",
+                      locals: {
+                        name: "user_policies[#{user[:ubid]}]",
+                        selected: user[:policies].first
+                      }
+                    ) %>
+                  <% else %>
+                    <span title="You can manage this user's policies from the Access Control tab.">
+                      <%= user[:policies].join(", ") %>
+                    </span>
+                  <% end %>
+                </td>
                 <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
                   <%== render(
                     "components/delete_button",
@@ -92,7 +106,6 @@
                     }
                   ) %>
                 </td>
-
               </tr>
             <% end %>
             <% @invitations.each do |invitation| %>


### PR DESCRIPTION
- **Make "Member" policy default for user invitation**
  

- **Run policy updates in transaction**
  

- **Add subject tags of user as policy to serializer**
  It will be used in the next commit.
  

- **Show all subject tags in the policy selector**
  If the current user doesn't have permission for a subject tag, it won't
  appear in the policy selector.

  This is an issue because the selector doesn't provide an option for that
  tag, which is interpreted as no policy option. We should display all
  subject tags in the policy selector, but if the user lacks permission to
  add one of them, it should be disabled.

- **Do not allow to invite with unauthorized subject tag**

- **Add space between flash messages when multiple types are shown**

| Before | After |
|--------|-------|
| ![CleanShot 2024-12-25 at 16 20 30@2x](https://github.com/user-attachments/assets/a12e66b9-2195-4888-aa4f-92d688c14f1e) | ![CleanShot 2024-12-25 at 16 23 38@2x](https://github.com/user-attachments/assets/7f895af8-77a0-4cf2-a438-4e79fcd31fd7) |

- **Fix invitation policy update**
   While testing, I found two issues:
   -  Even if the current user doesn't have the "SubjectTag:remove"
   permission, they can still remove the subject tag from the
   invitation.
   -  The `allowed_tags[policy]` always returns nil for `No Policy`, so we
   can't update the invitation policy to `No Policy`.

- **Add policy selector to user list**
  Most users don't need to know about our access control system and
  usually don't visit the access control page.
  
  It's better to add a policy selector to the user list page. This way,
  most users can choose from predefined subject tags without needing to go
  to the access control page.
  
  If a user has more than one subject tag, we won't show the policy
  selector. If so, probably the user is aware of the access control system
  and manages access control via its page.
  
| Before | After |
|--------|-------|
| ![CleanShot 2024-12-25 at 15 21 28@2x](https://github.com/user-attachments/assets/0525993b-0907-4055-83ee-868c74721d0e) | ![CleanShot 2024-12-25 at 15 21 51@2x](https://github.com/user-attachments/assets/79bc51f7-e2da-463e-bd11-424af23246e3) |