### PR TITLE
Fixing issues in allocator when using slices

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -72,7 +72,7 @@ module Scheduling::Allocator
       memory_gib_ratio = if arch_filter == "arm64"
         3.2
       elsif family == "standard-gpu"
-        5.34
+        10.68
       else
         8
       end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -998,7 +998,7 @@ RSpec.describe Al do
       vm = create_vm(family: "standard-gpu")
       req = create_req(vm, vol)
 
-      expect(req.memory_gib_for_cores(req.cores_for_vcpus(1))).to eq 10
+      expect(req.memory_gib_for_cores(req.cores_for_vcpus(2))).to eq 10
     end
 
     it "memory_gib_for_cores handles arm64" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -249,6 +249,21 @@ RSpec.configure do |config|
     Vm.create(**args)
   end
 
+  def create_vm_from_size(size, arch, **args)
+    vm_size = Validation.validate_vm_size(size, arch)
+    args_from_size = {
+      family: vm_size.family,
+      vcpus: vm_size.vcpus,
+      cpu_percent_limit: vm_size.cpu_percent_limit,
+      cpu_burst_percent_limit: vm_size.cpu_burst_percent_limit,
+      memory_gib: vm_size.memory_gib,
+      arch: arch
+    }
+
+    args = args_from_size.merge(args)
+    create_vm(**args)
+  end
+
   def add_ipv4_to_vm(vm, ipv4)
     host = VmHost.new_with_id(allocation_state: "accepting", location: "hetzner-fsn1", total_cores: 10, used_cores: 3)
     Sshable.create(id: host.id)


### PR DESCRIPTION
**Separating slice and no-slice VMs on hosts**
The allocator decided if the VM should be created with a slice or without a slice based on the host's accept_slices flag. However that logic only applied when the project had `use_slices_for_allocation` flag set to `true` When the project flag was false any host could be picked, and a VM with no slice was created. The result was a mix of VMs in-slices and VMs with no-slices on the same host, if the host had `accept_slices=true` flag. On hosts with `accept_slices=false` no slices were created.

This fix adds an extra constraint to not allow placement of no-slice VMs on hosts set with `accept_slices=true` from projects that do not want slices. It also sets a preference to pick a host that accepts slices for projects that do want that.

Tests added to cover all those cases explicitly.


**Fix for GEX44 memory computation**
Previous commit introduced a couple of problems in this area, for GEX44 hosts:
    - the amount of memory calculated for a VM/slice was based on number of cores and assumed 2:1 ratio of cpus to cores for stanard-gpu VM. It should be 1:1 ratio
    - the memory allocated was computed in the allocator but the memory freed was taken from VmSize structure, resulting in different values on GEX44 hosts.
    
This commit fixes those problems.
    - It computes the amount of memory based on vcpus, just like VmSize
    - The update to the host is based on request.memory_gib value when not creating a slice
    - The update to the host is based on the amount allocated for a slice when using slices
    
Added multiple tests to cover all those cases. Also reverted temporary fixes that Ben did to mitigate this issue.