### PR TITLE
Add destroying label to prevent hop to destroy again

### DIFF
--- a/model/ai/inference_endpoint.rb
+++ b/model/ai/inference_endpoint.rb
@@ -15,7 +15,7 @@ class InferenceEndpoint < Sequel::Model
   include SemaphoreMethods
   include ObjectTag::Cleanup
 
-  semaphore :destroy, :maintenance
+  semaphore :destroy, :maintenance, :destroying
 
   def display_location
     LocationNameConverter.to_display_name(location)

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -12,7 +12,7 @@ class GithubRunner < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :destroy, :skip_deregistration
+  semaphore :destroy, :skip_deregistration, :destroying
 
   def run_url
     "http://github.com/#{repository_name}/actions/runs/#{workflow_job["run_id"]}"

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -20,7 +20,7 @@ class LoadBalancer < Sequel::Model
   include SemaphoreMethods
   include ObjectTag::Cleanup
   dataset_module Pagination
-  semaphore :destroy, :update_load_balancer, :rewrite_dns_records, :refresh_cert
+  semaphore :destroy, :update_load_balancer, :rewrite_dns_records, :refresh_cert, :destroying
 
   def path
     "/location/#{private_subnet.display_location}/load-balancer/#{name}"

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -16,7 +16,7 @@ class MinioCluster < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
 
-  semaphore :destroy, :reconfigure
+  semaphore :destroy, :reconfigure, :destroying
 
   plugin :column_encryption do |enc|
     enc.column :admin_password

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -12,7 +12,7 @@ class MinioPool < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
 
-  semaphore :destroy, :add_additional_pool
+  semaphore :destroy, :add_additional_pool, :destroying
 
   def volumes_url
     return "/minio/dat1" if cluster.single_instance_single_drive?

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -26,7 +26,7 @@ class Vm < Sequel::Model
   include SemaphoreMethods
   include HealthMonitorMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
-  semaphore :restart, :stop
+  semaphore :restart, :stop, :destroying
 
   include ObjectTag::Cleanup
 

--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -7,9 +7,9 @@ class VmPool < Sequel::Model
   one_to_many :vms, key: :pool_id
 
   include ResourceMethods
-
   include SemaphoreMethods
-  semaphore :destroy
+
+  semaphore :destroy, :destroying
 
   def pick_vm
     # Find an available VM in the "running" state and not associated with a GitHub runner,

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -75,7 +75,7 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if strand.label != "destroy"
+      unless ["destroy", "self_destroy"].include?(strand.label)
         hop_destroy
       end
     end

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -75,7 +75,8 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "self_destroy"].include?(strand.label)
+      unless inference_endpoint.destroying_set?
+        inference_endpoint.incr_destroying
         hop_destroy
       end
     end

--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -53,7 +53,8 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "wait_pools_destroyed"].include?(strand.label)
+      unless minio_cluster.destroying_set?
+        minio_cluster.incr_destroying
         hop_destroy
       end
     end

--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -39,7 +39,8 @@ class Prog::Minio::MinioPoolNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "wait_servers_destroyed"].include?(strand.label)
+      unless minio_pool.destroying_set?
+        minio_pool.incr_destroying
         hop_destroy
       end
     end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -122,9 +122,10 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "wait_vm_destroy"].include?(strand.label)
+      unless github_runner.destroying_set?
         register_deadline(nil, 15 * 60)
         update_billing_record
+        github_runner.incr_destroying
         hop_destroy
       end
     end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -162,7 +162,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if strand.label != "destroy"
+      unless ["destroy", "wait_lb_expiry", "destroy_slice"].include?(strand.label)
         vm.active_billing_records.each(&:finalize)
         vm.assigned_vm_address&.active_billing_record&.finalize
         register_deadline(nil, 5 * 60)

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -162,10 +162,11 @@ class Prog::Vm::Nexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "wait_lb_expiry", "destroy_slice"].include?(strand.label)
+      unless vm.destroying_set?
         vm.active_billing_records.each(&:finalize)
         vm.assigned_vm_address&.active_billing_record&.finalize
         register_deadline(nil, 5 * 60)
