### PR TITLE
Don't update server name for development hosts

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -14,7 +14,8 @@ class Prog::Vm::HostNexus < Prog::Base
         HetznerHost.create(server_identifier: hetzner_server_identifier) { _1.id = vmh.id }
         vmh.create_addresses
         vmh.set_data_center
-        vmh.set_server_name
+        # Avoid overriding custom server names for development hosts.
+        vmh.set_server_name unless Config.development?
       else
         Address.create(cidr: sshable_hostname, routed_to_host_id: vmh.id) { _1.id = vmh.id }
         AssignedHostAddress.create_with_id(ip: sshable_hostname, address_id: vmh.id, host_id: vmh.id)

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(st.subject.provider).to eq("hetzner")
       expect(st.subject.data_center).to eq("fsn1-dc14")
     end
+
+    it "does not set the server name in development" do
+      expect(Config).to receive(:development?).and_return(true)
+      expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
+      expect(Hosting::Apis).to receive(:pull_data_center).and_return("fsn1-dc14")
+      expect(Hosting::Apis).not_to receive(:set_server_name)
+
+      described_class.assemble("127.0.0.1", provider: "hetzner", hetzner_server_identifier: "1")
+    end
   end
 
   describe "#before_run" do


### PR DESCRIPTION
Followup from #2533 

Don't update server name in development environments to avoid overriding custom names.