### PR TITLE
Add cli pg commands

### DIFF
--- a/bin/ubi
+++ b/bin/ubi
@@ -15,7 +15,7 @@ unless (token = ENV["UBI_TOKEN"])
 end
 
 url = ENV["UBI_URL"] || "http://api.localhost:9292/cli"
-allowed_progs = %w[ssh scp sftp psql]
+allowed_progs = %w[ssh scp sftp psql pg_dump pg_dumpall]
 
 get_prog = lambda do |prog|
   return unless allowed_progs.include?(prog)

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg") do
+  # :nocov:
+  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+    autoload_post_subcommand_dir("cli-commands/pg/post")
+  end
+  # :nocov:
+
+  args(2...)
+
+  run do |(pg_ref, *argv), opts, command|
+    @location, @pg_name, extra = pg_ref.split("/", 3)
+    raise Rodish::CommandFailure, "invalid pg reference, should be in location/(pg-name|_pg-ubid) format" if extra
+    command.run(self, opts, argv)
+  end
+end

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -3,6 +3,7 @@
 UbiRodish.on("pg") do
   # :nocov:
   unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+    autoload_subcommand_dir("cli-commands/pg")
     autoload_post_subcommand_dir("cli-commands/pg/post")
   end
   # :nocov:

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -1,18 +1,3 @@
 # frozen_string_literal: true
 
-UbiRodish.on("pg") do
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/pg")
-    autoload_post_subcommand_dir("cli-commands/pg/post")
-  end
-  # :nocov:
-
-  args(2...)
-
-  run do |(pg_ref, *argv), opts, command|
-    @location, @pg_name, extra = pg_ref.split("/", 3)
-    raise Rodish::CommandFailure, "invalid pg reference, should be in location/(pg-name|_pg-ubid) format" if extra
-    command.run(self, opts, argv)
-  end
-end
+UbiCli.base("pg")

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 
-UbiCli.base("pg")
+UbiCli.base("pg") do
+  post_options("ubi pg location-name/(vm-name|_vm-ubid) [options] subcommand [...]", key: :pg_psql) do
+    on("-d", "--dbname=name", "override database name")
+    on("-U", "--username=name", "override username")
+  end
+end

--- a/cli-commands/pg/list.rb
+++ b/cli-commands/pg/list.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg", "list") do
+  fields = %w[location name id version flavor].freeze.each(&:freeze)
+
+  options("ubi pg list [options]", key: :pg_list) do
+    on("-f", "--fields=fields", "show specific fields (default: #{fields.join(",")})")
+    on("-l", "--location=location", "only show PostgreSQL databases in given location")
+    on("-N", "--no-headers", "do not show headers")
+  end
+
+  run do |opts|
+    pg_opts = opts[:pg_list]
+    path = if pg_opts && (location = pg_opts[:location])
+      if LocationNameConverter.to_internal_name(location)
+        "location/#{location}/postgres"
+      else
+        raise Rodish::CommandFailure, "invalid location provided in pg list -l option"
+      end
+    else
+      "postgres"
+    end
+
+    get(project_path(path)) do |data|
+      keys = fields
+      headers = true
+
+      if (opts = opts[:pg_list])
+        keys = check_fields(opts[:fields], fields, "pg list -f option")
+        headers = false if opts[:"no-headers"] == false
+      end
+
+      format_rows(keys, data["items"], headers:)
+    end
+  end
+end

--- a/cli-commands/pg/list.rb
+++ b/cli-commands/pg/list.rb
@@ -1,36 +1,3 @@
 # frozen_string_literal: true
 
-UbiRodish.on("pg", "list") do
-  fields = %w[location name id version flavor].freeze.each(&:freeze)
-
-  options("ubi pg list [options]", key: :pg_list) do
-    on("-f", "--fields=fields", "show specific fields (default: #{fields.join(",")})")
-    on("-l", "--location=location", "only show PostgreSQL databases in given location")
-    on("-N", "--no-headers", "do not show headers")
-  end
-
-  run do |opts|
-    pg_opts = opts[:pg_list]
-    path = if pg_opts && (location = pg_opts[:location])
-      if LocationNameConverter.to_internal_name(location)
-        "location/#{location}/postgres"
-      else
-        raise Rodish::CommandFailure, "invalid location provided in pg list -l option"
-      end
-    else
-      "postgres"
-    end
-
-    get(project_path(path)) do |data|
-      keys = fields
-      headers = true
-
-      if (opts = opts[:pg_list])
-        keys = check_fields(opts[:fields], fields, "pg list -f option")
-        headers = false if opts[:"no-headers"] == false
-      end
-
-      format_rows(keys, data["items"], headers:)
-    end
-  end
-end
+UbiCli.list("pg", "PostgreSQL databases", %w[location name id version flavor], fragment: "postgres")

--- a/cli-commands/pg/post/add-firewall-rule.rb
+++ b/cli-commands/pg/post/add-firewall-rule.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_is("add-firewall-rule", args: 1, invalid_args_message: "cidr is required") do |cidr|
+  post(project_path("location/#{@location}/postgres/#{@name}/firewall-rule"), "cidr" => cidr) do |data|
+    ["Firewall rule added to PostgreSQL database.\n  rule id: #{data["id"]}, cidr: #{data["cidr"]}"]
+  end
+end

--- a/cli-commands/pg/post/add-metric-destination.rb
+++ b/cli-commands/pg/post/add-metric-destination.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_is("add-metric-destination", args: 3, invalid_args_message: "username, password, and url are required") do |username, password, url|
+  params = {
+    "username" => username,
+    "password" => password,
+    "url" => url
+  }
+  post(project_path("location/#{@location}/postgres/#{@name}/metric-destination"), params) do |data|
+    body = []
+    body << "Metric destination added to PostgreSQL database.\n"
+    body << "Current metric destinations:\n"
+    data["metric_destinations"].each_with_index do |md, i|
+      body << "  " << (i + 1).to_s << ": " << md["id"] << "  " << md["username"].to_s << "  " << md["url"] << "\n"
+    end
+    body
+  end
+end

--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -2,7 +2,7 @@
 
 UbiRodish.on("pg").run_on("create") do
   options("ubi pg location/pg_name create [options]", key: :pg_create) do
-    on("-f", "--flavor=type", "flavor (standard, paradedb, latern)")
+    on("-f", "--flavor=type", "flavor (standard, paradedb, lantern)")
     on("-h", "--ha_type=type", "replication type (none, async, sync)")
     on("-s", "--size=size", "server size (standard-{2,4,8,16,30,60})")
     on("-S", "--storage_size=size", "storage size GB (64, 128, 256)")

--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_on("create") do
+  options("ubi pg location/pg_name create [options]", key: :pg_create) do
+    on("-f", "--flavor=type", "flavor (standard, paradedb, latern)")
+    on("-h", "--ha_type=type", "replication type (none, async, sync)")
+    on("-s", "--size=size", "server size (standard-{2,4,8,16,30,60})")
+    on("-S", "--storage_size=size", "storage size GB (64, 128, 256)")
+    on("-v", "--version=version", "PostgreSQL version (16, 17)")
+  end
+
+  run do |opts|
+    params = opts[:pg_create]&.transform_keys(&:to_s) || {}
+    params["size"] ||= "standard-2"
+    post(project_path("location/#{@location}/postgres/#{@pg_name}"), params) do |data|
+      ["PostgreSQL database created with id: #{data["id"]}"]
+    end
+  end
+end

--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -12,7 +12,7 @@ UbiRodish.on("pg").run_on("create") do
   run do |opts|
     params = opts[:pg_create]&.transform_keys(&:to_s) || {}
     params["size"] ||= "standard-2"
