### PR TITLE
Show proper display_location in Kubernetes cluster list

### DIFF
--- a/views/kubernetes-cluster/index.erb
+++ b/views/kubernetes-cluster/index.erb
@@ -15,7 +15,7 @@
       [
         [
           [kc.name, {link: @project_data[:path] + kc.path}],
-          kc.location,
+          kc.display_location,
           kc.version,
           ["kubernetes_state_label", {component: { state: kc.display_state }}]
         ],


### PR DESCRIPTION
After a serializer-to-direct-assoc change, I put KubernetesCluster.location instead of KubernetesCluster.display_location in the cluster list page.