### PR TITLE
Read Load Balancer Node state according to threshold

### DIFF
--- a/model/load_balancers_vms.rb
+++ b/model/load_balancers_vms.rb
@@ -4,6 +4,18 @@ require_relative "../model"
 
 class LoadBalancersVms < Sequel::Model
   include ResourceMethods
+  many_to_one :load_balancer
+
+  def node_state
+    case state
+    when "up"
+      (state_counter >= load_balancer.health_check_up_threshold) ? "up" : "down"
+    when "down"
+      (state_counter >= load_balancer.health_check_down_threshold) ? "down" : "up"
+    else
+      state
+    end
+  end
 end
 
 # Table: load_balancers_vms

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -8,7 +8,7 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   end
 
   def vm_load_balancer_state
-    load_balancer.load_balancers_vms_dataset[vm_id: vm.id].state
+    load_balancer.load_balancers_vms_dataset[vm_id: vm.id].node_state
   end
 
   def before_run

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -45,6 +45,25 @@ RSpec.describe Prog::Vnet::UpdateLoadBalancerNode do
     end
   end
 
+  describe ".vm_load_balancer_state" do
+    it "returns the node state of the VM" do
+      lb.load_balancers_vms_dataset.update(state: "up", state_counter: 1)
+      expect(nx.vm_load_balancer_state).to eq("down")
+
+      lb.load_balancers_vms_dataset.update(state: "down", state_counter: 1)
+      expect(nx.vm_load_balancer_state).to eq("up")
+
+      lb.load_balancers_vms_dataset.update(state: "up", state_counter: 4)
+      expect(nx.vm_load_balancer_state).to eq("up")
+
+      lb.load_balancers_vms_dataset.update(state: "down", state_counter: 4)
+      expect(nx.vm_load_balancer_state).to eq("down")
+
+      lb.load_balancers_vms_dataset.update(state: "detaching", state_counter: 0)
+      expect(nx.vm_load_balancer_state).to eq("detaching")
+    end
+  end
+
   describe "#update_load_balancer" do
     context "when no healthy vm exists" do
       it "hops to remove load balancer" do


### PR DESCRIPTION
We are updating load balancer node when the defined thresholds are passed, but a flipping health check, or an unrelated update may simply declare nodes unhealthy when they are just in the verification phase (state_count < threshold).

This commit adds the new node_state function to better understand the status. We basically smoothen the state read curve.