### PR TITLE
Use vcpus for VM allocation and topology

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -55,17 +55,17 @@ module Option
   IoLimits = Struct.new(:max_ios_per_sec, :max_read_mbytes_per_sec, :max_write_mbytes_per_sec)
   NO_IO_LIMITS = IoLimits.new(nil, nil, nil).freeze
 
-  VmSize = Struct.new(:name, :family, :cores, :vcpus, :cpu_percent_limit, :cpu_burst_percent_limit, :memory_gib, :storage_size_options, :io_limits, :visible, :gpu, :arch) do
+  VmSize = Struct.new(:name, :family, :vcpus, :cpu_percent_limit, :cpu_burst_percent_limit, :memory_gib, :storage_size_options, :io_limits, :visible, :gpu, :arch) do
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
     storage_size_options = [_1 * 20, _1 * 40]
-    VmSize.new("standard-#{_1}", "standard", _1 / 2, _1, _1 * 100, 0, _1 * 4, storage_size_options, NO_IO_LIMITS, true, false, "x64")
+    VmSize.new("standard-#{_1}", "standard", _1, _1 * 100, 0, _1 * 4, storage_size_options, NO_IO_LIMITS, true, false, "x64")
   }.concat([2, 4, 8, 16, 30, 60].map {
     storage_size_options = [_1 * 20, _1 * 40]
-    VmSize.new("standard-#{_1}", "standard", _1, _1, _1 * 100, 0, (_1 * 3.2).to_i, storage_size_options, NO_IO_LIMITS, false, false, "arm64")
+    VmSize.new("standard-#{_1}", "standard", _1, _1 * 100, 0, (_1 * 3.2).to_i, storage_size_options, NO_IO_LIMITS, false, false, "arm64")
   }).concat([6].map {
-    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1 / 2, _1, _1 * 100, 0, (_1 * 5.34).to_i, [_1 * 30], NO_IO_LIMITS, false, true, "x64")
+    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, _1 * 100, 0, (_1 * 5.34).to_i, [_1 * 30], NO_IO_LIMITS, false, true, "x64")
   }).freeze
 
   PostgresSize = Struct.new(:location, :name, :vm_size, :family, :vcpu, :memory, :storage_size_options) do

--- a/loader.rb
+++ b/loader.rb
@@ -216,6 +216,8 @@ def clover_freeze
     Scheduling::Allocator::StorageAllocation,
     Scheduling::Allocator::StorageAllocation::StorageDeviceAllocation,
     Scheduling::Allocator::VmHostAllocation,
+    Scheduling::Allocator::VmHostCpuAllocation,
+    Scheduling::Allocator::VmHostSliceAllocation,
     SemaphoreMethods,
     SemaphoreMethods::ClassMethods,
     Sequel::Database,

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -61,10 +61,10 @@ class Prog::Vm::VmPool < Prog::Base
 
   label def wait
     if vm_pool.size - vm_pool.vms.count > 0
-      idle_cores = VmHost.where(allocation_state: "accepting", arch: vm_pool.arch, location: ["github-runners", "hetzner-hel1", "hetzner-fsn1"]).select_map { sum(:total_cores) - sum(:used_cores) }.first.to_i
-      waiting_cores = Vm.where(Sequel.like(:boot_image, "github%")).where(allocated_at: nil, arch: vm_pool.arch).sum(:cores).to_i
-      pool_vm_core = Validation.validate_vm_size(vm_pool.vm_size, vm_pool.arch).cores
-      hop_create_new_vm if idle_cores - waiting_cores - pool_vm_core >= 0
+      idle_cpus = VmHost.where(allocation_state: "accepting", arch: vm_pool.arch, location: ["github-runners", "hetzner-hel1", "hetzner-fsn1"]).select_map { sum((total_cores - used_cores) * total_cpus / total_cores) }.first.to_i
+      waiting_cpus = Vm.where(Sequel.like(:boot_image, "github%")).where(allocated_at: nil, arch: vm_pool.arch).sum(:vcpus).to_i
+      pool_vm_cpus = Validation.validate_vm_size(vm_pool.vm_size, vm_pool.arch).vcpus
+      hop_create_new_vm if idle_cpus - waiting_cpus - pool_vm_cpus >= 0
     end
     nap 30
   end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).not_to be_nil
       expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
-      expect(vm.cores).to eq(2)
+      expect(vm.vcpus).to eq(4)
       expect(vm.project_id).to eq(Config.github_runner_service_project_id)
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).not_to be_nil
       expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
-      expect(vm.cores).to eq(2)
+      expect(vm.vcpus).to eq(4)
     end
 
     it "uses the existing vm if pool can pick one" do

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Prog::Vm::VmPool do
 
   describe "#wait" do
     before do
