### PR TITLE
Fix Load Balancer port rewriting

### DIFF
--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -133,6 +133,8 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   label def destroy
     decr_destroy
     strand.children.map { _1.destroy }
+    load_balancer.private_subnet.incr_update_firewall_rules
+
     # The following if statement makes sure that it's OK to not have dns_zone
     # only if it's not in production.
     if (dns_zone = load_balancer.dns_zone) && (Config.production? || dns_zone)
@@ -186,6 +188,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
       end
     end
 
+    load_balancer.private_subnet.incr_update_firewall_rules
     hop_wait
   end
 end

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -17,6 +17,17 @@ class Prog::Vnet::UpdateFirewallRules < Prog::Base
 
     globally_blocked_ipv4s, globally_blocked_ipv6s = generate_globally_blocked_lists
 
+    load_balancer_allow_rule = if vm.load_balancer
+      allow_ipv4_lb_neigh_incoming = "ip saddr . tcp sport { #{vm.load_balancer.vms.reject { _1.id == vm.id }.map { _1.nics.first.private_ipv4.network.to_s + " . " + vm.load_balancer.src_port.to_s }.join(", ")} } ct state established,related,new counter accept" if vm.load_balancer.vms.reject { _1.id == vm.id }.any?
+      allow_ipv6_lb_neigh_incoming = "ip6 saddr . tcp sport { #{vm.load_balancer.vms.reject { _1.id == vm.id }.map { _1.nics.first.private_ipv6.nth(2).to_s + " . " + vm.load_balancer.src_port.to_s }.join(", ")} } ct state established,related,new counter accept" if vm.load_balancer.vms.reject { _1.id == vm.id }.any?
+      <<~LOAD_BALANCER_ALLOW_RULE
+#{allow_ipv4_lb_neigh_incoming}
+#{allow_ipv6_lb_neigh_incoming}
+      LOAD_BALANCER_ALLOW_RULE
+    else
+      ""
+    end
+
     vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<TEMPLATE)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
@@ -129,6 +140,9 @@ table inet fw_table {
     ip6 daddr ::/0 icmpv6 type echo-request counter accept
     ip6 saddr ::/0 icmpv6 type echo-reply counter accept
     ip6 daddr ::/0 icmpv6 type echo-reply counter accept
+
+    # Allow load balancer traffic
+#{load_balancer_allow_rule}
   }
 }
 TEMPLATE

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -54,19 +54,21 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
 
     ipv4_prerouting = if load_balancer.ipv4_enabled?
       <<-IPV4_PREROUTING
+ip daddr #{public_ipv4} tcp dport #{load_balancer.src_port} meta mark set 0x00B1C100D
 ip daddr #{public_ipv4} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to #{balance_mode_ip4} mod #{modulo} map { #{ipv4_map_def} }
 ip daddr #{private_ipv4} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to #{private_ipv4}:#{load_balancer.dst_port}
       IPV4_PREROUTING
     end
     ipv6_prerouting = if load_balancer.ipv6_enabled?
       <<-IPV6_PREROUTING
+ip6 daddr #{public_ipv6} tcp dport #{load_balancer.src_port} meta mark set 0x00B1C100D
 ip6 daddr #{public_ipv6} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to #{balance_mode_ip6} mod #{modulo} map { #{ipv6_map_def} }
 ip6 daddr #{private_ipv6} tcp dport #{load_balancer.src_port} ct state established,related,new counter dnat to [#{public_ipv6}]:#{load_balancer.dst_port}
       IPV6_PREROUTING
     end
 
     ipv4_postrouting_rule = load_balancer.ipv4_enabled? ? "ip daddr @neighbor_ips_v4 tcp dport #{load_balancer.src_port} ct state established,related,new counter snat to #{private_ipv4}" : ""
