### PR TITLE
Hopefully final preparation for authorization system switchover

### DIFF
--- a/lib/access_policy_converter.rb
+++ b/lib/access_policy_converter.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+module AccessPolicyConverter
+  # :nocov:
+  def self.convert_to_tag(klass, project_id, name, values, failures)
+    # No need to build single-element tags
+    return values unless values.is_a?(Array)
+
+    tag = klass.new_with_id(project_id:, name:)
+    old_values = values
+    values, issues = tag.check_members_to_add(values)
+    unless issues.empty?
+      failures << [:member_check_failed, project_id, name, klass.name, issues, old_values - values]
+    end
+    [tag, values]
+  end
+
+  def self.save_converted_access_policy_rows(rows)
+    projects, failures = convert_access_policy_rows(rows).values_at(:projects, :failures)
+    keys = [:subject_id, :action_id, :object_id]
+    projects.each do |project_id, hash|
+      hash[:aces] = hash[:aces].map do |ace|
+        keys.each do |key|
+          value = ace.send(key)
+          if value.is_a?(Array)
+            tag, values = value
+            tag.save_changes
+            tag.add_members(values)
+            ace[key] = tag.id
+          end
+        end
+        ace.save_changes
+      end
+    end
+    {projects:, failures:}
+  end
+
+  def self.convert_access_policy_rows(rows)
+    projects, failures = parse_access_policy_rows(rows).values_at(:projects, :failures)
+    keys = [:subject_id, :action_id, :object_id]
+    projects.each do |project_id, hash|
+      aces = hash[:aces] = hash[:aces].map do |ap_id, i, subject_id, action_id, object_id|
+        tag_name = "Access-Policy-#{ap_id}-#{i}"
+        subject_id = convert_to_tag(SubjectTag, project_id, tag_name, subject_id, failures)
+        action_id = convert_to_tag(ActionTag, project_id, tag_name, action_id, failures)
+        object_id = convert_to_tag(ObjectTag, project_id, tag_name, object_id, failures)
+        ace = AccessControlEntry.new_with_id(project_id:, subject_id:, action_id:, object_id:)
+        subject_id, action_id, object_id = ace.values.values_at(:subject_id, :action_id, :object_id)
+        keys.each do |column|
+          ace[column] = nil if ace[column].is_a?(Array)
+        end
+        unless ace.valid?
+          ace.errors.delete(:subject_id) if ace.subject_id.nil?
+          unless ace.errors.empty?
+            failures << [:ace_validation_failed, project_id, ap_id, i, subject_id, action_id, object_id, ace.errors]
+          end
+        end
+        ace.subject_id, ace.action_id, ace.object_id = subject_id, action_id, object_id
+        ace
+      end
+
+      admin_tag = convert_to_tag(SubjectTag, project_id, "Admin", hash[:admin], failures)
+      aces << AccessControlEntry.new_with_id(project_id:, subject_id: admin_tag)
+
+      member_tag = convert_to_tag(SubjectTag, project_id, "Member", hash[:member], failures)
+      aces << AccessControlEntry.new_with_id(project_id:, subject_id: member_tag, action_id: "ffffffff-ff00-834a-87ff-ff828ea2dd80") # Member global action tag
+      hash.delete(:admin)
+      hash.delete(:member)
+    end
+    {projects:, failures:}
+  end
+
+  def self.parse_access_policy_rows(rows)
+    projects = {}
+    failures = []
+    action_map = {
+      "Postgres:Firewall:edit" => "ffffffff-ff00-835a-87ff-f05a007343a0",
+      "Postgres:Firewall:view" => "ffffffff-ff00-835a-87ff-f05a00d85dc0",
+      "Project:*" => "ffffffff-ff00-834a-87ff-ff82d2028210",
+      "*" => Sequel::NULL,
+      "Vm:*" => "ffffffff-ff00-834a-87ff-ff8374028210",
+      "PrivateSubnet:*" => "ffffffff-ff00-834a-87ff-ff82d9028210",
+      "Firewall:*" => "ffffffff-ff00-834a-87ff-ff81fc028210",
+      "LoadBalancer:*" => "ffffffff-ff00-834a-87ff-ff802b028210",
+      "Postgres:*" => "ffffffff-ff00-834a-87ff-ff82d0028210"
+    }.merge(ActionType::NAME_MAP)
+    name_map = {}
+    account_project_set = {}
+    DB[:access_tag].select_map([:project_id, :name, :hyper_tag_id, :hyper_tag_table]).each do |project_id, name, hyper_tag_id, table|
+      (name_map[project_id] ||= {})[name] = hyper_tag_id
+      account_project_set[project_id] ||= true if table == "accounts"
+    end
+    inactive_project_set = DB[:project].exclude(:visible).select_hash(:id, Sequel[true].as(:v))
+    admin_array = ["*"]
+    member_array = ["Vm:*", "PrivateSubnet:*", "Firewall:*", "Postgres:*", "Project:view", "Project:github"]
+
+    project_id = nil
+    ap_id = nil
+    convert = lambda do |i, acl, type, map|
+      values = acl[type]
+      unless values.is_a?(Array)
+        failures << [:not_array, project_id, ap_id, i, type]
+        next []
+      end
+      values = values.map do
+        unless (value_id = map[_1])
+          failures << [:unrecognized_name, project_id, ap_id, i, type, _1]
+        end
+        value_id
+      end
+      values.compact!
+      values
+    end
+
+    rows.each do |row|
+      ap_id, project_id, name, body, managed = row.values_at(:id, :project_id, :name, :body, :managed)
+      raise unless project_id
+      next if inactive_project_set[project_id] # Ignore soft-deleted projects
+      next unless account_project_set[project_id] # Ignore projects without accounts
+
+      acls = body["acls"]
+
+      if managed
+        case name
+        when "admin"
+          is_admin = true
+          unless acls.length == 1 && acls[0]["actions"] == admin_array
+            failures << [:bad_admin_policy, project_id, ap_id, name]
+            next
+          end
+        when "member"
+          is_member = true
+          unless acls.length == 1 && member_array.all? { acls[0]["actions"].include?(_1) }
+            failures << [:bad_member_policy, project_id, ap_id, name, acls]
+            next
+          end
+        else
+          failures << [:bad_managed_name, project_id, ap_id, name]
+        end
+      end
+
+      unless acls.is_a?(Array)
+        failures << [:acls_not_array, project_id, ap_id]
+        next
+      end
+
+      acls.each_with_index do |acl, i|
+        subject_id = convert.call(i, acl, "subjects", name_map[project_id])
+        if subject_id.empty?
+          unless acl["subjects"].empty?
+            failures << [:no_valid_subjects, project_id, ap_id, i]
+          end
+          next
+        end
+
+        ace_hash = projects[project_id] ||= {admin: [], member: [], aces: []}
+        # Project:policy is not a valid action, but it was used previously.  If a user was
+        # granted the ability to change the project policy, de facto they are equivalent to an
+        # admin of the project, since they could change the policy to grant themselves any
+        # access they needed.
+        if is_admin || acl["actions"] == admin_array || acl["actions"].include?("Project:policy")
+          ace_hash[:admin].concat(subject_id)
+          subject_id = []
+        elsif is_member
+          api_keys, subject_id = subject_id.partition { UBID.from_uuidish(_1).to_s.start_with?("et") }
+          ace_hash[:member].concat(subject_id)
+          subject_id = api_keys.map { [_1] }
+        else
+          api_keys, subject_id = subject_id.partition { UBID.from_uuidish(_1).to_s.start_with?("et") }
+          subject_id = [subject_id] + api_keys.map { [_1] }
+        end
+
+        subject_id.each do |subject_id|
+          action_id = convert.call(i, acl, "actions", action_map)
+          object_id = convert.call(i, acl, "objects", name_map[project_id])
+          ace_hash[:aces] << [ap_id, i, subject_id, action_id, object_id].map! do
+            v = (_1.is_a?(Array) && _1.length == 1) ? _1[0] : _1
+            v = nil if v == Sequel::NULL
+            v
+          end
+        end
+      end
+    end
+
+    projects.each do |project_id, hash|
+      admin = hash[:admin]
+      if admin.empty?
+        project_accounts = Project[project_id].accounts
+
+        if project_accounts.length == 1
+          # If a project has only a single account, that account is the admin
+          admin.concat(project_accounts.map(&:id))
+        else
+          failures << [:no_admin_members, project_id]
+        end
+      else
+        hash[:aces].delete_if do
+          # No point in separate AccessControlEntry if subject has full admin access
+          admin.include?(_1[2])
+        end
+      end
+    end
+
+    {projects:, failures:}
+  end
+  # :nocov:
+end

