### PR TITLE
Update Load Balancer for newly added VMs even when they are down

### DIFF
--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -187,6 +187,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
     end
 
     load_balancer.private_subnet.incr_update_firewall_rules
+    load_balancer.incr_update_load_balancer
     hop_wait
   end
 end

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -18,6 +18,7 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   label def update_load_balancer
     if vm_load_balancer_state == "detaching"
       load_balancer.remove_vm(vm)
+      hop_remove_load_balancer
     end
 
     # if there is literally no up resources to balance for, we simply not do


### PR DESCRIPTION
We were waiting for the first "up" signal to update the load balancer node. However, the moment we add a new node, we update the dns records and this node starts getting traffic. If we do not update the load balancer nodes, this node simply doesn't start rerouting the traffic to already existing healthy nodes. Therefore, we must immediately update the load balancer nodes.

We were also not cleaning up the node NAT settings for a detached node which continues to reroute the traffic silently. We start removing it.