### PR TITLE
Remove bloated lease Clog messages

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -29,7 +29,6 @@ SQL
     return false unless affected
     lease_time = affected.fetch(:lease)
 
-    Clog.emit("obtained lease") { {lease_acquired: {time: lease_time, delay: Time.now - schedule}} }
     reload
 
     begin
@@ -47,7 +46,7 @@ UPDATE strand
 SET lease = NULL
 WHERE id = ? AND lease = ?
 SQL
-          Clog.emit("lease cleared") { {lease_cleared: {num_updated: num_updated}} }
+
           unless num_updated == 1
             Clog.emit("lease violated data") do
               {lease_clear_debug_snapshot: lease_clear_debug_snapshot}


### PR DESCRIPTION
These are too verbose relative to their value, imposing about 25% of log traffic by bytes.  But, they have not been useful in quite a while, at least, ever since the strand leasing/mutexing system has matured and not been changed much in a while.  They were useful assessing the crucial bug in bbf3e142bda5b408cd94150a435efca6bd40204c, though.