### PR TITLE
Handle case where have_flash_{error,notice} is called without being present

### DIFF
--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
 
   def flash_message_matcher(expected_type, expected_message)
     match do |page|
+      next false unless page.has_css?("#flash-#{expected_type}")
       actual_message = page.find_by_id("flash-#{expected_type}").text
       if expected_message.is_a?(String)
         actual_message == expected_message


### PR DESCRIPTION
Previously, the find_by_id in the match block would raise an exception, resulting rspec not displaying both the notice and error.