### PR TITLE
Do not wait for tap interface readiness for VMs with /32 ip

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -340,6 +340,8 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def update_via_routes(nics)
+    return if NetAddr::IPv4Net.parse(nics.first.net4).netmask.to_s == "/32"
+
     # we create tap devices in "interfaces" function in this file. but
     # code execution happens faster than linux taking care of the device creation.
     # that's why by the time we reach this function, we need to check whether the


### PR DESCRIPTION
Since we do not need to modify routes of VMs with /32 ip, we should skip that funciton altogether. A new condition is added to make sure it returns early on those cases.