### PR TITLE
Next steps in the switch from access_tag table to project_id columns

### DIFF
--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -33,7 +33,6 @@ class Clover
       location: @location,
       project_id: @project.id
     )
-    firewall.associate_with_project(@project)
 
     if api?
       Serializers::Firewall.serialize(firewall)

--- a/model/ai/inference_endpoint.rb
+++ b/model/ai/inference_endpoint.rb
@@ -26,10 +26,6 @@ class InferenceEndpoint < Sequel::Model
     "/location/#{display_location}/inference-endpoint/#{name}"
   end
 
-  def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{display_location}/inference-endpoint/#{name}"
-  end
-
   def display_state
     return "running" if ["wait"].include?(strand.label)
     return "deleting" if destroy_set? || strand.label == "destroy"

--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -15,10 +15,6 @@ class DnsZone < Sequel::Model
 
   semaphore :refresh_dns_servers
 
-  def hyper_tag_name(project)
-    "project/#{project.ubid}/dns-zone/#{ubid}"
-  end
-
   def insert_record(record_name:, type:, ttl:, data:)
     record_name = add_dot_if_missing(record_name)
     DnsRecord.create_with_id(dns_zone_id: id, name: record_name, type: type, ttl: ttl, data: data)

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -3,6 +3,7 @@
 require_relative "../model"
 
 class Firewall < Sequel::Model
+  many_to_one :project
   one_to_many :firewall_rules, key: :firewall_id
   many_to_many :private_subnets
 
@@ -11,9 +12,6 @@ class Firewall < Sequel::Model
   include ResourceMethods
   include Authorization::HyperTagMethods
   include ObjectTag::Cleanup
-  def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{display_location}/firewall/#{name}"
-  end
 
   dataset_module Pagination
 

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -3,6 +3,7 @@
 require_relative "../../model"
 
 class MinioCluster < Sequel::Model
+  many_to_one :project
   one_to_many :pools, key: :cluster_id, class: :MinioPool do |ds|
     ds.order(:start_index)
   end
@@ -22,14 +23,6 @@ class MinioCluster < Sequel::Model
     enc.column :admin_password
     enc.column :root_cert_key_1
     enc.column :root_cert_key_2
-  end
-
-  def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{display_location}/minio-cluster/#{name}"
-  end
-
-  def display_location
-    LocationNameConverter.to_display_name(location)
   end
 
   def generate_etc_hosts_entry

--- a/model/object_tag.rb
+++ b/model/object_tag.rb
@@ -33,10 +33,8 @@ class ObjectTag < Sequel::Model
 
   def self.valid_member?(project_id, object)
     case object
-    when ObjectTag, ObjectMetatag, SubjectTag, ActionTag, InferenceEndpoint
+    when ObjectTag, ObjectMetatag, SubjectTag, ActionTag, InferenceEndpoint, Vm, PrivateSubnet, PostgresResource, Firewall, LoadBalancer
       object.project_id == project_id
-    when Vm, PrivateSubnet, PostgresResource, Firewall, LoadBalancer
-      !AccessTag.where(project_id:, hyper_tag_id: object.id).empty?
     when Project
       object.id == project_id
     when ApiKey

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -39,10 +39,6 @@ class PostgresResource < Sequel::Model
     "/location/#{display_location}/postgres/#{name}"
   end
 
-  def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{display_location}/postgres/#{name}"
-  end
-
   def display_state
     return "unavailable" if representative_server&.strand&.label == "unavailable"
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -3,6 +3,7 @@
 require_relative "../model"
 
 class PrivateSubnet < Sequel::Model
+  many_to_one :project
   many_to_many :vms, join_table: :nic, left_key: :private_subnet_id, right_key: :vm_id
   one_to_many :nics, key: :private_subnet_id
   one_to_one :strand, key: :id
@@ -24,9 +25,6 @@ class PrivateSubnet < Sequel::Model
   dataset_module Pagination
   include Authorization::HyperTagMethods
   include ObjectTag::Cleanup
-  def hyper_tag_name(project)
-    "project/#{project.ubid}/location/#{display_location}/private-subnet/#{name}"
-  end
 
   def connected_subnets
     PrivateSubnet.where(

--- a/model/subject_tag.rb
+++ b/model/subject_tag.rb
@@ -36,8 +36,7 @@ class SubjectTag < Sequel::Model
     when Account
       !AccessTag.where(project_id:, hyper_tag_id: subject.id).empty?
     when ApiKey
-      subject.owner_table == "accounts" &&
-        !AccessTag.where(project_id:, hyper_tag_id: subject.owner_id).empty?
+      subject.owner_table == "accounts" && subject.project_id == project_id
     end
   end
 end

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -39,7 +39,7 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
 
   def self.assemble(project_id:, location:, boot_image:, name:, vm_size:, storage_volumes:, model_name:,
     engine:, engine_params:, replica_count:, is_public:, gpu_count:, tags:)
-    unless (project = Project[project_id])
+    unless Project[project_id]
       fail "No existing project"
     end
 
@@ -68,7 +68,6 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
         model_name:, engine:, engine_params:, replica_count:, is_public:,
         load_balancer_id: lb_s.id, private_subnet_id: subnet_s.id, gpu_count:, tags:
       ) { _1.id = ubid.to_uuid }
-      inference_endpoint.associate_with_project(project)
       Prog::Ai::InferenceEndpointReplicaNexus.assemble(inference_endpoint.id)
       Strand.create(prog: "Ai::InferenceEndpointNexus", label: "start") { _1.id = inference_endpoint.id }
     end

--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -7,7 +7,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
 
   def self.assemble(project_id, cluster_name, location, admin_user,
     storage_size_gib, pool_count, server_count, drive_count, vm_size)
-    unless (project = Project[project_id])
+    unless Project[project_id]
       fail "No existing project"
     end
 
@@ -38,7 +38,6 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
         root_cert_key_2: root_cert_key_2,
         project_id:
       ) { _1.id = ubid.to_uuid }
-      minio_cluster.associate_with_project(project)
 
       per_pool_server_count = server_count / pool_count
       per_pool_drive_count = drive_count / pool_count

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -14,7 +14,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
     ha_type: PostgresResource::HaType::NONE, parent_id: nil, restore_target: nil)
 
-    unless (project = Project[project_id])
+    unless Project[project_id]
       fail "No existing project"
     end
 
@@ -54,10 +54,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         superuser_password: superuser_password, ha_type: ha_type, version: version, flavor: flavor,
         parent_id: parent_id, restore_target: restore_target, hostname_version: "v2"
       )
-      postgres_resource.associate_with_project(project)
 
       firewall = Firewall.create_with_id(name: "#{postgres_resource.ubid}-firewall", location: location, description: "Postgres default firewall", project_id: Config.postgres_service_project_id)
-      firewall.associate_with_project(Project[Config.postgres_service_project_id])
 
       private_subnet_id = Prog::Vnet::SubnetNexus.assemble(Config.postgres_service_project_id, name: "#{postgres_resource.ubid}-subnet", location: location, firewall_id: firewall.id).id
       postgres_resource.update(private_subnet_id: private_subnet_id)

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -18,7 +18,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
         parent_id: parent_id,
         access_key: SecureRandom.hex(16),
         secret_key: SecureRandom.hex(32),
