### PR TITLE
Call setup-cni script on join-worker-node rhizome

### DIFF
--- a/rhizome/kubernetes/bin/join-worker-node
+++ b/rhizome/kubernetes/bin/join-worker-node
@@ -16,3 +16,5 @@ rescue KeyError => e
 end
 
 r "kubeadm join #{endpoint} --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash}"
+
+r("sudo /home/ubi/kubernetes/bin/setup-cni")


### PR DESCRIPTION
Calling the setup-cni script was missed in join script. Now the issue is fixed