### PR TITLE
Require confirmation for cli vm/pg destroy commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,3 +87,6 @@ Sequel/IrreversibleMigration:
 
 Capybara/ClickLinkOrButtonStyle:
   EnforcedStyle: strict
+
+Lint/UselessTimes:
+  Enabled: false

--- a/bin/ubi
+++ b/bin/ubi
@@ -23,80 +23,98 @@ get_prog = lambda do |prog|
 end
 
 uri = URI(url)
-data = {"argv" => ARGV}.to_json
+argv = ARGV
 headers = {
   "authorization" => "Bearer: #{token}",
   "content-type" => "application/json",
   "accept" => "text/plain",
   "connection" => "close"
 }
+confirmation_prompt = false
+confirmation = nil
 
-if ENV["UBI_DEBUG"] == "1"
-  p [:sending, *ARGV]
-end
-response = Net::HTTP.post(uri, data, headers)
+1.times do
+  if ENV["UBI_DEBUG"] == "1"
+    p [:sending, *ARGV]
+  end
+  response = Net::HTTP.post(uri, {"argv" => argv}.to_json, headers)
 
-case response.code.to_i
-when 200...300
-  if (prog_type = response["ubi-command-execute"])
-    unless ARGV.include?(prog_type)
-      warn "Invalid server response, not executing program not in original argv"
-      exit 1
-    end
+  case response.code.to_i
+  when 200...300
+    if (prog_type = response["ubi-command-execute"])
+      unless ARGV.include?(prog_type)
+        warn "Invalid server response, not executing program not in original argv"
+        exit 1
+      end
 
-    unless (prog = get_prog[prog_type])
-      warn "Invalid server response, unsupported program requested"
-      exit 1
-    end
+      unless (prog = get_prog[prog_type])
+        warn "Invalid server response, unsupported program requested"
+        exit 1
+      end
 
-    argv_set = ARGV.to_set
+      argv_set = ARGV.to_set
 
-    args = response.body.split("\0")
-    invalid_message = nil
-    sep_seen = false
-    custom_arg_seen = false
-    pg_dumpall = false
+      args = response.body.split("\0")
+      invalid_message = nil
+      sep_seen = false
+      custom_arg_seen = false
+      pg_dumpall = false
 
-    args.each do |arg|
-      if arg == "--"
-        sep_seen = true
-      elsif !argv_set.include?(arg)
-        if custom_arg_seen
-          invalid_message = "Invalid server response, multiple arguments not in submitted argv"
-          break
-        elsif sep_seen
-          custom_arg_seen = true
-        elsif prog_type == "pg_dumpall" && arg.start_with?("-d")
-          pg_dumpall = true
-          custom_arg_seen = true
-        else
-          invalid_message = "Invalid server response, argument before '--' not in submitted argv"
-          break
+      args.each do |arg|
+        if arg == "--"
+          sep_seen = true
+        elsif !argv_set.include?(arg)
+          if custom_arg_seen
+            invalid_message = "Invalid server response, multiple arguments not in submitted argv"
+            break
+          elsif sep_seen
+            custom_arg_seen = true
+          elsif prog_type == "pg_dumpall" && arg.start_with?("-d")
+            pg_dumpall = true
+            custom_arg_seen = true
+          else
+            invalid_message = "Invalid server response, argument before '--' not in submitted argv"
+            break
+          end
         end
       end
-    end
 
-    unless sep_seen || pg_dumpall
-      invalid_message = "Invalid server response, no '--' in returned argv"
-    end
-
-    if invalid_message
-      if ENV["UBI_DEBUG"] == "1"
-        p [:failure, prog, *args]
+      unless sep_seen || pg_dumpall
+        invalid_message = "Invalid server response, no '--' in returned argv"
       end
-      warn invalid_message
-      exit 1
+
+      if invalid_message
+        if ENV["UBI_DEBUG"] == "1"
+          p [:failure, prog, *args]
+        end
+        warn invalid_message
+        exit 1
+      else
+        if ENV["UBI_DEBUG"] == "1"
+          p [:exec, prog, *args]
+        end
+        Process.exec(prog, *args)
+      end
     else
-      if ENV["UBI_DEBUG"] == "1"
-        p [:exec, prog, *args]
+      if (confirmation_prompt = response["ubi-confirm"])
+        if confirmation
+          warn "Invalid server response, repeated confirmation attempt"
+          exit 1
+        else
+          $stdout.puts response.body
+          $stdout.print "\n#{confirmation_prompt}: "
+          confirmation = $stdin.readline.chomp
+          argv.unshift(confirmation)
+          argv.unshift("--confirm")
+          redo
+        end
+      else
+        $stdout.puts response.body
       end
-      Process.exec(prog, *args)
+      exit 0
     end
   else
-    $stdout.puts response.body
-    exit 0
+    warn response.body
+    exit 1
   end
-else
-  warn response.body
-  exit 1
 end

--- a/lib/ubi_rodish.rb
+++ b/lib/ubi_rodish.rb
@@ -6,6 +6,7 @@ UbiRodish = Rodish.processor do
   options("ubi [options] [subcommand [subcommand_options] ...]") do
     on("--version", "show program version") { halt "0.0.0" }
     on("--help", "show program help") { halt to_s }
