### PR TITLE
Condense text on the access control page

### DIFF
--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe Clover, "access control" do
 
       it "can view #{type} tags" do
         visit "#{project.path}/user/access-control"
-        click_link cap_type
+        find("##{cap_type.downcase}-tags-link").click
         expect(page.title).to eq "Ubicloud - Default - #{cap_type} Tags"
         tds = page.all("table#tag-list td").map(&:text)
 

--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -44,14 +44,11 @@ end
     <% if @token.nil? && edit_perm %>
       <div class="md:flex md:items-center md:justify-between">
         <div class="min-w-0 flex-1">
-          Access control in Ubicloud is defined using access control entries. Each access control entry has a single
-          subject, action, and object. Access is allowed if there is an access control entry allowing the subject to
-          take the action on the object. Subjects, actions, and objects can all be tags, which are used for grouping.
-          The recommended way to handle access control in Ubicloud is to create appropriate tags, add the subjects,
-          actions, and objects to the tags, and create the minimum number of access control entries you need to enforce
-          the access you want. However, you can create access control entries referencing specific subjects, actions,
-          or objects. You can click on the Subject, Action, and Object buttons below to manage the related tags. New
-          access control entries without a subject will be ignored.
+          Access is allowed if there is an access control entry allowing the subject to take the action on the object.
+          Subjects, actions, and objects can all be tags, which are used for grouping. The recommended way to handle
+          access control in Ubicloud is to create appropriate tags, add the subjects, actions, and objects to the tags,
+          and create the minimum number of access control entries you need to enforce the access you want. However, you
+          can create access control entries referencing specific subjects, actions, or objects.
         </div>
       </div>
     <% end %>
@@ -64,21 +61,20 @@ end
             <tr>
               <% table_headers.each do |type| %>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                  <% if @token %>
-                    <%= type %>
-                  <% else %>
-                    <%== render(
-                      "components/button",
-                      locals: {
-                        text: type,
-                        link: "#{@project_data[:path]}/user/access-control/tag/#{type.downcase}"
-                      }
-                    ) %>
+                  <%= type %>
+                  <% unless @token %>
+                    <a
+                      id="<%= type.downcase %>-tags-link"
+                      href="<%= "#{@project_data[:path]}/user/access-control/tag/#{type.downcase}" %>"
+                      class="text-orange-600 hover:text-orange-700 text-xs"
+                    >
+                      (Tags)
+                    </a>
                   <% end %>
                 </th>
               <% end %>
               <% if edit_perm %>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Delete</th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
               <% end %>
             </tr>
           </thead>


### PR DESCRIPTION
Sadly, many of us, myself included, don't read lengthy texts. Upon opening any page, I first navigate through it without reading.

I had trouble understanding the table header as a button. I added a `(Tags)` link next to it for clarity. We could also switch the text to `(Edit)` or `(Manage)`.

I've also cut down a few sentences from the description. It's best to keep it short, simple, and refer to the documentation for more details.

| Before | After |
|--------|-------|
| ![CleanShot 2024-12-31 at 14 53 37@2x](https://github.com/user-attachments/assets/4fcccad6-1729-487d-9df5-29d9b4c1bf3f) | ![CleanShot 2024-12-31 at 14 47 44@2x](https://github.com/user-attachments/assets/8380f9f9-ca3e-4ee6-b3fe-4b7923a10aa6) |
