### PR TITLE
Adding E2E tests for slices

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -23,6 +23,17 @@ def main(options)
     # on when the host is rebooted and can cause flaky issues for github runner tests.
     wait_until(encrypted_vms_st)
 
+    # Testing slices is not parallel with other tests as it requires a specific host state
+    Semaphore.incr(hetzner_server_st.id, "allow_slices")
+    wait_until(hetzner_server_st, "wait")
+
+    sliced_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], storage_encrypted: true, test_reboot: false, test_slices: true)
+    log(sliced_vms_st, "test_slices: true")
+    wait_until(sliced_vms_st)
+
+    Semaphore.incr(hetzner_server_st.id, "disallow_slices")
+    wait_until(hetzner_server_st, "wait")
+
     unencrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], storage_encrypted: false, test_reboot: false)
     log(unencrypted_vms_st, "storage_encrypted: false")
     tests_to_wait << unencrypted_vms_st
@@ -52,7 +63,7 @@ def wait_until(st, label = nil)
       st.destroy
       exit 1
     end
-    log(st.reload, "waiting #{label ? "for #{label}" : "exit"}")
+    log(st.reload, "waiting for #{label || "exit"}")
     sleep 10
   end
   log(st, "reached")

--- a/prog/test/connected_subnets.rb
+++ b/prog/test/connected_subnets.rb
@@ -190,10 +190,10 @@ ExecStart=nc -l 8080 -6
 
   def vm_to_be_connected
     connected_id = frame["vm_to_be_connected_id"]
-    @vm_to_be_connected ||= if connected_id.nil?
-      ps_multiple.vms.first
-    else
+    @vm_to_be_connected ||= if connected_id
       ps_multiple.vms.find { |vm| vm.id == connected_id }
+    else
+      ps_multiple.vms.first
     end
   end
 

--- a/prog/test/firewall_rules.rb
+++ b/prog/test/firewall_rules.rb
@@ -34,6 +34,9 @@ ExecStart=nc -l 8080 -6
     vm1.sshable.cmd("sudo systemctl daemon-reload")
     vm1.sshable.cmd("sudo systemctl enable listening_ipv4.service")
     vm1.sshable.cmd("sudo systemctl enable listening_ipv6.service")
+    update_stack({
+      "vm_to_be_connected_id" => vm1.id
+    })
 
     hop_perform_tests_none
   end
@@ -159,7 +162,12 @@ ExecStart=nc -l 8080 -6
   end
 
   def vm1
-    @vm1 ||= firewall.private_subnets.first.vms.first
+    connected_id = frame["vm_to_be_connected_id"]
+    @vm1 ||= if connected_id.nil?
+      firewall.private_subnets.first.vms.first
+    else
+      firewall.private_subnets.first.vms.find { |vm| vm.id == connected_id }
+    end
   end
 
   def vm2

--- a/prog/test/firewall_rules.rb
+++ b/prog/test/firewall_rules.rb
@@ -163,10 +163,10 @@ ExecStart=nc -l 8080 -6
 
   def vm1
     connected_id = frame["vm_to_be_connected_id"]
-    @vm1 ||= if connected_id.nil?
-      firewall.private_subnets.first.vms.first
-    else
+    @vm1 ||= if connected_id
       firewall.private_subnets.first.vms.find { |vm| vm.id == connected_id }
+    else
+      firewall.private_subnets.first.vms.first
     end
   end
 

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HetznerServer < Prog::Test::Base
-  semaphore :destroy
+  semaphore :destroy, :allow_slices, :disallow_slices
 
   def self.assemble(vm_host_id: nil, default_boot_images: [])
     frame = if vm_host_id
@@ -109,7 +109,29 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       hop_destroy
     end
 
+    when_allow_slices_set? do
+      hop_allow_slices
+    end
+
+    when_disallow_slices_set? do
+      hop_disallow_slices
+    end
+
     nap 15
+  end
+
+  label def allow_slices
+    vm_host.allow_slices
+    Semaphore.where(strand_id: strand.id, name: "allow_slices").destroy
+
+    hop_wait
+  end
+
+  label def disallow_slices
+    vm_host.disallow_slices
+    Semaphore.where(strand_id: strand.id, name: "disallow_slices").destroy
+
+    hop_wait
   end
 
   label def destroy

--- a/prog/test/vm_host_slices.rb
+++ b/prog/test/vm_host_slices.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "json"
+
+class Prog::Test::VmHostSlices < Prog::Test::Base
+  label def start
+    hop_verify_separation
+  end
+
+  label def verify_separation
+    slices.combination(2) do |slice1, slice2|
+      fail_test "Standard instances placed in the same slice" if slice1.id == slice2.id
+      fail_test "Standard instances are sharing at least one cpu" if !(slice1.cpus.map(&:cpu_number) & slice2.cpus.map(&:cpu_number)).empty?
+    end
+
+    hop_verify_on_host
+  end
+
+  label def verify_on_host
+    slices.each do |slice|
+      slice.vm_host.sshable.start_fresh_session do |session|
+        fail_test "Slice #{slice.id} is not setup correctly" unless slice.up? session
+      end
+    end
+
+    hop_finish
+  end
+
+  label def finish
+    pop "Verified VM Host Slices!"
+  end
+
+  label def failed
+    nap 15
+  end
+
+  def slices
+    @slices ||= frame["slices"].map { VmHostSlice[_1] }
+  end
+end

--- a/spec/prog/test/firewall_rules_spec.rb
+++ b/spec/prog/test/firewall_rules_spec.rb
@@ -56,6 +56,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv4.service")
       expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv6.service")
 
+      expect(firewall_test).to receive(:update_stack).with({"vm_to_be_connected_id" => "vm_1"})
+
       expect { firewall_test.start }.to hop("perform_tests_none")
     end
 
@@ -90,13 +92,15 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv4.service")
       expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv6.service")
 
+      expect(firewall_test).to receive(:update_stack).with({"vm_to_be_connected_id" => "vm_1"})
+
       expect { firewall_test.start }.to hop("perform_tests_none")
     end
   end
 
   describe "#perform_tests_none" do
     it "updates firewall rules when the frame is not set to none and naps if firewall rules are not updated" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => nil})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => nil, "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_none)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
