### PR TITLE
Add content with "text" to html element on playground

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -359,7 +359,7 @@ function setupPlayground() {
         parsedLines.forEach((parsedLine) => {
           const content = parsedLine?.choices?.[0]?.delta?.content;
           if (content) {
-            $('#inference_response_stream').append(content);
+            $('#inference_response_stream').text($('#inference_response_stream').text() + content);
           }
         });
       }


### PR DESCRIPTION
We need to write content received from the model to `inference_response_stream` without interpreting html. The append method, however, does not simply add text but interprets html. Therefore, we switch to `text` in order to append the content received from the model.