-        blob_storage_id: MinioCluster.where(location: location).all.find { _1.projects.map(&:id).include?(Config.postgres_service_project_id) }&.id
+        blob_storage_id: MinioCluster.first(project_id: Config.postgres_service_project_id, location: location)&.id
       )
       Strand.create(prog: "Postgres::PostgresTimelineNexus", label: "start") { _1.id = postgres_timeline.id }
     end

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -9,13 +9,10 @@ class Prog::Test::GithubRunner < Prog::Test::Base
 
   def self.assemble(vm_host_id, test_cases)
     github_service_project = Project.create(name: "Github-Runner-Service-Project") { _1.id = Config.github_runner_service_project_id }
-    github_service_project.associate_with_project(github_service_project)
 
     vm_pool_service_project = Project.create(name: "Vm-Pool-Service-Project") { _1.id = Config.vm_pool_project_id }
-    vm_pool_service_project.associate_with_project(vm_pool_service_project)
 
     github_test_project = Project.create_with_id(name: "Github-Runner-Test-Project")
-    github_test_project.associate_with_project(github_test_project)
     GithubInstallation.create_with_id(
       installation_id: Config.e2e_github_installation_id,
       name: "TestUser",

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -166,7 +166,7 @@ class Prog::Test::Vm < Prog::Test::Base
   end
 
   def vms_in_same_project
-    vm.projects.first.vms.filter { _1.id != vm.id }
+    vm.project.vms.filter { _1.id != vm.id }
   end
 
   def vms_with_same_subnet

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -24,7 +24,6 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def setup_vms
     project = Project.create_with_id(name: "project-1")
-    project.associate_with_project(project)
 
     subnet1_s = Prog::Vnet::SubnetNexus.assemble(
       project.id, name: "the-first-subnet", location: "hetzner-fsn1"

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -93,8 +93,6 @@ class Prog::Vm::Nexus < Prog::Base
         boot_image: boot_image, ip4_enabled: enable_ip4, pool_id: pool_id, arch: arch, project_id:) { _1.id = ubid.to_uuid }
       nic.update(vm_id: vm.id)
 
-      vm.associate_with_project(project)
-
       gpu_count = 1 if gpu_count == 0 && vm_size.gpu
       Strand.create(
         prog: "Vm::Nexus",
@@ -276,7 +274,7 @@ class Prog::Vm::Nexus < Prog::Base
   label def create_billing_record
     vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned") { [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: Time.now - vm.allocated_at}}] }
-    project = vm.projects.first
+    project = vm.project
     hop_wait unless project.billable
 
     BillingRecord.create_with_id(

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -32,7 +32,6 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
         custom_hostname: custom_hostname, custom_hostname_dns_zone_id: custom_hostname_dns_zone_id,
         stack: stack, project_id: ps.project_id
       )
-      lb.associate_with_project(ps.projects.first)
 
       Strand.create(prog: "Vnet::LoadBalancerNexus", label: "wait") { _1.id = lb.id }
     end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -21,7 +21,6 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     ipv4_range ||= random_private_ipv4(location, project).to_s
     DB.transaction do
       ps = PrivateSubnet.create(name: name, location: location, net6: ipv6_range, net4: ipv4_range, state: "waiting", project_id:) { _1.id = ubid.to_uuid }
-      ps.associate_with_project(project)
 
       firewall = if firewall_id
         existing_fw = project.firewalls_dataset.where(location: location).first(Sequel[:firewall][:id] => firewall_id)
@@ -30,7 +29,6 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       else
         port_range = allow_only_ssh ? 22..22 : 0..65535
         new_fw = Firewall.create_with_id(name: "#{name}-default", location: location, project_id:)
-        new_fw.associate_with_project(project)
         ["0.0.0.0/0", "::/0"].each { |cidr| FirewallRule.create_with_id(firewall_id: new_fw.id, cidr: cidr, port_range: Sequel.pg_range(port_range)) }
         new_fw
       end

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -60,7 +60,7 @@ class Clover
         else
           @nics = Serializers::Nic.serialize(ps.nics)
           @connected_subnets = Serializers::PrivateSubnet.serialize(ps.connected_subnets)
-          connectable_subnets = ps.projects.first.private_subnets.select do |ps1|
+          connectable_subnets = ps.project.private_subnets.select do |ps1|
             ps1_id = ps1.id
             ps1_id != ps.id && !ps.connected_subnets.find { |cs| cs.id == ps1_id }
           end

--- a/routes/project/token.rb
+++ b/routes/project/token.rb
@@ -6,7 +6,7 @@ class Clover
       authorize("Project:token", @project.id)
       token_ds = current_account
         .api_keys_dataset
-        .where(id: AccessTag.where(project_id: @project.id).select(:hyper_tag_id))
+        .where(project_id: @project.id)
         .reverse(:created_at)
 
       r.is do

--- a/spec/lib/access_control_model_tag_spec.rb
+++ b/spec/lib/access_control_model_tag_spec.rb
@@ -5,7 +5,6 @@
     let(:user) { Account.create_with_id(email: "auth1@example.com") }
     let(:project) do
       project = Project.create_with_id(name: "project-1")
-      project.associate_with_project(project)
       user.associate_with_project(project)
       project
     end

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -259,9 +259,6 @@ RSpec.describe Authorization do
   describe "#HyperTagMethods" do
     it "hyper_tag_name" do
       expect(users[0].hyper_tag_name).to eq("user/auth1@example.com")
-      p = vms[0].projects.first
-      expect(vms[0].hyper_tag_name(p)).to eq("project/#{p.ubid}/location/eu-central-h1/vm/vm0")
-      expect(projects[0].hyper_tag_name).to eq("project/#{projects[0].ubid}")
     end
 
     it "hyper_tag_name error" do

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe Pagination do
-  let(:project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+  let(:project) { Project.create_with_id(name: "default") }
 
   let!(:first_vm) do
     Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "dummy-vm-1").subject

--- a/spec/model/access_control_entry_spec.rb
+++ b/spec/model/access_control_entry_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe AccessControlEntry do
   it "enforces subject, action, and object are valid and related to project" do
     account = Account.create_with_id(email: "test@example.com", status_id: 2)
     project = Project.create_with_id(name: "Test")
-    project.associate_with_project(project)
     account.associate_with_project(project)
     project_id = project.id
 
@@ -26,7 +25,7 @@ RSpec.describe AccessControlEntry do
     expect(ace.valid?).to be false
     expect(ace.errors).to eq(subject_id: ["is not related to this project"])
 
-    ace.subject_id = ApiKey.create_personal_access_token(account).id
+    ace.subject_id = ApiKey.create_personal_access_token(account, project:).id
     expect(ace.valid?).to be true
 
     ace.subject_id = ApiKey.create_personal_access_token(account2).id
@@ -34,7 +33,6 @@ RSpec.describe AccessControlEntry do
     expect(ace.errors).to eq(subject_id: ["is not related to this project"])
 
     project2 = Project.create_with_id(name: "Test-2")
-    project2.associate_with_project(project2)
     account.associate_with_project(project2)
     ace.subject_id = SubjectTag.create_with_id(project_id: project2.id, name: "V").id
     expect(ace.valid?).to be false
@@ -70,7 +68,6 @@ RSpec.describe AccessControlEntry do
     expect(ace.errors).to eq(object_id: ["is not related to this project"])
 
     firewall.update(project_id: project.id)
-    firewall.associate_with_project(project)
     expect(ace.valid?).to be true
 
     ace.object_id = ApiKey.create_inference_api_key(project2).id

--- a/spec/model/api_key_spec.rb
+++ b/spec/model/api_key_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe ApiKey do
 
     it "can be deleted even with applied_tag references to related access tag" do
       token = described_class.create_personal_access_token(Account.create_with_id(email: "test@example.com"), project: prj)
-      DB[:applied_tag].insert(access_tag_id: token.access_tags.first.id, tagged_id: token.id, tagged_table: "")
+      access_tag_id = AccessTag.create(project_id: prj.id, hyper_tag_id: token.id, hyper_tag_table: "", name: "").id
+      DB[:applied_tag].insert(access_tag_id:, tagged_id: token.id, tagged_table: "")
       token.destroy
       expect(token).not_to be_exists
     end

--- a/spec/model/dns_zone/dns_zone_spec.rb
+++ b/spec/model/dns_zone/dns_zone_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe DnsZone do
     end
   end
 
-  it "generates correct hyper_tag_name" do
-    expect(dns_zone.hyper_tag_name(instance_double(Project, ubid: "prxxx"))).to eq("project/prxxx/dns-zone/#{dns_zone.ubid}")
-  end
-
   it "returns record_name with dot" do
     expect(dns_zone.add_dot_if_missing("pg-name.postgres.ubicloud.com")).to eq("pg-name.postgres.ubicloud.com.")
     expect(dns_zone.add_dot_if_missing("pg-name.postgres.ubicloud.com.")).to eq("pg-name.postgres.ubicloud.com.")

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Firewall do
       tag = ObjectTag.create_with_id(project_id: project.id, name: "t")
       tag.add_member(fw.id)
       fw.update(project_id: project.id)
-      fw.associate_with_project(project)
       ace = AccessControlEntry.create_with_id(project_id: project.id, subject_id: account.id, object_id: fw.id)
 
       fw.destroy

--- a/spec/model/github_installation_spec.rb
+++ b/spec/model/github_installation_spec.rb
@@ -4,7 +4,7 @@ require_relative "spec_helper"
 
 RSpec.describe GithubInstallation do
   subject(:installation) {
-    project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+    project = Project.create_with_id(name: "default")
 
     described_class.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
   }

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Invoice do
 
   describe ".send_failure_email" do
     it "sends failure email to accounts with billing permissions in addition to the provided billing email" do
-      project = Project.create_with_id(name: "cool-project").tap { |p| p.associate_with_project(p) }
+      project = Project.create_with_id(name: "cool-project")
       accounts = (0..2).map { Account.create_with_id(email: "account#{_1}@example.com").tap { |a| a.associate_with_project(project) } }
       AccessControlEntry.create_with_id(project_id: project.id, subject_id: accounts[0].id)
       AccessControlEntry.create_with_id(project_id: project.id, subject_id: accounts[1].id, action_id: ActionType::NAME_MAP["Vm:view"])

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -58,9 +58,4 @@ RSpec.describe MinioCluster do
     expect(mc.servers.first.vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
     expect(mc.ip4_urls).to eq(["https://1.1.1.1:9000"])
   end
-
-  it "returns hyper tag name properly" do
-    project = instance_double(Project, ubid: "project-ubid")
-    expect(mc.hyper_tag_name(project)).to eq("project/project-ubid/location/eu-central-h1/minio-cluster/minio-cluster-name")
-  end
 end

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe MinioServer do
 
   describe "#url" do
     before do
-      minio_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      minio_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:minio_service_project_id).and_return(minio_project.id)
     end
 

--- a/spec/model/nic_spec.rb
+++ b/spec/model/nic_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Nic do
   describe ".unlock" do
     it "destroys all semaphores with name lock" do
       prj = Project.create_with_id(name: "prj")
-      prj.associate_with_project(prj)
       ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps").subject
       nic = Prog::Vnet::NicNexus.assemble(ps.id, name: "nic").subject
       nic.incr_lock

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -97,11 +97,6 @@ RSpec.describe PrivateSubnet do
     it "returns path" do
       expect(private_subnet.path).to eq "/location/eu-central-h1/private-subnet/ps"
     end
-
-    it "returns tag name" do
-      pr = instance_double(Project, ubid: "prjubid")
-      expect(private_subnet.hyper_tag_name(pr)).to eq "project/prjubid/location/eu-central-h1/private-subnet/ps"
-    end
   end
 
   describe "display_state" do
@@ -158,9 +153,7 @@ RSpec.describe PrivateSubnet do
 
   describe "connected subnets related methods" do
     let(:prj) {
-      prj = Project.create_with_id(name: "test-prj")
-      prj.associate_with_project(prj)
-      prj
+      Project.create_with_id(name: "test-prj")
     }
 
     let(:ps1) {

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe Project do
 
     it "returns false if any accounts is suspended" do
       project = described_class.create_with_id(name: "test")
-      project.associate_with_project(project)
       Account.create_with_id(email: "user1@example.com").tap { _1.associate_with_project(project) }
       Account.create_with_id(email: "user2@example.com").tap { _1.associate_with_project(project) }.update(suspended_at: Time.now)
       expect(project.active?).to be false
@@ -124,7 +123,6 @@ RSpec.describe Project do
 
     it "returns true if any condition not match" do
       project = described_class.create_with_id(name: "test")
-      project.associate_with_project(project)
       Account.create_with_id(email: "user1@example.com").tap { _1.associate_with_project(project) }
       expect(project.active?).to be true
     end

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -26,12 +26,10 @@ RSpec.describe VmPool do
 
   describe ".pick_vm" do
     let(:prj) {
-      Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      Project.create_with_id(name: "default")
     }
     let(:vm) {
-      vm = create_vm(pool_id: pool.id, display_state: "running", project_id: prj.id)
-      vm.associate_with_project(prj)
-      vm
+      create_vm(pool_id: pool.id, display_state: "running", project_id: prj.id)
     }
 
     it "returns the vm if there is one in running state" do

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
   end
 
   describe ".assemble" do
-    let(:customer_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
-    let(:ie_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+    let(:customer_project) { Project.create_with_id(name: "default") }
+    let(:ie_project) { Project.create_with_id(name: "default") }
 
     it "validates input" do
       expect(Config).to receive(:inference_endpoint_service_project_id).and_return(ie_project.id).at_least(:once)
-      Firewall.create_with_id(name: "inference-endpoint-firewall", location: "hetzner-fsn1", project_id: ie_project.id).tap { _1.associate_with_project(ie_project) }
+      Firewall.create_with_id(name: "inference-endpoint-firewall", location: "hetzner-fsn1", project_id: ie_project.id)
       DnsZone.create_with_id(name: "ai.ubicloud.com", project_id: ie_project.id)
 
       expect {
@@ -111,7 +111,7 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
 
     it "works without dns zone" do
       expect(Config).to receive(:inference_endpoint_service_project_id).and_return(ie_project.id).at_least(:once)
-      Firewall.create_with_id(name: "inference-endpoint-firewall", location: "hetzner-fsn1", project_id: ie_project.id).tap { _1.associate_with_project(ie_project) }
+      Firewall.create_with_id(name: "inference-endpoint-firewall", location: "hetzner-fsn1", project_id: ie_project.id)
       expect {
         described_class.assemble(project_id: customer_project.id, location: "hetzner-fsn1", boot_image: "ai-ubuntu-2404-nvidia", name: "test-endpoint", vm_size: "standard-gpu-6", storage_volumes: [{encrypted: true, size_gib: 80}], model_name: "llama-3-1-8b-it", engine: "vllm", engine_params: "", replica_count: 1, is_public: false, gpu_count: 1, tags: {})
       }.not_to raise_error

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
 
   describe ".assemble" do
     it "creates replica and vm with sshable" do
-      user_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
-      ie_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
-      Firewall.create_with_id(name: "inference-endpoint-firewall", location: "hetzner-fsn1", project_id: ie_project.id).tap { _1.associate_with_project(ie_project) }
+      user_project = Project.create_with_id(name: "default")
+      ie_project = Project.create_with_id(name: "default")
+      Firewall.create_with_id(name: "inference-endpoint-firewall", location: "hetzner-fsn1", project_id: ie_project.id)
 
       expect(Config).to receive(:inference_endpoint_service_project_id).and_return(ie_project.id).at_least(:once)
       st_ie = Prog::Ai::InferenceEndpointNexus.assemble_with_model(
@@ -250,7 +250,7 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
   end
 
   describe "#ping_gateway" do
-    let(:projects) { [Project.create_with_id(name: "p1").tap { _1.associate_with_project(_1) }, Project.create_with_id(name: "p2").tap { _1.associate_with_project(_1) }] }
+    let(:projects) { [Project.create_with_id(name: "p1"), Project.create_with_id(name: "p2")] }
 
     before do
       ApiKey.create_inference_api_key(projects.first)

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       dz
     end
   end
-  let(:project) { Project.create_with_id(name: "ubicloud-dns").tap { _1.associate_with_project(_1) } }
+  let(:project) { Project.create_with_id(name: "ubicloud-dns") }
 
   describe ".assemble" do
     it "validates input" do

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
 
   describe ".assemble" do
     it "creates github repository or updates last_job_at if the repository exists" do
-      project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "default")
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
 
       expect {

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
     )
   }
 
-  let(:minio_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+  let(:minio_project) { Project.create_with_id(name: "default") }
 
   describe ".assemble" do
     before do
@@ -50,7 +50,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
       expect(MinioCluster.first.server_count).to eq 1
       expect(MinioCluster.first.drive_count).to eq 1
       expect(MinioCluster.first.pools.first.vm_size).to eq "standard-2"
-      expect(MinioCluster.first.projects).to eq [minio_project]
+      expect(MinioCluster.first.project).to eq minio_project
       expect(MinioCluster.first.strand.label).to eq "wait_pools"
     end
   end

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
     Prog::Vnet::SubnetNexus.assemble(minio_project.id, name: "minio-cluster-name")
   }
 
-  let(:minio_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+  let(:minio_project) { Project.create_with_id(name: "default") }
 
   before do
-    allow(minio_cluster).to receive(:projects).and_return([minio_project])
+    allow(minio_cluster).to receive(:project).and_return(minio_project)
     allow(Config).to receive(:minio_service_project_id).and_return(minio_project.id)
   end
 

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     }
   }
 
-  let(:minio_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+  let(:minio_project) { Project.create_with_id(name: "default") }
 
   before do
     allow(Config).to receive(:minio_service_project_id).and_return(minio_project.id)

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Prog::Minio::SetupMinio do
 
   let(:minio_server) {
     prj = Project.create_with_id(name: "default")
-    prj.associate_with_project(prj)
     ps = Prog::Vnet::SubnetNexus.assemble(
       prj.id, name: "minio-cluster-name"
     )

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   end
 
   describe ".assemble" do
-    let(:customer_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
-    let(:postgres_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+    let(:customer_project) { Project.create_with_id(name: "default") }
+    let(:postgres_project) { Project.create_with_id(name: "default") }
 
     it "validates input" do
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe ".assemble" do
-    let(:user_project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+    let(:user_project) { Project.create_with_id(name: "default") }
     let(:postgres_resource) {
       PostgresResource.create_with_id(
         project_id: user_project.id,
@@ -63,7 +63,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "creates postgres server and vm with sshable" do
       postgres_timeline = PostgresTimeline.create_with_id
-      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default")
       expect(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id).at_least(:once)
 
       st = described_class.assemble(resource_id: postgres_resource.id, timeline_id: postgres_timeline.id, timeline_access: "push", representative_at: Time.now)

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "creates postgres timeline with blob storage when it exists" do
-      project = Project.create_with_id(name: "mc-project").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "mc-project")
       expect(Config).to receive(:minio_service_project_id).and_return(project.id).at_least(:once)
       expect(Config).to receive(:postgres_service_project_id).and_return(project.id)
       mc = Prog::Minio::MinioClusterNexus.assemble(project.id, "minio", "hetzner-fsn1", "minio-admin", 100, 1, 1, 1, "standard-2").subject

--- a/spec/prog/test/connected_subnets_spec.rb
+++ b/spec/prog/test/connected_subnets_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe Prog::Test::ConnectedSubnets do
   }
 
   let(:project) {
-    prj = Project.create_with_id(name: "project1")
-    prj.associate_with_project(prj)
-    prj
+    Project.create_with_id(name: "project1")
   }
 
   let(:sshable) {

--- a/spec/prog/test/firewall_rules_spec.rb
+++ b/spec/prog/test/firewall_rules_spec.rb
@@ -502,7 +502,6 @@ ExecStart=nc -l 8080 -6
     it "returns the vm outside" do
       expect(firewall_test.vm1).to receive(:private_subnets).and_return([instance_double(PrivateSubnet, id: "ps1", vms: [instance_double(Vm, inhost_name: "vm1")])])
       prj = Project.create_with_id(name: "project1")
-      prj.associate_with_project(prj)
       ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-fsn1").subject
       Prog::Vm::Nexus.assemble("", prj.id, name: "vm-outside", location: "hetzner-fsn1", private_subnet_id: ps.id).subject
       expect(firewall_test.vm_outside.name).to eq("vm-outside")

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe Prog::Test::VmGroup do
 
     it "runs tests for the first connected subnet" do
       prj = Project.create_with_id(name: "project-1")
-      prj.associate_with_project(prj)
       ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-fsn1").subject
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-fsn1").subject
       expect(vg_test).to receive(:frame).and_return({"subnets" => [ps1.id, ps2.id]}).at_least(:once)
@@ -75,7 +74,6 @@ RSpec.describe Prog::Test::VmGroup do
 
     it "runs tests for the second connected subnet" do
       prj = Project.create_with_id(name: "project-1")
-      prj.associate_with_project(prj)
       ps1 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps1", location: "hetzner-fsn1").subject
       expect(ps1).to receive(:vms).and_return([instance_double(Vm, id: "vm1"), instance_double(Vm, id: "vm2")]).at_least(:once)
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location: "hetzner-fsn1").subject

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Prog::Test::Vm do
       ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a3::/64"),
       nics: [nic3])
 
-    project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+    project = Project.create_with_id(name: "default")
     allow(project).to receive(:vms).and_return([vm1, vm2, vm3])
-    allow(vm1).to receive(:projects).and_return [project]
+    allow(vm1).to receive(:project).and_return project
     allow(vm_test).to receive_messages(sshable: sshable, vm: vm1)
   }
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe ".assemble" do
     it "creates github runner and vm with sshable" do
-      project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "default")
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
 
       st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud")
@@ -45,7 +45,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "creates github runner with custom size" do
-      project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "default")
       installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
       st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud-standard-8")
 
@@ -63,10 +63,10 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe ".pick_vm" do
-    let(:project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+    let(:project) { Project.create_with_id(name: "default") }
 
     before do
-      runner_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      runner_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:github_runner_service_project_id).and_return(runner_project.id)
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
       expect(vm.cores).to eq(2)
-      expect(vm.projects.map(&:id)).to include(Config.github_runner_service_project_id)
+      expect(vm.project_id).to eq(Config.github_runner_service_project_id)
     end
 
     it "provisions a new vm if pool is valid but there is no vm" do
@@ -116,7 +116,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe ".update_billing_record" do
-    let(:project) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+    let(:project) { Project.create_with_id(name: "default") }
 
     before do
       allow(github_runner).to receive(:installation).and_return(instance_double(GithubInstallation, project: project)).at_least(:once)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Prog::Vm::Nexus do
     }
     vm
   }
-  let(:prj) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+  let(:prj) { Project.create_with_id(name: "default") }
 
   describe ".assemble" do
     let(:ps) {
@@ -248,7 +248,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(1, 1, 1, 1))
       expect(vm).to receive(:pci_devices).and_return([pci]).at_least(:once)
       prj.set_ff_vm_public_ssh_keys(["operator_ssh_key"])
-      expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
+      expect(vm).to receive(:project).and_return(prj).at_least(:once)
 
       sshable = instance_spy(Sshable)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
@@ -544,19 +544,19 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:assigned_vm_address).and_return(vm_addr).at_least(:once)
       expect(vm).to receive(:ip4_enabled).and_return(true)
       expect(BillingRecord).to receive(:create_with_id).exactly(4).times
-      expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
+      expect(vm).to receive(:project).and_return(prj).at_least(:once)
       expect { nx.create_billing_record }.to hop("wait")
     end
 
     it "creates billing records when ip4 is not enabled" do
       expect(vm).to receive(:ip4_enabled).and_return(false)
       expect(BillingRecord).to receive(:create_with_id).exactly(3).times
-      expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
+      expect(vm).to receive(:project).and_return(prj).at_least(:once)
       expect { nx.create_billing_record }.to hop("wait")
     end
 
     it "not create billing records when the project is not billable" do
-      expect(vm).to receive(:projects).and_return([prj]).at_least(:once)
+      expect(vm).to receive(:project).and_return(prj).at_least(:once)
       expect(prj).to receive(:billable).and_return(false)
       expect(BillingRecord).not_to receive(:create_with_id)
       expect { nx.create_billing_record }.to hop("wait")

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#create_new_vm" do
     let(:prj) {
-      Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      Project.create_with_id(name: "default")
     }
 
     it "creates a new vm and hops to wait" do

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   let(:st) { Strand.new }
   let(:project) {
-    Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    Project.create_with_id(name: "test-prj")
   }
   let(:dns_zone) {
     DnsZone.create_with_id(name: "test-dns-zone", project_id: project.id)

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Prog::Vnet::CertServer do
   }
 
   let(:lb) {
-    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    prj = Project.create_with_id(name: "test-prj")
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
     lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080).subject
     dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: prj.id)

--- a/spec/prog/vnet/load_balancer_health_probes_spec.rb
+++ b/spec/prog/vnet/load_balancer_health_probes_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
     Strand.create_with_id(prog: "Vnet::LoadBalancerHealthProbes", stack: [{"subject_id" => lb.id, "vm_id" => vm.id}], label: "health_probe")
   }
   let(:lb) {
-    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    prj = Project.create_with_id(name: "test-prj")
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
     dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: prj.id)
     cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
