### PR TITLE
Catch unique constraint exception raised by database

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -161,7 +161,7 @@ class Clover < Roda
     end
 
     case e
-    when Sequel::ValidationFailed, Roda::RodaPlugins::InvalidRequestBody::Error
+    when Sequel::ValidationFailed, Sequel::UniqueConstraintViolation, Roda::RodaPlugins::InvalidRequestBody::Error
       code = 400
       type = "InvalidRequest"
       message = e.to_s
@@ -216,7 +216,7 @@ class Clover < Roda
       @error = error
 
       case e
-      when Sequel::ValidationFailed, DependencyError
+      when Sequel::ValidationFailed, Sequel::UniqueConstraintViolation, DependencyError
         flash["error"] = message
         redirect_back_with_inputs
       when Sequel::SerializationFailure


### PR DESCRIPTION
We had a similar issue for GitHub cache entries and fixed at b73dd78.

If a customer tries to create multiple virtual machines with the same name at the same time, a race condition could cause two threads to try to create the same VM, resulting in an HTTP 500 error. We encountered this issue in production.

`Sequel::ValidationFailed` exception is raised when unique validation fails at the Sequel model level. `Sequel::UniqueConstraintViolation` exception is raised when uniqueness validation passes at the Sequel model level but fails at the database level due to concurrency.