### PR TITLE
Add E2E test for HA postgres

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,github_runner_ubuntu_2004,postgres_standard'
+        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,github_runner_ubuntu_2004,postgres_standard,postgres_ha'
         type: string
 
   schedule:
@@ -118,6 +118,7 @@ jobs:
         GITHUB_CACHE_BLOB_STORAGE_ACCOUNT_ID: ${{ secrets.GH_CACHE_BLOB_STORAGE_ACCOUNT_ID }}
         GITHUB_CACHE_BLOB_STORAGE_API_KEY: ${{ secrets.GH_CACHE_BLOB_STORAGE_API_KEY }}
         POSTGRES_SERVICE_PROJECT_ID: "546a1ed8-53e5-86d2-966c-fb782d2ae5ab"
+        MINIO_SERVICE_PROJECT_ID: "37ad2a8d-0220-4e8b-a67f-38db95d6c657"
         VM_POOL_PROJECT_ID: ${{ secrets.VM_POOL_PROJECT_ID }}
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
         HETZNER_SSH_PUBLIC_KEY: ${{ secrets.HETZNER_SSH_PUBLIC_KEY }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,6 +93,7 @@ jobs:
       env:
         BASE_URL: https://${{ secrets.NGROK_ADDRESS }}
         RACK_ENV: production
+        IS_E2E: "true"
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
         CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
         CLOVER_RUNTIME_TOKEN_SECRET: r3rV5RzYVpDMlXxY1VnrHlmoMnXdUVt5ABec/TWXnmO7Ok/riFRDNATAMmDWTvtH+cSyXAniH3hHL6EetHj/FA==

--- a/bin/ci
+++ b/bin/ci
@@ -46,6 +46,9 @@ def main(options)
   if options[:test_cases].include?("postgres_standard")
     tests_to_wait << Prog::Test::PostgresResource.assemble
   end
+  if options[:test_cases].include?("postgres_ha")
+    tests_to_wait << Prog::Test::HaPostgresResource.assemble
+  end
 
   # Although wait_until will be blocked while checking the first one
   # it won't affect the total time as other strands will continue in parallel.

--- a/config.rb
+++ b/config.rb
@@ -175,6 +175,7 @@ module Config
 
   # e2e
   optional :e2e_github_installation_id, string
+  override :is_e2e, false, bool
 
   # Load Balancer
   optional :load_balancer_service_project_id, string

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -3,3 +3,4 @@
 - { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2204.yml, branch_name: main} }
 - { name: github_runner_ubuntu_2004, images: ["github-ubuntu-2004"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2004.yml, branch_name: main} }
 - { name: postgres_standard,         images: ["postgres16-ubuntu-2204"] }
+- { name: postgres_ha,               images: ["postgres16-ubuntu-2204", "ubuntu-jammy"] }

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -30,7 +30,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
         boot_image: "ubuntu-jammy",
         enable_ip4: true,
         private_subnet_id: minio_pool.cluster.private_subnet.id,
-        distinct_storage_devices: Config.production?
+        distinct_storage_devices: Config.production? && !Config.is_e2e
       )
 
       minio_server = MinioServer.create(minio_pool_id: minio_pool_id, vm_id: vm_st.id, index: index) { _1.id = ubid.to_uuid }
@@ -206,7 +206,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       root_cert_key = OpenSSL::PKey::EC.new(minio_server.cluster.root_cert_key_2)
     end
 
