### PR TITLE
Install all gems in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update --no-cache && \
     apk add build-base git curl postgresql-dev --no-cache
 WORKDIR /app
 COPY Gemfile Gemfile.lock ./
-RUN bundle config set --local without development:test
+
 RUN bundle install
 
 


### PR DESCRIPTION
We previously installed only the production gems in the Docker image, but since it's used only for demo purposes and not for our production, we need all the gems.

Running the demo in development mode failed because some gems were missing.

     ubicloud-app          | 10:58:33 respirate.1 | /usr/local/bundle/gems/bundler-2.5.17/lib/bundler/definition.rb:601:in `materialize': Could not find awesome_print-1.9.2, by-1.1.0, pry-byebug-3.10.1, rackup-2.2.1, cuprite-0.15.1, sequel-annotate-1.7.0, byebug-11.1.3, capybara-3.40.0, ferrum-0.15, rack-test-2.2.0, xpath-3.2.0, webrick-1.9.1, websocket-driver-0.7.7, websocket-extensions-0.1.5 in locally installed gems (Bundler::GemNotFound)


So, we decided to install all gems in the Docker image since it's only for demo purposes.

I think it might be broken due to the change in
https://github.com/ubicloud/ubicloud/pull/2425, but I'm not sure.

Fixes #2575