### PR TITLE
Add ipv4 routes for cross vm packets

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -51,7 +51,7 @@ class Vm < Sequel::Model
   end
 
   def private_ipv4
-    nics.first.private_ipv4.network
+    (nics.first.private_ipv4.netmask.to_s == "/32") ? nics.first.private_ipv4.network : nics.first.private_ipv4.nth(1)
   end
 
   def private_ipv6

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:prepare_pci_devices).with([])
       expect(vs).to receive(:start_systemd_unit)
       expect(vs).to receive(:enable_bursting).with("some_slice.slice", 200)
+      expect(vs).to receive(:update_via_routes)
 
       vs.recreate_unpersisted(
         "gua", "ip4", "local_ip4", "nics", 4, false, "storage_params", "storage_secrets",
@@ -169,6 +170,7 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:storage).with("storage_params", "storage_secrets", false)
       expect(vs).to receive(:prepare_pci_devices).with([])
       expect(vs).to receive(:start_systemd_unit)
+      expect(vs).to receive(:update_via_routes)
 
       vs.recreate_unpersisted(
         "gua", "ip4", "local_ip4", "nics", 4, false, "storage_params", "storage_secrets",

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -236,7 +236,13 @@ options ndots:5
     subnet_size = calculate_subnet_size(subnet)
 
     base = subnet.to_i & subnet.mask(subnet.prefix).to_i
-    random_offset = SecureRandom.random_number(subnet_size - 2) + 1
+    # We subtract 3 from subnet_size:
+    #   - 1 for the network address (offset 0)
+    #   - 1 for the first usable IP (offset 1)
+    #   - 1 for the broadcast address (offset = subnet_size - 1)
+    #
+    # Then we add 2 to the result of random_number so offsets start at 2.
+    random_offset = SecureRandom.random_number(subnet_size - 3) + 2
     IPAddr.new(base + random_offset, subnet.ipv4? ? Socket::AF_INET : Socket::AF_INET6)
   end
 

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe MinioServer do
   end
 
   it "returns private ipv4 address properly" do
-    nic = instance_double(Nic, private_ipv4: instance_double(NetAddr::IPv4Net, network: "192.168.0.0"))
-    expect(ms.vm).to receive(:nics).and_return([nic])
+    nic = instance_double(Nic, private_ipv4: instance_double(NetAddr::IPv4Net, network: "192.168.0.0", netmask: "/32"))
+    expect(ms.vm).to receive(:nics).and_return([nic]).at_least(:once)
     expect(ms.private_ipv4_address).to eq("192.168.0.0")
   end
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -138,6 +138,16 @@ RSpec.describe Vm do
     it "can compute nil if ipv4 is not assigned" do
       expect(vm.ephemeral_net4).to be_nil
     end
+
+    it "returns the right private_ipv4 based on the netmask" do
+      nic = instance_double(Nic, private_ipv4: instance_double(NetAddr::IPv4Net, network: "192.168.12.13", netmask: "/32"))
+      expect(vm).to receive(:nics).and_return([nic]).twice
+      expect(vm.private_ipv4.to_s).to eq("192.168.12.13")
+
+      nic = instance_double(Nic, private_ipv4: NetAddr.parse_net("10.10.240.0/24"))
+      expect(vm).to receive(:nics).and_return([nic]).twice
+      expect(vm.private_ipv4.to_s).to eq("10.10.240.1")
+    end
   end
 
   it "initiates a new health monitor session" do

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
       expect(github_runner.installation).to receive(:cache_enabled).and_return(true)
-      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))])
+      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))]).at_least(:once)
       expect(sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"


### PR DESCRIPTION
So far, VMs had a /32 ip range and VMs did not need to route packets for other entities with ip inside. For Kubernetes CNI, we will have pods which need to send packets out of the VM to another destination in the same private subnet. In that case we need to add routes to the VM's network namespace.

For creating the routes, the code execution is faster than linux taking care of device creation, so we would wait for at most 0.5 second to change the routes.