-    ipv6_postrouting_rule = load_balancer.ipv6_enabled? ? "ip6 daddr @neighbor_ips_v6 tcp dport #{load_balancer.dst_port} ct state established,related,new counter snat to #{private_ipv6}" : ""
+    ipv6_postrouting_rule = load_balancer.ipv6_enabled? ? "ip6 daddr @neighbor_ips_v6 tcp dport #{load_balancer.src_port} ct state established,related,new counter snat to #{private_ipv6}" : ""
     <<TEMPLATE
 table ip nat;
 delete table ip nat;
@@ -119,7 +121,8 @@ TEMPLATE
     end.join(", "),
       load_balancer.active_vms.map.with_index do |active_vm, i|
         port = (active_vm.id == vm.id) ? load_balancer.dst_port : load_balancer.src_port
-        "#{i} : #{active_vm.nics.first.private_ipv6.nth(2)} . #{port}"
+        address = (active_vm.id == vm.id) ? vm.ephemeral_net6.nth(2) : active_vm.nics.first.private_ipv6.nth(2)
+        "#{i} : #{address} . #{port}"
       end.join(", ")]
   end
 

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Prog::Vnet::UpdateFirewallRules do
     vmh = instance_double(VmHost, sshable: instance_double(Sshable, cmd: nil))
     nic = instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.0/32"), private_ipv6: NetAddr::IPv6Net.parse("fd00::1/128"), ubid_to_tap_name: "tap0")
     ephemeral_net6 = NetAddr::IPv6Net.parse("fd00::1/79")
-    instance_double(Vm, private_subnets: [ps], vm_host: vmh, inhost_name: "x", nics: [nic], ephemeral_net6: ephemeral_net6)
+    instance_double(Vm, private_subnets: [ps], vm_host: vmh, inhost_name: "x", nics: [nic], ephemeral_net6: ephemeral_net6, load_balancer: nil)
   }
 
   describe "#before_run" do
@@ -59,10 +59,22 @@ table inet fw_table {
 elements = {1.1.1.1/32 . 22,10.10.10.0/26 . 80-9999,123.123.123.64/26 . 9000-15999,123.123.123.64/27 . 8080-8999}
   }
 
