### PR TITLE
Apply timeout of 10 seconds to stopping a vm

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -417,7 +417,7 @@ class Prog::Vm::Nexus < Prog::Base
 
     unless host.nil?
       begin
-        host.sshable.cmd("sudo systemctl stop #{q_vm}")
+        host.sshable.cmd("sudo timeout 10s systemctl stop #{q_vm}")
       rescue Sshable::SshError => ex
         raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
       end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -759,7 +759,7 @@ RSpec.describe Prog::Vm::Nexus do
       end
 
       it "absorbs an already deleted errors as a success" do
-        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/).and_raise(
+        expect(sshable).to receive(:cmd).with("sudo timeout 10s systemctl stop #{nx.vm_name}").and_raise(
           Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil)
         )
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/).and_raise(
@@ -773,7 +773,7 @@ RSpec.describe Prog::Vm::Nexus do
 
       it "absorbs an already deleted errors as a success and hops to lb_expiry if vm is part of a load balancer" do
         expect(vm).to receive(:load_balancer).and_return(instance_double(LoadBalancer)).at_least(:once)
-        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/).and_raise(
+        expect(sshable).to receive(:cmd).with("sudo timeout 10s systemctl stop #{nx.vm_name}").and_raise(
           Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil)
         )
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/).and_raise(
@@ -785,20 +785,20 @@ RSpec.describe Prog::Vm::Nexus do
 
       it "raises other stop errors" do
         ex = Sshable::SshError.new("stop", "", "unknown error", 1, nil)
-        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/).and_raise(ex)
+        expect(sshable).to receive(:cmd).with("sudo timeout 10s systemctl stop #{nx.vm_name}").and_raise(ex)
 
         expect { nx.destroy }.to raise_error ex
       end
 
       it "raises other stop-dnsmasq errors" do
         ex = Sshable::SshError.new("stop", "", "unknown error", 1, nil)
-        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/)
+        expect(sshable).to receive(:cmd).with("sudo timeout 10s systemctl stop #{nx.vm_name}")
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/).and_raise(ex)
         expect { nx.destroy }.to raise_error ex
       end
 
       it "deletes and pops when all commands are succeeded" do
-        expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}/)
+        expect(sshable).to receive(:cmd).with("sudo timeout 10s systemctl stop #{nx.vm_name}")
         expect(sshable).to receive(:cmd).with(/sudo.*systemctl.*stop.*#{nx.vm_name}-dnsmasq/)
         expect(sshable).to receive(:cmd).with(/sudo.*bin\/setup-vm delete #{nx.vm_name}/)
 


### PR DESCRIPTION
Stopping a busy virtual machine can take a long time, which has the potential to cause issues for our control plane. This commit limits the time for `systemctl stop` of the vm's systemd service to 10 seconds.