### PR TITLE
Destroy bucket and tokens of repository if there is no cache entry

### DIFF
--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -113,6 +113,11 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
         total_usage -= oldest_entry.size
       end
     end
+
+    if github_repository.cache_entries.empty?
+      Clog.emit("Deleting empty bucket and tokens") { {deleting_empty_bucket: {repository_name: github_repository.name}} }
+      github_repository.destroy_blob_storage
+    end
   end
 
   def before_run

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -164,6 +164,11 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect(blob_storage_client).to receive(:delete_object).with(bucket: github_repository.bucket_name, key: three_gib_cache.blob_key)
       nx.cleanup_cache
     end
+
+    it "deletes blob storage if there are no cache entries" do
+      expect(github_repository).to receive(:destroy_blob_storage)
+      nx.cleanup_cache
+    end
   end
 
   describe "#before_run" do


### PR DESCRIPTION
Since we have a bucket and token limit on Cloudflare, destroying them if there is no cache entry exist for the repository.