### PR TITLE
Merge e2e test cases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,7 +82,12 @@ jobs:
 
     - name: Add e2e script to Procfile
       run: |
-        echo "e2e: bin/ci --test-cases=${{ github.event_name != 'workflow_dispatch' && 'vm,github_runner_ubuntu_2204,github_runner_ubuntu_2004' || inputs.test_cases }}" >> Procfile
+        test_cases="$(yq -r '[.[].name] | join(",")' config/e2e_test_cases.yml)"
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          test_cases="${{ inputs.test_cases }}"
+        fi
+        echo "Running e2e test cases: $test_cases"
+        echo "e2e: bin/ci --test-cases=$test_cases" >> Procfile
 
     - name: Run tests
       env:

--- a/bin/ci
+++ b/bin/ci
@@ -8,44 +8,38 @@ require "optparse"
 @started_at = Time.now
 
 def main(options)
-  boot_images = get_additional_boot_images(options[:test_cases])
-  hetzner_server_st = Prog::Test::HetznerServer.assemble(vm_host_id: options[:vm_host_id], additional_boot_images: boot_images)
+  all_test_cases = YAML.load_file("config/e2e_test_cases.yml").to_h { [_1["name"], _1] }
+  boot_images = all_test_cases.values_at(*options[:test_cases]).flat_map { _1["images"] }.uniq
+
+  hetzner_server_st = Prog::Test::HetznerServer.assemble(vm_host_id: options[:vm_host_id], default_boot_images: boot_images)
   wait_until(hetzner_server_st, "wait")
 
   tests_to_wait = []
-  if options[:test_cases].include?("vm")
-    encrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: true, test_reboot: true)
+  if options[:test_cases].include?("vm") && (test_case = all_test_cases["vm"])
+    encrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], storage_encrypted: true, test_reboot: true)
     log(encrypted_vms_st, "storage_encrypted: true")
     # Not running in parallel but waiting, since host is rebooted during test.
     # Rebooting makes the next test to test reboot practically as well depending
     # on when the host is rebooted and can cause flaky issues for github runner tests.
     wait_until(encrypted_vms_st)
 
-    unencrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: false, test_reboot: false)
+    unencrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], storage_encrypted: false, test_reboot: false)
     log(unencrypted_vms_st, "storage_encrypted: false")
-    tests_to_wait << [unencrypted_vms_st, nil]
+    tests_to_wait << unencrypted_vms_st
   end
 
-  github_runner_test_cases = options[:test_cases].select { _1.include?("github_runner") }
-  unless github_runner_test_cases.empty?
-    runner_st = Prog::Test::GithubRunner.assemble(options[:vm_host_id], github_runner_test_cases)
-    tests_to_wait << [runner_st, nil]
+  if (gh_test_cases = all_test_cases.values_at(*options[:test_cases].select { _1.include?("github_runner") }))
+    tests_to_wait << Prog::Test::GithubRunner.assemble(gh_test_cases)
   end
 
-  postgres_test_cases = options[:test_cases].select { _1.include?("postgres") }
-  unless postgres_test_cases.empty?
-    if postgres_test_cases.include?("postgres_standard")
-      postgres_st = Prog::Test::PostgresResource.assemble
-      tests_to_wait << [postgres_st, nil]
-    end
+  if options[:test_cases].include?("postgres_standard")
+    tests_to_wait << Prog::Test::PostgresResource.assemble
   end
 
   # Although wait_until will be blocked while checking the first one
   # it won't affect the total time as other strands will continue in parallel.
   # No need to make it parallel.
-  tests_to_wait.each do |strand, label|
-    wait_until(strand, label)
-  end
+  tests_to_wait.each { |st| wait_until(st) }
 
   Semaphore.incr(hetzner_server_st.id, "destroy")
   wait_until(hetzner_server_st)
@@ -76,11 +70,6 @@ def log(st, msg)
     "#{st.prog}.#{st.label}"
   end
   $stdout.write "#{((Time.now - @started_at) / 60).round(2)}m | #{st.id} | #{st.prog}.#{st.label} | #{msg} | #{resources}\n"
