### PR TITLE
Attempt to recreate VM up to 2 times if it fails during prep

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -13,7 +13,8 @@ class Prog::Vm::Nexus < Prog::Base
     unix_user: "ubi", location: "hetzner-fsn1", boot_image: Config.default_boot_image_name,
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
     enable_ip4: false, pool_id: nil, arch: "x64", swap_size_bytes: nil,
-    distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [], gpu_count: 0)
+    distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [], gpu_count: 0,
+    ubid: nil, vm_size: nil, attempt: 1, strand: nil)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -22,8 +23,9 @@ class Prog::Vm::Nexus < Prog::Base
       fail "Cannot force and exclude the same host"
     end
     Validation.validate_location(location)
-    vm_size = Validation.validate_vm_size(size, arch)
+    vm_size ||= Validation.validate_vm_size(size, arch)
 
+    assemble_storage_volumes = storage_volumes
     storage_volumes ||= [{
       size_gib: vm_size.storage_size_options.first,
       encrypted: true
@@ -49,7 +51,7 @@ class Prog::Vm::Nexus < Prog::Base
 
     Validation.validate_storage_volumes(storage_volumes, boot_disk_index)
 
-    ubid = Vm.generate_ubid
+    ubid ||= Vm.generate_ubid
     name ||= Vm.ubid_to_name(ubid)
 
     Validation.validate_name(name)
@@ -108,18 +110,26 @@ class Prog::Vm::Nexus < Prog::Base
       nic.update(vm_id: vm.id)
 
       gpu_count = 1 if gpu_count == 0 && vm_size.gpu
-      Strand.create(
+
+      strand ||= Strand.new { _1.id = vm.id }
+      frame = strand.stack[-1] || {}
+      strand.update(
         prog: "Vm::Nexus",
         label: "start",
-        stack: [{
+        stack: [frame.merge(
+          "assemble_storage_volumes" => assemble_storage_volumes,
           "storage_volumes" => storage_volumes.map { |v| v.transform_keys(&:to_s) },
           "swap_size_bytes" => swap_size_bytes,
           "distinct_storage_devices" => distinct_storage_devices,
           "force_host_id" => force_host_id,
           "exclude_host_ids" => exclude_host_ids,
+          "private_subnet_id" => private_subnet_id,
+          "nic_id" => nic_id,
+          "pool_id" => pool_id,
+          "attempt" => attempt,
           "gpu_count" => gpu_count
-        }]
-      ) { _1.id = vm.id }
+        )]
+      )
     end
   end
 
@@ -258,8 +268,21 @@ class Prog::Vm::Nexus < Prog::Base
     when "Succeeded"
       host.sshable.cmd("common/bin/daemonizer --clean prep_#{q_vm}")
       vm.private_subnets.each(&:incr_add_new_nic)
+      # To simulate failure case in development:
+      # if frame["attempt"] < 3
+      #   Clog.emit("VM prep forced fail for #{vm.ubid}, attempt: #{frame["attempt"]}")
+      #   incr_recreate
+      #   hop_destroy
+      # end
       hop_wait_sshable
-    when "NotStarted", "Failed"
+    when "Failed"
+      if frame["attempt"] >= 3
+        Prog::PageNexus.assemble("VM prep has failed for #{vm.ubid} (attempt: #{frame["attempt"]}", ["VmPrepFailed", vm.ubid], vm.ubid)
+        hop_prep_failed
+      end
+      incr_recreate
+      hop_destroy
+    when "NotStarted"
       secrets_json = JSON.generate({
         storage: vm.storage_secrets
       })
@@ -425,6 +448,10 @@ class Prog::Vm::Nexus < Prog::Base
     nap 30
   end
 
+  label def prep_failed
+    nap(5 * 60)
+  end
+
   label def prevent_destroy
     register_deadline("destroy", 24 * 60 * 60)
     nap 30
@@ -505,9 +532,14 @@ class Prog::Vm::Nexus < Prog::Base
 
   label def destroy_slice
     slice = vm.vm_host_slice
+    skip_nic_destroy_for_id = nil
+
+    when_recreate_set? do
+      skip_nic_destroy_for_id = frame["nic_id"]
+    end
 
     # Remove the VM before we destroy the slice
-    final_clean_up
+    final_clean_up(skip_nic_destroy_for_id:)
 
     # Trigger the slice deletion if there are no
     # VMs using it.
@@ -528,17 +560,43 @@ class Prog::Vm::Nexus < Prog::Base
       end
     end
 
+    when_recreate_set? do
+      decr_recreate
+
+      # This does not pass boot_index_id, as the information contained in it is
+      # encoded in the storage_volumes argument.
+      #
+      # It's possible to add the VM's current host to exclude_host_ids, but that will
+      # break cases where it is the only available host. Could extend the allocator
+      # to prefer a different host without excluding it if we really want to try another
+      # host.
+      self.class.assemble(vm.public_key, vm.project_id, name: vm.name, vm_size: vm.vm_size,
+        unix_user: vm.unix_user, location: vm.location, boot_image: vm.boot_image,
+        enable_ip4: vm.ip4_enabled, arch: vm.arch, ubid: UBID.parse(vm.ubid),
+        nic_id: frame["nic_id"],
+        private_subnet_id: frame["private_subnet_id"],
+        storage_volumes: frame["storage_volumes"]&.map { _1.transform_keys(&:to_sym) },
+        distinct_storage_devices: frame["distinct_storage_devices"],
+        swap_size_bytes: frame["swap_size_bytes"],
+        pool_id: frame["pool_id"],
+        gpu_count: frame["gpu_count"] || 0,
+        force_host_id: frame["force_host_id"],
+        exclude_host_ids: frame["exclude_host_ids"],
+        attempt: frame["attempt"] + 1,
+        strand:)
+
+      hop_start
+    end
+
     pop "vm deleted"
   end
 
-  def final_clean_up
-    DB.transaction do
-      vm.nics.map do |nic|
-        nic.update(vm_id: nil)
-        nic.incr_destroy
-      end
-      vm.destroy
+  def final_clean_up(skip_nic_destroy_for_id: nil)
+    vm.nics.map do |nic|
+      nic.update(vm_id: nil)
+      nic.incr_destroy unless nic.id == skip_nic_destroy_for_id
     end
+    vm.destroy
   end
 
   label def start_after_host_reboot

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Vm do
       expect(vm.display_state).to eq("deleting")
     end
 
+    it "does not return deleting if recreate semaphore increased" do
+      expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "recreate")]).at_least(:once)
+      expect(vm.display_state).to eq("creating")
+    end
+
     it "returns restarting if restart semaphore increased" do
       expect(vm).to receive(:semaphores).and_return([instance_double(Semaphore, name: "restart")]).at_least(:once)
       expect(vm.display_state).to eq("restarting")


