### PR TITLE
Start using encryption for MinIO drives

### DIFF
--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -26,7 +26,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
         size: minio_pool.vm_size,
         storage_volumes: [
           {encrypted: true, size_gib: 30}
-        ] + Array.new(minio_pool.per_server_drive_count) { {encrypted: false, size_gib: (minio_pool.per_server_storage_size / minio_pool.per_server_drive_count).floor} },
+        ] + Array.new(minio_pool.per_server_drive_count) { {encrypted: true, size_gib: (minio_pool.per_server_storage_size / minio_pool.per_server_drive_count).floor} },
         boot_image: "ubuntu-jammy",
         enable_ip4: true,
         private_subnet_id: minio_pool.cluster.private_subnet.id,

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(Vm.first.unix_user).to eq "ubi"
       expect(Vm.first.sshable.host).to eq "temp_#{Vm.first.id}"
       expect(Vm.first.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
+
+      expect(Vm.first.strand.stack[0]["storage_volumes"].length).to eq 2
+      expect(Vm.first.strand.stack[0]["storage_volumes"][0]["encrypted"]).to be true
+      expect(Vm.first.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 30
+      expect(Vm.first.strand.stack[0]["storage_volumes"][1]["encrypted"]).to be true
+      expect(Vm.first.strand.stack[0]["storage_volumes"][1]["size_gib"]).to eq 100
     end
 
     it "fails if pool is not valid" do


### PR DESCRIPTION
At the time when we first introduced no-raid VM setup for MinIO servers, we did not have encryption support. Now, we do. So, we are starting to use the encryption for MinIO servers, too.