### PR TITLE
Add new minimum disk size for PG

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -88,10 +88,10 @@ class Clover
     options.add_option(name: "location", values: Option.postgres_locations.map(&:display_name), parent: "flavor")
     options.add_option(name: "size", values: [2, 4, 8, 16, 30, 60].map { "standard-#{_1}" }, parent: "location")
 
-    options.add_option(name: "storage_size", values: ["128", "256", "512", "1024", "2048", "4096"], parent: "size") do |flavor, location, size, storage_size|
+    options.add_option(name: "storage_size", values: ["64", "128", "256", "512", "1024", "2048", "4096"], parent: "size") do |flavor, location, size, storage_size|
       size = size.split("-").last.to_i
-      lower_limit = [size * 64, 1024].min
-      upper_limit = size * ((location == "eu-central-h1") ? 256 : 128)
+      lower_limit = [size * 32, 1024].min
+      upper_limit = (2**Math.log2(size).ceil) * ((location == "eu-central-h1") ? 128 : 64)
       storage_size.to_i >= lower_limit && storage_size.to_i <= upper_limit
     end
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -68,7 +68,7 @@ module Option
     alias_method :display_name, :name
   end
   PostgresSizes = Option.postgres_locations.product([2, 4, 8, 16, 30, 60]).flat_map {
-    storage_size_options = [_2 * 64, _2 * 128, _2 * 256]
+    storage_size_options = [_2 * 32, _2 * 64, _2 * 128]
     storage_size_options.map! { |size| size / 15 * 16 } if [30, 60].include?(_2)
 
     storage_size_options.pop if _1.name == "leaseweb-wdc02"

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -204,11 +204,10 @@ RSpec.describe Validation do
     describe "#validate_postgres_storage_size" do
       it "valid postgres storage sizes" do
         [
-          ["hetzner-fsn1", "standard-2", "128"],
+          ["hetzner-fsn1", "standard-2", "64"],
           ["hetzner-fsn1", "standard-2", "256"],
-          ["hetzner-fsn1", "standard-4", "1024"],
-          ["hetzner-fsn1", "standard-4", "1024"],
-          ["leaseweb-wdc02", "standard-4", "512"]
+          ["hetzner-fsn1", "standard-4", "512"],
+          ["leaseweb-wdc02", "standard-4", "256"]
         ].each do |location, pg_size, storage_size|
           expect(described_class.validate_postgres_storage_size(location, pg_size, storage_size)).to eq(storage_size.to_f)
         end


### PR DESCRIPTION
We used to have minimum disk size of 128GB for PG databases. With this commit we are adding new minimum disk size of 64GB for PG databases.