+    on("--confirm=confirmation", "confirmation value (not for direct use)")
   end
 
   # :nocov:

--- a/spec/routes/api/cli/options_spec.rb
+++ b/spec/routes/api/cli/options_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Clover, "cli" do
       Options:
               --version                    show program version
               --help                       show program help
+              --confirm=confirmation       confirmation value (not for direct use)
 
       Subcommands: pg vm
     OUTPUT
@@ -36,6 +37,7 @@ RSpec.describe Clover, "cli" do
       Options:
               --version                    show program version
               --help                       show program help
+              --confirm=confirmation       confirmation value (not for direct use)
 
       Subcommands: pg vm
     OUTPUT

--- a/spec/routes/api/cli/pg/destroy_spec.rb
+++ b/spec/routes/api/cli/pg/destroy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Clover, "cli pg destroy" do
     pg = PostgresResource.first
     expect(pg).to be_a PostgresResource
     expect(Semaphore.where(strand_id: pg.id, name: "destroy")).to be_empty
-    expect(cli(%w[pg eu-central-h1/test-pg destroy])).to eq "PostgreSQL database, if it exists, is now scheduled for destruction"
+    expect(cli(%w[pg eu-central-h1/test-pg destroy -f])).to eq "PostgreSQL database, if it exists, is now scheduled for destruction"
     expect(Semaphore.where(strand_id: pg.id, name: "destroy")).not_to be_empty
   end
 end

--- a/spec/routes/api/cli/spec_helper.rb
+++ b/spec/routes/api/cli/spec_helper.rb
@@ -3,10 +3,11 @@
 require_relative "../spec_helper"
 
 RSpec.configure do |config|
-  def cli(argv, status: 200, env: {})
+  def cli(argv, status: 200, env: {}, confirm_prompt: nil)
     post("/cli", {"argv" => argv}.to_json, env)
     expect(last_response.status).to eq(status), "status is #{last_response.status} not #{status}, body for failing status: #{last_response.body}"
     expect(last_response["content-type"]).to eq("text/plain")
+    expect(last_response["ubi-confirm"]).to eq(confirm_prompt) if confirm_prompt
     last_response.body
   end
 

--- a/spec/routes/api/cli/vm/destroy_spec.rb
+++ b/spec/routes/api/cli/vm/destroy_spec.rb
@@ -3,15 +3,39 @@
 require_relative "../spec_helper"
 
 RSpec.describe Clover, "cli vm destroy" do
-  it "destroys vm" do
+  before do
     expect(Vm.count).to eq 0
     expect(PrivateSubnet.count).to eq 0
     cli(%w[vm eu-central-h1/test-vm create a])
     expect(Vm.count).to eq 1
-    vm = Vm.first
-    expect(vm).to be_a Vm
-    expect(Semaphore.where(strand_id: vm.id, name: "destroy")).to be_empty
-    expect(cli(%w[vm eu-central-h1/test-vm destroy])).to eq "VM, if it exists, is now scheduled for destruction"
-    expect(Semaphore.where(strand_id: vm.id, name: "destroy")).not_to be_empty
+    @vm = Vm.first
+    expect(@vm).to be_a Vm
+  end
+
+  it "destroys vm directly if -f option is given" do
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).to be_empty
+    expect(cli(%w[vm eu-central-h1/test-vm destroy -f])).to eq "VM, if it exists, is now scheduled for destruction"
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).not_to be_empty
+  end
+
+  it "asks for confirmation if -f option is not given" do
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).to be_empty
+    expect(cli(%w[vm eu-central-h1/test-vm destroy], confirm_prompt: "Confirmation")).to eq <<~END
+      Destroying this VM is not recoverable.
+      Enter the following to confirm destruction of the VM: #{@vm.name}
+    END
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).to be_empty
+  end
+
+  it "works on correct confirmation" do
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).to be_empty
+    expect(cli(%w[--confirm test-vm vm eu-central-h1/test-vm destroy])).to eq "VM, if it exists, is now scheduled for destruction"
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).not_to be_empty
+  end
+
+  it "fails on incorrect confirmation" do
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).to be_empty
+    expect(cli(%w[--confirm foo vm eu-central-h1/test-vm destroy], status: 400)).to eq "\nConfirmation of VM name not successful.\n"
+    expect(Semaphore.where(strand_id: @vm.id, name: "destroy")).to be_empty
   end
 end


### PR DESCRIPTION
This requires changes to the cli at all levels, since the cli was not originally designed to be interactive.

Have the /cli API endpoint ask for confirmation via an ubi-confirm header.  Make bin/ubi recognize the ubi-confirm header and prompt the user for confirmation.  The confirmation value is sent in the top level --confirm option.

Change UbiCli.destroy, used for both vm and pg destory to support an -f/--force option to destroy without asking for confirmation. Unless the -f option is given, it asks for confirmation.  If confirmation is already provided, and it is correct, it runs the destroy command.  If the confirmation is already provided and it is incorrect, an error is returned.

To ease implementation of this in bin/ubi, a 1.times do block is used. If confirmation is required, argv is prepended with the --confirm option and confirmation value, and then redo is used to send another request.  Rubocop doesn't understand this and tries to remove the 1.times do, breaking the code, so disable that cop.