### PR TITLE
Do not trigger a deadline page if the host is unavailable

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -108,7 +108,9 @@ SQL
             {}
           end
           extra_data.compact!
-          Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+          if Strand[extra_data[:vm_host]]&.label != "unavailable" || label == "unavailable"
+            Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+          end
           modified!(:stack)
         end
       end

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -121,6 +121,11 @@ class Prog::Test < Prog::Base
   label def push_subject_id
     push Prog::Test, {"subject_id" => "70b633b7-1d24-4526-a47f-d2580597d53f"}
   end
+
+  label def unavailable
+    register_deadline("unavailable", -1)
+    nap(123)
+  end
 end
 
 class Prog::Test2 < Prog::Test


### PR DESCRIPTION
When the host crashes, all resources on it trigger a deadline page, which creates a page storm. This is overwhelming for the on-call engineer and serves no purpose. If the VM host is unavailable, there’s no need to trigger a deadline page.

Some resources don't have separate unavailability page type and instead use deadlines to create them. Because of this, even if the VM host is unavailable, we create a deadlines page if the current label is "unavailable".

Our VM host monitoring isn't very sufficient right now. Adding disk monitoring and possibly SPDK service monitoring will make this PR more useful.