### PR TITLE
Introduce pgbouncer

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -87,10 +87,13 @@ class PostgresResource < Sequel::Model
 
   def set_firewall_rules
     vm_firewall_rules = firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(5432..5432)} }
+    vm_firewall_rules.concat(firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(6432..6432)} })
     vm_firewall_rules.push({cidr: "0.0.0.0/0", port_range: Sequel.pg_range(22..22)})
     vm_firewall_rules.push({cidr: "::/0", port_range: Sequel.pg_range(22..22)})
     vm_firewall_rules.push({cidr: private_subnet.net4.to_s, port_range: Sequel.pg_range(5432..5432)})
+    vm_firewall_rules.push({cidr: private_subnet.net4.to_s, port_range: Sequel.pg_range(6432..6432)})
     vm_firewall_rules.push({cidr: private_subnet.net6.to_s, port_range: Sequel.pg_range(5432..5432)})
+    vm_firewall_rules.push({cidr: private_subnet.net6.to_s, port_range: Sequel.pg_range(6432..6432)})
     private_subnet.firewalls.first.replace_firewall_rules(vm_firewall_rules)
   end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -160,6 +160,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     end
 
     vm.sshable.cmd("sudo -u postgres pg_ctlcluster #{postgres_server.resource.version} main reload")
+    vm.sshable.cmd("sudo systemctl reload pgbouncer")
     hop_wait
   end
 
@@ -421,6 +422,7 @@ SQL
   label def restart
     decr_restart
     vm.sshable.cmd("sudo postgres/bin/restart #{postgres_server.resource.version}")
+    vm.sshable.cmd("sudo systemctl restart pgbouncer")
     pop "postgres server is restarted"
   end
 

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -46,6 +46,7 @@ pg_hba_entries = <<-PG_HBA
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 # Database administrative login by Unix domain socket
 local   all             postgres                                peer map=system2postgres
+local   all             pgbouncer                               peer map=system2pgbouncer
 
 # "local" is for Unix domain socket connections only
 local   all             all                                     peer
@@ -86,6 +87,7 @@ pg_ident_entries = <<-PG_IDENT
 # Authentication" for a complete description.
 # MAPNAME             SYSTEM-USERNAME         PG-USERNAME
 system2postgres       postgres                postgres
+system2pgbouncer      postgres                pgbouncer
 system2postgres       ubi                     postgres
 standby2replication   #{identity}             ubi_replication
 PG_IDENT
@@ -93,3 +95,36 @@ safe_write_to_file("/etc/postgresql/#{v}/main/pg_ident.conf", pg_ident_entries)
 
 # Reload the postmaster to apply changes
 r "pg_ctlcluster #{v} main reload || pg_ctlcluster #{v} main restart"
+
+# PgBouncer config
+pgbouncer_config = <<-PGBOUNCER_CONFIG
+# PgBouncer configuration file
+# ============================
+[databases]
+; any db over Unix socket
+* =
+
+[pgbouncer]
+listen_port = 6432
+listen_addr = 0.0.0.0
+
+unix_socket_dir = /var/run/postgresql
+
+auth_type = hba
+auth_hba_file = /etc/postgresql/#{v}/main/pg_hba.conf
+auth_ident_file = /etc/postgresql/#{v}/main/pg_ident.conf
+auth_user = pgbouncer
+auth_query = SELECT p_user, p_password FROM pgbouncer.get_auth($1)
+
+client_tls_sslmode = require
+client_tls_protocols = tlsv1.3
+client_tls_ca_file = /etc/ssl/certs/ca.crt
+client_tls_cert_file = /etc/ssl/certs/server.crt
+client_tls_key_file = /etc/ssl/certs/server.key
+
+user = postgres
+
+max_client_conn = 5000
+max_db_connections = #{configure_hash["configs"]["max_connections"]}
+PGBOUNCER_CONFIG
+safe_write_to_file("/etc/pgbouncer/pgbouncer.ini", pgbouncer_config)

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -19,3 +19,53 @@ r "pg_createcluster #{v} main --start --locale=C.UTF8"
 
 r "sudo -u postgres psql -c 'CREATE ROLE ubi_replication WITH REPLICATION LOGIN'"
 r "sudo -u postgres psql -c 'CREATE ROLE ubi_monitoring WITH LOGIN IN ROLE pg_monitor'"
+
+pgbouncer_setup_query = <<~PGBOUNCER_SETUP
+  BEGIN;
+
+  /**
+    * Create pgbouncer role if it does not exist.
+    */
+  DO $$
+  BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgbouncer') THEN
+          CREATE ROLE pgbouncer LOGIN;
+      END IF;
+  END
+  $$;
+
+  /**
+    * Lock down the privileges of the pgbouncer role.
+    */
+  REVOKE ALL PRIVILEGES ON SCHEMA public FROM pgbouncer;
+
+  /**
+    * Create the pgbouncer schema if it does not exist. All of the
+    * administrative functions for pgbouncer will live in its own schema.
+    */
+  CREATE SCHEMA IF NOT EXISTS pgbouncer;
+
+  /**
+    * Lock down the privileges of the pgbouncer schema.
+    */
+  REVOKE ALL PRIVILEGES ON SCHEMA pgbouncer FROM pgbouncer;
+  GRANT USAGE ON SCHEMA pgbouncer TO pgbouncer;
+
+  /**
+    * The "get_auth" function is used by pgbouncer to authenticate users.
+    * See: http://www.pgbouncer.org/config.html#auth_query
+    */
+  CREATE OR REPLACE FUNCTION pgbouncer.get_auth (
+    INOUT p_user     name,
+    OUT   p_password text
+  ) RETURNS record
+    LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS
+  $$SELECT usename, passwd FROM pg_shadow WHERE usename = p_user$$;
+
+  REVOKE ALL ON FUNCTION pgbouncer.get_auth(name) FROM PUBLIC, pgbouncer;
+  GRANT EXECUTE ON FUNCTION pgbouncer.get_auth(name) TO pgbouncer;
+
+  COMMIT;
+PGBOUNCER_SETUP
+
+r "sudo -u postgres psql", stdin: pgbouncer_setup_query

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -58,14 +58,17 @@ RSpec.describe PostgresResource do
 
   it "sets firewall rules" do
     firewall = instance_double(Firewall, name: "#{postgres_resource.ubid}-firewall")