-end
-
-def get_additional_boot_images(test_cases)
-  images = YAML.load_file("./config/e2e_boot_images.yml").to_h { [_1["test_case"], _1["images"]] }
-  test_cases.flat_map { |test_case| images[test_case] || [] }.compact
 end
 
 options = {test_cases: ["vm"]}

--- a/config/e2e_boot_images.yml
+++ b/config/e2e_boot_images.yml
@@ -1,1 +1,0 @@
-- {test_case: "postgres_standard", images: ["postgres16-ubuntu-2204"]}

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -1,0 +1,5 @@
+- { name: vm,                        images: ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"] }
+- { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2404.yml, branch_name: main} }
+- { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2204.yml, branch_name: main} }
+- { name: github_runner_ubuntu_2004, images: ["github-ubuntu-2004"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2004.yml, branch_name: main} }
+- { name: postgres_standard,         images: ["postgres16-ubuntu-2204"] }

--- a/config/github_runner_e2e_tests.yml
+++ b/config/github_runner_e2e_tests.yml
@@ -1,3 +1,0 @@
-- {name: github_runner_ubuntu_2404, image_name: github-ubuntu-2404, runs: [{repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2404.yml, branch_name: main}]}
-- {name: github_runner_ubuntu_2204, image_name: github-ubuntu-2204, runs: [{repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2204.yml, branch_name: main}]}
-- {name: github_runner_ubuntu_2004, image_name: github-ubuntu-2004, runs: [{repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2004.yml, branch_name: main}]}

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -5,18 +5,18 @@ require_relative "../../lib/util"
 class Prog::Test::HetznerServer < Prog::Test::Base
   semaphore :destroy
 
-  def self.assemble(vm_host_id: nil, additional_boot_images: [])
+  def self.assemble(vm_host_id: nil, default_boot_images: [])
     frame = if vm_host_id
       vm_host = VmHost[vm_host_id]
       {
         vm_host_id: vm_host.id, server_id: vm_host.hetzner_host.server_identifier,
         hostname: vm_host.sshable.host, setup_host: false,
-        additional_boot_images: additional_boot_images
+        default_boot_images:
       }
     else
       {
         server_id: Config.ci_hetzner_sacrificial_server_id, setup_host: true,
-        additional_boot_images: additional_boot_images
+        default_boot_images:
       }
     end
 
@@ -62,12 +62,11 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   end
 
   label def setup_host
-    boot_images = (Option::BootImages.map { _1.name } || []) + frame["additional_boot_images"]
     vm_host = Prog::Vm::HostNexus.assemble(
       frame["hostname"],
       provider: "hetzner",
       hetzner_server_identifier: frame["server_id"],
-      default_boot_images: boot_images
+      default_boot_images: frame["default_boot_images"]
     ).subject
     update_stack({"vm_host_id" => vm_host.id})
 

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -2,10 +2,8 @@
 
 require "net/ssh"
 
-DEFAULT_BOOT_IMAGE_NAMES = Option::BootImages.map { _1.name }.freeze
-
 class Prog::Test::VmGroup < Prog::Test::Base
