### PR TITLE
Rename reset to reimage to avoid confusion with hetzner's own reset api.

### DIFF
--- a/lib/hosting/apis.rb
+++ b/lib/hosting/apis.rb
@@ -10,9 +10,9 @@ class Hosting::Apis
     end
   end
 
-  def self.reset_server(vm_host)
+  def self.reimage_server(vm_host)
     if vm_host.provider == HetznerHost::PROVIDER_NAME
-      vm_host.hetzner_host.api.reset(vm_host.hetzner_host.server_identifier)
+      vm_host.hetzner_host.api.reimage(vm_host.hetzner_host.server_identifier)
     else
       raise "unknown provider #{vm_host.provider}"
     end

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -6,7 +6,7 @@ class Hosting::HetznerApis
     @host = hetzner_host
   end
 
-  def reset(server_id, hetzner_ssh_key: Config.hetzner_ssh_key, dist: "Ubuntu 22.04.2 LTS base")
+  def reimage(server_id, hetzner_ssh_key: Config.hetzner_ssh_key, dist: "Ubuntu 22.04.2 LTS base")
     unless hetzner_ssh_key
       raise "hetzner_ssh_key is not set"
     end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -239,12 +239,12 @@ class VmHost < Sequel::Model
     Hosting::Apis.set_server_name(self)
   end
 
-  def reset
+  def reimage
     unless Config.development?
-      fail "BUG: reset is only allowed in development"
+      fail "BUG: reimage is only allowed in development"
     end
 
-    Hosting::Apis.reset_server(self)
+    Hosting::Apis.reimage_server(self)
   end
 
   def init_health_monitor_session

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -45,20 +45,20 @@ class Prog::Test::HetznerServer < Prog::Test::Base
     hetzner_api.add_key("ubicloud_ci_key_#{strand.ubid}", keypair.public_key)
     update_stack({"hetzner_ssh_keypair" => Base64.encode64(keypair.keypair)})
 
-    hop_reset
+    hop_reimage
   end
 
-  label def reset
-    hetzner_api.reset(
+  label def reimage
+    hetzner_api.reimage(
       frame["server_id"],
       hetzner_ssh_key: hetzner_ssh_keypair.public_key,
       dist: "Ubuntu 24.04 LTS base"
     )
 
-    hop_wait_reset
+    hop_wait_reimage
   end
 
-  label def wait_reset
+  label def wait_reimage
     begin
       Util.rootish_ssh(frame["hostname"], "root", [hetzner_ssh_keypair.private_key], "echo 1")
     rescue

--- a/spec/lib/hosting/apis_spec.rb
+++ b/spec/lib/hosting/apis_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe Hosting::Apis do
     end
   end
 
-  describe "reset_server" do
-    it "can reset a server" do
-      expect(hetzner_apis).to receive(:reset).with(123).and_return(true)
-      described_class.reset_server(vm_host)
+  describe "reimage_server" do
+    it "can reimage a server" do
+      expect(hetzner_apis).to receive(:reimage).with(123).and_return(true)
+      described_class.reimage_server(vm_host)
     end
 
     it "raises an error if the provider is unknown" do
       expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
-      expect { described_class.reset_server(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
+      expect { described_class.reimage_server(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
     end
   end
 

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -11,30 +11,30 @@ RSpec.describe Hosting::HetznerApis do
   let(:hetzner_host) { instance_double(HetznerHost, connection_string: "https://robot-ws.your-server.de", server_identifier: "123", user: "user1", password: "pass", vm_host: vm_host) }
   let(:hetzner_apis) { described_class.new(hetzner_host) }
 
-  describe "reset" do
-    it "can reset a server" do
+  describe "reimage" do
+    it "can reimage a server" do
       expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 200, body: ""})
       Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 200, body: ""})
-      expect(hetzner_apis.reset(123)).to be_nil
+      expect(hetzner_apis.reimage(123)).to be_nil
     end
 
-    it "raises an error if the reset fails" do
+    it "raises an error if the reimage fails" do
       expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 200, body: ""})
       Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 400, body: ""})
