### PR TITLE
Increase E2E timeout from 40m to 50m

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
   schedule:
-    - cron:  '0 */1 * * *'
+    - cron:  '0 */2 * * *'
 
 jobs:
   run-ci:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
     if: vars.RUN_E2E == 'true'
     runs-on: ubicloud
     environment: E2E-CI
-    timeout-minutes: 45
+    timeout-minutes: 55
     concurrency: e2e_environment
 
     env:
@@ -124,7 +124,7 @@ jobs:
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
       run: |
         set -o pipefail
-        timeout 40m foreman start | tee foreman.log | grep "e2e.1"
+        timeout 50m foreman start | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
       if: always()


### PR DESCRIPTION
- **Increase E2E timeout from 40m to 50m**
  We recently added E2E tests for the PostgreSQL service and VM slices.
  These tests have increased the overall duration of the E2E tests. 40
  minutes is no longer enough for them to finish. I’m raising the timeout
  to 50 minutes to allow more time for completion.
  

- **Run E2E tests every 2 hours**
  Right now, we run E2E tests every hour, but they take 40 minutes to
  complete. Since we have only one VM host for the tests, we can only run
  one test at a time. Our developers also run E2E tests to check their
  branches, so running them every hour doesn't give enough time for
  developers to do their tests. I think it's okay to run E2E tests every 2
  hours.
  