### PR TITLE
Don't verify_host_capacity for unencrypted_vms E2E test.

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -34,7 +34,7 @@ def main(options)
     Semaphore.incr(hetzner_server_st.id, "disallow_slices")
     wait_until(hetzner_server_st, "wait")
 
-    unencrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], storage_encrypted: false, test_reboot: false)
+    unencrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], storage_encrypted: false, test_reboot: false, verify_host_capacity: false)
     log(unencrypted_vms_st, "storage_encrypted: false")
     tests_to_wait << unencrypted_vms_st
   end


### PR DESCRIPTION
`unencrypted_vms` test runs concurrently with github runner E2E tests. If the `verify_host_capacity` step overlaps with github runner VMs being destroyed, then there's a race condition that host's capacity has been updated in `Nexus::destroy` but Vm's record hasn't been deleted yet, which happens in a following `Nexus::destroy_slice` label.

An example of such failure was: https://github.com/ubicloud/ubicloud/actions/runs/13269484154/job/37045283146

In this failure, sequence of events that caused the problem were:

```
{"runner_allocated":{... "vm_ubid":"vmm5zmzc4qst7qx1h9gjahnk9x" ...}}
{"strand_hopped":{"from":"Vm::Nexus.wait","to":"Vm::Nexus.destroy"},"thread":"vmm5zmzc4qst7qx1h9gjahnk9x"}
{"strand_hopped":{"from":"Test::VmGroup.wait_verify_vms","to":"Test::VmGroup.verify_host_capacity"}}
{"strand_hopped":{"from":"Test::VmGroup.verify_host_capacity","to":"Test::VmGroup.failed"}}
{"strand_hopped":{"from":"Vm::Nexus.destroy","to":"Vm::Nexus.destroy_slice"},"thread":"vmm5zmzc4qst7qx1h9gjahnk9x"}
```

To avoid sporadic failure, and given that `verify_host_capacity` is already exercised in few relevant situations, we disable `verify_host_capacity`.

Also added more details to failure's error message, so we have more data to look into if this fails again.