--- a/model/access_control_entry.rb
+++ b/model/access_control_entry.rb
@@ -16,16 +16,17 @@ class AccessControlEntry < Sequel::Model
         next unless value
         ubid = UBID.from_uuidish(value).to_s
 
-        valid = case field
+        model = case field
         when :subject_id
-          SubjectTag.valid_member?(project_id, ubid.start_with?("et") ? ApiKey[value] : UBID.decode(ubid))
+          SubjectTag
         when :action_id
-          ActionTag.valid_member?(project_id, UBID.decode(ubid))
+          ActionTag
         else
-          ObjectTag.valid_member?(project_id, UBID.decode(ubid))
+          ObjectTag
         end
 
-        unless valid
+        object = ubid.start_with?("et") ? ApiKey.with_pk(value) : UBID.decode(ubid)
+        unless model.valid_member?(project_id, object)
           errors.add(field, "is not related to this project")
         end
       end

--- a/model/action_tag.rb
+++ b/model/action_tag.rb
@@ -9,7 +9,7 @@ class ActionTag < Sequel::Model
   def self.valid_member?(project_id, action)
     case action
     when ActionTag
-      action.project_id == project_id
+      action.project_id == project_id || !action.project_id
     when ActionType
       true
     end

--- a/model/object_tag.rb
+++ b/model/object_tag.rb
@@ -8,12 +8,14 @@ class ObjectTag < Sequel::Model
 
   def self.valid_member?(project_id, object)
     case object
