### PR TITLE
Add pattern for project name to match e281824

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1911,6 +1911,7 @@ components:
           description: Name of the project
           type: string
           example: my-project
+          pattern: '^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$'
       additionalProperties: false
       required:
         - credit


### PR DESCRIPTION
https://github.com/ubicloud/ubicloud/commit/e281824d3466a12094e4e87c976dd41bac291757

Obsoletes #2376. Same stuff, but I squash and use a commit number so that git can internally reference it:


![image](https://github.com/user-attachments/assets/6074cd8d-3243-45f5-86ba-0cab721ec52d)
