### PR TITLE
Do not treat string value list as text array

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -9,7 +9,7 @@ db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "db_ca_bundle.cr
 Util.safe_write_to_file(db_ca_bundle_filename, Config.clover_database_root_certs)
 max_connections = Config.db_pool - 1
 max_connections = 1 if ENV["SHARED_CONNECTION"] == "1"
-DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout, treat_string_list_as_text_array: true).tap do |db|
+DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout).tap do |db|
   # Replace dangerous (for cidrs) Ruby IPAddr type that is otherwise
   # used by sequel_pg.  Has come up more than once in the bug tracker:
   #


### PR DESCRIPTION
This will reintroduce the issue where query SQL is not consistent, and varies based on the number of array elements, but the current code is not ready for this assumption.