-    when ObjectTag, SubjectTag, ActionTag
+    when ObjectTag, SubjectTag, ActionTag, InferenceEndpoint
       object.project_id == project_id
     when Vm, PrivateSubnet, PostgresResource, Firewall, LoadBalancer
       !AccessTag.where(project_id:, hyper_tag_id: object.id).empty?
     when Project
       object.id == project_id
+    when ApiKey
+      object.owner_table == "project" && object.owner_id == project_id
     end
   end
 end

--- a/spec/model/access_control_entry_spec.rb
+++ b/spec/model/access_control_entry_spec.rb
@@ -72,6 +72,47 @@ RSpec.describe AccessControlEntry do
     firewall.associate_with_project(project)
     expect(ace.valid?).to be true
 
+    ace.object_id = ApiKey.create_inference_token(project2).id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(object_id: ["is not related to this project"])
+
+    ace.object_id = ApiKey.create_inference_token(project).id
+    expect(ace.valid?).to be true
+
+    private_subnet_id = PrivateSubnet.create_with_id(
+      name: "",
+      net6: "fd1b:9793:dcef:cd0a:c::/79",
+      net4: "10.9.39.5/32",
+      location: ""
+    ).id
+    load_balancer_id = LoadBalancer.create_with_id(
+      name: "",
+      src_port: 1024,
+      dst_port: 1025,
+      private_subnet_id:,
+      health_check_endpoint: ""
+    ).id
+    inference_endpoint = InferenceEndpoint.create_with_id(
+      location: "",
+      boot_image: "",
+      name: "",
+      vm_size: "",
+      model_name: "",
+      storage_volumes: "{}",
+      engine: "",
+      engine_params: "",
+      replica_count: 1,
+      project_id: project2.id,
+      load_balancer_id:,
+      private_subnet_id:
+    )
+    ace.object_id = inference_endpoint.id
+    expect(ace.valid?).to be false
+    expect(ace.errors).to eq(object_id: ["is not related to this project"])
+
+    inference_endpoint.update(project_id:)
+    expect(ace.valid?).to be true
+
     ace.object_id = ObjectTag.create_with_id(project_id:, name: "V").id
     expect(ace.valid?).to be true
 

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -324,11 +324,13 @@ RSpec.describe UBID do
     page = Page.create_with_id(summary: "x", tag: "y")
     a_type = ActionType.first
     api_key = ApiKey.create(owner_table: "project", owner_id: Project.create(name: "test-project").id, used_for: "inference_endpoint", key: "1")
-    hash = {page.id => nil, a_type.id => nil, api_key.id => nil}
+    invalid = described_class.to_uuid("han2sefsk4f61k91z77vn0y978")
+    hash = {page.id => nil, a_type.id => nil, api_key.id => nil, invalid => nil}
     described_class.resolve_map(hash)
     expect(hash[page.id]).to eq page
     expect(hash[a_type.id]).to eq a_type
     expect(hash[api_key.id]).to eq api_key
+    expect(hash[invalid]).to be_nil
   end
 
   it ".type_match? checks whether given ubid has given type" do

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -323,10 +323,12 @@ RSpec.describe UBID do
   it ".resolve_map populates hash with uuid keys" do
     page = Page.create_with_id(summary: "x", tag: "y")
     a_type = ActionType.first
-    hash = {page.id => nil, a_type.id => nil}
+    api_key = ApiKey.create(owner_table: "project", owner_id: Project.create(name: "test-project").id, used_for: "inference_endpoint", key: "1")
+    hash = {page.id => nil, a_type.id => nil, api_key.id => nil}
     described_class.resolve_map(hash)
     expect(hash[page.id]).to eq page
     expect(hash[a_type.id]).to eq a_type
+    expect(hash[api_key.id]).to eq api_key
   end
 
   it ".type_match? checks whether given ubid has given type" do

--- a/ubid.rb
+++ b/ubid.rb
@@ -162,7 +162,11 @@ class UBID
   end
 
   def self.resolve_map(uuids)
-    uuids.keys.group_by { class_for_ubid(from_uuidish(_1).to_s) }.each do |model, model_uuids|
+    uuids.keys.group_by do
+      ubid = from_uuidish(_1).to_s
+      # Bad hack, needed because ApiKey does not use a fixed ubid type
+      ubid.start_with?("et") ? ApiKey : class_for_ubid(ubid)
+    end.each do |model, model_uuids|
       model.where(id: model_uuids).each do
         uuids[_1.id] = _1
       end

--- a/ubid.rb
+++ b/ubid.rb
@@ -167,6 +167,7 @@ class UBID
       # Bad hack, needed because ApiKey does not use a fixed ubid type
       ubid.start_with?("et") ? ApiKey : class_for_ubid(ubid)
     end.each do |model, model_uuids|
+      next unless model
       model.where(id: model_uuids).each do
         uuids[_1.id] = _1
       end


### PR DESCRIPTION
This commits the access policy converter and a few other small changes that the converter depends on to work.  This brings us to the commit directly before the switchover to using the new access control system.

One possible rollout approach is to commit this first, and just before pushing the authorization system changes (#2384) into production, run the access policy converter.