### PR TITLE
Set the server name as the UBID of the VM host for Hetzner hosts automatically

### DIFF
--- a/lib/hosting/apis.rb
+++ b/lib/hosting/apis.rb
@@ -25,4 +25,12 @@ class Hosting::Apis
       raise "unknown provider #{vm_host.provider}"
     end
   end
+
+  def self.set_server_name(vm_host)
+    if vm_host.provider == HetznerHost::PROVIDER_NAME
+      vm_host.hetzner_host.api.set_server_name(vm_host.hetzner_host.server_identifier, vm_host.ubid)
+    else
+      raise "unknown provider #{vm_host.provider}"
+    end
+  end
 end

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -150,4 +150,14 @@ class Hosting::HetznerApis
     json_server = JSON.parse(response.body)
     json_server.dig("server", "dc")
   end
+
+  def set_server_name(server_id, name)
+    connection = Excon.new(@host.connection_string,
+      user: @host.user,
+      password: @host.password,
+      headers: {"Content-Type" => "application/x-www-form-urlencoded"})
+    connection.post(path: "/server/#{server_id}",
+      body: URI.encode_www_form(server_name: name),
+      expects: 200)
+  end
 end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -235,6 +235,10 @@ class VmHost < Sequel::Model
     update(data_center: Hosting::Apis.pull_data_center(self))
   end
 
+  def set_server_name
+    Hosting::Apis.set_server_name(self)
+  end
+
   def reset
     unless Config.development?
       fail "BUG: reset is only allowed in development"

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -14,6 +14,7 @@ class Prog::Vm::HostNexus < Prog::Base
         HetznerHost.create(server_identifier: hetzner_server_identifier) { _1.id = vmh.id }
         vmh.create_addresses
         vmh.set_data_center
+        vmh.set_server_name
       else
         Address.create(cidr: sshable_hostname, routed_to_host_id: vmh.id) { _1.id = vmh.id }
         AssignedHostAddress.create_with_id(ip: sshable_hostname, address_id: vmh.id, host_id: vmh.id)

--- a/spec/lib/hosting/apis_spec.rb
+++ b/spec/lib/hosting/apis_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Hosting::Apis do
   let(:vm_host) {
     instance_double(
       VmHost,
+      ubid: "vhgkz40v22ny2qkf4maddr8xv1",
       provider: HetznerHost::PROVIDER_NAME,
       hetzner_host: hetzner_host
     )
@@ -53,6 +54,18 @@ RSpec.describe Hosting::Apis do
     it "raises an error if the provider is unknown" do
       expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
       expect { described_class.pull_data_center(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
+    end
+  end
+
+  describe "set_server_name" do
+    it "can set server name" do
+      expect(hetzner_apis).to receive(:set_server_name).with(123, "vhgkz40v22ny2qkf4maddr8xv1").and_return(nil)
+      described_class.set_server_name(vm_host)
+    end
+
+    it "raises an error if the provider is unknown" do
+      expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
+      expect { described_class.set_server_name(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
     end
   end
 end

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -284,4 +284,21 @@ RSpec.describe Hosting::HetznerApis do
       expect(hetzner_apis.pull_ips).to eq expected
     end
   end
+
+  describe "set_server_name" do
+    it "can set the server name" do
+      Excon.stub({path: "/server/123", method: :post, body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0"}, {status: 200, body: "{}"})
+      expect { hetzner_apis.set_server_name(123, "84fe406c-42af-8771-bcde-4a29adc23bb0") }.not_to raise_error
+    end
+
+    it "raises an error if setting the server name fails due to invalid input" do
+      Excon.stub({path: "/server/123", method: :post, body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0"}, {status: 400, body: ""})
+      expect { hetzner_apis.set_server_name(123, "84fe406c-42af-8771-bcde-4a29adc23bb0") }.to raise_error Excon::Error::BadRequest
+    end
+
+    it "raises an error if setting the server name fails due to not found" do
+      Excon.stub({path: "/server/123", method: :post, body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0"}, {status: 404, body: ""})
+      expect { hetzner_apis.set_server_name(123, "84fe406c-42af-8771-bcde-4a29adc23bb0") }.to raise_error Excon::Error::NotFound
+    end
+  end
 end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -37,9 +37,10 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(st.subject.provider).to be_nil
     end
 
-    it "creates addresses properly for a hetzner host" do
+    it "creates addresses properly and sets the server name for a hetzner host" do
       expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
       expect(Hosting::Apis).to receive(:pull_data_center).and_return("fsn1-dc14")
+      expect(Hosting::Apis).to receive(:set_server_name).and_return(nil)
       st = described_class.assemble("127.0.0.1", provider: "hetzner", hetzner_server_identifier: "1")
       expect(st).to be_a Strand
       expect(st.label).to eq("start")

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -99,7 +99,7 @@ module ThawedMock
   allow_mocking(BillingRate, :from_resource_properties)
   allow_mocking(Clog, :emit)
   allow_mocking(CloudflareClient, :new)
-  allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reset_server)
+  allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reset_server, :set_server_name)
   allow_mocking(Minio::Client, :new)
   allow_mocking(Minio::Crypto, :new)
   allow_mocking(Scheduling::Allocator, :allocate)


### PR DESCRIPTION
Fixes #1034 

Call Hetzner API to update server name to the UBID of the VM host on `HostNexus.assemble`. API docs: https://robot.hetzner.com/doc/webservice/en.html#post-server-server-number


## Tests
- [x] Unit tests
- [ ] E2E test