### PR TITLE
Improve validation logic for setting up DNS Server VM

### DIFF
--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -83,6 +83,7 @@ module ThawedMock
   # Progs
   allow_mocking(Prog::Ai::InferenceEndpointNexus, :assemble, :model_for_id)
   allow_mocking(Prog::Ai::InferenceEndpointReplicaNexus, :assemble)
+  allow_mocking(Prog::DnsZone::SetupDnsServerVm, :vms_in_sync?)
   allow_mocking(Prog::Github::DestroyGithubInstallation, :assemble)
   allow_mocking(Prog::PageNexus, :assemble)
   allow_mocking(Prog::Postgres::PostgresResourceNexus, :dns_zone)


### PR DESCRIPTION
This commit improves the validation logic of DNS Server VM setup.

1. Validate existing VMs in .assemble In case of any sync issues within the VMs of a DNS server, the prog fails earlier in the .assemble step to make investigation easier. We hit such a case, although it should be pretty rare.

2. Validation should ignore the serial number of SOA records as the number is incremented with every update and it's OK to see different values on different VMs.