@@ -18,7 +18,7 @@ RSpec.describe Prog::Vnet::LoadBalancerHealthProbes do
     lb
   }
   let(:vm) {
-    Prog::Vm::Nexus.assemble("pub-key", lb.projects.first.id, name: "test-vm", private_subnet_id: lb.private_subnet.id).subject
+    Prog::Vm::Nexus.assemble("pub-key", lb.project_id, name: "test-vm", private_subnet_id: lb.private_subnet.id).subject
   }
 
   before do

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
   }
 
   let(:st) { Strand.new }
-  let(:prj) { Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) } }
+  let(:prj) { Project.create_with_id(name: "default") }
   let(:ps) {
     PrivateSubnet.create_with_id(name: "ps", location: "hetzner-fsn1", net6: "fd10:9b0b:6b4b:8fbb::/64",
       net4: "1.1.1.0/26", state: "waiting")
@@ -53,7 +53,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "uses firewall if provided" do
-      fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: prj.id).tap { _1.associate_with_project(prj) }
+      fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: prj.id)
       ps = described_class.assemble(prj.id, firewall_id: fw.id)
       expect(ps.subject.firewalls.count).to eq(1)
       expect(ps.subject.firewalls.first).to eq(fw)
@@ -73,7 +73,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "fails if both allow_only_ssh and firewall_id are specified" do
-      fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: prj.id).tap { _1.associate_with_project(prj) }
+      fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: prj.id)
       expect {
         described_class.assemble(prj.id, firewall_id: fw.id, allow_only_ssh: true)
       }.to raise_error RuntimeError, "Cannot specify both allow_only_ssh and firewall_id"
