### PR TITLE
Add privacy policy link to the login and registration pages

### DIFF
--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Clover, "auth" do
     fill_in "Email Address", with: TEST_USER_EMAIL
     fill_in "Password", with: TEST_USER_PASSWORD
     fill_in "Password Confirmation", with: TEST_USER_PASSWORD
-    expect(page).to have_no_content "By signing up you agree to our"
+    expect(page).to have_no_content "By using Ubicloud console you agree to our"
     click_button "Create Account"
 
     expect(page).to have_flash_notice("An email has been sent to you with a link to verify your account")
@@ -115,7 +115,7 @@ RSpec.describe Clover, "auth" do
     AccessControlEntry.create_with_id(project_id: p.id, subject_id:, action_id: ActionType::NAME_MAP["Project:view"])
     p.add_invitation(email: TEST_USER_EMAIL, policy: "Admin", inviter_id: "bd3479c6-5ee3-894c-8694-5190b76f84cf", expires_at: Time.now + 7 * 24 * 60 * 60)
 
-    expect(Config).to receive(:managed_service).and_return(true)
+    expect(Config).to receive(:managed_service).and_return(true).at_least(:once)
     expect(Config).to receive(:cloudflare_turnstile_site_key).and_return("1")
     visit "/create-account"
     expect(page.find(".cf-turnstile")["data-sitekey"]).to eq "1"
@@ -124,7 +124,7 @@ RSpec.describe Clover, "auth" do
     fill_in "Email Address", with: TEST_USER_EMAIL
     fill_in "Password", with: TEST_USER_PASSWORD
     fill_in "Password Confirmation", with: TEST_USER_PASSWORD
-    expect(page).to have_content "By signing up you agree to our"
+    expect(page).to have_content "By using Ubicloud console you agree to our"
     click_button "Create Account"
 
     expect(page).to have_flash_notice("An email has been sent to you with a link to verify your account")

--- a/views/auth/create_account.erb
+++ b/views/auth/create_account.erb
@@ -30,14 +30,3 @@
 </form>
 
 <%== render("auth/social_buttons") %>
-
-<% if Config.managed_service %>
-  <div class="flex items-center justify-center mt-6">
-    <p class="text-sm text-gray-500 text-center">By signing up you agree to our
-      <a
-        href="https://ubicloud.com/terms-of-service"
-        target="_blank"
-        class="font-medium text-orange-500 hover:text-orange-600 underline underline-offset-2"
-      >terms of service</a>.</p>
-  </div>
-<% end %>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -88,6 +88,26 @@
             <%== render("components/icon", locals: { name: "hero-envelope" }) %>
           </a>
         </div>
+        <% if Config.managed_service %>
+          <div class="md:absolute md:bottom-6 md:left-1/2 md:-translate-x-1/2 text-sm text-gray-500 text-center mt-10 w-full">
+            By using Ubicloud console you agree to our
+            <a
+              href="https://www.ubicloud.com/docs/about/terms-of-service"
+              class="font-medium text-orange-500 hover:text-orange-600"
+              target="_blank"
+            >
+              terms of service
+            </a>
+            and
+            <a
+              href="https://www.ubicloud.com/docs/about/privacy-policy"
+              class="font-medium text-orange-500 hover:text-orange-600"
+              target="_blank"
+            >
+              privacy policy
+            </a>
+          </div>
+        <% end %>
       </div>
     <% end %>
     <%== assets(:js) %>


### PR DESCRIPTION
Google requires you to provide a privacy policy on the page used for the "Login with Google" option.

![CleanShot 2025-01-19 at 11 35 53@2x](https://github.com/user-attachments/assets/0133c572-df0f-4137-ab31-846144316c74)
