### PR TITLE
Fail correctly when the e2e script fails

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm,github_runner_ubuntu_2204,github_runner_ubuntu_2004' || inputs.test_cases }}" >> Procfile
 
-    - name: Run services
+    - name: Run tests
       env:
         RACK_ENV: production
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
@@ -119,9 +119,11 @@ jobs:
         timeout 40m foreman start | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
+      if: always()
       run: grep -h -v -E "sleep_duration_sec|monitor.1" foreman.log
 
     - name: Upload logs
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: e2e-${{ github.run_id }}-logs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,7 +114,9 @@ jobs:
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
         HETZNER_SSH_PUBLIC_KEY: ${{ secrets.HETZNER_SSH_PUBLIC_KEY }}
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
-      run: timeout 40m foreman start | tee foreman.log | grep "e2e.1"
+      run: |
+        set -o pipefail
+        timeout 40m foreman start | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
       run: grep -h -v -E "sleep_duration_sec|monitor.1" foreman.log


### PR DESCRIPTION
### Fail correctly when the e2e script fails

I added `tee` and `grep` to print only the relevant lines of the e2e script output in commit https://github.com/ubicloud/ubicloud/commit/e7304e56ce0829d74e7340e96db2c8b9eb026608.

However, the pipe suppressed the exit code of the e2e script, causing the test to always pass.

I should have used `set -o pipefail` to ensure the test fails when the e2e script fails.

### Upload E2E logs even it fails

If the tests are failed, it's not upload all logs currently. It's good to upload them for debugging even for failures.
