### PR TITLE
Selectively run Load Balancer health probes for each stack

### DIFF
--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -24,7 +24,7 @@ class Clover
   def load_balancer_post(name)
     authorize("LoadBalancer:create", @project.id)
 
-    required_parameters = %w[private_subnet_id algorithm src_port dst_port health_check_protocol]
+    required_parameters = %w[private_subnet_id algorithm src_port dst_port health_check_protocol stack]
     required_parameters << "name" if web?
     optional_parameters = %w[health_check_endpoint]
     request_body_params = validate_request_params(required_parameters, optional_parameters)
@@ -38,6 +38,7 @@ class Clover
       ps.id,
       name:,
       algorithm: request_body_params["algorithm"],
+      stack: Validation.validate_load_balancer_stack(request_body_params["stack"]),
       src_port: Validation.validate_port(:src_port, request_body_params["src_port"]),
       dst_port: Validation.validate_port(:dst_port, request_body_params["dst_port"]),
       health_check_endpoint: request_body_params["health_check_endpoint"],
@@ -58,6 +59,7 @@ class Clover
     options.add_option(name: "description")
     options.add_option(name: "private_subnet_id", values: dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map { {value: _1.ubid, display_name: _1.name} })
     options.add_option(name: "algorithm", values: ["Round Robin", "Hash Based"].map { {value: _1.downcase.tr(" ", "_"), display_name: _1} })
+    options.add_option(name: "stack", values: [LoadBalancer::Stack::IPV4, LoadBalancer::Stack::IPV6, LoadBalancer::Stack::DUAL].map { {value: _1.downcase, display_name: _1.gsub("ip", "IP")} })
     options.add_option(name: "src_port")
     options.add_option(name: "dst_port")
     options.add_option(name: "health_check_endpoint")

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -99,6 +99,7 @@ module Validation
     unless [LoadBalancer::Stack::IPV4, LoadBalancer::Stack::IPV6, LoadBalancer::Stack::DUAL].include?(stack)
       fail ValidationFailed.new({stack: "\"#{stack}\" is not a valid load balancer stack option. Available options: #{LoadBalancer::Stack::IPV4}, #{LoadBalancer::Stack::IPV6}, #{LoadBalancer::Stack::DUAL}"})
     end
+    stack
   end
 
   def self.validate_os_user_name(os_user_name)

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -282,6 +282,9 @@ paths:
                 algorithm:
                   description: Algorithm of the Load Balancer
                   type: string
+                stack:
+                  description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
+                  type: string
                 dst_port:
                   description: Destination port for the Load Balancer
                   type: integer
@@ -714,6 +717,9 @@ paths:
                 algorithm:
                   description: Algorithm of the Load Balancer
                   type: string
+                stack:
+                  description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
+                  type: string
                 dst_port:
                   description: Destination port for the Load Balancer
                   type: integer
@@ -748,6 +754,9 @@ paths:
               properties:
                 algorithm:
                   description: Algorithm of the Load Balancer
+                  type: string
+                stack:
+                  description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
                   type: string
                 dst_port:
                   description: Destination port for the Load Balancer
@@ -1717,6 +1726,9 @@ components:
       properties:
         algorithm:
           description: Algorithm of the Load Balancer
+          type: string
+        stack:
+          description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
           type: string
         dst_port:
           description: Destination port for the Load Balancer

--- a/prog/vnet/load_balancer_health_probes.rb
+++ b/prog/vnet/load_balancer_health_probes.rb
@@ -8,20 +8,24 @@ class Prog::Vnet::LoadBalancerHealthProbes < Prog::Base
   end
 
   label def health_probe
