### PR TITLE
Allow Rodish to accept a custom error message for invalid arguments

### DIFF
--- a/lib/rodish.rb
+++ b/lib/rodish.rb
@@ -71,8 +71,9 @@ module Rodish
       @command.before = block
     end
 
-    def args(args)
+    def args(args, invalid_args_message: nil)
       @command.num_args = args
+      @command.invalid_args_message = invalid_args_message
     end
 
     def autoload_subcommand_dir(base)
@@ -95,12 +96,12 @@ module Rodish
       @command.run_block = block
     end
 
-    def is(command_name, args: 0, &block)
-      _is(:on, command_name, args:, &block)
+    def is(command_name, args: 0, invalid_args_message: nil, &block)
+      _is(:on, command_name, args:, invalid_args_message:, &block)
     end
 
-    def run_is(command_name, args: 0, &block)
-      _is(:run_on, command_name, args:, &block)
+    def run_is(command_name, args: 0, invalid_args_message: nil, &block)
+      _is(:run_on, command_name, args:, invalid_args_message:, &block)
     end
 
     private
@@ -111,9 +112,9 @@ module Rodish
       end
     end
 
-    def _is(meth, command_name, args:, &block)
+    def _is(meth, command_name, args:, invalid_args_message: nil, &block)
       public_send(meth, command_name) do
-        args args
+        args(args, invalid_args_message:)
         run(&block)
       end
     end
@@ -134,6 +135,7 @@ module Rodish
     attr_accessor :option_key
     attr_accessor :before
     attr_accessor :num_args
+    attr_accessor :invalid_args_message
 
     def initialize(command_path)
       # Development assertions:
@@ -189,6 +191,8 @@ module Rodish
           else
             context.instance_exec(argv, options, self, &run_block)
           end
+        elsif @invalid_args_message
+          raise CommandFailure, "invalid arguments#{subcommand_name} (#{@invalid_args_message})"
         else
           raise CommandFailure, "invalid number of arguments#{subcommand_name} (accepts: #{@num_args}, given: #{argv.length})"
         end

--- a/spec/lib/rodish_spec.rb
+++ b/spec/lib/rodish_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Rodish do
           end
         end
 
-        args 2
+        args 2, invalid_args_message: "accepts: x y"
         run do |x, y|
           push [:a, x, y]
         end
@@ -155,11 +155,11 @@ RSpec.describe Rodish do
         expect(res).to be_empty
         expect { app.process(%w[a b], context: res) }.to raise_error(Rodish::CommandFailure, "invalid number of arguments for a b subcommand (accepts: 1..., given: 0)")
         expect(res).to eq [:top, :before_a]
-        expect { app.process(%w[a], context: res.clear) }.to raise_error(Rodish::CommandFailure, "invalid number of arguments for a subcommand (accepts: 2, given: 0)")
+        expect { app.process(%w[a], context: res.clear) }.to raise_error(Rodish::CommandFailure, "invalid arguments for a subcommand (accepts: x y)")
         expect(res).to eq [:top]
-        expect { app.process(%w[a 1], context: res.clear) }.to raise_error(Rodish::CommandFailure, "invalid number of arguments for a subcommand (accepts: 2, given: 1)")
+        expect { app.process(%w[a 1], context: res.clear) }.to raise_error(Rodish::CommandFailure, "invalid arguments for a subcommand (accepts: x y)")
         expect(res).to eq [:top]
-        expect { app.process(%w[a 1 2 3], context: res.clear) }.to raise_error(Rodish::CommandFailure, "invalid number of arguments for a subcommand (accepts: 2, given: 3)")
+        expect { app.process(%w[a 1 2 3], context: res.clear) }.to raise_error(Rodish::CommandFailure, "invalid arguments for a subcommand (accepts: x y)")
         expect(res).to eq [:top]
         expect { app.process(%w[c 1], context: res.clear) }.to raise_error(Rodish::CommandFailure, "invalid number of arguments for c subcommand (accepts: 0, given: 1)")
         expect(res).to eq [:top]


### PR DESCRIPTION
Previously, it could only report the number of arguments was not correct, with the expected number or range.  It couldn't display what the expected argument names were.

This adds underlying support needed to address the "We could improve the error messages to indicate which parameters are missing" request in https://github.com/ubicloud/ubicloud/pull/2671#issuecomment-2636021590 .  After it is merged, I can update the ubi cli commands to use it.  This isn't done in this pull request because it would cause additional conflicts (I think this already conflicts with other open PRs, though this conflict should be easy to resolve).