### PR TITLE
Add more data to the deadline pages

### DIFF
--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -4,9 +4,9 @@ require_relative "spec_helper"
 
 RSpec.describe GithubRunner do
   subject(:github_runner) {
-    vmh = VmHost.create(location: "hetzner-fsn1") { _1.id = Sshable.create_with_id.id }
     ins = GithubInstallation.create_with_id(installation_id: 123, name: "test-installation", type: "User")
-    vm = Vm.create(vm_host: vmh, unix_user: "ubi", public_key: "ssh-key", name: "runner-vm", location: "hetzner-fsn1", boot_image: "github-ubuntu-2204", family: "standard", arch: "x64", cores: 1, vcpus: 2, memory_gib: 8, project_id: Project.create(name: "test").id) { _1.id = Sshable.create_with_id.id }
+    vm = create_vm(vm_host: create_vm_host, boot_image: "github-ubuntu-2204")
+    Sshable.create { _1.id = vm.id }
     described_class.create_with_id(repository_name: "test-repo", label: "ubicloud", vm_id: vm.id, installation_id: ins.id)
   }
 

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -129,12 +129,14 @@ RSpec.describe Project do
 
   describe ".default_location" do
     it "returns the location with the highest available core capacity" do
-      VmHost.create(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3) { _1.id = Sshable.create_with_id.id }
-      VmHost.create(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3) { _1.id = Sshable.create_with_id.id }
-      VmHost.create(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 1) { _1.id = Sshable.create_with_id.id }
-      VmHost.create(allocation_state: "accepting", location: "leaseweb-wdc02", total_cores: 100, used_cores: 99) { _1.id = Sshable.create_with_id.id }
-      VmHost.create(allocation_state: "draining", location: "location-4", total_cores: 100, used_cores: 0) { _1.id = Sshable.create_with_id.id }
-      VmHost.create(allocation_state: "accepting", location: "github-runners", total_cores: 100, used_cores: 0) { _1.id = Sshable.create_with_id.id }
+      [
+        {allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3},
+        {allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3},
+        {allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 1},
+        {allocation_state: "accepting", location: "leaseweb-wdc02", total_cores: 100, used_cores: 99},
+        {allocation_state: "draining", location: "location-4", total_cores: 100, used_cores: 0},
+        {allocation_state: "accepting", location: "github-runners", total_cores: 100, used_cores: 0}
+      ].each { create_vm_host(**_1) }
 
       expect(project.default_location).to eq("hetzner-fsn1")
     end

--- a/spec/model/vm_host_slice_spec.rb
+++ b/spec/model/vm_host_slice_spec.rb
@@ -17,23 +17,10 @@ RSpec.describe VmHostSlice do
     )
   end
 
-  let(:sshable) {
-    Sshable.create_with_id
-  }
-
-  let(:vm_host) {
-    sshable = Sshable.create_with_id
-    VmHost.create(
-      location: "x",
-      total_cores: 4,
-      total_cpus: 8,
-      used_cores: 1
-    ) { _1.id = sshable.id }
-  }
+  let(:vm_host) { create_vm_host(total_cores: 4, total_cpus: 8, used_cores: 1) }
 
   before do
     allow(vm_host_slice).to receive(:vm_host).and_return(vm_host)