+  set allowed_ipv4_lb_dest_set {
+    type ipv4_addr . inet_service;
+    flags interval;
+
+  }
+
   set allowed_ipv6_port_tuple {
     type ipv6_addr . inet_service;
     flags interval;
 elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
+  }
+
+  set allowed_ipv6_lb_dest_set {
+    type ipv6_addr . inet_service;
+    flags interval;
+
   }
 
   set private_ipv4_cidrs {
@@ -158,6 +170,328 @@ elements = {2a00:1450:400e:811::200e/128}
     ip6 daddr ::/0 icmpv6 type echo-request counter accept
     ip6 saddr ::/0 icmpv6 type echo-reply counter accept
     ip6 daddr ::/0 icmpv6 type echo-reply counter accept
+
+    # Allow load balancer traffic
+
+  }
+}
+ADD_RULES
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rule is added"})
+    end
+
+    it "populates load balancer destination sets and adds related rules" do
+      GloballyBlockedDnsname.create_with_id(dns_name: "blockedhost.com", ip_list: Sequel.lit("ARRAY['123.123.123.123'::inet, '2a00:1450:400e:811::200e'::inet]"))
+      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
+      expect(vm).to receive(:firewalls).and_return([instance_double(Firewall, name: "fw_table", firewall_rules: [
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: nil),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("10.10.10.0/26"), port_range: Sequel.pg_range(80..10000)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("123.123.123.64/27"), port_range: Sequel.pg_range(8080..12000)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("123.123.123.64/26"), port_range: Sequel.pg_range(9000..16000)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("::/0"), port_range: nil),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(8080..65536)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/64"), port_range: Sequel.pg_range(0..8081)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::2/64"), port_range: Sequel.pg_range(80..10000))
+      ])])
+      expect(vm).to receive(:id).and_return(1).at_least(:once)
+      vm2 = instance_double(Vm, id: 2, nics: [instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"), private_ipv6: NetAddr::IPv6Net.parse("fd00::/124"))])
+      lb = instance_double(LoadBalancer, name: "lb_table", src_port: 443, dst_port: 8443, vms: [vm, vm2])
+      expect(vm).to receive(:load_balancer).and_return(lb).at_least(:once)
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
+# An nftables idiom for idempotent re-create of a named entity: merge
+# in an empty table (a no-op if the table already exists) and then
+# delete, before creating with a new definition.
+table inet fw_table;
+delete table inet fw_table;
+table inet fw_table {
+  set allowed_ipv4_port_tuple {
+    type ipv4_addr . inet_service;
+    flags interval;
+elements = {1.1.1.1/32 . 22,10.10.10.0/26 . 80-9999,123.123.123.64/26 . 9000-15999,123.123.123.64/27 . 8080-8999}
+  }
+
+  set allowed_ipv4_lb_dest_set {
+    type ipv4_addr . inet_service;
+    flags interval;
+elements = {10.10.10.0/26 . 8443}
+  }
+
+  set allowed_ipv6_port_tuple {
+    type ipv6_addr . inet_service;
+    flags interval;
+elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
+  }
+
+  set allowed_ipv6_lb_dest_set {
+    type ipv6_addr . inet_service;
+    flags interval;
+elements = {fd00::/64 . 8443}
+  }
+
+  set private_ipv4_cidrs {
+    type ipv4_addr;
+    flags interval;
+    elements = {
+      10.0.0.0/32
+    }
+  }
+
+  set private_ipv6_cidrs {
+    type ipv6_addr
+    flags interval
+    elements = { fd00::1/128 }
+  }
+
+  set globally_blocked_ipv4s {
+    type ipv4_addr;
+    flags interval;
+elements = {123.123.123.123/32}
+  }
+
+  set globally_blocked_ipv6s {
+    type ipv6_addr;
+    flags interval;
+elements = {2a00:1450:400e:811::200e/128}
+  }
+
+  flowtable ubi_flowtable {
+    hook ingress priority filter
+    devices = { tap0 }
+  }
+
+  chain forward_ingress {
+    type filter hook forward priority filter; policy drop;
+
+    # Offload to ubi_flowtable. This is used to offload already filtered
+    # traffic to reduce the latency.
+    meta l4proto { tcp, udp } flow offload @ubi_flowtable
+
+    # Destination port 111 is reserved for the portmapper. We block it to
+    # prevent abuse.
+    meta l4proto { tcp, udp } th dport 111 drop
+
+    # Drop all traffic from globally blocked IPs. This is mainly used to
+    # block access to malicious IPs that are known to cause issues on the
+    # internet.
+    ip saddr @globally_blocked_ipv4s drop
+    ip6 saddr @globally_blocked_ipv6s drop
+    ip daddr @globally_blocked_ipv4s drop
+    ip6 daddr @globally_blocked_ipv6s drop
+
+    # If we are using @private_ipv4_cidrs as source address, we allow all
+    # established,related,new traffic because this is outgoing traffic.
+    ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
+
+    # If we are using clover_ephemeral, that means we are using ipsec. We need
+    # to allow traffic for the private communication and block via firewall
+    # rules through @allowed_ipv4_port_tuple and @allowed_ipv6_port_tuple in the
+    # next section of rules.
+    ip6 daddr fd00::1:0:0:0/80 counter accept
+    ip6 saddr fd00::1:0:0:0/80 counter accept
+
+    # Allow TCP and UDP traffic for allowed_ipv4_port_tuple and
+    # allowed_ipv6_port_tuple into the VM using any address, such as;
+    #  - public ipv4
+    #  - private ipv4
+    #  - public ipv6 (guest_ephemeral)
+    #  - private ipv6
+    #  - private clover ephemeral ipv6
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ct state established,related,new counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ct state established,related,new counter accept
+    ip6 saddr . tcp dport @allowed_ipv6_port_tuple ct state established,related,new counter accept
+    ip6 saddr . udp dport @allowed_ipv6_port_tuple ct state established,related,new counter accept
+
+    # Allow outgoing traffic from the VM using the following addresses as
+    # source address.
+    ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
+    ip6 saddr fd00::/80 ct state established,related,new counter accept
+
+    # Allow incoming traffic to the VM using the following addresses as
+    # destination address. This is needed to allow the return traffic.
+    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
+    ip6 daddr fd00::/80 ct state established,related counter accept
+    ip daddr @private_ipv4_cidrs ct state established,related counter accept
+
+    # Allow ping for all
+    ip saddr 0.0.0.0/0 icmp type echo-request counter accept
+    ip daddr 0.0.0.0/0 icmp type echo-request counter accept
+    ip saddr 0.0.0.0/0 icmp type echo-reply counter accept
+    ip daddr 0.0.0.0/0 icmp type echo-reply counter accept
+    ip6 saddr ::/0 icmpv6 type echo-request counter accept
+    ip6 daddr ::/0 icmpv6 type echo-request counter accept
+    ip6 saddr ::/0 icmpv6 type echo-reply counter accept
+    ip6 daddr ::/0 icmpv6 type echo-reply counter accept
+
+    # Allow load balancer traffic
+ip saddr . tcp sport { 10.0.0.1 . 443 } ct state established,related,new counter accept
+ip6 saddr . tcp sport { fd00::2 . 443 } ct state established,related,new counter accept
+
+# The traffic that is routed to the local VM from the load balancer
+# is marked with 0x00B1C100D. We need to allow this traffic to
+# the local VM.
+meta mark 0x00B1C100D ip saddr . tcp dport @allowed_ipv4_lb_dest_set ct state established,related,new counter accept
+meta mark 0x00B1C100D ip6 saddr . tcp dport @allowed_ipv6_lb_dest_set ct state established,related,new counter accept
+
+  }
+}
+ADD_RULES
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rule is added"})
+    end
+
+    it "populates load balancer destination sets and adds related rules when there is a single load balancer vm" do
+      GloballyBlockedDnsname.create_with_id(dns_name: "blockedhost.com", ip_list: Sequel.lit("ARRAY['123.123.123.123'::inet, '2a00:1450:400e:811::200e'::inet]"))
+      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
+      expect(vm).to receive(:firewalls).and_return([instance_double(Firewall, name: "fw_table", firewall_rules: [
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: nil),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("10.10.10.0/26"), port_range: Sequel.pg_range(80..10000)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("123.123.123.64/27"), port_range: Sequel.pg_range(8080..12000)),
+        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("123.123.123.64/26"), port_range: Sequel.pg_range(9000..16000)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("::/0"), port_range: nil),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(8080..65536)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/64"), port_range: Sequel.pg_range(0..8081)),
+        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::2/64"), port_range: Sequel.pg_range(80..10000))
+      ])])
+      expect(vm).to receive(:id).and_return(1).at_least(:once)
+      lb = instance_double(LoadBalancer, name: "lb_table", src_port: 443, dst_port: 8443, vms: [vm])
+      expect(vm).to receive(:load_balancer).and_return(lb).at_least(:once)
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)
+# An nftables idiom for idempotent re-create of a named entity: merge
+# in an empty table (a no-op if the table already exists) and then
+# delete, before creating with a new definition.
+table inet fw_table;
+delete table inet fw_table;
+table inet fw_table {
+  set allowed_ipv4_port_tuple {
+    type ipv4_addr . inet_service;
+    flags interval;
+elements = {1.1.1.1/32 . 22,10.10.10.0/26 . 80-9999,123.123.123.64/26 . 9000-15999,123.123.123.64/27 . 8080-8999}
+  }
+
+  set allowed_ipv4_lb_dest_set {
+    type ipv4_addr . inet_service;
+    flags interval;
+elements = {10.10.10.0/26 . 8443}
+  }
+
+  set allowed_ipv6_port_tuple {
+    type ipv6_addr . inet_service;
+    flags interval;
+elements = {fd00::/64 . 0-9999,fd00::1/128 . 10000-65535}
+  }
+
+  set allowed_ipv6_lb_dest_set {
+    type ipv6_addr . inet_service;
+    flags interval;
+elements = {fd00::/64 . 8443}
+  }
+
+  set private_ipv4_cidrs {
+    type ipv4_addr;
+    flags interval;
+    elements = {
+      10.0.0.0/32
+    }
+  }
+
+  set private_ipv6_cidrs {
+    type ipv6_addr
+    flags interval
+    elements = { fd00::1/128 }
+  }
+
+  set globally_blocked_ipv4s {
+    type ipv4_addr;
+    flags interval;
+elements = {123.123.123.123/32}
+  }
+
+  set globally_blocked_ipv6s {
+    type ipv6_addr;
+    flags interval;
+elements = {2a00:1450:400e:811::200e/128}
+  }
+
+  flowtable ubi_flowtable {
+    hook ingress priority filter
+    devices = { tap0 }
+  }
+
+  chain forward_ingress {
+    type filter hook forward priority filter; policy drop;
+
+    # Offload to ubi_flowtable. This is used to offload already filtered
+    # traffic to reduce the latency.
+    meta l4proto { tcp, udp } flow offload @ubi_flowtable
+
+    # Destination port 111 is reserved for the portmapper. We block it to
+    # prevent abuse.
+    meta l4proto { tcp, udp } th dport 111 drop
+
+    # Drop all traffic from globally blocked IPs. This is mainly used to
+    # block access to malicious IPs that are known to cause issues on the
+    # internet.
+    ip saddr @globally_blocked_ipv4s drop
+    ip6 saddr @globally_blocked_ipv6s drop
+    ip daddr @globally_blocked_ipv4s drop
+    ip6 daddr @globally_blocked_ipv6s drop
+
+    # If we are using @private_ipv4_cidrs as source address, we allow all
+    # established,related,new traffic because this is outgoing traffic.
+    ip saddr @private_ipv4_cidrs ct state established,related,new counter accept
+
+    # If we are using clover_ephemeral, that means we are using ipsec. We need
+    # to allow traffic for the private communication and block via firewall
+    # rules through @allowed_ipv4_port_tuple and @allowed_ipv6_port_tuple in the
+    # next section of rules.
+    ip6 daddr fd00::1:0:0:0/80 counter accept
+    ip6 saddr fd00::1:0:0:0/80 counter accept
+
+    # Allow TCP and UDP traffic for allowed_ipv4_port_tuple and
+    # allowed_ipv6_port_tuple into the VM using any address, such as;
+    #  - public ipv4
+    #  - private ipv4
+    #  - public ipv6 (guest_ephemeral)
+    #  - private ipv6
+    #  - private clover ephemeral ipv6
+    ip saddr . tcp dport @allowed_ipv4_port_tuple ct state established,related,new counter accept
+    ip saddr . udp dport @allowed_ipv4_port_tuple ct state established,related,new counter accept
+    ip6 saddr . tcp dport @allowed_ipv6_port_tuple ct state established,related,new counter accept
+    ip6 saddr . udp dport @allowed_ipv6_port_tuple ct state established,related,new counter accept
+
+    # Allow outgoing traffic from the VM using the following addresses as
+    # source address.
+    ip6 saddr @private_ipv6_cidrs ct state established,related,new counter accept
+    ip6 saddr fd00::/80 ct state established,related,new counter accept
+
+    # Allow incoming traffic to the VM using the following addresses as
+    # destination address. This is needed to allow the return traffic.
+    ip6 daddr @private_ipv6_cidrs ct state established,related counter accept
+    ip6 daddr fd00::/80 ct state established,related counter accept
+    ip daddr @private_ipv4_cidrs ct state established,related counter accept
+
+    # Allow ping for all
+    ip saddr 0.0.0.0/0 icmp type echo-request counter accept
+    ip daddr 0.0.0.0/0 icmp type echo-request counter accept
+    ip saddr 0.0.0.0/0 icmp type echo-reply counter accept
+    ip daddr 0.0.0.0/0 icmp type echo-reply counter accept
+    ip6 saddr ::/0 icmpv6 type echo-request counter accept
+    ip6 daddr ::/0 icmpv6 type echo-request counter accept
+    ip6 saddr ::/0 icmpv6 type echo-reply counter accept
+    ip6 daddr ::/0 icmpv6 type echo-reply counter accept
+
+    # Allow load balancer traffic
+
+
+
+# The traffic that is routed to the local VM from the load balancer
+# is marked with 0x00B1C100D. We need to allow this traffic to
+# the local VM.
+meta mark 0x00B1C100D ip saddr . tcp dport @allowed_ipv4_lb_dest_set ct state established,related,new counter accept
+meta mark 0x00B1C100D ip6 saddr . tcp dport @allowed_ipv6_lb_dest_set ct state established,related,new counter accept
+
   }
 }
 ADD_RULES
