### PR TITLE
Fix node version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-         node-version: "22"
+         node-version-file: "package.json"
 
     - name: Install node packages
       run: npm ci


### PR DESCRIPTION
We use 23 as node version in "package.json", but CI has 22 as hardcoded.
"actions/setup-node" is able to read correct version from "package.json"