-    allow(vm_host).to receive(:sshable).and_return(sshable)
     (0..15).each { |i|
       VmHostCpu.create(
         vm_host_id: vm_host.id,
@@ -128,7 +115,7 @@ RSpec.describe VmHostSlice do
   describe "availability monitoring" do
     it "initiates a new health monitor session" do
       allow(vm_host_slice).to receive_messages(vm_host: vm_host)
-      expect(sshable).to receive(:start_fresh_session)
+      expect(vm_host.sshable).to receive(:start_fresh_session)
       vm_host_slice.init_health_monitor_session
     end
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -106,10 +106,7 @@ RSpec.describe Vm do
   end
 
   describe "#update_spdk_version" do
-    let(:vmh) {
-      sshable = Sshable.create_with_id
-      VmHost.create(location: "a") { _1.id = sshable.id }
-    }
+    let(:vmh) { create_vm_host }
 
     before do
       expect(vm).to receive(:vm_host).and_return(vmh)

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Prog::DownloadBootImage do
   let(:dbi_without_version) { described_class.new(Strand.new(stack: [{"image_name" => "my-image", "custom_url" => "https://example.com/my-image.raw"}])) }
   let(:dbi_with_version_nil) { described_class.new(Strand.new(stack: [{"image_name" => "my-image", "version" => nil, "custom_url" => "https://example.com/my-image.raw"}])) }
 
-  let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-fsn1", arch: "x64") { _1.id = sshable.id } }
+  let(:sshable) { vm_host.sshable }
+  let(:vm_host) { create_vm_host }
 
   before do
     allow(dbi).to receive_messages(sshable: sshable, vm_host: vm_host)

--- a/spec/prog/download_cloud_hypervisor_spec.rb
+++ b/spec/prog/download_cloud_hypervisor_spec.rb
@@ -5,8 +5,8 @@ require_relative "../model/spec_helper"
 RSpec.describe Prog::DownloadCloudHypervisor do
   subject(:df) { described_class.new(Strand.new(stack: [{"version" => "35.1", "sha256_ch_bin" => "thesha", "sha256_ch_remote" => "anothersha"}])) }
 
-  let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-fsn1", arch: "x64") { _1.id = sshable.id } }
+  let(:sshable) { vm_host.sshable }
+  let(:vm_host) { create_vm_host }
 
   before do
     allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)

--- a/spec/prog/download_firmware_spec.rb
+++ b/spec/prog/download_firmware_spec.rb
@@ -5,8 +5,8 @@ require_relative "../model/spec_helper"
 RSpec.describe Prog::DownloadFirmware do
   subject(:df) { described_class.new(Strand.new(stack: [{"version" => "202405", "sha256" => "thesha"}])) }
 
-  let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-fsn1", arch: "x64") { _1.id = sshable.id } }
+  let(:sshable) { vm_host.sshable }
+  let(:vm_host) { create_vm_host }
 
   before do
     allow(df).to receive_messages(sshable: sshable, vm_host: vm_host)

--- a/spec/prog/log_vm_host_utilizations_spec.rb
+++ b/spec/prog/log_vm_host_utilizations_spec.rb
@@ -8,14 +8,13 @@ RSpec.describe Prog::LogVmHostUtilizations do
   describe "#wait" do
     it "logs vm host utilizations every minute" do
       [
-        ["1.1.1.1", "hetzner-fsn1", "x64", "accepting", 3, 10, 20, 80],
-        ["2.2.2.2", "hetzner-fsn1", "x64", "draining", 5, 20, 50, 150],
-        ["3.3.3.3", "hetzner-fsn1", "arm64", "accepting", 10, 80, 30, 200],
-        ["4.4.4.4", "hetzner-hel1", "x64", "accepting", 2, 10, 20, 100],
-        ["5.5.5.5", "hetzner-hel1", "x64", "accepting", 0, nil, 0, 0]
-      ].each do |host, location, arch, allocation_state, used_cores, total_cores, used_hugepages_1g, total_hugepages_1g|
-        sshable = Sshable.create_with_id(host:)
-        VmHost.create(location:, arch:, allocation_state:, used_cores:, total_cores:, used_hugepages_1g:, total_hugepages_1g:) { _1.id = sshable.id }
+        ["hetzner-fsn1", "x64", "accepting", 3, 10, 20, 80],
+        ["hetzner-fsn1", "x64", "draining", 5, 20, 50, 150],
+        ["hetzner-fsn1", "arm64", "accepting", 10, 80, 30, 200],
+        ["hetzner-hel1", "x64", "accepting", 2, 10, 20, 100],
+        ["hetzner-hel1", "x64", "accepting", 0, nil, 0, 0]
+      ].each do |location, arch, allocation_state, used_cores, total_cores, used_hugepages_1g, total_hugepages_1g|
+        create_vm_host(location:, arch:, allocation_state:, used_cores:, total_cores:, used_hugepages_1g:, total_hugepages_1g:)
       end
 
       expect(Clog).to receive(:emit).with("location utilization") do |&blk|

--- a/spec/prog/remove_boot_image_spec.rb
+++ b/spec/prog/remove_boot_image_spec.rb
@@ -5,14 +5,13 @@ require_relative "../model/spec_helper"
 RSpec.describe Prog::RemoveBootImage do
   subject(:rbi) { described_class.new(Strand.new(stack: [{}])) }
 
-  let(:sshable) { Sshable.create_with_id }
-  let(:vm_host) { VmHost.create(location: "hetzner-fsn1") { _1.id = sshable.id } }
+  let(:sshable) { vm_host.sshable }
+  let(:vm_host) { create_vm_host }
   let(:boot_image) { BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vm_host.id, size_gib: 14) }
 
   before do
     allow(rbi).to receive(:boot_image).and_return(boot_image)
     allow(boot_image).to receive(:vm_host).and_return(vm_host)
-    allow(vm_host).to receive(:sshable).and_return(sshable)
   end
 
   describe "#start" do

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -13,20 +13,8 @@ RSpec.describe Prog::Storage::SetupSpdk do
   }
 
   let(:spdk_version) { "v23.09-ubi-0.2" }
