### PR TITLE
Support bdev_ubi 0.3 & increase iobuf pool capacity used for SPDK.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -126,7 +126,7 @@ module Config
   override :minio_version, "minio_20240406052602.0.0_amd64"
 
   # Spdk
-  override :spdk_version, "v23.09-ubi-0.2"
+  override :spdk_version, "v23.09-ubi-0.3"
 
   # Boot Images
   override :default_boot_image_name, "ubuntu-jammy", string

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -4,8 +4,8 @@ class Prog::Storage::SetupSpdk < Prog::Base
   subject_is :sshable, :vm_host
 
   SUPPORTED_SPDK_VERSIONS = [
-    ["v23.09-ubi-0.2", "x64"],
-    ["v23.09-ubi-0.2", "arm64"]
+    ["v23.09-ubi-0.3", "x64"],
+    ["v23.09-ubi-0.3", "arm64"]
   ]
 
   def self.assemble(vm_host_id, version, start_service: false, allocation_weight: 0)
@@ -36,7 +36,7 @@ class Prog::Storage::SetupSpdk < Prog::Base
       allocation_weight: 0,
       vm_host_id: vm_host.id,
       cpu_count: vm_host.spdk_cpu_count,
-      hugepages: 2
+      hugepages: 4
     ) { _1.id = SpdkInstallation.generate_uuid }
 
     hop_install_spdk

--- a/rhizome/host/lib/spdk_path.rb
+++ b/rhizome/host/lib/spdk_path.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-DEFAULT_SPDK_VERSION = "v23.09-ubi-0.2"
+DEFAULT_SPDK_VERSION = "v23.09-ubi-0.3"
 
 module SpdkPath
   def self.user

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -59,8 +59,8 @@ class SpdkSetup
     end
 
     case @spdk_version
-    when "v23.09-ubi-0.2"
-      "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.2b/ubicloud-spdk-#{os_version}-#{arch}.tar.gz"
+    when "v23.09-ubi-0.3"
+      "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.3/ubicloud-spdk-#{os_version}-#{arch}.tar.gz"
     else
       fail "BUG: unsupported SPDK version"
     end
@@ -133,7 +133,7 @@ Description=SPDK hugepages mount #{@spdk_version}
 What=hugetlbfs
 Where=#{hugepages_dir}
 Type=hugetlbfs
-Options=uid=#{user},size=2G
+Options=uid=#{user},size=4G
 
 [Install]
 WantedBy=#{spdk_service}
@@ -155,10 +155,10 @@ SPDK_HUGEPAGES_MOUNT
         #
         # So, small_pool_count must be at least #Volumes-per-host*3*128, and
         # large_pool_count must be at least #Volumes-per-host*3*16. This config,
-        # which modifies the defaults, is enough for 100 encrypted volumes in a
+        # which modifies the defaults, is enough for 200 encrypted volumes in a
         # host.
-        small_pool_count: 38400,
-        large_pool_count: 4800,
+        small_pool_count: 76800,
+        large_pool_count: 9600,
         small_bufsize: 8192,
         large_bufsize: 135168
       }

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Storage::SetupSpdk do
     ))
   }
 
-  let(:spdk_version) { "v23.09-ubi-0.2" }
+  let(:spdk_version) { "v23.09-ubi-0.3" }
   let(:sshable) { vm_host.sshable }
   let(:vm_host) { create_vm_host(used_hugepages_1g: 0, total_hugepages_1g: 20, total_cpus: 96, os_version: "ubuntu-24.04") }
 


### PR DESCRIPTION
### Rhizome: Support bdev_ubi 0.3 and change SPDK iobuf sizes.
Whenever an IO channel is made to a bdev, it gets some pre-allocated iobufs from SPDK's pre-allocated buffer pools. SPDK has 2 pools, one with small buffers (8kb per item), and one with large buffers (128kb per item).

This sizes of these pools are configurable at SPDK startup time.

We were getting crashes in production because of no free items in these pools.

To fix this, this change:
1. Increases the sizes of these pools.
2. Increases the number of 1g hugepages used for SPDK, to have enough  space for the new sizes of pools
3. Adds support for bdev_ubi-0.3 which will avoid avoid crash & will just error out in case were are out free pool items.

### Clover: Support bdev_ubi 0.3 & increase SPDK hugepages.
bdev_ubi 0.3 fixes several error handling issues, mainly the ones related to when we are out of iobuf free items which caused crashes in production.

When we added support for bdev_ubi 0.3 in the Clover side, we increased number of hugepages used for SPDK. So, this PR also increases that on the Clover side.

### Set used_hugepages_1g using total SPDK hugepages
SPDK allocates memory lazily as it needs, so although we mount 4G of hugepages to SPDK, `cat /proc/meminfo` shows only 3 hugepages used.

This PR changes fixes that by using the amount of hugepages reserved for SPDK on reboot.