### PR DESCRIPTION
Previously, if a VM failed during Vm::Nexus#prep, it would continually be stuck in that step, because #prep treated Failed the same as NotStarted, and the steps to initially start prep are not the same as the steps to recover from failure.  I'm not sure what the steps are to recover from failure (since there are many different things that could fail), so this takes the hammer approach.  It sets a recreate semaphore and hops to destroy.

When destroy (#destroy_slice) is called, if the recreate semaphore is set, after destroying the VM, it assembles a new VM with the same ubid, and then hops to start instead of exiting.

To prevent infinite recreation, there is a hard coded limit of 3 attempts. After 3 failed attempts, the Strand is moved to prep_failed state, where it stays until manual intervention. This generates a page to ensure it isn't missed.

To implement this, I added the following keyword arguments to Vm::Nexus#assemble:

* ubid: ubid to set on the created Vm
* vm_size: a VmSize object, which can be used directly instead of determining it from the size and arch arguments
* attempt: The number of attempts made to create the VM, defaults to 1
* strand: Updates existing strand instead of creating a new strand

To hold more state, it adds some additional data to the strand's stack, so that the destroy_slice method can pass it back to assemble.

Other minor changes:

* Add Vm#vm_size. Extracted from Vm#display_size, this is used to set the vm_size argument to assemble.

* Do not show "deleting" as the display state for a Vm with recreate set, as showing that would look weird to the user.

* If requesting to create a Vm with a specific Nic (passing nic_id to assemble), when destroying and recreate is set, the related Nic is not destroyed when the Vm is destroyed, as it will be used for the newly created Vm.  I'm not sure this is used outside the tests, so it may be overkill.

* Remove transaction around Vm::Nexus#final_clean_up. This isn't needed, as it is only called inside a label, and labels have an implicit transaction around them.