### PR TITLE
Fix flakiness in GitHub runner e2e spec

### DIFF
--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -66,22 +66,22 @@ RSpec.describe Prog::Test::GithubRunner do
 
   describe "#check_test_runs" do
     it "check test runs completed" do
-      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now}]})
+      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
 
     it "check test runs in progress with nil" do
-      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: nil, created_at: Time.now}]})
+      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: nil, created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to nap(15)
     end
 
     it "check test runs in progress state" do
-      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "in_progress", created_at: Time.now}]})
+      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "in_progress", created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to nap(15)
     end
 
     it "check test runs failed" do
-      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now}]})
+      expect(client).to receive(:workflow_runs).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
 


### PR DESCRIPTION
We compare `Time.now` with `Time.now` at `latest_run[:created_at] <
Time.parse(frame["created_at"])`, expecting that
`latest_run[:created_at]` is not always less than `frame["created_at"]`.

This is always true for x64 but not for arm64, interestingly. To make it
more reliable, I added 10 seconds to one of the timestamps.