@@ -319,7 +319,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
 
     it "finds a new subnet if the one it found is taken" do
       expect(PrivateSubnet).to receive(:random_subnet).and_return("10.0.0.0/8").at_least(:once)
-      project = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "test-project")
       described_class.assemble(project.id, location: "hetzner-fsn1", name: "test-subnet", ipv4_range: "10.0.0.128/26")
       allow(SecureRandom).to receive(:random_number).with(2**(26 - 8) - 1).and_return(1, 2)
       expect(described_class.random_private_ipv4("hetzner-fsn1", project).to_s).to eq("10.0.0.192/26")
@@ -327,7 +327,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
 
     it "finds a new subnet if the one it found is banned" do
       expect(PrivateSubnet).to receive(:random_subnet).and_return("172.16.0.0/16", "10.0.0.0/8")
-      project = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "test-project")
       allow(SecureRandom).to receive(:random_number).with(2**(26 - 16) - 1).and_return(1)
       allow(SecureRandom).to receive(:random_number).with(2**(26 - 8) - 1).and_return(1)
       expect(described_class.random_private_ipv4("hetzner-fsn1", project).to_s).to eq("10.0.0.128/26")
@@ -340,7 +340,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "finds a new subnet if the one it found is taken" do
-      project = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
+      project = Project.create_with_id(name: "test-project")
       described_class.assemble(project.id, location: "hetzner-fsn1", name: "test-subnet", ipv6_range: "fd61:6161:6161:6161::/64")
       expect(SecureRandom).to receive(:bytes).with(7).and_return("a" * 7, "b" * 7)
       expect(described_class.random_private_ipv6("hetzner-fsn1", project).to_s).to eq("fd62:6262:6262:6262::/64")
