### PR TITLE
Remove Version and Subnet Selection From Kubernetes Cluster Creation Form

### DIFF
--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -4,32 +4,20 @@ class Clover
   def kubernetes_cluster_post(name)
     authorize("KubernetesCluster:create", @project.id)
 
-    required_parameters = ["name", "location", "private_subnet_id", "cp_nodes", "worker_nodes"]
+    required_parameters = ["name", "location", "cp_nodes", "worker_nodes"]
     request_body_params = validate_request_params(required_parameters)
-
-    private_subnet_id = request_body_params["private_subnet_id"]
-
-    authorize("PrivateSubnet:edit", private_subnet_id)
-
-    private_subnet = PrivateSubnet.from_ubid(private_subnet_id)
-
-    unless private_subnet.location == @location
-      fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{request_body_params["private_subnet_id"]}\" and the location \"#{@location}\" is not found"})
-    end
 
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
         name: name,
-        version: "v1.32",
-        private_subnet_id: private_subnet.id,
         project_id: @project.id,
         location: @location,
-        cp_node_count: request.params["cp_nodes"].to_i
+        cp_node_count: request_body_params["cp_nodes"].to_i
       ).subject
 
       Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
         name: name + "-np",
-        node_count: request.params["worker_nodes"].to_i,
+        node_count: request_body_params["worker_nodes"].to_i,
         kubernetes_cluster_id: kc.id
       )
 
@@ -51,17 +39,6 @@ class Clover
     options.add_option(name: "location", values: Option.kubernetes_locations.map(&:display_name))
     options.add_option(name: "cp_nodes", values: ["1", "3"])
     options.add_option(name: "worker_nodes", values: (1..6).map { {value: _1.to_s, display_name: _1.to_s} })
-
-    subnets = dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map {
-      {
-        location: LocationNameConverter.to_display_name(_1.location),
-        value: _1.ubid,
-        display_name: _1.name
-      }
-    }
-    options.add_option(name: "private_subnet_id", values: subnets, parent: "location") do |location, private_subnet|
-      private_subnet[:location] == location
-    end
 
     options.serialize
   end

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -4,7 +4,7 @@ class Clover
   def kubernetes_cluster_post(name)
     authorize("KubernetesCluster:create", @project.id)
 
-    required_parameters = ["name", "location", "version", "private_subnet_id", "cp_nodes", "worker_nodes"]
+    required_parameters = ["name", "location", "private_subnet_id", "cp_nodes", "worker_nodes"]
     request_body_params = validate_request_params(required_parameters)
 
     private_subnet_id = request_body_params["private_subnet_id"]
@@ -20,7 +20,7 @@ class Clover
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
         name: name,
-        version: request.params["version"],
+        version: "v1.32",
         private_subnet_id: private_subnet.id,
         project_id: @project.id,
         location: @location,
@@ -49,7 +49,6 @@ class Clover
 
     options.add_option(name: "name")
     options.add_option(name: "location", values: Option.kubernetes_locations.map(&:display_name))
-    options.add_option(name: "version", values: ["v1.32", "v1.31"])
     options.add_option(name: "cp_nodes", values: ["1", "3"])
     options.add_option(name: "worker_nodes", values: (1..6).map { {value: _1.to_s, display_name: _1.to_s} })
 

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -129,10 +129,6 @@ module ContentGenerator
       Option.kubernetes_locations.find { _1.display_name == location }.ui_name
     end
 
-    def self.private_subnet(location, private_subnet)
-      private_subnet[:display_name]
-    end
-
     def self.cp_nodes(cp_nodes)
       cp_nodes.to_s
     end

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -129,10 +129,6 @@ module ContentGenerator
       Option.kubernetes_locations.find { _1.display_name == location }.ui_name
     end
 
-    def self.version(version)
-      version
-    end
-
     def self.private_subnet(location, private_subnet)
       private_subnet[:display_name]
     end

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -9,7 +9,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
         fail "No existing project"
       end
 
-      unless ["v1.32"].include?(version)
+      unless ["v1.32", "v1.31"].include?(version)
         fail "Invalid Kubernetes Version"
       end
 

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   subject_is :kubernetes_cluster
 
