### PR TITLE
Improve thread dump reporting

### DIFF
--- a/lib/thread_printer.rb
+++ b/lib/thread_printer.rb
@@ -2,9 +2,17 @@
 
 module ThreadPrinter
   def self.run
+    now = Time.now
+    puts "--BEGIN THREAD DUMP, #{now}"
     Thread.list.each do |thread|
       puts "Thread: #{thread.inspect}"
+
+      if (created_at = thread[:created_at])
+        puts "Created at: #{created_at}, #{now - created_at} ago"
+      end
+
       puts thread.backtrace&.join("\n")
     end
+    puts "--END THREAD DUMP, #{now}"
   end
 end

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -34,6 +34,7 @@ class Scheduling::Dispatcher
     notify_r, notify_w = IO.pipe
 
     Thread.new do
+      Thread.current[:created_at] = Time.now
       ready, _, _ = IO.select([apoptosis_r], nil, nil, @apoptosis_timeout)
 
       if ready.nil?
@@ -51,6 +52,7 @@ class Scheduling::Dispatcher
     end.tap { _1.name = "apoptosis:" + strand_ubid }
 
     Thread.new do
+      Thread.current[:created_at] = Time.now
       strand.run Strand::LEASE_EXPIRATION / 4
     rescue => ex
       Clog.emit("exception terminates thread") { Util.exception_to_hash(ex) }

--- a/spec/lib/thread_printer_spec.rb
+++ b/spec/lib/thread_printer_spec.rb
@@ -3,17 +3,24 @@
 RSpec.describe ThreadPrinter do
   describe "#print" do
     it "can dump threads" do
+      expect(described_class).to receive(:puts).with(/--BEGIN THREAD DUMP, .*/)
       expect(described_class).to receive(:puts).with(/Thread: #<Thread:.*>/)
       expect(described_class).to receive(:puts).with(/backtrace/)
+      expect(described_class).to receive(:puts).with(/--END THREAD DUMP, .*/)
       described_class.run
     end
 
-    it "can handle threads with a nil backtrace" do
+    it "can handle threads with a nil backtrace and/or a created_at" do
       # The documentation calls out that the backtrace is an array or
       # nil.
+      expect(described_class).to receive(:puts).with(/--BEGIN THREAD DUMP, .*/)
       expect(described_class).to receive(:puts).with(/Thread: #<InstanceDouble.*>/)
+      expect(described_class).to receive(:puts).with(/Created at: .*/)
       expect(described_class).to receive(:puts).with(nil)
-      expect(Thread).to receive(:list).and_return([instance_double(Thread, backtrace: nil)])
+      expect(described_class).to receive(:puts).with(/--END THREAD DUMP, .*/)
+      th = instance_double(Thread, backtrace: nil)
+      expect(th).to receive(:[]).with(:created_at).and_return(Time.now - 30)
+      expect(Thread).to receive(:list).and_return([th])
       described_class.run
     end
   end


### PR DESCRIPTION
Improve thread dump reporting

It's been a while since this has been revised.  This revision seeks to
make the following easier:

It's hard to find the beginning and end of thread dumps, particularly
if they are consecutive.  Solution: add `--BEGIN...` and `--END...`
framing, plus a disambiguating timestamp that matches between the two.
The rough inspiration is MIME format of email.

The thread dumps are often triggered by apoptosis, which needs to exit
the entire process in a timely manner to maintain mutual exclusion.
In doing so, it does collatoral damage to other threads that happen to
be running in the same process at the time.

The thread dump emitted likewise includes every thread, not just the
problematic one.  So, print the thread age, when available.  The
oldest are most likely to be implicated.

To make the thread age available in the case I care about most, the
`created_at` thread local variable is set in the dispatcher which runs
Strands.