+        vm.incr_destroying
         hop_destroy
       end
     end

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -24,7 +24,8 @@ class Prog::Vm::VmPool < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "wait_vms_destroy"].include?(strand.label)
+      unless vm_pool.destroying_set?
+        vm_pool.incr_destroying
         hop_destroy
       end
     end

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -39,7 +39,10 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      hop_destroy unless %w[destroy wait_destroy].include?(strand.label)
+      unless load_balancer.destroying_set?
+        load_balancer.incr_destroying
+        hop_destroy
+      end
     end
   end
 

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -121,12 +121,14 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
   describe "#before_run" do
     it "hops to destroy when needed" do
       expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(inference_endpoint).to receive(:destroying_set?).and_return(false)
+      expect(inference_endpoint).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
 
     it "does not hop to destroy if already in the destroy state" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(inference_endpoint).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
   end

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
 
     it "does not hop to destroy if strand label is destroy" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(nx.minio_cluster).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
   end

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
 
     it "does not hop to destroy if strand label is destroy" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(nx.minio_pool).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
   end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -236,20 +236,16 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#before_run" do
     it "hops to destroy when needed" do
       expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(github_runner).to receive(:destroying_set?).and_return(false)
       expect(nx).to receive(:register_deadline)
       expect(nx).to receive(:update_billing_record)
+      expect(github_runner).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
 
     it "does not hop to destroy if already in the destroy state" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_vm_destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("wait_vm_destroy")
+      expect(github_runner).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -604,12 +604,14 @@ RSpec.describe Prog::Vm::Nexus do
   describe "#before_run" do
     it "hops to destroy when needed" do
       expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(vm).to receive(:destroying_set?).and_return(false)
+      expect(vm).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
 
     it "does not hop to destroy if already in the destroy state" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(vm).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
 
@@ -620,6 +622,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm).to receive(:assigned_vm_address).and_return(assigned_adr)
       expect(assigned_adr).to receive(:active_billing_record).and_return(instance_double(BillingRecord)).at_least(:once)
       expect(assigned_adr.active_billing_record).to receive(:finalize)
+      expect(vm).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
 
@@ -627,6 +630,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect(nx).to receive(:when_destroy_set?).and_yield
       expect(vm).to receive(:active_billing_records).and_return([])
       expect(vm).to receive(:assigned_vm_address).and_return(nil)
+      expect(vm).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
 
@@ -636,7 +640,7 @@ RSpec.describe Prog::Vm::Nexus do
       assigned_adr = instance_double(AssignedVmAddress)
       expect(vm).to receive(:assigned_vm_address).and_return(assigned_adr)
       expect(assigned_adr).to receive(:active_billing_record).and_return(nil)
-
+      expect(vm).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
   end

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -3,11 +3,23 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Vm::VmPool do
-  subject(:nx) { described_class.new(st) }
+  subject(:nx) {
+    described_class.new(st).tap {
+      _1.instance_variable_set(:@vm_pool, pool)
+    }
+  }
 
   let(:st) { Strand.new }
 
   let(:project_id) { Project.create(name: "test-project").id }
+
+  let(:pool) {
+    VmPool.create_with_id(
+      size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1",
+      storage_size_gib: 86, storage_encrypted: true, storage_skip_sync: true,
+      arch: "x64"
+    )
+  }
 
   describe ".assemble" do
     it "creates the entity and strand properly" do
@@ -30,22 +42,9 @@ RSpec.describe Prog::Vm::VmPool do
   end
 
   describe "#create_new_vm" do
-    let(:prj) {
-      Project.create_with_id(name: "default")
-    }
-
     it "creates a new vm and hops to wait" do
-      expect(Config).to receive(:vm_pool_project_id).and_return(prj.id).at_least(:once)
-      st = described_class.assemble(
-        size: 3, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1",
-        storage_size_gib: 86, storage_encrypted: true,
-        storage_skip_sync: false, arch: "arm64"
-      )
-      st.update(label: "create_new_vm")
-      expect(SshKey).to receive(:generate).and_call_original
-      expect(nx).to receive(:vm_pool).and_return(VmPool[st.id]).at_least(:once)
+      expect(Config).to receive(:vm_pool_project_id).and_return(project_id).at_least(:once)
       expect { nx.create_new_vm }.to hop("wait")
-      pool = VmPool[st.id]
       expect(pool.vms.count).to eq(1)
       expect(pool.vms.first.sshable).not_to be_nil
     end
@@ -56,30 +55,18 @@ RSpec.describe Prog::Vm::VmPool do
       create_vm_host(location: "github-runners", total_cores: 2, used_cores: 0)
     end
 
