### PR TITLE
Add array casting in additional cases

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -9,7 +9,8 @@ db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "db_ca_bundle.cr
 Util.safe_write_to_file(db_ca_bundle_filename, Config.clover_database_root_certs)
 max_connections = Config.db_pool - 1
 max_connections = 1 if ENV["SHARED_CONNECTION"] == "1"
-DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout).tap do |db|
+pg_auto_parameterize_min_array_size = 1 if Config.test? && ENV["CLOVER_FREEZE"] == "1"
+DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:).tap do |db|
   # Replace dangerous (for cidrs) Ruby IPAddr type that is otherwise
   # used by sequel_pg.  Has come up more than once in the bug tracker:
   #

--- a/lib/access_control_model_tag.rb
+++ b/lib/access_control_model_tag.rb
@@ -30,7 +30,7 @@ module AccessControlModelTag
   end
 
   def remove_members(member_ids)
-    applied_dataset.where(:tag_id => id, applied_column => Sequel.any_uuid(member_ids)).delete
+    applied_dataset.where(:tag_id => id, applied_column => member_ids).delete
   end
 
   def currently_included_in

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -41,7 +41,7 @@ module Authorization
 
     base_ds = DB[table]
       .select(:tag_id, 0)
-      .where(column => Sequel.any_uuid(values))
+      .where(column => values)
 
     if project_id
       # We only look for applied_action_tag entries with an action_tag for the project or global action_tags.
@@ -66,7 +66,7 @@ module Authorization
 
     if actions
       actions = Array(actions).map { ActionType::NAME_MAP.fetch(it) }
-      dataset = dataset.where(Sequel.or([nil, Sequel.any_uuid(actions), recursive_tag_query(:action, actions, project_id:)].map { [:action_id, it] }))
+      dataset = dataset.where(Sequel.or([nil, actions, recursive_tag_query(:action, actions, project_id:)].map { [:action_id, it] }))
     end
 
     if object_id

--- a/model.rb
+++ b/model.rb
@@ -22,18 +22,6 @@ Sequel::Model.plugin :pg_auto_constraint_validations, cache_file: "cache/pg_auto
 Sequel::Model.plugin :pg_auto_validate_enums, message: proc { |valid_values| "is not one of the supported values (#{valid_values.sort.join(", ")})" }
 Sequel::Model.plugin :pg_eager_any_typed_array
 
-def Sequel.any_type(array, type)
-  Sequel.function(:ANY, Sequel.pg_array(array, type))
-end
-
-def Sequel.any_uuid(array)
-  if array.is_a?(Array)
-    any_type(array, :uuid)
-  else
-    array
-  end
-end
-
 if (level = Config.database_logger_level) || Config.test?
   require "logger"
   LOGGER = Logger.new($stdout, level: level || "fatal")

--- a/model.rb
+++ b/model.rb
@@ -42,7 +42,7 @@ end
 
 if ENV["CHECK_LOGGED_SQL"]
   require "logger"
-  File.unlink("sql.log")
+  File.unlink("sql.log") if File.file?("sql.log")
   f = File.open("sql.log", "ab")
 
   # Remove optimization that does not use parameterization

--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -66,7 +66,7 @@ class DnsZone < Sequel::Model
         .having { count.function.* =~ dns_server_ids.count }.all
 
       records_to_purge = obsoleted_records + seen_tombstoned_records
-      DB[:seen_dns_records_by_dns_servers].where(dns_record_id: Sequel.any_uuid(records_to_purge.map(&:id).uniq)).delete(force: true)
+      DB[:seen_dns_records_by_dns_servers].where(dns_record_id: records_to_purge.map(&:id).uniq).delete(force: true)
       records_to_purge.uniq(&:id).map(&:destroy)
 
       update(last_purged_at: Time.now)

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -14,7 +14,7 @@ class LoadBalancer < Sequel::Model
   many_to_one :custom_hostname_dns_zone, class: :DnsZone, key: :custom_hostname_dns_zone_id
   many_to_many :vm_ports, join_table: :load_balancer_port, right_key: :id, right_primary_key: :load_balancer_port_id, class: :LoadBalancerVmPort, read_only: true
   many_to_many :active_vm_ports, join_table: :load_balancer_port, right_key: :id, right_primary_key: :load_balancer_port_id, class: :LoadBalancerVmPort, read_only: true, conditions: {state: "up"}
