### PR TITLE
Improve billing info update

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -31,7 +31,7 @@ class Clover
           begin
             Stripe::Customer.update(billing_info.stripe_id, {
               name: r.params["name"],
-              email: r.params["email"],
+              email: r.params["email"].strip,
               address: {
                 country: r.params["country"],
                 state: r.params["state"],

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -28,22 +28,26 @@ class Clover
 
       r.post true do
         if (billing_info = @project.billing_info)
-          Stripe::Customer.update(billing_info.stripe_id, {
-            name: r.params["name"],
-            email: r.params["email"],
-            address: {
-              country: r.params["country"],
-              state: r.params["state"],
-              city: r.params["city"],
-              postal_code: r.params["postal_code"],
-              line1: r.params["address"],
-              line2: nil
-            },
-            metadata: {
-              tax_id: r.params["tax_id"],
-              company_name: r.params["company_name"]
-            }
-          })
+          begin
+            Stripe::Customer.update(billing_info.stripe_id, {
+              name: r.params["name"],
+              email: r.params["email"],
+              address: {
+                country: r.params["country"],
+                state: r.params["state"],
+                city: r.params["city"],
+                postal_code: r.params["postal_code"],
+                line1: r.params["address"],
+                line2: nil
+              },
+              metadata: {
+                tax_id: r.params["tax_id"],
+                company_name: r.params["company_name"]
+              }
+            })
+          rescue Stripe::InvalidRequestError => e
+            flash["error"] = e.message
+          end
 
           r.redirect @project.path + "/billing"
         end

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Clover do
     click_button "Sign in"
 
     expect(page.status_code).to eq(400)
-    expect(page).to have_content("An invalid security token submitted with this request")
+    expect(page).to have_flash_error("An invalid security token submitted with this request, please try again")
   end
 
   it "handles expected errors" do

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Clover, "firewall" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' is created"
+        expect(page).to have_flash_notice("'#{name}' is created")
         expect(Firewall.count).to eq(1)
         expect(Firewall.first.projects.first.id).to eq(project.id)
       end
@@ -94,7 +94,7 @@ RSpec.describe Clover, "firewall" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' is created"
+        expect(page).to have_flash_notice("'#{name}' is created")
         fw = Firewall[name: name]
         expect(fw.private_subnets.first.id).to eq(ps.id)
 
@@ -180,7 +180,7 @@ RSpec.describe Clover, "firewall" do
         click_button "Attach"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_content "Private subnet #{ps.name} is attached to the firewall"
+        expect(page).to have_flash_notice("Private subnet #{ps.name} is attached to the firewall")
         expect(firewall.private_subnets_dataset.count).to eq(1)
 
         visit "#{project.path}#{firewall.path}"
@@ -198,7 +198,7 @@ RSpec.describe Clover, "firewall" do
         click_button "Attach"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_content "Private subnet not found"
+        expect(page).to have_flash_error("Private subnet not found")
         expect(firewall.private_subnets_dataset.count).to eq(0)
       end
 
@@ -212,7 +212,7 @@ RSpec.describe Clover, "firewall" do
         click_button "Detach"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_content "Private subnet #{ps.name} is detached from the firewall"
+        expect(page).to have_flash_notice("Private subnet #{ps.name} is detached from the firewall")
         expect(firewall.private_subnets_dataset.count).to eq(0)
 
         visit "#{project.path}#{ps.path}"
@@ -232,7 +232,7 @@ RSpec.describe Clover, "firewall" do
         click_button "Detach"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_content "Private subnet not found"
+        expect(page).to have_flash_error("Private subnet not found")
         expect(firewall.private_subnets_dataset.count).to eq(0)
       end
     end
@@ -247,7 +247,7 @@ RSpec.describe Clover, "firewall" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_content "Firewall rule is created"
+        expect(page).to have_flash_notice("Firewall rule is created")
         expect(firewall.firewall_rules_dataset.count).to eq(1)
       end
 

--- a/spec/routes/web/github_spec.rb
+++ b/spec/routes/web/github_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Clover, "github" do
     visit "/github/callback?code=123123&installation_id=#{installation.installation_id}"
 
     expect(page.title).to eq("Ubicloud - Active Runners")
-    expect(page).to have_content("GitHub runner integration is already enabled for #{project.name} project.")
+    expect(page).to have_flash_notice("GitHub runner integration is already enabled for #{project.name} project.")
   end
 
   it "raises forbidden when does not have permissions to access already enabled installation" do
@@ -44,7 +44,7 @@ RSpec.describe Clover, "github" do
     visit "/github/callback?code=123123&installation_id=345"
 
     expect(page.title).to eq("Ubicloud - Projects")
-    expect(page).to have_content("You should initiate the GitHub App installation request from the project's GitHub runner integration page.")
+    expect(page).to have_flash_error("You should initiate the GitHub App installation request from the project's GitHub runner integration page.")
   end
 
   it "raises forbidden when does not have permissions to the project in session" do
@@ -66,7 +66,7 @@ RSpec.describe Clover, "github" do
     visit "/github/callback?code=123123&setup_action=request"
 
     expect(page.title).to eq("Ubicloud - #{project.name} - Users")
-    expect(page).to have_content("awaiting approval from the GitHub organization's administrator")
+    expect(page).to have_flash_notice(/.*awaiting approval from the GitHub organization's administrator.*/)
   end
 
   it "fails if oauth code is invalid" do
@@ -76,7 +76,7 @@ RSpec.describe Clover, "github" do
     visit "/github/callback?code=invalid"
 
     expect(page.title).to eq("Ubicloud - GitHub Runner Settings")
-    expect(page).to have_content("GitHub App installation failed.")
+    expect(page).to have_flash_error(/^GitHub App installation failed.*/)
   end
 
   it "fails if installation not found" do
@@ -87,7 +87,7 @@ RSpec.describe Clover, "github" do
     visit "/github/callback?code=123123"
 
     expect(page.title).to eq("Ubicloud - GitHub Runner Settings")
-    expect(page).to have_content("GitHub App installation failed.")
+    expect(page).to have_flash_error(/^GitHub App installation failed.*/)
   end
 
   it "fails if the project is not active" do
@@ -99,7 +99,7 @@ RSpec.describe Clover, "github" do
     visit "/github/callback?code=123123&installation_id=345"
 
     expect(page.title).to eq("Ubicloud - project-1 Dashboard")
-    expect(page).to have_content("GitHub runner integration is not allowed for inactive projects")
+    expect(page).to have_flash_error("GitHub runner integration is not allowed for inactive projects")
   end
 
   it "creates installation with project from session" do
@@ -110,7 +110,7 @@ RSpec.describe Clover, "github" do
     visit "/github/callback?code=123123&installation_id=345"
 
     expect(page.title).to eq("Ubicloud - Active Runners")
-    expect(page).to have_content("GitHub runner integration is enabled for #{project.name} project.")
+    expect(page).to have_flash_notice("GitHub runner integration is enabled for #{project.name} project.")
     installation = GithubInstallation[installation_id: 345]
     expect(installation.name).to eq("test-user")
     expect(installation.type).to eq("User")

--- a/spec/routes/web/inference_token_spec.rb
+++ b/spec/routes/web/inference_token_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Clover, "inference-token" do
     end
 
     it "inference token page allows creating inference tokens" do
-      expect(find_by_id("flash-notice").text).to include("Created inference token with id ")
+      expect(page).to have_flash_notice("Created inference token with id #{@api_key.ubid}")
 
       expect(ApiKey.count).to eq(1)
       expect(@api_key.owner_id).to eq(project.id)
@@ -40,7 +40,7 @@ RSpec.describe Clover, "inference-token" do
       expect(ApiKey.all).to be_empty
       expect(access_tag_ds.all).to be_empty
       visit "#{project.path}/user/token"
-      expect(find_by_id("flash-notice").text).to eq("Inference token deleted successfully")
+      expect(page).to have_flash_notice("Inference token deleted successfully")
 
       page.driver.delete data_url, {_csrf:}
       expect(page.status_code).to eq(204)

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Clover, "load balancer" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' is created"
+        expect(page).to have_flash_notice("'#{name}' is created")
         expect(LoadBalancer.count).to eq(1)
         expect(LoadBalancer.first.projects.first.id).to eq(project.id)
       end
@@ -212,7 +212,7 @@ RSpec.describe Clover, "load balancer" do
         click_button "Attach"
 
         expect(page.title).to eq("Ubicloud - #{lb.name}")
-        expect(page).to have_content "VM is attached"
+        expect(page).to have_flash_notice("VM is attached to the load balancer")
         expect(lb.vms.count).to eq(1)
 
         visit "#{project.path}#{lb.path}"
@@ -277,7 +277,7 @@ RSpec.describe Clover, "load balancer" do
         click_button "Detach"
 
         expect(page.title).to eq("Ubicloud - #{lb.name}")
-        expect(page).to have_content "VM is detached"
+        expect(page).to have_flash_notice("VM is detached from the load balancer")
         expect(Strand.where(prog: "Vnet::LoadBalancerHealthProbes").all.count { |st| st.stack[0]["subject_id"] == lb.id && st.stack[0]["vm_id"] == vm.id }).to eq(0)
         expect(lb.update_load_balancer_set?).to be(true)
         expect(lb.load_balancers_vms_dataset.where(vm_id: vm.id).first.state).to eq("detaching")

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Clover, "private subnet" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' will be ready in a few seconds"
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few seconds")
         expect(PrivateSubnet.count).to eq(1)
         expect(PrivateSubnet.first.projects.first.id).to eq(project.id)
       end
@@ -93,7 +93,7 @@ RSpec.describe Clover, "private subnet" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - Create Private Subnet")
-        expect(page).to have_content "name is already taken"
+        expect(page).to have_flash_error("project_id and name is already taken")
       end
     end
 

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Clover, "billing" do
       click_button "Add new billing information"
 
       expect(page.status_code).to eq(200)
-      expect(page).to have_content("We couldn't pre-authorize your card for verification. Please make sure it can be pre-authorized up to $5 or contact our support team at support@ubicloud.com.")
+      expect(page).to have_flash_error("We couldn't pre-authorize your card for verification. Please make sure it can be pre-authorized up to $5 or contact our support team at support@ubicloud.com.")
     end
 
     it "can update billing info" do
@@ -141,7 +141,7 @@ RSpec.describe Clover, "billing" do
       click_button "Update"
 
       expect(page.status_code).to eq(200)
-      expect(find_by_id("flash-error").text).to eq("Invalid email address: test@test.com")
+      expect(page).to have_flash_error("Invalid email address: test@test.com")
     end
 
     it "can add new payment method" do
@@ -185,7 +185,7 @@ RSpec.describe Clover, "billing" do
       expect(page.title).to eq("Ubicloud - Project Billing")
       expect(billing_info.payment_methods.count).to eq(1)
       expect(page).to have_content "Visa"
-      expect(page).to have_content("Payment method you added is labeled as fraud. Please contact support.")
+      expect(page).to have_flash_error("Payment method you added is labeled as fraud. Please contact support.")
     end
 
     it "raises not found when payment method not exists" do

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Clover, "github" do
 
       expect(page.status_code).to eq(200)
       expect(page.title).to eq("Ubicloud - GitHub Runner Settings")
-      expect(page).to have_content "Project doesn't have valid billing information"
+      expect(page).to have_flash_error("Project doesn't have valid billing information")
     end
 
     it "shows new billing info button instead of connect account if project has no valid payment method" do
@@ -194,7 +194,7 @@ RSpec.describe Clover, "github" do
       expect(page.status_code).to eq(204)
 
       visit "#{project.path}/github/cache"
-      expect(page).to have_content "Cache '#{entry.key}' deleted"
+      expect(page).to have_flash_notice("Cache '#{entry.key}' deleted.")
     end
 
     it "raises not found when cache entry not exists" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Clover, "postgres" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(PostgresResource.count).to eq(1)
         expect(PostgresResource.first.projects.first.id).to eq(project.id)
       end
@@ -109,7 +109,7 @@ RSpec.describe Clover, "postgres" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(PostgresResource.count).to eq(1)
         expect(PostgresResource.first.projects.first.id).to eq(project.id)
       end
@@ -136,7 +136,7 @@ RSpec.describe Clover, "postgres" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
-        expect(page).to have_content "name is already taken"
+        expect(page).to have_flash_error("name is already taken")
       end
 
       it "can not select invisible location" do
@@ -235,7 +235,7 @@ RSpec.describe Clover, "postgres" do
         click_button "Reset"
 
         expect(page.status_code).to eq(400)
-        expect(page).to have_content "Superuser password cannot be updated during restore!"
+        expect(page).to have_flash_error("Superuser password cannot be updated during restore!")
       end
 
       it "can restart PostgreSQL database" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Clover, "project" do
 
         expect(page).to have_content user.email
         expect(page).to have_content new_email
-        expect(page).to have_content "Invitation sent successfully to '#{new_email}'."
+        expect(page).to have_flash_notice(/Invitation sent successfully to '#{new_email}'.*/)
         expect(page).to have_select("invitation_policies[#{new_email}]", selected: "Admin")
         expect(Mail::TestMailer.deliveries.length).to eq 1
         expect(ProjectInvitation.where(email: new_email).count).to eq 1
@@ -227,7 +227,7 @@ RSpec.describe Clover, "project" do
         fill_in "Email", with: new_email.downcase
         click_button "Invite"
 
-        expect(page).to have_content "'#{new_email.downcase}' already invited to join the project."
+        expect(page).to have_flash_error("'#{new_email.downcase}' already invited to join the project.")
       end
 
       it "can remove user from project" do
@@ -256,7 +256,7 @@ RSpec.describe Clover, "project" do
 
         visit "#{project.path}/user"
         expect(page).to have_content user.email
-        expect(page.find_by_id("flash-notice").text).to eq("Removed #{user2.email} from #{project.name}")
+        expect(page).to have_flash_notice("Removed #{user2.email} from #{project.name}")
 
         visit "#{project.path}/user"
         expect(page).to have_content user.email
@@ -289,7 +289,7 @@ RSpec.describe Clover, "project" do
           select "Member", from: "user_policies[#{user.ubid}]"
           click_button "Update"
         end
-        expect(page).to have_content "The project must have at least one admin"
+        expect(page).to have_flash_error("The project must have at least one admin.")
         expect(page).to have_select("user_policies[#{user.ubid}]", selected: "Admin")
       end
 
@@ -306,7 +306,7 @@ RSpec.describe Clover, "project" do
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
         visit "#{project.path}/user"
-        expect(page.find_by_id("flash-notice").text).to eq("Invitation for '#{invited_email}' is removed successfully.")
+        expect(page).to have_flash_notice("Invitation for '#{invited_email}' is removed successfully.")
 
         visit "#{project.path}/user"
         expect(page).to have_no_content invited_email
@@ -340,7 +340,7 @@ RSpec.describe Clover, "project" do
         click_button "Invite"
 
         expect(page).to have_no_content "new@example.com"
-        expect(page).to have_content "You can't have more than 50 pending invitations"
+        expect(page).to have_flash_error("You can't have more than 50 pending invitations.")
       end
 
       it "raises bad request when it's the last user" do

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -39,6 +39,33 @@ RSpec.configure do |config|
     Capybara.reset_sessions!
     Capybara.use_default_driver
   end
+
+  def flash_message_matcher(expected_type, expected_message)
+    match do |page|
+      actual_message = page.find_by_id("flash-#{expected_type}").text
+      if expected_message.is_a?(String)
+        actual_message == expected_message
+      else
+        actual_message =~ expected_message
+      end
+    end
+
+    failure_message do |page|
+      <<~MESSAGE
+        #{"expected: ".rjust(16)}#{expected_type} - #{expected_message}
+        #{"actual error: ".rjust(16)}#{page.has_css?("#flash-error") ? page.find_by_id("flash-error").text : "(no error message)"}
+        #{"actual notice: ".rjust(16)}#{page.has_css?("#flash-notice") ? page.find_by_id("flash-notice").text : "(no notice message)"}
+      MESSAGE
+    end
+  end
+
+  RSpec::Matchers.define :have_flash_notice do |expected_message|
+    flash_message_matcher(:notice, expected_message)
+  end
+
+  RSpec::Matchers.define :have_flash_error do |expected_message|
+    flash_message_matcher(:error, expected_message)
+  end
 end
 
 def login(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)

--- a/spec/routes/web/token_spec.rb
+++ b/spec/routes/web/token_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Clover, "personal access token management" do
   end
 
   it "user page allows creating personal access tokens" do
-    expect(find_by_id("flash-notice").text).to include("Created personal access token with id ")
+    expect(page).to have_flash_notice("Created personal access token with id #{@api_key.ubid}")
 
     expect(ApiKey.count).to eq(1)
     expect(@api_key.owner_id).to eq(user.id)
@@ -38,7 +38,7 @@ RSpec.describe Clover, "personal access token management" do
     expect(ApiKey.all).to be_empty
     expect(access_tag_ds.all).to be_empty
     visit "#{project.path}/user/token"
-    expect(find_by_id("flash-notice").text).to eq("Personal access token deleted successfully")
+    expect(page).to have_flash_notice("Personal access token deleted successfully")
 
     page.driver.delete data_url, {_csrf:}
     expect(page.status_code).to eq(204)
@@ -53,7 +53,7 @@ RSpec.describe Clover, "personal access token management" do
       select "Admin", from: "token_policies[#{@api_key.ubid}]"
       click_button "Update Personal Access Token Policies"
     end
-    expect(find_by_id("flash-notice").text).to eq("Personal access token policies updated successfully.")
+    expect(page).to have_flash_notice("Personal access token policies updated successfully.")
     expect(page).to have_select("token_policies[#{@api_key.ubid}]", selected: "Admin")
     expect(Authorization.has_permission?(@api_key.id, "*", project.id)).to be(true)
   end

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Clover, "vm" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
         expect(Vm.first.projects.first.id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).not_to be_nil
@@ -98,7 +98,7 @@ RSpec.describe Clover, "vm" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
         expect(Vm.first.projects.first.id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).not_to be_nil
@@ -123,7 +123,7 @@ RSpec.describe Clover, "vm" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
         expect(Vm.first.projects.first.id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).to eq(ps.id)
@@ -147,7 +147,7 @@ RSpec.describe Clover, "vm" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
-        expect(page).to have_content "'#{name}' will be ready in a few minutes"
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
         expect(Vm.first.projects.first.id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).not_to eq(ps.id)
@@ -200,7 +200,7 @@ RSpec.describe Clover, "vm" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
-        expect(page).to have_content "name is already taken"
+        expect(page).to have_flash_error("project_id and name is already taken")
       end
 
       it "can not create virtual machine if project has no valid payment method" do


### PR DESCRIPTION
- **Show an error message when Stripe update fails**
  We don’t store any billing information or payment methods in our
  database. To update the billing method, we send a request to Stripe. I
  noticed a few failed requests that resulted in a 500 error. Instead of
  showing a 500 error, we can display the error message to the user.
  

- **Trim whitespace from billing email before sending**
  I noticed a few failed web requests caused by whitespace email address.
  
  Let's trim the email address before sending it to the API.
  

- **Add rspec helper for flash messages**
  We have many tests that check for flash messages. Currently, we search the whole page for the content or find it by a specific ID. To make it easier to test the exact content of flash messages, I added a spec helper.
  

Example failure message:

     Failure/Error: expect(page).to have_flash_notice("An email has been sent to you with a link to verify your account2")

             expected: notice - An email has been sent to you with a link to verify your account2
         actual error: (no error message)
        actual notice: An email has been sent to you with a link to verify your account
