### PR TITLE
Make token creation for github repository idempotent

### DIFF
--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -66,6 +66,9 @@ class GithubRepository < Sequel::Model
 
   def setup_blob_storage
     DB.transaction do
+      lock!
+      return if access_key && secret_key
+
       begin
         admin_client.create_bucket({
           bucket: bucket_name,


### PR DESCRIPTION
If concurrent cache requests come for the same repository while setting it ip, multiple tokens can be created. It causes tokens to accumulate on E2E tests. Making it idempotent by creating them only if bucket is created before.