-  many_through_many :vms_to_dns, [[:load_balancer_port, :load_balancer_id, :id], [:load_balancer_vm_port, :load_balancer_port_id, :load_balancer_vm_id], [:load_balancers_vms, :id, :vm_id]], class: :Vm, conditions: Sequel.~(Sequel[:load_balancer_vm_port][:state] => Sequel.any_type(["evacuating", "detaching"], :lb_node_state))
+  many_through_many :vms_to_dns, [[:load_balancer_port, :load_balancer_id, :id], [:load_balancer_vm_port, :load_balancer_port_id, :load_balancer_vm_id], [:load_balancers_vms, :id, :vm_id]], class: :Vm, conditions: Sequel.~(Sequel[:load_balancer_vm_port][:state] => ["evacuating", "detaching"])
 
   plugin :association_dependencies, load_balancers_vms: :destroy, ports: :destroy, certs_load_balancers: :destroy
 

--- a/model/object_metatag.rb
+++ b/model/object_metatag.rb
@@ -22,7 +22,7 @@ class ObjectMetatag < DelegateClass(ObjectTag)
 
   # Designed solely for use with UBID.resolve_map
   def self.where(id:)
-    ObjectTag.where(id: Sequel.any_uuid(id.args[0].map { from_meta_uuid(it) })).map(&:metatag)
+    ObjectTag.where(id: id.map { from_meta_uuid(it) }).map(&:metatag)
   end
 
   # Designed solely for use with UBID.decode

--- a/model/subject_tag.rb
+++ b/model/subject_tag.rb
@@ -17,7 +17,7 @@ class SubjectTag < Sequel::Model
   def self.subject_id_map_for_project_and_accounts(project_id, account_ids)
     DB[:applied_subject_tag]
       .join(:subject_tag, id: :tag_id)
-      .where(project_id:, subject_id: Sequel.any_uuid(account_ids))
+      .where(project_id:, subject_id: account_ids)
       .order(:subject_id, :name)
       .select_hash_groups(:subject_id, :name)
   end

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -80,7 +80,7 @@ class Clover
           allowed_remove_tags = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:remove").to_hash(:name)
           project_account_ids = @project
             .accounts_dataset
-            .where(Sequel[:accounts][:id] => Sequel.any_uuid(account_ids))
+            .where(Sequel[:accounts][:id] => account_ids)
             .select_map(Sequel[:accounts][:id])
           subject_tag_map = SubjectTag.subject_id_map_for_project_and_accounts(@project.id, project_account_ids)
           project_account_ids.each do |account_id|

--- a/ubid.rb
+++ b/ubid.rb
@@ -189,7 +189,7 @@ class UBID
       ubid.start_with?("et") ? ApiKey : class_for_ubid(ubid)
     end.each do |model, model_uuids|
       next unless model
-      model.where(id: Sequel.any_uuid(model_uuids)).each do
+      model.where(id: model_uuids).each do
         uuids[it.id] = it
       end
     end

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -1,8 +1,8 @@
 <% @page_title = @ps[:name]
 
 perm_checks = {
-  "Firewall:view" => Firewall.where(id: Sequel.any_uuid(@ps[:firewalls].map { UBID.to_uuid(it[:id]) })),
-  "PrivateSubnet:view" => PrivateSubnet.where(id: Sequel.any_uuid(@connected_subnets.map { UBID.to_uuid(it[:id]) }))
+  "Firewall:view" => Firewall.where(id: @ps[:firewalls].map { UBID.to_uuid(it[:id]) }),
+  "PrivateSubnet:view" => PrivateSubnet.where(id: @connected_subnets.map { UBID.to_uuid(it[:id]) })
 }
 
 viewable_fws, viewable_subnets =


### PR DESCRIPTION
This addresses the issues caused by the merge of #2730 earlier today, and subsequent partial revert in #2763.

Reenable the automatic conversion of string value lists to text arrays only in development and when running frozen tests, and do it for all non-empty arrays, instead of the default of only arrays of 2 or more elements.

I do not feel comfortable enough to turn this on in production, since it will not catch places in the tests where we are only using empty arrays, but where the arrays will be non-empty in production.  I'm not sure we have that case, but since we don't have the tooling to ensure that, enabling this in production seems too risky.  Doing it only in the frozen tests is sufficient for now, since it will still result in the query parameterization log having consistent SQL. I'm also enabling it in development, because after enough time, if there are any issues that are not caught by the tests, they should occur in a developer's development environment, and once reported, they can be easily fixed.

Update the Sequel checkout to pull in support for automatically using correct array type when eager loading associations using join tables, and for supporting automatic conversion for arrays with 1 element.