### PR TITLE
Improve inference endpoint listing

### DIFF
--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -1,74 +1,72 @@
 <% @page_title = "Inference Endpoints" %>
 <%== render("inference/tabbar") %>
 
-<% @inference_endpoints.each_with_index do | ie, index |
-
-  path, model_type, model_icon, curl_message = case ie[:model_type]
-    when :text_generation
-      [
-        "/v1/chat/completions",
-        "Text Generation",
-        "hero-chat-bubble-bottom-center-text",
-      <<-MSG
+<div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">
+  <% @inference_endpoints.each_with_index do | ie, index |
+    path, model_type, model_icon, curl_message = case ie[:model_type]
+      when :text_generation
+        [
+          "/v1/chat/completions",
+          "Text Generation",
+          "hero-chat-bubble-bottom-center-text",
+        <<-MSG
 "messages": [{"role": "user", "content": "say something"}],
-  "stream": true
+    "stream": true
 MSG
-      ]
-    when :guard
-      [
-        "/v1/chat/completions",
-        "Guard",
-        "hero-shield-check",
-      <<-MSG
-"messages": [{"role": "user", "content": "is this safe?"}]
-MSG
-      ]
-    when :embedding
-      ["/v1/embeddings", "Embedding", "hero-document-arrow-down", "\"input\": \"embed me!\"\n"]
-    else
-      fail "Unknown model type"
-  end
-  
+        ]
+      when :guard
+        [
+          "/v1/chat/completions",
+          "Guard",
+          "hero-shield-check",
+        <<~MSG
+  "messages": [{"role": "user", "content": "is this safe?"}]
+  MSG
+        ]
+      when :embedding
+        ["/v1/embeddings", "Embedding", "hero-document-arrow-down", "\"input\": \"embed me!\"\n"]
+      else
+        fail "Unknown model type"
+    end
 
-  curl_snippet = <<-CURL
+
+    curl_snippet = <<-CURL
 curl #{ie[:url]}#{path} \\
- -H <span class="text-green-400">"Content-Type: application/json"</span> \\
- -H <span class="text-green-400">"Authorization: Bearer <span class="text-orange-500">$INFERENCE_TOKEN</span>"</span> \\
- -d <span class="text-green-400">'{
-  "model": "#{ie[:model_name]}",
-  #{curl_message} }'</span>
-CURL
-%>
-
-<div class="inline-block w-auto bg-white shadow-md rounded-lg p-4 mr-4 <%= (index > 0) ? "mt-6" : "" %>">
-  <h2 class="text-lg font-bold mb-4 text-gray-800"><%= ie[:name] %></h2>
-  <div class="grid grid-cols-2 gap-4">
-    <div>
-      <div class="mb-4">
+  -H <span class="text-green-400">"Content-Type: application/json"</span> \\
+  -H <span class="text-green-400">"Authorization: Bearer <span class="text-orange-500">$INFERENCE_TOKEN</span>"</span> \\
+  -d <span class="text-green-400">'{
+    "model": "#{ie[:model_name]}",
+    #{curl_message}   }'</span>
+  CURL
+    %>
+  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white p-4">
+    <h2 class="text-lg font-bold mb-4 text-gray-800"><%= ie[:name] %></h2>
+    <div class="grid sm:grid-cols-2 gap-4">
+      <div>
         <h3 class="text-sm font-semibold text-gray-900">Type</h3>
-        <p class="text-gray-500"><%== render("components/icon", locals: { name: model_icon, classes: "inline-block w-5 h-5 flex-shrink-0 text-gray-400" }) %> <%= model_type %></p>
+        <div class="flex items-center gap-1 text-gray-500">
+          <%== render("components/icon", locals: { name: model_icon, classes: "w-5 h-5 text-gray-400" }) %>
+          <%= model_type %>
+        </div>
+      </div>
+      <div>
+        <h3 class="text-sm font-semibold text-gray-900">Pricing per million tokens</h3>
+        <p class="text-gray-500">$<%= ie[:price_million_tokens] %></p>
+      </div>
+      <div class="sm:col-span-2">
+        <h3 class="text-sm font-semibold text-gray-900">URL</h3>
+        <p class="text-gray-500"><%== render("components/copyable_content", locals: { content: ie[:url], message: "Copied URL" }) %></p>
+      </div>
+      <div class="sm:col-span-2">
+        <h3 class="text-sm font-semibold text-gray-900">
+          CURL usage example
+        </h3>
+        <div class="mt-2">
+          <pre class="text-sm bg-gray-800 text-white p-2 rounded-lg overflow-scroll"><%== curl_snippet %></pre>
+        </div>
       </div>
     </div>
-    <div class="mb-4">
-      <h3 class="text-sm font-semibold text-gray-900">Pricing per million tokens</h3>
-      <p class="text-gray-500">$<%= ie[:price_million_tokens] %></p>
-    </div>
   </div>
-  <div class="grid grid-cols-1 gap-4">
-    <div class="mb-4">
-      <h3 class="text-sm font-semibold text-gray-900">URL</h3>
-      <p class="text-gray-500"><%== render("components/copyable_content", locals: { content: ie[:url], message: "Copied URL" }) %></p>
-    </div>
-  </div>
-  <div class="grid grid-cols-1 gap-2">
-    <div class="mb-2">
-      <h3 class="text-sm font-semibold text-gray-900">
-        CURL usage example
-      </h3>
-      <div class="mt-2">
-        <pre class="text-sm bg-gray-800 text-white p-1 rounded-lg"><%== curl_snippet %></pre>
-      </div>
-    </div>
-  </div>
+  <% end %>
+
 </div>
