### PR TITLE
Raise a parse error for all types of invalid UBID

### DIFF
--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe UBID do
   end
 
   it "fails to convert U to base32" do
-    expect { described_class.to_base32("u") }.to raise_error RuntimeError, "Invalid base32 encoding: U"
+    expect { described_class.to_base32("u") }.to raise_error UBIDParseError, "Invalid base32 encoding: U"
   end
 
   it "can convert from base32" do
@@ -68,11 +68,11 @@ RSpec.describe UBID do
   it "fails to convert from out of range numbers" do
     expect {
       described_class.from_base32(-1)
-    }.to raise_error RuntimeError, "Invalid base32 number: -1"
+    }.to raise_error UBIDParseError, "Invalid base32 number: -1"
 
     expect {
       described_class.from_base32(32)
-    }.to raise_error RuntimeError, "Invalid base32 number: 32"
+    }.to raise_error UBIDParseError, "Invalid base32 number: 32"
   end
 
   it "can calculate parity" do
@@ -106,21 +106,27 @@ RSpec.describe UBID do
   it "fails to parse if length is not 26" do
     expect {
       described_class.parse("123456")
-    }.to raise_error RuntimeError, "Invalid encoding length: 6"
+    }.to raise_error UBIDParseError, "Invalid encoding length: 6"
+  end
+
+  it "fails to parse if length is 26 but has invalid characters" do
+    expect {
+      described_class.parse("vm164pbm96-a3grq6vbsvjb3ax")
+    }.to raise_error UBIDParseError, "Invalid base32 encoding: -"
   end
 
   it "fails to parse if top bits parity is incorrect" do
     invalid_ubid = "vm164pbm96ba3grq6vbsvjb3ax"
     expect {
       described_class.parse(invalid_ubid)
-    }.to raise_error RuntimeError, "Invalid top bits parity"
+    }.to raise_error UBIDParseError, "Invalid top bits parity"
   end
 
   it "fails to parse if bottom bits parity is incorrect" do
     invalid_ubid = "vm064pbm96ba3grq6vbsvjb3az"
     expect {
       described_class.parse(invalid_ubid)
-    }.to raise_error RuntimeError, "Invalid bottom bits parity"
+    }.to raise_error UBIDParseError, "Invalid bottom bits parity"
   end
 
   it "generates random timestamp for most types" do
@@ -304,7 +310,7 @@ RSpec.describe UBID do
   it "fails to decode unknown type" do
     expect {
       described_class.decode("han2sefsk4f61k91z77vn0y978")
-    }.to raise_error RuntimeError, "Couldn't decode ubid: han2sefsk4f61k91z77vn0y978"
+    }.to raise_error UBIDParseError, "Couldn't decode ubid: han2sefsk4f61k91z77vn0y978"
   end
 
   it "can be inspected" do

--- a/ubid.rb
+++ b/ubid.rb
@@ -186,7 +186,7 @@ class UBID
     ubid_str = ubid.to_s
     uuid = UBID.parse(ubid_str).to_uuid
     klass = class_for_ubid(ubid)
-    fail "Couldn't decode ubid: #{ubid_str}" if klass.nil?
+    fail UBIDParseError.new("Couldn't decode ubid: #{ubid_str}") if klass.nil?
 
     klass[uuid]
   end
@@ -346,7 +346,7 @@ class UBID
       end
     end
 
-    raise "Invalid base32 encoding: #{c}"
+    fail UBIDParseError.new("Invalid base32 encoding: #{c}")
   end
 
   def self.to_base32_n(s)
@@ -358,7 +358,7 @@ class UBID
   end
 
   def self.from_base32(num)
-    fail "Invalid base32 number: #{num}" if num < 0 || num >= 32
+    fail UBIDParseError.new("Invalid base32 number: #{num}") if num < 0 || num >= 32
     BASE32_DATA[num][0].downcase
   end
 


### PR DESCRIPTION
If the UBID is not 26 characters long, we raise a UBIDParseError exception. In `Model.from_ubid`, if the UBIDParseError exception is raised, we catch it and return nil since the resource does not exist.

However, a UBID can be 26 characters long but still not valid. For example, "vm164pbm96-a3grq6vbsvjb3ax" has 26 characters, but because of the "-", it's not a valid UBID. When an invalid UBID with 26 characters is passed to the URL, it raises an "Invalid base32 encoding" error and returns an HTTP 500 exception which happens in production time to time. Instead, we should return HTTP 404 since the resource with the given ID does not exist. We return 404 if the UBID doesn't have 26 characters.