@@ -387,7 +387,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     end
 
     it "disconnects all subnets" do
-      prj = Project.create_with_id(name: "test-project").tap { _1.associate_with_project(_1) }
+      prj = Project.create_with_id(name: "test-project")
       ps1 = described_class.assemble(prj.id, name: "ps1").subject
       ps2 = described_class.assemble(prj.id, name: "ps2").subject
       ps1.connect_subnet(ps2)

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Vnet::UpdateLoadBalancerNode do
     Strand.create_with_id(prog: "Vnet::UpdateLoadBalancerNode", stack: [{"subject_id" => vm.id, "load_balancer_id" => lb.id}], label: "update_load_balancer")
   }
   let(:lb) {
-    prj = Project.create_with_id(name: "test-prj").tap { _1.associate_with_project(_1) }
+    prj = Project.create_with_id(name: "test-prj")
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
     lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080).subject
     dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: prj.id)
@@ -18,10 +18,10 @@ RSpec.describe Prog::Vnet::UpdateLoadBalancerNode do
     lb
   }
   let(:vm) {
-    Prog::Vm::Nexus.assemble("pub-key", lb.projects.first.id, name: "test-vm", private_subnet_id: lb.private_subnet.id).subject
+    Prog::Vm::Nexus.assemble("pub-key", lb.project_id, name: "test-vm", private_subnet_id: lb.private_subnet.id).subject
   }
   let(:neighbor_vm) {
-    Prog::Vm::Nexus.assemble("pub-key", lb.projects.first.id, name: "neighbor-vm", private_subnet_id: lb.private_subnet.id).subject
+    Prog::Vm::Nexus.assemble("pub-key", lb.project_id, name: "neighbor-vm", private_subnet_id: lb.private_subnet.id).subject
   }
 
   before do

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Clover, "firewall" do
 
   let(:project) { project_with_default_policy(user) }
 