-      create_vm_host(location: "github-runners", total_cores: 2, used_cores: 0)
+      create_vm_host(location: "github-runners", total_cores: 2, total_cpus: 4, used_cores: 0)
     end
 
     let(:pool) {
@@ -80,7 +80,7 @@ RSpec.describe Prog::Vm::VmPool do
       pool.update(size: 1)
 
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
-      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "key", name: "vm1", location: "github-runners", boot_image: "github-ubuntu-2204", family: "standard", arch: "arm64", cores: 4, vcpus: 2, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
+      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "key", name: "vm1", location: "github-runners", boot_image: "github-ubuntu-2204", family: "standard", arch: "arm64", cores: 2, vcpus: 2, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
 
       expect { nx.wait }.to hop("create_new_vm")
     end
@@ -89,7 +89,7 @@ RSpec.describe Prog::Vm::VmPool do
       pool.update(size: 1)
 
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
-      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "key", name: "vm1", location: "github-runners", boot_image: "github-ubuntu-2204", family: "standard", arch: "x64", cores: 2, vcpus: 2, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
+      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "key", name: "vm1", location: "github-runners", boot_image: "github-ubuntu-2204", family: "standard", arch: "x64", cores: 2, vcpus: 4, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
 
       expect { nx.wait }.to nap(30)
     end

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Clover, "billing" do
           resource_name: vm.name,
           span: Sequel::Postgres::PGRange.new(begin_time, end_time),
           billing_rate_id: BillingRate.from_resource_properties("VmVCpu", vm.family, vm.location)["id"],
-          amount: vm.cores
+          amount: vm.vcpus
         )
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -243,7 +243,7 @@ RSpec.configure do |config|
   end
 
   def create_vm(**args)
-    defaults = {unix_user: "ubi", public_key: "ssh-ed25519 key", name: "test-vm", family: "standard", cores: 1, vcpus: 2, cpu_percent_limit: 200, cpu_burst_percent_limit: 0, memory_gib: 8, arch: "x64", location: "hetzner-fsn1", boot_image: "ubuntu-jammy", display_state: "running", ip4_enabled: false, created_at: Time.now}
+    defaults = {unix_user: "ubi", public_key: "ssh-ed25519 key", name: "test-vm", family: "standard", cores: 0, vcpus: 2, cpu_percent_limit: 200, cpu_burst_percent_limit: 0, memory_gib: 8, arch: "x64", location: "hetzner-fsn1", boot_image: "ubuntu-jammy", display_state: "running", ip4_enabled: false, created_at: Time.now}
     args = defaults.merge(args)
     args[:project_id] ||= Project.create(name: "create-vm-project").id
     Vm.create(**args)

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -109,6 +109,7 @@ module ThawedMock
   allow_mocking(Scheduling::Allocator, :allocate)
   allow_mocking(Scheduling::Allocator::Allocation, :best_allocation, :candidate_hosts, :new, :random_score, :update_vm)
   allow_mocking(Scheduling::Allocator::StorageAllocation, :new)
+  allow_mocking(Scheduling::Allocator::VmHostCpuAllocation, :new)
   allow_mocking(Scheduling::Allocator::VmHostAllocation, :new)
   allow_mocking(Serializers::Vm, :serialize_internal)
   allow_mocking(SshKey, :generate)


### PR DESCRIPTION
This patch switches the VM allocation from Cores to VCpus when selecting a host. There are two use cases motivating this change:
- we have x64 hosts that have threads_per_cores ratio of 1 (GEX44). That breaks the assumption encoded in the VmSizes, per architecture type
- we are going to introduce Burstable family, where relation between number of CPUs allocated for a VM and number of Cores allocated to a slice hosting that VM may vary per VM instance, regardless of the architecture.

With this change, the number of cores is computed during the allocation, based on the actual architecture of the candidate host and then updated back to the VM. In case when the VM is allocated in a slice, the number of cores is left as 0 on the VM, and instead, the number of cores is saved in the VmHostSlice, and that is subtracted from the host. At any point in time this should be true: `vm_host.used_cores == SUM(vm_host_slice.cores) + SUM(vm.cores if vm.vm_host_slice_id.nil?)`

This logic also helps us indicate who is really controlling the cores - it is either the VmHostSlice or a Vm running without the slice. Vms inside the slice, do not control the cores and relay on the slice instead.

The special case for vcpus==1 in `cloud_hypervisor_cpu_topology` is needed for Burstables, where we will have Burstable-1 size. I wanted to include this in the review together with this patch for completeness.

There is also a separate commit now to Losen the restrictions on slice allocation. We allow now projects with `use_slice_for_allocation` flag enabled to create Standard VMs on all hosts. When the host is marked with `accept_slices`, the allocation will create a VM inside a slice. When `accepts_slices` is off, the VM creation will use the earlier allocation logic.