### PR TITLE
Assemble kubeconfig for customers

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -41,9 +41,9 @@ class KubernetesCluster < Sequel::Model
     api_server_lb.hostname
   end
 
-  def kubeconfig
-    rbac_token = cp_vms.first.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system get secret k8s-access -o jsonpath='{.data.token}' | base64 -d")
-    admin_kubeconfig = cp_vms.first.sshable.cmd("sudo cat /etc/kubernetes/admin.conf")
+  def self.kubeconfig(vm)
+    rbac_token = vm.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system get secret k8s-access -o jsonpath='{.data.token}' | base64 -d")
+    admin_kubeconfig = vm.sshable.cmd("sudo cat /etc/kubernetes/admin.conf")
     kubeconfig = YAML.safe_load(admin_kubeconfig)
     kubeconfig["users"].each do |user|
       user["user"].delete("client-certificate-data")
@@ -51,6 +51,10 @@ class KubernetesCluster < Sequel::Model
       user["user"]["token"] = rbac_token
     end
     kubeconfig.to_yaml
+  end
+
+  def kubeconfig
+    self.class.kubeconfig(cp_vms.first)
   end
 end
 

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -18,6 +18,8 @@ rescue KeyError => e
   puts "Needed #{e.key} in parameters"
   exit 1
 end
+service_account_name = "k8s-access"
+secret_name = service_account_name
 
 config = {
   "apiVersion" => "kubeadm.k8s.io/v1beta3",
@@ -56,3 +58,31 @@ config_path = "/tmp/kubeadm-config.yaml"
 safe_write_to_file(config_path, config.to_yaml)
 
 r "sudo kubeadm init --config #{config_path}"
+
+api_server_up = false
+5.times do
+  r("kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw='/healthz'", expect: [0])
+  api_server_up = true
+  break
+rescue CommandFail
+  puts "API server is not up yet, retrying in 5 seconds..."
+  sleep 5
+end
+unless api_server_up
+  puts "API server is not healthy. Could not create customer credentials."
+  exit 1
+end
+
+r "kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system create serviceaccount #{service_account_name}"
+r "kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system create clusterrolebinding #{service_account_name}-binding --clusterrole=cluster-admin --serviceaccount=kube-system:#{service_account_name}"
+r "kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #{secret_name}
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: #{service_account_name}
+type: kubernetes.io/service-account-token
+EOF
+"

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -27,6 +27,17 @@ class Clover
           kc.incr_destroy
           204
         end
+
+        r.on "kubeconfig" do
+          r.get do
+            authorize("KubernetesCluster:create", kc.id)
+
+            content = kc.kubeconfig
+            response["Content-Type"] = "text/plain"
+            response["Content-Disposition"] = "attachment; filename=\"#{kc.name}-kubeconfig.yaml\""
+            response.write(content)
+          end
+        end
       end
     end
   end

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe KubernetesCluster do
     let(:cp_vms) { [vm] }
 
     it "removes client certificate and key data from users and adds an RBAC token to users" do
-      expect(kc).to receive(:cp_vms).and_return(cp_vms).twice
+      expect(kc).to receive(:cp_vms).and_return(cp_vms)
       expect(sshable).to receive(:cmd).with("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system get secret k8s-access -o jsonpath='{.data.token}' | base64 -d").and_return("mocked_rbac_token")
       expect(sshable).to receive(:cmd).with("sudo cat /etc/kubernetes/admin.conf").and_return(kubeconfig)
       customer_config = kc.kubeconfig

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -304,7 +304,8 @@ RSpec.describe Clover, "Kubernetes" do
       end
 
       it "returns kubeconfig content for authorized users" do
-        allow_any_instance_of(KubernetesCluster).to receive(:kubeconfig).and_return("kubeconfig content")
+        expect(KubernetesCluster).to receive(:kubeconfig).and_return "kubeconfig content"
+
         visit "#{project.path}#{kc.path}/kubeconfig"
 
         expect(page.response_headers["Content-Type"]).to eq("text/plain")
@@ -329,7 +330,7 @@ RSpec.describe Clover, "Kubernetes" do
       end
 
       it "returns proper content headers and content" do
-        allow_any_instance_of(KubernetesCluster).to receive(:kubeconfig).and_return("mocked kubeconfig content")
+        expect(KubernetesCluster).to receive(:kubeconfig).and_return "mocked kubeconfig content"
 
         visit "#{project.path}#{kc.path}/kubeconfig"
         expect(page.response_headers["Content-Type"]).to eq("text/plain")

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -62,7 +62,7 @@ module ThawedMock
   allow_mocking(GithubRunner, :[], :any?, :first, :join)
   allow_mocking(HetznerHost, :create)
   allow_mocking(IpsecTunnel, :[], :create)
-  allow_mocking(KubernetesCluster, :[])
+  allow_mocking(KubernetesCluster, :[], :kubeconfig)
   allow_mocking(MinioCluster, :[])
   allow_mocking(Nic, :[], :create)
   allow_mocking(Page, :from_tag_parts)

--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -13,7 +13,10 @@
       ["Kubernetes Clusters", "#{@project_data[:path]}/kubernetes-cluster"],
       [@kc[:name], "#"]
     ],
-    right_items: [render("components/kubernetes_state_label", locals: { state: @kc[:state], extra_class: "text-md" })]
+    right_items: [
+      render("components/kubernetes_state_label", locals: { state: @kc[:state], extra_class: "text-md" }),
+      render("components/button", locals: { text: "Download kubeconfig", link: "#{request.path}/kubeconfig" })
+    ]
   }
 ) %>
 


### PR DESCRIPTION
We do not want to pass the admin kubeconfig to the customers. So for now we will create a SA, ClusterRolebinding and secret for creating a RBAC token and then passing the customers a kubeconfig with that.

We will use the cluster-admin ClusterRole to give enough access to the customer to do whatever they want.