### PR TITLE
Drop columns from access_tag, and drop applied_tag and access_policy

### DIFF
--- a/migrate/20250120_access_tag_null_changes.rb
+++ b/migrate/20250120_access_tag_null_changes.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  up do
+    drop_table :applied_tag, :access_policy
+
+    # Remove non-account entries, otherwise the foreign key creation will fail
+    from(:access_tag).exclude(hyper_tag_id: from(:accounts).select(:id)).delete
+
+    alter_table(:access_tag) do
+      drop_index [:project_id, :name], name: :access_tag_project_id_name_index, concurrently: true
+      drop_column :id
+      drop_column :hyper_tag_table
+      drop_column :name
+      set_column_not_null :hyper_tag_id
+      add_foreign_key [:hyper_tag_id], :accounts, name: :access_tag_hyper_tag_id_fkey
+    end
+
+    run "ALTER TABLE access_tag ADD CONSTRAINT access_tag_pkey PRIMARY KEY USING INDEX access_tag_project_id_hyper_tag_id_index"
+  end
+
+  down do
+    run "ALTER TABLE access_tag DROP CONSTRAINT access_tag_pkey"
+
+    alter_table(:access_tag) do
+      add_column :id, :uuid
+      add_column :hyper_tag_table, String
+      add_column :name, String
+      add_index [:project_id, :hyper_tag_id], name: :access_tag_project_id_hyper_tag_id_index, unique: true, concurrently: true
+      add_index [:project_id, :name], name: :access_tag_project_id_name_index, unique: true, concurrently: true
+      drop_constraint :access_tag_hyper_tag_id_fkey
+      set_column_allow_null :hyper_tag_id
+    end
+
+    create_table(:access_policy) do
+      uuid :id, primary_key: true
+      foreign_key :project_id, :project, type: :uuid, null: false
+      String :name, null: false
+      jsonb :body, null: false
+      timestamptz :created_at, default: Sequel::CURRENT_TIMESTAMP, null: false
+      TrueClass :managed, default: false, null: false
+      index [:project_id, :name], unique: true, name: :access_policy_project_id_name_index
+    end
+
+    create_table(:applied_tag) do
+      uuid :access_tag_id
+      uuid :tagged_id, index: true
+      String :tagged_table, null: false
+      primary_key [:access_tag_id, :tagged_id]
+    end
+  end
+end

--- a/model/account.rb
+++ b/model/account.rb
@@ -56,6 +56,7 @@ end
 # Foreign key constraints:
 #  accounts_status_id_fkey | (status_id) REFERENCES account_statuses(id)
 # Referenced By:
+#  access_tag                        | access_tag_hyper_tag_id_fkey                      | (hyper_tag_id) REFERENCES accounts(id)
 #  account_active_session_keys       | account_active_session_keys_account_id_fkey       | (account_id) REFERENCES accounts(id)
 #  account_activity_times            | account_activity_times_id_fkey                    | (id) REFERENCES accounts(id)
 #  account_authentication_audit_logs | account_authentication_audit_logs_account_id_fkey | (account_id) REFERENCES accounts(id)

--- a/model/project.rb
+++ b/model/project.rb
@@ -180,7 +180,6 @@ end
 #  project_billing_info_id_fkey | (billing_info_id) REFERENCES billing_info(id)
 # Referenced By:
 #  access_control_entry | access_control_entry_project_id_fkey | (project_id) REFERENCES project(id)
-#  access_policy        | access_policy_project_id_fkey        | (project_id) REFERENCES project(id)
 #  access_tag           | access_tag_project_id_fkey           | (project_id) REFERENCES project(id)
 #  action_tag           | action_tag_project_id_fkey           | (project_id) REFERENCES project(id)
 #  api_key              | api_key_project_id_fkey              | (project_id) REFERENCES project(id)


### PR DESCRIPTION
This builds on #2637, and implements the final 2 steps of the plan in #2594.

This makes access_tag a pure project <-> accounts join table (modulo the created_at column to see when the two were associated).
    
While here, drop the applied_tag and access_policy tables, as they are no longer used.