### PR TITLE
Add billing check and free quota for AI inference (v2)

### DIFF
--- a/config/billing_rates.yml
+++ b/config/billing_rates.yml
@@ -1,5 +1,6 @@
 # Active billing rates
 - { id: fc9877ec-131c-4572-a3f2-fd512d95b348, resource_type: InferenceTokens,         resource_family: test-model,          location: global,         unit_price: 0.0000000500, billed_by: amount,   active_from: 2024-10-14T00:00:00Z }
+- { id: f74122a3-186a-4273-b60b-511e03f29f3d, resource_type: InferenceTokens,         resource_family: test-model2,         location: global,         unit_price: 0.0000002000, billed_by: amount,   active_from: 2024-10-14T00:00:00Z }
 - { id: 74eb807c-75dd-49e4-95f8-5de25163b845, resource_type: InferenceTokens,         resource_family: gemma-2-2b-it,       location: global,         unit_price: 0.0000000000, billed_by: amount,   active_from: 2024-10-14T00:00:00Z }
 - { id: 195bd918-8a0b-4c07-8b57-289de6d6163e, resource_type: InferenceTokens,         resource_family: llama-3-2-3b-it,     location: global,         unit_price: 0.0000001000, billed_by: amount,   active_from: 2024-10-14T00:00:00Z }
 - { id: c385da12-e15c-4bcf-aa5d-fb9551158eb2, resource_type: InferenceTokens,         resource_family: e5-mistral-7b-it,    location: global,         unit_price: 0.0000001000, billed_by: amount,   active_from: 2024-10-14T00:00:00Z }

--- a/config/free_quotas.yml
+++ b/config/free_quotas.yml
@@ -1,0 +1,1 @@
+- { name: inference-tokens, value: 500000, resource_type: "InferenceTokens" }

--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -20,6 +20,12 @@ class BillingRate
     }.max_by { _1["active_from"] }
   end
 
+  def self.from_resource_type(resource_type)
+    rates.select {
+      _1["resource_type"] == resource_type
+    }
+  end
+
   def self.from_id(billing_rate_id)
     rates.find { _1["id"] == billing_rate_id }
   end

--- a/lib/free_quota.rb
+++ b/lib/free_quota.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+class FreeQuota
+  # :nocov:
+  def self.freeze
+    free_quotas
+    super
+  end
+  # :nocov:
+
+  def self.free_quotas
+    @free_quotas ||= begin
+      quotas = YAML.load_file("config/free_quotas.yml")
+      quotas.each_with_object({}) do |item, hash|
+        item["billing_rate_ids"] = BillingRate.from_resource_type(item["resource_type"]).map { _1["id"] }
+        hash[item["name"]] = item
+      end
+    end
+    @free_quotas
+  end
+
+  def self.remaining_free_quota(name, project_id)
+    free_quota = free_quotas[name]
+    used_amount = BillingRecord
+      .where(project_id:, billing_rate_id: free_quota["billing_rate_ids"])
+      .where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }
+      .sum(:amount) || 0
+    [0, free_quota["value"] - used_amount].max
+  end
+
+  def self.get_exhausted_projects(name)
+    free_quota = free_quotas[name]
+    BillingRecord
+      .where(billing_rate_id: free_quota["billing_rate_ids"])
+      .where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }
+      .group(:project_id)
+      .having { sum(:amount) >= free_quota["value"] }
+      .select(:project_id)
+  end
+
+  def self.begin_of_month
+    Time.new(Time.now.year, Time.now.month, 1)
+  end
+end

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -217,6 +217,7 @@ class Invoice < Sequel::Model
       # :nocov:
       (data[:discount] != "$0.00") ? ["Discount:", "-#{data[:discount]}"] : nil,
       (data[:credit] != "$0.00") ? ["Credit:", "-#{data[:credit]}"] : nil,
