### PR TITLE
Make DnsZone#delete_record not insert tombstoned records for already tombstoned records

### DIFF
--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -30,7 +30,7 @@ class DnsZone < Sequel::Model
     fail "Type needs to be specified if data is specified!" if data && type.nil?
 
     record_name = add_dot_if_missing(record_name)
-    records = records_dataset.where(name: record_name)
+    records = records_dataset.where(name: record_name, tombstoned: false)
     records = records.where(type: type) if type
     records = records.where(data: data) if data
 

--- a/spec/model/dns_zone/dns_zone_spec.rb
+++ b/spec/model/dns_zone/dns_zone_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe DnsZone do
       expect(dns_zone.records_dataset.where(:tombstoned).count).to eq(3)
     end
 
+    it "does not insert new tombstoned records for existing tombstoned records" do
+      4.times do
+        dns_zone.delete_record(record_name: "test1")
+      end
+      expect(dns_zone.records_dataset.where(:tombstoned).count).to eq(12)
+    end
+
     it "deletes all matching records from database when record_name and type are passed" do
       dns_zone.delete_record(record_name: "test1", type: "A")
       expect(dns_zone.records_dataset.where(:tombstoned).count).to eq(2)


### PR DESCRIPTION
Otherwise, you end up with exponential growth of tombstoned records if you repeatedly delete a record with the same name.