### PR TITLE
Increase IO buff sizes of SPDK

### DIFF
--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -36,7 +36,7 @@ class Prog::Storage::SetupSpdk < Prog::Base
       allocation_weight: 0,
       vm_host_id: vm_host.id,
       cpu_count: vm_host.spdk_cpu_count,
-      hugepages: 2
+      hugepages: 3
     ) { _1.id = SpdkInstallation.generate_uuid }
 
     hop_install_spdk

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -133,7 +133,7 @@ Description=SPDK hugepages mount #{@spdk_version}
 What=hugetlbfs
 Where=#{hugepages_dir}
 Type=hugetlbfs
-Options=uid=#{user},size=2G
+Options=uid=#{user},size=3G
 
 [Install]
 WantedBy=#{spdk_service}
@@ -155,10 +155,10 @@ SPDK_HUGEPAGES_MOUNT
         #
         # So, small_pool_count must be at least #Volumes-per-host*3*128, and
         # large_pool_count must be at least #Volumes-per-host*3*16. This config,
-        # which modifies the defaults, is enough for 100 encrypted volumes in a
+        # which modifies the defaults, is enough for 150 encrypted volumes in a
         # host.
-        small_pool_count: 38400,
-        large_pool_count: 4800,
+        small_pool_count: 57600,
+        large_pool_count: 7200,
         small_bufsize: 8192,
         large_bufsize: 135168
       }


### PR DESCRIPTION
Whenever an IO channel is made to a bdev, it gets some pre-allocated iobufs from SPDK's pre-allocated buffer pools. SPDK has 2 pools, one with small buffers (8kb per item), and one with large buffers (128kb per item).

This sizes of these pools are configurable at SPDK startup time.

We were getting crashes in production because of no free items in these pools.

To fix this, this change:

1. Increases the sizes of these pools.
2. Increases the number of 1g hugepages used for SPDK, to have enough space for the new sizes of pools