### PR TITLE
Change linear scaling of Postgres max_connections to a constant

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -22,7 +22,7 @@ class PostgresServer < Sequel::Model
   def configure_hash
     configs = {
       "listen_addresses" => "'*'",
-      "max_connections" => (vm.memory_gib * 25).to_s,
+      "max_connections" => "500",
       "superuser_reserved_connections" => "3",
       "shared_buffers" => "#{vm.memory_gib * 1024 / 4}MB",
       "work_mem" => "#{vm.memory_gib / 8}MB",


### PR DESCRIPTION

This creates difficult problems with hot standby, since a database
cannot enter hot standby without an equal-or-larger `max_connections`
to size some shared memory arrays that permit the system to answer
queries.  Warm standby is still operable, though.

Also, larger database sizes will calculate excessively large
`max_connections`, e.g. 6000, that slow down snapshot acquisition.

Now it is set to 500, a value that seemed okay in the previous decade
or so over several services.  Though, occasional customers did need
custom settings, and the service needed to grow an awareness of how to
set `max_connections` on standbys based on the parent's setting(s)
over time.

This will have some implications on existing databases adding HA
standbys (in that, they will fail), but producing more databases with
very large connection counts is likely a worse outcome.