-  let(:sshable) {
-    instance_double(Sshable)
-  }
-  let(:vm_host) {
-    Sshable.create { _1.id = "adec2977-74a9-8b71-8473-cf3940a45ac5" }
-    VmHost.create(
-      location: "xyz",
-      arch: "x64",
-      used_hugepages_1g: 0,
-      total_hugepages_1g: 20,
-      total_cpus: 96,
-      os_version: "ubuntu-24.04"
-    ) { _1.id = "adec2977-74a9-8b71-8473-cf3940a45ac5" }
-  }
+  let(:sshable) { vm_host.sshable }
+  let(:vm_host) { create_vm_host(used_hugepages_1g: 0, total_hugepages_1g: 20, total_cpus: 96, os_version: "ubuntu-24.04") }
 
   before do
     allow(setup_spdk).to receive_messages(sshable: sshable, vm_host: vm_host)

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -214,8 +214,7 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#vm_host" do
     it "returns first VM's host" do
-      sshable = Sshable.create_with_id
-      vm_host = VmHost.create(location: "A") { _1.id = sshable.id }
+      vm_host = create_vm_host
       vm = create_vm(vm_host_id: vm_host.id)
       expect(vg_test).to receive(:frame).and_return({"vms" => [vm.id]})
       expect(vg_test.vm_host).to eq(vm_host)

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -292,8 +292,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#wait_concurrency_limit" do
     before do
       [["hetzner-fsn1", "x64"], ["github-runners", "x64"], ["github-runners", "arm64"]].each_with_index do |(location, arch), i|
-        ssh = Sshable.create_with_id(host: "0.0.0.#{i}")
-        VmHost.create(location: location, allocation_state: "accepting", arch: arch, total_cores: 16, used_cores: 16) { _1.id = ssh.id }
+        create_vm_host(location:, arch:, total_cores: 16, used_cores: 16)
       end
     end
 

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -7,17 +7,9 @@ require_relative "../../../prog/vm/host_nexus"
 RSpec.describe Prog::Vm::VmHostSliceNexus do
   subject(:nx) { described_class.new(Strand.create(id: "b231a172-8f56-8b10-bbed-8916ea4e5c28", prog: "Prog::Vm::VmHostSliceNexus", label: "create")) }
 
-  let(:sshable) {
-    Sshable.create
-  }
+  let(:sshable) { vm_host.sshable }
 
