### PR TITLE
Reduce e2e logs while running services

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,7 +114,16 @@ jobs:
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
         HETZNER_SSH_PUBLIC_KEY: ${{ secrets.HETZNER_SSH_PUBLIC_KEY }}
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
-      run: timeout 40m foreman start
+      run: timeout 40m foreman start | tee foreman.log | grep "e2e.1"
+
+    - name: Print logs
+      run: grep -h -v -E "sleep_duration_sec|monitor.1" foreman.log
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: e2e-${{ github.run_id }}-logs
+        path: foreman.log
 
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}

--- a/bin/ci
+++ b/bin/ci
@@ -5,6 +5,8 @@ require_relative "../loader"
 require "time"
 require "optparse"
 
+@started_at = Time.now
+
 def main(options)
   hetzner_server_st = Prog::Test::HetznerServer.assemble(vm_host_id: options[:vm_host_id])
   wait_until(hetzner_server_st, "wait")
@@ -64,7 +66,7 @@ def log(st, msg)
   else
     "#{st.prog}.#{st.label}"
   end
-  $stdout.write "#{Time.now.utc.iso8601} | #{st.id} | #{st.prog}.#{st.label} | #{msg} | #{resources}\n"
+  $stdout.write "#{((Time.now - @started_at) / 60).round(2)}m | #{st.id} | #{st.prog}.#{st.label} | #{msg} | #{resources}\n"
 end
 
 options = {test_cases: ["vm"]}


### PR DESCRIPTION
We are getting too many logs from respirate while running services. The logs from the e2e script alone are enough to determine the current test status. I also added a step to print all logs for those who want to see everything for debugging. I excluded sleep and monitor logs to reduce repetitive logs.

Also foreman already shows timestamp for logs, so I changed the timestamp with the minute duration in the e2e script. It makes easy to see timeline of the e2e test.

Example run: https://github.com/ubicloud/ubicloud/actions/runs/12828015637/job/35771180036