### PR TITLE
MinIO Client cert chain update

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -85,7 +85,7 @@ class MinioServer < Sequel::Model
       endpoint: server_url,
       access_key: cluster.admin_user,
       secret_key: cluster.admin_password,
-      ssl_ca_file_data: cluster.root_certs,
+      ssl_ca_file_data: cluster.root_certs + cert,
       socket: socket
     )
   end

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe MinioServer do
     described_class.create_with_id(
       minio_pool_id: mp.id,
       vm_id: vm.id,
-      index: 0
+      index: 0,
+      cert: "cert"
     )
   }
 

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -424,6 +424,10 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   end
 
   describe "#available?" do
+    before do
+      allow(nx.minio_server).to receive(:cert).and_return("cert")
+    end
+
     it "returns true if initial provisioning is set" do
       expect(nx.minio_server).to receive(:initial_provisioning_set?).and_return(true)
       expect(nx.available?).to be(true)


### PR DESCRIPTION
Some of the devs (including me) found out that the ca_bundle that doesn't have the server side cert fails to get validate the certificate. Here, we start passing the minio server cert together with the root certs.