### PR TITLE
Add support for FlashInfer

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -167,7 +167,7 @@ module Config
   override :postgres17_paradedb_ubuntu_2204_version, "20250123.1.0", string
   override :postgres16_lantern_ubuntu_2204_version, "20250103.1.0", string
   override :postgres17_lantern_ubuntu_2204_version, "20250103.1.0", string
-  override :ai_ubuntu_2404_nvidia_version, "20250210.1.0", string
+  override :ai_ubuntu_2404_nvidia_version, "20250213.1.0", string
 
   # Allocator
   override :allocator_target_host_utilization, 0.55, float

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -106,7 +106,7 @@ class Prog::DownloadBootImage < Prog::Base
       ["ai-model-qwq-32b-preview", "x64", "20241209.1.0"] => "38ca4912134ed9b115726eff258666d68ce6df92330a3585d47494099821f9b1",
       ["ai-model-ds-r1-qwen-32b", "x64", "20250121.1.0"] => "38b0d2fa870c90196e016ac69a89f5decd1ad3ea1258ae11ca039f212326f5c5",
       ["ai-model-ds-r1-qwen-1-5b", "x64", "20250129.1.0"] => "9135a2e81fc6129d6d12bd633b5a30d4bfe2fd219ec5e370404758dda1159001",
-      ["ai-model-ms-phi-4", "x64", "20250206.1.0"] => "3c4a0e6edc6abcaef779da9789fdab0c1f62ca15d5846cbb6ad49502c674f4cf"
+      ["ai-model-ms-phi-4", "x64", "20250213.1.0"] => "0e998c4916c837c0992c4546404ecb51d0c5d5923f998f7cff0a9cddc5bf1689"
     }
 
     # YYY: In future all images should be checked for sha256 sum, so the nil

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -92,7 +92,7 @@ class Prog::DownloadBootImage < Prog::Base
       ["postgres17-paradedb-ubuntu-2204", "x64", "20250123.1.0"] => "e150b0e9b6a5adc8550f2191276f603d120718e06c53bf398578a7d79dca7a84",
       ["postgres16-lantern-ubuntu-2204", "x64", "20250103.1.0"] => "bfb56867513045bc88396d529a3cc186dc44ba4d691acb51dbf45fc5a0eeb7e6",
       ["postgres17-lantern-ubuntu-2204", "x64", "20250103.1.0"] => "a95b2e5d03291783dc1753228d7a87949257a06c7b1eca2c94502ab21ffdecdb",
-      ["ai-ubuntu-2404-nvidia", "x64", "20250210.1.0"] => "94a6dc521c9b2f28b7557efafa96ad1eec3341885af8e3c1b01d64f89800d9c9",
+      ["ai-ubuntu-2404-nvidia", "x64", "20250213.1.0"] => "cde384cd27f8be38c69ac4d878b2515ef1434ba751bffad854ba623e4bc39f1a",
       ["ai-model-gemma-2-2b-it", "x64", "20240918.1.0"] => "b726ead6d5f48fb8e6de7efb48fb22367c9a7c155cfee71a3a7e5527be5df08e",
       ["ai-model-llama-3-1-8b-it", "x64", "20250118.1.0"] => "7296f70a861c364f59c38b816e1210152ebafbec85ce797888c16b4d48a15e8f",
       ["ai-model-llama-3-1-405b-it", "x64", "20241029.1.0"] => "54680b8b18ed501956a78c63b94576b7200fbd8fbe025eccb90152d13478882e",

--- a/rhizome/inference_endpoint/lib/replica_setup.rb
+++ b/rhizome/inference_endpoint/lib/replica_setup.rb
@@ -184,6 +184,7 @@ Environment=XDG_CACHE_HOME=/ie/workdir/.cache
 Environment=XDG_CONFIG_HOME=/ie/workdir/.config
 Environment=OUTLINES_CACHE_DIR=/ie/workdir/.outlines
 Environment=TRITON_CACHE_DIR=/ie/workdir/.triton
+Environment=HOME=/ie/workdir
 WorkingDirectory=/ie/workdir
 User=ie
 Group=ie


### PR DESCRIPTION
**Make vLLM work with FlashInfer**

In order for FlashInfer to work we need to set the HOME variable to a
writable location. FlashInfer creates a cache directory under the users
home. With this change, it will be created at `/ie/workdir/.cache/flashinfer`.

More details on FlashInfer: https://github.com/flashinfer-ai/flashinfer

---

**Update AI base image to 20250213.1.0**

Job producing the image:
https://github.com/ubicloud/ai-images/actions/runs/13307618520

The image contains
- Python 3.12
- vLLM: 0.7.2
- inference gateway: v0.1.6

The main difference from the previous ai base image is that it comes
with https://github.com/flashinfer-ai/flashinfer preinstalled.

---

**Update model ms-phi-4 to 20250213.1.0**

More details about the model:
https://huggingface.co/microsoft/phi-4

Job producing the image:
https://github.com/ubicloud/ai-images/actions/runs/13313129815