### PR TITLE
[k8s] Introduce Kubernetes Nodepools

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -8,6 +8,7 @@ class KubernetesCluster < Sequel::Model
   many_to_one :private_subnet
   many_to_one :project
   many_to_many :cp_vms, join_table: :kubernetes_clusters_cp_vms, class: :Vm, order: :created_at
+  one_to_many :nodepools, class: :KubernetesNodepool
 
   dataset_module Pagination
 
@@ -32,6 +33,10 @@ class KubernetesCluster < Sequel::Model
 
   def endpoint
     api_server_lb.hostname
+  end
+
+  def sshable
+    cp_vms.first.sshable
   end
 end
 

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -1,0 +1,28 @@
+#  frozen_string_literal: true
+
+require_relative "../../model"
+
+class KubernetesNodepool < Sequel::Model
+  one_to_one :strand, key: :id
+  many_to_one :cluster, key: :kubernetes_cluster_id, class: :KubernetesCluster
+  many_to_many :vms, order: :created_at
+
+  include ResourceMethods
+  include SemaphoreMethods
+
+  semaphore :destroy
+end
+
+# Table: kubernetes_nodepool
+# Columns:
+#  id                    | uuid                     | PRIMARY KEY
+#  name                  | text                     | NOT NULL
+#  node_count            | integer                  | NOT NULL
+#  created_at            | timestamp with time zone | NOT NULL DEFAULT CURRENT_TIMESTAMP
+#  kubernetes_cluster_id | uuid                     | NOT NULL
+# Indexes:
+#  kubernetes_nodepool_pkey | PRIMARY KEY btree (id)
+# Foreign key constraints:
+#  kubernetes_nodepool_kubernetes_cluster_id_fkey | (kubernetes_cluster_id) REFERENCES kubernetes_cluster(id)
+# Referenced By:
+#  kubernetes_nodepools_vms | kubernetes_nodepools_vms_kubernetes_nodepool_id_fkey | (kubernetes_nodepool_id) REFERENCES kubernetes_nodepool(id)

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -23,14 +23,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       # TODO: Move resources (vms, subnet, LB, etc.) into own project
       # TODO: Validate node count
 
-      kc = KubernetesCluster.create_with_id(
-        name: name,
-        version: version,
-        cp_node_count: cp_node_count,
-        private_subnet_id: private_subnet_id,
-        location: location,
-        project_id: project.id
-      )
+      kc = KubernetesCluster.create_with_id(name:, version:, cp_node_count:, private_subnet_id:, location:, project_id: project.id)
 
       Strand.create(prog: "Kubernetes::KubernetesClusterNexus", label: "start") { _1.id = kc.id }
     end
@@ -81,6 +74,8 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     kubernetes_cluster.api_server_lb.incr_destroy
     kubernetes_cluster.cp_vms.each(&:incr_destroy)
     kubernetes_cluster.remove_all_cp_vms
+    kubernetes_cluster.nodepools.each { _1.incr_destroy }
+    nap 5 unless kubernetes_cluster.nodepools.empty?
     kubernetes_cluster.destroy
     pop "kubernetes cluster is deleted"
   end

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
+  subject_is :kubernetes_nodepool
+
+  def self.assemble(name:, node_count:, kubernetes_cluster_id:)
+    DB.transaction do
+      unless KubernetesCluster[kubernetes_cluster_id]
+        fail "No existing cluster"
+      end
+
+      kn = KubernetesNodepool.create(name:, node_count:, kubernetes_cluster_id:)
+
+      Strand.create(prog: "Kubernetes::KubernetesNodepoolNexus", label: "start") { _1.id = kn.id }
+    end
+  end
+
+  def before_run
+    when_destroy_set? do
+      if strand.label != "destroy"
+        hop_destroy
+      end
+    end
+  end
+
+  label def start
+    nap 30 unless kubernetes_nodepool.cluster.strand.label == "wait"
+    register_deadline("wait", 120 * 60)
+    hop_bootstrap_worker_vms
+  end
+
+  label def bootstrap_worker_vms
+    hop_wait if kubernetes_nodepool.vms.count >= kubernetes_nodepool.node_count
+    push Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kubernetes_nodepool.id, "subject_id" => kubernetes_nodepool.kubernetes_cluster_id}
+  end
+
+  label def wait
+    nap 30
+  end
+
+  label def destroy
+    kubernetes_nodepool.vms.each(&:incr_destroy)
+    kubernetes_nodepool.remove_all_vms
+    kubernetes_nodepool.destroy
+    pop "kubernetes nodepool is deleted"
+  end
+end