-    expect(postgres_resource).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, firewalls: [firewall], net4: "10.238.50.0/26", net6: "fd19:9c92:e9b9:a1a::/64")).at_least(:once)
-    expect(postgres_resource).to receive(:firewall_rules).and_return([instance_double(PostgresFirewallRule, cidr: "0.0.0.0/0")])
+    expect(postgres_resource).to receive(:private_subnet).exactly(2).and_return(instance_double(PrivateSubnet, firewalls: [firewall], net4: "10.238.50.0/26", net6: "fd19:9c92:e9b9:a1a::/64")).at_least(:once)
+    expect(postgres_resource).to receive(:firewall_rules).exactly(2).and_return([instance_double(PostgresFirewallRule, cidr: "0.0.0.0/0")])
     expect(firewall).to receive(:replace_firewall_rules).with([
       {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(5432..5432)},
+      {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(6432..6432)},
       {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(22..22)},
       {cidr: "::/0", port_range: Sequel.pg_range(22..22)},
       {cidr: "10.238.50.0/26", port_range: Sequel.pg_range(5432..5432)},
-      {cidr: "fd19:9c92:e9b9:a1a::/64", port_range: Sequel.pg_range(5432..5432)}
+      {cidr: "10.238.50.0/26", port_range: Sequel.pg_range(6432..6432)},
+      {cidr: "fd19:9c92:e9b9:a1a::/64", port_range: Sequel.pg_range(5432..5432)},
+      {cidr: "fd19:9c92:e9b9:a1a::/64", port_range: Sequel.pg_range(6432..6432)}
     ])
     postgres_resource.set_firewall_rules
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -290,13 +290,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:cmd).with("sudo chgrp cert_readers /etc/ssl/certs/server.crt && sudo chmod 640 /etc/ssl/certs/server.crt")
       expect(sshable).to receive(:cmd).with("sudo chgrp cert_readers /etc/ssl/certs/server.key && sudo chmod 640 /etc/ssl/certs/server.key")
       expect(sshable).to receive(:cmd).with("sudo -u postgres pg_ctlcluster 16 main reload")
+      expect(sshable).to receive(:cmd).with("sudo systemctl reload pgbouncer")
       expect(nx).to receive(:refresh_walg_credentials)
       expect { nx.refresh_certificates }.to hop("wait")
     end
   end
 
   describe "#configure_prometheus" do
-    it "configures prometheus and hops configure during initial provisioning" do
+    it "configures prometheus and hops configure_pgbouncer during initial provisioning" do
       expect(nx).to receive(:when_initial_provisioning_set?).and_yield
       expect(sshable).to receive(:cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
       expect(sshable).to receive(:cmd).with("sudo -u prometheus tee /home/prometheus/prometheus.yml > /dev/null", stdin: anything)
@@ -638,6 +639,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#restart" do
     it "restarts and exits" do
       expect(sshable).to receive(:cmd).with("sudo postgres/bin/restart 16")
+      expect(sshable).to receive(:cmd).with("sudo systemctl restart pgbouncer")
       expect { nx.restart }.to exit({"msg" => "postgres server is restarted"})
     end
   end


### PR DESCRIPTION
## Description

Introduce pgbouncer to improve the cost of connection overhead,
improving the idle and short-lived connections at the database server.
The pgbouncer service runs as a systemd unit listening on port 6432,
relaying connections to the postgres server over a Unix domain socket.


## Limitations/TODOs

- [x] Plaintext password in userlist.txt
  * pgbouncer auth_type limitations: https://github.com/pgbouncer/pgbouncer/blob/master/doc/config.md#limitations
  * https://www.perplexity.ai/search/can-a-scram-secret-be-used-in-7ycLTyuDQMWP0McJPYkSdw

- [x] Warnings in pgbouncer logs

  ```
  Feb 05 20:56:39 vm2qhphx pgbouncer[589]: hba line 9: Ident map system2postgres is not found in ident config file
  Feb 05 20:56:39 vm2qhphx pgbouncer[589]: could not parse hba config line 9
  Feb 05 20:56:39 vm2qhphx pgbouncer[589]: hba line 36: Ident map standby2replication is not found in ident config file
  Feb 05 20:56:39 vm2qhphx pgbouncer[589]: could not parse hba config line 36
  ```

- [x] The get_auth function is in the public schema, should be moved to a dedicated pgbouncer schema

## Tests
- [x] Unit tests
- [x] Local run
- [x] E2E tests

## Rollout

- [x] Update all hosts to use the new postgres image with pgbouncer
- [x] Update default postgres image version in `download_boot_image.rb`
- [ ] Performance benchmarks
- [ ] Update documentation to reference availability of pgbouncer endpoint
- [ ] Update postgres details page to show pgbouncer connection string
