### PR TITLE
More preparation for new authorization system

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -79,6 +79,7 @@ module Config
   override :puma_min_threads, 1, int
   override :puma_workers, 3, int
   override :raise_errors, false, bool
+  override :recursive_tag_limit, 32, int
   override :root, File.expand_path(__dir__), string
   override :timeout, 10, int
   override :versioning, false, bool

--- a/lib/access_control_model_tag.rb
+++ b/lib/access_control_model_tag.rb
@@ -20,4 +20,86 @@ module AccessControlModelTag
   def add_member(member_id)
     applied_dataset.insert(:tag_id => id, applied_column => member_id)
   end
+
+  def member_ids
+    applied_dataset.where(tag_id: id).select_map(applied_column)
+  end
+
+  def add_members(member_ids)
+    applied_dataset.import([:tag_id, applied_column], member_ids.map { [id, _1] })
+  end
+
+  def remove_members(member_ids)
+    applied_dataset.where(:tag_id => id, applied_column => member_ids).delete
+  end
+
+  def currently_included_in
+    DB[:tag]
+      .with_recursive(:tag,
+        DB[applied_table].where(applied_column => id).select(:tag_id, 0),
+        DB[applied_table].join(:tag, tag_id: applied_column)
+          .select(Sequel[applied_table][:tag_id], Sequel[:level] + 1)
+          .where { level < Config.recursive_tag_limit },
+        args: [:tag_id, :level])
+      .select_map(:tag_id)
+  end
+
+  def check_members_to_add(to_add)
+    issues = []
+
+    current_members = member_ids
+
+    # Do not allow tag to include itself (prevent simple recursion)
+    if to_add.include?(id)
+      to_add.delete(id)
+      issues << "cannot include tag in itself"
+    end
+
+    # Remove current members so there are no duplicates
+    size = to_add.size
+    to_add -= current_members
+    if to_add.size != size
+      issues << "#{size - to_add.size} members already in tag"
+    end
+
+    # Check that current tag is not included already in one of the tags
+    # being added directly or indirectly (prevent complex recursion)
+    size = to_add.size
+    to_add -= currently_included_in
+    if to_add.size != size
+      issues << "#{size - to_add.size} members already include tag directly or indirectly"
+    end
+
+    proposed_additions = {}
+    to_add.each { proposed_additions[_1] = nil }
+    UBID.resolve_map(proposed_additions)
+
+    to_add = []
+    # Only allow valid members into the tag
+    proposed_additions.each_value do
+      if is_a?(SubjectTag) && _1.is_a?(SubjectTag) && _1.name == "Admin"
+        issues << "cannot include Admin subject tag in another tag"
+        next
+      end
+      to_add << _1 if _1 && self.class.valid_member?(project_id, _1)
+    end
+    if proposed_additions.size != to_add.size
+      issues << "#{proposed_additions.size - to_add.size} members not valid"
+    end
+
+    to_add.map!(&:id)
+    to_add.uniq!
+    [to_add, issues]
+  end
+
+  def before_destroy
+    applied_dataset.where(tag_id: id).or(applied_column => id).delete
+    AccessControlEntry.where(applied_column => id).destroy
+    super
+  end
+
+  def validate
+    validates_format(%r{\A[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\z}i, :name, message: "must only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
+    super
+  end
 end

--- a/lib/access_control_model_tag.rb
+++ b/lib/access_control_model_tag.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module AccessControlModelTag
+  def self.included(model)
+    model.class_eval do
+      base = name.delete_suffix("Tag").downcase
+      table = :"applied_#{base}_tag"
+      column = :"#{base}_id"
+
+      define_method(:applied_table) { table }
+      define_method(:applied_column) { column }
+      define_method(:"add_#{base}") { add_member(_1) }
+    end
+  end
+
+  def applied_dataset
+    DB[applied_table]
+  end
+
+  def add_member(member_id)
+    applied_dataset.insert(:tag_id => id, applied_column => member_id)
+  end
+end

--- a/migrate/20241230_archived_record_trigger.rb
+++ b/migrate/20241230_archived_record_trigger.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    run <<~SQL
+      CREATE FUNCTION archived_record_insert() RETURNS TRIGGER LANGUAGE plpgsql AS $$
+        BEGIN
+          INSERT INTO archived_record (model_name, model_values) VALUES (TG_ARGV[0], to_jsonb(OLD));
+          RETURN NEW;
+        END;
+      $$
+    SQL
+
+    %w[subject action object].each do |tag_type|
+      run <<~SQL
+        CREATE TRIGGER archived_record_insert AFTER DELETE ON applied_#{tag_type}_tag
+        FOR EACH ROW EXECUTE FUNCTION archived_record_insert('applied_#{tag_type}_tag')
+      SQL
+    end
+  end
+
+  down do
+    %w[subject action object].each do |tag_type|
+      run "DROP TRIGGER archived_record_insert ON applied_#{tag_type}_tag"
+    end
+
+    run "DROP FUNCTION archived_record_insert()"
+  end
+end

--- a/model/access_control_entry.rb
+++ b/model/access_control_entry.rb
@@ -3,6 +3,8 @@
 require_relative "../model"
 
 class AccessControlEntry < Sequel::Model
+  many_to_one :project
+
   include ResourceMethods
 end
 

--- a/model/access_control_entry.rb
+++ b/model/access_control_entry.rb
@@ -9,6 +9,30 @@ class AccessControlEntry < Sequel::Model
 
   # use __id__ if you want the internal object id
   def_column_alias :object_id, :object_id
+
+  def validate
+    if project_id
+      {subject_id:, action_id:, object_id:}.each do |field, value|
+        next unless value
+        ubid = UBID.from_uuidish(value).to_s
+
+        valid = case field
+        when :subject_id
+          SubjectTag.valid_member?(project_id, ubid.start_with?("et") ? ApiKey[value] : UBID.decode(ubid))
+        when :action_id
+          ActionTag.valid_member?(project_id, UBID.decode(ubid))
+        else
+          ObjectTag.valid_member?(project_id, UBID.decode(ubid))
+        end
+
+        unless valid
+          errors.add(field, "is not related to this project")
+        end
+      end
+    end
+
+    super
+  end
 end
 
 # Table: access_control_entry

--- a/model/access_control_entry.rb
+++ b/model/access_control_entry.rb
@@ -6,6 +6,9 @@ class AccessControlEntry < Sequel::Model
   many_to_one :project
 
   include ResourceMethods
+
+  # use __id__ if you want the internal object id
+  def_column_alias :object_id, :object_id
 end
 
 # Table: access_control_entry

--- a/model/action_tag.rb
+++ b/model/action_tag.rb
@@ -3,6 +3,16 @@
 require_relative "../model"
 
 class ActionTag < Sequel::Model
+  include ResourceMethods
+
+  def self.valid_member?(project_id, action)
+    case action
+    when ActionTag
+      action.project_id == project_id
+    when ActionType
+      true
+    end
+  end
 end
 
 # Table: action_tag

--- a/model/action_tag.rb
+++ b/model/action_tag.rb
@@ -4,6 +4,7 @@ require_relative "../model"
 
 class ActionTag < Sequel::Model
   include ResourceMethods
+  include AccessControlModelTag
 
   def self.valid_member?(project_id, action)
     case action

--- a/model/object_tag.rb
+++ b/model/object_tag.rb
@@ -4,6 +4,7 @@ require_relative "../model"
 
 class ObjectTag < Sequel::Model
   include ResourceMethods
+  include AccessControlModelTag
 
   def self.valid_member?(project_id, object)
     case object

--- a/model/object_tag.rb
+++ b/model/object_tag.rb
@@ -3,6 +3,18 @@
 require_relative "../model"
 
 class ObjectTag < Sequel::Model
+  include ResourceMethods
+
+  def self.valid_member?(project_id, object)
+    case object
+    when ObjectTag, SubjectTag, ActionTag
+      object.project_id == project_id
+    when Vm, PrivateSubnet, PostgresResource, Firewall, LoadBalancer
+      !AccessTag.where(project_id:, hyper_tag_id: object.id).empty?
+    when Project
+      object.id == project_id
+    end
+  end
 end
 
 # Table: object_tag

--- a/model/project.rb
+++ b/model/project.rb
@@ -31,7 +31,7 @@ class Project < Sequel::Model
   dataset_module Authorization::Dataset
   dataset_module Pagination
 
-  plugin :association_dependencies, access_tags: :destroy, access_policies: :destroy, billing_info: :destroy, github_installations: :destroy, api_keys: :destroy
+  plugin :association_dependencies, access_tags: :destroy, access_policies: :destroy, billing_info: :destroy, github_installations: :destroy, api_keys: :destroy, access_control_entries: :destroy, subject_tags: :destroy, action_tags: :destroy, object_tags: :destroy
 
   include ResourceMethods
   include Authorization::HyperTagMethods

--- a/model/subject_tag.rb
+++ b/model/subject_tag.rb
@@ -8,6 +8,18 @@ class SubjectTag < Sequel::Model
   def add_subject(subject_id)
     DB[:applied_subject_tag].insert(tag_id: id, subject_id:)
   end
+
+  def self.valid_member?(project_id, subject)
+    case subject
+    when SubjectTag
+      subject.project_id == project_id
+    when Account
+      !AccessTag.where(project_id:, hyper_tag_id: subject.id).empty?
+    when ApiKey
+      subject.owner_table == "accounts" &&
+        !AccessTag.where(project_id:, hyper_tag_id: subject.owner_id).empty?
+    end
+  end
 end
 
 # Table: subject_tag

--- a/model/subject_tag.rb
+++ b/model/subject_tag.rb
@@ -4,10 +4,7 @@ require_relative "../model"
 
 class SubjectTag < Sequel::Model
   include ResourceMethods
-
-  def add_subject(subject_id)
-    DB[:applied_subject_tag].insert(tag_id: id, subject_id:)
-  end
+  include AccessControlModelTag
 
   def self.valid_member?(project_id, subject)
     case subject

--- a/spec/lib/access_control_model_tag_spec.rb
+++ b/spec/lib/access_control_model_tag_spec.rb
@@ -37,6 +37,16 @@
       expect(tag.member_ids).to be_empty
     end
 
+    it "#remove_members moves deleted records to archived_records" do
+      tag.add_members([tag1.id, tag2.id])
+      tag.remove_members([tag1.id, tag2.id])
+      column = model.table_name.to_s.sub("tag", "id")
+      rows = DB[:archived_record].where(model_name: "applied_#{model.table_name}").select_map(:model_values)
+      expect(rows.length).to eq 2
+      expect(rows.map { _1["tag_id"] }.uniq).to eq [tag.id]
+      expect(rows.map { _1[column] }.sort).to eq [tag1.id, tag2.id].sort
+    end
+
     it "#currently_included_in returns all tag ids that directly or indirectly include this tag" do
       expect(tag.currently_included_in).to be_empty
       tag1.add_member(tag.id)

--- a/spec/lib/access_control_model_tag_spec.rb
+++ b/spec/lib/access_control_model_tag_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+[SubjectTag, ActionTag, ObjectTag].each do |model|
+  RSpec.describe model do
+    let(:user) { Account.create_with_id(email: "auth1@example.com") }
+    let(:project) do
+      project = Project.create_with_id(name: "project-1")
+      project.associate_with_project(project)
+      user.associate_with_project(project)
+      project
+    end
+    let(:tag) { model.create_with_id(project_id: project.id, name: "test-#{model}") }
+    # rubocop:disable RSpec/IndexedLet
+    let(:tag1) { model.create_with_id(project_id: project.id, name: "tag1") }
+    let(:tag2) { model.create_with_id(project_id: project.id, name: "tag2") }
+    # rubocop:enable RSpec/IndexedLet
+
+    it "#add_member adds a member to the tag" do
+      expect(tag.member_ids).to be_empty
+      tag.add_member(tag1.id)
+      expect(tag.member_ids).to eq [tag1.id]
+      tag.add_member(tag2.id)
+      expect(tag.member_ids.sort).to eq [tag1.id, tag2.id].sort
+    end
+
+    it "#add_members adds multiple members to a tag" do
+      expect(tag.member_ids).to be_empty
+      tag.add_members([tag1.id, tag2.id])
+      expect(tag.member_ids.sort).to eq [tag1.id, tag2.id].sort
+    end
+
+    it "#remove_members removes multiple members from a tag" do
+      expect(tag.member_ids).to be_empty
+      tag.add_members([tag1.id, tag2.id])
+      expect(tag.member_ids.sort).to eq [tag1.id, tag2.id].sort
+      tag.remove_members([tag1.id, tag2.id])
+      expect(tag.member_ids).to be_empty
+    end
+
+    it "#currently_included_in returns all tag ids that directly or indirectly include this tag" do
+      expect(tag.currently_included_in).to be_empty
+      tag1.add_member(tag.id)
+      expect(tag.currently_included_in).to eq [tag1.id]
+      tag2.add_member(tag1.id)
+      expect(tag.currently_included_in.sort).to eq [tag1.id, tag2.id].sort
+    end
+
+    it "#check_members_to_add returns array of ids that can be added and array of issues" do
+      expect(tag.check_members_to_add([])).to eq [[], []]
+      expect(tag.check_members_to_add([tag.id])).to eq [[], ["cannot include tag in itself"]]
+
+      tag.add_member(tag1.id)
+      expect(tag.check_members_to_add([tag1.id])).to eq [[], ["1 members already in tag"]]
+      expect(tag.check_members_to_add([tag.id, tag1.id])).to eq [[], ["cannot include tag in itself", "1 members already in tag"]]
+
+      tag2.add_member(tag.id)
+      expect(tag.check_members_to_add([tag2.id])).to eq [[], ["1 members already include tag directly or indirectly"]]
+
+      tag.applied_dataset.delete
+      expect(tag.check_members_to_add([tag1.id, tag1.id])).to eq [[tag1.id], []]
+
+      expect(tag.check_members_to_add([AccessTag.first.id])).to eq [[], ["1 members not valid"]]
+    end
+
+    if model == SubjectTag
+      it "#check_members_to_add does not allow including Admin subject tag" do
+        expect(tag.check_members_to_add([SubjectTag.create_with_id(project_id: project.id, name: "Admin").id])).to eq [[], ["cannot include Admin subject tag in another tag", "1 members not valid"]]
+      end
+    end
+
+    it "destroys referenced applied tags and access control entries when destroying" do
+      tag1.add_member(tag.id)
+      tag.add_member(tag2.id)
+      case tag
+      when SubjectTag
+        subject_id = tag.id
+      when ActionTag
+        action_id = tag.id
+      when ObjectTag
+        object_id = tag.id
+      end
+      subject_id ||= SubjectTag.create_with_id(project_id: project.id, name: "t").id
+      ace = AccessControlEntry.create_with_id(project_id: project.id, subject_id:, action_id:, object_id:)
+
+      tag.destroy
+      expect(tag1.member_ids).to be_empty
+      expect(ace.exists?).to be false
+    end
+
+    it "validates name format" do
+      error = "must only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number"
+      tag = model.new(project_id: project.id)
+      expect(tag.valid?).to be false
+      expect(tag.errors[:name]).to eq([error, "is not present"])
+
+      tag.name = "@"
+      expect(tag.valid?).to be false
+      expect(tag.errors[:name]).to eq([error])
+
+      tag.name = "a"
+      tag.valid?
+      expect(tag.valid?).to be true
+
+      tag.name = "a-"
+      expect(tag.valid?).to be false
+      expect(tag.errors[:name]).to eq([error])
+
+      tag.name = "a-b"
+      expect(tag.valid?).to be true
+
+      tag.name = "a-#{"b" * 63}"
+      expect(tag.valid?).to be false
+      expect(tag.errors[:name]).to eq([error])
+    end
+  end
+end

--- a/spec/model/access_control_entry_spec.rb
+++ b/spec/model/access_control_entry_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe AccessControlEntry do
+  it "enforces subject, action, and object are valid and related to project" do
+    account = Account.create_with_id(email: "test@example.com", status_id: 2)
+    project = Project.create_with_id(name: "Test")
+    project.associate_with_project(project)
+    account.associate_with_project(project)
+    project_id = project.id
+
+    ace = described_class.new
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(project_id: ["is not present"], subject_id: ["is not present"])
+
+    ace.project_id = project.id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(subject_id: ["is not present"])
+
+    ace.subject_id = account.id
+    expect(ace.valid?).to be true
+
+    account2 = Account.create_with_id(email: "test2@example.com", status_id: 2)
+    ace.subject_id = account2.id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(subject_id: ["is not related to this project"])
+
+    ace.subject_id = ApiKey.create_personal_access_token(account).id
+    expect(ace.valid?).to be true
+
+    ace.subject_id = ApiKey.create_personal_access_token(account2).id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(subject_id: ["is not related to this project"])
+
+    project2 = Project.create_with_id(name: "Test-2")
+    project2.associate_with_project(project2)
+    account.associate_with_project(project2)
+    ace.subject_id = SubjectTag.create_with_id(project_id: project2.id, name: "V").id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(subject_id: ["is not related to this project"])
+
+    ace.subject_id = SubjectTag.create_with_id(project_id:, name: "V").id
+    expect(ace.valid?).to be true
+
+    ace.action_id = ActionType::NAME_MAP["Project:view"]
+    expect(ace.valid?).to be true
+
+    ace.action_id = ActionTag.create_with_id(project_id: project2.id, name: "V").id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(action_id: ["is not related to this project"])
+
+    ace.action_id = ActionTag.create_with_id(project_id:, name: "V").id
+    expect(ace.valid?).to be true
+
+    ace.object_id = ObjectTag.create_with_id(project_id: project2.id, name: "V").id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(object_id: ["is not related to this project"])
+
+    ace.object_id = project2.id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(object_id: ["is not related to this project"])
+
+    ace.object_id = project.id
+    expect(ace.valid?).to be true
+
+    firewall = Firewall.create_with_id(location: "F")
+    ace.object_id = firewall.id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(object_id: ["is not related to this project"])
+
+    firewall.associate_with_project(project)
+    expect(ace.valid?).to be true
+
+    ace.object_id = ObjectTag.create_with_id(project_id:, name: "V").id
+    expect(ace.valid?).to be true
+
+    ace.subject_id = ace.action_id = ace.object_id
+    ace.object_id = described_class.generate_uuid
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(
+      subject_id: ["is not related to this project"],
+      action_id: ["is not related to this project"],
+      object_id: ["is not related to this project"]
+    )
+  end
+end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Project do
   describe ".soft_delete" do
     it "deletes github installations" do
       SubjectTag.create_with_id(project_id: project.id, name: "test").add_subject(project.id)
-      AccessControlEntry.create_with_id(project_id: project.id, subject_id: project.id)
+      AccessControlEntry.new_with_id(project_id: project.id, subject_id: project.id).save_changes(validate: false)
       expect(project).to receive(:access_tags_dataset).and_return(instance_double(AccessTag.dataset.class, destroy: nil))
       expect(project).to receive(:github_installations).and_return([instance_double(GithubInstallation)])
       expect(Prog::Github::DestroyGithubInstallation).to receive(:assemble)

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -203,6 +203,20 @@ RSpec.describe UBID do
     policy = prj.access_policies.first
     expect(policy.ubid).to start_with UBID::TYPE_ACCESS_POLICY
 
+    st = SubjectTag.create_with_id(project_id: prj.id, name: "T")
+    expect(st.ubid).to start_with UBID::TYPE_SUBJECT_TAG
+
+    at = ActionTag.create_with_id(project_id: prj.id, name: "T")
+    expect(at.ubid).to start_with UBID::TYPE_ACTION_TAG
+
+    ot = ObjectTag.create_with_id(project_id: prj.id, name: "T")
+    expect(ot.ubid).to start_with UBID::TYPE_OBJECT_TAG
+
+    ace = AccessControlEntry.create_with_id(project_id: prj.id, subject_id: st.id)
+    expect(ace.ubid).to start_with UBID::TYPE_ACCESS_CONTROL_ENTRY
+
+    expect(ActionType.first.ubid).to start_with UBID::TYPE_ACTION_TYPE
+
     atag = AccessTag.create_with_id(project_id: prj.id, hyper_tag_table: "x", name: "x")
     expect(atag.ubid).to start_with UBID::TYPE_ACCESS_TAG
 
@@ -256,6 +270,11 @@ RSpec.describe UBID do
     account = Account.create_with_id(email: "x@y.net")
     project = account.create_project_with_default_policy("x")
     policy = project.access_policies.first
+    st = SubjectTag.create_with_id(project_id: project.id, name: "T")
+    at = ActionTag.create_with_id(project_id: project.id, name: "T")
+    ot = ObjectTag.create_with_id(project_id: project.id, name: "T")
+    ace = AccessControlEntry.create_with_id(project_id: project.id, subject_id: st.id)
+    a_type = ActionType.first
     atag = AccessTag.create_with_id(project_id: project.id, hyper_tag_table: "x", name: "x")
     subnet = PrivateSubnet.create_with_id(net6: "0::0", net4: "127.0.0.1", name: "x", location: "x")
     nic = Nic.create_with_id(private_ipv6: "fd10:9b0b:6b4b:8fbb::/128", private_ipv4: "10.0.0.12/32", mac: "00:11:22:33:44:55", encryption_key: "0x30613961313636632d653765372d343434372d616232392d376561343432623562623065", private_subnet_id: subnet.id, name: "def-nic")
@@ -273,6 +292,11 @@ RSpec.describe UBID do
     expect(described_class.decode(account.ubid)).to eq(account)
     expect(described_class.decode(project.ubid)).to eq(project)
     expect(described_class.decode(policy.ubid)).to eq(policy)
+    expect(described_class.decode(st.ubid)).to eq(st)
+    expect(described_class.decode(at.ubid)).to eq(at)
+    expect(described_class.decode(ot.ubid)).to eq(ot)
+    expect(described_class.decode(ace.ubid)).to eq(ace)
+    expect(described_class.decode(a_type.ubid)).to eq(a_type)
     expect(described_class.decode(atag.ubid)).to eq(atag)
     expect(described_class.decode(tun.ubid)).to eq(tun)
     expect(string_kv(described_class.decode(subnet.ubid))).to eq(string_kv(subnet))


### PR DESCRIPTION
This adds the tag member validation code and some other commits that do not conflict with the existing authorization system. We need to commit the tag member validation code early so that we can use it for the access policy to access control entry converter testing.

I've rebased #2384 on this, so these are now the first 5 commits in that PR.