### PR TITLE
Enable transparent cache by default for new users

### DIFF
--- a/migrate/20250121_enable_transparent_cache_by_default.rb
+++ b/migrate/20250121_enable_transparent_cache_by_default.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:github_installation) do
+      set_column_default(:cache_enabled, true)
+    end
+  end
+end

--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -28,7 +28,7 @@ end
 #  name            | text    | NOT NULL
 #  type            | text    | NOT NULL
 #  project_id      | uuid    |
-#  cache_enabled   | boolean | NOT NULL DEFAULT false
+#  cache_enabled   | boolean | NOT NULL DEFAULT true
 # Indexes:
 #  github_installation_pkey | PRIMARY KEY btree (id)
 # Foreign key constraints:


### PR DESCRIPTION
Enabling transparent cache by default for new users, as it is proved that it works reliably and improves performance significantly. For the existing users, it will be enabled separately.