### PR TITLE
Reduce amount of respirate logs

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -157,7 +157,8 @@ SQL
       fail "BUG: Prog #{prog}##{label} did not provide flow control"
     end
   ensure
-    Clog.emit("finished strand") { [self, {strand_finished: {duration: Time.now - start_time, prog_label: prog_label}}] }
+    duration = Time.now - start_time
+    Clog.emit("finished strand") { [self, {strand_finished: {duration:, prog_label:}}] } if duration > 1
   end
 
   def run(seconds = 0)

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -28,8 +28,9 @@ RETURNING lease
 SQL
     return false unless affected
     lease_time = affected.fetch(:lease)
+    verbose_logging = rand(1000) == 0
 
-    Clog.emit("obtained lease") { {lease_acquired: {time: lease_time, delay: Time.now - schedule}} }
+    Clog.emit("obtained lease") { {lease_acquired: {time: lease_time, delay: Time.now - schedule}} } if verbose_logging
     reload
 
     begin
@@ -47,7 +48,7 @@ UPDATE strand
 SET lease = NULL
 WHERE id = ? AND lease = ?
 SQL
-          Clog.emit("lease cleared") { {lease_cleared: {num_updated: num_updated}} }
+          Clog.emit("lease cleared") { {lease_cleared: {num_updated: num_updated}} } if verbose_logging
           unless num_updated == 1
             Clog.emit("lease violated data") do
               {lease_clear_debug_snapshot: lease_clear_debug_snapshot}

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -79,7 +79,6 @@ SQL
   def unsynchronized_run
     start_time = Time.now
     prog_label = "#{prog}.#{label}"
-    Clog.emit("starting strand") { [self, {strand_started: {prog_label: prog_label}}] }
 
     if label == stack.first["deadline_target"]
       if (pg = Page.from_tag_parts("Deadline", id, prog, stack.first["deadline_target"]))

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -58,7 +58,7 @@ SQL
       end.at_least(:once)
 
       expect(Clog).to receive(:emit).with("lease violated data").and_call_original
-      expect(Clog).to receive(:emit).at_least(:once).and_call_original
+      allow(Clog).to receive(:emit).and_call_original
       expect { st.run }.to raise_error RuntimeError, "BUG: lease violated"
     end
   end
@@ -102,5 +102,14 @@ SQL
     expect(Time).to receive(:now).and_return(Time.now - 10, Time.now, Time.now)
     expect(Clog).to receive(:emit).with("finished strand").and_call_original
     st.unsynchronized_run
+  end
+
+  it "occasionally logs acquisition and release of lease" do
+    st.label = "napper"
+    st.save_changes
+    expect(st).to receive(:rand).and_return(0)
+    expect(Clog).to receive(:emit).with("obtained lease").and_call_original
+    expect(Clog).to receive(:emit).with("lease cleared").and_call_original
+    st.take_lease_and_reload {}
   end
 end

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -95,4 +95,12 @@ SQL
       st.run(10)
     }.to change { [st.label, st.exitval] }.from(["hop_entry", nil]).to(["hop_exit", {msg: "hop finished"}])
   end
+
+  it "logs end of strand if it took long" do
+    st.label = "napper"
+    st.save_changes
+    expect(Time).to receive(:now).and_return(Time.now - 10, Time.now, Time.now)
+    expect(Clog).to receive(:emit).with("finished strand").and_call_original
+    st.unsynchronized_run
+  end
 end


### PR DESCRIPTION
**Stop emitting "starting strand" log lines**
We produce a high volume of "starting strand" log lines, which are not useful enough to justify the downstream cost of processing and storing them.

**Emit "finished strand" logs only if duration > 1sec**
We produce a high volume of "finished strand" log lines. To reduce the volume, we emit the log line only if the duration is noteworthy, i.e. greater than 1s.

**Reduce amount of obtained/cleared lease log lines**
The system currently generates a large number of "obtained lease" and "lease cleared" log entries, which contributes to increased downstream costs. Since some views rely on these log entries, this update does not eliminate them entirely. Instead, it reduces their frequency by emitting them at a rate of approximately one per thousand.