### PR TITLE
Do not report down if the runner is getting destroyed

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -65,11 +65,15 @@ class GithubRunner < Sequel::Model
     rescue
       "down"
     end
-    aggregate_readings(previous_pulse: previous_pulse, reading: reading, data: {available_memory: available_memory})
+    aggregate_readings(previous_pulse: previous_pulse, reading: reading, data: {available_memory: available_memory}) unless is_destroying?
   end
 
   def self.redacted_columns
     super + [:workflow_job]
+  end
+
+  def is_destroying?
+    destroy_set? || %w[destroy wait_vm_destroy].include?(strand&.label)
   end
 end
 


### PR DESCRIPTION
Our monitor prints out all of the "down" signals, however, because of the continuous churn of the runner VMs, it's almost impossible to watch the down signals in a reasonable way. This commit simply adds a check. This way, if the runner is getting destroyed, we report it as up.