-  def self.assemble(name:, version:, private_subnet_id:, project_id:, location:, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
+  def self.assemble(name:, project_id:, location:, version: "v1.32", private_subnet_id: nil, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
     DB.transaction do
       unless (project = Project[project_id])
         fail "No existing project"
@@ -16,14 +16,24 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       Validation.validate_kubernetes_name(name)
       Validation.validate_kubernetes_cp_node_count(cp_node_count)
 
-      # TODO: Validate subnet location if given
-      # TODO: Validate subnet size if given
-      # TODO: Create subnet if not given
+      subnet = if private_subnet_id
+        project.private_subnets_dataset.first(id: private_subnet_id) || fail("Given subnet is not available in the given project")
+      else
+        subnet_name = name + "-k8s-subnet"
+        ps = project.private_subnets_dataset.first(:location => location, Sequel[:private_subnet][:name] => subnet_name)
+        ps || Prog::Vnet::SubnetNexus.assemble(
+          project_id,
+          name: subnet_name,
+          location:,
+          ipv4_range: Prog::Vnet::SubnetNexus.random_private_ipv4(location, project, 18).to_s
+        ).subject
+      end
+
       # TODO: Validate location
-      # TODO: Move resources (vms, subnet, LB, etc.) into own project
+      # TODO: Move resources (vms, subnet, LB, etc.) into our own project
       # TODO: Validate node count
 
-      kc = KubernetesCluster.create_with_id(name:, version:, cp_node_count:, private_subnet_id:, location:, target_node_size:, target_node_storage_size_gib:, project_id: project.id)
+      kc = KubernetesCluster.create_with_id(name:, version:, cp_node_count:, location:, target_node_size:, target_node_storage_size_gib:, project_id: project.id, private_subnet_id: subnet.id)
 
       Strand.create(prog: "Kubernetes::KubernetesClusterNexus", label: "start") { _1.id = kc.id }
     end

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -333,6 +333,14 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(described_class.random_private_ipv4("hetzner-fsn1", project).to_s).to eq("10.0.0.128/26")
     end
 
+    it "finds a new subnet if the initial range is smaller than the requested cidr range" do
+      expect(PrivateSubnet).to receive(:random_subnet).and_return("172.16.0.0/16", "10.0.0.0/8")
+      project = Project.create_with_id(name: "test-project")
+      expect(SecureRandom).not_to receive(:random_number).with(2**(16 - 16) - 1)
+      allow(SecureRandom).to receive(:random_number).with(2**(16 - 8) - 1).and_return(15)
+      expect(described_class.random_private_ipv4("hetzner-fsn1", project, 16).to_s).to eq("10.16.0.0/16")
+    end
+
     it "raises an error when invalid CIDR is given" do
       project = Project.create_with_id(name: "test-project")
       expect { described_class.random_private_ipv4("hetzner-fsn1", project, 33) }.to raise_error(ArgumentError)

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -129,7 +129,6 @@ RSpec.describe Clover, "Kubernetes" do
 
       it "can create new kubernetes cluster" do
         fill_in "Name", with: "k8stest"
-        choose option: "v1.32"
         choose option: "eu-central-h1"
         select "mysubnet", from: "private_subnet_id"
         choose option: 3
@@ -149,7 +148,6 @@ RSpec.describe Clover, "Kubernetes" do
 
       it "can not create kubernetes cluster with invalid name" do
         fill_in "Name", with: "invalid name"
-        choose option: "v1.32"
         choose option: "eu-central-h1"
         select "mysubnet", from: "private_subnet_id"
         choose option: 3
@@ -170,7 +168,6 @@ RSpec.describe Clover, "Kubernetes" do
         params = {
           name: "dummy",
           location: "eu-central-h1",
-          version: "v1.32",
           private_subnet_id: UBID.generate_random("ps"),
           cp_nodes: 3,
           worker_nodes: 2,
@@ -197,7 +194,6 @@ RSpec.describe Clover, "Kubernetes" do
         params = {
           name: "dummy",
           location: "us-east-a2",
-          version: "v1.32",
           private_subnet_id: kc.private_subnet.ubid,
           cp_nodes: 3,
           worker_nodes: 2,
@@ -217,7 +213,6 @@ RSpec.describe Clover, "Kubernetes" do
 
       it "can not create kubernetes cluster with same name in same project & location" do
         fill_in "Name", with: "myk8s"
-        choose option: "v1.32"
         choose option: "eu-central-h1"
         select "mysubnet", from: "private_subnet_id"
         choose option: 3

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -15,7 +15,6 @@
   form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:location)},
-    {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Please select a subnet", content_generator: ContentGenerator::KubernetesCluster.method(:private_subnet), opening_tag: "<div class='sm:col-span-3'>"},
     {name: "cp_nodes", type: "radio_small_cards", label: "Control Plane Nodes", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:cp_nodes)},
     {name: "worker_nodes", type: "select", label: "Worker Nodes", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:worker_nodes), opening_tag: "<div class='sm:col-span-3'>"},
   ]

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -14,7 +14,6 @@
 <%
   form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name"},
-    {name: "version", type: "radio_small_cards", label: "Kubernetes Version", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:version)},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:location)},
     {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Please select a subnet", content_generator: ContentGenerator::KubernetesCluster.method(:private_subnet), opening_tag: "<div class='sm:col-span-3'>"},
     {name: "cp_nodes", type: "radio_small_cards", label: "Control Plane Nodes", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:cp_nodes)},

--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -21,6 +21,7 @@
     ["ID", @kc.ubid],
     ["Name", @kc.name],
     ["Location", @kc.display_location],
+    ["Private Subnet", @kc.private_subnet.name],
     ["Kubernetes Version", @kc.version],
     ["Control Plane Nodes", @kc.cp_node_count]
   ]


### PR DESCRIPTION
Remove the version selection from k8s creation form

    Since we are a new service, let's not deal with allowing an older
    version of k8s on the form. If someone asks for it, we can create
    v1.31 on the backend anyway. Otherwise, everything is v1.32.

    This is a leftover item that fell through the cracks during the
    lengthy review process.

    We expect v1.33 to be released in a short while and will bring this
    back again.


Remove Subnet Selection From k8s Creation Form

    With this patch, we remove the Subnet Selection from Kubernetes
    creation form. Instead, we create a default subnet with a larger
    ipv4 prefix (/16 instead of /26) with the name "cluster-k8s-subnet".

    This way, the flow is simplified, as we don't require a customer to create
    a subnet before creating a cluster. Also, the subnet would need to have
    a larger prefix and changing that is not easy at the moment.
    
Fix private subnet selection in a way to support larger subnets (/16)

    Previously, random_private_ipv4 function could randomly error out
    when requesting larger subnets, because one of the classes were not
    large enough to accomodate /16 and the code didn't handle this case.

    Now we retry the function if the initially selected family of large subnet
    cannot accomodate the requested cidr size.

    This is needed when we request bigger subnets for kubernetes clusters.