### PR TITLE
Enable 4x storage option for Postgres in US

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -91,7 +91,7 @@ class Clover
     options.add_option(name: "storage_size", values: ["64", "128", "256", "512", "1024", "2048", "4096"], parent: "size") do |flavor, location, size, storage_size|
       size = size.split("-").last.to_i
       lower_limit = [size * 32, 1024].min
-      upper_limit = (2**Math.log2(size).ceil) * ((location == "eu-central-h1") ? 128 : 64)
+      upper_limit = (2**Math.log2(size).ceil) * 128
       storage_size.to_i >= lower_limit && storage_size.to_i <= upper_limit
     end
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -71,8 +71,6 @@ module Option
     storage_size_options = [_2 * 32, _2 * 64, _2 * 128]
     storage_size_options.map! { |size| size / 15 * 16 } if [30, 60].include?(_2)
 
-    storage_size_options.pop if _1.name == "leaseweb-wdc02"
-
     storage_size_limiter = [4096, storage_size_options.last].min.fdiv(storage_size_options.last)
     storage_size_options.map! { |size| size * storage_size_limiter }
     [


### PR DESCRIPTION
We previously disabled the 4x storage option for Postgres in the US region. Now, with the introduction of new smallest size, new 2x option become equivalent to old 1x option. This change re-enables the option 4x option.