+      (data[:free_inference_tokens_credit] != "$0.00") ? ["Free Inference Tokens:", "-#{data[:free_inference_tokens_credit]}"] : nil,
       # :nocov:
       ["Total:", data[:total]]
     ].compact

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -171,7 +171,10 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
       .exists
 
     eligible_projects_ds = Project.where(api_key_ds)
+    free_quota_exhausted_projects_ds = FreeQuota.get_exhausted_projects("inference-tokens")
     eligible_projects_ds = eligible_projects_ds.where(id: inference_endpoint.project.id) unless inference_endpoint.is_public
+    eligible_projects_ds = eligible_projects_ds
+      .exclude(billing_info_id: nil, credit: 0.0, id: free_quota_exhausted_projects_ds)
 
     eligible_projects = eligible_projects_ds.all
       .select(&:active?)

--- a/routes/project/inference_api_key.rb
+++ b/routes/project/inference_api_key.rb
@@ -5,6 +5,9 @@ class Clover
     r.web do
       r.get true do
         @inference_api_keys = Serializers::InferenceApiKey.serialize(inference_api_key_ds.all)
+        @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
+        @free_quota_unit = "inference tokens"
+        @has_valid_payment_method = @project.has_valid_payment_method?
         view "inference/api_key/index"
       end
 

--- a/routes/project/inference_endpoint.rb
+++ b/routes/project/inference_endpoint.rb
@@ -4,6 +4,9 @@ class Clover
   hash_branch(:project_prefix, "inference-endpoint") do |r|
     r.get web? do
       @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.all)
+      @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
+      @free_quota_unit = "inference tokens"
+      @has_valid_payment_method = @project.has_valid_payment_method?
       view "inference/endpoint/index"
     end
   end

--- a/routes/project/inference_playground.rb
+++ b/routes/project/inference_playground.rb
@@ -5,6 +5,9 @@ class Clover
     r.get web? do
       @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation"))
       @inference_api_keys = Serializers::InferenceApiKey.serialize(inference_api_key_ds.all)
+      @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
+      @free_quota_unit = "inference tokens"
+      @has_valid_payment_method = @project.has_valid_payment_method?
       view "inference/endpoint/playground"
     end
   end

--- a/serializers/invoice.rb
+++ b/serializers/invoice.rb
@@ -14,6 +14,7 @@ class Serializers::Invoice < Serializers::Base
       end_time: inv.end_time.strftime("%b %d, %Y"),
       subtotal: "$%0.02f" % inv.content["subtotal"],
       credit: "$%0.02f" % inv.content["credit"],
+      free_inference_tokens_credit: "$%0.02f" % (inv.content["free_inference_tokens_credit"] || 0),
       discount: "$%0.02f" % inv.content["discount"],
       total: "$%0.02f" % inv.content["cost"],
       status: inv.status,

--- a/spec/routes/web/inference_endpoint_spec.rb
+++ b/spec/routes/web/inference_endpoint_spec.rb
@@ -55,6 +55,50 @@ RSpec.describe Clover, "inference-endpoint" do
       expect(page.title).to eq("Ubicloud - Inference Endpoints")
       expect(page).to have_no_content("e5-mistral-7b-it")
     end
