### PR TITLE
Update docker base images to alpine 3.21

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.2.6
 postgres 15.8
-nodejs 23.2.0
+nodejs 23.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23.2-alpine3.19 AS frontend-builder
+FROM node:23.2-alpine3.21 AS frontend-builder
 WORKDIR /app
 COPY tailwind.config.js package.json package-lock.json ./
 COPY views/ ./views/
@@ -7,7 +7,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM ruby:3.2.6-alpine3.19 AS bundler
+FROM ruby:3.2.6-alpine3.21 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -19,7 +19,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM ruby:3.2.6-alpine3.19
+FROM ruby:3.2.6-alpine3.21
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23.2-alpine3.21 AS frontend-builder
+FROM node:23.6-alpine3.21 AS frontend-builder
 WORKDIR /app
 COPY tailwind.config.js package.json package-lock.json ./
 COPY views/ ./views/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "tailwindcss": "^3.4.17"
       },
       "engines": {
-        "node": "23.2.0",
-        "npm": "10.9.0"
+        "node": "23.6.0",
+        "npm": "10.9.2"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --watch"
   },
   "engines": {
-    "node": "23.2.0",
-    "npm": "10.9.0"
+    "node": "23.6.0",
+    "npm": "10.9.2"
   }
 }


### PR DESCRIPTION
- **Update base docker images from alpine 3.19 to 3.21**
  The new Node versions don't have docker images for alpine 3.19, so let's
  update to 3.21.
  

- **Update node from 23.2 to 23.6**
  Heroku supports it already
  
  https://github.com/heroku/heroku-buildpack-nodejs/pull/1363
  