-    ip_san = Config.development? ? ",IP:#{minio_server.vm.ephemeral_net4}" : nil
+    ip_san = (Config.development? || Config.is_e2e) ? ",IP:#{minio_server.vm.ephemeral_net4}" : nil
 
     Util.create_certificate(
       subject: "/C=US/O=Ubicloud/CN=#{minio_server.cluster.ubid} Server Certificate",

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -178,7 +178,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   label def wait
     # Only create one standby at a time to ensure that they are allocated on different hosts
     if postgres_resource.required_standby_count + 1 > servers.count && servers.none? { _1.vm.vm_host.nil? }
-      exclude_host_ids = Config.development? ? [] : servers.map { _1.vm.vm_host.id }
+      exclude_host_ids = (Config.development? || Config.is_e2e) ? [] : servers.map { _1.vm.vm_host.id }
       Prog::Postgres::PostgresServerNexus.assemble(resource_id: postgres_resource.id, timeline_id: postgres_resource.timeline.id, timeline_access: "fetch", exclude_host_ids: exclude_host_ids)
     end
 

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/util"
+
+class Prog::Test::HaPostgresResource < Prog::Test::Base
+  semaphore :destroy
+
+  def self.assemble
+    postgres_test_project = Project.create(name: "Postgres-HA-Test-Project")
+    Project[Config.postgres_service_project_id] ||
+      Project.create(name: "Postgres-Service-Project") { _1.id = Config.postgres_service_project_id }
+    Project[Config.minio_service_project_id] ||
+      Project.create(name: "Minio-Service-Project") { _1.id = Config.minio_service_project_id }
+
+    frame = {
+      "postgres_test_project_id" => postgres_test_project.id,
+      "failover_wait_started" => false
+    }
+
+    Strand.create_with_id(
+      prog: "Test::HaPostgresResource",
+      label: "start",
+      stack: [frame]
+    )
+  end
+
+  label def start
+    st = Prog::Minio::MinioClusterNexus.assemble(Config.postgres_service_project_id,
+      "postgres-minio-test-0", "hetzner-fsn1", "admin", 32, 1, 1, 1, "standard-2")
+
+    update_stack({"minio_cluster_id" => st.id})
+    hop_wait_minio_cluster
+  end
+
+  label def wait_minio_cluster
+    if minio_cluster.strand.label == "wait"
+      hop_create_postgres_resource
+    else
+      nap 10
+    end
+  end
+
+  label def create_postgres_resource
+    st = Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: frame["postgres_test_project_id"],
+      location: "hetzner-fsn1",
+      name: "postgres-test-ha",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 128,
+      ha_type: "async"
+    )
+
+    update_stack({"postgres_resource_id" => st.id})
+    hop_wait_postgres_resource
+  end
+
+  label def wait_postgres_resource
+    server_count = postgres_resource.servers.count
+    required_server_count = 1 + postgres_resource.required_standby_count
+    nap 10 if server_count != required_server_count || postgres_resource.servers.filter { _1.strand.label != "wait" }.any?
+    hop_test_postgres
+  end
+
+  label def test_postgres
+    unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
+      update_stack({"fail_message" => "Failed to run test queries"})
+      hop_destroy_postgres
+    end
+
+    hop_trigger_failover
+  end
+
+  label def trigger_failover
+    primary = postgres_resource.servers.find { _1.timeline_access == "push" }
+    update_stack({"primary_ubid" => primary.ubid})
+
+    primary.vm.sshable.cmd("echo -e '\nfoobar' | sudo tee -a /etc/postgresql/#{postgres_resource.version}/main/conf.d/001-service.conf")
+
+    # Get postgres pid and send SIGKILL
+    primary.vm.sshable.cmd("ps aux | grep -v grep | grep '/usr/lib/postgresql/#{postgres_resource.version}/bin/postgres' | awk '{print $2}' | xargs sudo kill -9")
+
+    hop_wait_failover
+  end
+
+  label def wait_failover
+    # Wait 3 minutes for the failover to finish.
+    failover_wait_started = frame["failover_wait_started"]
+    update_stack({"failover_wait_started" => true})
+
+    nap 180 unless failover_wait_started
+
+    hop_test_postgres_after_failover
+  end
+
+  label def test_postgres_after_failover
+    unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
+      update_stack({"fail_message" => "Failed to run read queries after failover"})
+      hop_destroy_postgres
+    end
+
+    unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
+      update_stack({"fail_message" => "Failed to run write queries after failover"})
+    end
+
+    hop_destroy_postgres
+  end
+
+  label def destroy_postgres
+    postgres_resource.incr_destroy
+    minio_cluster.incr_destroy
+    hop_destroy
+  end
+
+  label def destroy
+    postgres_test_project.destroy
+
+    fail_test(frame["fail_message"]) if frame["fail_message"]
+
+    pop "Postgres tests are finished!"
+  end
+
+  label def failed
+    nap 15
+  end
+
+  def postgres_test_project
+    @postgres_test_project ||= Project[frame["postgres_test_project_id"]]
+  end
+
+  def postgres_resource
+    @postgres_resource ||= PostgresResource[frame["postgres_resource_id"]]
+  end
+
+  def representative_server
+    @representative_server ||= postgres_resource.representative_server
+  end
+
+  def minio_cluster
+    @minio_cluster ||= MinioCluster[frame["minio_cluster_id"]]
+  end
+
+  def test_queries_sql
+    File.read("./prog/test/testdata/order_analytics_queries.sql")
+  end
+
+  def read_queries_sql
+    File.read("./prog/test/testdata/order_analytics_read_queries.sql")
+  end
+end

