### PR TITLE
Automate host SSH key setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,6 +112,8 @@ jobs:
         GITHUB_CACHE_BLOB_STORAGE_API_KEY: ${{ secrets.GH_CACHE_BLOB_STORAGE_API_KEY }}
         VM_POOL_PROJECT_ID: ${{ secrets.VM_POOL_PROJECT_ID }}
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
+        HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+        HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
       run: timeout 40m foreman start
 
     - name: Send notification if failed

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,7 +112,7 @@ jobs:
         GITHUB_CACHE_BLOB_STORAGE_API_KEY: ${{ secrets.GH_CACHE_BLOB_STORAGE_API_KEY }}
         VM_POOL_PROJECT_ID: ${{ secrets.VM_POOL_PROJECT_ID }}
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
-        HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+        HETZNER_SSH_PUBLIC_KEY: ${{ secrets.HETZNER_SSH_PUBLIC_KEY }}
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
       run: timeout 40m foreman start
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -489,7 +489,9 @@ We show cloudifying a host from Hetzner, but the principles should work everywhe
     ```ruby
     ENV["HETZNER_USER"] ||= HETZNER_ACCOUNT_ID 
     ENV["HETZNER_PASSWORD"] ||= HETZNER_ACCOUNT_PASS
-    ENV["HETZNER_SSH_KEY"] ||= YOUR_PUBLIC_SSH_KEY
+    ENV["HETZNER_SSH_PUBLIC_KEY"] ||= YOUR_PUBLIC_SSH_KEY
+    ENV["HETZNER_SSH_PRIVATE_KEY"] ||= YOUR_PRIVATE_SSH_KEY
+    ENV["OPERATOR_SSH_PUBLIC_KEYS"] ||= YOUR_PUBLIC_SSH_KEY\nOTHER_PUBLIC_SSH_KEYS
     ```
 
 2. In **terminal 1**, start the respirate process:
@@ -507,14 +509,7 @@ We show cloudifying a host from Hetzner, but the principles should work everywhe
     vmh = st.subject
     ```
 
-4. Get and copy the public key used by Clover
-    ```ruby
-    pub_key = vmh.sshable.keys.map(&:public_key)
-    ```
-
-5. In **terminal 3**, connect to the host via `ssh root@VM_HOST_IP` and paste the public key you obtained into `~/.ssh/authorized_keys`. After that, you can exit the host.
-
-6. Get back to **terminal 2** and observe `VmHost` cloudification process
+4. Get back to **terminal 2** and observe `VmHost` cloudification process
     ```ruby
     while true
       lbl = vmh.strand.reload.label

--- a/config.rb
+++ b/config.rb
@@ -92,7 +92,7 @@ module Config
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)
-  override :hetzner_ssh_key, string
+  override :hetzner_ssh_public_key, string
   override :minimum_invoice_charge_threshold, 0.5, float
   optional :cloudflare_turnstile_site_key, string
   optional :cloudflare_turnstile_secret_key, string

--- a/config.rb
+++ b/config.rb
@@ -54,6 +54,9 @@ module Config
   optional :omniauth_github_secret, string, clear: true
   optional :omniauth_google_id, string, clear: true
   optional :omniauth_google_secret, string, clear: true
+  optional :hetzner_ssh_private_key, string, clear: true
+  optional :hetzner_ssh_private_key_passphrase, string, clear: true
+  optional :operator_ssh_public_keys, string
 
   # :nocov:
   override :mail_driver, (production? ? :smtp : :logger), symbol

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -6,12 +6,12 @@ class Hosting::HetznerApis
     @host = hetzner_host
   end
 
-  def reimage(server_id, hetzner_ssh_key: Config.hetzner_ssh_key, dist: "Ubuntu 22.04.2 LTS base")
-    unless hetzner_ssh_key
-      raise "hetzner_ssh_key is not set"
+  def reimage(server_id, hetzner_ssh_public_key: Config.hetzner_ssh_public_key, dist: "Ubuntu 22.04.2 LTS base")
+    unless hetzner_ssh_public_key
+      raise "hetzner_ssh_public_key is not set"
     end
 
