### PR TITLE
Add private_ipv4 and private_ipv6 utility functions

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -26,7 +26,7 @@ class MinioServer < Sequel::Model
   end
 
   def private_ipv4_address
-    vm.nics.first.private_ipv4.network.to_s
+    vm.private_ipv4.to_s
   end
 
   def minio_volumes

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -101,7 +101,7 @@ class PostgresServer < Sequel::Model
         }
       },
       identity: resource.identity,
-      hosts: "#{resource.representative_server.vm.nics.first.private_ipv4.network} #{resource.identity}"
+      hosts: "#{resource.representative_server.vm.private_ipv4} #{resource.identity}"
     }
   end
 

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -50,6 +50,14 @@ class Vm < Sequel::Model
     assigned_vm_address&.ip
   end
 
+  def private_ipv4
+    nics.first.private_ipv4.network
+  end
+
+  def private_ipv6
+    nics.first.private_ipv6.nth(2)
+  end
+
   def runtime_token
     JWT.encode({sub: ubid, iat: Time.now.to_i}, Config.clover_runtime_token_secret, "HS256")
   end

--- a/prog/test/connected_subnets.rb
+++ b/prog/test/connected_subnets.rb
@@ -94,8 +94,8 @@ ExecStart=nc -l 8080 -6
 
     start_listening(ipv4: false)
 
-    test_connection(vm_to_be_connected.nics.first.private_ipv6.nth(2).to_s, vm_to_connect_outside, should_fail: false, ipv4: false)
-    test_connection(vm_to_be_connected.nics.first.private_ipv6.nth(2).to_s, vm_to_connect, should_fail: true, ipv4: false)
+    test_connection(vm_to_be_connected.private_ipv6.to_s, vm_to_connect_outside, should_fail: false, ipv4: false)
+    test_connection(vm_to_be_connected.private_ipv6.to_s, vm_to_connect, should_fail: true, ipv4: false)
 
     hop_perform_blocked_private_ipv4
   end
@@ -132,8 +132,8 @@ ExecStart=nc -l 8080 -6
     end
 
     start_listening(ipv4: false)
-    test_connection(vm_to_be_connected.nics.first.private_ipv6.nth(2).to_s, vm_to_connect, should_fail: false, ipv4: false)
-    test_connection(vm_to_be_connected.nics.first.private_ipv6.nth(2).to_s, vm_to_connect_outside, should_fail: true, ipv4: false)
+    test_connection(vm_to_be_connected.private_ipv6.to_s, vm_to_connect, should_fail: false, ipv4: false)
+    test_connection(vm_to_be_connected.private_ipv6.to_s, vm_to_connect_outside, should_fail: true, ipv4: false)
 
     hop_finish
   end

--- a/prog/test/firewall_rules.rb
+++ b/prog/test/firewall_rules.rb
@@ -121,7 +121,7 @@ ExecStart=nc -l 8080 -6
 
     vm1.sshable.cmd("sudo systemctl stop listening_ipv4.service")
     vm1.sshable.cmd("sudo systemctl start listening_ipv6.service")
-    test_connection(vm1.nics.first.private_ipv6.nth(2), vm2, should_fail: false, ipv4: false, hop_method_symbol: nil)
+    test_connection(vm1.private_ipv6, vm2, should_fail: false, ipv4: false, hop_method_symbol: nil)
     test_connection(vm1.ephemeral_net6.nth(2), vm2, should_fail: true, ipv4: false, hop_method_symbol: :hop_finish)
     fail_test "#{vm2.inhost_name} should not be able to connect to #{vm1.ephemeral_net6.nth(2)} on port 8080"
   end
@@ -150,7 +150,7 @@ ExecStart=nc -l 8080 -6
     when :perform_tests_private_ipv4
       {cidr: vm2.nics.first.private_ipv4.to_s, port_range: Sequel.pg_range(8080..8080)}
     when :perform_tests_private_ipv6
-      {cidr: vm2.nics.first.private_ipv6.nth(2).to_s, port_range: Sequel.pg_range(8080..8080)}
+      {cidr: vm2.private_ipv6.to_s, port_range: Sequel.pg_range(8080..8080)}
     else
       raise "Unknown config: #{config}"
     end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -224,9 +224,8 @@ class Prog::Vm::GithubRunner < Prog::Base
     COMMAND
 
     if github_runner.installation.cache_enabled
-      local_ip = vm.nics.first.private_ipv4.network.to_s
       command += <<~COMMAND
-        echo "CUSTOM_ACTIONS_CACHE_URL=http://#{local_ip}:51123/random_token/" | sudo tee -a /etc/environment
+        echo "CUSTOM_ACTIONS_CACHE_URL=http://#{vm.private_ipv4}:51123/random_token/" | sudo tee -a /etc/environment
       COMMAND
     end
 

