### PR TITLE
Fix allocation for standard-gpu

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -72,7 +72,7 @@ module Scheduling::Allocator
       memory_gib_ratio = if arch_filter == "arm64"
         3.2
       elsif family == "standard-gpu"
-        10.68
+        5.34
       else
         8
       end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -916,7 +916,7 @@ RSpec.describe Al do
       vm = create_vm(family: "standard-gpu")
       req = create_req(vm, vol)
 
-      expect(req.memory_gib_for_cores(req.cores_for_vcpus(2))).to eq 10
+      expect(req.memory_gib_for_cores(req.cores_for_vcpus(1))).to eq 10
     end
 
     it "memory_gib_for_cores handles arm64" do


### PR DESCRIPTION
We used to allocate 32GB of memory for a standard-gpu VM with 6 vCPUs. PR https://github.com/ubicloud/ubicloud/pull/2713 effectively lead to doubling the requested memory during allocation. This commit halves the memory requested per core for the standard-gpu family.