### PR TITLE
Add hardware reset for vm host

### DIFF
--- a/lib/hosting/apis.rb
+++ b/lib/hosting/apis.rb
@@ -18,6 +18,18 @@ class Hosting::Apis
     end
   end
 
+  # Cuts power to a Server and starts it again. This forcefully stops it
+  # without giving the Server operating system time to gracefully stop. This
+  # may lead to data loss, it’s equivalent to pulling the power cord and
+  # plugging it in again. Reset should only be used when reboot does not work.
+  def self.hardware_reset_server(vm_host)
+    if vm_host.provider == HetznerHost::PROVIDER_NAME
+      vm_host.hetzner_host.api.reset(vm_host.hetzner_host.server_identifier)
+    else
+      raise "unknown provider #{vm_host.provider}"
+    end
+  end
+
   def self.pull_data_center(vm_host)
     if vm_host.provider == HetznerHost::PROVIDER_NAME
       vm_host.hetzner_host.api.pull_dc(vm_host.hetzner_host.server_identifier)

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -24,6 +24,15 @@ class Hosting::HetznerApis
     nil
   end
 
+  # Cuts power to a Server and starts it again. This forcefully stops it
+  # without giving the Server operating system time to gracefully stop. This
+  # may lead to data loss, it’s equivalent to pulling the power cord and
+  # plugging it in again. Reset should only be used when reboot does not work.
+  def reset(server_id, dist: "Ubuntu 22.04.2 LTS base")
+    create_connection.post(path: "/reset/#{server_id}", body: "type=hw", expects: 200)
+    nil
+  end
+
   def add_key(name, key)
     create_connection.post(path: "/key",
       body: URI.encode_www_form(name: name, data: key),

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -20,7 +20,7 @@ class VmHost < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :checkup, :reboot, :destroy
+  semaphore :checkup, :reboot, :hardware_reset, :destroy
 
   def host_prefix
     net6.netmask.prefix_len
@@ -245,6 +245,14 @@ class VmHost < Sequel::Model
     end
 
     Hosting::Apis.reimage_server(self)
+  end
+
+  # Cuts power to a Server and starts it again. This forcefully stops it
+  # without giving the Server operating system time to gracefully stop. This
+  # may lead to data loss, it’s equivalent to pulling the power cord and
+  # plugging it in again. Reset should only be used when reboot does not work.
+  def hardware_reset
+    Hosting::Apis.hardware_reset_server(self)
   end
 
   def init_health_monitor_session

--- a/spec/lib/hosting/apis_spec.rb
+++ b/spec/lib/hosting/apis_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe Hosting::Apis do
     end
   end
 
+  describe "hardware_reset_server" do
+    it "can hardware reset a server" do
+      expect(hetzner_apis).to receive(:reset).with(123).and_return(true)
+      described_class.hardware_reset_server(vm_host)
+    end
+
+    it "raises an error if the provider is unknown" do
+      expect(vm_host).to receive(:provider).and_return("unknown").at_least(:once)
+      expect { described_class.hardware_reset_server(vm_host) }.to raise_error RuntimeError, "unknown provider unknown"
+    end
+  end
+
   describe "pull_dc" do
     it "can set dc of a server" do
       expect(hetzner_apis).to receive(:pull_dc).with(123).and_return("dc1")

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe Hosting::HetznerApis do
     end
   end
 
+  describe "reset" do
+    it "can reset a server" do
+      Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 200, body: ""})
+      expect(hetzner_apis.reset(123)).to be_nil
+    end
+
+    it "raises an error if the reset fails" do
+      Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 400, body: ""})
+      expect { hetzner_apis.reset(123) }.to raise_error Excon::Error::BadRequest
+    end
+  end
+
   describe "add_key" do
     it "can add a key" do
       key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ8Z9Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0"

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -224,6 +224,11 @@ RSpec.describe VmHost do
     vh.reimage
   end
 
+  it "hardware resets the server" do
+    expect(Hosting::Apis).to receive(:hardware_reset_server).with(vh)
+    vh.hardware_reset
+  end
+
   it "create_addresses fails if a failover ip of non existent server is being added" do
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
     expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -99,7 +99,7 @@ module ThawedMock
   allow_mocking(BillingRate, :from_resource_properties)
   allow_mocking(Clog, :emit)
   allow_mocking(CloudflareClient, :new)
-  allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :set_server_name)
+  allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :hardware_reset_server, :set_server_name)
   allow_mocking(Minio::Client, :new)
   allow_mocking(Minio::Crypto, :new)
   allow_mocking(Scheduling::Allocator, :allocate)


### PR DESCRIPTION
Calls the Hetzner API to perform a hardware host reset and then reboot. This enhances remote server management and recovery, particularly when the host is unresponsive.