-    post(project_path("location/#{@location}/postgres/#{@pg_name}"), params) do |data|
+    post(project_path("location/#{@location}/postgres/#{@name}"), params) do |data|
       ["PostgreSQL database created with id: #{data["id"]}"]
     end
   end

--- a/cli-commands/pg/post/delete-firewall-rule.rb
+++ b/cli-commands/pg/post/delete-firewall-rule.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_is("delete-firewall-rule", args: 1, invalid_args_message: "rule id is required") do |ubid|
+  if ubid.include?("/")
+    raise Rodish::CommandFailure, "invalid firewall rule id format"
+  end
+
+  delete(project_path("location/#{@location}/postgres/#{@name}/firewall-rule/#{ubid}")) do |data|
+    ["Firewall rule, if it exists, has been scheduled for deletion"]
+  end
+end

--- a/cli-commands/pg/post/delete-metric-destination.rb
+++ b/cli-commands/pg/post/delete-metric-destination.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_is("delete-metric-destination", args: 1, invalid_args_message: "metric destination id is required") do |ubid|
+  if ubid.include?("/")
+    raise Rodish::CommandFailure, "invalid metric destination id format"
+  end
+
+  delete(project_path("location/#{@location}/postgres/#{@name}/metric-destination/#{ubid}")) do |data|
+    ["Metric destination, if it exists, has been scheduled for deletion"]
+  end
+end

--- a/cli-commands/pg/post/destroy.rb
+++ b/cli-commands/pg/post/destroy.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.destroy("pg", "PostgreSQL database", fragment: "postgres")

--- a/cli-commands/pg/post/failover.rb
+++ b/cli-commands/pg/post/failover.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_is("failover") do
+  post(project_path("location/#{@location}/postgres/#{@name}/failover")) do |data|
+    ["Failover initiated for PostgreSQL database with id: #{data["id"]}"]
+  end
+end

--- a/cli-commands/pg/post/pg_dump.rb
+++ b/cli-commands/pg/post/pg_dump.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.pg_cmd("pg_dump")

--- a/cli-commands/pg/post/pg_dumpall.rb
+++ b/cli-commands/pg/post/pg_dumpall.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.pg_cmd("pg_dumpall")

--- a/cli-commands/pg/post/psql.rb
+++ b/cli-commands/pg/post/psql.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.pg_cmd("psql")

--- a/cli-commands/pg/post/reset-superuser-password.rb
+++ b/cli-commands/pg/post/reset-superuser-password.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_is("reset-superuser-password", args: 1, invalid_args_message: "password is required") do |password|
+  post(project_path("location/#{@location}/postgres/#{@name}/reset-superuser-password"), "password" => password) do |data|
+    ["Superuser password reset scheduled for PostgreSQL database with id: #{data["id"]}"]
+  end
+end

--- a/cli-commands/pg/post/restore.rb
+++ b/cli-commands/pg/post/restore.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_is("restore", args: 2, invalid_args_message: "name and restore target are required") do |name, restore_target|
+  params = {
+    "name" => name,
+    "restore_target" => restore_target
+  }
+  post(project_path("location/#{@location}/postgres/#{@name}/restore"), params) do |data|
+    ["Restored PostgreSQL database scheduled for creation with id: #{data["id"]}"]
+  end
+end

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+UbiRodish.on("pg").run_on("show") do
+  fields = %w[id name state location vm_size storage_size_gib version ha_type flavor connection_string primary earliest_restore_time latest_restore_time firewall_rules metric_destinations ca_certificates].freeze.each(&:freeze)
+
+  options("ubi pg location/(vm-name|_vm-ubid) show [options]", key: :pg_show) do
+    on("-f", "--fields=fields", "show specific fields (default: #{fields.join(",")})")
+  end
+
+  run do |opts|
+    get(project_path("location/#{@location}/postgres/#{@pg_name}")) do |data|
+      keys = fields
+
+      if (opts = opts[:pg_show])
+        keys = check_fields(opts[:fields], fields, "pg show -f option")
+      end
+
+      body = []
+
+      keys.each do |key|
+        case key
+        when "firewall_rules"
+          body << "firewall rules:\n"
+          data[key].each_with_index do |rule, i|
+            body << "  " << (i + 1).to_s << ": " << rule["id"] << "  " << rule["cidr"].to_s << "\n"
+          end
+        when "metric_destinations"
+          body << "metric destinations:\n"
+          data[key].each_with_index do |md, i|
+            body << "  " << (i + 1).to_s << ": " << md["id"] << "  " << md["username"].to_s << "  " << md["url"] << "\n"
+          end
+        when "ca_certificates"
+          body << "CA certificates:\n" << data[key].to_s << "\n"
+        else
+          body << key << ": " << data[key].to_s << "\n"
+        end
+      end
+
+      body
+    end
+  end
+end

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -8,7 +8,7 @@ UbiRodish.on("pg").run_on("show") do
   end
 
   run do |opts|
-    get(project_path("location/#{@location}/postgres/#{@pg_name}")) do |data|
+    get(project_path("location/#{@location}/postgres/#{@name}")) do |data|
       keys = fields
 
       if (opts = opts[:pg_show])

--- a/cli-commands/vm.rb
+++ b/cli-commands/vm.rb
@@ -1,24 +1,9 @@
 # frozen_string_literal: true
 
-UbiRodish.on("vm") do
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/vm")
-    autoload_post_subcommand_dir("cli-commands/vm/post")
-  end
-  # :nocov:
-
-  args(2...)
-
+UbiCli.base("vm") do
   post_options("ubi vm location-name/(vm-name|_vm-ubid) [options] subcommand [...]", key: :vm_ssh) do
     on("-4", "--ip4", "use IPv4 address")
     on("-6", "--ip6", "use IPv6 address")
     on("-u", "--user user", "override username")
-  end
-
-  run do |(vm_ref, *argv), opts, command|
-    @location, @vm_name, extra = vm_ref.split("/", 3)
-    raise Rodish::CommandFailure, "invalid vm reference, should be in location/(vm-name|_vm-ubid) format" if extra
-    command.run(self, opts, argv)
   end
 end

--- a/cli-commands/vm.rb
+++ b/cli-commands/vm.rb
@@ -10,6 +10,12 @@ UbiRodish.on("vm") do
 
   args(2...)
 
+  post_options("ubi vm location-name/(vm-name|_vm-ubid) [options] subcommand [...]", key: :vm_ssh) do
+    on("-4", "--ip4", "use IPv4 address")
+    on("-6", "--ip6", "use IPv6 address")
+    on("-u", "--user user", "override username")
+  end
+
   run do |(vm_ref, *argv), opts, command|
     @location, @vm_name, extra = vm_ref.split("/", 3)
     raise Rodish::CommandFailure, "invalid vm reference, should be in location/(vm-name|_vm-ubid) format" if extra

--- a/cli-commands/vm/list.rb
+++ b/cli-commands/vm/list.rb
@@ -1,36 +1,3 @@
 # frozen_string_literal: true
 
-UbiRodish.on("vm", "list") do
-  fields = %w[location name id ip4 ip6].freeze.each(&:freeze)
-
-  options("ubi vm list [options]", key: :vm_list) do
-    on("-f", "--fields=fields", "show specific fields (default: #{fields.join(",")})")
-    on("-l", "--location=location", "only show VMs in given location")
-    on("-N", "--no-headers", "do not show headers")
-  end
-
-  run do |opts|
-    vm_opts = opts[:vm_list]
-    path = if vm_opts && (location = vm_opts[:location])
-      if LocationNameConverter.to_internal_name(location)
-        "location/#{location}/vm"
-      else
-        raise Rodish::CommandFailure, "invalid location provided in vm list -l option"
-      end
-    else
-      "vm"
-    end
-
-    get(project_path(path)) do |data|
-      keys = fields
-      headers = true
-
-      if (opts = opts[:vm_list])
-        keys = check_fields(opts[:fields], fields, "vm list -f option")
-        headers = false if opts[:"no-headers"] == false
-      end
-
-      format_rows(keys, data["items"], headers:)
-    end
-  end
-end
+UbiCli.list("vm", "VMs", %w[location name id ip4 ip6])

