### PR TITLE
Make Kubernetes Resources Created in Internal Project

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -197,6 +197,7 @@ module Config
   optional :dns_service_project_id, string
 
   # Kubernetes
+  optional :kubernetes_service_project_id, string
   optional :kubernetes_service_hostname, string
 
   # Billing

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -41,7 +41,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     boot_image = "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}"
 
     vm = Prog::Vm::Nexus.assemble_with_sshable(
-      kubernetes_cluster.project.id,
+      Config.kubernetes_service_project_id,
       sshable_unix_user: "ubi",
       name: name,
       location_id: kubernetes_cluster.location.id,

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
   let(:kubernetes_cluster) {
     project = Project.create(name: "default")
-    subnet = PrivateSubnet.create(net6: "0::0/16", net4: "127.0.0.0/8", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
+    subnet = PrivateSubnet.create(net6: "0::0/16", net4: "127.0.0.0/8", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
     kc = KubernetesCluster.create(
       name: "k8scluster",
       version: "v1.32",
@@ -19,7 +19,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       target_node_storage_size_gib: 37
     )
 
-    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: project.id)
+    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
     kc.add_cp_vm(create_vm)
     kc.add_cp_vm(create_vm)
@@ -31,6 +31,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   let(:kubernetes_nodepool) { KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kubernetes_cluster.id, target_node_size: "standard-8", target_node_storage_size_gib: 78) }
 
   before do
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
     allow(prog).to receive_messages(kubernetes_cluster: kubernetes_cluster, frame: {"vm_id" => create_vm.id})
   end
 

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Clover, "Kubernetes" do
       name: "myk8s",
       version: "v1.32",
       project_id: project.id,
-      private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "mysubnet", location_id: Location::HETZNER_FSN1_ID, project_id: project.id).id,
+      private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "mysubnet", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id).id,
       location_id: Location::HETZNER_FSN1_ID
     ).subject
   end
@@ -24,12 +24,13 @@ RSpec.describe Clover, "Kubernetes" do
       name: "not-my-k8s",
       version: "v1.32",
       project_id: project_wo_permissions.id,
-      private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "othersubnet", location_id: Location::HETZNER_FSN1_ID, project_id: project_wo_permissions.id).id,
+      private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "othersubnet", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id).id,
       location_id: Location::HETZNER_FSN1_ID
     ).subject
   end
 
   before do
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
     project.set_ff_kubernetes true
     project_wo_permissions.set_ff_kubernetes true
   end
@@ -157,7 +158,7 @@ RSpec.describe Clover, "Kubernetes" do
         expect(new_kc.project_id).to eq(project.id)
         expect(new_kc.cp_node_count).to eq(3)
         expect(new_kc.nodepools.first.node_count).to eq(2)
-        expect(new_kc.private_subnet.name).to eq("k8stest-k8s-subnet")
+        expect(new_kc.private_subnet.name).to eq("#{new_kc.ubid}-subnet")
       end
 
       it "can not create kubernetes cluster with invalid name" do


### PR DESCRIPTION
Make Kubernetes Resources Created in Internal Project

This change makes the resources required for a kubernetes cluster get
created within a pre-created kubernetes service project.

Previously, the resources for a cluster were meant to live in project
belonging to the customer. Even the subnet was meant to be provided by
the customer once, but then we took the creation of that subnet in our hands.
Now, the subnet is created during the assemble phase in the
kubernetes service project and all VMs and LBs will also be created in that
project. The name of the subnet is also changed to a ubid-based one.

The KubernetesCluster entity is still tied to customer project and the
resources will be shown to the customer in the UI & API.