### PR TITLE
Disable the RSpec/MultipleMemoizedHelpers cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,7 +80,7 @@ RSpec/SpecFilePathFormat:
     - 'spec/routes/**/*.rb'
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 6
+  Enabled: false
 
 Sequel/IrreversibleMigration:
   Enabled: false


### PR DESCRIPTION
Disabled the RSpec/MultipleMemoizedHelpers cop to allow flexibility in using multiple `let` statements in tests. From time to time we hit the limit and increased it to workaround the limit.