### PR TITLE
Fix issue in rake spec_separate

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -91,6 +91,8 @@ autoload_normal.call("model", flat: true)
 if ENV["LOAD_FILES_SEPARATELY_CHECK"] == "1"
   files = %w[model lib scheduling prog serializers].flat_map { Dir["#{_1}/**/*.rb"] }
   files.concat(%w[clover.rb clover_error.rb])
+
+  Sequel::DATABASES.each(&:disconnect)
   files.each do |file|
     pid = fork do
       require_relative file


### PR DESCRIPTION
Disconnect all databases before the loop over the files, as the file using POSTGRES_MONITOR_DB does not use cached schema, and issuing a query after forking can cause problems such as:

```
ERROR: problems loading model/postgres/postgres_lsn_monitor.rb: Sequel::DatabaseDisconnectError: PG::ConnectionBad: PQconsumeInput() server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request
```