### PR TITLE
Increase the timeout for kubeadm join and init commands

### DIFF
--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -50,6 +50,9 @@ config = {
     "local" => {
       "dataDir" => "/var/lib/etcd"
     }
+  },
+  "timeouts" => {
+    "controlPlaneComponentHealthCheck" => "10m0s"
   }
 }
 


### PR DESCRIPTION
We rely on DNS to discover API Server and sometimes it takes a bit of time to have the records updated and successfully run some queries. In order to increase the success rate of kubeadm init, timeout is increased to 10 minutes.