-  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id).tap { _1.associate_with_project(project) } }
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id) }
 
   let(:firewall_rule) { FirewallRule.create_with_id(firewall_id: firewall.id, cidr: "0.0.0.0/0", port_range: Sequel.pg_range(80..5432)) }
 

--- a/spec/routes/api/project/firewall_spec.rb
+++ b/spec/routes/api/project/firewall_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Clover, "firewall" do
 
   let(:project) { project_with_default_policy(user) }
 
-  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id).tap { _1.associate_with_project(project) } }
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id) }
 
   describe "unauthenticated" do
     it "not list" do
@@ -29,7 +29,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "success get all firewalls" do
-      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1", project_id: project.id).associate_with_project(project)
+      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1", project_id: project.id)
 
       get "/project/#{project.ubid}/firewall"
 

--- a/spec/routes/api/project/load_balancer_spec.rb
+++ b/spec/routes/api/project/load_balancer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Clover, "vm" do
   describe "authenticated" do
     before do
       login_api(user.email)
-      lb_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      lb_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:load_balancer_service_project_id).and_return(lb_project.id)
     end
 

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Clover, "firewall" do
 
   let(:project) { project_with_default_policy(user) }
 
-  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id).tap { _1.associate_with_project(project) } }
+  let(:firewall) { Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id) }
 
   describe "unauthenticated" do
     it "not delete" do
@@ -41,7 +41,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "success get all location firewalls" do
-      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1", project_id: project.id).associate_with_project(project)
+      Firewall.create_with_id(name: "#{firewall.name}-2", location: "hetzner-fsn1", project_id: project.id)
 
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall"
 

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Clover, "load-balancer" do
   describe "authenticated" do
     before do
       login_api(user.email)
-      lb_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      lb_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:load_balancer_service_project_id).and_return(lb_project.id)
     end
 
@@ -147,7 +147,6 @@ RSpec.describe Clover, "load-balancer" do
         vm = create_vm
         nic.update(vm_id: vm.id)
         vm.update(project_id: project.id)
-        vm.associate_with_project(project)
         vm
       }
 
@@ -207,7 +206,7 @@ RSpec.describe Clover, "load-balancer" do
 
       it "vm already attached to a different load balancer" do
         lb2 = Prog::Vnet::LoadBalancerNexus.assemble(lb.private_subnet.id, name: "lb-2", src_port: 80, dst_port: 80).subject
-        dz = DnsZone.create_with_id(name: "test-dns-zone2", project_id: lb2.private_subnet.projects.first.id)
+        dz = DnsZone.create_with_id(name: "test-dns-zone2", project_id: lb2.private_subnet.project_id)
         cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
         lb2.add_cert(cert)
         lb2.add_vm(vm)
@@ -240,7 +239,6 @@ RSpec.describe Clover, "load-balancer" do
 
       it "success" do
         vm.update(project_id: project.id)
-        vm.associate_with_project(project)
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: vm.ubid}.to_json
 
         expect(last_response.status).to eq(200)
@@ -263,7 +261,6 @@ RSpec.describe Clover, "load-balancer" do
 
       it "success" do
         vm.update(project_id: project.id)
-        vm.associate_with_project(project)
         lb.add_vm(vm)
 
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: vm.ubid}.to_json

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Clover, "postgres" do
 
   describe "unauthenticated" do
     it "cannot perform authenticated operations" do
-      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
 
       [
@@ -47,7 +47,7 @@ RSpec.describe Clover, "postgres" do
   describe "authenticated" do
     before do
       login_api(user.email)
-      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end
 

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Clover, "private_subnet" do
       end
 
       it "with valid firewall" do
-        fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id).tap { _1.associate_with_project(project) }
+        fw = Firewall.create_with_id(name: "default-firewall", location: "hetzner-fsn1", project_id: project.id)
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/test-ps", {firewall_id: fw.ubid}.to_json
 
         expect(last_response.status).to eq(200)

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Clover, "vm" do
   describe "authenticated" do
     before do
       login_api(user.email)