-    key_data = hetzner_ssh_key.split(" ")[1]
+    key_data = hetzner_ssh_public_key.split(" ")[1]
     decoded_data = Base64.decode64(key_data)
     fingerprint = OpenSSL::Digest::MD5.new(decoded_data).hexdigest
     formatted_fingerprint = fingerprint.scan(/../).join(":")

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -13,26 +13,26 @@ RSpec.describe Hosting::HetznerApis do
 
   describe "reimage" do
     it "can reimage a server" do
-      expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
+      expect(Config).to receive(:hetzner_ssh_public_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 200, body: ""})
       Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 200, body: ""})
       expect(hetzner_apis.reimage(123)).to be_nil
     end
 
     it "raises an error if the reimage fails" do
-      expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
+      expect(Config).to receive(:hetzner_ssh_public_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 200, body: ""})
       Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 400, body: ""})
       expect { hetzner_apis.reimage(123) }.to raise_error Excon::Error::BadRequest
     end
 
     it "raises an error if the ssh key is not set" do
-      expect(Config).to receive(:hetzner_ssh_key).and_return(nil)
-      expect { hetzner_apis.reimage(123) }.to raise_error RuntimeError, "hetzner_ssh_key is not set"
+      expect(Config).to receive(:hetzner_ssh_public_key).and_return(nil)
+      expect { hetzner_apis.reimage(123) }.to raise_error RuntimeError, "hetzner_ssh_public_key is not set"
     end
 
     it "raises an error if the boot fails" do
-      expect(Config).to receive(:hetzner_ssh_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
+      expect(Config).to receive(:hetzner_ssh_public_key).and_return("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0").at_least(:once)
       Excon.stub({path: "/boot/123/linux", method: :post}, {status: 400, body: ""})
       expect { hetzner_apis.reimage(123) }.to raise_error Excon::Error::BadRequest
     end

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -46,20 +46,13 @@ RSpec.describe Prog::Test::HetznerServer do
   describe "#fetch_hostname" do
     it "can fetch hostname" do
       expect(hetzner_api).to receive(:get_main_ip4)
-      expect { hs_test.fetch_hostname }.to hop("add_ssh_key")
-    end
-  end
-
-  describe "#add_ssh_key" do
-    it "can add ssh key" do
-      expect(hetzner_api).to receive(:add_key)
-      expect { hs_test.add_ssh_key }.to hop("reimage")
+      expect { hs_test.fetch_hostname }.to hop("reimage")
     end
   end
 
   describe "#reimage" do
     it "can reimage" do
-      expect(hetzner_api).to receive(:reimage).with("1234", dist: "Ubuntu 24.04 LTS base", hetzner_ssh_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbDGrHrzWaxywYEtpDaJZCw5gEFUsO1BZ7+B/c1E3IH")
+      expect(hetzner_api).to receive(:reimage).with("1234", dist: "Ubuntu 24.04 LTS base")
       expect { hs_test.reimage }.to hop("wait_reimage")
     end
   end
@@ -158,9 +151,8 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.destroy }.to hop("finish")
     end
 
-    it "deletes key and vm host" do
+    it "deletes vm host" do
       expect(hs_test).to receive(:frame).and_return({"setup_host" => true})
-      expect(hetzner_api).to receive(:delete_key).with("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbDGrHrzWaxywYEtpDaJZCw5gEFUsO1BZ7+B/c1E3IH")
       expect(vm_host).to receive(:incr_destroy)
       expect { hs_test.destroy }.to hop("wait_vm_host_destroyed")
     end


### PR DESCRIPTION
## Description

* Automate setting up the host SSH key by using a configured key to establish the initial connection and adding the generated VM host key before preparing the host.
* Update E2E tests to avoid setting up a new SSH key in hetzner on every run.

## Tests
- [x] Unit tests
- [x] HostNexus run

## Rollout
- [x] Generate and add a `ubicloud_ci_key_root` to the CI Hetzner account (key added to 1pass)
- [x] Update GH actions secret to add `HETZNER_SSH_PUBLIC_KEY` and `HETZNER_SSH_PRIVATE_KEY`
- [ ] Update docs to have devs setup their private key in `.env.rb`, and add operational public keys in dev/prod
