### PR TITLE
Sshd configure more

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -48,6 +48,7 @@ sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh
 sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authorized_keys
 echo #{SSHD_CONFIG.shellescape} | sudo tee /etc/ssh/sshd_config.d/10-clover.conf > /dev/null
 echo #{sshable.keys.map(&:public_key).join("\n").shellescape} | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+sync
 SH
 
     push Prog::InstallRhizome, {"target_folder" => frame["target_folder"]}

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -99,23 +99,3 @@ CRON
 
 r "systemctl enable cron"
 r "systemctl start cron"
-
-# Taken from https://infosec.mozilla.org/guidelines/openssh
-safe_write_to_file("/etc/ssh/sshd_config.d/10-clover.conf", <<~SSHD_CONFIG)
-# Supported HostKey algorithms by order of preference.
-HostKey /etc/ssh/ssh_host_ed25519_key
-HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_ecdsa_key
-
-KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
-
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
-
-# Password based logins are disabled - only public key based logins are allowed.
-AuthenticationMethods publickey
-
-# LogLevel VERBOSE logs user's key fingerprint on login. Needed to have a clear audit track of which key was using to log in.
-LogLevel VERBOSE
-SSHD_CONFIG

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -63,6 +63,7 @@ echo \#\ Supported\ HostKey\ algorithms\ by\ order\ of\ preference.'
 'LogLevel\ VERBOSE'
 ' | sudo tee /etc/ssh/sshd_config.d/10-clover.conf > /dev/null
 echo test\ key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+sync
 FIXTURE
 
       expect { br.setup }.to hop("start", "InstallRhizome")

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Prog::BootstrapRhizome do
   describe "#setup" do
     before { br.strand.label = "setup" }
 
-    it "runs initializing shell wih public keys" do
+    it "runs initializing shell with public keys" do
       sshable = instance_double(Sshable, host: "hostname", keys: [instance_double(SshKey, public_key: "test key", private_key: "test private key")])
       expect(br).to receive(:sshable).and_return(sshable).at_least(:once)
       expect(Util).to receive(:rootish_ssh).with "hostname", "root", ["test private key"], <<'FIXTURE'

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Prog::BootstrapRhizome do
 
     it "runs initializing shell wih public keys" do
       sshable = instance_double(Sshable, host: "hostname", keys: [instance_double(SshKey, public_key: "test key", private_key: "test private key")])
-      allow(br).to receive(:sshable).and_return(sshable)
+      expect(br).to receive(:sshable).and_return(sshable).at_least(:once)
       expect(Util).to receive(:rootish_ssh).with "hostname", "root", ["test private key"], <<'FIXTURE'
 set -ueo pipefail
 sudo apt update && sudo apt-get -y install ruby-bundler

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -45,6 +45,11 @@ sudo adduser --disabled-password --gecos '' rhizome
 echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
 sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh
 sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authorized_keys
+sudo mkdir -p /etc/systemd/logind.conf.d
+echo \[Login\]'
+'KillOnlyUsers\=rhizome'
+'KillUserProcesses\=yes'
+' | sudo tee /etc/systemd/logind.conf.d/rhizome.conf > /dev/null
 echo \#\ Supported\ HostKey\ algorithms\ by\ order\ of\ preference.'
 'HostKey\ /etc/ssh/ssh_host_ed25519_key'
 'HostKey\ /etc/ssh/ssh_host_rsa_key'
@@ -61,6 +66,10 @@ echo \#\ Supported\ HostKey\ algorithms\ by\ order\ of\ preference.'
 ''
 '\#\ LogLevel\ VERBOSE\ logs\ user\'s\ key\ fingerprint\ on\ login.\ Needed\ to\ have\ a\ clear\ audit\ track\ of\ which\ key\ was\ using\ to\ log\ in.'
 'LogLevel\ VERBOSE'
+''
+'\#\ Terminate\ sessions\ with\ clients\ that\ cannot\ return\ packets\ rapidly.'
+'ClientAliveInterval\ 2'
+'ClientAliveCountMax\ 4'
 ' | sudo tee /etc/ssh/sshd_config.d/10-clover.conf > /dev/null
 echo test\ key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 sync

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Prog::BootstrapRhizome do
     it "runs initializing shell wih public keys" do
       sshable = instance_double(Sshable, host: "hostname", keys: [instance_double(SshKey, public_key: "test key", private_key: "test private key")])
       allow(br).to receive(:sshable).and_return(sshable)
