### PR TITLE
Decrease neg-ttl in dnsmasq config

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -484,6 +484,7 @@ dns-forward-max=10000
 dhcp-option=option6:dns-server,#{dnsmasq_address_ip6}
 listen-address=#{dnsmasq_address_ip6}
 all-servers
+neg-ttl=30
 DNSMASQ_CONF
 
     ethernets = nics.map do |nic|


### PR DESCRIPTION
Default neg-ttl is 300 seconds which is a lot to wait for retrying dns queries. For bootstrapping kubernetes, we have 4 minute timeout to discover the apiserver through the loadbalancer and DNS. If the first query fails, the bootstrap will fail and way more complex measurements should be added to resolve it.

In this commit the neg-ttl is set to 30 seconds which is reasonable for retrying failed dns queries