--- a/rhizome/kubernetes/bin/join-worker-node
+++ b/rhizome/kubernetes/bin/join-worker-node
@@ -1,0 +1,18 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../../common/lib/util"
+
+params = JSON.parse($stdin.read)
+
+begin
+  endpoint = params.fetch("endpoint")
+  join_token = params.fetch("join_token")
+  discovery_token_ca_cert_hash = params.fetch("discovery_token_ca_cert_hash")
+rescue KeyError => e
+  puts "Needed #{e.key} in parameters"
+  exit 1
+end
+
+r "kubeadm join #{endpoint} --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash}"

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
+  subject(:nx) { described_class.new(Strand.new(id: "8148ebdf-66b8-8ed0-9c2f-8cfe93f5aa77")) }
+
+  let(:project) { Project.create(name: "default") }
+  let(:subnet) { PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location: "x", project_id: project.id) }
+
+  let(:kc) {
+    kc = KubernetesCluster.create(
+      name: "k8scluster",
+      version: "v1.32",
+      cp_node_count: 3,
+      private_subnet_id: subnet.id,
+      location: "hetzner-fsn1",
+      project_id: project.id
+    )
+
+    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", src_port: 123, dst_port: 456, health_check_endpoint: "/foo", project_id: project.id)
+    kc.add_cp_vm(create_vm)
+    kc.add_cp_vm(create_vm)
+    kc.update(api_server_lb_id: lb.id)
+    kc
+  }
+
+  let(:kn) { KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kc.id) }
+
+  before do
+    allow(nx).to receive(:kubernetes_nodepool).and_return(kn)
+  end
+
+  describe ".assemble" do
+    it "validates input" do
+      expect {
+        described_class.assemble(name: "name", node_count: 2, kubernetes_cluster_id: SecureRandom.uuid)
+      }.to raise_error RuntimeError, "No existing cluster"
+    end
+
+    it "creates a kubernetes nodepool" do
+      st = described_class.assemble(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kc.id)
+
+      expect(st.subject.name).to eq "k8stest-np"
+      expect(st.subject.ubid).to start_with("kn")
+      expect(st.subject.kubernetes_cluster_id).to eq kc.id
+      expect(st.subject.node_count).to eq 2
+      expect(st.label).to eq "start"
+    end
+  end
+
+  describe "#before_run" do
+    it "hops to destroy" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "does not hop to destroy if already in the destroy state" do
+      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect { nx.before_run }.not_to hop("destroy")
+    end
+  end
+
+  describe "#start" do
+    it "naps if the kubernetes cluster is not ready" do
+      expect(kn.cluster).to receive(:strand).and_return(Strand.new(label: "not-wait"))
+      expect { nx.start }.to nap(30)
+    end
+
+    it "registers a deadline and hops if the cluster is ready" do
+      expect(kn.cluster).to receive(:strand).and_return(Strand.new(label: "wait"))
+      expect(nx).to receive(:register_deadline)
+      expect { nx.start }.to hop("bootstrap_worker_vms")
+    end
+  end
+
+  describe "#bootstrap_worker_vms" do
+    it "hops wait if the target number of vms is reached" do
+      expect(kn).to receive(:vms).and_return [1, 2]
+      expect { nx.bootstrap_worker_vms }.to hop("wait")
+    end
+
+    it "pushes ProvisionKubernetesNode prog to create VMs" do
+      expect(nx).to receive(:push).with(Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kn.id, "subject_id" => kn.cluster.id})
+      nx.bootstrap_worker_vms
+    end
+  end
+
+  describe "#wait" do
+    it "just naps for 30 seconds for now" do
+      expect { nx.wait }.to nap(30)
+    end
+  end
+
+  describe "#destroy" do
+    it "destroys the nodepool and its vms" do
+      vms = [create_vm, create_vm]
+      expect(kn).to receive(:vms).and_return(vms)
+
+      expect(vms).to all(receive(:incr_destroy))
+      expect(kn).to receive(:remove_all_vms)
+      expect(kn).to receive(:destroy)
+      expect { nx.destroy }.to exit({"msg" => "kubernetes nodepool is deleted"})
+    end
+  end
+end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     kc
   }
 
+  let(:kubernetes_nodepool) { KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kubernetes_cluster.id) }
+
   before do
     allow(prog).to receive_messages(kubernetes_cluster: kubernetes_cluster, frame: {"vm_id" => create_vm.id})
   end
@@ -52,7 +54,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(Config).to receive(:development?).and_return(true)
 
       expect(sshable).to receive(:cmd).with("cat /etc/hosts").and_return("nothing relevant")
-      expect(kubernetes_cluster.cp_vms.first).to receive(:ephemeral_net4).and_return("SOMEIP")
+      expect(kubernetes_cluster).to receive(:sshable).and_return(instance_double(Sshable, host: "SOMEIP"))
       expect(sshable).to receive(:cmd).with("sudo tee -a /etc/hosts", {stdin: /SOMEIP somelb\..*\n/})
 
       prog.write_hosts_file_if_needed
@@ -64,7 +66,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(Config).to receive(:development?).and_return(true)
 
       expect(sshable).to receive(:cmd).with("cat /etc/hosts").and_return("nothing relevant")