@@ -184,7 +518,19 @@ table inet fw_table {
 
   }
 
+  set allowed_ipv4_lb_dest_set {
+    type ipv4_addr . inet_service;
+    flags interval;
+
+  }
+
   set allowed_ipv6_port_tuple {
+    type ipv6_addr . inet_service;
+    flags interval;
+
+  }
+
+  set allowed_ipv6_lb_dest_set {
     type ipv6_addr . inet_service;
     flags interval;
 
@@ -283,6 +629,9 @@ table inet fw_table {
     ip6 daddr ::/0 icmpv6 type echo-request counter accept
     ip6 saddr ::/0 icmpv6 type echo-reply counter accept
     ip6 daddr ::/0 icmpv6 type echo-reply counter accept
+
+    # Allow load balancer traffic
+
   }
 }
 ADD_RULES

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -91,8 +91,14 @@ table inet nat {
 
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
+ip daddr 100.100.100.100/32 tcp dport 80 meta mark set 0x00B1C100D
 ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 192.168.1.0 . 8080 }
-ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+ip daddr 192.168.1.0 tcp dport 80 ct state established,related,new counter dnat to 192.168.1.0:8080
+
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 meta mark set 0x00B1C100D
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 2a02:a464:deb2:a000::2 . 8080 }
+ip6 daddr fd10:9b0b:6b4b:8fbb::2 tcp dport 80 ct state established,related,new counter dnat to [2a02:a464:deb2:a000::2]:8080
+
 
     # Basic NAT for public IPv4 to private IPv4
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
@@ -100,8 +106,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
+ip daddr @neighbor_ips_v4 tcp dport 80 ct state established,related,new counter snat to 192.168.1.0
+ip6 daddr @neighbor_ips_v6 tcp dport 80 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -134,7 +140,10 @@ table inet nat {
 
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
+ip daddr 100.100.100.100/32 tcp dport 80 meta mark set 0x00B1C100D
 ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 192.168.1.0 . 8080 }
