### PR TITLE
Remove obsoleted config

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -135,7 +135,6 @@ module Config
   # Postgres
   optional :postgres_service_project_id, string
   override :postgres_service_hostname, "postgres.ubicloud.com", string
-  optional :postgres_service_blob_storage_id, string
   override :postgres_monitor_database_url, Config.clover_database_url, string
   optional :postgres_monitor_database_root_certs, string
   optional :postgres_paradedb_notification_email, string


### PR DESCRIPTION
We don't use postgres_service_blob_storage_id anymore. We find the blob storage by searching it in the relevant project instead.