-      expect(kubernetes_cluster.cp_vms.first).not_to receive(:ephemeral_net4)
+      expect(kubernetes_cluster).not_to receive(:sshable)
       expect(sshable).to receive(:cmd).with("sudo tee -a /etc/hosts", {stdin: /ANOTHERIP somelb\..*\n/})
 
       prog.write_hosts_file_if_needed "ANOTHERIP"
@@ -72,7 +74,8 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#start" do
-    it "creates a VM and hops" do
+    it "creates a CP VM and hops if a nodepool is not given" do
+      expect(prog.kubernetes_nodepool).to be_nil
       expect(kubernetes_cluster.cp_vms.count).to eq(2)
       expect(kubernetes_cluster.api_server_lb).to receive(:add_vm)
 
@@ -82,6 +85,19 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
       new_vm = kubernetes_cluster.cp_vms.last
       expect(new_vm.name).to start_with("k8scluster-control-plane-")
+      expect(new_vm.sshable).not_to be_nil
+    end
+
+    it "creates a worker VM and hops if a nodepool is given" do
+      expect(prog).to receive(:frame).and_return({"nodepool_id" => kubernetes_nodepool.id})
+      expect(kubernetes_nodepool.vms.count).to eq(0)
+
+      expect { prog.start }.to hop("install_software")
+
+      expect(kubernetes_nodepool.reload.vms.count).to eq(1)
+
+      new_vm = kubernetes_nodepool.vms.last
+      expect(new_vm.name).to start_with("k8stest-np-")
       expect(new_vm.sshable).not_to be_nil
     end
   end
@@ -137,6 +153,11 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "hops to join_control_plane if this is the not the first vm of the cluster" do
       expect(prog.kubernetes_cluster.cp_vms.count).to eq(2)
       expect { prog.assign_role }.to hop("join_control_plane")
+    end
+
+    it "hops to join_worker if a nodepool is specified to the prog" do
+      expect(prog).to receive(:kubernetes_nodepool).and_return(kubernetes_nodepool)
+      expect { prog.assign_role }.to hop("join_worker")
     end
   end
 
@@ -212,6 +233,48 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "naps forever if the daemonizer check returns something unknown" do
       expect(prog.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check join_control_plane").and_return("Unknown")
       expect { prog.join_control_plane }.to nap(65536)
+    end
+  end
+
+  describe "#join_worker" do
+    before {
+      allow(prog.vm).to receive(:sshable).and_return(instance_double(Sshable))
+      allow(prog).to receive(:kubernetes_nodepool).and_return(kubernetes_nodepool)
+    }
+
+    it "runs the join-worker-node script if it's not started" do
+      expect(prog.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check join_worker").and_return("NotStarted")
+
+      sshable = instance_double(Sshable)
+      allow(kubernetes_cluster.cp_vms.first).to receive(:sshable).and_return(sshable)
+      expect(sshable).to receive(:cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication").and_return("\njt\n")
+      expect(sshable).to receive(:cmd).with("sudo kubeadm token create --print-join-command").and_return("discovery-token-ca-cert-hash dtcch")
+      expect(prog.vm.sshable).to receive(:cmd).with(
+        "common/bin/daemonizer kubernetes/bin/join-worker-node join_worker",
+        {stdin: /{"endpoint":"somelb\..*:443","join_token":"jt","discovery_token_ca_cert_hash":"dtcch"}/}
+      )
+
+      expect { prog.join_worker }.to nap(15)
+    end
+
+    it "naps if the join-worker-node script is in progress" do
+      expect(prog.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check join_worker").and_return("InProgress")
+      expect { prog.join_worker }.to nap(10)
+    end
+
+    it "naps and does nothing (for now) if the join-worker-node script is failed" do
+      expect(prog.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check join_worker").and_return("Failed")
+      expect { prog.join_worker }.to nap(65536)
+    end
+
+    it "pops if the join-worker-node script is successful" do
+      expect(prog.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check join_worker").and_return("Succeeded")
+      expect { prog.join_worker }.to hop("install_cni")
+    end
+
+    it "naps for a long time if the daemonizer check returns something unknown" do
+      expect(prog.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check join_worker").and_return("Unknown")
+      expect { prog.join_worker }.to nap(65536)
     end
   end
 

--- a/ubid.rb
+++ b/ubid.rb
@@ -82,6 +82,7 @@ class UBID
   TYPE_OBJECT_METATAG = "t2"
   TYPE_VM_HOST_SLICE = "vs"
   TYPE_KUBERNETES_CLUSTER = "kc"
+  TYPE_KUBERNETES_NODEPOOL = "kn"
 
   # Common entropy-based type for everything else
   TYPE_ETC = "et"


### PR DESCRIPTION
This change adds the concept of Kubernetes Nodepools.

Each kubernetes nodepool is a set of VMs that act as the nodes that run the actual application workloads.

A cluster have multiple nodepools with different size and characteristics. The logic in this PR is also implemented this way. However, product-wise, we may hide this feature for now and default to a single nodepool.

A kubernetes cluster without a nodepool is kinda useless at this point.

Nodepools should be created separately from the cluster. However, a nodepool nexus strand would wait until its cluster is stable.