+ip daddr 192.168.1.0 tcp dport 80 ct state established,related,new counter dnat to 192.168.1.0:8080
+
 
 
     # Basic NAT for public IPv4 to private IPv4
@@ -143,7 +152,7 @@ ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counte
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
+ip daddr @neighbor_ips_v4 tcp dport 80 ct state established,related,new counter snat to 192.168.1.0
 
 
     # Basic NAT for private IPv4 to public IPv4
@@ -178,8 +187,14 @@ table inet nat {
 
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
+ip daddr 100.100.100.100/32 tcp dport 80 meta mark set 0x00B1C100D
 ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to jhash ip saddr . tcp sport . ip daddr . tcp dport mod 1 map { 0 : 192.168.1.0 . 8080 }
-ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to jhash ip6 saddr . tcp sport . ip6 daddr . tcp dport mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+ip daddr 192.168.1.0 tcp dport 80 ct state established,related,new counter dnat to 192.168.1.0:8080
+
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 meta mark set 0x00B1C100D
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to jhash ip6 saddr . tcp sport . ip6 daddr . tcp dport mod 1 map { 0 : 2a02:a464:deb2:a000::2 . 8080 }
+ip6 daddr fd10:9b0b:6b4b:8fbb::2 tcp dport 80 ct state established,related,new counter dnat to [2a02:a464:deb2:a000::2]:8080
+
 
     # Basic NAT for public IPv4 to private IPv4
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
@@ -187,8 +202,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
+ip daddr @neighbor_ips_v4 tcp dport 80 ct state established,related,new counter snat to 192.168.1.0
+ip6 daddr @neighbor_ips_v6 tcp dport 80 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -231,8 +246,14 @@ elements = {fd10:9b0b:6b4b:aaa::2}
 
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
-ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : 192.168.1.0 . 8080, 1 : 172.10.1.0 . 8080 }
-ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080, 1 : fd10:9b0b:6b4b:aaa::2 . 8080 }
+ip daddr 100.100.100.100/32 tcp dport 80 meta mark set 0x00B1C100D
+ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : 192.168.1.0 . 8080, 1 : 172.10.1.0 . 80 }
+ip daddr 192.168.1.0 tcp dport 80 ct state established,related,new counter dnat to 192.168.1.0:8080
+
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 meta mark set 0x00B1C100D
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : 2a02:a464:deb2:a000::2 . 8080, 1 : fd10:9b0b:6b4b:aaa::2 . 80 }
+ip6 daddr fd10:9b0b:6b4b:8fbb::2 tcp dport 80 ct state established,related,new counter dnat to [2a02:a464:deb2:a000::2]:8080
+
 
     # Basic NAT for public IPv4 to private IPv4
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
@@ -240,8 +261,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
+ip daddr @neighbor_ips_v4 tcp dport 80 ct state established,related,new counter snat to 192.168.1.0
+ip6 daddr @neighbor_ips_v6 tcp dport 80 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -274,7 +295,10 @@ elements = {fd10:9b0b:6b4b:aaa::2}
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
 
-ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080, 1 : fd10:9b0b:6b4b:aaa::2 . 8080 }
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 meta mark set 0x00B1C100D
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 2 map { 0 : 2a02:a464:deb2:a000::2 . 8080, 1 : fd10:9b0b:6b4b:aaa::2 . 80 }
+ip6 daddr fd10:9b0b:6b4b:8fbb::2 tcp dport 80 ct state established,related,new counter dnat to [2a02:a464:deb2:a000::2]:8080
+
 
     # Basic NAT for public IPv4 to private IPv4
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
@@ -283,7 +307,7 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
 
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
+ip6 daddr @neighbor_ips_v6 tcp dport 80 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -315,8 +339,14 @@ elements = {fd10:9b0b:6b4b:aaa::2}
 
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
-ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 172.10.1.0 . 8080 }
-ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:aaa::2 . 8080 }
+ip daddr 100.100.100.100/32 tcp dport 80 meta mark set 0x00B1C100D
+ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 172.10.1.0 . 80 }
+ip daddr 192.168.1.0 tcp dport 80 ct state established,related,new counter dnat to 192.168.1.0:8080
+
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 meta mark set 0x00B1C100D
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:aaa::2 . 80 }
+ip6 daddr fd10:9b0b:6b4b:8fbb::2 tcp dport 80 ct state established,related,new counter dnat to [2a02:a464:deb2:a000::2]:8080
+
 
     # Basic NAT for public IPv4 to private IPv4
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
@@ -324,8 +354,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
+ip daddr @neighbor_ips_v4 tcp dport 80 ct state established,related,new counter snat to 192.168.1.0
+ip6 daddr @neighbor_ips_v6 tcp dport 80 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32
@@ -357,8 +387,14 @@ table inet nat {
 
   chain prerouting {
     type nat hook prerouting priority dstnat; policy accept;
+ip daddr 100.100.100.100/32 tcp dport 80 meta mark set 0x00B1C100D
 ip daddr 100.100.100.100/32 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 192.168.1.0 . 8080 }
-ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : fd10:9b0b:6b4b:8fbb::2 . 8080 }
+ip daddr 192.168.1.0 tcp dport 80 ct state established,related,new counter dnat to 192.168.1.0:8080
+
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 meta mark set 0x00B1C100D
+ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new counter dnat to numgen inc mod 1 map { 0 : 2a02:a464:deb2:a000::2 . 8080 }
+ip6 daddr fd10:9b0b:6b4b:8fbb::2 tcp dport 80 ct state established,related,new counter dnat to [2a02:a464:deb2:a000::2]:8080
+
 
     # Basic NAT for public IPv4 to private IPv4
     ip daddr 100.100.100.100/32 dnat to 192.168.1.0
