### PR TITLE
Remove version from demo docker-compose template

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:15.4


### PR DESCRIPTION
It shows the following warning:

    WARN[0000] ./ubicloud/demo/docker-compose.yml: the attribute
    `version` is obsolete, it will be ignored, please remove it to avoid
    potential confusion