### PR TITLE
Support log method in specs to allow query logging inside a given block

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -20,9 +20,10 @@ Sequel::Model.plugin :inspect_pk
 Sequel::Model.plugin :static_cache_cache, "cache/static_cache.cache"
 Sequel::Model.plugin :pg_auto_constraint_validations, cache_file: "cache/pg_auto_constraint_validations.cache"
 
-if (level = Config.database_logger_level)
+if (level = Config.database_logger_level) || Config.test?
   require "logger"
-  DB.loggers << Logger.new($stdout, level: level)
+  LOGGER = Logger.new($stdout, level: level || "fatal")
+  DB.loggers << LOGGER
 end
 
 module SequelExtensions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -227,6 +227,14 @@ RSpec.configure do |config|
     require "coderay"
   end
 
+  def log
+    level = LOGGER.level
+    LOGGER.level = "info"
+    yield
+  ensure
+    LOGGER.level = level
+  end
+
   def create_vm_host(**args)
     args = {location: "hetzner-fns1", allocation_state: "accepting", arch: "x64", total_cores: 48, used_cores: 2}.merge(args)
     ubid = VmHost.generate_ubid


### PR DESCRIPTION
This makes it significantly easier to debug database behavior for parts of a spec.  Without this, you need to use the DATABASE_LOGGER_LEVEL environment variable, which turns on query logging for everything, making it significantly more difficult to focus on what you are trying to debug.

To use this, inside the spec, wrap the code you want in the log method:

```ruby
  it "should do something" do
    setup_code

    log do
      code_you_are_trying_to_debug
    end

    # ...
  end
```