### PR TITLE
Fix Nic label progress sync issue after VM allocation

### DIFF
--- a/model/nic.rb
+++ b/model/nic.rb
@@ -14,7 +14,7 @@ class Nic < Sequel::Model
   include SemaphoreMethods
 
   semaphore :destroy, :start_rekey, :trigger_outbound_update,
-    :old_state_drop_trigger, :setup_nic, :repopulate, :lock
+    :old_state_drop_trigger, :setup_nic, :repopulate, :lock, :vm_allocated
 
   plugin :column_encryption do |enc|
     enc.column :encryption_key

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -197,6 +197,7 @@ class Prog::Vm::Nexus < Prog::Base
       nap 30
     end
 
+    vm.nics.each(&:incr_vm_allocated)
     decr_waiting_for_capacity
     if (page = Page.from_tag_parts("NoCapacity", vm.location, vm.arch, vm.family)) && page.created_at < Time.now - 15 * 60 && queued_vms.count <= 1
       page.incr_resolve

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -27,13 +27,14 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_allocation
-    if nic.vm.allocated_at
+    when_vm_allocated_set? do
       hop_wait_setup
     end
     nap 5
   end
 
   label def wait_setup
+    decr_vm_allocated
     when_start_rekey_set? do
       decr_setup_nic
       hop_start_rekey

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -68,22 +68,23 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#wait_allocation" do
     it "naps if nothing to do" do
-      expect(nx).to receive(:nic).and_return(instance_double(Nic, vm: instance_double(Vm, allocated_at: nil)))
       expect { nx.wait_allocation }.to nap(5)
     end
 
     it "hops to wait_setup if allocated" do
-      expect(nx).to receive(:nic).and_return(instance_double(Nic, vm: instance_double(Vm, allocated_at: Time.now)))
+      expect(nx).to receive(:when_vm_allocated_set?).and_yield
       expect { nx.wait_allocation }.to hop("wait_setup")
     end
   end
 
   describe "#wait_setup" do
     it "naps if nothing to do" do
+      expect(nx).to receive(:decr_vm_allocated)
       expect { nx.wait_setup }.to nap(5)
     end
 
     it "starts rekeying if setup is triggered" do
+      expect(nx).to receive(:decr_vm_allocated)
       expect(nx).to receive(:when_start_rekey_set?).and_yield
       expect(nx).to receive(:decr_setup_nic)
       expect { nx.wait_setup }.to hop("start_rekey")


### PR DESCRIPTION
We were using vm's allocated_at field to progress NicNexus to the next label. This is problemmatic because VM can get allocated and subnet can be triggered to rekey before nic strand switches states because of nap
5. Semaphores on the other hand, wakes the strand up the moment it is incremented. Therefore, the new way simply switches the state before subnet gets the signal.