### PR TITLE
Remove postgres image override

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -163,7 +163,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :postgresql_base_image, :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :access_all_cache_scopes
+  feature_flag :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :access_all_cache_scopes
 end
 
 # Table: project

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -32,7 +32,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
           {encrypted: true, size_gib: 30},
           {encrypted: true, size_gib: postgres_resource.target_storage_size_gib}
         ],
-        boot_image: postgres_resource.project.get_ff_postgresql_base_image || boot_image,
+        boot_image: boot_image,
         private_subnet_id: postgres_resource.private_subnet_id,
         enable_ip4: true,
         exclude_host_ids: exclude_host_ids

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -56,7 +56,7 @@ class Clover
           fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered during restore!")
         end
 
-        unless @project.get_ff_postgresql_base_image
+        unless [PostgresResource::Flavor::LANTERN, PostgresResource::Flavor::PARADEDB].include?(pg.flavor)
           fail CloverError.new(400, "InvalidRequest", "Failover cannot be triggered for this resource!")
         end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "failover" do
-        project.set_ff_postgresql_base_image(true)
+        pg.flavor = PostgresResource::Flavor::PARADEDB
         pg.save_changes
         rs = pg.representative_server
         rs.update(timeline_access: "push")
@@ -275,7 +275,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "failover no standby" do
-        project.set_ff_postgresql_base_image(true)
+        pg.flavor = PostgresResource::Flavor::PARADEDB
         pg.save_changes
 
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"


### PR DESCRIPTION
We used to override the base postgres image based on the project flags, but we no longer need to do that. This commit removes the override.