### PR TITLE
Fix Subnet Nexus rekeying synchronisation issue

### DIFF
--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Prog::Vnet::NicNexus do
         private_subnet_id: "57afa8a7-2357-4012-9632-07fbe13a3133",
         name: "demonic"
       ).and_return(nic)
-      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait_setup").and_yield(Strand.new).and_return(Strand.new)
+      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait_allocation").and_yield(Strand.new).and_return(Strand.new)
       described_class.assemble(ps.id, ipv6_addr: "fd10:9b0b:6b4b:8fbb::/128", name: "demonic")
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Prog::Vnet::NicNexus do
         private_subnet_id: "57afa8a7-2357-4012-9632-07fbe13a3133",
         name: "demonic"
       ).and_return(nic)
-      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait_setup").and_yield(Strand.new).and_return(Strand.new)
+      expect(Strand).to receive(:create).with(prog: "Vnet::NicNexus", label: "wait_allocation").and_yield(Strand.new).and_return(Strand.new)
       described_class.assemble(ps.id, ipv4_addr: "10.0.0.12/32", name: "demonic")
     end
   end
@@ -63,6 +63,18 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(nx).to receive(:when_destroy_set?).and_yield
       expect(nx.strand).to receive(:label).and_return("destroy")
       expect { nx.before_run }.not_to hop("destroy")
+    end
+  end
+
+  describe "#wait_allocation" do
+    it "naps if nothing to do" do
+      expect(nx).to receive(:nic).and_return(instance_double(Nic, vm: instance_double(Vm, allocated_at: nil)))
+      expect { nx.wait_allocation }.to nap(5)
+    end
+
+    it "hops to wait_setup if allocated" do
+      expect(nx).to receive(:nic).and_return(instance_double(Nic, vm: instance_double(Vm, allocated_at: Time.now)))
+      expect { nx.wait_allocation }.to hop("wait_setup")
     end
   end
 


### PR DESCRIPTION
A recent bug report showed that when multiple VMs are provisioned, sometimes, the private subnet gets stuck in wait_inbound_setup. The main reason is that, when we start rekeying nics, we include all of the nics in wait_setup label. The problem with that is, sometimes the VM is not allocated just yet. If it's not allocated, its public ipv6 address is not set. Therefore, for tunnels that target this nic, RekeyNicTunnel prog errors out in subdivide_network method. To solve this, we add a new state to NicNexus to wait VM allocation, we jump to the next label only after the allocation is completed.