### PR TITLE
Add the target's ubid to SSH command logs

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -82,9 +82,7 @@ class Sshable < Sequel::Model
     if log
       Clog.emit("ssh cmd execution") do
         finish = Time.now
-        embed = {start: start, finish: finish, duration: finish - start,
-                 cmd: cmd,
-                 exit_code: exit_code, exit_signal: exit_signal}
+        embed = {start:, finish:, cmd:, exit_code:, exit_signal:, duration: finish - start}
 
         # Suppress large outputs to avoid annoyance in duplication
         # when in the REPL.  In principle, the user of the REPL could

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -82,7 +82,7 @@ class Sshable < Sequel::Model
     if log
       Clog.emit("ssh cmd execution") do
         finish = Time.now
-        embed = {start:, finish:, cmd:, exit_code:, exit_signal:, duration: finish - start}
+        embed = {start:, finish:, cmd:, exit_code:, exit_signal:, ubid:, duration: finish - start}
 
         # Suppress large outputs to avoid annoyance in duplication
         # when in the REPL.  In principle, the user of the REPL could


### PR DESCRIPTION
- **Omit unnecessary hash values in sshable log**
  

- **Add the target's ubid to SSH command logs**
  Our logs include the ubid of the strand that initiated the command as
  the `thread` property. However, this ubid refers to the initiator, not
  the target.
  
  For example, when a GitHub runner strand runs SSH commands on both the
  VM host and the VM, the `thread` for both is the same. If the host
  experiences SSH latencies, we can't aggregate the channel durations of
  the VM host by `thread`. Adding the sshable's `ubid` will help us
  aggregate the durations for the target. This way, if a specific host has
  SSH latencies, we can monitor it effectively.
  