### PR TITLE
Use public IPs for minio cluster communication

### DIFF
--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -24,12 +24,6 @@ class MinioCluster < Sequel::Model
     enc.column :root_cert_key_2
   end
 
-  def generate_etc_hosts_entry
-    servers.map do |server|
-      "#{server.private_ipv4_address} #{server.hostname}"
-    end.join("\n")
-  end
-
   def storage_size_gib
     pools.sum(&:storage_size_gib)
   end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -21,12 +21,24 @@ class MinioServer < Sequel::Model
     enc.column :cert_key
   end
 
+  def generate_etc_hosts_entry
+    entries = ["::1 #{hostname}"]
+    entries += cluster.servers.reject { _1.id == id }.map do |server|
+      "#{server.public_ipv6_address} #{server.hostname}"
+    end
+    entries.join("\n")
+  end
+
   def hostname
     "#{cluster.name}#{index}.#{Config.minio_host_name}"
   end
 
   def private_ipv4_address
     vm.private_ipv4.to_s
+  end
+
+  def public_ipv6_address
+    vm.ephemeral_net6.nth(2).to_s
   end
 
   def minio_volumes

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -60,6 +60,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     register_deadline("wait", 10 * 60)
 
     minio_server.cluster.dns_zone&.insert_record(record_name: cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
+    minio_server.cluster.dns_zone&.insert_record(record_name: cluster.hostname, type: "AAAA", ttl: 10, data: vm.ephemeral_net6.nth(2).to_s)
     cert, cert_key = create_certificate
     minio_server.update(cert: cert, cert_key: cert_key)
 
@@ -206,7 +207,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       root_cert_key = OpenSSL::PKey::EC.new(minio_server.cluster.root_cert_key_2)
     end
 
-    ip_san = (Config.development? || Config.is_e2e) ? ",IP:#{minio_server.vm.ephemeral_net4}" : nil
+    ip_san = (Config.development? || Config.is_e2e) ? ",IP:#{minio_server.vm.ephemeral_net4},IP:#{minio_server.vm.ephemeral_net6.nth(2)}" : nil
 
     Util.create_certificate(
       subject: "/C=US/O=Ubicloud/CN=#{minio_server.cluster.ubid} Server Certificate",

--- a/prog/minio/setup_minio.rb
+++ b/prog/minio/setup_minio.rb
@@ -35,7 +35,7 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
-#{minio_server.cluster.generate_etc_hosts_entry}
+#{minio_server.generate_etc_hosts_entry}
 ECHO
       config_json = JSON.generate({
         minio_config: minio_config,

--- a/spec/model/minio/minio_cluster_spec.rb
+++ b/spec/model/minio/minio_cluster_spec.rb
@@ -30,15 +30,6 @@ RSpec.describe MinioCluster do
     mc
   }
 
-  it "generates /etc/hosts entries properly when there are multiple pool" do
-    server = mc.servers.first
-    expect(mc).to receive(:servers).and_return([server, server]).at_least(:once)
-    expect(server).to receive(:hostname).and_return("hostname").at_least(:once)
-    expect(server).to receive(:private_ipv4_address).and_return("10.0.0.0").at_least(:once)
-
-    expect(mc.generate_etc_hosts_entry).to eq("10.0.0.0 hostname\n10.0.0.0 hostname")
-  end
-
   it "returns minio servers properly" do
     expect(mc.servers.map(&:index)).to eq([0])
   end

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe MinioServer do
     expect(ms.private_ipv4_address).to eq("192.168.0.0")
   end
 
+  it "returns public ipv6 address properly" do
+    expect(ms.public_ipv6_address).to eq("fdfa:b5aa:14a3:4a3d::2")
+  end
+
   it "returns minio cluster properly" do
     expect(ms.cluster.name).to eq("minio-cluster-name")
   end
@@ -115,6 +119,14 @@ RSpec.describe MinioServer do
 
   it "needs event loop for pulse check" do
     expect(ms).to be_needs_event_loop_for_pulse_check
+  end
+
+  it "generates /etc/hosts entries properly when there are multiple servers" do
+    servers = [instance_double(described_class, id: ms.id, public_ipv6_address: "fdfa:b5aa:14a3:4a3d::/64", hostname: "minio-cluster-name1.minio.ubicloud.com"),
+      instance_double(described_class, id: 2, public_ipv6_address: "fdfb:b5aa:14a3:4a3f::/64", hostname: "minio-cluster-name2.minio.ubicloud.com")]
+    mc = instance_double(MinioCluster, name: "minio-cluster-name", servers: servers)
+    expect(ms).to receive(:cluster).and_return(mc).at_least(:once)
+    expect(ms.generate_etc_hosts_entry).to eq("::1 minio-cluster-name0.minio.ubicloud.com\nfdfb:b5aa:14a3:4a3f::/64 minio-cluster-name2.minio.ubicloud.com")
   end
 
   describe "#url" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe Prog::Minio::MinioServerNexus do
 
       expect(Config).to receive(:development?).and_return(true)
       expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
-      create_certificate_payload[:extensions] = ["subjectAltName=DNS:minio-cluster-name.minio.ubicloud.com,DNS:minio-cluster-name0.minio.ubicloud.com,IP:1.1.1.1", "keyUsage=digitalSignature,keyEncipherment", "subjectKeyIdentifier=hash", "extendedKeyUsage=serverAuth"]
+      expect(vm).to receive(:ephemeral_net6).and_return(NetAddr::IPv6Net.parse("2a01:4f8:10a:128b:814c::/79"))
+      create_certificate_payload[:extensions] = ["subjectAltName=DNS:minio-cluster-name.minio.ubicloud.com,DNS:minio-cluster-name0.minio.ubicloud.com,IP:1.1.1.1,IP:2a01:4f8:10a:128b:814c::2", "keyUsage=digitalSignature,keyEncipherment", "subjectKeyIdentifier=hash", "extendedKeyUsage=serverAuth"]
       expect(Util).to receive(:create_certificate).with(create_certificate_payload).and_return([instance_double(OpenSSL::X509::Certificate, to_pem: "cert"), instance_double(OpenSSL::PKey::EC, to_pem: "cert_key")])
 
       expect(nx.minio_server).to receive(:update).and_call_original
@@ -130,8 +131,11 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(nx.minio_server.cluster).to receive(:dns_zone).and_return(dz).at_least(:once)
       vm = nx.minio_server.vm
       vm.strand.update(label: "wait")
+      expect(vm).to receive(:ephemeral_net4).and_return("1.1.1.1")
+      expect(vm).to receive(:ephemeral_net6).and_return(NetAddr::IPv6Net.parse("2a01:4f8:10a:128b:814c::/79"))
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(nx.minio_server.cluster.dns_zone).to receive(:insert_record).with(record_name: nx.cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
+      expect(nx.minio_server.cluster.dns_zone).to receive(:insert_record).with(record_name: nx.cluster.hostname, type: "A", ttl: 10, data: "1.1.1.1")
+      expect(nx.minio_server.cluster.dns_zone).to receive(:insert_record).with(record_name: nx.cluster.hostname, type: "AAAA", ttl: 10, data: "2a01:4f8:10a:128b:814c::2")
       expect(nx).to receive(:register_deadline)
       expect(OpenSSL::X509::Certificate).to receive(:new).with("root_cert_1").and_return(cert_1)
       expect(OpenSSL::PKey::EC).to receive(:new).with("root_cert_key_1").and_return(key_1)

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -86,7 +86,7 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
-192.168.0.0 minio-cluster-name0.minio.ubicloud.com
+::1 minio-cluster-name0.minio.ubicloud.com
 ECHO
       JSON.generate({
         minio_config: minio_config,
@@ -102,7 +102,6 @@ ECHO
     end
 
     it "configures minio if not started" do
-      expect(nx.minio_server.cluster.servers.first).to receive(:private_ipv4_address).and_return("192.168.0.0")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check configure_minio").and_return("NotStarted")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo minio/bin/configure-minio' configure_minio", stdin: config)
 
@@ -111,7 +110,6 @@ ECHO
 
     it "configures minio without server_url if dns is not configures" do
       expect(nx.minio_server.cluster).to receive(:dns_zone).and_return(false)
-      expect(nx.minio_server.cluster.servers.first).to receive(:private_ipv4_address).and_return("192.168.0.0")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check configure_minio").and_return("NotStarted")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo minio/bin/configure-minio' configure_minio", stdin: config.gsub("MINIO_SERVER_URL=\\\"https://minio-cluster-name.minio.ubicloud.com:9000\\\"", ""))
 
@@ -125,7 +123,6 @@ ECHO
     end
 
     it "configures minio if failed" do
-      expect(nx.minio_server.cluster.servers.first).to receive(:private_ipv4_address).and_return("192.168.0.0")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check configure_minio").and_return("Failed")
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo minio/bin/configure-minio' configure_minio", stdin: config)
 


### PR DESCRIPTION
## Description
Use public IPs for peer communication in minio cluster, to avoid private networking performance penalty.

## Tests
- [x] Unit tests
- [x] Create a minio cluster with multiple servers