### PR TITLE
Make sure allocated memory matches vm memory

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -210,10 +210,9 @@ module Scheduling::Allocator
       @candidate_host = candidate_host
       @request = request
       request_cores = request.cores_for_vcpus(candidate_host[:total_cpus] / candidate_host[:total_cores])
-      request_memory = request.memory_gib_for_cores(request_cores)
 
       @vm_host_allocations = [VmHostCpuAllocation.new(:used_cores, candidate_host[:total_cores], candidate_host[:used_cores], request_cores),
-        VmHostAllocation.new(:used_hugepages_1g, candidate_host[:total_hugepages_1g], candidate_host[:used_hugepages_1g], request_memory)]
+        VmHostAllocation.new(:used_hugepages_1g, candidate_host[:total_hugepages_1g], candidate_host[:used_hugepages_1g], request.memory_gib)]
       @device_allocations = [StorageAllocation.new(candidate_host, request)]
       @device_allocations << GpuAllocation.new(candidate_host, request) if request.gpu_count > 0
 


### PR DESCRIPTION
In https://github.com/ubicloud/ubicloud/pull/2666, the memory allocated for a vm is dynamically calculated and in some cases may differ from the vm's `memory_gib` property. In vm destroy, we return memory back to the host by consulting `vm.memory_gib`. That means if our calculation differs from `vm.memory_gib` we may leak memory. One instance where that calculation differs (2x higher than `vm.memory_gib`) is allocating a standard family vm on a GEX44 host.

This commit makes sure we allocate memory according `vm.memory_gib` for non-burstables.