-  let(:vm_host) {
-    VmHost.create(
-      location: "x",
-      total_cores: 4,
-      used_cores: 1
-    ) { _1.id = sshable.id }
-  }
+  let(:vm_host) { create_vm_host(total_cores: 4, used_cores: 1) }
 
   let(:vm_host_slice) {
     VmHostSlice.create(
@@ -36,7 +28,6 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
   before do
     allow(nx).to receive_messages(vm_host_slice: vm_host_slice)
     allow(vm_host_slice).to receive_messages(vm_host: vm_host)
-    allow(vm_host).to receive_messages(sshable: sshable)
     (0..15).each { |i|
       VmHostCpu.create(
         spdk: i < 2,

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#wait" do
     before do
-      VmHost.create(location: "github-runners", allocation_state: "accepting", arch: "x64", total_cores: 2, used_cores: 0) { _1.id = Sshable.create_with_id.id }
+      create_vm_host(location: "github-runners", total_cores: 2, used_cores: 0)
     end
 
     let(:pool) {

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -116,11 +116,11 @@ RSpec.describe Al do
     end
 
     it "disqualifies invalid candidates" do
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 6, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "draining", arch: "x64", location: "loc1", total_cores: 8, used_cores: 1, total_hugepages_1g: 8, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh3 = VmHost.create(allocation_state: "accepting", arch: "arm64", location: "loc1", total_cores: 8, used_cores: 0, total_hugepages_1g: 8, used_hugepages_1g: 0) { _1.id = Sshable.create_with_id.id }
-      vmh4 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 8, used_cores: 6, total_hugepages_1g: 8, used_hugepages_1g: 5) { _1.id = Sshable.create_with_id.id }
-      vmh5 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "github-runners", total_cores: 8, used_cores: 6, total_hugepages_1g: 80, used_hugepages_1g: 5) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 6, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(allocation_state: "draining", arch: "x64", location: "loc1", total_cores: 8, used_cores: 1, total_hugepages_1g: 8, used_hugepages_1g: 2)
+      vmh3 = create_vm_host(allocation_state: "accepting", arch: "arm64", location: "loc1", total_cores: 8, used_cores: 0, total_hugepages_1g: 8, used_hugepages_1g: 0)
+      vmh4 = create_vm_host(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 8, used_cores: 6, total_hugepages_1g: 8, used_hugepages_1g: 5)
+      vmh5 = create_vm_host(allocation_state: "accepting", arch: "x64", location: "github-runners", total_cores: 8, used_cores: 6, total_hugepages_1g: 80, used_hugepages_1g: 5)
 
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
@@ -139,7 +139,7 @@ RSpec.describe Al do
     end
 
     it "retrieves correct values" do
-      vmh = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh = create_vm_host(total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
       sd1 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
       sd2 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 12, total_storage_gib: 99)
@@ -166,7 +166,7 @@ RSpec.describe Al do
     end
 
     it "retrieves provisioning count" do
-      vmh = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh = create_vm_host(total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
       sd1 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
       create_vm(vm_host_id: vmh.id, location: vmh.location, boot_image: "", display_state: "creating")
@@ -193,8 +193,8 @@ RSpec.describe Al do
     end
 
     it "applies host filter" do
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
@@ -210,8 +210,8 @@ RSpec.describe Al do
     end
 
     it "applies host exclusion filter" do
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
@@ -227,8 +227,8 @@ RSpec.describe Al do
     end
 
     it "applies location filter" do
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc2", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(location: "loc2", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
@@ -244,8 +244,8 @@ RSpec.describe Al do
     end
 
     it "retrieves candidates with enough storage devices" do
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor2", available_storage_gib: 100, total_storage_gib: 100)
@@ -261,8 +261,8 @@ RSpec.describe Al do
     end
 
     it "retrieves candidates with available ipv4 addresses if ip4_enabled" do
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
@@ -277,8 +277,8 @@ RSpec.describe Al do
 
     it "retrieves candidates without available ipv4 addresses if not ip4_enabled" do
       req.ip4_enabled = false
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
@@ -291,8 +291,8 @@ RSpec.describe Al do
     end
 
     it "retrieves candidates with gpu if gpu_count > 0" do
-      vmh1 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
-      vmh2 = VmHost.create(allocation_state: "accepting", arch: "x64", location: "loc1", total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh1 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create_with_id(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
@@ -526,7 +526,7 @@ RSpec.describe Al do
     }
 
     before do
-      vmh = VmHost.create(allocation_state: "accepting", arch: "x64", location: "hetzner-fsn1", total_mem_gib: 64, total_sockets: 2, total_dies: 2, net6: "fd10:9b0b:6b4b:8fbb::/64", total_cpus: 16, total_cores: 8, used_cores: 1, total_hugepages_1g: 54, used_hugepages_1g: 2) { _1.id = Sshable.create_with_id.id }
+      vmh = create_vm_host(net6: "fd10:9b0b:6b4b:8fbb::/64", total_cpus: 16, total_cores: 8, used_cores: 1, total_hugepages_1g: 54, used_hugepages_1g: 2)
       BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -226,6 +226,13 @@ RSpec.configure do |config|
     require "ripper"
     require "coderay"
   end
+
+  def create_vm_host(**args)
+    args = {location: "hetzner-fns1", allocation_state: "accepting", arch: "x64", total_cores: 48, used_cores: 2}.merge(args)
+    ubid = VmHost.generate_ubid
+    Sshable.create { _1.id = ubid.to_uuid }
+    VmHost.create(**args) { _1.id = ubid.to_uuid }
+  end
 end
 
 def create_vm(**args)

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe UBID do
     sshable = Sshable.create_with_id
     expect(sshable.ubid).to start_with UBID::TYPE_SSHABLE
 
-    host = VmHost.create(location: "x") { _1.id = sshable.id }
+    host = create_vm_host
     si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
 
     vm = create_vm
@@ -255,7 +255,7 @@ RSpec.describe UBID do
 
   it "can decode ids" do
     sshable = Sshable.create_with_id
-    host = VmHost.create(location: "x") { _1.id = sshable.id }
+    host = create_vm_host
     si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
     vm = create_vm
     dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }


### PR DESCRIPTION
- **Add create_vm_host spec helper**
  The VmHost model requires a Sshable record due to database constraints.
  Currently, we're creating VmHost models with dummy Sshable data across
  multiple test locations, leading to code duplication.
  
  Additionally, we're creating VmHost instances using `VmHost.create(...)
  { _1.id = Sshable.create.id }`, which results in VmHost having a Sshable
  UBID instead of its own UBID. While this doesn't break any test, it's
  conceptually incorrect and should be fixed.
  

- **Add more data to the deadline pages**
  Currently, the deadline pages only show the resource type, ID, and
  expected target label. It would be helpful to include additional data
  based on the resource type for the on-call engineer. For example, when a
  host crashes, we receive multiple deadline pages from virtual machines,
  making it easier for the on-call engineer to identify the host by
  reviewing the incident details in Slack.
  
  Additionally, while I haven't implemented this, we could choose whether
  or not to trigger the page based on the resource type to avoid page
  storms. For instance, when creating a new deadline page for a virtual
  machine, we can check if its host is unavailable. If the host is down,
  we can decide not to trigger the page for the virtual machine.
  