-  def self.assemble(storage_encrypted: true, test_reboot: true, boot_images: DEFAULT_BOOT_IMAGE_NAMES)
+  def self.assemble(boot_images:, storage_encrypted: true, test_reboot: true)
     Strand.create_with_id(
       prog: "Test::VmGroup",
       label: "start",

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Test::GithubRunner do
-  subject(:gr_test) { described_class.new(described_class.assemble(12345, ["github_runner_ubuntu_2204"])) }
+  subject(:gr_test) { described_class.new(described_class.assemble([{"name" => "github_runner_ubuntu_2204", "images" => ["github-ubuntu-2204"], "details" => {"repo_name" => "ubicloud/github-e2e-test-workflows", "workflow_name" => "test_2204.yml", "branch_name" => "main"}}])) }
 
   let(:client) { instance_double(Octokit::Client) }
 
@@ -15,30 +15,8 @@ RSpec.describe Prog::Test::GithubRunner do
   end
 
   describe "#start" do
-    it "hops to hop_download_boot_images" do
-      expect { gr_test.start }.to hop("download_boot_images")
-    end
-  end
-
-  describe "#download_boot_images" do
-    it "hops to hop_wait_download_boot_images" do
-      expect(gr_test).to receive(:bud).with(Prog::DownloadBootImage, {"subject_id" => 12345, "image_name" => "github-ubuntu-2204"})
-      expect { gr_test.download_boot_images }.to hop("wait_download_boot_images")
-    end
-  end
-
-  describe "#wait_download_boot_images" do
-    it "hops to hop_wait_download_boot_images" do
-      expect(gr_test).to receive(:reap)
-      expect(gr_test).to receive(:leaf?).and_return(true)
-      expect { gr_test.wait_download_boot_images }.to hop("create_vm_pool")
-    end
-
-    it "stays in wait_download_boot_images" do
-      expect(gr_test).to receive(:reap)
-      expect(gr_test).to receive(:leaf?).and_return(false)
-      expect(gr_test).to receive(:donate).and_call_original
-      expect { gr_test.wait_download_boot_images }.to nap(1)
+    it "hops to hop_create_vm_pool" do
+      expect { gr_test.start }.to hop("create_vm_pool")
     end
   end
 
@@ -136,7 +114,7 @@ RSpec.describe Prog::Test::GithubRunner do
       expect(GithubRunner).to receive(:any?).and_return(false)
       expect(VmPool).to receive(:[]).with(anything).and_return(instance_double(VmPool, vms: [instance_double(Vm)], incr_destroy: nil))
       expect(Project).to receive(:[]).with(anything).and_return(nil).at_least(:once)
-      expect(gr_test).to receive(:frame).and_return({"fail_message" => "Failed test", "test_cases" => ["github_runner_ubuntu_2204"]}).at_least(:once)
+      expect(gr_test).to receive(:frame).and_return({"fail_message" => "Failed test", "test_cases" => gr_test.frame["test_cases"]}).at_least(:once)
       expect { gr_test.clean_resources }.to hop("failed")
     end
 

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -5,10 +5,13 @@ require_relative "../../model/spec_helper"
 RSpec.describe Prog::Test::GithubRunner do
   subject(:gr_test) { described_class.new(described_class.assemble(12345, ["github_runner_ubuntu_2204"])) }
 
+  let(:client) { instance_double(Octokit::Client) }
+
   before do
     expect(Config).to receive(:github_runner_service_project_id).and_return("fabd95f8-d002-8ed2-9f4c-00625eb7f574")
     expect(Config).to receive(:vm_pool_project_id).and_return("c3fd495f-9888-82d2-8100-7fae94e87e27")
     expect(Config).to receive(:e2e_github_installation_id).and_return(123456).at_least(:once)
+    allow(Github).to receive(:installation_client).with(Config.e2e_github_installation_id).and_return(client)
   end
 
   describe "#start" do
@@ -68,8 +71,6 @@ RSpec.describe Prog::Test::GithubRunner do
 
   describe "#trigger_test_runs" do
     it "triggers test runs" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client)
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
       expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main", {inputs: {triggered_by: "12345"}}).and_return(true)
@@ -78,8 +79,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "can not triggers test runs" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client)
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
       expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main", {inputs: {triggered_by: "12345"}}).and_return(false)
@@ -89,50 +88,33 @@ RSpec.describe Prog::Test::GithubRunner do
 
   describe "#check_test_runs" do
     it "check test runs completed" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now}]})
-      expect(gr_test).to receive(:frame).and_return({"created_at" => Time.new(2023, 1, 1).to_s, "test_cases" => ["github_runner_ubuntu_2204"]}).at_least(:once)
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
 
     it "check test runs in progress with nil" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: nil, created_at: Time.now}]})
