### PR TITLE
Remove automatically created routes after creating ipv6 link

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -297,6 +297,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       # Allocate ::1 in the guest network for DHCPv6.
       r "ip -n #{q_vm} addr replace #{ip6.nth(1)}/#{ip6.netmask.prefix_len} dev #{nic.tap}"
       r "ip -n #{q_vm} route replace #{ip6.to_s.shellescape} via #{mac_to_ipv6_link_local(nic.mac)} dev #{nic.tap}"
+      r "ip -n #{q_vm} route del #{ip6.to_s.shellescape} dev #{nic.tap}"
     end
 
     r "ip -n #{q_vm} addr replace fd00:0b1c:100d:5AFE:CE::/56 dev #{nics.first.tap}"


### PR DESCRIPTION
When we create a new linux interface using ip link, a corresponding linux route is also created.

For IPV6, we create a new link in the VM's network namespace and a route is automatically added. Since that route does not route the packets to the gateway, containers inside with IPV6 ips would fail.

In this commit, we are deleting that route and rely on the route with via option.

to route the packets but that automatically created route will assume the destination is in the same subnet and ipv6 wouldn't work properly