-      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -141,7 +141,6 @@ RSpec.describe Clover, "project" do
           it "success with authorized personal access token" do
             project = user.create_project_with_default_policy("project-1")
             @pat.update(project_id: project.id)
-            @pat.associate_with_project(project)
             AccessControlEntry.create_with_id(project_id: project.id, subject_id: @pat.id, action_id: ActionType::NAME_MAP["Project:view"])
 
             get "/project/#{project.ubid}"
@@ -153,7 +152,6 @@ RSpec.describe Clover, "project" do
           it "failure with unauthorized personal access token" do
             project = user.create_project_with_default_policy("project-1")
             @pat.update(project_id: project.id)
-            @pat.associate_with_project(project)
             AccessControlEntry.create_with_id(project_id: project.id, subject_id: @pat.id, action_id: ActionType::NAME_MAP["Project:edit"])
 
             get "/project/#{project.ubid}"

--- a/spec/routes/api/spec_helper.rb
+++ b/spec/routes/api/spec_helper.rb
@@ -21,7 +21,6 @@ RSpec.configure do |config|
     if @pat
       SubjectTag.first(project_id: project.id, name: "Admin").add_subject(@pat.id)
       @pat.update(project_id: project.id)
-      @pat.associate_with_project(project)
     end
 
     project

--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Clover, "access control" do
     end
 
     it "does not show access control entries for tokens" do
-      AccessControlEntry.create_with_id(project_id: project.id, subject_id: ApiKey.create_personal_access_token(user).id)
+      AccessControlEntry.create_with_id(project_id: project.id, subject_id: ApiKey.create_personal_access_token(user, project:).id)
 
       visit "#{project.path}/user/access-control"
       expect(displayed_access_control_entries).to eq [

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Clover, "auth" do
   end
 
   it "can create new account, verify it, and visit project which invited" do
-    p = Project.create_with_id(name: "Invited-project").tap { _1.associate_with_project(_1) }
+    p = Project.create_with_id(name: "Invited-project")
     p.add_invitation(email: TEST_USER_EMAIL, inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)
 
     visit "/create-account"
@@ -110,7 +110,7 @@ RSpec.describe Clover, "auth" do
   end
 
   it "can create new account, verify it, and visit project which invited with default policy" do
-    p = Project.create_with_id(name: "Invited-project").tap { _1.associate_with_project(_1) }
+    p = Project.create_with_id(name: "Invited-project")
     subject_id = SubjectTag.create_with_id(project_id: p.id, name: "Admin").id
     AccessControlEntry.create_with_id(project_id: p.id, subject_id:, action_id: ActionType::NAME_MAP["Project:view"])
     p.add_invitation(email: TEST_USER_EMAIL, policy: "Admin", inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)
@@ -444,7 +444,6 @@ RSpec.describe Clover, "auth" do
       vm = create_vm
       project = Account[email: TEST_USER_EMAIL].projects.first
       vm.update(project_id: project.id)
-      vm.associate_with_project(project)
 
       visit "/account/close-account"
 

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -10,15 +10,11 @@ RSpec.describe Clover, "firewall" do
   let(:project_wo_permissions) { user.create_project_with_default_policy("project-2", default_policy: nil) }
 
   let(:firewall) do
-    fw = Firewall.create_with_id(name: "dummy-fw", description: "dummy-fw", location: "hetzner-fsn1", project_id: project.id)
-    fw.associate_with_project(project)
-    fw
+    Firewall.create_with_id(name: "dummy-fw", description: "dummy-fw", location: "hetzner-fsn1", project_id: project.id)
   end
 
   let(:fw_wo_permission) {
-    fw = Firewall.create_with_id(name: "dummy-fw-2", description: "dummy-fw-2", location: "hetzner-fsn1", project_id: project_wo_permissions.id)
-    fw.associate_with_project(project_wo_permissions)
-    fw
+    Firewall.create_with_id(name: "dummy-fw-2", description: "dummy-fw-2", location: "hetzner-fsn1", project_id: project_wo_permissions.id)
   }
 
   describe "unauthenticated" do
@@ -64,7 +60,6 @@ RSpec.describe Clover, "firewall" do
       it "does not show links to firewalls if user lacks Firewall:view access to them" do
         firewall
         fw = Firewall.create_with_id(name: "viewable-fw", description: "viewable-fw", location: "hetzner-fsn1", project_id: project.id)
-        fw.associate_with_project(project)
 
         visit "#{project.path}/firewall"
         link_texts = page.all("a").map(&:text)
@@ -123,7 +118,7 @@ RSpec.describe Clover, "firewall" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' is created")
         expect(Firewall.count).to eq(1)
-        expect(Firewall.first.projects.first.id).to eq(project.id)
+        expect(Firewall.first.project_id).to eq(project.id)
       end
 
       it "can create new firewall with private subnet" do

--- a/spec/routes/web/inference_api_key_spec.rb
+++ b/spec/routes/web/inference_api_key_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Clover, "inference-api-key" do
       expect(ApiKey.count).to eq(1)
       expect(@api_key.owner_id).to eq(project.id)
       expect(@api_key.owner_table).to eq("project")
-      expect(@api_key.projects).to eq([project])
+      expect(@api_key.project).to eq(project)
       expect(@api_key.used_for).to eq("inference_endpoint")
       expect(@api_key.is_valid).to be(true)
 
@@ -39,9 +39,6 @@ RSpec.describe Clover, "inference-api-key" do
     end
 
     it "inference api key page allows removing inference api keys" do
-      access_tag_ds = DB[:access_tag].where(hyper_tag_id: @api_key.id)
-      expect(access_tag_ds.all).not_to be_empty
-
       btn = find(".delete-btn")
       data_url = btn["data-url"]
       _csrf = btn["data-csrf"]

--- a/spec/routes/web/inference_endpoint_spec.rb
+++ b/spec/routes/web/inference_endpoint_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe Clover, "inference-endpoint" do
         ["ie6", "test-model", project_wo_permissions, false, true, {capability: "Text Generation"}],
         ["ie7", "unknown-capability", project_wo_permissions, true, true, {capability: "wrong capability"}]
       ].each do |name, model_name, project, is_public, visible, tags|
-        ie = InferenceEndpoint.create_with_id(name:, model_name:, project_id: project.id, is_public:, visible:, load_balancer_id: lb.id, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, tags:)
-        ie.associate_with_project(project)
+        InferenceEndpoint.create_with_id(name:, model_name:, project_id: project.id, is_public:, visible:, load_balancer_id: lb.id, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, tags:)
       end
 
       visit "#{project.path}/inference-endpoint"
@@ -50,8 +49,7 @@ RSpec.describe Clover, "inference-endpoint" do
     it "does not show inference endpoints without permissions" do
       ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
       lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up")
