### PR TITLE
Update Inference API Key creation messaging

### DIFF
--- a/routes/project/inference_api_key.rb
+++ b/routes/project/inference_api_key.rb
@@ -11,7 +11,7 @@ class Clover
       r.post true do
         authorize("InferenceApiKey:create", @project.id)
         iak = DB.transaction { ApiKey.create_inference_api_key(@project) }
-        flash["notice"] = "Created Inference API Key with id #{iak.ubid}"
+        flash["notice"] = "Created Inference API Key with id #{iak.ubid}. It may take a few minutes to sync."
         r.redirect "#{@project.path}/inference-api-key"
       end
 

--- a/spec/routes/web/inference_api_key_spec.rb
+++ b/spec/routes/web/inference_api_key_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Clover, "inference-api-key" do
     end
 
     it "inference api key page allows creating inference api key" do
-      expect(page).to have_flash_notice("Created Inference API Key with id #{@api_key.ubid}")
+      expect(page).to have_flash_notice("Created Inference API Key with id #{@api_key.ubid}. It may take a few minutes to sync.")
 
       expect(ApiKey.count).to eq(1)
       expect(@api_key.owner_id).to eq(project.id)


### PR DESCRIPTION
The inference API key can take a few minutes to sync across API endpoints. We inform users about this to prevent surprises if it doesn’t work immediately.