--- a/cli-commands/vm/list.rb
+++ b/cli-commands/vm/list.rb
@@ -24,22 +24,9 @@ UbiRodish.on("vm", "list") do
     get(project_path(path)) do |data|
       keys = fields
       headers = true
+
       if (opts = opts[:vm_list])
-        if opts[:fields]
-          keys = opts[:fields].split(",")
-          if keys.empty?
-            raise Rodish::CommandFailure, "no fields given in vm list -f option"
-          end
-          unless keys.size == keys.uniq.size
-            raise Rodish::CommandFailure, "duplicate field(s) in vm list -f option"
-          end
-
-          invalid_keys = keys - fields
-          unless invalid_keys.empty?
-            raise Rodish::CommandFailure, "invalid field(s) given vm list -f option: #{invalid_keys.join(",")}"
-          end
-        end
-
+        keys = check_fields(opts[:fields], fields, "vm list -f option")
         headers = false if opts[:"no-headers"] == false
       end
 

--- a/cli-commands/vm/list.rb
+++ b/cli-commands/vm/list.rb
@@ -4,12 +4,24 @@ UbiRodish.on("vm", "list") do
   fields = %w[location name id ip4 ip6].freeze.each(&:freeze)
 
   options("ubi vm list [options]", key: :vm_list) do
-    on("-N", "--no-headers", "do not show headers")
     on("-f", "--fields=fields", "show specific fields (default: #{fields.join(",")})")
+    on("-l", "--location=location", "only show VMs in given location")
+    on("-N", "--no-headers", "do not show headers")
   end
 
   run do |opts|
-    get(project_path("vm")) do |data|
+    vm_opts = opts[:vm_list]
+    path = if vm_opts && (location = vm_opts[:location])
+      if LocationNameConverter.to_internal_name(location)
+        "location/#{location}/vm"
+      else
+        raise Rodish::CommandFailure, "invalid location provided in vm list -l option"
+      end
+    else
+      "vm"
+    end
+
+    get(project_path(path)) do |data|
       keys = fields
       headers = true
       if (opts = opts[:vm_list])

--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+UbiRodish.on("vm").run_on("create") do
+  options("ubi vm location/vm_name create [options] public_key", key: :vm_create) do
+    on("-6", "--ipv6-only", "do not enable IPv4")
+    on("-b", "--boot_image=image_name", "boot image (ubuntu-noble,ubuntu-jammy,debian-12,almalinux-9)")
+    on("-p", "--private_subnet_id=id", "place VM into specific private subnet")
+    on("-s", "--size=size", "server size (standard-{2,4,8,16,30,60})")
+    on("-S", "--storage_size=size", "storage size (40, 80)")
+    on("-u", "--unix_user=username", "username (default: ubi)")
+  end
+
+  args(1, invalid_args_message: "public_key is required")
+
+  run do |public_key, opts|
+    params = opts[:vm_create]&.transform_keys(&:to_s) || {}
+    unless params.delete("ipv6-only")
+      params["enable_ip4"] = "1"
+    end
+    params["public_key"] = public_key
+    post(project_path("location/#{@location}/vm/#{@vm_name}"), params) do |data|
+      ["VM created with id: #{data["id"]}"]
+    end
+  end
+end

--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -18,7 +18,7 @@ UbiRodish.on("vm").run_on("create") do
       params["enable_ip4"] = "1"
     end
     params["public_key"] = public_key
-    post(project_path("location/#{@location}/vm/#{@vm_name}"), params) do |data|
+    post(project_path("location/#{@location}/vm/#{@name}"), params) do |data|
       ["VM created with id: #{data["id"]}"]
     end
   end

--- a/cli-commands/vm/post/destroy.rb
+++ b/cli-commands/vm/post/destroy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+UbiRodish.on("vm").run_is("destroy") do
+  delete(project_path("location/#{@location}/vm/#{@vm_name}")) do |_, res|
+    ["VM, if it exists, is now scheduled for destruction"]
+  end
+end

--- a/cli-commands/vm/post/destroy.rb
+++ b/cli-commands/vm/post/destroy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiRodish.on("vm").run_is("destroy") do
-  delete(project_path("location/#{@location}/vm/#{@vm_name}")) do |_, res|
+  delete(project_path("location/#{@location}/vm/#{@name}")) do |_, res|
     ["VM, if it exists, is now scheduled for destruction"]
   end
 end

--- a/cli-commands/vm/post/destroy.rb
+++ b/cli-commands/vm/post/destroy.rb
@@ -1,7 +1,3 @@
 # frozen_string_literal: true
 
-UbiRodish.on("vm").run_is("destroy") do
-  delete(project_path("location/#{@location}/vm/#{@name}")) do |_, res|
-    ["VM, if it exists, is now scheduled for destruction"]
-  end
-end
+UbiCli.destroy("vm", "VM")

--- a/cli-commands/vm/post/scp.rb
+++ b/cli-commands/vm/post/scp.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 UbiRodish.on("vm").run_on("scp") do
-  options("ubi vm location-name/(vm-name|_vm-ubid) scp [options] (local-path :remote-path|:remote-path local-path) [scp-options]", key: :vm_ssh, &UbiCli::SSHISH_OPTS)
+  skip_option_parsing
 
   args(2...)
 
-  run do |(path1, path2, *argv), opts|
+  run do |(*argv, path1, path2), opts|
     remote_path1 = path1[0] == ":"
     remote_path2 = path2[0] == ":"
 

--- a/cli-commands/vm/post/sftp.rb
+++ b/cli-commands/vm/post/sftp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiRodish.on("vm").run_on("sftp") do
-  options("ubi vm location-name/(vm-name|_vm-ubid) sftp [options] [-- sftp-options]", key: :vm_ssh, &UbiCli::SSHISH_OPTS)
+  skip_option_parsing
 
   args(0...)
 

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+UbiRodish.on("vm").run_on("show") do
+  fields = %w[id name state location size unix_user storage_size_gib ip6 ip4_enabled ip4 private_ipv4 private_ipv6 subnet firewalls].freeze.each(&:freeze)
+  firewall_fields = %w[id name description location path firewall_rules].freeze.each(&:freeze)
+  firewall_rule_fields = %w[id cidr port_range].freeze.each(&:freeze)
+
+  options("ubi vm location/(vm-name|_vm-ubid) show [options]", key: :vm_show) do
+    on("-f", "--fields=fields", "show specific fields (default: #{fields.join(",")})")
+    on("-r", "--firewall_rule_fields=fields", "show specific fields (default: #{firewall_rule_fields.join(",")})")
+    on("-w", "--firewall_fields=fields", "show specific fields (default: #{firewall_fields.join(",")})")
+  end
+
+  run do |opts|
+    get(project_path("location/#{@location}/vm/#{@vm_name}")) do |data|
+      keys = fields
+      firewall_keys = firewall_fields
+      firewall_rule_keys = firewall_rule_fields
+
+      if (opts = opts[:vm_show])
+        keys = check_fields(opts[:fields], fields, "vm show -f option")
+        firewall_keys = check_fields(opts[:firewall_fields], firewall_fields, "vm show -w option")
+        firewall_rule_keys = check_fields(opts[:firewall_rule_fields], firewall_rule_fields, "vm show -r option")
+      end
+
+      body = []
+
+      keys.each do |key|
+        if key == "firewalls"
+          data[key].each_with_index do |firewall, i|
+            body << "firewall " << (i + 1).to_s << ":\n"
+            firewall_keys.each do |fw_key|
+              if fw_key == "firewall_rules"
+                firewall[fw_key].each_with_index do |rule, i|
+                  body << "  rule " << (i + 1).to_s << ": "
+                  firewall_rule_keys.each do |fwr_key|
+                    body << rule[fwr_key].to_s << "  "
+                  end
+                  body << "\n"
+                end
+              else
+                body << "  " << fw_key << ": " << firewall[fw_key].to_s << "\n"
+              end
+            end
+          end
+        else
+          body << key << ": " << data[key].to_s << "\n"
+        end
+      end
+
+      body
+    end
+  end
+end

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -12,7 +12,7 @@ UbiRodish.on("vm").run_on("show") do
   end
 
   run do |opts|
