### PR TITLE
Mark Finland as not visible

### DIFF
--- a/config/providers.yml
+++ b/config/providers.yml
@@ -4,7 +4,7 @@
     provider_internal_name: hetzner,
     locations: [
       {display_name: eu-central-h1, internal_name: hetzner-fsn1, ui_name: "Germany", visible: true },
-      {display_name: eu-north-h1, internal_name: hetzner-hel1, ui_name: "Finland", visible: true },
+      {display_name: eu-north-h1, internal_name: hetzner-hel1, ui_name: "Finland", visible: false },
       {display_name: github-runners, internal_name: github-runners, ui_name: "GithubRunner", visible: false },
       {display_name: hetzner-ai, internal_name: hetzner-ai, ui_name: "hetzner-ai", visible: false },
     ]


### PR DESCRIPTION
We plan on dropping support for the Helsinki region, so the first step is to stop advertising it as an option for new VMs.