### PR TITLE
Fix default value for classes in the icon component

### DIFF
--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -1,6 +1,5 @@
-<%# locals: (name:, classes: "") %>
+<%# locals: (name:, classes: "w-6 h-6") %>
 
-<% classes ||= "w-6 h-6" %>
 <% case name %>
 <% when "hero-arrow-up-right" %>
   <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="<%= classes %>">


### PR DESCRIPTION
Recently, we started using fixed locals at 73149c4.

Interestingly, the current default value definition for the `classes` variable in `icon.erb` is broken.

If the page has multiple icons, the icons after the first one are not rendered correctly.


![CleanShot 2025-01-08 at 18 32 47@2x](https://github.com/user-attachments/assets/4c12a081-fdef-4d30-9dea-9b527833d5e0)

![CleanShot 2025-01-08 at 18 33 24@2x](https://github.com/user-attachments/assets/d5058de5-52d0-4ea7-b997-e8360736d29b)

![CleanShot 2025-01-08 at 18 35 08@2x](https://github.com/user-attachments/assets/e8b7a535-3aaf-4c05-ad02-488b46e7a1a6)
