### PR TITLE
[openapi] fix a mis-tagged postgres firewall rule route

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -944,7 +944,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
       tags:
-        - Firewall Rule
+        - Postgres Firewall Rule
     get:
       operationId: getLocationPostgresFirewallRuleDetailsWithId
       summary: Get details of a Postgres firewall rule


### PR DESCRIPTION
Should fix API docs (when next regenerated) so that this route appears in the correct place.