### PR TITLE
Explicitly request access to the email in the GitHub omniauth provider

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -358,7 +358,7 @@ class Clover < Roda
     # :nocov:
     if Config.omniauth_github_id
       require "omniauth-github"
-      omniauth_provider :github, Config.omniauth_github_id, Config.omniauth_github_secret
+      omniauth_provider :github, Config.omniauth_github_id, Config.omniauth_github_secret, scope: "user:email"
     end
     if Config.omniauth_google_id
       require "omniauth-google-oauth2"


### PR DESCRIPTION
Without a specified scope, GitHub only gives read-only access to public information.

If the user doesn't have a public email address, the email field will be nil, causing account creation to fail.

We need to explicitly request the email scope in the omniauth provider.

https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps