### PR TITLE
CertNexus restart counter is added to not DOS ZeroSSL

### DIFF
--- a/model/cert.rb
+++ b/model/cert.rb
@@ -11,7 +11,7 @@ class Cert < Sequel::Model
 
   include ResourceMethods
   include SemaphoreMethods
-  semaphore :destroy
+  semaphore :destroy, :restarted
 
   plugin :column_encryption do |enc|
     enc.column :account_key


### PR DESCRIPTION
In case the passed DNSZone is not valid globally, DNS validation or cert generation may fail. In that case, CertNexus restarts to do a new acme dance. It goes on forever. Instead of this, we are introducing a restart logic. In case of restarts, we start napping aggressively up until 10 minutes.

Fixes https://linear.app/ubicloud/issue/UBI-33/do-we-back-off-acme-zerossl-if-customer-doesnt-control-ns