-      expect(Util).to receive(:rootish_ssh).with "hostname", "root", ["test private key"], <<FIXTURE
+      expect(Util).to receive(:rootish_ssh).with "hostname", "root", ["test private key"], <<'FIXTURE'
 set -ueo pipefail
 sudo apt update && sudo apt-get -y install ruby-bundler
 sudo userdel -rf rhizome || true
@@ -45,7 +45,24 @@ sudo adduser --disabled-password --gecos '' rhizome
 echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
 sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh
 sudo install -o rhizome -g rhizome -m 0600 /dev/null /home/rhizome/.ssh/authorized_keys
-echo test\\ key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+echo \#\ Supported\ HostKey\ algorithms\ by\ order\ of\ preference.'
+'HostKey\ /etc/ssh/ssh_host_ed25519_key'
+'HostKey\ /etc/ssh/ssh_host_rsa_key'
+'HostKey\ /etc/ssh/ssh_host_ecdsa_key'
+''
+'KexAlgorithms\ curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256'
+''
+'Ciphers\ chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+''
+'MACs\ hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com'
+''
+'\#\ Password\ based\ logins\ are\ disabled\ -\ only\ public\ key\ based\ logins\ are\ allowed.'
+'AuthenticationMethods\ publickey'
+''
+'\#\ LogLevel\ VERBOSE\ logs\ user\'s\ key\ fingerprint\ on\ login.\ Needed\ to\ have\ a\ clear\ audit\ track\ of\ which\ key\ was\ using\ to\ log\ in.'
+'LogLevel\ VERBOSE'
+' | sudo tee /etc/ssh/sshd_config.d/10-clover.conf > /dev/null
+echo test\ key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 FIXTURE
 
       expect { br.setup }.to hop("start", "InstallRhizome")


### PR DESCRIPTION
@byucesoy kinda an invasive one that will require some care in deployment, wanted to run it by you, and why not @shikharbhardwaj since you work together more closely, and he saw my last patch fixing that typo in 4461be0b541bacb8f6e2d92d28acb11a5813a942.

Also @jeremyevans because this should both obsolete, and be superior to forking the `timeout` program every time we do a command

.
Terminate SSH sessions promptly and their processes

This is done with two configuration changes: one, to use ClientAlive
settings in the SSH server to take action on connections without a
responsive client, and secondly, to use `logind` configuration to
specify that processes that belong to that session are to be
terminated rather than re-parented as orphans.

A downside is that running `ssh` with even a single `-v` (verbose)
flag will spam annoying messages to the screen during the session.  I
have often used the lowest level of verbosity to supervise at what
stage an establishing connection is hanging or slow at, now I cannot
leave that flag on anymore.

Verification is a bit of a pain. First, it's best to have two paths to
the test computer, e.g. allocate two VMs, where one acts as a SSH jump
host to a test VM, as well as connecting to the test VM directly from
your laptop: that way you can cut network access to the jump host and
observe the results.

Secondly, it's important to know that signal propagation in SSH is
different if a `pty` is allocated (e.g. for interactive mode): with a
`pty`, SIGHUP is propagated, and most processes will decide to exit at
that point.  Without a `pty`, there is no signal.  So, when testing
this, it is better to do something like:

    ssh host sleep 3600

To start a session that is non-interactive, and waits.  By omitting
the changes in this patch, you should be able to see `sleep` hanging
around after the SSH server has closed the forked SSH process because
of a non-responsive client.  You can use `pstree -s` to check its
parentage.

From the session with the jump host, start such a hanging command.
Then, on your other connection, drop TCP packets to the jump host's
address, by running `nft -f` on nftable rules like this, substituting
the `saddr` for the jump host address:

    add table inet filter
    flush table inet filter
    table inet filter {
      chain input {
        type filter hook input priority filter; policy accept;
        ip6 saddr 2a01:4f8:2b01:d85:214a::2 tcp dport 22 drop
      }
    }

By using commands like `w` and `loginctl list-sessions`, you should
see the process disappear momentarily.

If you need to re-set the test and allow the jump host to send traffic
again, use `nft -f` again with:

    delete table inet filter;

Sync the end of rhizome bootstrapping

Out of an abundance of caution, block until files and directories have
been flushed, so an unlucky reboot that did not go through graceful
flushing would leave empty or incomplete files or directories that are
connected to the sensitive process of setting up the rhizome user and
secure shell.

Move openssh server configuration to BootstrapRhizome

Previously, it was prep_host, which only affected the bare metal
layer, whereas I think we would be better off with uniform
configuration for managed services (e.g. Postgres) as well.


