### PR TITLE
Support VmHost#incr_graceful_reboot to gracefully reboot a host

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -20,7 +20,7 @@ class VmHost < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :checkup, :reboot, :hardware_reset, :destroy
+  semaphore :checkup, :reboot, :hardware_reset, :destroy, :graceful_reboot
 
   def host_prefix
     net6.netmask.prefix_len


### PR DESCRIPTION
In a graceful reboot, the host is set to draining, and when it no longer has any VMs, it transitions to reboot.  After the reboot, it is automatically put back in accepting state.