-      expect { hetzner_apis.reset(123) }.to raise_error Excon::Error::BadRequest
+      expect { hetzner_apis.reimage(123) }.to raise_error Excon::Error::BadRequest
     end
 
     it "raises an error if the ssh key is not set" do
       expect(Config).to receive(:hetzner_ssh_key).and_return(nil)
-      expect { hetzner_apis.reset(123) }.to raise_error RuntimeError, "hetzner_ssh_key is not set"
+      expect { hetzner_apis.reimage(123) }.to raise_error RuntimeError, "hetzner_ssh_key is not set"
     end
 
     it "raises an error if the boot fails" do
       expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 400, body: ""})
-      expect { hetzner_apis.reset(123) }.to raise_error Excon::Error::BadRequest
+      expect { hetzner_apis.reimage(123) }.to raise_error Excon::Error::BadRequest
     end
   end
 

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -211,17 +211,17 @@ RSpec.describe VmHost do
     vh.hetznerify("12")
   end
 
-  it "reset server fails for non development" do
+  it "reimage server fails for non development" do
     expect(Config).to receive(:development?).and_return(false)
     expect {
-      vh.reset
-    }.to raise_error(RuntimeError, "BUG: reset is only allowed in development")
+      vh.reimage
+    }.to raise_error(RuntimeError, "BUG: reimage is only allowed in development")
   end
 
-  it "resets the server in development" do
+  it "reimages the server in development" do
     expect(Config).to receive(:development?).and_return(true)
-    expect(Hosting::Apis).to receive(:reset_server).with(vh)
-    vh.reset
+    expect(Hosting::Apis).to receive(:reimage_server).with(vh)
+    vh.reimage
   end
 
   it "create_addresses fails if a failover ip of non existent server is being added" do

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -53,26 +53,26 @@ RSpec.describe Prog::Test::HetznerServer do
   describe "#add_ssh_key" do
     it "can add ssh key" do
       expect(hetzner_api).to receive(:add_key)
-      expect { hs_test.add_ssh_key }.to hop("reset")
+      expect { hs_test.add_ssh_key }.to hop("reimage")
     end
   end
 
-  describe "#reset" do
-    it "can reset" do
-      expect(hetzner_api).to receive(:reset).with("1234", dist: "Ubuntu 24.04 LTS base", hetzner_ssh_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbDGrHrzWaxywYEtpDaJZCw5gEFUsO1BZ7+B/c1E3IH")
-      expect { hs_test.reset }.to hop("wait_reset")
+  describe "#reimage" do
+    it "can reimage" do
+      expect(hetzner_api).to receive(:reimage).with("1234", dist: "Ubuntu 24.04 LTS base", hetzner_ssh_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbDGrHrzWaxywYEtpDaJZCw5gEFUsO1BZ7+B/c1E3IH")
+      expect { hs_test.reimage }.to hop("wait_reimage")
     end
   end
 
-  describe "#wait_reset" do
+  describe "#wait_reimage" do
     it "hops to setup_host if the server is up" do
       expect(Util).to receive(:rootish_ssh)
-      expect { hs_test.wait_reset }.to hop("setup_host")
+      expect { hs_test.wait_reimage }.to hop("setup_host")
     end
 
     it "naps if the server is not up yet" do
       expect(Util).to receive(:rootish_ssh).and_raise RuntimeError, "ssh failed"
-      expect { hs_test.wait_reset }.to nap(15)
+      expect { hs_test.wait_reimage }.to nap(15)
     end
   end
 

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -99,7 +99,7 @@ module ThawedMock
   allow_mocking(BillingRate, :from_resource_properties)
   allow_mocking(Clog, :emit)
   allow_mocking(CloudflareClient, :new)
-  allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reset_server, :set_server_name)
+  allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :set_server_name)
   allow_mocking(Minio::Client, :new)
   allow_mocking(Minio::Crypto, :new)
   allow_mocking(Scheduling::Allocator, :allocate)


### PR DESCRIPTION
Rename reset to factory_reset in hetzner api lib. This avoids confusion with the reset method in the hetzner REST api, which does hardware reset.