### PR TITLE
Add openrouter model config file

### DIFF
--- a/config/openrouter.json
+++ b/config/openrouter.json
@@ -1,0 +1,33 @@
+{
+  "data": [
+    {
+      "id": "mistral-small-3",
+      "name": "mistralai/Mistral-Small-24B-Instruct-2501",
+      "base_url": "https://mistral-small-3.ai.ubicloud.com/v1",
+      "created": 1739816399,
+      "context_length": 32768,
+      "quantization": "bf16",
+      "pricing": {
+        "prompt": "0.0000003",
+        "completion": "0.0000003",
+        "image": "0",
+        "request": "0"
+      },
+      "supported_sampling_parameters": [
+        "frequency_penalty",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Openrouter integration requires providing an endpoint that returns all supported models, see https://openrouter.ai/docs/use-cases/for-providers.

After merging, the openrouter config should be available at: https://raw.githubusercontent.com/ubicloud/ubicloud/refs/heads/main/config/openrouter.json

Our initial model listed at OpenRouter is `mistral-small-3`.