@@ -366,8 +402,8 @@ ip6 daddr 2a02:a464:deb2:a000::2 tcp dport 80 ct state established,related,new c
 
   chain postrouting {
     type nat hook postrouting priority srcnat; policy accept;
-ip daddr @neighbor_ips_v4 tcp dport 8080 ct state established,related,new counter snat to 192.168.1.0:8080
-ip6 daddr @neighbor_ips_v6 tcp dport 8080 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2:8080
+ip daddr @neighbor_ips_v4 tcp dport 80 ct state established,related,new counter snat to 192.168.1.0
+ip6 daddr @neighbor_ips_v6 tcp dport 80 ct state established,related,new counter snat to fd10:9b0b:6b4b:8fbb::2
 
     # Basic NAT for private IPv4 to public IPv4
     ip saddr 192.168.1.0 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 100.100.100.100/32


### PR DESCRIPTION
## Do not overwrite the source port when load balancing
With the PR https://github.com/ubicloud/ubicloud/pull/2272, we have
introduced source port overwriting when load balancing to a neighbor
node. This has created confusion for connection tracking and simply
broke load balancer. In this commit, I am changing the logic back to not
overwriting, but introducing selective destination port overwriting.

This way, if the connection is forwarded to a neighbor node, we are
still using the load balancer public port and keep the source port same.
To be able to process that on the neighbor side, we are overwriting the
destination port from public to private upon arrival. For packs that are
coming from a neighbor node's private IP to the arrival private IP but
in public port.

This creates a problem for connections to be forwarded to the local VM.
The reason is, DNATing can only be done at the preforward hook which is
executed before applying the firewall rules. Therefore, we cannot leave
the public port, we must overwrite it to private port since the
application is running in the private port. Once we overwrite that, we
have to make sure firewall rules for the public port are still applied
to that connection. We will solve that in the next commit.

## Mark lb packets to be forwarded to local and apply FW rules
Since we are overwriting the destination port to the private port in the
preforward hook, we have to make sure the firewall rules for the public
port are applied. For that, when we are creating the firewall rule sets,
we generate a new copy of the sets and replace the public port with the
private port. It is not enough to do that because we only need to apply
the rules to the packets coming through the load balancer. For that, we
introduce marking in the load balancer and catch the marked packets in
the forward hook.

Since now load balancer and firewall need to work together, we have to
make sure firewall rules are updated when a node is removed or added. We
catch those in the dns update or destroy sequence.