### PR TITLE
Fix timeline creation at the end of the restore

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -319,7 +319,7 @@ SQL
     end
 
     if !is_in_recovery
-      timeline_id = Prog::Postgres::PostgresTimelineNexus.assemble(parent_id: postgres_server.timeline.id).id
+      timeline_id = Prog::Postgres::PostgresTimelineNexus.assemble(location: postgres_server.resource.location, parent_id: postgres_server.timeline.id).id
       postgres_server.timeline_id = timeline_id
       postgres_server.timeline_access = "push"
       postgres_server.save_changes

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -8,7 +8,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   extend Forwardable
   def_delegators :postgres_timeline, :blob_storage_client
 
-  def self.assemble(parent_id: nil, location: nil)
+  def self.assemble(location:, parent_id: nil)
     if parent_id && (PostgresTimeline[parent_id]).nil?
       fail "No existing parent"
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       version: "16",
       representative_server: postgres_server,
       metric_destinations: [instance_double(PostgresMetricDestination, ubid: "pgmetricubid", url: "url", username: "username", password: "password")],
-      ca_certificates: "root_cert_1\nroot_cert_2"
+      ca_certificates: "root_cert_1\nroot_cert_2",
+      location: "hetzner-fsn1"
     )
   }
 

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
   describe ".assemble" do
     it "throws an exception if parent is not found" do
       expect {
-        described_class.assemble(parent_id: "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b")
+        described_class.assemble(location: "hetzner-fsn1", parent_id: "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b")
       }.to raise_error RuntimeError, "No existing parent"
     end
 
     it "creates postgres timeline" do
-      st = described_class.assemble
+      st = described_class.assemble(location: "hetzner-fsn1")
 
       postgres_timeline = PostgresTimeline[st.id]
       expect(postgres_timeline).not_to be_nil


### PR DESCRIPTION
**Pass location while creating new timeline at the end of restore**
We used to keep blob storage id in a config variable, but then we started to
search it using location and project id. However, we forgot to pass location
while creating new timeline at the end of restore. This prevents us taking
backups of the restored databases. This commit fixes this issue by passing the
location while creating new timeline at the end of restore.

**Make location mandatory parameter for PostgresTimelineNexus.assemble**
We introduced a bug due to this parameter being optional. There is no use case
for it to be optional, so we are making it mandatory.