### PR TITLE
Update to Ruby 3.2.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.2.6
+ruby 3.2.7
 postgres 15.8
 nodejs 23.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM ruby:3.2.6-alpine3.21 AS bundler
+FROM ruby:3.2.7-alpine3.21 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -19,7 +19,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM ruby:3.2.6-alpine3.21
+FROM ruby:3.2.7-alpine3.21
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.2.6"
+ruby "3.2.7"
 
 gem "argon2"
 gem "committee"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.6p234
+   ruby 3.2.7p253
 
 BUNDLED WITH
    2.5.17


### PR DESCRIPTION
Heroku shows the following warning:

    remote:
    remote: ###### WARNING:
    remote:
    remote:        There is a more recent Ruby version available for you to use:
    remote:
    remote:        3.2.7
    remote:
    remote:        The latest version will include security and bug fixes. We always recommend
    remote:        running the latest version of your minor release.
    remote:
    remote:        Please upgrade your Ruby version.
    remote:
    remote:        For all available Ruby versions see:
    remote:          https://devcenter.heroku.com/articles/ruby-support#supported-runtimes

We don't have any reason to not upgrade
https://github.com/ruby/ruby/releases/tag/v3_2_7