### PR TITLE
Fix 2pc problem between `daemonizer --clean` and hop

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -259,9 +259,8 @@ class Prog::Vm::Nexus < Prog::Base
   label def prep
     case host.sshable.cmd("common/bin/daemonizer --check prep_#{q_vm}")
     when "Succeeded"
-      host.sshable.cmd("common/bin/daemonizer --clean prep_#{q_vm}")
       vm.private_subnets.each(&:incr_add_new_nic)
-      hop_wait_sshable
+      hop_clean_prep
     when "NotStarted", "Failed"
       secrets_json = JSON.generate({
         storage: vm.storage_secrets
@@ -273,6 +272,11 @@ class Prog::Vm::Nexus < Prog::Base
     end
 
     nap 1
+  end
+
+  label def clean_prep
+    host.sshable.cmd("common/bin/daemonizer --clean prep_#{q_vm}")
+    hop_wait_sshable
   end
 
   def write_params_json

--- a/rhizome/common/bin/daemonizer
+++ b/rhizome/common/bin/daemonizer
@@ -27,6 +27,9 @@ def clean(name)
   case state
   when "InProgress", "Unknown"
     fail "Cannot clean unless the service is in Succeeded or Failed state!"
+  when "NotStarted"
+    # no-op, can occur if a previous clean was run but transition
+    # recording that it ran could not commit.
   when "Succeeded"
     r "sudo systemctl stop #{name}.service"
   when "Failed"

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -262,10 +262,9 @@ RSpec.describe Prog::Vm::Nexus do
     it "hops to run if prep command is succeeded" do
       sshable = instance_spy(Sshable)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("Succeeded")
-      expect(sshable).to receive(:cmd).with(/common\/bin\/daemonizer --clean prep_/)
       vmh = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vmh)
-      expect { nx.prep }.to hop("wait_sshable")
+      expect { nx.prep }.to hop("clean_prep")
     end
 
     it "generates and passes a params json if prep command is not started yet" do
@@ -321,6 +320,16 @@ RSpec.describe Prog::Vm::Nexus do
       vmh = instance_double(VmHost, sshable: sshable)
       expect(vm).to receive(:vm_host).and_return(vmh)
       expect { nx.prep }.to nap(1)
+    end
+  end
+
+  describe "#clean_prep" do
+    it "cleans and hops" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with(/common\/bin\/daemonizer --clean prep_/)
+      vmh = instance_double(VmHost, sshable: sshable)
+      expect(vm).to receive(:vm_host).and_return(vmh)
+      expect { nx.clean_prep }.to hop("wait_sshable")
     end
   end
 


### PR DESCRIPTION
Running `daemonizer --clean` has an immediate side effect on the remote instance, but there's no guarantee that the transaction nesting the side effect, implied in the label, will commit.  This creates a problem on retry, as the daemonized process will have been cleaned, but `prep` would have not recorded it had done so, and then it would try to run the `prep` daemon again as though nothing ever happened.

Reported-By: Enes Cakir <enes@ubicloud.com>