-<% end %>

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -1,57 +1,59 @@
 <% @page_title = "Playground" %>
 <%== render("inference/tabbar") %>
 <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-  <div class="flex space-x-4">
-    <div class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+  <div class="px-4 py-5 sm:p-6 grid gap-6">
+    <div class="flex gap-10 text-gray-900">
+      <div class="flex items-center gap-2">
+        <label for="inference_endpoint" class="text-sm font-medium leading-6">Inference Endpoint</label>
+        <%== render(
+          "components/form/select",
+          locals: {
+            name: "inference_endpoint",
+            placeholder: "Pick an endpoint",
+            options: @inference_endpoints.map { |ie| [ie[:url], ie[:model_name]] },
+            selected: @inference_endpoints.any? ? @inference_endpoints.first[:url] : nil
+          }
+        ) %>
+      </div>
+      <div class="flex items-center gap-2">
+        <label for="inference_token" class="text-sm font-medium leading-6">Inference Token</label>
+        <%== render(
+          "components/form/select",
+          locals: {
+            name: "inference_token",
+            placeholder: "Pick a token",
+            options: @inference_tokens.map { |it| [it[:key], it[:id]] },
+            selected: @inference_tokens.any? ? @inference_tokens.first[:key] : nil
+          }
+        ) %>
+      </div>
+    </div>
+    <div class="shadow-md rounded-lg p-2 bg-gray-50">
       <%== render(
-        "components/form/select",
+        "components/form/textarea",
         locals: {
-          name: "inference_endpoint",
-          label: "Inference Endpoint",
-          placeholder: "Pick an endpoint",
-          options: @inference_endpoints.map { |ie| [ie[:url], ie[:model_name]] },
-          selected: @inference_endpoints.any? ? @inference_endpoints.first[:url] : nil
+          name: "inference_prompt",
+          attributes: {
+            "autofocus" => true,
+            "placeholder" => "User prompt to be submitted to the inference endpoint"
+          }
+        }
+      ) %>
+      <%== render(
+        "components/button",
+        locals: {
+          text: "Submit",
+          attributes: {
+            "name" => "inference_submit",
+            "id" => "inference_submit",
+            "type" => "button"
+          },
+          extra_class: "mt-2"
         }
       ) %>
     </div>
-    <div class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-      <%== render(
-        "components/form/select",
-        locals: {
-          name: "inference_token",
-          label: "Inference Token",
-          placeholder: "Pick a token",
-          options: @inference_tokens.map { |it| [it[:key], it[:id]] },
-          selected: @inference_tokens.any? ? @inference_tokens.first[:key] : nil
-        }
-      ) %>
+    <div class="mt-4 text-gray-900">
+      <span id="inference_response" class="overflow-auto min-h-48 whitespace-pre-line"></span>
     </div>
-  </div>
-  <div class="shadow-md rounded-lg p-2 ml-2 mr-2 mb-2 bg-gray-50">
-    <%== render(
-      "components/form/textarea",
-      locals: {
-        name: "inference_prompt",
-        attributes: {
-          "autofocus" => true,
-          "placeholder" => "User prompt to be submitted to the inference endpoint"
-        }
-      }
-    ) %>
-    <%== render(
-      "components/button",
-      locals: {
-        text: "Submit",
-        attributes: {
-          "name" => "inference_submit",
-          "id" => "inference_submit",
-          "type" => "button"
-        },
-        extra_class: "mt-2"
-      }
-    ) %>
-  </div>
-  <div class="mt-4 ml-2 mr-2 text-sm text-gray-900">
-    <span id="inference_response" class="overflow-auto min-h-48 whitespace-pre-line"></span>
   </div>
 </div>


### PR DESCRIPTION
### Improve inference endpoint listing
I wrapped them with a grid and small other improvements.

| Before | After |
|--------|-------|
| ![CleanShot 2024-12-30 at 23 40 59@2x](https://github.com/user-attachments/assets/610fdead-4d7f-42a1-98ce-a3a445cf5795) | ![CleanShot 2024-12-31 at 09 54 06@2x](https://github.com/user-attachments/assets/bc81bbfc-17ae-4e5a-84f5-328c73e596ff) |
| ![CleanShot 2024-12-31 at 09 01 30@2x](https://github.com/user-attachments/assets/52f87698-22bb-464b-9b5f-2acb283ab31c) | ![CleanShot 2024-12-31 at 09 04 28@2x](https://github.com/user-attachments/assets/e5951f59-a166-40ec-a0cf-09f770ae766a) |




### Improve AI playground view

| Before | After |
|--------|-------|
| ![CleanShot 2024-12-31 at 09 51 03@2x](https://github.com/user-attachments/assets/8adbf888-6a29-4dfe-8a45-808f7e885160) | ![CleanShot 2024-12-31 at 09 51 21@2x](https://github.com/user-attachments/assets/62960e5d-6e27-43e6-bcf4-e031641a6508) |

