### PR TITLE
Run specs in verbose mode by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -168,11 +168,11 @@ desc "Run specs in with coverage in unfrozen mode, and without coverage in froze
 task default: [:coverage, :frozen_spec]
 
 rspec = lambda do |env|
-  sh(env.merge("RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "rspec", "spec")
+  sh(env.merge("RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "rspec", "spec")
 end
 
 turbo_tests = lambda do |env|
-  sh(env.merge("RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "turbo_tests", "-n", nproc.call)
+  sh(env.merge("RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "turbo_tests", "-n", nproc.call)
 end
 
 spec = lambda do |env|
@@ -213,7 +213,7 @@ task "coverage_pspec" do
   Dir.mkdir("coverage") unless File.directory?("coverage")
   output_file = "coverage/output.txt"
   command = "bundle exec turbo_tests -n #{nproc.call} 2>&1 | tee #{output_file}"
-  sh({"RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "COVERAGE" => "1"}, command)
+  sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "COVERAGE" => "1"}, command)
   command_output = File.binread(output_file)
   unless command_output.include?("Line Coverage: 100.0%") && command_output.include?("Branch Coverage: 100.0%")
     warn "SimpleCov failed with exit 2 due to a coverage related error"
@@ -238,7 +238,7 @@ task :spec_separate do
 
   failures = []
   Dir["spec/**/*_spec.rb"].each do |file|
-    failures << file unless system(RbConfig.ruby, "-S", "rspec", file)
+    failures << file unless system(RbConfig.ruby, "-w", "-S", "rspec", file)
   end
 
   if failures.empty?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,20 +22,24 @@ ENV["HETZNER_USER"] = "user1"
 ENV["HETZNER_PASSWORD"] = "pass"
 ENV["OMNIAUTH_GITHUB_ID"] = "1234567890"
 ENV["OMNIAUTH_GOOGLE_ID"] = "1234567890"
+
+require "warning"
+Warning.ignore(:void_context, /.*ubicloud\/loader\.rb/)
+Warning.ignore(:method_redefined, /.*lib\/net\/ssh\/transport\/gcm_cipher\.rb/)
+Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser/)
+Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations/)
+Warning.ignore([:unused_var], /.*lib\/aws-sdk-(s3|core)\/(endpoint_provider|cbor)/)
+Warning.ignore(/URI::ABS_URI is obsolete/, /.*lib\/omniauth\/strategy\.rb/)
+Warning.ignore(/URI::RFC3986_PARSER.make_regexp is obsolete/, /.*lib\/capybara\/session\/config\.rb/)
+# https://github.com/prawnpdf/prawn/issues/1349
+Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
+
 require_relative "coverage_helper"
 require_relative "../loader"
 require "rspec"
 require "logger"
 require "sequel/core"
 require "webmock/rspec"
-
-Warning.ignore([:not_reached, :unused_var], /.*lib\/mail\/parser.*/)
-Warning.ignore([:mismatched_indentations], /.*lib\/stripe\/api_operations.*/)
-Warning.ignore([:unused_var], /.*lib\/aws-sdk-(s3|core)\/(endpoint_provider|cbor).*/)
-Warning.ignore(/URI::ABS_URI is obsolete/, /.*lib\/omniauth\/strategy\.rb/)
-Warning.ignore(/URI::RFC3986_PARSER.make_regexp is obsolete/, /.*lib\/capybara\/session\/config\.rb/)
-# https://github.com/prawnpdf/prawn/issues/1349
-Warning.ignore(/circular require considered harmful/, /.*lib\/prawn\/fonts\.rb/)
 
 RSpec.configure do |config|
   config.before(:suite) do


### PR DESCRIPTION
I noticed that we weren't running specs in verbose mode by default. This hid a fairly important issue in rodauth-omniauth that I only discovered when running `rake spec_separate`.  This switches to running specs in verbose mode by default. This moves the warning filters before the requiring of other libraries in spec_helper. It adds a couple more warning filters, to filter out a couple of verbose-mode only warnings.  I did not filter out the rodauth-omniauth warning, since that is a real bug that needs to be fixed upstream.

Note that in some cases, rspec will enable verbose warnings by default, but it does not appear to happen in all cases, and turbo_tests does not seem to enable verbose warnings by default.