### PR TITLE
Delete firewalls while deleting project in E2E

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -129,7 +129,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def destroy_resources
     frame["vms"].each { Vm[_1].incr_destroy }
-    frame["subnets"].each { PrivateSubnet[_1].incr_destroy }
+    frame["subnets"].each { PrivateSubnet[_1].tap { |ps| ps.firewalls.each { |fw| fw.destroy } }.incr_destroy }
 
     hop_wait_resources_destroyed
   end

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Prog::Test::VmGroup do
     it "hops to wait_resources_destroyed" do
       allow(vg_test).to receive(:frame).and_return({"vms" => ["vm_id"], "subnets" => ["subnet_id"]}).twice
       expect(Vm).to receive(:[]).with("vm_id").and_return(instance_double(Vm, incr_destroy: nil))
-      expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(instance_double(PrivateSubnet, incr_destroy: nil))
+      expect(PrivateSubnet).to receive(:[]).with("subnet_id").and_return(instance_double(PrivateSubnet, incr_destroy: nil, firewalls: []))
       expect { vg_test.destroy_resources }.to hop("wait_resources_destroyed")
     end
   end


### PR DESCRIPTION
    2025-01-17 05:36:13 [st06a75bgn762k2v0exgmkysvj] Exception: PG::ForeignKeyViolation - ERROR:  update or delete on table "project" violates foreign key constraint "firewall_project_id_fkey" on table "firewall"
    DETAIL:  Key (id)=(b8ea5a46-8edd-8ed2-88b7-b3eb1b704558) is still referenced from table "firewall".

    sequel/adapters/postgres.rb:171:in `exec'
    .....
    ubicloud/model.rb:43:in `delete'
    sequel/model/base.rb:1728:in `_destroy_delete'
    sequel/model/base.rb:1717:in `block in _destroy'
    sequel/model/base.rb:1060:in `around_destroy'
    ....
    ubicloud/prog/test/vm_group.rb:146:in `finish'