### PR TITLE
Add option to specify custom range cidrs for IPV4

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -177,11 +177,13 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     selected_addr
   end
 
-  def self.random_private_ipv4(location, project)
+  def self.random_private_ipv4(location, project, cidr_size = 26)
+    raise ArgumentError, "CIDR size must be between 0 and 32" unless cidr_size.between?(0, 32)
+
     private_range = PrivateSubnet.random_subnet
     addr = NetAddr::IPv4Net.parse(private_range)
 
-    selected_addr = addr.nth_subnet(26, SecureRandom.random_number(2**(26 - addr.netmask.prefix_len) - 1).to_i + 1)
+    selected_addr = addr.nth_subnet(cidr_size, SecureRandom.random_number(2**(cidr_size - addr.netmask.prefix_len) - 1).to_i + 1)
 
     selected_addr = random_private_ipv4(location, project) if PrivateSubnet::BANNED_IPV4_SUBNETS.any? { _1.rel(selected_addr) } || project.private_subnets_dataset[Sequel[:net4] => selected_addr.to_s, :location => location]
 

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -332,6 +332,11 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       allow(SecureRandom).to receive(:random_number).with(2**(26 - 8) - 1).and_return(1)
       expect(described_class.random_private_ipv4("hetzner-fsn1", project).to_s).to eq("10.0.0.128/26")
     end
+
+    it "raises an error when invalid CIDR is given" do
+      project = Project.create_with_id(name: "test-project")
+      expect { described_class.random_private_ipv4("hetzner-fsn1", project, 33) }.to raise_error(ArgumentError)
+    end
   end
 
   describe ".random_private_ipv6" do


### PR DESCRIPTION
Currently subnets are created with /26 netmask and VMs get a /32 IP. For kubernetes CNI, we need to have bigger subnets (perferably /16) so each VM gets a /24 range to host pods and assign an IP from subnet to them.

In this commit, based on the subnet mask, we always try to assign at most 2**8 ips to each vm. If the subnet mask is 26 min(32, 26+8) would be calculated which is 32 so each VM gets a /32 ip. but for bigger subnets, VMs would get at most 256 ips.