### PR TITLE
Enable autofocus at otp input field

### DIFF
--- a/views/components/rodauth/otp_auth_code_field.erb
+++ b/views/components/rodauth/otp_auth_code_field.erb
@@ -7,7 +7,8 @@
     attributes: {
       required: true,
       autocomplete: "off",
-      inputmode: "numeric"
+      inputmode: "numeric",
+      autofocus: true
     }
   }
 ) %>


### PR DESCRIPTION
Closes #1316

I check that `autofocus="true"` is added whenever I enter an OTP authentication code, as shown below.

`<input id="otp" type="text" name="otp" value="" class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600 " required="true" autocomplete="off" inputmode="numeric" autofocus="true">`