--- a/prog/test/testdata/order_analytics_read_queries.sql
+++ b/prog/test/testdata/order_analytics_read_queries.sql
@@ -1,0 +1,3 @@
+SELECT ROUND(SUM(order_amount)::numeric, 2) as total_revenue FROM order_analytics;
+SELECT ROUND(AVG(order_amount)::numeric, 2) as avg_order_value FROM order_analytics;
+SELECT ROUND(AVG(delivery_days)::numeric, 1) as avg_delivery_days FROM order_analytics WHERE delivery_days IS NOT NULL;

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Test::HaPostgresResource do
+  subject(:pgr_test) { described_class.new(described_class.assemble) }
+
+  let(:postgres_service_project_id) { "546a1ed8-53e5-86d2-966c-fb782d2ae3ab" }
+  let(:working_representative_server) { instance_double(PostgresServer, run_query: "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1") }
+  let(:faulty_representative_server) { instance_double(PostgresServer, run_query: "") }
+  let(:vm) { instance_double(Vm, sshable: instance_double(Sshable, cmd: "")) }
+  let(:servers) { [instance_double(PostgresServer, ubid: "1234", timeline_access: "push", vm: vm), instance_double(PostgresServer, ubid: "5678", timeline_access: "fetch", vm: vm)] }
+  let(:servers_after_failover) { [instance_double(PostgresServer, ubid: "5678", timeline_access: "push", vm: vm), instance_double(PostgresServer, ubid: "9012", timeline_access: "fetch", vm: vm)] }
+
+  describe ".assemble" do
+    it "creates a strand and service projects" do
+      expect(Config).to receive(:postgres_service_project_id).exactly(2).and_return(postgres_service_project_id)
+      st = described_class.assemble
+      expect(st).to be_a Strand
+      expect(st.label).to eq("start")
+    end
+  end
+
+  describe "#start" do
+    it "hops to wait_minio_cluster" do
+      expect(Prog::Minio::MinioClusterNexus).to receive(:assemble).and_return(instance_double(Strand, id: "1234"))
+      expect { pgr_test.start }.to hop("wait_minio_cluster")
+    end
+  end
+
+  describe "#wait_minio_cluster" do
+    it "naps for 10 seconds if the minio cluster is not ready" do
+      expect(pgr_test).to receive(:minio_cluster).and_return(instance_double(MinioCluster, strand: instance_double(Strand, label: "start")))
+      expect { pgr_test.wait_minio_cluster }.to nap(10)
+    end
+
+    it "hops to create_postgres_resource if the minio cluster is ready" do
+      expect(pgr_test).to receive(:minio_cluster).and_return(instance_double(MinioCluster, strand: instance_double(Strand, label: "wait")))
+      expect { pgr_test.wait_minio_cluster }.to hop("create_postgres_resource")
+    end
+  end
+
+  describe "#create_postgres_resource" do
+    it "creates a postgres resource" do
+      expect(Prog::Postgres::PostgresResourceNexus).to receive(:assemble).and_return(instance_double(Strand, id: "1234"))
+      expect { pgr_test.create_postgres_resource }.to hop("wait_postgres_resource")
+    end
+  end
+
+  describe "#wait_postgres_resource" do
+    it "hops to test_postgres if the postgres resource is ready" do
+      expect(pgr_test).to receive(:postgres_resource).exactly(3).and_return(instance_double(PostgresResource, required_standby_count: 1, servers: [instance_double(PostgresServer, strand: instance_double(Strand, label: "wait")), instance_double(PostgresServer, strand: instance_double(Strand, label: "wait"))]))
+      expect { pgr_test.wait_postgres_resource }.to hop("test_postgres")
+    end
+
+    it "naps for 10 seconds if the postgres resource is not ready" do
+      expect(pgr_test).to receive(:postgres_resource).exactly(2).and_return(instance_double(PostgresResource, required_standby_count: 1, servers: [instance_double(PostgresServer, strand: instance_double(Strand, label: "start"))]))
+      expect { pgr_test.wait_postgres_resource }.to nap(10)
+    end
+  end
+
+  describe "#test_postgres" do
+    it "fails if the postgres test fails" do
+      expect(pgr_test).to receive(:representative_server).and_return(faulty_representative_server)
+      expect { pgr_test.test_postgres }.to hop("destroy_postgres")
+    end
+
+    it "hops to trigger_failover if the postgres test passes" do
+      expect(pgr_test).to receive(:representative_server).and_return(working_representative_server)
+      expect { pgr_test.test_postgres }.to hop("trigger_failover")
+    end
+  end
+
+  describe "#trigger_failover" do
+    it "triggers a failover and hops to wait_failover" do
+      expect(pgr_test).to receive(:postgres_resource).exactly(3).and_return(instance_double(PostgresResource, servers: servers, version: "16"))
+      expect(pgr_test).to receive(:update_stack).with({"primary_ubid" => "1234"})
+      expect { pgr_test.trigger_failover }.to hop("wait_failover")
+    end
+  end
+
+  describe "#wait_failover" do
+    it "naps for 3 minutes for the 1st time" do
+      expect(pgr_test).to receive(:frame).and_return({"failover_wait_started" => false})
+      expect { pgr_test.wait_failover }.to nap(180)
+    end
+
+    it "hops to test_postgres_after_failover 2nd time" do
+      expect(pgr_test).to receive(:frame).and_return({"failover_wait_started" => true})
+      expect { pgr_test.wait_failover }.to hop("test_postgres_after_failover")
+    end
+  end
+
+  describe "#test_postgres_after_failover" do
+    it "fails if the postgres test fails" do
+      expect(pgr_test).to receive(:representative_server).and_return(faulty_representative_server)
+      expect(pgr_test).to receive(:update_stack).with({"fail_message" => "Failed to run read queries after failover"})
+      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
+    end
+
+    it "hops to destroy_postgres if the standby does not exit read-only mode" do
+      working_representative_server_1 = instance_double(PostgresServer, run_query: "4159.90\n415.99\n4.1")
+      working_representative_server_2 = instance_double(PostgresServer, run_query: "")
+
+      expect(pgr_test).to receive(:representative_server).and_return(working_representative_server_1, working_representative_server_2)
+      expect(pgr_test).to receive(:update_stack).with({"fail_message" => "Failed to run write queries after failover"})
+      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
+    end
+
+    it "hops to destroy_postgres if the postgres test succeeds" do
+      working_representative_server_1 = instance_double(PostgresServer, run_query: "4159.90\n415.99\n4.1")
+      working_representative_server_2 = instance_double(PostgresServer, run_query: "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
+
+      expect(pgr_test).to receive(:representative_server).and_return(working_representative_server_1, working_representative_server_2)
+      expect(pgr_test).not_to receive(:update_stack)
+      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
+    end
+  end
+
+  describe "#destroy_postgres" do
+    it "increments the destroy count and hops to destroy" do
+      postgres_resource = instance_double(Prog::Postgres::PostgresResourceNexus, incr_destroy: nil)
+      expect(PostgresResource).to receive(:[]).and_return(postgres_resource)
+      expect(postgres_resource).to receive(:incr_destroy)
+
+      minio_cluster = instance_double(MinioCluster, incr_destroy: nil)
+      expect(MinioCluster).to receive(:[]).and_return(minio_cluster)
+      expect(minio_cluster).to receive(:incr_destroy)
+
+      expect(pgr_test).to receive(:frame).exactly(2).and_return({})
+      expect { pgr_test.destroy_postgres }.to hop("destroy")
+    end
+  end
+
+  describe "#destroy" do
+    it "increments the destroy count and exits if no failure happened" do
+      expect(Project).to receive(:[]).exactly(3).and_return(instance_double(Project, id: "1234", destroy: nil))
+      expect(pgr_test).to receive(:frame).exactly(3).and_return({"project_created" => false})
+      expect { pgr_test.destroy }.to exit({"msg" => "Postgres tests are finished!"})
+    end
+
+    it "increments the destroy count and hops to failed if a failure happened" do
+      expect(Project).to receive(:[]).exactly(3).and_return(instance_double(Project, id: "1234", destroy: nil))
+      expect(pgr_test).to receive(:frame).exactly(3).and_return({"fail_message" => "Test failed", "project_created" => true})
+      expect { pgr_test.destroy }.to hop("failed")
+    end
+  end
+
+  describe "#failed" do
+    it "naps" do
+      expect { pgr_test.failed }.to nap(15)
+    end
+  end
+
+  describe ".representative_server" do
+    it "returns the representative server" do
+      postgres_resource = instance_double(Prog::Postgres::PostgresResourceNexus, representative_server: working_representative_server)
+      expect(pgr_test).to receive(:postgres_resource).and_return(postgres_resource)
+      expect(pgr_test.representative_server).to eq(working_representative_server)
+    end
+  end
+
+  describe ".minio_cluster" do
+    it "returns the minio cluster" do
+      minio_cluster = instance_double(MinioCluster)
+      expect(pgr_test).to receive(:frame).and_return({"minio_cluster_id" => "1234"})
+      expect(MinioCluster).to receive(:[]).with("1234").and_return(minio_cluster)
+      expect(pgr_test.minio_cluster).to eq(minio_cluster)
+    end
+  end
+end

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prog::Test::PostgresResource do
 
   describe ".assemble" do
     it "creates a strand and service projects" do
-      expect(Config).to receive(:postgres_service_project_id).and_return(postgres_service_project_id)
+      expect(Config).to receive(:postgres_service_project_id).exactly(2).and_return(postgres_service_project_id)
       st = described_class.assemble
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
@@ -39,12 +39,12 @@ RSpec.describe Prog::Test::PostgresResource do
 
   describe "#test_postgres" do
     it "fails if the basic connectivity test fails" do
-      expect(pgr_test).to receive(:postgres_server).and_return(faulty_representative_server)
+      expect(pgr_test).to receive(:representative_server).and_return(faulty_representative_server)
       expect { pgr_test.test_postgres }.to hop("destroy_postgres")
     end
 
     it "hops to test_table_create if the basic connectivity test passes" do
-      expect(pgr_test).to receive(:postgres_server).and_return(working_representative_server)
+      expect(pgr_test).to receive(:representative_server).and_return(working_representative_server)
       expect { pgr_test.test_postgres }.to hop("destroy_postgres")
     end
   end
@@ -61,14 +61,14 @@ RSpec.describe Prog::Test::PostgresResource do
 
   describe "#destroy" do
     it "increments the destroy count and exits if no failure happened" do
-      expect(Project).to receive(:[]).exactly(2).and_return(instance_double(Project, destroy: nil))
-      expect(pgr_test).to receive(:frame).exactly(4).and_return({})
+      expect(Project).to receive(:[]).exactly(2).and_return(instance_double(Project, id: "1234", destroy: nil))
+      expect(pgr_test).to receive(:frame).exactly(3).and_return({"project_created" => false})
       expect { pgr_test.destroy }.to exit({"msg" => "Postgres tests are finished!"})
     end
 
     it "increments the destroy count and hops to failed if a failure happened" do
-      expect(Project).to receive(:[]).exactly(2).and_return(instance_double(Project, destroy: nil))
-      expect(pgr_test).to receive(:frame).exactly(4).and_return({"fail_message" => "Test failed"})
+      expect(Project).to receive(:[]).exactly(2).and_return(instance_double(Project, id: "1234", destroy: nil))
+      expect(pgr_test).to receive(:frame).exactly(3).and_return({"fail_message" => "Test failed", "project_created" => true})
       expect { pgr_test.destroy }.to hop("failed")
     end
   end
@@ -79,11 +79,11 @@ RSpec.describe Prog::Test::PostgresResource do
     end
   end
 
-  describe ".postgres_server" do
+  describe ".representative_server" do
     it "returns the representative server" do
       postgres_resource = instance_double(Prog::Postgres::PostgresResourceNexus, representative_server: working_representative_server)
       expect(pgr_test).to receive(:postgres_resource).and_return(postgres_resource)
-      expect(pgr_test.postgres_server).to eq(working_representative_server)
+      expect(pgr_test.representative_server).to eq(working_representative_server)
     end
   end
 end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -88,6 +88,7 @@ module ThawedMock
   allow_mocking(Prog::Ai::InferenceEndpointReplicaNexus, :assemble)
   allow_mocking(Prog::DnsZone::SetupDnsServerVm, :vms_in_sync?)
   allow_mocking(Prog::Github::DestroyGithubInstallation, :assemble)
+  allow_mocking(Prog::Minio::MinioClusterNexus, :assemble)
   allow_mocking(Prog::PageNexus, :assemble)
   allow_mocking(Prog::Postgres::PostgresResourceNexus, :assemble, :dns_zone)
   allow_mocking(Prog::Postgres::PostgresServerNexus, :assemble)


### PR DESCRIPTION
## Description
Adds an E2E test for postgres with async HA. Triggers a failover and verifies that the database recovers.

## Tests
- [x] Unit tests
- [x] Local E2E test run
- [x] GH Actions E2E test run