-    response_code = begin
-      cmd = if load_balancer.health_check_protocol == "tcp"
-        "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{vm.nics.first.private_ipv4.network} #{load_balancer.dst_port} && echo 200 || echo 400"
-      else
-        "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer.dst_port}:#{vm.nics.first.private_ipv4.network} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{load_balancer.hostname}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
-      end
+    address_ipv4 = load_balancer.ipv4_enabled? ? vm.nics.first.private_ipv4.network : nil
+    address_ipv6 = load_balancer.ipv6_enabled? ? vm.ephemeral_net6.nth(2) : nil
 
-      vm.vm_host.sshable.cmd(cmd)
-    rescue
-      "500"
+    response_codes = [address_ipv4, address_ipv6].compact.map do |address|
+      cmd = if load_balancer.health_check_protocol == "tcp"
+        "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{address} #{load_balancer.dst_port} && echo 200 || echo 400"
+      else
+        "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer.dst_port}:#{(address.version == 6) ? "[#{address}]" : address} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{load_balancer.hostname}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
+      end
+      begin
+        vm.vm_host.sshable.cmd(cmd).strip
+      rescue
+        "500"
+      end
     end
 
     vm_state, vm_state_counter = load_balancer.load_balancers_vms_dataset.where(vm_id: vm.id).get([:state, :state_counter])
-    threshold, health_check = (response_code.to_i == 200) ?
+    threshold, health_check = response_codes.include?("200") ?
       [load_balancer.health_check_up_threshold, "up"] :
       [load_balancer.health_check_down_threshold, "down"]
     counter = (vm_state == health_check) ? vm_state_counter + 1 : 1

--- a/serializers/load_balancer.rb
+++ b/serializers/load_balancer.rb
@@ -7,6 +7,7 @@ class Serializers::LoadBalancer < Serializers::Base
       name: lb.name,
       hostname: lb.hostname,
       algorithm: lb.algorithm,
+      stack: lb.stack,
       health_check_endpoint: lb.health_check_endpoint,
       health_check_protocol: lb.health_check_protocol,
       src_port: lb.src_port,

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Clover, "load-balancer" do
         ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-1", location: "hetzner-fsn1").subject
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {
           private_subnet_id: ps.ubid,
+          stack: LoadBalancer::Stack::IPV4,
           src_port: "80", dst_port: "80",
           health_check_endpoint: "/up", algorithm: "round_robin",
           health_check_protocol: "http"
@@ -101,6 +102,7 @@ RSpec.describe Clover, "load-balancer" do
       it "invalid private_subnet_id" do
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/lb1", {
           private_subnet_id: "invalid",
+          stack: LoadBalancer::Stack::IPV6,
           src_port: "80", dst_port: "80",
           health_check_endpoint: "/up", algorithm: "round_robin",
           health_check_protocol: "http"

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -17,6 +17,7 @@
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "algorithm", type: "select", label: "Load Balancing Algorithm", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
+    {name: "stack", type: "select", label: "Stack", required: "required", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "forwarding_rule", type: "section", label: "Forwarding Rule", content: "Configures the routing of traffic from the load balancer to your virtual machines."},
     {name: "src_port", type: "number", label: "Load Balancer Port", required: "required", placeholder: "80", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-3 xl:col-end-2'>"},
     {name: "dst_port", type: "number", label: "Application Port", required: "required", placeholder: "80", opening_tag: "<div class='col-span-6 col-start-1 md:col-start-3 md:col-end-5 xl:col-start-2 xl:col-end-3'>"},

--- a/views/networking/load_balancer/show.erb
+++ b/views/networking/load_balancer/show.erb
@@ -27,6 +27,7 @@
           { escape: false }
         ],
         ["Algorithm", (@lb[:algorithm] == "round_robin") ? "Round Robin" : "Hash Based"],
+        ["Stack", @lb[:stack].gsub("ip", "IP")],
         ["Load Balancer Port", @lb[:src_port]],
         ["Application Port", @lb[:dst_port]],
         ["HTTP Health Check Endpoint", @lb[:health_check_endpoint]]


### PR DESCRIPTION
We had introduced stack option at the backend but we forgot to update the health probes accordingly. This PR fixes that.