+
+    it "shows free quota notice with correct free inference tokens" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location: "hetzner-fsn1").subject
+      lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", src_port: 80, dst_port: 80, health_check_endpoint: "/up", project_id: project.id)
+      ie = InferenceEndpoint.create_with_id(name: "ie1", model_name: "test-model", project_id: project.id, is_public: true, visible: true, location: "loc", vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id)
+      visit "#{project.path}/inference-api-key"
+      expect(page.text).to include("You have 500000 free inference tokens available (few-minute delay). Free quota refreshes next month.")
+
+      BillingRecord.create_with_id(
+        project_id: project.id,
+        resource_id: ie.id,
+        resource_name: ie.name,
+        span: Sequel::Postgres::PGRange.new(Time.now, nil),
+        billing_rate_id: BillingRate.from_resource_type("InferenceTokens").first["id"],
+        amount: 100000
+      )
+      visit "#{project.path}/inference-api-key"
+      expect(page.text).to include("You have 400000 free inference tokens available (few-minute delay). Free quota refreshes next month.")
+
+      BillingRecord.create_with_id(
+        project_id: project.id,
+        resource_id: ie.id,
+        resource_name: ie.name,
+        span: Sequel::Postgres::PGRange.new(Time.now, nil),
+        billing_rate_id: BillingRate.from_resource_type("InferenceTokens").first["id"],
+        amount: 99999999
+      )
+      visit "#{project.path}/inference-api-key"
+      expect(page.text).to include("You have 0 free inference tokens available (few-minute delay). Free quota refreshes next month.")
+    end
+
+    it "shows free quota notice with billing valid message" do
+      expect(Config).to receive(:stripe_secret_key).at_least(:once).and_return(nil)
+      expect(project.has_valid_payment_method?).to be true
+      visit "#{project.path}/inference-api-key"
+      expect(page.text).to include("Billing information is valid. Charges start after the free quota.")
+    end
+
+    it "shows free quota notice with billing unavailable message" do
+      expect(Config).to receive(:stripe_secret_key).at_least(:once).and_return("test_stripe_secret_key")
+      expect(project.has_valid_payment_method?).to be false
+      visit "#{project.path}/inference-api-key"
+      expect(page.text).to include("To avoid service interruption, please click here to add a valid billing method.")
+    end
   end
 
   describe "unauthenticated" do

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe Clover, "billing" do
         content["billing_info"]["tax_id"] = "123XYZ"
         content["discount"] = 1
         content["credit"] = 2
+        content["free_inference_tokens_credit"] = 3
         expect(page).to have_content issuer_name
         invoice.this.update(content:)
 
@@ -313,6 +314,7 @@ RSpec.describe Clover, "billing" do
         expect(page).to have_no_content issuer_name
         expect(find_by_id("invoice-discount").text).to eq "-$1.00"
         expect(find_by_id("invoice-credit").text).to eq "-$2.00"
+        expect(find_by_id("invoice-free-inference-tokens").text).to eq "-$3.00"
       end
 
       it "show current invoice when no usage" do

--- a/views/components/free_quota.erb
+++ b/views/components/free_quota.erb
@@ -1,0 +1,28 @@
+<% warning_style = !@has_valid_payment_method %>
+<% bold_text_color = warning_style ? "text-orange-700" : "text-green-900" %>
+<div class="mb-2 rounded-md p-4 <%= warning_style ? "bg-orange-50" : "bg-green-50" %>">
+  <div class="flex items-center <%= warning_style ? "text-orange-600" : "text-green-800" %>">
+    <div class="flex-shrink-0">
+      <%== part("components/icon", name: "hero-banknotes", classes: "h-9 w-9") %>
+    </div>
+    <div class="ml-3">
+      <h3 class="text-sm font-medium">
+        <span>You have
+          <%= @remaining_free_quota.to_i %>
+          free
+          <%= @free_quota_unit %>
+          available (few-minute delay).</span>
+        <span>Free quota refreshes next month.</span>
+        <br>
+        <% if @has_valid_payment_method %>
+          <a href="<%= @project_data[:path] %>/billing" class="font-bold <%= bold_text_color %>">Billing</a>
+          <span>information is valid. Charges start after the free quota.</span>
+        <% else %>
+          <span>To avoid service interruption, please</span>
+          <a href="<%= @project_data[:path] %>/billing" class="font-bold <%= bold_text_color %>">click here</a>
+          <span>to add a valid billing method.</span>
+        <% end %>
+      </h3>
+    </div>
+  </div>
+</div>

--- a/views/inference/api_key/index.erb
+++ b/views/inference/api_key/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Inference API Keys" %>
+<%== render("components/free_quota") %>
 <%== render("inference/tabbar") %>
 
 <div>

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Inference Endpoints" %>
+<%== render("components/free_quota") %>
 <%== render("inference/tabbar") %>
 
 <div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Playground" %>
