### PR TITLE
Add download button for Postgres CA certicates

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -94,6 +94,10 @@ class PostgresResource < Sequel::Model
     private_subnet.firewalls.first.replace_firewall_rules(vm_firewall_rules)
   end
 
+  def ca_certificates
+    [root_cert_1, root_cert_2].join("\n") if root_cert_1 && root_cert_2
+  end
+
   module HaType
     NONE = "none"
     ASYNC = "async"

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -938,6 +938,31 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/id/{postgres_database_id}/ca-certificates':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_id'
+    get:
+      operationId: getPostgresCACertificatesByID
+      summary: Download CA certificates for a specific Postgres Database in a location with ID
+      responses:
+        '200':
+          description: CA certificate file
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: attachment; filename="postgres-ca-certificate.pem"
+          content:
+            application/x-pem-file:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/id/{postgres_database_id}/firewall-rule/{firewall_rule_id}':
     parameters:
       - $ref: '#/components/parameters/location'
@@ -1097,6 +1122,31 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/ca-certificates':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_name'
+    get:
+      operationId: getPostgresCACertificatesByName
+      summary: Download CA certificates for a specific Postgres Database in a location with name
+      responses:
+        '200':
+          description: CA certificate file
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: attachment; filename="postgres-ca-certificate.pem"
+          content:
+            application/x-pem-file:
+              schema:
+                type: string
+                format: binary
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1823,6 +1873,10 @@ components:
         vm_size:
           description: Size of the underlying VM
           type: string
+        ca_certificates:
+          description: CA certificates of the root CA used to issue postgres server certificates
+          type: string
+          nullable: true
       additionalProperties: false
       required:
         - flavor

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -142,7 +142,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
     nap 5 if postgres_server.resource.server_cert.nil?
 
-    ca_bundle = [postgres_server.resource.root_cert_1, postgres_server.resource.root_cert_2].join("\n")
+    ca_bundle = postgres_server.resource.ca_certificates
     vm.sshable.cmd("sudo tee /etc/ssl/certs/ca.crt > /dev/null", stdin: ca_bundle)
     vm.sshable.cmd("sudo tee /etc/ssl/certs/server.crt > /dev/null", stdin: postgres_server.resource.server_cert)
     vm.sshable.cmd("sudo tee /etc/ssl/certs/server.key > /dev/null", stdin: postgres_server.resource.server_cert_key)

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -210,6 +210,16 @@ class Clover
           r.redirect "#{@project.path}#{pg.path}"
         end
       end
+
+      r.get "ca-certificates" do
+        authorize("Postgres:view", pg.id)
+
+        return 404 unless (certs = pg.ca_certificates)
+
+        response.headers["Content-Disposition"] = "attachment; filename=\"#{pg.name}.pem\""
+        response.headers["Content-Type"] = "application/x-pem-file"
+        certs
+      end
     end
 
     # 204 response for invalid names

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -11,7 +11,8 @@ class Serializers::Postgres < Serializers::Base
       storage_size_gib: pg.target_storage_size_gib,
       version: pg.version,
       ha_type: pg.ha_type,
-      flavor: pg.flavor
+      flavor: pg.flavor,
+      ca_certificates: pg.ca_certificates
     }
 
     if options[:include_path]

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       superuser_password: "dummy-password",
       version: "16",
       representative_server: postgres_server,
-      metric_destinations: [instance_double(PostgresMetricDestination, ubid: "pgmetricubid", url: "url", username: "username", password: "password")]
+      metric_destinations: [instance_double(PostgresMetricDestination, ubid: "pgmetricubid", url: "url", username: "username", password: "password")],
+      ca_certificates: "root_cert_1\nroot_cert_2"
     )
   }
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -190,9 +190,11 @@ RSpec.describe Clover, "postgres" do
         expect(page).to have_content "Waiting for host to be ready..."
 
         expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(true)
+        pg.update(root_cert_1: "root_cert_1", root_cert_2: "root_cert_2")
         page.refresh
         expect(page).to have_content "#{pg.name}.#{pg.ubid}.postgres.ubicloud.com"
         expect(page).to have_no_content "Waiting for host to be ready..."
+        expect(page).to have_content "Download"
       end
 
       it "does not show delete or edit options without the appropriate permissions" do

--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -9,6 +9,9 @@
     <%= atr_key %>="<%= atr_value %>"
     <% end%>
   >
+    <% if icon %>
+      <%== render("components/icon", locals: { name: icon, classes: "h-5 w-5" }) %>
+    <% end %>
     <%= text %>
   </a>
 <% else %>

--- a/views/components/download_button.erb
+++ b/views/components/download_button.erb
@@ -1,0 +1,12 @@
+<%# locals: (text: "Download", link:) %>
+
+<%== render(
+  "components/button",
+  locals: {
+    link: link,
+    text: text,
+    icon: "hero-document-arrow-down",
+    extra_class: "download-btn",
+    type: "primary"
+  }
+) %>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -31,6 +31,18 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
     data.push(["Connection String", @pg[:connection_string], { copyable: true, revealable: true }])
   else
     data.push(["Connection String", "Waiting for host to be ready..."])
+  end
+  
+  if @pg[:ca_certificates]
+    data.push(
+      [
+        "CA Certificates",
+        render("components/download_button", locals: { link: "#{request.path}/ca-certificates" }),
+        { escape: false }
+      ]
+    )
+  else
+    data.push(["CA Certificates", "Waiting for host to be ready..."])
   end %>
 
   <div class="grid grid-cols-1 gap-6 md:grid-cols-6">


### PR DESCRIPTION
## Description
Add a download button on the postgres DB page to download the CA certificates as a `.pem` file.

## Tests
- [x] Local run
- [x] Unit tests

## Screenshots
While getting ready
![image](https://github.com/user-attachments/assets/0d4caaa0-1978-4451-a088-7867509373eb)

After ready
![image](https://github.com/user-attachments/assets/7d4a95e2-0011-463a-82b0-b36e8236eeb7)

Downloaded file
![image](https://github.com/user-attachments/assets/519251d9-c22f-4696-96f4-dc0d2ac9cd00)