--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -18,8 +18,8 @@ class Prog::Vnet::UpdateFirewallRules < Prog::Base
     globally_blocked_ipv4s, globally_blocked_ipv6s = generate_globally_blocked_lists
 
     load_balancer_allow_rule = if vm.load_balancer
-      allow_ipv4_lb_neigh_incoming = "ip saddr . tcp sport { #{vm.load_balancer.vms.reject { _1.id == vm.id }.map { _1.nics.first.private_ipv4.network.to_s + " . " + vm.load_balancer.src_port.to_s }.join(", ")} } ct state established,related,new counter accept" if vm.load_balancer.vms.reject { _1.id == vm.id }.any?
-      allow_ipv6_lb_neigh_incoming = "ip6 saddr . tcp sport { #{vm.load_balancer.vms.reject { _1.id == vm.id }.map { _1.nics.first.private_ipv6.nth(2).to_s + " . " + vm.load_balancer.src_port.to_s }.join(", ")} } ct state established,related,new counter accept" if vm.load_balancer.vms.reject { _1.id == vm.id }.any?
+      allow_ipv4_lb_neigh_incoming = "ip saddr . tcp sport { #{vm.load_balancer.vms.reject { _1.id == vm.id }.map { "#{_1.private_ipv4} . #{vm.load_balancer.src_port}" }.join(", ")} } ct state established,related,new counter accept" if vm.load_balancer.vms.reject { _1.id == vm.id }.any?
+      allow_ipv6_lb_neigh_incoming = "ip6 saddr . tcp sport { #{vm.load_balancer.vms.reject { _1.id == vm.id }.map { "#{_1.private_ipv6} . #{vm.load_balancer.src_port}" }.join(", ")} } ct state established,related,new counter accept" if vm.load_balancer.vms.reject { _1.id == vm.id }.any?
       <<~LOAD_BALANCER_ALLOW_RULE
 #{allow_ipv4_lb_neigh_incoming}
 #{allow_ipv6_lb_neigh_incoming}

--- a/serializers/vm.rb
+++ b/serializers/vm.rb
@@ -22,8 +22,8 @@ class Serializers::Vm < Serializers::Base
     if options[:detailed]
       base.merge!(
         firewalls: Serializers::Firewall.serialize(vm.firewalls, {include_path: true}),
-        private_ipv4: vm.nics.first.private_ipv4.network,
-        private_ipv6: vm.nics.first.private_ipv6.nth(2),
+        private_ipv4: vm.private_ipv4,
+        private_ipv6: vm.private_ipv6,
         subnet: vm.nics.first.private_subnet.name
       )
     end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe PostgresServer do
       ],
       nics: [
         instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.70.205.205/32"))
-      ]
+      ],
+      private_ipv4: NetAddr::IPv4Net.parse("10.70.205.205/32").network
     )
   }
 

--- a/spec/prog/test/connected_subnets_spec.rb
+++ b/spec/prog/test/connected_subnets_spec.rb
@@ -129,7 +129,7 @@ ExecStart=nc -l 8080 -6
 
     it "tests connection between the two subnets and hops to perform_blocked_private_ipv4" do
       expect(connected_subnets_test).to receive(:frame).and_return({"firewalls" => "connected_private_ipv6"})
-      vm1 = instance_double(Vm, sshable: sshable, nics: [instance_double(Nic, private_ipv6: NetAddr::IPv6Net.parse("2001:db8::/64"))])
+      vm1 = instance_double(Vm, sshable: sshable, nics: [instance_double(Nic, private_ipv6: NetAddr::IPv6Net.parse("2001:db8::/64"))], private_ipv6: NetAddr::IPv6.parse("2001:db8::2"))
       vm2 = instance_double(Vm)
       expect(connected_subnets_test).to receive(:vm_to_be_connected).and_return(vm1).at_least(:once)
       expect(connected_subnets_test).to receive(:vm_to_connect).and_return(vm2).at_least(:once)
@@ -181,7 +181,7 @@ ExecStart=nc -l 8080 -6
 
     it "tests connection between the two subnets and hops to perform_tests_public_blocked" do
       expect(connected_subnets_test).to receive(:frame).and_return({"firewalls" => "blocked_private_ipv6"})
-      vm1 = instance_double(Vm, sshable: sshable, nics: [instance_double(Nic, private_ipv6: NetAddr::IPv6Net.parse("2001:db8::/64"))])
+      vm1 = instance_double(Vm, sshable: sshable, nics: [instance_double(Nic, private_ipv6: NetAddr::IPv6Net.parse("2001:db8::/64"))], private_ipv6: NetAddr::IPv6.parse("2001:db8::2"))
       vm2 = instance_double(Vm)
       expect(connected_subnets_test).to receive(:vm_to_be_connected).and_return(vm1).at_least(:once)
       expect(connected_subnets_test).to receive(:vm_to_connect).and_return(vm2).at_least(:once)

