### PR TITLE
Aggregate invoice line items only for vm and ip address

### DIFF
--- a/serializers/invoice.rb
+++ b/serializers/invoice.rb
@@ -50,9 +50,7 @@ class Serializers::Invoice < Serializers::Base
                    }
                  end
                end.group_by { _1[:description] }.flat_map do |description, line_items|
-                 if line_items.count <= 5 || description.end_with?("GitHub Runner")
-                   line_items
-                 else
+                 if line_items.count > 100 && description.end_with?("Address", "Virtual Machine")
                    duration_sum = line_items.sum { _1[:duration] }
                    amount_sum = line_items.sum { _1[:amount] }
                    cost_sum = line_items.sum { _1[:cost] }
@@ -65,6 +63,8 @@ class Serializers::Invoice < Serializers::Base
                      cost_humanized: humanized_cost(cost_sum),
                      usage: BillingRate.line_item_usage(line_items.first["resource_type"], line_items.first["resource_family"], amount_sum, duration_sum)
                    }
+                 else
+                   line_items
                  end
                end.sort_by { _1[:name] }
       )

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Clover, "billing" do
       it "show invoice details" do
         expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}, "metadata" => {"company_name" => "Foo Companye Name"}}).at_least(:once)
         bi = billing_record(Time.parse("2023-06-01"), Time.parse("2023-07-01"))
-        10.times do
+        100.times do
           billing_record(Time.parse("2023-06-01"), Time.parse("2023-06-01") + 10)
         end
         InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true).run


### PR DESCRIPTION
This slightly changes the condition to aggregate line items on invoices. With this change, only virtual machine and ip address line items are aggregated, if an individual category surpasses 100 items.