### PR TITLE
Use deadline pages for VM/Slice unavailability

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -409,11 +409,12 @@ class Prog::Vm::Nexus < Prog::Base
 
     begin
       if available?
-        Page.from_tag_parts("VmUnavailable", vm.ubid)&.incr_resolve
         decr_checkup
         hop_wait
       else
-        Prog::PageNexus.assemble("#{vm} is unavailable", ["VmUnavailable", vm.ubid], vm.ubid)
+        # Use deadlines to create a page instead of a custom page, so page
+        # resolution in different states can be handled properly.
+        register_deadline("wait", 0)
       end
     rescue Sshable::SshError
       # Host is likely to be down, which will be handled by HostNexus. No need

--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -75,11 +75,12 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
 
     begin
       if available?
-        Page.from_tag_parts("VmHostSliceUnavailable", vm_host_slice.ubid)&.incr_resolve
         decr_checkup
         hop_wait
       else
-        Prog::PageNexus.assemble("#{vm_host_slice.inhost_name} is unavailable", ["VmHostSliceUnavailable", vm_host_slice.ubid], vm_host_slice.ubid)
+        # Use deadlines to create a page instead of a custom page, so page
+        # resolution in different states can be handled properly.
+        register_deadline("wait", 0)
       end
     rescue Net::SSH::Disconnect, Net::SSH::ConnectionTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, IOError
       # Host is likely to be down, which will be handled by HostNexus. No need

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -745,23 +745,14 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.unavailable }.to hop("start_after_host_reboot")
     end
 
-    it "creates a page if vm is unavailable" do
-      expect(Prog::PageNexus).to receive(:assemble)
+    it "register an immediate deadline if vm is unavailable" do
+      expect(nx).to receive(:register_deadline).with("wait", 0)
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(30)
     end
 
-    it "resolves the page if vm is available" do
-      pg = instance_double(Page)
-      expect(pg).to receive(:incr_resolve)
+    it "hops to wait if vm is available" do
       expect(nx).to receive(:available?).and_return(true)
-      expect(Page).to receive(:from_tag_parts).and_return(pg)
-      expect { nx.unavailable }.to hop("wait")
-    end
-
-    it "does not resolves the page if there is none" do
-      expect(nx).to receive(:available?).and_return(true)
-      expect(Page).to receive(:from_tag_parts).and_return(nil)
       expect { nx.unavailable }.to hop("wait")
     end
   end

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -169,23 +169,14 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
       expect { nx.unavailable }.to hop("start_after_host_reboot")
     end
 
-    it "creates a page if vm is unavailable" do
-      expect(Prog::PageNexus).to receive(:assemble)
+    it "registers an immediate deadline if slice is unavailable" do
+      expect(nx).to receive(:register_deadline).with("wait", 0)
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(30)
     end
 
-    it "resolves the page if vm is available" do
-      pg = instance_double(Page)
-      expect(pg).to receive(:incr_resolve)
+    it "hops to wait if slice is available" do
       expect(nx).to receive(:available?).and_return(true)
-      expect(Page).to receive(:from_tag_parts).and_return(pg)
-      expect { nx.unavailable }.to hop("wait")
-    end
-
-    it "does not resolves the page if there is none" do
-      expect(nx).to receive(:available?).and_return(true)
-      expect(Page).to receive(:from_tag_parts).and_return(nil)
       expect { nx.unavailable }.to hop("wait")
     end
   end


### PR DESCRIPTION
Replaced `VmUnavailable` and `VmHostSliceUnavailable` pages with deadline pages. Deadlines automatically resolve on resource deletion and provide additional context useful for on-call debugging.