### PR TITLE
Use custom_hostname_prefix for k8s apiserver loadbalancers

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -54,6 +54,9 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
 
   label def create_load_balancer
     custom_hostname_dns_zone_id = DnsZone[name: Config.kubernetes_service_hostname]&.id
+    custom_hostname_prefix = if custom_hostname_dns_zone_id
+      "#{kubernetes_cluster.name}-apiserver-#{kubernetes_cluster.ubid.to_s[-5...]}"
+    end
     load_balancer_st = Prog::Vnet::LoadBalancerNexus.assemble(
       kubernetes_cluster.private_subnet_id,
       name: "#{kubernetes_cluster.name}-apiserver",
@@ -63,6 +66,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       health_check_endpoint: "/healthz",
       health_check_protocol: "tcp",
       custom_hostname_dns_zone_id:,
+      custom_hostname_prefix:,
       stack: LoadBalancer::Stack::IPV4
     )
     kubernetes_cluster.update(api_server_lb_id: load_balancer_st.id)

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -122,11 +122,10 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::IPV4
       expect(kubernetes_cluster.api_server_lb.private_subnet_id).to eq subnet.id
       expect(kubernetes_cluster.api_server_lb.custom_hostname_dns_zone_id).to eq dns_zone.id
+      expect(kubernetes_cluster.api_server_lb.custom_hostname).to eq "k8scluster-apiserver-#{kubernetes_cluster.ubid[-5...]}.k8s.ubicloud.com"
     end
 
     it "creates a load balancer with dns zone id on development for api server and hops" do
-      allow(Config).to receive(:development?).and_return(true)
-
       expect { nx.create_load_balancer }.to hop("bootstrap_control_plane_vms")
 
       expect(kubernetes_cluster.api_server_lb.name).to eq "k8scluster-apiserver"
@@ -136,6 +135,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kubernetes_cluster.api_server_lb.health_check_protocol).to eq "tcp"
       expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::IPV4
       expect(kubernetes_cluster.api_server_lb.private_subnet_id).to eq subnet.id
+      expect(kubernetes_cluster.api_server_lb.custom_hostname).to be_nil
     end
   end
 


### PR DESCRIPTION
Due to some issues in loadbalancer custom zone without custom prefixes, we will set the custom_hostname_prefix manually for now until those are fixed. Later we will drop setting the custom_hostname_prefix.