### PR TITLE
Fix display_size for vms without cpu_percent_limit

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -125,7 +125,7 @@ class Vm < Sequel::Model
       _1.family == family &&
         _1.arch == arch &&
         _1.vcpus == vcpus &&
-        _1.cpu_percent_limit == cpu_percent_limit
+        (cpu_percent_limit.nil? || _1.cpu_percent_limit == cpu_percent_limit)
     }
     vm_size.name
   end


### PR DESCRIPTION
The data model currently allows for VMs with a null value for `cpu_percent_limit`. All VMs created before merging https://github.com/ubicloud/ubicloud/pull/2666 don't have cpu_percent_limit set. As long as existing VMs may have a null cpu_percent_limit, we need to gracefully handle that case in `display_size`.