### PR TITLE
Fix deadline label in for PostgresServerNexus

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -369,7 +369,7 @@ SQL
   end
 
   label def unavailable
-    register_deadline(:wait, 10 * 60)
+    register_deadline("wait", 10 * 60)
 
     nap 0 if postgres_server.trigger_failover
 


### PR DESCRIPTION
We previously changed these to be string but missed this one.