### PR TITLE
Fix cli pg pg_dumpall command, and some minor ubi fixes

### DIFF
--- a/bin/ubi
+++ b/bin/ubi
@@ -55,6 +55,7 @@ when 200...300
     invalid_message = nil
     sep_seen = false
     custom_arg_seen = false
+    pg_dumpall = false
 
     args.each do |arg|
       if arg == "--"
@@ -65,6 +66,9 @@ when 200...300
           break
         elsif sep_seen
           custom_arg_seen = true
+        elsif prog_type == "pg_dumpall" && arg.start_with?("-d")
+          pg_dumpall = true
+          custom_arg_seen = true
         else
           invalid_message = "Invalid server response, argument before '--' not in submitted argv"
           break
@@ -72,7 +76,7 @@ when 200...300
       end
     end
 
-    unless sep_seen
+    unless sep_seen || pg_dumpall
       invalid_message = "Invalid server response, no '--' in returned argv"
     end
 

--- a/bin/ubi
+++ b/bin/ubi
@@ -31,6 +31,9 @@ headers = {
   "connection" => "close"
 }
 
+if ENV["UBI_DEBUG"] == "1"
+  p [:sending, *ARGV]
+end
 response = Net::HTTP.post(uri, data, headers)
 
 case response.code.to_i

--- a/bin/ubi
+++ b/bin/ubi
@@ -82,7 +82,7 @@ when 200...300
       end
       warn invalid_message
       exit 1
-    elsif (prog = get_prog[prog])
+    else
       if ENV["UBI_DEBUG"] == "1"
         p [:exec, prog, *args]
       end

--- a/bin/ubi
+++ b/bin/ubi
@@ -38,8 +38,13 @@ response = Net::HTTP.post(uri, data, headers)
 
 case response.code.to_i
 when 200...300
-  if (prog = response["ubi-command-execute"])
-    unless (prog = get_prog[prog])
+  if (prog_type = response["ubi-command-execute"])
+    unless ARGV.include?(prog_type)
+      warn "Invalid server response, not executing program not in original argv"
+      exit 1
+    end
+
+    unless (prog = get_prog[prog_type])
       warn "Invalid server response, unsupported program requested"
       exit 1
     end

--- a/cli-commands/pg/post/pg_dumpall.rb
+++ b/cli-commands/pg/post/pg_dumpall.rb
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 
-UbiCli.pg_cmd("pg_dumpall")
+UbiCli.pg_cmd("pg_dumpall") do |argv|
+  conn_string = argv.pop
+  argv.pop # --
+  argv << "-d#{conn_string}"
+end

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -94,7 +94,10 @@ class UbiCli
             end
           end
 
-          execute_argv([cmd, *argv, "--", conn_string], res)
+          argv = [cmd, *argv, "--", conn_string]
+          argv = yield(argv) if block_given?
+
+          execute_argv(argv, res)
         end
       end
     end

--- a/spec/routes/api/cli/pg/pg_dumpall_spec.rb
+++ b/spec/routes/api/cli/pg/pg_dumpall_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg pg_dumpall" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+    @pg = Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: @project.id,
+      location: "hetzner-fsn1",
+      name: "test-pg",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 64
+    ).subject
+    @ref = [@pg.display_location, @pg.name].join("/")
+    @conn_string = URI("postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require")
+    expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
+    @dns_zone = DnsZone.new
+    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
+  end
+
+  it "connects to database via pg_dumpall" do
+    expect(cli_exec(["pg", @ref, "pg_dumpall"])).to eq %W[pg_dumpall -dpostgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
+  end
+
+  it "supports pg_dumpall options" do
+    expect(cli_exec(["pg", @ref, "pg_dumpall", "-a"])).to eq %W[pg_dumpall -a -dpostgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
+  end
+
+  it "supports -U option for user name" do
+    expect(cli_exec(["pg", @ref, "-Ufoo", "pg_dumpall", "-a"])).to eq %W[pg_dumpall -a -dpostgres://foo@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
+  end
+
+  it "supports -d option for database name" do
+    expect(cli_exec(["pg", @ref, "-dfoo", "pg_dumpall", "-a"])).to eq %W[pg_dumpall -a -dpostgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com/foo?channel_binding=require]
+  end
+end

--- a/spec/routes/api/cli/pg/psql_pg_dump_spec.rb
+++ b/spec/routes/api/cli/pg/psql_pg_dump_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../spec_helper"
 
-%w[psql pg_dump pg_dumpall].each do |cmd|
+%w[psql pg_dump].each do |cmd|
   RSpec.describe Clover, "cli pg #{cmd}" do
     before do
       expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
@@ -20,11 +20,11 @@ require_relative "../spec_helper"
       expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
     end
 
-    it "connects to database via psql" do
+    it "connects to database via #{cmd}" do
       expect(cli_exec(["pg", @ref, cmd])).to eq %W[#{cmd} -- postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
     end
 
-    it "supports psql options" do
+    it "supports #{cmd} options" do
       expect(cli_exec(["pg", @ref, cmd, "-a"])).to eq %W[#{cmd} -a -- postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com?channel_binding=require]
     end
 


### PR DESCRIPTION
The pg_dumpall command does not take an argument, it takes the command
line string as part of the -d option. Add special code to bin/ubi to
allow the new argument to appear without --, but it must start with -d.

Change the pg_dumpall command handling to replace the ["--", conn_string]
arguments with ["-d#{conn_string}"].

This also has some minor fixes and improvements for bin/ubi:

* Extra security check that server requested program is in original argv

* UBI_DEBUG now shows argv sent to server

* UBI_SSH and similar environment variables no longer break things.