### PR TITLE
Restrict GEX44 hosts to standard-gpu VMs

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -180,6 +180,7 @@ module Scheduling::Allocator
       ds = ds.exclude(Sequel[:vm_host][:id] => request.host_exclusion_filter) unless request.host_exclusion_filter.empty?
       ds = ds.where(location: request.location_filter) unless request.location_filter.empty?
       ds = ds.where(allocation_state: request.allocation_state_filter) unless request.allocation_state_filter.empty?
+      ds = ds.exclude(total_cores: 14, total_cpus: 14) unless request.family == "standard-gpu"
 
       # Emit the allocation query if the project is flagged for
       # diagnostics.

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -757,6 +757,7 @@ RSpec.describe Al do
       vmh.update(arch: "x64", total_dies: 1, total_sockets: 1, total_cpus: 14, total_cores: 14, used_cores: 2)
 
       vm = create_vm
+      vm.family = "standard-gpu"
       used_cores = vmh.used_cores
       described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
         {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
@@ -767,6 +768,17 @@ RSpec.describe Al do
       expect(vm.vcpus).to eq(2)
       expect(vm.cores).to eq(2)
       expect(used_cores + vm.cores).to eq(vmh.used_cores)
+    end
+
+    it "only allocates standard-gpu vms on GEX44 host" do
+      vmh = VmHost.first
+      vmh.update(arch: "x64", total_dies: 1, total_sockets: 1, total_cpus: 14, total_cores: 14, used_cores: 2)
+
+      vm = create_vm
+      expect {
+        described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
+          {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      }.to raise_error(RuntimeError, /no space left on any eligible host/)
     end
   end
 


### PR DESCRIPTION
Due to existing issues with allocating standard VMs on GEX44 hosts, we are reserving these hosts exclusively for standard-gpu VMs. Given the limited number of GEX44 hosts, this restriction should have little impact on the allocation of standard VMs.