### PR TITLE
Default bin/ubi to use the production server

### DIFF
--- a/bin/ubi
+++ b/bin/ubi
@@ -14,7 +14,7 @@ unless (token = ENV["UBI_TOKEN"])
   exit 1
 end
 
-url = ENV["UBI_URL"] || "http://api.localhost:9292/cli"
+url = ENV["UBI_URL"] || "https://api.ubicloud.com/cli"
 allowed_progs = %w[ssh scp sftp psql pg_dump pg_dumpall]
 
 get_prog = lambda do |prog|


### PR DESCRIPTION
You can set the following in your .env.rb file for using the local development server (as it did before this commit):

```ruby
  ENV["UBI_URL"] ||= "http://api.localhost:9292/cli"
```