### PR TITLE
Add kubernetes cluster and node pool upgrades

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -34,6 +34,14 @@ class Kubernetes::Client
     @session.exec!("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf #{cmd}")
   end
 
+  def version
+    kubectl("version --client")[/Client Version: (v1\.\d\d)\.\d/, 1]
+  end
+
+  def delete_node(node_name)
+    kubectl("delete node #{node_name.shellescape}")
+  end
+
   def set_load_balancer_hostname(svc, hostname)
     patch_data = JSON.generate({
       "status" => {

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -18,7 +18,7 @@ class KubernetesCluster < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
 
-  semaphore :destroy, :sync_kubernetes_services
+  semaphore :destroy, :sync_kubernetes_services, :upgrade
 
   def validate
     super
@@ -109,6 +109,14 @@ class KubernetesCluster < Sequel::Model
       "down"
     end
     aggregate_readings(previous_pulse: previous_pulse, reading: reading)
+  end
+
+  def all_vms
+    cp_vms + nodepools.flat_map(&:vms)
+  end
+
+  def worker_vms
+    nodepools.flat_map(&:vms)
   end
 end
 

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -44,7 +44,7 @@ class KubernetesCluster < Sequel::Model
     api_server_lb.hostname
   end
 
-  def client(session: cp_vms.first.sshable.start_fresh_session)
+  def client(session: cp_vms.first.sshable.connect)
     Kubernetes::Client.new(self, session)
   end
 

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -10,7 +10,7 @@ class KubernetesNodepool < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
 
-  semaphore :destroy, :start_bootstrapping
+  semaphore :destroy, :start_bootstrapping, :upgrade
 end
 
 # Table: kubernetes_nodepool

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -124,6 +124,10 @@ class Sshable < Sequel::Model
     cmd("common/bin/daemonizer2 run #{unit_name.shellescape} #{Shellwords.join(run_command)}", stdin:, log:)
   end
 
+  def d_restart(unit_name)
+    cmd("common/bin/daemonizer2 restart #{unit_name}")
+  end
+
   # A huge number of settings are needed to isolate net-ssh from the
   # host system and provide some anti-hanging assurance (keepalive,
   # timeout).

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -145,7 +145,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     decr_upgrade
 
     node_to_upgrade = kubernetes_cluster.cp_vms.find do |vm|
-      vm_version = kubernetes_cluster.client(session: vm.sshable.start_fresh_session).version
+      vm_version = kubernetes_cluster.client(session: vm.sshable.connect).version
       vm_minor_version = vm_version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
       cluster_minor_version = kubernetes_cluster.version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
 

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -145,9 +145,12 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     decr_upgrade
 
     node_to_upgrade = kubernetes_cluster.cp_vms.find do |vm|
-      # TODO: Put another check here to make sure the version we receive is either one version old or the correct version, just in case
       vm_version = kubernetes_cluster.client(session: vm.sshable.start_fresh_session).version
-      vm_version != kubernetes_cluster.version
+      vm_minor_version = vm_version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
+      cluster_minor_version = kubernetes_cluster.version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
+
+      next false unless vm_minor_version && cluster_minor_version
+      vm_minor_version == cluster_minor_version - 1
     end
 
     hop_wait unless node_to_upgrade

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -87,7 +87,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
     decr_upgrade
 
     node_to_upgrade = kubernetes_nodepool.vms.find do |vm|
-      vm_version = kubernetes_nodepool.cluster.client(session: vm.sshable.start_fresh_session).version
+      vm_version = kubernetes_nodepool.cluster.client(session: vm.sshable.connect).version
       vm_minor_version = vm_version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
       cluster_minor_version = kubernetes_nodepool.cluster.version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
 

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -87,9 +87,12 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
     decr_upgrade
 
     node_to_upgrade = kubernetes_nodepool.vms.find do |vm|
-      # TODO: Put another check here to make sure the version we receive is either one version old or the correct version, just in case
       vm_version = kubernetes_nodepool.cluster.client(session: vm.sshable.start_fresh_session).version
-      vm_version != kubernetes_nodepool.cluster.version
+      vm_minor_version = vm_version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
+      cluster_minor_version = kubernetes_nodepool.cluster.version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
+
+      next false unless vm_minor_version && cluster_minor_version
+      vm_minor_version == cluster_minor_version - 1
     end
 
     hop_wait unless node_to_upgrade

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -11,14 +11,6 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     @kubernetes_nodepool ||= KubernetesNodepool[frame["nodepool_id"]]
   end
 
-  def write_hosts_file_if_needed(ip = nil)
-    return unless Config.development?
-    return if vm.sshable.cmd("cat /etc/hosts").include?(kubernetes_cluster.endpoint.to_s)
-    ip ||= kubernetes_cluster.sshable.host
-
-    vm.sshable.cmd("sudo tee -a /etc/hosts", stdin: "#{ip} #{kubernetes_cluster.endpoint}\n")
-  end
-
   # We need to create a random ula cidr for the cluster services subnet with
   # a NetMask of /108
   # For reference read here:
@@ -122,8 +114,6 @@ TEMPLATE
   end
 
   label def assign_role
-    write_hosts_file_if_needed
-
     hop_join_worker if kubernetes_nodepool
 
     hop_init_cluster if kubernetes_cluster.cp_vms.count == 1

--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -60,7 +60,8 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
     when "InProgress"
       nap 10
     when "Failed"
-      nap 60 * 60
+      vm.sshable.d_restart("drain_node")
+      nap 10
     end
     nap 60 * 60
   end

--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
+  subject_is :kubernetes_cluster
+
+  def old_vm
+    @old_vm ||= Vm[frame.fetch("old_vm_id")]
+  end
+
+  def new_vm
+    @new_vm ||= Vm[frame.fetch("new_vm_id")]
+  end
+
+  def kubernetes_nodepool
+    @kubernetes_nodepool ||= KubernetesNodepool[frame.fetch("nodepool_id", nil)]
+  end
+
+  def before_run
+    if kubernetes_cluster.strand.label == "destroy" && strand.label != "destroy"
+      reap
+      donate unless leaf?
+      pop "upgrade cancelled"
+    end
+  end
+
+  label def start
+    new_frame = if kubernetes_nodepool
+      {"nodepool_id" => kubernetes_nodepool.id}
+    else
+      {}
+    end
+
+    bud Prog::Kubernetes::ProvisionKubernetesNode, new_frame
+
+    hop_wait_new_node
+  end
+
+  label def wait_new_node
+    res = reap
+    donate if res.empty?
+
+    current_frame = strand.stack.first
+    current_frame["new_vm_id"] = res.first.exitval.fetch("vm_id")
+    strand.modified!(:stack)
+
+    hop_drain_old_node
+  end
+
+  label def drain_old_node
+    register_deadline("remove_old_node_from_cluster", 60 * 60)
+
+    vm = kubernetes_cluster.cp_vms.last
+    case vm.sshable.d_check("drain_node")
+    when "Succeeded"
+      hop_remove_old_node_from_cluster
+    when "NotStarted"
+      vm.sshable.d_run("drain_node", "sudo", "kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",
+        "drain", old_vm.name, "--ignore-daemonsets", "--delete-emptydir-data")
+      nap 10
+    when "InProgress"
+      nap 10
+    when "Failed"
+      nap 60 * 60
+    end
+    nap 60 * 60
+  end
+
+  label def remove_old_node_from_cluster
+    if kubernetes_nodepool
+      kubernetes_nodepool.remove_vm(old_vm)
+    else
+      kubernetes_cluster.remove_cp_vm(old_vm)
+      kubernetes_cluster.api_server_lb.detach_vm(old_vm)
+    end
+
+    # kubeadm reset is necessary for etcd member removal, delete node itself
+    # doesn't remove node from the etcd member, hurting the etcd cluster health
+    old_vm.sshable.cmd("sudo kubeadm reset --force")
+
+    hop_delete_node_object
+  end
+
+  label def delete_node_object
+    res = kubernetes_cluster.client.delete_node(old_vm.name)
+    fail "delete node object failed: #{res}" unless res.exitstatus.zero?
+    hop_destroy_node
+  end
+
+  label def destroy_node
+    old_vm.incr_destroy
+    pop "upgraded node"
+  end
+end

--- a/rhizome/common/bin/daemonizer2
+++ b/rhizome/common/bin/daemonizer2
@@ -40,6 +40,10 @@ def clean(name, stdin_path)
   end
 end
 
+def restart(name)
+  r "sudo systemctl restart #{name}"
+end
+
 command = ARGV[0]
 name = ARGV[1]
 stdin_path = "/dev/shm/#{name}.stdin"
@@ -49,6 +53,8 @@ when "check"
   print(get_state(name))
 when "clean"
   clean(name, stdin_path)
+when "restart"
+  restart(name)
 when "run"
   command_parts = ARGV[2..]
   state = get_state(name)

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -202,6 +202,20 @@ RSpec.describe Kubernetes::Client do
     end
   end
 
+  describe "version" do
+    it "runs a version command on kubectl" do
+      expect(session).to receive(:exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf version --client").and_return("Client Version: v1.33.0\nKustomize Version: v5.6.0")
+      expect(kubernetes_client.version).to eq("v1.33")
+    end
+  end
+
+  describe "delete_node" do
+    it "deletes a node" do
+      expect(session).to receive(:exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete node asdf")
+      kubernetes_client.delete_node("asdf")
+    end
+  end
+
   describe "set_load_balancer_hostname" do
     it "calls kubectl function with right inputs" do
       svc = {

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -164,4 +164,19 @@ RSpec.describe KubernetesCluster do
       expect(missing_ports[0][0]).to eq(443)
     end
   end
+
+  describe "#all_vms" do
+    it "returns all VMs in the cluster, including CP and worker nodes" do
+      expect(kc).to receive(:cp_vms).and_return([1, 2])
+      expect(kc).to receive(:nodepools).and_return([instance_double(KubernetesNodepool, vms: [3, 4]), instance_double(KubernetesNodepool, vms: [5, 6])])
+      expect(kc.all_vms).to eq([1, 2, 3, 4, 5, 6])
+    end
+  end
+
+  describe "#worker_vms" do
+    it "returns all worker VMs in the cluster" do
+      expect(kc).to receive(:nodepools).and_return([instance_double(KubernetesNodepool, vms: [3, 4]), instance_double(KubernetesNodepool, vms: [5, 6])])
+      expect(kc.worker_vms).to eq([3, 4, 5, 6])
+    end
+  end
 end

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -175,6 +175,11 @@ RSpec.describe Sshable do
       sa.d_clean(unit_name)
     end
 
+    it "calls cmd with the correct restart command" do
+      expect(sa).to receive(:cmd).with("common/bin/daemonizer2 restart test_unit")
+      sa.d_restart(unit_name)
+    end
+
     it "calls cmd with the correct run command and no stdin" do
       expect(sa).to receive(:cmd).with("common/bin/daemonizer2 run test_unit sudo\\ host/bin/setup-vm\\ prep\\ test_unit", stdin: nil, log: true)
       sa.d_run(unit_name, run_command)

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -257,8 +257,8 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kubernetes_cluster).to receive(:cp_vms).and_return([first_vm, second_vm])
       allow(first_vm).to receive(:sshable).and_return(sshable0)
       allow(second_vm).to receive(:sshable).and_return(sshable1)
-      allow(sshable0).to receive(:start_fresh_session)
-      allow(sshable1).to receive(:start_fresh_session)
+      allow(sshable0).to receive(:connect)
+      allow(sshable1).to receive(:connect)
 
       expect(kubernetes_cluster).to receive(:client).and_return(client).at_least(:once)
     end

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -165,24 +165,55 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     before do
       sshable0, sshable1 = instance_double(Sshable), instance_double(Sshable)
       expect(kn).to receive(:vms).and_return([first_vm, second_vm])
-      expect(first_vm).to receive(:sshable).and_return(sshable0)
-      expect(second_vm).to receive(:sshable).and_return(sshable1)
-      expect(sshable0).to receive(:start_fresh_session)
-      expect(sshable1).to receive(:start_fresh_session)
+      allow(first_vm).to receive(:sshable).and_return(sshable0)
+      allow(second_vm).to receive(:sshable).and_return(sshable1)
+      allow(sshable0).to receive(:start_fresh_session)
+      allow(sshable1).to receive(:start_fresh_session)
 
-      expect(kn.cluster).to receive(:client).and_return(client).twice
+      expect(kn.cluster).to receive(:client).and_return(client).at_least(:once)
     end
 
-    it "picks a node to upgrade and pushes UpgradeKubernetesNode prog with it" do
-      expect(client).to receive(:version).and_return("v1.32")
-      expect(client).to receive(:version).and_return("v1.31")
-      expect(nx).to receive(:bud).with(Prog::Kubernetes::UpgradeKubernetesNode, {"nodepool_id" => kn.id, "old_vm_id" => second_vm.id, "subject_id" => kc.id})
+    it "selects a VM with minor version one less than the cluster's version" do
+      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
+      expect(client).to receive(:version).and_return("v1.32", "v1.31")
+      expect(nx).to receive(:bud).with(Prog::Kubernetes::UpgradeKubernetesNode, {"nodepool_id" => kn.id, "old_vm_id" => second_vm.id, "subject_id" => kn.cluster.id})
       expect { nx.upgrade }.to hop("wait_upgrade")
     end
 
-    it "returns to wait if all nodes are in desired version" do
-      expect(client).to receive(:version).and_return("v1.32")
-      expect(client).to receive(:version).and_return("v1.32")
+    it "hops to wait when all VMs are at the cluster's version" do
+      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
+      expect(client).to receive(:version).and_return("v1.32", "v1.32")
+      expect { nx.upgrade }.to hop("wait")
+    end
+
+    it "does not select a VM with minor version more than one less than the cluster's version" do
+      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
+      expect(client).to receive(:version).and_return("v1.30", "v1.32")
+      expect { nx.upgrade }.to hop("wait")
+    end
+
+    it "skips VMs with invalid version formats" do
+      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
+      expect(client).to receive(:version).and_return("invalid", "v1.32")
+      expect { nx.upgrade }.to hop("wait")
+    end
+
+    it "selects the first VM that is one minor version behind" do
+      expect(kn.cluster).to receive(:version).and_return("v1.32")
+      expect(client).to receive(:version).and_return("v1.31")
+      expect(nx).to receive(:bud).with(Prog::Kubernetes::UpgradeKubernetesNode, {"nodepool_id" => kn.id, "old_vm_id" => first_vm.id, "subject_id" => kn.cluster.id})
+      expect { nx.upgrade }.to hop("wait_upgrade")
+    end
+
+    it "hops to wait if cluster version is invalid" do
+      expect(kn.cluster).to receive(:version).and_return("invalid").twice
+      expect(client).to receive(:version).and_return("v1.31", "v1.31")
+      expect { nx.upgrade }.to hop("wait")
+    end
+
+    it "does not select a VM with a higher minor version than the cluster" do
+      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
+      expect(client).to receive(:version).and_return("v1.33", "v1.32")
       expect { nx.upgrade }.to hop("wait")
     end
   end

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -167,8 +167,8 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       expect(kn).to receive(:vms).and_return([first_vm, second_vm])
       allow(first_vm).to receive(:sshable).and_return(sshable0)
       allow(second_vm).to receive(:sshable).and_return(sshable1)
-      allow(sshable0).to receive(:start_fresh_session)
-      allow(sshable1).to receive(:start_fresh_session)
+      allow(sshable0).to receive(:connect)
+      allow(sshable1).to receive(:connect)
 
       expect(kn.cluster).to receive(:client).and_return(client).at_least(:once)
     end

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -132,9 +132,10 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
       expect { prog.drain_old_node }.to nap(10)
     end
 
-    it "naps when it fails and waits for the page" do
+    it "restarts when it fails" do
       expect(sshable).to receive(:d_check).with("drain_node").and_return("Failed")
-      expect { prog.drain_old_node }.to nap(60 * 60)
+      expect(sshable).to receive(:d_restart).with("drain_node")
+      expect { prog.drain_old_node }.to nap(10)
     end
 
     it "naps when daemonizer something unexpected and waits for the page" do

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+class MockStringWithExitstatus < String
+  attr_accessor :exitstatus
+
+  def initialize(str, exitstatus = 0)
+    super(str)
+    self.exitstatus = exitstatus
+  end
+end
+
+RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
+  subject(:prog) { described_class.new(Strand.new) }
+
+  let(:project) {
+    Project.create(name: "default")
+  }
+  let(:subnet) {
+    Prog::Vnet::SubnetNexus.assemble(Config.kubernetes_service_project_id, name: "test", ipv4_range: "172.19.0.0/16", ipv6_range: "fd40:1a0a:8d48:182a::/64").subject
+  }
+
+  let(:kubernetes_cluster) {
+    kc = KubernetesCluster.create_with_id(
+      name: "k8scluster",
+      version: "v1.32",
+      cp_node_count: 3,
+      private_subnet_id: subnet.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      project_id: project.id,
+      target_node_size: "standard-4",
+      target_node_storage_size_gib: 37
+    )
+
+    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
+    LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
+    kc.add_cp_vm(create_vm)
+    kc.add_cp_vm(create_vm)
+
+    kc.update(api_server_lb_id: lb.id)
+    kc
+  }
+
+  let(:kubernetes_nodepool) {
+    kn = KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kubernetes_cluster.id, target_node_size: "standard-8", target_node_storage_size_gib: 78)
+    kn.add_vm(create_vm)
+    kn.add_vm(create_vm)
+    kn.reload
+  }
+
+  before do
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
+    allow(prog).to receive(:kubernetes_cluster).and_return(kubernetes_cluster)
+  end
+
+  describe "#before_run" do
+    before do
+      Strand.create(id: kubernetes_cluster.id, label: "wait", prog: "KubernetesClusterNexus")
+    end
+
+    it "exits when kubernetes cluster is deleted and has no children itself" do
+      prog.before_run # Nothing happens
+
+      kubernetes_cluster.strand.label = "destroy"
+      prog.strand.label = "somestep"
+      expect(prog).to receive(:reap)
+      expect(prog).to receive(:leaf?).and_return(true)
+      expect { prog.before_run }.to exit({"msg" => "upgrade cancelled"})
+    end
+
+    it "donates when kubernetes cluster is deleted and but has a child" do
+      kubernetes_cluster.strand.label = "destroy"
+      prog.strand.label = "somestep"
+      expect(prog).to receive(:reap)
+      expect(prog).to receive(:leaf?).and_return(false)
+      expect { prog.before_run }.to nap(1)
+    end
+  end
+
+  describe "#start" do
+    it "provisions a new kubernetes node" do
+      expect(prog).to receive(:frame).and_return({})
+      expect(prog).to receive(:bud).with(Prog::Kubernetes::ProvisionKubernetesNode, {})
+      expect { prog.start }.to hop("wait_new_node")
+
+      expect(prog).to receive(:frame).and_return({"nodepool_id" => kubernetes_nodepool.id})
+      expect(prog).to receive(:bud).with(Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kubernetes_nodepool.id})
+      expect { prog.start }.to hop("wait_new_node")
+    end
+  end
+
+  describe "#wait_new_node" do
+    it "donates if there are sub-programs running" do
+      expect(prog).to receive(:reap).and_return([])
+      expect(prog).to receive(:donate).and_call_original
+
+      expect { prog.wait_new_node }.to nap(1)
+    end
+
+    it "hops to assign_role if there are no sub-programs running" do
+      expect(prog).to receive(:reap).and_return([instance_double(Strand, exitval: {"vm_id" => "12345"})])
+
+      expect { prog.wait_new_node }.to hop("drain_old_node")
+
+      expect(prog.strand.stack.first["new_vm_id"]).to eq "12345"
+    end
+  end
+
+  describe "#drain_old_node" do
+    let(:sshable) { instance_double(Sshable) }
+    let(:old_vm) { create_vm }
+
+    before do
+      allow(prog).to receive(:frame).and_return({"old_vm_id" => old_vm.id})
+      expect(prog.old_vm.id).to eq(old_vm.id)
+      cp_vm = create_vm
+      expect(kubernetes_cluster).to receive(:cp_vms).and_return([old_vm, cp_vm])
+      allow(cp_vm).to receive(:sshable).and_return(sshable)
+
+      expect(prog).to receive(:register_deadline).with("remove_old_node_from_cluster", 60 * 60)
+    end
+
+    it "starts the drain process when run for the first time and naps" do
+      expect(sshable).to receive(:d_check).with("drain_node").and_return("NotStarted")
+      expect(sshable).to receive(:d_run).with("drain_node", "sudo", "kubectl", "--kubeconfig=/etc/kubernetes/admin.conf", "drain", old_vm.name, "--ignore-daemonsets", "--delete-emptydir-data")
+      expect { prog.drain_old_node }.to nap(10)
+    end
+
+    it "naps when the node is getting drained" do
+      expect(sshable).to receive(:d_check).with("drain_node").and_return("InProgress")
+      expect { prog.drain_old_node }.to nap(10)
+    end
+
+    it "naps when it fails and waits for the page" do
+      expect(sshable).to receive(:d_check).with("drain_node").and_return("Failed")
+      expect { prog.drain_old_node }.to nap(60 * 60)
+    end
+
+    it "naps when daemonizer something unexpected and waits for the page" do
+      expect(sshable).to receive(:d_check).with("drain_node").and_return("UnexpectedState")
+      expect { prog.drain_old_node }.to nap(60 * 60)
+    end
+
+    it "drains the old node and hops to drop the old node" do
+      expect(sshable).to receive(:d_check).with("drain_node").and_return("Succeeded")
+      expect { prog.drain_old_node }.to hop("remove_old_node_from_cluster")
+    end
+  end
+
+  describe "#remove_old_node_from_cluster" do
+    before do
+      old_vm = create_vm
+      new_vm = create_vm
+      allow(prog).to receive(:frame).and_return({"old_vm_id" => old_vm.id, "new_vm_id" => new_vm.id})
+      expect(prog.old_vm.id).to eq(old_vm.id)
+      expect(prog.new_vm.id).to eq(new_vm.id)
+
+      expect(kubernetes_nodepool.vms.count).to eq(2)
+      expect(kubernetes_cluster.reload.all_vms.map(&:id)).to eq((kubernetes_cluster.cp_vms + kubernetes_nodepool.vms).map(&:id))
+
+      mock_sshable = instance_double(Sshable)
+      expect(prog.old_vm).to receive(:sshable).and_return(mock_sshable)
+      expect(mock_sshable).to receive(:cmd).with("sudo kubeadm reset --force")
+    end
+
+    it "removes the old node from the CP while upgrading the control plane" do
+      expect(prog.kubernetes_nodepool).to be_nil
+      api_server_lb = instance_double(LoadBalancer)
+      expect(kubernetes_cluster).to receive(:api_server_lb).and_return(api_server_lb)
+      expect(kubernetes_cluster).to receive(:remove_cp_vm).with(prog.old_vm)
+      expect(api_server_lb).to receive(:detach_vm).with(prog.old_vm)
+      expect { prog.remove_old_node_from_cluster }.to hop("delete_node_object")
+    end
+
+    it "removes the old node from the nodepool while upgrading the node pool" do
+      allow(prog).to receive(:frame).and_return({"old_vm_id" => prog.old_vm.id, "new_vm_id" => prog.new_vm.id, "nodepool_id" => kubernetes_nodepool.id})
+      expect(prog.kubernetes_nodepool).not_to be_nil
+      expect(prog.kubernetes_nodepool).to receive(:remove_vm).with(prog.old_vm)
+      expect { prog.remove_old_node_from_cluster }.to hop("delete_node_object")
+    end
+  end
+
+  describe "#delete_node_object" do
+    before do
+      old_vm = create_vm
+      allow(prog).to receive(:frame).and_return({"old_vm_id" => old_vm.id})
+      expect(prog.old_vm.id).to eq(old_vm.id)
+    end
+
+    it "deletes the node object from kubernetes" do
+      result = instance_double(MockStringWithExitstatus)
+      client = instance_double(Kubernetes::Client)
+      expect(kubernetes_cluster).to receive(:client).and_return(client)
+      expect(client).to receive(:delete_node).with(prog.old_vm.name).and_return(result)
+      expect(result).to receive(:exitstatus).and_return(0)
+      expect { prog.delete_node_object }.to hop("destroy_node")
+    end
+
+    it "raises if the error of delete node command is not successful" do
+      result = instance_double(MockStringWithExitstatus)
+      client = instance_double(Kubernetes::Client)
+      expect(kubernetes_cluster).to receive(:client).and_return(client)
+      expect(client).to receive(:delete_node).with(prog.old_vm.name).and_return(result)
+      expect(result).to receive(:exitstatus).and_return(1)
+      expect { prog.delete_node_object }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "#destroy_node" do
+    before do
+      old_vm = create_vm
+      allow(prog).to receive(:frame).and_return({"old_vm_id" => old_vm.id})
+      expect(prog.old_vm.id).to eq(old_vm.id)
+    end
+
+    it "destroys the old node" do
+      expect(prog.old_vm).to receive(:incr_destroy)
+      expect { prog.destroy_node }.to exit({"msg" => "upgraded node"})
+    end
+  end
+end


### PR DESCRIPTION
This patch implements the upgrade logic for kubernetes clusters.

Upgrade is done sequentially, node-by-node, in the order of creation time.
Upgrade operation starts with the CP nodes.

Nodepools need to "incr_upgrade"d separately to start their upgrade process.

For upgrading a node, it creates a new node with upgraded version of k8s, adds it to
the cluster and drains/removes the corresponding old node. There's no actual relation
between the old node and new node in reality.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds sequential upgrade logic for Kubernetes clusters and node pools, including new methods and tests for handling node upgrades.
> 
>   - **Behavior**:
>     - Implements sequential node upgrade logic for Kubernetes clusters, starting with control plane nodes.
>     - Node pools require separate `incr_upgrade` to initiate upgrades.
>     - New nodes are created with upgraded Kubernetes versions, old nodes are drained and removed.
>   - **Functions**:
>     - Adds `version` and `delete_node` methods to `Kubernetes::Client`.
>     - Adds `all_vms` and `worker_vms` methods to `KubernetesCluster`.
>     - Adds `d_restart` method to `Sshable`.
>   - **Programs**:
>     - Adds `upgrade` and `wait_upgrade` labels to `KubernetesClusterNexus` and `KubernetesNodepoolNexus`.
>     - New `Prog::Kubernetes::UpgradeKubernetesNode` class for handling node upgrades.
>   - **Tests**:
>     - Adds tests for new methods in `client_spec.rb`, `kubernetes_cluster_spec.rb`, and `sshable_spec.rb`.
>     - Adds tests for upgrade logic in `kubernetes_cluster_nexus_spec.rb`, `kubernetes_nodepool_nexus_spec.rb`, and `upgrade_kubernetes_node_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8c4e526d742aa6127da01cfc8ee9e033f55f378c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->