### PR TITLE
Remove transparent cache enable screenshot from regen-screenshots

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -113,15 +113,6 @@ class RegenScreenshots
     screenshot "github-actions-integration/quickstart-2-screenshot.png"
 
     project = Project.first
-    GithubInstallation.create_with_id(
-      name: "github-actions-integration",
-      project_id: project.id,
-      installation_id: 1234567890,
-      type: "user"
-    )
-    click_link "GitHub Runners"
-    click_link "Settings"
-    screenshot "github-actions-integration/transparent-cache-enable-screenshot.png"
 
     resize(650)
     click_link "PostgreSQL"


### PR DESCRIPTION
Since we've enabled transparent cache enabled for new customers by default, removing the screenshot.