### PR TITLE
Keep scrolling to the bottom in the AI playground

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -363,10 +363,12 @@ function setupPlayground() {
             $('#inference_response_stream').append(content);
           }
         });
+        window.scrollTo(0, document.body.scrollHeight);
       }
       const parsed_response = DOMPurify.sanitize(marked.parse($('#inference_response_stream').text()));
       $('#inference_response_stream').text("");
       $('#inference_response_pretty').html(parsed_response);
+      window.scrollTo(0, document.body.scrollHeight);
     }
     catch (error) {
       let errorMessage;

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -1,7 +1,7 @@
 <% @page_title = "Playground" %>
 <% @enable_marked = true %>
 <%== render("inference/tabbar") %>
-<div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+<div class="rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
   <div class="px-4 py-5 sm:p-6 grid gap-6">
     <div class="flex gap-10 text-gray-900">
       <div class="flex items-center gap-2">
@@ -29,7 +29,7 @@
         ) %>
       </div>
     </div>
-    <div class="shadow-md rounded-lg p-2 bg-gray-50">
+    <div class="shadow-md rounded-lg p-2 bg-gray-50 sticky top-16 z-40">
       <%== render(
         "components/form/textarea",
         locals: {


### PR DESCRIPTION
Keeping the playground scrolled to the bottom makes it difficult to click the Stop button for long responses.

I made the prompt card sticky.

![CleanShot 2025-01-05 at 21 30 30](https://github.com/user-attachments/assets/af7121fe-6b42-426d-952b-485482df140f)
