### PR TITLE
Make specs work when database timezone doesn't match local timezone

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -48,7 +48,7 @@ class InvoiceGenerator
             line_item_content[:amount] = li[:amount].to_f
             line_item_content[:duration] = li[:duration]
             line_item_content[:cost] = li[:cost].to_f
-            line_item_content[:begin_time] = li[:begin_time]
+            line_item_content[:begin_time] = li[:begin_time].utc
             line_item_content[:unit_price] = li[:unit_price].to_f
 
             resource_content[:line_items].push(line_item_content)

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe InvoiceGenerator do
           "amount" => vm.vcpus.to_f,
           "duration" => duration_mins,
           "cost" => cost,
-          "begin_time" => begin_time.to_s,
+          "begin_time" => begin_time.utc.to_s,
           "unit_price" => br["unit_price"]
         }],
         "cost" => cost


### PR DESCRIPTION
In the invoice generator, always use UTC for the begin_time.