### PR TITLE
Use post options for cli vm ssh/sftp/scp commands

### DIFF
--- a/cli-commands/vm.rb
+++ b/cli-commands/vm.rb
@@ -10,6 +10,12 @@ UbiRodish.on("vm") do
 
   args(2...)
 
+  post_options("ubi vm location-name/(vm-name|_vm-ubid) [options] subcommand [...]", key: :vm_ssh) do
+    on("-4", "--ip4", "use IPv4 address")
+    on("-6", "--ip6", "use IPv6 address")
+    on("-u", "--user user", "override username")
+  end
+
   run do |(vm_ref, *argv), opts, command|
     @location, @vm_name, extra = vm_ref.split("/", 3)
     raise Rodish::CommandFailure, "invalid vm reference, should be in location/(vm-name|_vm-ubid) format" if extra

--- a/cli-commands/vm/post/scp.rb
+++ b/cli-commands/vm/post/scp.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 UbiRodish.on("vm").run_on("scp") do
-  options("ubi vm location-name/(vm-name|_vm-ubid) scp [options] (local-path :remote-path|:remote-path local-path) [scp-options]", key: :vm_ssh, &UbiCli::SSHISH_OPTS)
+  skip_option_parsing
 
   args(2...)
 
-  run do |(path1, path2, *argv), opts|
+  run do |(*argv, path1, path2), opts|
     remote_path1 = path1[0] == ":"
     remote_path2 = path2[0] == ":"
 

--- a/cli-commands/vm/post/sftp.rb
+++ b/cli-commands/vm/post/sftp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiRodish.on("vm").run_on("sftp") do
-  options("ubi vm location-name/(vm-name|_vm-ubid) sftp [options] [-- sftp-options]", key: :vm_ssh, &UbiCli::SSHISH_OPTS)
+  skip_option_parsing
 
   args(0...)
 

--- a/cli-commands/vm/post/ssh.rb
+++ b/cli-commands/vm/post/ssh.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiRodish.on("vm").run_on("ssh") do
-  options("ubi vm location-name/(vm-name|_vm-ubid) ssh [options] [-- ssh-options --] [cmd [arg, ...]]", key: :vm_ssh, &UbiCli::SSHISH_OPTS)
+  skip_option_parsing
 
   args(0...)
 

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -7,12 +7,6 @@ class UbiCli
     [e.failure? ? 400 : 200, {"content-type" => "text/plain"}, [e.message]]
   end
 
-  SSHISH_OPTS = proc do
-    on("-4", "--ip4", "use IPv4 address")
-    on("-6", "--ip6", "use IPv6 address")
-    on("-u", "--user user", "override username")
-  end
-
   def initialize(env)
     @env = env
   end

--- a/spec/lib/rodish_spec.rb
+++ b/spec/lib/rodish_spec.rb
@@ -102,6 +102,16 @@ RSpec.describe Rodish do
         end
       end
 
+      on "l" do
+        skip_option_parsing
+
+        args(0...)
+
+        run do |argv|
+          push [:l, argv]
+        end
+      end
+
       run do
         push :empty
       end
@@ -160,6 +170,12 @@ RSpec.describe Rodish do
         expect(res).to eq [:top, [:g, "1"], nil, "2", :i]
         app.process(%w[g 1 -k 2 i k], context: res.clear)
         expect(res).to eq [:top, [:g, "1"], nil, "2", :k]
+      end
+
+      it "supports skipping option parsing" do
+        res = []
+        app.process(%w[l -A 1 b], context: res.clear)
+        expect(res).to eq [:top, [:l, %w[-A 1 b]]]
       end
 
       it "handles invalid subcommands dispatched to during run" do
@@ -238,7 +254,7 @@ RSpec.describe Rodish do
                   --version                    show program version
                   --help                       show program help
 
-          Subcommands: a c d e g
+          Subcommands: a c d e g l
         USAGE
       end
 
@@ -253,7 +269,7 @@ RSpec.describe Rodish do
                   --version                    show program version
                   --help                       show program help
 
-          Subcommands: a c d e g
+          Subcommands: a c d e g l
         USAGE
         expect(usages["a"]).to eq <<~USAGE
           Usage: example a [options] [subcommand [subcommand_options] [...]]

--- a/spec/routes/api/cli/vm/scp_spec.rb
+++ b/spec/routes/api/cli/vm/scp_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Clover, "cli vm scp" do
   end
 
   it "supports scp options" do
-    expect(cli_exec(["vm", @ref, "scp", ":remote", "local", "-A"])).to eq %w[scp -A -- ubi@[128:1234::2]:remote local]
+    expect(cli_exec(["vm", @ref, "scp", "-A", ":remote", "local"])).to eq %w[scp -A -- ubi@[128:1234::2]:remote local]
   end
 
   it "returns error if both files are local" do

