### PR TITLE
Reduce VM create time

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -244,17 +244,6 @@ class Prog::Vm::Nexus < Prog::Base
 
     host.sshable.cmd(command)
 
-    hop_wait_for_slice
-  end
-
-  label def wait_for_slice
-    if vm.vm_host_slice
-      if !vm.vm_host_slice.enabled
-        # Just wait here until the slice creation is completed
-        nap 1
-      end
-    end
-
     hop_prep
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -233,28 +233,7 @@ RSpec.describe Prog::Vm::Nexus do
         sudo usermod -a -G kvm #{nx.vm_name}
       COMMAND
 
-      expect { nx.create_unix_user }.to hop("wait_for_slice")
-    end
-  end
-
-  describe "#wait_for_slice" do
-    it "hop to prep if no slice" do
-      expect(vm).to receive(:vm_host_slice).and_return(nil)
-      expect { nx.wait_for_slice }.to hop("prep")
-    end
-
-    it "naps until slice is created" do
-      vm_host_slice = instance_double(VmHostSlice)
-      expect(vm).to receive(:vm_host_slice).and_return(vm_host_slice).twice
-      expect(vm_host_slice).to receive(:enabled).and_return(false)
-      expect { nx.wait_for_slice }.to nap(1)
-    end
-
-    it "hop after slice is created" do
-      vm_host_slice = instance_double(VmHostSlice)
-      expect(vm).to receive(:vm_host_slice).and_return(vm_host_slice).twice
-      expect(vm_host_slice).to receive(:enabled).and_return(true)
-      expect { nx.wait_for_slice }.to hop("prep")
+      expect { nx.create_unix_user }.to hop("prep")
     end
   end
 


### PR DESCRIPTION
Remove the `wait_for_slice` label from the Vm Nexus and with that remove the wait time before calling the `prep`. The VM service on the host (systemctl service) has an implicit dependency on the slice by specifying the slice name in the service file. That ensures that the VM is not started until the slice is started and ready. That waiting can happen in `wait_for_sshable`, as we are waiting there anyway for the service to start and be connectable. This allows the slice creation to proceed fully parallel to the Vm creation.