+<%== render("components/free_quota") %>
 <% @enable_marked = true %>
 <%== render("inference/tabbar") %>
 <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -112,24 +112,30 @@
 
         <div class="mt-8 flex justify-end">
             <div class="grid gap-2 text-right">
-              <dl class="grid grid-cols-2 gap-x-3">
-                <dt class="text-right font-semibold text-gray-800">Subtotal:</dt>
+              <dl class="grid grid-cols-3 gap-x-3">
+                <dt class="text-right font-semibold text-gray-800 col-span-2">Subtotal:</dt>
                 <dd class="text-gray-500"><%= @invoice_data[:subtotal] %></dd>
               </dl>
               <% if @invoice_data[:discount] != "$0.00" %>
-                <dl class="grid grid-cols-2 gap-x-3">
-                  <dt class="text-right font-semibold text-gray-800">Discount:</dt>
+                <dl class="grid grid-cols-3 gap-x-3">
+                  <dt class="text-right font-semibold text-gray-800 col-span-2">Discount:</dt>
                   <dd class="text-gray-500" id="invoice-discount">-<%= @invoice_data[:discount] %></dd>
                 </dl>
               <% end %>
               <% if @invoice_data[:credit] != "$0.00" %>
-                <dl class="grid grid-cols-2 gap-x-3">
-                  <dt class="text-right font-semibold text-gray-800">Credit:</dt>
+                <dl class="grid grid-cols-3 gap-x-3">
+                  <dt class="text-right font-semibold text-gray-800 col-span-2">Credit:</dt>
                   <dd class="text-gray-500" id="invoice-credit">-<%= @invoice_data[:credit] %></dd>
                 </dl>
               <% end %>
-              <dl class="grid grid-cols-2 gap-x-3 text-2xl">
-                <dt class="text-right font-semibold text-gray-800">Total:</dt>
+              <% if @invoice_data[:free_inference_tokens_credit] != "$0.00" %>
+                <dl class="grid grid-cols-3 gap-x-3">
+                  <dt class="text-right font-semibold text-gray-800 col-span-2">Free Inference Tokens:</dt>
+                  <dd class="text-gray-500" id="invoice-free-inference-tokens">-<%= @invoice_data[:free_inference_tokens_credit] %></dd>
+                </dl>
+              <% end %>
+              <dl class="grid grid-cols-3 gap-x-3 text-2xl">
+                <dt class="text-right font-semibold text-gray-800 col-span-2">Total:</dt>
                 <dd class="text-gray-500"><%= @invoice_data[:total] %></dd>
               </dl>
             </div>


### PR DESCRIPTION
Provide free quota for AI inference. Projects without valid billing info will have requests rejected after the free quota is exhausted.

Free quota is configurable in free_quota.yml, currently set to 500,000 tokens/month/project, based on conversation with Ozgun.

Here's how the frontend would look like for projects with and without valid billing respectively.

<img width="1290" alt="Screenshot 2025-02-07 at 6 55 13 PM" src="https://github.com/user-attachments/assets/929fabc8-66fb-45bb-8feb-a1cbc2bf91d2" />
<img width="1290" alt="Screenshot 2025-02-07 at 6 55 25 PM" src="https://github.com/user-attachments/assets/83bef2b0-3a82-4fa8-8714-0bc395dda38d" />

The invoice will convert the free tokens to a dollar credit. Here's how the invoice will look like.
<img width="1490" alt="Screenshot 2025-02-14 at 5 09 34 PM" src="https://github.com/user-attachments/assets/a150ee4e-7b54-495d-938e-a96ffb0ae83b" />
<img width="807" alt="Screenshot 2025-02-14 at 5 09 47 PM" src="https://github.com/user-attachments/assets/466a4b37-c283-4c14-a604-9347490d70e4" />