-      ie = InferenceEndpoint.create_with_id(name: "ie1", model_name: "test-model", project_id: project_wo_permissions.id, is_public: true, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
-      ie.associate_with_project(project_wo_permissions)
+      InferenceEndpoint.create_with_id(name: "ie1", model_name: "test-model", project_id: project_wo_permissions.id, is_public: true, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
       visit "#{project_wo_permissions.path}/inference-endpoint"
 
       expect(page.title).to eq("Ubicloud - Inference Endpoints")

--- a/spec/routes/web/inference_playground_spec.rb
+++ b/spec/routes/web/inference_playground_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe Clover, "inference-playground" do
         ["ie5", "llama-3-2-3b-it", project, false, false, lb.id, {capability: "Text Generation"}],
         ["ie6", "test-model", project_wo_permissions, true, true, lb.id, {capability: "Text Generation"}]
       ].each do |name, model_name, project, is_public, visible, load_balancer_id, tags|
-        ie = InferenceEndpoint.create_with_id(name:, model_name:, project_id: project.id, is_public:, visible:, load_balancer_id:, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, tags:)
-        ie.associate_with_project(project)
+        InferenceEndpoint.create_with_id(name:, model_name:, project_id: project.id, is_public:, visible:, load_balancer_id:, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, tags:)
       end
       visit "#{project.path}/inference-playground"
 

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -11,16 +11,12 @@ RSpec.describe Clover, "load balancer" do
 
   let(:lb) do
     ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
-    lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up", project_id: project.id)
-    lb.associate_with_project(project)
-    lb
+    LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up", project_id: project.id)
   end
 
   let(:lb_wo_permission) {
     ps = Prog::Vnet::SubnetNexus.assemble(project_wo_permissions.id, name: "dummy-ps-2", location: "hetzner-fsn1").subject
-    lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-2", src_port: 80, dst_port: 80, health_check_endpoint: "/up", project_id: project_wo_permissions.id)
-    lb.associate_with_project(project_wo_permissions)
-    lb
+    LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-2", src_port: 80, dst_port: 80, health_check_endpoint: "/up", project_id: project_wo_permissions.id)
   }
 
   describe "unauthenticated" do
@@ -104,7 +100,7 @@ RSpec.describe Clover, "load balancer" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' is created")
         expect(LoadBalancer.count).to eq(1)
-        expect(LoadBalancer.first.projects.first.id).to eq(project.id)
+        expect(LoadBalancer.first.project_id).to eq(project.id)
       end
 
       it "can not create load balancer with invalid name" do

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Clover, "private subnet" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few seconds")
         expect(PrivateSubnet.count).to eq(1)
-        expect(PrivateSubnet.first.projects.first.id).to eq(project.id)
+        expect(PrivateSubnet.first.project_id).to eq(project.id)
       end
 
       it "can not create private subnet with same name" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Clover, "postgres" do
 
   describe "authenticated" do
     before do
-      postgres_project = Project.create_with_id(name: "default").tap { _1.associate_with_project(_1) }
+      postgres_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
       login(user.email)
 
@@ -90,7 +90,7 @@ RSpec.describe Clover, "postgres" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(PostgresResource.count).to eq(1)
-        expect(PostgresResource.first.projects.first.id).to eq(project.id)
+        expect(PostgresResource.first.project_id).to eq(project.id)
       end
 
       it "handles errors when creating new PostgreSQL database" do
@@ -129,7 +129,7 @@ RSpec.describe Clover, "postgres" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(PostgresResource.count).to eq(1)
-        expect(PostgresResource.first.projects.first.id).to eq(project.id)
+        expect(PostgresResource.first.project_id).to eq(project.id)
       end
 
       it "can not open create page with invalid flavor" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Clover, "project" do
         name = "new-project"
         visit "/project/create"
 
+        expect(project.access_tags.count).to eq 1
         expect(page.title).to eq("Ubicloud - Create Project")
 
         fill_in "Name", with: name
@@ -71,7 +72,7 @@ RSpec.describe Clover, "project" do
         expect(page).to have_content name
 
         project = Project[name: name]
-        expect(project.access_tags.count).to eq 2
+        expect(project.access_tags.count).to eq 1
         expect(project.access_control_entries.count).to eq 2
         expect(project.subject_tags.map(&:name).sort).to eq %w[Admin Member]
         expect(user.hyper_tag(project)).to exist

--- a/spec/routes/web/token_spec.rb
+++ b/spec/routes/web/token_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Clover, "personal access token management" do
     expect(ApiKey.count).to eq(1)
     expect(@api_key.owner_id).to eq(user.id)
     expect(@api_key.owner_table).to eq("accounts")
-    expect(@api_key.projects).to eq([project])
+    expect(@api_key.project).to eq(project)
     expect(@api_key.used_for).to eq("api")
     expect(@api_key.is_valid).to be(true)
     expect(SubjectTag[project_id: project.id, name: "Admin"].member_ids).to include @api_key.id
@@ -90,8 +90,6 @@ RSpec.describe Clover, "personal access token management" do
   end
 
   it "user page allows removing personal access tokens" do
-    access_tag_ds = DB[:access_tag].where(hyper_tag_id: @api_key.id)
-    expect(access_tag_ds.all).not_to be_empty
     AccessControlEntry.create_with_id(project_id: project.id, subject_id: @api_key.id)
 
     path = page.current_path
@@ -101,7 +99,6 @@ RSpec.describe Clover, "personal access token management" do
     page.driver.delete data_url, {_csrf:}
     expect(page.status_code).to eq(204)
     expect(ApiKey.all).to be_empty
-    expect(access_tag_ds.all).to be_empty
     expect(DB[:applied_subject_tag].where(tag_id: project.subject_tags_dataset.first(name: "Admin").id, subject_id: @api_key.id).all).to be_empty
     expect(AccessControlEntry.where(project_id: project.id, subject_id: @api_key.id).all).to be_empty
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
-        expect(Vm.first.projects.first.id).to eq(project.id)
+        expect(Vm.first.project_id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).not_to be_nil
         expect(Vm.first.ip4_enabled).to be_falsey
 
@@ -177,7 +177,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
-        expect(Vm.first.projects.first.id).to eq(project.id)
+        expect(Vm.first.project_id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).not_to be_nil
         expect(Vm.first.ip4_enabled).to be_truthy
       end
@@ -202,7 +202,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
-        expect(Vm.first.projects.first.id).to eq(project.id)
+        expect(Vm.first.project_id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).to eq(ps.id)
       end
 
@@ -226,7 +226,7 @@ RSpec.describe Clover, "vm" do
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
         expect(Vm.count).to eq(1)
-        expect(Vm.first.projects.first.id).to eq(project.id)
+        expect(Vm.first.project_id).to eq(project.id)
         expect(Vm.first.private_subnets.first.id).not_to eq(ps.id)
         expect(Vm.first.private_subnets.first.name).to eq("default-#{LocationNameConverter.to_display_name(ps.location)}")
 


### PR DESCRIPTION
This builds on top of #2602.  After we have fully populated the newly added `project_id` columns, we can switch to using them for authorization, and mark them as NOT NULL.

This implements steps 4-6 and 9 of the 12-step plan discussed in #2594.  The remaining steps in the plan after this PR are just cleaning up unnecessary data.