--- a/spec/prog/test/firewall_rules_spec.rb
+++ b/spec/prog/test/firewall_rules_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Prog::Test::FirewallRules do
 
   let(:private_subnet_1) {
     nic = instance_double(Nic, private_ipv6: NetAddr::IPv6Net.parse("fd01:0db8:85a1::/64"), private_ipv4: NetAddr::IPv4Net.parse("192.168.0.1/32"))
-    vm_1 = instance_double(Vm, id: "vm_1", sshable: sshable, boot_image: "ubuntu-noble", ephemeral_net4: "1.1.1.1", ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a1::/64"), inhost_name: "vm1", nics: [nic])
-    vm_2 = instance_double(Vm, id: "vm_2", sshable: sshable, boot_image: "almalinux-9", ephemeral_net4: "1.1.1.2", ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a2::/64"), inhost_name: "vm2", nics: [nic])
+    vm_1 = instance_double(Vm, id: "vm_1", sshable: sshable, boot_image: "ubuntu-noble", ephemeral_net4: "1.1.1.1", ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a1::/64"), inhost_name: "vm1", nics: [nic], private_ipv6: NetAddr::IPv6.parse("fd01:0db8:85a1::2"))
+    vm_2 = instance_double(Vm, id: "vm_2", sshable: sshable, boot_image: "almalinux-9", ephemeral_net4: "1.1.1.2", ephemeral_net6: NetAddr::IPv6Net.parse("2001:0db8:85a2::/64"), inhost_name: "vm2", nics: [nic], private_ipv6: NetAddr::IPv6.parse("fd01:0db8:85a2::2"))
     instance_double(PrivateSubnet, id: "subnet_1", vms: [vm_1, vm_2])
   }
 
@@ -479,7 +479,7 @@ ExecStart=nc -l 8080 -6
       expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}, {cidr: "192.168.0.1/32", port_range: "8080..8080"}])
       firewall_test.update_firewall_rules(config: :perform_tests_private_ipv4)
 
-      expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}, {cidr: "fd01:db8:85a1::2", port_range: "8080..8080"}])
+      expect(firewall_test.firewall).to receive(:replace_firewall_rules).with([{cidr: "100.100.100.100/32", port_range: "22..22"}, {cidr: "fd01:db8:85a2::2", port_range: "8080..8080"}])
       firewall_test.update_firewall_rules(config: :perform_tests_private_ipv6)
 
       expect { firewall_test.update_firewall_rules(config: :unknown) }.to raise_error("Unknown config: unknown")

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Prog::Vnet::UpdateFirewallRules do
     vmh = instance_double(VmHost, sshable: instance_double(Sshable, cmd: nil))
     nic = instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.0/32"), private_ipv6: NetAddr::IPv6Net.parse("fd00::1/128"), ubid_to_tap_name: "tap0")
     ephemeral_net6 = NetAddr::IPv6Net.parse("fd00::1/79")
-    instance_double(Vm, private_subnets: [ps], vm_host: vmh, inhost_name: "x", nics: [nic], ephemeral_net6: ephemeral_net6, load_balancer: nil)
+    instance_double(Vm, private_subnets: [ps], vm_host: vmh, inhost_name: "x", nics: [nic], ephemeral_net6: ephemeral_net6, load_balancer: nil, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.0/32").network)
   }
 
   describe "#before_run" do
@@ -195,7 +195,7 @@ ADD_RULES
         instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::2/64"), port_range: Sequel.pg_range(80..10000))
       ])])
       expect(vm).to receive(:id).and_return(1).at_least(:once)
-      vm2 = instance_double(Vm, id: 2, nics: [instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"), private_ipv6: NetAddr::IPv6Net.parse("fd00::/124"))])
+      vm2 = instance_double(Vm, id: 2, nics: [instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"), private_ipv6: NetAddr::IPv6Net.parse("fd00::/124"))], private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32").network, private_ipv6: NetAddr::IPv6.parse("fd00::2"))
       lb = instance_double(LoadBalancer, name: "lb_table", src_port: 443, dst_port: 8443, vms: [vm, vm2])
       expect(vm).to receive(:load_balancer).and_return(lb).at_least(:once)
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ip netns exec x nft --file -", stdin: <<ADD_RULES)


### PR DESCRIPTION
Our code base had many vm.nics.first.private_ipv(4/6) calls. This commit moves these into 2 util functions in the vm model and reuses that to improve code readability and maintainability.