### PR TITLE
Add stopped label to VM Nexus

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -25,7 +25,7 @@ class Vm < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
-  semaphore :restart
+  semaphore :restart, :stop
 
   include Authorization::HyperTagMethods
 
@@ -62,6 +62,7 @@ class Vm < Sequel::Model
   def display_state
     return "deleting" if destroy_set? || strand&.label == "destroy"
     return "restarting" if restart_set? || strand&.label == "restart"
+    return "stopped" if stop_set? || strand&.label == "stopped"
     if waiting_for_capacity_set?
       return "no capacity available" if Time.now - created_at > 15 * 60
       return "waiting for capacity"

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -330,6 +330,10 @@ class Prog::Vm::Nexus < Prog::Base
       hop_restart
     end
 
+    when_stop_set? do
+      hop_stopped
+    end
+
     when_checkup_set? do
       hop_unavailable if !available?
       decr_checkup
@@ -362,6 +366,15 @@ class Prog::Vm::Nexus < Prog::Base
     decr_restart
     host.sshable.cmd("sudo systemctl restart #{vm.inhost_name}")
     hop_wait
+  end
+
+  label def stopped
+    when_stop_set? do
+      host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}")
+    end
+    decr_stop
+
+    nap 60 * 60
   end
 
   label def unavailable

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Vm do
       expect(vm.display_state).to eq("restarting")
     end
 
+    it "returns stopped if stop semaphore increased" do
+      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "stop")]).at_least(:once)
+      expect(vm.display_state).to eq("stopped")
+    end
+
     it "returns waiting for capacity if semaphore increased" do
       expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "waiting_for_capacity")]).at_least(:once)
       expect(vm.display_state).to eq("waiting for capacity")


### PR DESCRIPTION
We need to stop a few virtual machines every month due to fraudulent activity before permanently deleting the data.

Currently, we manually stop the VM on the dataplane, which causes an unavailability page, and users can't see that it's stopped in the UI.

A proper stop may require releasing CPU and memory resources, but the initial version only stops the VM process without releasing those resources.

This will help with operational tasks.