### PR TITLE
Fix ssh config for the server that were applied to the client

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -101,7 +101,7 @@ r "systemctl enable cron"
 r "systemctl start cron"
 
 # Taken from https://infosec.mozilla.org/guidelines/openssh
-safe_write_to_file("/etc/ssh/ssh_config.d/10-clover.conf", <<~SSHD_CONFIG)
+safe_write_to_file("/etc/ssh/sshd_config.d/10-clover.conf", <<~SSHD_CONFIG)
 # Supported HostKey algorithms by order of preference.
 HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key


### PR DESCRIPTION
There was a single-character miss here, that I only noticed upon trying to use SSSH from a host to do some diagnostics, as it causes the `ssh` client to crash complaining about incorrect options.

Conversely, it means these SSH server options were never applied...or tested, I guess (e.g. inspecting for verbose output that included SSH key fingerprints, per the comment on `LogLevel VERBOSE`)