### PR TITLE
Fix 500 for an invalid subnet for connect_subnet

### DIFF
--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -48,7 +48,7 @@ class Clover
           authorize("PrivateSubnet:disconnect", subnet.id)
           ps.disconnect_subnet(subnet)
           flash["notice"] = "#{subnet.name} will be disconnected in a few seconds"
-          ""
+          204
         end
       end
 

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -26,6 +26,11 @@ class Clover
         r.post "connect" do
           authorize("PrivateSubnet:connect", ps.id)
           subnet = PrivateSubnet.from_ubid(r.params["connected-subnet-ubid"])
+          unless subnet
+            flash["error"] = "Subnet to be connected not found"
+            r.redirect "#{@project.path}#{ps.path}"
+          end
+
           authorize("PrivateSubnet:connect", subnet.id)
           ps.connect_subnet(subnet)
           flash["notice"] = "#{subnet.name} will be connected in a few seconds"
@@ -35,6 +40,11 @@ class Clover
         r.post "disconnect", String do |disconnecting_ps_ubid|
           authorize("PrivateSubnet:disconnect", ps.id)
           subnet = PrivateSubnet.from_ubid(disconnecting_ps_ubid)
+          unless subnet
+            response.status = 400
+            next {error: {message: "Subnet to be disconnected not found"}}
+          end
+
           authorize("PrivateSubnet:disconnect", subnet.id)
           ps.disconnect_subnet(subnet)
           flash["notice"] = "#{subnet.name} will be disconnected in a few seconds"


### PR DESCRIPTION
## Fix 500 for an invalid subnet for connect_subnet
In case the passed private subnet id doesn't exist, we crash with 500.
This is not a good user experience. While this should never be the case
if the private subnet is picked from the list, it can be done via
inspect elements. Here, I am handling this scenario, too.

## Fix Private Subnet disconnect
Using redirect doesn't really work since we did not submit a form. We
need to return.