-      expect(gr_test).to receive(:frame).and_return({"created_at" => Time.new(2023, 1, 1).to_s, "test_cases" => ["github_runner_ubuntu_2204"]}).at_least(:once)
       expect { gr_test.check_test_runs }.to nap(15)
     end
 
     it "check test runs in progress state" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "in_progress", created_at: Time.now}]})
-      expect(gr_test).to receive(:frame).and_return({"created_at" => Time.new(2023, 1, 1).to_s, "test_cases" => ["github_runner_ubuntu_2204"]}).at_least(:once)
       expect { gr_test.check_test_runs }.to nap(15)
     end
 
     it "check test runs failed" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now}]})
-      expect(gr_test).to receive(:frame).and_return({"created_at" => Time.new(2023, 1, 1).to_s, "test_cases" => ["github_runner_ubuntu_2204"]}).at_least(:once)
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
 
     it "check test runs created before" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client)
-      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.new(2023, 1, 1)}]})
-      expect(gr_test).to receive(:frame).and_return({"created_at" => Time.now.to_s, "test_cases" => ["github_runner_ubuntu_2204"]}).at_least(:once)
+      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now - 2 * 60 * 60}]})
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
   end
 
   describe "#clean_resources" do
     it "not clean with github exists" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
       expect(client).to receive(:cancel_workflow_run).with("ubicloud/github-e2e-test-workflows", 10)
       expect(GithubRunner).to receive(:any?).and_return(true)
@@ -140,8 +122,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop finish" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
       expect(client).to receive(:cancel_workflow_run).with("ubicloud/github-e2e-test-workflows", 10)
       expect(GithubRunner).to receive(:any?).and_return(false)
@@ -151,8 +131,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop failed" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
       expect(client).to receive(:cancel_workflow_run).with("ubicloud/github-e2e-test-workflows", 10)
       expect(GithubRunner).to receive(:any?).and_return(false)
@@ -163,8 +141,6 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources already cancelled" do
-      client = instance_double(Octokit::Client)
-      expect(gr_test).to receive(:client).and_return(client).at_least(:twice)
       expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
       expect(client).to receive(:cancel_workflow_run).and_raise(StandardError)
       expect(GithubRunner).to receive(:any?).and_return(true)
@@ -181,14 +157,6 @@ RSpec.describe Prog::Test::GithubRunner do
   describe "failed" do
     it "finish" do
       expect { gr_test.failed }.to nap(15)
-    end
-  end
-
-  describe "get_client" do
-    it "get_client" do
-      expect(Github).to receive(:installation_client).with(Config.e2e_github_installation_id).and_return(Octokit::Client)
-
-      gr_test.client
     end
   end
 end

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Test::VmGroup do
-  subject(:vg_test) { described_class.new(described_class.assemble) }
+  subject(:vg_test) { described_class.new(described_class.assemble(boot_images: ["ubuntu-noble"])) }
 
   describe "#start" do
     it "hops to setup_vms" do


### PR DESCRIPTION
- **Deduplicate the client in GitHub runner E2E rspecs**
  

- **Merge e2e test case configs and image downloads**
  We are adding more e2e test cases for different services. Each service
  has its own configuration and requires different boot images. Some boot
  images are downloaded while setting up the VM host, while others are
  downloaded just before running the tests, like the GitHub E2E runner
  tests. This makes it hard to debug and maintain the test cases. This PR
  merges all the e2e test case configurations and image requirements into
  a single file. We will download all the required images at the beginning
  of the test during the VM host setup. This will make the test cases
  easier to maintain and debug.
  

- **Load default tests cases from config file**
  

- **Ensure all boot images are tested.**
  Previously, we randomly selected a boot image for VM tests. This means
  that if a specific boot image broke, we might miss it since we don’t
  test all boot images all the time.
  
  However, the green mark can mislead developers into thinking everything
  is fine.
  
  We should test all boot images to ensure they are functioning properly.
  This PR creates virtual machines to test at least a minimum number of
  boot images.
  
  If the number of provided boot images is less than 3, it will repeat the
  boot images to reach a total of 3. This way, we will create at least 3
  virtual machines for testing.
  