-    get(project_path("location/#{@location}/vm/#{@vm_name}")) do |data|
+    get(project_path("location/#{@location}/vm/#{@name}")) do |data|
       keys = fields
       firewall_keys = firewall_fields
       firewall_rule_keys = firewall_rule_fields

--- a/cli-commands/vm/post/ssh.rb
+++ b/cli-commands/vm/post/ssh.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiRodish.on("vm").run_on("ssh") do
-  options("ubi vm location-name/(vm-name|_vm-ubid) ssh [options] [-- ssh-options --] [cmd [arg, ...]]", key: :vm_ssh, &UbiCli::SSHISH_OPTS)
+  skip_option_parsing
 
   args(0...)
 

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -7,12 +7,6 @@ class UbiCli
     [e.failure? ? 400 : 200, {"content-type" => "text/plain"}, [e.message]]
   end
 
-  SSHISH_OPTS = proc do
-    on("-4", "--ip4", "use IPv4 address")
-    on("-6", "--ip6", "use IPv6 address")
-    on("-u", "--user user", "override username")
-  end
-
   def initialize(env)
     @env = env
   end

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -66,6 +66,14 @@ class UbiCli
     end
   end
 
+  def self.destroy(cmd, label, fragment: cmd)
+    UbiRodish.on(cmd).run_is("destroy") do
+      delete(project_path("location/#{@location}/#{fragment}/#{@name}")) do |_, res|
+        ["#{label}, if it exists, is now scheduled for destruction"]
+      end
+    end
+  end
+
   def initialize(env)
     @env = env
   end

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -278,7 +278,7 @@ class UbiCli
         error_message << "\nDetails: #{error}"
         if (details = parsed_body.dig("error", "details"))
           details.each do |k, v|
-            error_message << "\n  " << k << ": " << v
+            error_message << "\n  " << k.to_s << ": " << v.to_s
           end
         end
       end

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -46,6 +46,28 @@ class UbiCli
     end
   end
 
+  def check_fields(given_fields, allowed_fields, option_name)
+    if given_fields
+      keys = given_fields.split(",")
+
+      if keys.empty?
+        raise Rodish::CommandFailure, "no fields given in #{option_name}"
+      end
+      unless keys.size == keys.uniq.size
+        raise Rodish::CommandFailure, "duplicate field(s) in #{option_name}"
+      end
+
+      invalid_keys = keys - allowed_fields
+      unless invalid_keys.empty?
+        raise Rodish::CommandFailure, "invalid field(s) given in #{option_name}: #{invalid_keys.join(",")}"
+      end
+
+      keys
+    else
+      allowed_fields
+    end
+  end
+
   def delete(path, params = {}, &block)
     _req(_req_env("DELETE", path, params), &block)
   end

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -21,8 +21,7 @@ class UbiCli
       instance_exec(&block) if block
 
       run do |(ref, *argv), opts, command|
-        @location, name, extra = ref.split("/", 3)
-        instance_variable_set(:"@#{cmd}_name", name)
+        @location, @name, extra = ref.split("/", 3)
         raise Rodish::CommandFailure, "invalid #{cmd} reference, should be in location/(#{cmd}-name|_#{cmd}-ubid) format" if extra
         command.run(self, opts, argv)
       end
@@ -76,7 +75,7 @@ class UbiCli
   end
 
   def handle_ssh(opts)
-    get(project_path("location/#{@location}/vm/#{@vm_name}")) do |data, res|
+    get(project_path("location/#{@location}/vm/#{@name}")) do |data, res|
       if (opts = opts[:vm_ssh])
         user = opts[:user]
         if opts[:ip4]

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -90,7 +90,7 @@ class UbiCli
     sizes = Hash.new(0)
     string_keys = keys.map(&:to_s)
     string_keys.each do |key|
-      sizes[key] = key.size
+      sizes[key] = headers ? key.size : 0
     end
     rows = rows.map do |row|
       row.transform_values(&:to_s)

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -719,21 +719,6 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
-  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/failover':
-    parameters:
-      - $ref: '#/components/parameters/project_id'
-      - $ref: '#/components/parameters/location'
-      - $ref: '#/components/parameters/postgres_database_name'
-    post:
-      operationId: failoverPostgresDatabaseWithName
-      summary: Failover a specific Postgres Database with name
-      responses:
-        '200':
-          $ref: '#/components/responses/PostgresDatabase'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/_{postgres_database_id}/failover':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -868,6 +853,21 @@ paths:
               schema:
                 type: string
                 format: binary
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/failover':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_name'
+    post:
+      operationId: failoverPostgresDatabaseWithName
+      summary: Failover a specific Postgres Database with name
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
         default:
           $ref: '#/components/responses/Error'
       tags:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -719,6 +719,21 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/failover':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_name'
+    post:
+      operationId: failoverPostgresDatabaseWithName
+      summary: Failover a specific Postgres Database with name
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/_{postgres_database_id}/failover':
     parameters:
       - $ref: '#/components/parameters/project_id'

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -819,6 +819,9 @@ paths:
                 storage_size:
                   description: Requested storage size in GiB
                   type: integer
+                version:
+                  description: PostgreSQL version
+                  type: string
               additionalProperties: false
               required:
                 - size

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -92,7 +92,7 @@ class Clover
           end
 
           if api?
-            Serializers::PostgresFirewallRule.serialize(firewall_rule, {detailed: true})
+            Serializers::PostgresFirewallRule.serialize(firewall_rule)
           else
             flash["notice"] = "Firewall rule is created"
             r.redirect "#{@project.path}#{pg.path}"

--- a/spec/lib/rodish_spec.rb
+++ b/spec/lib/rodish_spec.rb
@@ -102,6 +102,16 @@ RSpec.describe Rodish do
         end
       end
 
+      on "l" do
+        skip_option_parsing
+
+        args(0...)
+
+        run do |argv|
+          push [:l, argv]
+        end
+      end
+
       run do
         push :empty
       end
@@ -160,6 +170,12 @@ RSpec.describe Rodish do
         expect(res).to eq [:top, [:g, "1"], nil, "2", :i]
         app.process(%w[g 1 -k 2 i k], context: res.clear)
         expect(res).to eq [:top, [:g, "1"], nil, "2", :k]
+      end
+
+      it "supports skipping option parsing" do
+        res = []
+        app.process(%w[l -A 1 b], context: res.clear)
+        expect(res).to eq [:top, [:l, %w[-A 1 b]]]
       end
 
       it "handles invalid subcommands dispatched to during run" do
@@ -238,7 +254,7 @@ RSpec.describe Rodish do
                   --version                    show program version
                   --help                       show program help
 
-          Subcommands: a c d e g
+          Subcommands: a c d e g l
         USAGE
       end
 
@@ -253,7 +269,7 @@ RSpec.describe Rodish do
                   --version                    show program version
                   --help                       show program help
 
