### PR TITLE
Redirect to the login page instead of the previous page

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -384,7 +384,7 @@ class Clover < Roda
         flash["error"] = "There is already an account with this email address, and it has not been linked to the #{omniauth_provider.capitalize} account.
         Please login to the existing account normally, and then link it to the #{omniauth_provider.capitalize} account from your account settings.
         Then you can can login using the #{omniauth_provider.capitalize} account."
-        scope.redirect_back_with_inputs
+        redirect "/login"
       end
     end
 


### PR DESCRIPTION
When we redirect back from Google login, it shows
"https://myaccount.google.com" instead of the previous page on Ubicloud.