### PR TITLE
Use feature flags to show invisable locations

### DIFF
--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -82,7 +82,7 @@ class Clover
     options = OptionTreeGenerator.new
 
     options.add_option(name: "name")
-    options.add_option(name: "location", values: Option.locations.map(&:display_name))
+    options.add_option(name: "location", values: Option.locations(feature_flags: @project.feature_flags).map(&:display_name))
 
     subnets = dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map {
       {

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -3,7 +3,7 @@
 module ContentGenerator
   module Vm
     def self.location(location)
-      Option.locations.find { _1.display_name == location }.ui_name
+      Option.locations(only_visible: false).find { _1.display_name == location }.ui_name
     end
 
     def self.private_subnet(location, private_subnet)


### PR DESCRIPTION
The latitude-fra region was added behind a feature flag. With the commit `2c98838`, we started not passing feature flags to the content generator which ended up not listing regions behind a feature flag. This commit fixes that bug.