### PR TITLE
Enable AI Inference in UI by default

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -159,7 +159,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :inference_ui, :access_all_cache_scopes
+  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :access_all_cache_scopes
 end
 
 # Table: project

--- a/routes/project/inference_endpoint.rb
+++ b/routes/project/inference_endpoint.rb
@@ -2,13 +2,9 @@
 
 class Clover
   hash_branch(:project_prefix, "inference-endpoint") do |r|
-    r.web do
-      next unless @project.get_ff_inference_ui
-
-      r.get true do
-        @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.all)
-        view "inference/endpoint/index"
-      end
+    r.get web? do
+      @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.all)
+      view "inference/endpoint/index"
     end
   end
 end

--- a/routes/project/inference_playground.rb
+++ b/routes/project/inference_playground.rb
@@ -2,14 +2,10 @@
 
 class Clover
   hash_branch(:project_prefix, "inference-playground") do |r|
-    r.on web? do
-      next unless @project.get_ff_inference_ui
-
-      r.get true do
-        @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation"))
-        @inference_tokens = Serializers::InferenceToken.serialize(inference_token_ds.all)
-        view "inference/endpoint/playground"
-      end
+    r.get web? do
+      @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation"))
+      @inference_tokens = Serializers::InferenceToken.serialize(inference_token_ds.all)
+      view "inference/endpoint/playground"
     end
   end
 end

--- a/routes/project/inference_token.rb
+++ b/routes/project/inference_token.rb
@@ -3,8 +3,6 @@
 class Clover
   hash_branch(:project_prefix, "inference-token") do |r|
     r.web do
-      next unless @project.get_ff_inference_ui
-
       r.get true do
         @inference_tokens = Serializers::InferenceToken.serialize(inference_token_ds.all)
         view "inference/token/index"

--- a/spec/routes/web/inference_endpoint_spec.rb
+++ b/spec/routes/web/inference_endpoint_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe Clover, "inference-endpoint" do
 
   describe "feature enabled" do
     before do
-      project.set_ff_inference_ui(true)
-      project_wo_permissions.set_ff_inference_ui(true)
-      login
+      login(user.email)
     end
 
     it "can handle empty list of inference endpoints" do
@@ -57,18 +55,6 @@ RSpec.describe Clover, "inference-endpoint" do
 
       expect(page.title).to eq("Ubicloud - Inference Endpoints")
       expect(page).to have_no_content("e5-mistral-7b-it")
-    end
-  end
-
-  describe "feature disabled" do
-    before do
-      project.set_ff_inference_ui(false)
-      login(user.email)
-      visit "#{project.path}/inference-endpoint"
-    end
-
-    it "inference endpoint page is not accessible" do
-      expect(page.status_code).to eq(404)
     end
   end
 

--- a/spec/routes/web/inference_playground_spec.rb
+++ b/spec/routes/web/inference_playground_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe Clover, "inference-playground" do
 
   describe "feature enabled" do
     before do
-      project.set_ff_inference_ui(true)
-      project_wo_permissions.set_ff_inference_ui(true)
-      login
+      login(user.email)
     end
 
     it "can handle empty list of inference endpoints" do
@@ -55,15 +53,6 @@ RSpec.describe Clover, "inference-playground" do
 
       expect(page.title).to eq("Ubicloud - Playground")
       expect(page).to have_select("inference_token", selected: ApiKey.first.ubid)
-    end
-  end
-
-  describe "feature disabled" do
-    it "inference playground page is not accessible" do
-      project.set_ff_inference_ui(false)
-      login
-      visit "#{project.path}/inference-playground"
-      expect(page.status_code).to eq(404)
     end
   end
 

--- a/spec/routes/web/inference_token_spec.rb
+++ b/spec/routes/web/inference_token_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Clover, "inference-token" do
 
   describe "feature enabled" do
     before do
-      project.set_ff_inference_ui(true)
       login(user.email)
       visit "#{project.path}/inference-token"
       expect(ApiKey.all).to be_empty
@@ -46,18 +45,6 @@ RSpec.describe Clover, "inference-token" do
       expect(page.status_code).to eq(204)
       visit "#{project.path}/user/token"
       expect(page.html).not_to include("Inference token deleted successfully")
-    end
-  end
-
-  describe "feature disabled" do
-    before do
-      project.set_ff_inference_ui(false)
-      login(user.email)
-      visit "#{project.path}/inference-token"
-    end
-
-    it "inference token page is not accessible" do
-      expect(page.status_code).to eq(404)
     end
   end
 

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -48,17 +48,15 @@
                 icon: "hero-circle-stack"
               }
             ) %>
-            <% if @project.get_ff_inference_ui %>
-              <%== render(
-                "layouts/sidebar/item",
-                locals: {
-                  name: "AI Inference",
-                  url: "#{@project_data[:path]}/inference-endpoint",
-                  is_active: request.path.start_with?("#{@project_data[:path]}/inference"),
-                  icon: "tabler-robot"
-                }
-              ) %>
-            <% end %>
+            <%== render(
+              "layouts/sidebar/item",
+              locals: {
+                name: "AI Inference",
+                url: "#{@project_data[:path]}/inference-endpoint",
+                is_active: request.path.start_with?("#{@project_data[:path]}/inference"),
+                icon: "tabler-robot"
+              }
+            ) %>
           <% else %>
             <%== render(
               "layouts/sidebar/item",


### PR DESCRIPTION
This removes the `inference_ui` feature flag and shows `AI Inference` in the navigation sidebar to everyone.

![Screenshot 2025-01-08 at 11 16 25](https://github.com/user-attachments/assets/47ef45ec-0b5e-46d4-a0f2-8ca7fc595a85)
