### PR TITLE
Convert K8s API Server LB to IPv4

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -58,7 +58,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       dst_port: 6443,
       health_check_endpoint: "/healthz",
       health_check_protocol: "tcp",
-      stack: LoadBalancer::Stack::DUAL
+      stack: LoadBalancer::Stack::IPV4
     )
     kubernetes_cluster.update(api_server_lb_id: load_balancer_st.id)
 

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -38,9 +38,6 @@ RSpec.describe KubernetesCluster do
       expect(kc.errors[:version]).to eq(["must be a valid Kubernetes version"])
 
       kc.version = "v1.32"
-      puts kc.valid?
-      puts kc.errors
-
       expect(kc.valid?).to be true
     end
   end

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kubernetes_cluster.api_server_lb.dst_port).to eq 6443
       expect(kubernetes_cluster.api_server_lb.health_check_endpoint).to eq "/healthz"
       expect(kubernetes_cluster.api_server_lb.health_check_protocol).to eq "tcp"
-      expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::DUAL
+      expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::IPV4
       expect(kubernetes_cluster.api_server_lb.private_subnet_id).to eq subnet.id
     end
   end


### PR DESCRIPTION
Our kubernetes installation does not play well with IPv6, therefore we should have used IPv4 until fully testing the dual stack.

Also, this patch deletes some leftover `puts` statements in the tests.