### PR TITLE
Allow cli vm create to support multiple public keys

### DIFF
--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -17,7 +17,7 @@ UbiRodish.on("vm").run_on("create") do
     unless params.delete("ipv6-only")
       params["enable_ip4"] = "1"
     end
-    params["public_key"] = public_key
+    params["public_key"] = public_key.gsub(/(?!\r)\n/, "\r\n")
     post(project_path("location/#{@location}/vm/#{@name}"), params) do |data|
       ["VM created with id: #{data["id"]}"]
     end

--- a/spec/routes/api/cli/vm/create_spec.rb
+++ b/spec/routes/api/cli/vm/create_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe Clover, "cli vm create" do
     expect(body).to eq "VM created with id: #{vm.ubid}"
   end
 
+  it "translates LF to CRLF in public keys to work with multiple public keys" do
+    body = cli(%w[vm eu-north-h1/test-vm2 create] << "a\nb")
+    vm = Vm.first
+    expect(vm.public_key).to eq "a\r\nb"
+    expect(body).to eq "VM created with id: #{vm.ubid}"
+  end
+
   it "shows errors if trying to create a vm with an invalid private subnet" do
     expect(Vm.count).to eq 0
     ps = PrivateSubnet.create(project_id: @project.id, name: "test-ps", location: "hetzner-fsn1", net6: "fe80::/64", net4: "192.168.0.0/24")


### PR DESCRIPTION
This worked on the web, but not previously in the cli, and that's because on the web, newlines are submitted as CRLF, but if you do

  ubi vm loc/name create "$(< ~/.ssh/authorized_keys)"

newlines will be LF, and somehow this breaks something internally and doesn't allow you to log in after the VM is created.  Converting the LF to CRLF fixes it.