### PR TITLE
Use deadline pages for VM host unavailability

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -311,12 +311,12 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def unavailable
-    Prog::PageNexus.assemble("#{vm_host} disk(s) is unhealthy", ["VmHostUnavailable", vm_host.ubid], vm_host.ubid)
     if available?
-      Page.from_tag_parts("VmHostUnavailable", vm_host.ubid)&.incr_resolve
       decr_checkup
       hop_wait
     end
+
+    register_deadline("wait", 0)
     nap 30
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -324,28 +324,14 @@ RSpec.describe Prog::Vm::HostNexus do
   end
 
   describe "#unavailable" do
-    it "creates a page if host is unavailable" do
-      expect(vm_host).to receive(:ubid).and_return("vhxxxx").at_least(:once)
-      expect(Prog::PageNexus).to receive(:assemble)
+    it "registers an immediate deadline if host is unavailable" do
+      expect(nx).to receive(:register_deadline).with("wait", 0)
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(30)
     end
 
-    it "resolves the page if host is available" do
-      expect(vm_host).to receive(:ubid).and_return("vhxxxx").at_least(:once)
-      expect(Prog::PageNexus).to receive(:assemble)
-      pg = instance_double(Page)
-      expect(pg).to receive(:incr_resolve)
+    it "hops to wait if host is available" do
       expect(nx).to receive(:available?).and_return(true)
-      expect(Page).to receive(:from_tag_parts).and_return(pg)
-      expect { nx.unavailable }.to hop("wait")
-    end
-
-    it "does not resolves the page if there is none" do
-      expect(vm_host).to receive(:ubid).and_return("vhxxxx").at_least(:once)
-      expect(Prog::PageNexus).to receive(:assemble)
-      expect(nx).to receive(:available?).and_return(true)
-      expect(Page).to receive(:from_tag_parts).and_return(nil)
       expect { nx.unavailable }.to hop("wait")
     end
   end


### PR DESCRIPTION
PostgresServer was using deadlines instead of separate unavailability
pages. Hadi recently replaced them with deadline pages for both VM and
VM slice at 57f2d0f7.

The advantage of deadline pages is that they automatically resolve when
the resource is deleted and provide extra context useful for on-call
debugging. Otherwise, operators often forget to resolve them if the
resource is deleted.
