### PR TITLE
Set docker mirror client code for the runners on the test host

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -108,6 +108,9 @@ module Config
   optional :github_runner_service_project_id, string
   override :enable_github_workflow_poller, true, bool
 
+  # Docker Mirror Test
+  optional :docker_mirror_server_vm_id, string
+
   # GitHub Cache
   optional :github_cache_blob_storage_endpoint, string
   optional :github_cache_blob_storage_region, string


### PR DESCRIPTION
In order to test docker registry mirror performance, registry mirror server is set up on one of the host manually. Updating docker and buildkit config here to use that server for the runners provisioned on the test host.