@@ -105,7 +109,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "doesn't update firewall rules when the frame is set to none and naps if firewall rules are not updated" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
@@ -115,7 +119,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "doesn't update firewall rules and tests connectivity and hops when the fw update is done" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
@@ -133,7 +137,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "updates firewall rules and tests connectivity and fails when the fw update is done" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
@@ -154,7 +158,7 @@ ExecStart=nc -l 8080 -6
 
   describe "#perform_tests_public_ipv4" do
     it "updates firewall rules and naps when the fw update is not done yet" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "none"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
@@ -163,7 +167,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules and naps when the fw update is not done yet" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
@@ -174,7 +178,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
@@ -188,7 +192,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
@@ -205,7 +209,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
@@ -225,7 +229,7 @@ ExecStart=nc -l 8080 -6
 
   describe "#perform_tests_public_ipv6" do
     it "updates firewall rules and naps when the fw update is not done yet" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
@@ -234,7 +238,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules and naps when the fw update is not done yet" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
@@ -245,7 +249,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
@@ -262,7 +266,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
@@ -281,7 +285,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
@@ -302,7 +306,7 @@ ExecStart=nc -l 8080 -6
 
   describe "#perform_tests_private_ipv4" do
     it "updates firewall rules and naps when the fw update is not done yet" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "public_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
@@ -311,7 +315,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules and naps when the fw update is not done yet" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
@@ -322,7 +326,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
@@ -338,7 +342,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
@@ -357,7 +361,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules and tests connectivity and fails when the vm_outside can connect to VM1 publicly" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
@@ -379,7 +383,7 @@ ExecStart=nc -l 8080 -6
 
   describe "#perform_tests_private_ipv6" do
     it "updates firewall rules and naps when the fw update is not done yet" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv4"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
