### PR TITLE
Add tabs to switch between preview and raw content

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -317,8 +317,8 @@ function setupPlayground() {
       return;
     }
 
-    $('#inference_response_stream').text("");
-    $('#inference_response_pretty').text("");
+    $('#inference_response_raw').text("");
+    $('#inference_response_preview').text("");
     $('#inference_submit').text("Stop");
 
     controller = new AbortController();
@@ -359,13 +359,13 @@ function setupPlayground() {
         parsedLines.forEach((parsedLine) => {
           const content = parsedLine?.choices?.[0]?.delta?.content;
           if (content) {
-            $('#inference_response_stream').text($('#inference_response_stream').text() + content);
+            $('#inference_response_raw').text($('#inference_response_raw').text() + content);
           }
         });
       }
-      const parsed_response = DOMPurify.sanitize(marked.parse($('#inference_response_stream').text()));
-      $('#inference_response_stream').text("");
-      $('#inference_response_pretty').html(parsed_response);
+      const parsed_response = DOMPurify.sanitize(marked.parse($('#inference_response_raw').text()));
+      $('#inference_response_raw').text("");
+      $('#inference_response_preview').html(parsed_response);
     }
     catch (error) {
       let errorMessage;
@@ -378,7 +378,7 @@ function setupPlayground() {
         errorMessage = `An error occurred: ${error.message}`;
       }
 
-      $('#inference_response_stream').text(errorMessage);
+      $('#inference_response_raw').text(errorMessage);
     } finally {
       $('#inference_submit').text("Submit");
       controller = null;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -290,6 +290,19 @@ function setupPlayground() {
     return;
   }
 
+  function show_tab(name) {
+    $(".inference-tab").removeClass("active");
+    $(".inference-response").hide();
+    $(`#inference_tab_${name}`).show().parent().addClass("active");
+    $(`#inference_response_${name}`).show().removeClass("max-h-96");
+  }
+
+  $(".inference-tab").on("click", function (event) {
+    show_tab($(this).data("target"));
+  });
+
+  $('#inference_tab_preview').hide();
+
   let controller = null;
 
   const generate = async () => {
@@ -320,6 +333,9 @@ function setupPlayground() {
     $('#inference_response_raw').text("");
     $('#inference_response_preview').text("");
     $('#inference_submit').text("Stop");
+    show_tab("raw");
+    $('#inference_tab_preview').hide();
+    $('#inference_response_raw').addClass("max-h-96");
 
     controller = new AbortController();
     const signal = controller.signal;
@@ -364,8 +380,8 @@ function setupPlayground() {
         });
       }
       const parsed_response = DOMPurify.sanitize(marked.parse($('#inference_response_raw').text()));
-      $('#inference_response_raw').text("");
       $('#inference_response_preview').html(parsed_response);
+      show_tab("preview");
     }
     catch (error) {
       let errorMessage;

--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -155,6 +155,14 @@
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
     <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0 1 19.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 0 0 4.5 10.5a7.464 7.464 0 0 1-1.15 3.993m1.989 3.559A11.209 11.209 0 0 0 8.25 10.5a3.75 3.75 0 1 1 7.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 0 1-3.6 9.75m6.633-4.596a18.666 18.666 0 0 1-2.485 5.33" />
   </svg>
+<% when "hero-code-bracket" %>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"  class="<%= classes %>">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" />
+</svg>
+<% when "hero-eye" %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"  class="<%= classes %>">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+  </svg>
 <% else %>
   <p>Not found icon</p>
 <% end %>

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -53,9 +53,8 @@
         }
       ) %>
     </div>
-    <div class="mt-4 text-gray-900">
-      <span id="inference_response_stream" class="overflow-auto min-h-48 whitespace-pre-line"></span>
-      <span id="inference_response_pretty" class="prose"></span>
+      <span id="inference_response_raw" class="overflow-auto min-h-48 whitespace-pre-line"></span>
+      <span id="inference_response_preview" class="prose"></span>
     </div>
   </div>
 </div>

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -53,8 +53,31 @@
         }
       ) %>
     </div>
-      <span id="inference_response_raw" class="overflow-auto min-h-48 whitespace-pre-line"></span>
-      <span id="inference_response_preview" class="prose"></span>
+    <div class="border-b border-gray-200">
+      <ul class="flex flex-wrap -mb-px text-sm font-medium text-center text-gray-500 dark:text-gray-400">
+        <% [
+          ["raw", "hero-code-bracket"],
+          ["preview", "hero-eye"]
+      ].each do |name, icon| %>
+          <li class="me-2 group inference-tab <%= (name == "raw") ? "active" : "" %>" data-target="<%= name %>">
+            <a
+              id="inference_tab_<%= name %>"
+              href="#"
+              class="inline-flex items-center justify-center p-4 border-b-2 rounded-t-lg group-[.active]:text-orange-600 group-[.active]:border-orange-600 group-[:not(.active)]:hover:text-gray-600 group-[:not(.active)]:hover:border-gray-300"
+            >
+              <%== render("components/icon", locals: { name: icon, classes: "h-4 w-4 mr-1" }) %>
+              <%= name.capitalize %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+    <div class="mt-1 text-gray-900">
+      <span
+        id="inference_response_raw"
+        class="inference-response whitespace-pre-line flex flex-col-reverse overflow-y-auto leading-7"
+      ></span>
+      <span id="inference_response_preview" class="inference-response prose"></span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Add two tabs to the response section of the playground:

1. Raw: This shows the raw response of the model.
2. Preview: A rendered representation of the model response.

While the response is streaming in, only the "Raw" tab is visible. When the request has finished, the Preview tab becomes available and users can switch back and forth between the raw response and the rendered representation.

During request processing the length of the streaming element is restricted and auto-scrolled to the bottom. That way, the focus remains on the most recently received content.
![Screenshot 2025-01-07 at 12 24 01](https://github.com/user-attachments/assets/2373b406-62a8-4838-a6c1-29a81abdeea9)



Once request processing has finished:

A "Preview" tab becomes available and is auto-selected:
![Screenshot 2025-01-07 at 12 24 54](https://github.com/user-attachments/assets/afc824ba-166d-40ad-8d8f-c012f321b2a5)


But users can go back and forth between "Preview" and "Raw". At this point, "Raw" doesn't have size restrictions or scrollbars anymore:
![Screenshot 2025-01-07 at 12 25 09](https://github.com/user-attachments/assets/194ec90f-4c35-4fbc-ab1a-f9cb6d52bc1d)



