### PR TITLE
Pass workflow run ID to e2e GitHub workflow

### DIFF
--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -149,7 +149,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   end
 
   def trigger_test_run(repo_name, workflow_name, branch_name)
-    client.workflow_dispatch(repo_name, workflow_name, branch_name)
+    client.workflow_dispatch(repo_name, workflow_name, branch_name, {inputs: {triggered_by: ENV["GITHUB_RUN_ID"]}})
   end
 
   def latest_run(repo_name, workflow_name, branch_name)

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe Prog::Test::GithubRunner do
     it "triggers test runs" do
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client)
-      expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main").and_return(true)
+      allow(ENV).to receive(:[]).and_call_original
+      expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
+      expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main", {inputs: {triggered_by: "12345"}}).and_return(true)
       expect(gr_test).to receive(:sleep).with(30)
       expect { gr_test.trigger_test_runs }.to hop("check_test_runs")
     end
@@ -78,7 +80,9 @@ RSpec.describe Prog::Test::GithubRunner do
     it "can not triggers test runs" do
       client = instance_double(Octokit::Client)
       expect(gr_test).to receive(:client).and_return(client)
-      expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main").and_return(false)
+      allow(ENV).to receive(:[]).and_call_original
+      expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
+      expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main", {inputs: {triggered_by: "12345"}}).and_return(false)
       expect { gr_test.trigger_test_runs }.to hop("clean_resources")
     end
   end


### PR DESCRIPTION
Since we run e2e tests every hour, it's hard to tell which run is which. This PR adds the workflow ID to the run name to make it easier to identify them.

It's optional, so you can still run the workflow without it.

https://github.com/ubicloud/github-e2e-test-workflows/pull/11