### PR TITLE
Remove max token limit on inference playground

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -334,7 +334,6 @@ function setupPlayground() {
         body: JSON.stringify({
           model: $('#inference_endpoint option:selected').text().trim(),
           messages: [{ role: "user", content: prompt }],
-          max_tokens: 1000,
           stream: true,
         }),
         signal,


### PR DESCRIPTION
For verbose models, setting `max_tokens` to 1000 is too restrictive. Removing the limit for now. We could make `max_tokens` and other settings configurable in the future.