### PR TITLE
Remove unnecessary transactions in progs

### DIFF
--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -103,20 +103,16 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
 
   label def destroy
     register_deadline(nil, 10 * 60)
-    DB.transaction do
-      decr_destroy
-      minio_cluster.pools.each(&:incr_destroy)
-    end
+    decr_destroy
+    minio_cluster.pools.each(&:incr_destroy)
     hop_wait_pools_destroyed
   end
 
   label def wait_pools_destroyed
     nap 10 unless minio_cluster.pools.empty?
-    DB.transaction do
-      minio_cluster.private_subnet.firewalls.map(&:destroy)
-      minio_cluster.private_subnet.incr_destroy
-      minio_cluster.destroy
-    end
+    minio_cluster.private_subnet.firewalls.map(&:destroy)
+    minio_cluster.private_subnet.incr_destroy
+    minio_cluster.destroy
 
     pop "destroyed"
   end

--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -69,9 +69,7 @@ class Prog::Minio::MinioPoolNexus < Prog::Base
   label def destroy
     register_deadline(nil, 10 * 60)
     decr_destroy
-    DB.transaction do
-      minio_pool.servers.each(&:incr_destroy)
-    end
+    minio_pool.servers.each(&:incr_destroy)
 
     hop_wait_servers_destroyed
   end

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -179,14 +179,12 @@ class Prog::Minio::MinioServerNexus < Prog::Base
 
   label def destroy
     register_deadline(nil, 10 * 60)
-    DB.transaction do
-      decr_destroy
-      minio_server.cluster.dns_zone&.delete_record(record_name: cluster.hostname, type: "A", data: vm.ephemeral_net4&.to_s)
-      minio_server.vm.sshable.destroy
-      minio_server.vm.nics.each { _1.incr_destroy }
-      minio_server.vm.incr_destroy
-      minio_server.destroy
-    end
+    decr_destroy
+    minio_server.cluster.dns_zone&.delete_record(record_name: cluster.hostname, type: "A", data: vm.ephemeral_net4&.to_s)
+    minio_server.vm.sshable.destroy
+    minio_server.vm.nics.each { _1.incr_destroy }
+    minio_server.vm.incr_destroy
+    minio_server.destroy
 
     pop "minio server destroyed"
   end

--- a/prog/rotate_storage_kek.rb
+++ b/prog/rotate_storage_kek.rb
@@ -17,16 +17,14 @@ class Prog::RotateStorageKek < Prog::Base
     key_wrapping_iv = cipher.random_iv
     auth_data = vm_storage_volume.device_id
 
-    DB.transaction do
-      key_encryption_key = StorageKeyEncryptionKey.create(
-        algorithm: key_wrapping_algorithm,
-        key: Base64.encode64(key_wrapping_key),
-        init_vector: Base64.encode64(key_wrapping_iv),
-        auth_data: auth_data
-      )
+    key_encryption_key = StorageKeyEncryptionKey.create(
+      algorithm: key_wrapping_algorithm,
+      key: Base64.encode64(key_wrapping_key),
+      init_vector: Base64.encode64(key_wrapping_iv),
+      auth_data: auth_data
+    )
 
-      vm_storage_volume.update({key_encryption_key_2_id: key_encryption_key.id})
-    end
+    vm_storage_volume.update({key_encryption_key_2_id: key_encryption_key.id})
 
     hop_install
   end


### PR DESCRIPTION
We already run the prog labels in a DB transaction when we call `strand.run`, so there's no need to wrap them in another transaction.

We only use DB transactions in the assemble function in progs because they might be called from web routes or pry, so they aren't wrapped by a tra transaction all the time.