-    let(:pool) {
-      VmPool.create_with_id(
-        size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1",
-        storage_size_gib: 86, storage_encrypted: true,
-        storage_skip_sync: false, arch: "x64"
-      )
-    }
-
     it "waits if nothing to do" do
-      expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       expect { nx.wait }.to nap(30)
     end
 
     it "hops to create_new_vm if there are enough idle cores" do
       pool.update(size: 1)
-      expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
 
       expect { nx.wait }.to hop("create_new_vm")
     end
 
     it "hops to create_new_vm if there are enough idle cores for the given arch" do
       pool.update(size: 1)
-
-      expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "key", name: "vm1", location: "github-runners", boot_image: "github-ubuntu-2204", family: "standard", arch: "arm64", cores: 4, vcpus: 2, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
 
       expect { nx.wait }.to hop("create_new_vm")
@@ -87,8 +74,6 @@ RSpec.describe Prog::Vm::VmPool do
 
     it "waits if there are not enough idle cores due to waiting github runners" do
       pool.update(size: 1)
-
-      expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "key", name: "vm1", location: "github-runners", boot_image: "github-ubuntu-2204", family: "standard", arch: "x64", cores: 2, vcpus: 2, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
 
       expect { nx.wait }.to nap(30)
@@ -96,14 +81,9 @@ RSpec.describe Prog::Vm::VmPool do
   end
 
   describe "#destroy" do
-    let(:pool) {
-      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
-    }
-
     it "increments vms' destroy semaphore and hops to wait_vms_destroy" do
       ps = instance_double(PrivateSubnet)
       vm = instance_double(Vm, private_subnets: [ps])
-      expect(nx).to receive(:vm_pool).and_return(pool)
       expect(pool).to receive(:vms).and_return([vm])
       expect(vm).to receive(:incr_destroy)
       expect(ps).to receive(:incr_destroy)
@@ -112,12 +92,7 @@ RSpec.describe Prog::Vm::VmPool do
   end
 
   describe "#wait_vms_destroy" do
-    let(:pool) {
-      VmPool.create_with_id(size: 0, vm_size: "standard-2", boot_image: "img", location: "hetzner-fsn1", storage_size_gib: 86)
-    }
-
     it "pops if vms are all destroyed" do
-      expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       expect(pool).to receive(:destroy)
       expect(pool).to receive(:vms).and_return([])
 
@@ -125,7 +100,6 @@ RSpec.describe Prog::Vm::VmPool do
     end
 
     it "naps if there are still vms" do
-      expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
       expect(pool).to receive(:vms).and_return([true])
       expect { nx.wait_vms_destroy }.to nap(10)
     end

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -108,12 +108,14 @@ RSpec.describe Prog::Vm::VmPool do
   describe "#before_run" do
     it "hops to destroy when needed" do
       expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(pool).to receive(:destroying_set?).and_return(false)
+      expect(pool).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
 
     it "does not hop to destroy if already in the destroy state" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(pool).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
   end

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -52,18 +52,14 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
   describe "#before_run" do
     it "hops to destroy when needed" do
       expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.load_balancer).to receive(:destroying_set?).and_return(false)
+      expect(nx.load_balancer).to receive(:incr_destroying)
       expect { nx.before_run }.to hop("destroy")
     end
 
     it "does not hop to destroy if already in the destroy state" do
-      expect(nx.strand).to receive(:label).and_return("destroy")
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_destroy state" do
-      expect(nx.strand).to receive(:label).and_return("wait_destroy").at_least(:once)
-      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx.load_balancer).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
   end


### PR DESCRIPTION
- **Clean up vm pool nexus tests**
  

- **Fix destroy labels for the vm and inference endpoint**
  If the resource is already being destroyed, we don't want to hop to the
  `destroy` label again when the `destroy` semaphore is incremented.
  
  We check the current label to avoid hopping again. Some resources have
  labels after the `destroy` label, so we need to check those as well.
  
  We checked this for some resources, but it seems we missed it for the vm
  and inference endpoint.
  

- **Add destroying label to prevent hop to destroy again**
  If the resource is already being destroyed, we don't want to hop to the
  `destroy` label again when the `destroy` semaphore is incremented.
  
  We check the current label to avoid hopping again. Sometimes we forget
  to update the list of labels to check when we add new labels after a
  destroy.
  
  Instead of checking the labels separately, we can increase another
  semaphore, like `destroying`, along with the `destroy` semaphore and
  keep it incremented until the resource is destroyed.
  