@@ -399,7 +403,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
@@ -415,7 +419,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
@@ -431,7 +435,7 @@ ExecStart=nc -l 8080 -6
     end
 
     it "does not update firewall rules and tests connectivity and fails when the vm2 can connect to VM1 publicly" do
-      expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
+      expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
       expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
@@ -488,6 +492,7 @@ ExecStart=nc -l 8080 -6
 
   describe ".vm1" do
     it "returns the first vm" do
+      expect(firewall_test).to receive_messages(frame: {"vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test.vm1).to eq(firewall_test.firewall.private_subnets.first.vms.first)
     end
   end

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -141,8 +141,32 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.wait }.to hop("destroy")
     end
 
+    it "hops to allow_slices when signaled" do
+      expect(hs_test).to receive(:when_allow_slices_set?).and_yield
+      expect { hs_test.wait }.to hop("allow_slices")
+    end
+
+    it "hops to disallow_slices when signaled" do
+      expect(hs_test).to receive(:when_disallow_slices_set?).and_yield
+      expect { hs_test.wait }.to hop("disallow_slices")
+    end
+
     it "naps" do
       expect { hs_test.wait }.to nap(15)
+    end
+  end
+
+  describe "#allow_slices" do
+    it "allows slices" do
+      expect(vm_host).to receive(:allow_slices)
+      expect { hs_test.allow_slices }.to hop("wait")
+    end
+  end
+
+  describe "#disallow_slices" do
+    it "disallows slices" do
+      expect(vm_host).to receive(:disallow_slices)
+      expect { hs_test.disallow_slices }.to hop("wait")
     end
   end
 

--- a/spec/prog/test/vm_host_slices_spec.rb
+++ b/spec/prog/test/vm_host_slices_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+require "netaddr"
+
+RSpec.describe Prog::Test::VmHostSlices do
+  subject(:vm_host_slices) {
+    described_class.new(Strand.new(prog: "Test::VmHostSlices", label: "start"))
+  }
+
+  # rubocop:disable RSpec/IndexedLet
+  let(:slice1) {
+    instance_double(VmHostSlice,
+      id: "ff7539aa-e3e3-48d6-8a77-6e77cead900d",
+      allowed_cpus_cgroup: "2-3",
+      cpus: [instance_double(VmHostCpu, cpu_number: 2), instance_double(VmHostCpu, cpu_number: 3)])
+  }
+
+  let(:slice2) {
+    instance_double(VmHostSlice,
+      id: "115dd7bb-3081-4403-8b74-eda45e0e2fb1",
+      allowed_cpus_cgroup: "4-5",
+      cpus: [instance_double(VmHostCpu, cpu_number: 4), instance_double(VmHostCpu, cpu_number: 5)])
+  }
+
+  let(:slice3) {
+    instance_double(VmHostSlice,
+      id: "da2b7a0e-be79-440f-8797-54e367a4aabd",
+      allowed_cpus_cgroup: "6-7",
+      cpus: [instance_double(VmHostCpu, cpu_number: 6), instance_double(VmHostCpu, cpu_number: 7)])
+  }
+  # rubocop:enable RSpec/IndexedLet
+
+  let(:slice2_overlap) {
+    instance_double(VmHostSlice,
+      id: "7f509282-6598-4fee-8a55-481f9fd6add4",
+      allowed_cpus_cgroup: "3-4",
+      cpus: [instance_double(VmHostCpu, cpu_number: 3), instance_double(VmHostCpu, cpu_number: 4)])
+  }
+
+  let(:vm_host) {
+    instance_double(VmHost,
+      sshable: instance_double(Sshable, start_fresh_session: instance_double(Net::SSH::Connection::Session, shutdown!: nil, close: nil)))
+  }
+
+  let(:strand) {
+    instance_double(Strand)
+  }
+
+  before do
+    allow(vm_host_slices).to receive_messages(strand: strand)
+  end
+
+  describe "#start" do
+    it "hops to verify_separation" do
+      expect { vm_host_slices.start }.to hop("verify_separation")
+    end
+  end
+
+  describe "#verify_separation" do
+    it "fails the test if the slices are the same" do
+      allow(vm_host_slices).to receive_messages(slices: [slice1, slice1, slice2])
+      expect(strand).to receive(:update).with(exitval: {msg: "Standard instances placed in the same slice"})
+
+      expect { vm_host_slices.verify_separation }.to hop("failed")
+    end
+
+    it "fails the test if the slices are on the same CPUs" do
+      allow(vm_host_slices).to receive_messages(slices: [slice2, slice3, slice2_overlap])
+      expect(strand).to receive(:update).with(exitval: {msg: "Standard instances are sharing at least one cpu"})
+
+      expect { vm_host_slices.verify_separation }.to hop("failed")
+    end
+
+    it "hops to verify_on_host" do
+      allow(vm_host_slices).to receive_messages(slices: [slice1, slice2, slice3])
+      expect { vm_host_slices.verify_separation }.to hop("verify_on_host")
+    end
+  end
+
+  describe "#verify_on_host" do
+    before do
+      allow(vm_host_slices).to receive_messages(slices: [slice1, slice2, slice3])
+
+      sshable = instance_double(Sshable)
+      session = instance_double(Net::SSH::Transport::Session)
+      expect(vm_host).to receive_messages(sshable: sshable)
+      expect(sshable).to receive(:start_fresh_session).and_yield(session).exactly(3).times
+
+      [slice1, slice2, slice3].each do |slice|
+        expect(slice).to receive(:vm_host).and_return(vm_host)
+        expect(slice).to receive(:up?).with(session).and_return(true) unless slice == slice3
+      end
+    end
+
+    it "fails the test if the slice is not setup correctly" do
+      expect(slice3).to receive(:up?).and_return(false)
+      expect(strand).to receive(:update).with(exitval: {msg: "Slice #{slice3.id} is not setup correctly"})
+
+      expect { vm_host_slices.verify_on_host }.to hop("failed")
+    end
+
+    it "hops to finish" do
+      expect(slice3).to receive(:up?).and_return(true)
+      expect { vm_host_slices.verify_on_host }.to hop("finish")
+    end
+  end
+
+  describe "#finish" do
+    it "pops 'Verified VM Host Slices!'" do
+      expect(vm_host_slices).to receive(:pop).with("Verified VM Host Slices!")
+      vm_host_slices.finish
+    end
+  end
+
+  describe "#failed" do
+    it "naps for 15 seconds" do
+      expect { vm_host_slices.failed }.to nap(15)
+    end
+  end
+
+  describe "slices access method" do
+    it "returns slices" do
+      expect(vm_host_slices).to receive(:frame).and_return({"slices" => [slice1.id, slice2.id, slice3.id]})
+
+      [slice1, slice2, slice3].each do |slice|
+        expect(VmHostSlice).to receive(:[]).with(slice.id).and_return(slice)
+      end
+
+      expect(vm_host_slices.slices).to eq([slice1, slice2, slice3])
+    end
+  end
+end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -81,7 +81,7 @@ module ThawedMock
   allow_mocking(Vm, :[], :where)
   allow_mocking(VmPool, :[], :where)
   allow_mocking(VmHostCpu, :create)
-  allow_mocking(VmHostSlice, :dataset)
+  allow_mocking(VmHostSlice, :[], :dataset)
 
   # Progs
   allow_mocking(Prog::Ai::InferenceEndpointNexus, :assemble, :model_for_id)


### PR DESCRIPTION
Updating E2E tests to validate VM creation inside a slice. The test switches the host's `accept_slices` flag to true and sets the project flag to use slices, then runs the standard VM test to create VMs and test them. Those VMs are creted inside slices on a host. An additional verification is added into VmGroup to check the validity of the slices - `VmHostSlices`.

In a separate commit, fixing a race condition in `Test::ConnectedSubnets` and `Test::FirewallRules`.