-          Subcommands: a c d e g
+          Subcommands: a c d e g l
         USAGE
         expect(usages["a"]).to eq <<~USAGE
           Usage: example a [options] [subcommand [subcommand_options] [...]]

--- a/spec/routes/api/cli/options_spec.rb
+++ b/spec/routes/api/cli/options_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Clover, "cli" do
               --version                    show program version
               --help                       show program help
 
-      Subcommands: vm
+      Subcommands: pg vm
     OUTPUT
   end
 
@@ -37,7 +37,7 @@ RSpec.describe Clover, "cli" do
               --version                    show program version
               --help                       show program help
 
-      Subcommands: vm
+      Subcommands: pg vm
     OUTPUT
   end
 end

--- a/spec/routes/api/cli/pg/add-firewall-rule_spec.rb
+++ b/spec/routes/api/cli/pg/add-firewall-rule_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg add-firewall-rule" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "adds a firewall rule to the database" do
+    cli(%w[pg eu-central-h1/test-pg create])
+    pg = PostgresResource.first
+    expect(pg.firewall_rules_dataset.select_order_map(:cidr).map(&:to_s)).to eq %w[0.0.0.0/0]
+    expect(cli(%w[pg eu-central-h1/test-pg add-firewall-rule 1.2.3.0/24])).to eq <<~END.chomp
+      Firewall rule added to PostgreSQL database.
+        rule id: #{pg.firewall_rules_dataset.first(cidr: "1.2.3.0/24").ubid}, cidr: 1.2.3.0/24
+    END
+    expect(pg.firewall_rules_dataset.select_order_map(:cidr).map(&:to_s)).to eq %w[0.0.0.0/0 1.2.3.0/24]
+  end
+end

--- a/spec/routes/api/cli/pg/add-metric-destination_spec.rb
+++ b/spec/routes/api/cli/pg/add-metric-destination_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg add-metric-destination" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "adds a metric desintation to the database" do
+    cli(%w[pg eu-central-h1/test-pg create])
+    pg = PostgresResource.first
+    expect(pg.metric_destinations_dataset).to be_empty
+    body = cli(%w[pg eu-central-h1/test-pg add-metric-destination foo bar https://baz.example.com])
+    expect(pg.metric_destinations_dataset.count).to eq 1
+    md = pg.metric_destinations.first
+    expect(body).to eq <<~END
+      Metric destination added to PostgreSQL database.
+      Current metric destinations:
+        1: #{md.ubid}  foo  https://baz.example.com
+    END
+    expect(md.username).to eq "foo"
+    expect(md.password).to eq "bar"
+    expect(md.url).to eq "https://baz.example.com"
+  end
+end

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg create" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "creates PostgreSQL database with no options" do
+    expect(PostgresResource.count).to eq 0
+    body = cli(%w[pg eu-central-h1/test-pg create])
+    expect(PostgresResource.count).to eq 1
+    pg = PostgresResource.first
+    expect(pg).to be_a PostgresResource
+    expect(pg.name).to eq "test-pg"
+    expect(pg.display_location).to eq "eu-central-h1"
+    expect(pg.target_vm_size).to eq "standard-2"
+    expect(pg.target_storage_size_gib).to eq 64
+    expect(pg.ha_type).to eq "none"
+    expect(pg.version).to eq "16"
+    expect(pg.flavor).to eq "standard"
+    expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}"
+  end
+
+  it "creates PostgreSQL database with all options" do
+    expect(PostgresResource.count).to eq 0
+    body = cli(%w[pg eu-central-h1/test-pg create -s standard-4 -S 128 -h async -v 17 -f lantern])
+    expect(PostgresResource.count).to eq 1
+    pg = PostgresResource.first
+    expect(pg).to be_a PostgresResource
+    expect(pg.name).to eq "test-pg"
+    expect(pg.display_location).to eq "eu-central-h1"
+    expect(pg.target_vm_size).to eq "standard-4"
+    expect(pg.target_storage_size_gib).to eq 128
+    expect(pg.ha_type).to eq "async"
+    expect(pg.version).to eq "17"
+    expect(pg.flavor).to eq "lantern"
+    expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}"
+  end
+end