--- a/spec/routes/api/cli/vm/sftp_spec.rb
+++ b/spec/routes/api/cli/vm/sftp_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe Clover, "cli vm sftp" do
   end
 
   it "supports sftp options" do
-    expect(cli_exec(["vm", @ref, "sftp", "--", "-A"])).to eq %w[sftp -A -- ubi@[128:1234::2]]
+    expect(cli_exec(["vm", @ref, "sftp", "-A"])).to eq %w[sftp -A -- ubi@[128:1234::2]]
   end
 end

--- a/spec/routes/api/cli/vm/ssh_spec.rb
+++ b/spec/routes/api/cli/vm/ssh_spec.rb
@@ -37,23 +37,23 @@ RSpec.describe Clover, "cli vm ssh" do
   end
 
   it "-4 option fails if VM has no IPv4 address" do
-    expect(cli(["vm", @ref, "ssh", "-4"], status: 400)).to eq "No valid IPv4 address for requested VM"
+    expect(cli(["vm", @ref, "-4", "ssh"], status: 400)).to eq "No valid IPv4 address for requested VM"
   end
 
   it "-4 option uses IPv4 even if connection is made via IPv6" do
     add_ipv4_to_vm(@vm, "128.0.0.1")
     @socket = UDPSocket.new(Socket::AF_INET6)
-    expect(cli_exec(["vm", @ref, "ssh", "-4"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128.0.0.1]
+    expect(cli_exec(["vm", @ref, "-4", "ssh"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128.0.0.1]
   end
 
   it "-6 option uses IPv6 even if connection is made via IPv4" do
     add_ipv4_to_vm(@vm, "128.0.0.1")
     @socket = UDPSocket.new(Socket::AF_INET)
-    expect(cli_exec(["vm", @ref, "ssh", "-6"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128:1234::2]
+    expect(cli_exec(["vm", @ref, "-6", "ssh"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128:1234::2]
   end
 
   it "-u option overrides user to connect with" do
-    expect(cli_exec(["vm", @ref, "ssh", "-ufoo"])).to eq %w[ssh -- foo@128:1234::2]
+    expect(cli_exec(["vm", @ref, "-ufoo", "ssh"])).to eq %w[ssh -- foo@128:1234::2]
   end
 
   it "handles ssh cmd without args" do
@@ -65,21 +65,21 @@ RSpec.describe Clover, "cli vm ssh" do
   end
 
   it "handles ssh cmd with options and without args" do
-    expect(cli_exec(["vm", @ref, "ssh", "--", "-A", "--"])).to eq %w[ssh -A -- ubi@128:1234::2]
+    expect(cli_exec(["vm", @ref, "ssh", "-A", "--"])).to eq %w[ssh -A -- ubi@128:1234::2]
   end
 
   it "handles ssh cmd with options and args" do
-    expect(cli_exec(["vm", @ref, "ssh", "--", "-A", "--", "uname", "-a"])).to eq %w[ssh -A -- ubi@128:1234::2 uname -a]
+    expect(cli_exec(["vm", @ref, "ssh", "-A", "--", "uname", "-a"])).to eq %w[ssh -A -- ubi@128:1234::2 uname -a]
   end
 
   it "handles multiple options" do
     add_ipv4_to_vm(@vm, "128.0.0.1")
-    expect(cli_exec(["vm", @ref, "ssh", "-6u", "foo"])).to eq %w[ssh -- foo@128:1234::2]
+    expect(cli_exec(["vm", @ref, "-6u", "foo", "ssh"])).to eq %w[ssh -- foo@128:1234::2]
   end
 
   it "handles invalid vm reference" do
-    expect(cli(["vm", "#{@vm.display_location}/foo", "ssh", "-4"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
-    expect(cli(["vm", "foo/#{@vm.name}", "ssh", "-4"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
-    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh", "-4"], status: 400)).to eq "invalid vm reference, should be in location/(vm-name|_vm-ubid) format"
+    expect(cli(["vm", "#{@vm.display_location}/foo", "ssh"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
+    expect(cli(["vm", "foo/#{@vm.name}", "ssh"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
+    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh"], status: 400)).to eq "invalid vm reference, should be in location/(vm-name|_vm-ubid) format"
   end
 end


### PR DESCRIPTION
This changes the commands to use the following formats:
    
```
      vm location/vm-name -4 ssh cmd
      vm location/vm-name -6 sftp -A
      vm location/vm-name -u username scp -r local-path :remote-path
      vm location/vm-name ssh -A -- cmd
      vm location/vm-name ssh -A --
```

The `--` is still needed for ssh with ssh options to separate ssh options from arguments, but otherwise I think this makes the commands simpler and more in line with the standard ssh/sftp/scp behavior.

The first two commits add the necessary support to Rodish, and the third uses the support to update the commands.