### PR TITLE
Add InferenceEndpoint:view to the Member global action tag

### DIFF
--- a/migrate/20241224_member_action_tag_inference_endpoint_view.rb
+++ b/migrate/20241224_member_action_tag_inference_endpoint_view.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    # member global action tag includes InferenceEndpoint:view
+    DB[:applied_action_tag].insert(tag_id: "ffffffff-ff00-834a-87ff-ff828ea2dd80", action_id: "ffffffff-ff00-835a-87ff-f005c0d85dc0")
+  end
+
+  down do
+    DB[:applied_action_tag].where(tag_id: "ffffffff-ff00-834a-87ff-ff828ea2dd80", action_id: "ffffffff-ff00-835a-87ff-f005c0d85dc0").delete
+  end
+end


### PR DESCRIPTION
It was added to the member access policy after the new authorization system was designed, but this change didn't make it into the authorization system migration.