--- a/spec/routes/api/cli/pg/delete-firewall-rule_spec.rb
+++ b/spec/routes/api/cli/pg/delete-firewall-rule_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg delete-firewall-rule" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "deletes the specified firewall rule for the database" do
+    cli(%w[pg eu-central-h1/test-pg create])
+    pg = PostgresResource.first
+    fwr = pg.firewall_rules_dataset.first
+    expect(cli(%w[pg eu-central-h1/test-pg delete-firewall-rule a/b], status: 400)).to eq "invalid firewall rule id format"
+    expect(pg.firewall_rules_dataset).not_to be_empty
+    expect(cli(%W[pg eu-central-h1/test-pg delete-firewall-rule #{fwr.ubid}])).to eq "Firewall rule, if it exists, has been scheduled for deletion"
+    expect(pg.firewall_rules_dataset).to be_empty
+  end
+end

--- a/spec/routes/api/cli/pg/delete-metric-destination_spec.rb
+++ b/spec/routes/api/cli/pg/delete-metric-destination_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg delete-metric-destination" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "deletes the specified metric destination for the database" do
+    cli(%w[pg eu-central-h1/test-pg create])
+    cli(%w[pg eu-central-h1/test-pg add-metric-destination foo bar https://baz.example.com])
+    pg = PostgresResource.first
+    md = pg.metric_destinations.first
+    expect(cli(%w[pg eu-central-h1/test-pg delete-metric-destination a/b], status: 400)).to eq "invalid metric destination id format"
+    expect(pg.metric_destinations_dataset).not_to be_empty
+    expect(cli(%W[pg eu-central-h1/test-pg delete-metric-destination #{md.ubid}])).to eq "Metric destination, if it exists, has been scheduled for deletion"
+    expect(pg.metric_destinations_dataset).to be_empty
+  end
+end

--- a/spec/routes/api/cli/pg/destroy_spec.rb
+++ b/spec/routes/api/cli/pg/destroy_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg destroy" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "destroys PostgreSQL database" do
+    expect(PostgresResource.count).to eq 0
+    cli(%w[pg eu-central-h1/test-pg create])
+    expect(PostgresResource.count).to eq 1
+    pg = PostgresResource.first
+    expect(pg).to be_a PostgresResource
+    expect(Semaphore.where(strand_id: pg.id, name: "destroy")).to be_empty
+    expect(cli(%w[pg eu-central-h1/test-pg destroy])).to eq "PostgreSQL database, if it exists, is now scheduled for destruction"
+    expect(Semaphore.where(strand_id: pg.id, name: "destroy")).not_to be_empty
+  end
+end

--- a/spec/routes/api/cli/pg/failover_spec.rb
+++ b/spec/routes/api/cli/pg/failover_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg failover" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "fails over PostgreSQL database if a suitable failover target exists" do
+    expect(PostgresResource.count).to eq 0
+    cli(%w[pg eu-central-h1/test-pg create -h sync -f lantern])
+    expect(PostgresResource.count).to eq 1
+    pg = PostgresResource.first
+    expect(pg).to be_a PostgresResource
+    expect(Semaphore.where(name: "take_over")).to be_empty
+    expect(cli(%w[pg eu-central-h1/test-pg failover], status: 400)).to eq <<~END.chomp
+      Error: unexpected response status: 400
+      Details: There is not a suitable standby server to failover!
+    END
+    rs = pg.representative_server
+    rs.update(timeline_access: "push")
+    st = Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: rs.timeline_id, timeline_access: "fetch")
+    st.update(label: "wait")
+    expect(PostgresServer).to receive(:run_query).and_return "16/B374D848"
+
+    expect(Semaphore.where(name: "take_over")).to be_empty
+    expect(cli(%w[pg eu-central-h1/test-pg failover])).to eq "Failover initiated for PostgreSQL database with id: #{pg.ubid}"
+    expect(Semaphore.where(name: "take_over")).not_to be_empty
+  end
+end

--- a/spec/routes/api/cli/pg/list_spec.rb
+++ b/spec/routes/api/cli/pg/list_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg list" do
+  id_headr = "id" + " " * 24
+
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+    @pg = Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: @project.id,
+      location: "hetzner-fsn1",
+      name: "test-pg",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 64
+    ).subject
+  end
+
+  it "shows list of PostgreSQL databases" do
+    expect(cli(%w[pg list -N])).to eq "eu-central-h1  test-pg  #{@pg.ubid}  16  standard\n"
+  end
+
+  it "-f option specifies fields" do
+    expect(cli(%w[pg list -Nf id,name])).to eq "#{@pg.ubid}  test-pg\n"
+  end
+
+  it "-l option filters to specific location" do
+    expect(cli(%w[pg list -Nleu-central-h1])).to eq "eu-central-h1  test-pg  #{@pg.ubid}  16  standard\n"
+    expect(cli(%w[pg list -Nleu-north-h1])).to eq ""
+  end
+
+  it "headers are shown by default" do
+    expect(cli(%w[pg list])).to eq <<~END
+      location       name     #{id_headr}  version  flavor  
+      eu-central-h1  test-pg  #{@pg.ubid}  16       standard
+    END
+  end
+
+  it "handles case where header size is larger than largest column size" do
+    @pg.update(name: "Abc")
+    expect(cli(%w[pg list])).to eq <<~END
+      location       name  #{id_headr}  version  flavor  
+      eu-central-h1  Abc   #{@pg.ubid}  16       standard
+    END
+  end
+
+  it "handles multiple options" do
+    expect(cli(%w[pg list -Nflocation,name,id])).to eq "eu-central-h1  test-pg  #{@pg.ubid}\n"
+    expect(cli(%w[pg list -flocation,name,id])).to eq <<~END
+      location       name     #{id_headr}
+      eu-central-h1  test-pg  #{@pg.ubid}
+    END
+  end
+
+  it "shows error for empty fields" do
+    expect(cli(%w[pg list -Nf] + [""], status: 400)).to eq "no fields given in pg list -f option"
+  end
+
+  it "shows error for duplicate fields" do
+    expect(cli(%w[pg list -Nfid,id], status: 400)).to eq "duplicate field(s) in pg list -f option"
+  end
+
+  it "shows error for invalid fields" do
+    expect(cli(%w[pg list -Nffoo], status: 400)).to eq "invalid field(s) given in pg list -f option: foo"
+  end
+
+  it "shows error for invalid location" do
+    expect(cli(%w[pg list -Nleu-foo-h1], status: 400)).to eq "invalid location provided in pg list -l option"
+  end
+end

--- a/spec/routes/api/cli/pg/psql_pg_dump_pg_dumpall_spec.rb
+++ b/spec/routes/api/cli/pg/psql_pg_dump_pg_dumpall_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+%w[psql pg_dump pg_dumpall].each do |cmd|
+  RSpec.describe Clover, "cli pg #{cmd}" do
+    before do
+      expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+      @pg = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: @project.id,
+        location: "hetzner-fsn1",
+        name: "test-pg",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 64
+      ).subject
+      @ref = [@pg.display_location, @pg.name].join("/")
+      @conn_string = URI("postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require")
+      expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
+      @dns_zone = DnsZone.new
+      expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
+    end
+
+    it "connects to database via psql" do
+      expect(cli_exec(["pg", @ref, cmd])).to eq %W[#{cmd} -- postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
+    end
+
+    it "supports psql options" do
+      expect(cli_exec(["pg", @ref, cmd, "-a"])).to eq %W[#{cmd} -a -- postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
+    end
+
+    it "supports -U option for user name" do
+      expect(cli_exec(["pg", @ref, "-Ufoo", cmd, "-a"])).to eq %W[#{cmd} -a -- postgres://foo@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
+    end
+
+    it "supports -d option for database name" do
+      expect(cli_exec(["pg", @ref, "-dfoo", cmd, "-a"])).to eq %W[#{cmd} -a -- postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com/foo?channel_binding=require]
+    end
+  end
+end

--- a/spec/routes/api/cli/pg/reset-superuser-password_spec.rb
+++ b/spec/routes/api/cli/pg/reset-superuser-password_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg reset-superuser-password" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "schedules reset of superuser password for database" do
+    cli(%w[pg eu-central-h1/test-pg create])
+    expect(Semaphore.where(name: "update_superuser_password")).to be_empty
+    pg = PostgresResource.first
+    expect(cli(%w[pg eu-central-h1/test-pg reset-superuser-password fooBar123456])).to eq "Superuser password reset scheduled for PostgreSQL database with id: #{pg.ubid}"
+    expect(Semaphore.where(name: "update_superuser_password")).not_to be_empty
+    expect(pg.reload.superuser_password).to eq "fooBar123456"
+  end
+end

--- a/spec/routes/api/cli/pg/restore_spec.rb
+++ b/spec/routes/api/cli/pg/restore_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg restore" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "schedules a restore of the database to the given time" do
+    backup = Struct.new(:key, :last_modified)
+    restore_target = Time.now.utc
+    expect(MinioCluster).to receive(:[]).and_return(instance_double(MinioCluster, url: "dummy-url", root_certs: "dummy-certs")).at_least(:once)
+    expect(Minio::Client).to receive(:new).and_return(instance_double(Minio::Client, list_objects: [backup.new("basebackups_005/backup_stop_sentinel.json", restore_target - 10 * 60)])).at_least(:once)
+
+    cli(%w[pg eu-central-h1/test-pg create])
+    expect(PostgresResource.select_order_map(:name)).to eq %w[test-pg]
+    body = cli(%w[pg eu-central-h1/test-pg restore test-pg-2] << Time.now.utc)
+    expect(PostgresResource.select_order_map(:name)).to eq %w[test-pg test-pg-2]
+    pg = PostgresResource.first(name: "test-pg-2")
+    expect(body).to eq "Restored PostgreSQL database scheduled for creation with id: #{pg.ubid}"
+  end
+end

--- a/spec/routes/api/cli/pg/show_spec.rb
+++ b/spec/routes/api/cli/pg/show_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg show" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+    @pg = Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: @project.id,
+      location: "hetzner-fsn1",
+      name: "test-pg",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 64
+    ).subject
+    @ref = [@pg.display_location, @pg.name].join("/")
+  end
+
+  it "shows information for PostgreSQL database" do
+    expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
+    @dns_zone = DnsZone.new
+    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
+    @pg.add_metric_destination(username: "md-user", password: "1", url: "https://md.example.com")
+    @pg.update(root_cert_1: "a", root_cert_2: "b")
+
+    expect(cli(%W[pg #{@ref} show])).to eq <<~END
+      id: #{@pg.ubid}
+      name: test-pg
+      state: creating
+      location: eu-central-h1
+      vm_size: standard-2
+      storage_size_gib: 64
+      version: 16
+      ha_type: none
+      flavor: standard
+      connection_string: postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require
+      primary: true
+      earliest_restore_time: 
+      latest_restore_time: #{@pg.timeline.latest_restore_time.utc.iso8601}
+      firewall rules:
+        1: #{@pg.firewall_rules[0].ubid}  0.0.0.0/0
+      metric destinations:
+        1: #{@pg.metric_destinations[0].ubid}  md-user  https://md.example.com
+      CA certificates:
+      a
+      b
+    END
+  end
+
+  it "-f option controls which fields are shown for the PostgreSQL database" do
+    expect(cli(%W[pg #{@ref} show -f id,name])).to eq <<~END
+      id: #{@pg.ubid}
+      name: test-pg
+    END
+  end
+end

--- a/spec/routes/api/cli/vm/create_spec.rb
+++ b/spec/routes/api/cli/vm/create_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli vm create" do
+  it "creates vm with no options" do
+    expect(Vm.count).to eq 0
+    expect(PrivateSubnet.count).to eq 0
+    body = cli(%w[vm eu-central-h1/test-vm create a])
+    expect(Vm.count).to eq 1
+    expect(PrivateSubnet.count).to eq 1
+    vm = Vm.first
+    expect(vm).to be_a Vm
+    ps = PrivateSubnet.first
+    expect(ps).to be_a PrivateSubnet
+    expect(vm.name).to eq "test-vm"
+    expect(vm.public_key).to eq "a"
+    expect(vm.display_location).to eq "eu-central-h1"
+    expect(vm.display_size).to eq "standard-2"
+    expect(vm.boot_image).to eq Config.default_boot_image_name
+    expect(vm.ip4_enabled).to be true
+    expect(vm.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 40
+    expect(vm.nics.first.private_subnet_id).to eq ps.id
+    expect(body).to eq "VM created with id: #{vm.ubid}"
+  end
+
+  it "creates vm with all options" do
+    expect(Vm.count).to eq 0
+    ps = PrivateSubnet.create(project_id: @project.id, name: "test-ps", location: "hetzner-hel1", net6: "fe80::/64", net4: "192.168.0.0/24")
+    body = cli(%W[vm eu-north-h1/test-vm2 create -6 -b debian-12 -u foo -s standard-4 -S 80 -p #{ps.ubid} b])
+    vm = Vm.first
+    expect(Vm.count).to eq 1
+    expect(PrivateSubnet.count).to eq 1
+    expect(vm).to be_a Vm
+    expect(vm.name).to eq "test-vm2"
+    expect(vm.public_key).to eq "b"
+    expect(vm.display_location).to eq "eu-north-h1"
+    expect(vm.display_size).to eq "standard-4"
+    expect(vm.boot_image).to eq "debian-12"
+    expect(vm.ip4_enabled).to be false
+    expect(vm.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 80
+    expect(vm.nics.first.private_subnet_id).to eq ps.id
+    expect(body).to eq "VM created with id: #{vm.ubid}"
+  end
+
+  it "shows errors if trying to create a vm with an invalid private subnet" do
+    expect(Vm.count).to eq 0
+    ps = PrivateSubnet.create(project_id: @project.id, name: "test-ps", location: "hetzner-fsn1", net6: "fe80::/64", net4: "192.168.0.0/24")
+    expect(cli(%W[vm eu-north-h1/test-vm2 create -p #{ps.ubid} c], status: 400)).to eq(<<~END.chomp)
+      Error: unexpected response status: 400
+      Details: Validation failed for following fields: private_subnet_id
+        private_subnet_id: Private subnet with the given id "#{ps.ubid}" is not found in the location "eu-north-h1"
+    END
+    expect(Vm.count).to eq 0
+  end
+
+  it "shows errors if trying to create a vm with an invalid number of arguments" do
+    expect(Vm.count).to eq 0
+    expect(cli(%W[vm eu-north-h1/test-vm2 create], status: 400).b).to eq "invalid arguments for vm create subcommand (public_key is required)"
+    expect(cli(%W[vm eu-north-h1/test-vm2 create c d], status: 400).b).to eq "invalid arguments for vm create subcommand (public_key is required)"
+    expect(Vm.count).to eq 0
+  end
+end

--- a/spec/routes/api/cli/vm/destroy_spec.rb
+++ b/spec/routes/api/cli/vm/destroy_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli vm destroy" do
+  it "destroys vm" do
+    expect(Vm.count).to eq 0
+    expect(PrivateSubnet.count).to eq 0
+    cli(%w[vm eu-central-h1/test-vm create a])
+    expect(Vm.count).to eq 1
+    vm = Vm.first
+    expect(vm).to be_a Vm
+    expect(Semaphore.where(strand_id: vm.id, name: "destroy")).to be_empty
+    expect(cli(%w[vm eu-central-h1/test-vm destroy])).to eq "VM, if it exists, is now scheduled for destruction"
+    expect(Semaphore.where(strand_id: vm.id, name: "destroy")).not_to be_empty
+  end
+end

--- a/spec/routes/api/cli/vm/list_spec.rb
+++ b/spec/routes/api/cli/vm/list_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Clover, "cli vm list" do
   end
 
   it "shows error for invalid fields" do
-    expect(cli(%w[vm list -Nffoo], status: 400)).to eq "invalid field(s) given vm list -f option: foo"
+    expect(cli(%w[vm list -Nffoo], status: 400)).to eq "invalid field(s) given in vm list -f option: foo"
   end
 
   it "shows error for invalid location" do

--- a/spec/routes/api/cli/vm/list_spec.rb
+++ b/spec/routes/api/cli/vm/list_spec.rb
@@ -14,24 +14,29 @@ RSpec.describe Clover, "cli vm list" do
     expect(cli(%w[vm list -N])).to eq "eu-central-h1  test-vm  #{@vm.ubid}  128.0.0.1  128:1234::2\n"
   end
 
-  it "-i option includes VM ubid" do
+  it "-f id option includes VM ubid" do
     expect(cli(%w[vm list -Nfid])).to eq "#{@vm.ubid}\n"
   end
 
-  it "-n option includes VM name" do
+  it "-f name option includes VM name" do
     expect(cli(%w[vm list -Nfname])).to eq "test-vm\n"
   end
 
-  it "-l option includes VM location" do
+  it "-f location option includes VM location" do
     expect(cli(%w[vm list -Nflocation])).to eq "eu-central-h1\n"
   end
 
-  it "-4 option includes VM IPv4 address" do
+  it "-f ip4 option includes VM IPv4 address" do
     expect(cli(%w[vm list -Nfip4])).to eq "128.0.0.1\n"
   end
 
-  it "-6 option includes VM IPv6 address" do
+  it "-f ip6 option includes VM IPv6 address" do
     expect(cli(%w[vm list -Nfip6])).to eq "128:1234::2\n"
+  end
+
+  it "-l option filters to specific location" do
+    expect(cli(%w[vm list -Nleu-central-h1])).to eq "eu-central-h1  test-vm  #{@vm.ubid}  128.0.0.1  128:1234::2\n"
+    expect(cli(%w[vm list -Nleu-north-h1])).to eq ""
   end
 
   it "headers are shown by default" do
@@ -67,5 +72,9 @@ RSpec.describe Clover, "cli vm list" do
 
   it "shows error for invalid fields" do
     expect(cli(%w[vm list -Nffoo], status: 400)).to eq "invalid field(s) given vm list -f option: foo"
+  end
+
+  it "shows error for invalid location" do
+    expect(cli(%w[vm list -Nleu-foo-h1], status: 400)).to eq "invalid location provided in vm list -l option"
   end
 end

--- a/spec/routes/api/cli/vm/scp_spec.rb
+++ b/spec/routes/api/cli/vm/scp_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Clover, "cli vm scp" do
   end
 
   it "supports scp options" do
-    expect(cli_exec(["vm", @ref, "scp", ":remote", "local", "-A"])).to eq %w[scp -A -- ubi@[128:1234::2]:remote local]
+    expect(cli_exec(["vm", @ref, "scp", "-A", ":remote", "local"])).to eq %w[scp -A -- ubi@[128:1234::2]:remote local]
   end
 
   it "returns error if both files are local" do

--- a/spec/routes/api/cli/vm/sftp_spec.rb
+++ b/spec/routes/api/cli/vm/sftp_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe Clover, "cli vm sftp" do
   end
 
   it "supports sftp options" do
-    expect(cli_exec(["vm", @ref, "sftp", "--", "-A"])).to eq %w[sftp -A -- ubi@[128:1234::2]]
+    expect(cli_exec(["vm", @ref, "sftp", "-A"])).to eq %w[sftp -A -- ubi@[128:1234::2]]
   end
 end

--- a/spec/routes/api/cli/vm/show_spec.rb
+++ b/spec/routes/api/cli/vm/show_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli vm show" do
+  before do
+    @vm = create_vm(project_id: @project.id, ephemeral_net6: "128:1234::0/64")
+    @ref = [@vm.display_location, @vm.name].join("/")
+    add_ipv4_to_vm(@vm, "128.0.0.1")
+    subnet = @project.default_private_subnet(@vm.location)
+    nic = Prog::Vnet::NicNexus.assemble(subnet.id, name: "#{@vm.name}-nic").subject
+    nic.update(vm_id: @vm.id)
+    @fw = subnet.firewalls.first
+  end
+
+  it "shows information for VM" do
+    expect(cli(%W[vm #{@ref} show])).to eq <<~END
+      id: #{@vm.ubid}
+      name: test-vm
+      state: running
+      location: eu-central-h1
+      size: standard-2
+      unix_user: ubi
+      storage_size_gib: 0
+      ip6: 128:1234::2
+      ip4_enabled: false
+      ip4: 128.0.0.1
+      private_ipv4: #{@vm.private_ipv4}
+      private_ipv6: #{@vm.private_ipv6}
+      subnet: default-eu-central-h1
+      firewall 1:
+        id: #{@fw.ubid}
+        name: default-eu-central-h1-default
+        description: Default firewall
+        location: eu-central-h1
+        path: /location/eu-central-h1/firewall/default-eu-central-h1-default
+        rule 1: #{@fw.firewall_rules[0].ubid}  0.0.0.0/0  0..65535  
+        rule 2: #{@fw.firewall_rules[1].ubid}  ::/0  0..65535  
+    END
+  end
+
+  it "-f option controls which fields are shown for VM" do
+    expect(cli(%W[vm #{@ref} show -f id,name])).to eq <<~END
+      id: #{@vm.ubid}
+      name: test-vm
+    END
+  end
+
+  it "-w option controls which fields are shown for VM's firewalls" do
+    expect(cli(%W[vm #{@ref} show -f id,firewalls -w id,name])).to eq <<~END
+      id: #{@vm.ubid}
+      firewall 1:
+        id: #{@fw.ubid}
+        name: default-eu-central-h1-default
+    END
+  end
+
+  it "-r option controls which fields are shown rules for VM's firewalls" do
+    expect(cli(%W[vm #{@ref} show -f firewalls -w firewall_rules -r cidr,port_range])).to eq <<~END
+      firewall 1:
+        rule 1: 0.0.0.0/0  0..65535  
+        rule 2: ::/0  0..65535  
+    END
+  end
+end

--- a/spec/routes/api/cli/vm/ssh_spec.rb
+++ b/spec/routes/api/cli/vm/ssh_spec.rb
@@ -37,23 +37,23 @@ RSpec.describe Clover, "cli vm ssh" do
   end
 
   it "-4 option fails if VM has no IPv4 address" do
-    expect(cli(["vm", @ref, "ssh", "-4"], status: 400)).to eq "No valid IPv4 address for requested VM"
+    expect(cli(["vm", @ref, "-4", "ssh"], status: 400)).to eq "No valid IPv4 address for requested VM"
   end
 
   it "-4 option uses IPv4 even if connection is made via IPv6" do
     add_ipv4_to_vm(@vm, "128.0.0.1")
     @socket = UDPSocket.new(Socket::AF_INET6)
-    expect(cli_exec(["vm", @ref, "ssh", "-4"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128.0.0.1]
+    expect(cli_exec(["vm", @ref, "-4", "ssh"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128.0.0.1]
   end
 
   it "-6 option uses IPv6 even if connection is made via IPv4" do
     add_ipv4_to_vm(@vm, "128.0.0.1")
     @socket = UDPSocket.new(Socket::AF_INET)
-    expect(cli_exec(["vm", @ref, "ssh", "-6"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128:1234::2]
+    expect(cli_exec(["vm", @ref, "-6", "ssh"], env: {"puma.socket" => @socket})).to eq %w[ssh -- ubi@128:1234::2]
   end
 
   it "-u option overrides user to connect with" do
-    expect(cli_exec(["vm", @ref, "ssh", "-ufoo"])).to eq %w[ssh -- foo@128:1234::2]
+    expect(cli_exec(["vm", @ref, "-ufoo", "ssh"])).to eq %w[ssh -- foo@128:1234::2]
   end
 
   it "handles ssh cmd without args" do
@@ -65,21 +65,21 @@ RSpec.describe Clover, "cli vm ssh" do
   end
 
   it "handles ssh cmd with options and without args" do
-    expect(cli_exec(["vm", @ref, "ssh", "--", "-A", "--"])).to eq %w[ssh -A -- ubi@128:1234::2]
+    expect(cli_exec(["vm", @ref, "ssh", "-A", "--"])).to eq %w[ssh -A -- ubi@128:1234::2]
   end
 
   it "handles ssh cmd with options and args" do
-    expect(cli_exec(["vm", @ref, "ssh", "--", "-A", "--", "uname", "-a"])).to eq %w[ssh -A -- ubi@128:1234::2 uname -a]
+    expect(cli_exec(["vm", @ref, "ssh", "-A", "--", "uname", "-a"])).to eq %w[ssh -A -- ubi@128:1234::2 uname -a]
   end
 
   it "handles multiple options" do
     add_ipv4_to_vm(@vm, "128.0.0.1")
-    expect(cli_exec(["vm", @ref, "ssh", "-6u", "foo"])).to eq %w[ssh -- foo@128:1234::2]
+    expect(cli_exec(["vm", @ref, "-6u", "foo", "ssh"])).to eq %w[ssh -- foo@128:1234::2]
   end
 
   it "handles invalid vm reference" do
-    expect(cli(["vm", "#{@vm.display_location}/foo", "ssh", "-4"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
-    expect(cli(["vm", "foo/#{@vm.name}", "ssh", "-4"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
-    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh", "-4"], status: 400)).to eq "invalid vm reference, should be in location/(vm-name|_vm-ubid) format"
+    expect(cli(["vm", "#{@vm.display_location}/foo", "ssh"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
+    expect(cli(["vm", "foo/#{@vm.name}", "ssh"], status: 404)).to eq "Error: unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for."
+    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh"], status: 400)).to eq "invalid vm reference, should be in location/(vm-name|_vm-ubid) format"
   end
 end


### PR DESCRIPTION
This builds on top of #2775 and adds CLI support for all actions you can take in the API:

* pg list
* pg loc/name create [-f -h -s -S -v]
* pg loc/name show
* pg loc/name destroy
* pg loc/name add-firewall-rule cidr
* pg loc/name delete-firewall-rule ubid
* pg loc/name add-metric-destination user pass url
* pg loc/name delete-metric-destination ubid
* pg loc/name failover
* pg loc/name restore name time
* pg loc/name reset-superuser-password pass

In addition, it also supports commands for using PostgreSQL CLI tools, similar to how the vm ssh/sftp/scp commands are supported:

* pg loc/name [-U -d] psql
* pg loc/name [-U -d] pg_dump
* pg loc/name [-U -d] pg_dumpall
