### PR TITLE
Make cli lb list command include location

### DIFF
--- a/cli-commands/lb/list.rb
+++ b/cli-commands/lb/list.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-UbiCli.list("lb", %w[name id src-port dst-port hostname])
+UbiCli.list("lb", %w[location name id src-port dst-port hostname])

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def load_balancer_list
-    dataset = dataset_authorize(@project.load_balancers_dataset, "LoadBalancer:view")
+    dataset = dataset_authorize(@project.load_balancers_dataset, "LoadBalancer:view").eager(:private_subnet)
     dataset = dataset.join(:private_subnet, id: Sequel[:load_balancer][:private_subnet_id]).where(location: @location).select_all(:load_balancer) if @location
     if api?
       result = dataset.paginated_result(

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1432,6 +1432,9 @@ components:
           type: string
           example: 1bhw8r4pn73t1m5f7rn7a5pej2
           pattern: '^1b[0-9a-hj-km-np-tv-z]{24}$'
+        location:
+          description: Location of the Load Balancer
+          type: string
         name:
           description: Name of the Load Balancer
           type: string
@@ -1726,9 +1729,6 @@ components:
             allOf:
               - $ref: '#/components/schemas/LoadBalancer'
               - properties:
-                  location:
-                    description: Location of the Load Balancer
-                    type: string
                   subnet:
                     description: Subnet of the Load Balancer
                     type: string

--- a/serializers/load_balancer.rb
+++ b/serializers/load_balancer.rb
@@ -5,6 +5,7 @@ class Serializers::LoadBalancer < Serializers::Base
     base = {
       id: lb.ubid,
       name: lb.name,
+      location: lb.private_subnet.display_location,
       hostname: lb.hostname,
       algorithm: lb.algorithm,
       stack: lb.stack,
@@ -20,7 +21,6 @@ class Serializers::LoadBalancer < Serializers::Base
 
     if options[:detailed]
       base[:subnet] = lb.private_subnet.name
-      base[:location] = lb.private_subnet.display_location
       base[:vms] = lb.vms.map { _1.ubid } || []
     end
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -98,7 +98,7 @@ Options:
     -f, --fields=fields              show specific fields (comma separated)
     -l, --location=location          only show load balancers in given location
     -N, --no-headers                 do not show headers
-Fields: name id src-port dst-port hostname
+Fields: location name id src-port dst-port hostname
 
 
 Usage: ubi lb location/(lb-name|_lb-ubid) attach-vm vm-id

--- a/spec/routes/api/cli/golden-files/lb list -N.txt
+++ b/spec/routes/api/cli/golden-files/lb list -N.txt
@@ -1,1 +1,1 @@
-test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345  54321  test-lb.dpqe2.
+eu-central-h1  test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345  54321  test-lb.dpqe2.

--- a/spec/routes/api/cli/golden-files/lb list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/lb list -l eu-central-h1.txt
@@ -1,2 +1,2 @@
-name     id                          src_port  dst_port  hostname      
-test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345     54321     test-lb.dpqe2.
+location       name     id                          src_port  dst_port  hostname      
+eu-central-h1  test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345     54321     test-lb.dpqe2.

--- a/spec/routes/api/cli/golden-files/lb list -l eu-north-h1.txt
+++ b/spec/routes/api/cli/golden-files/lb list -l eu-north-h1.txt
@@ -1,1 +1,1 @@
-name  id  src_port  dst_port  hostname
+location  name  id  src_port  dst_port  hostname

--- a/spec/routes/api/cli/golden-files/lb list invalid.txt
+++ b/spec/routes/api/cli/golden-files/lb list invalid.txt
@@ -6,4 +6,4 @@ Options:
     -f, --fields=fields              show specific fields (comma separated)
     -l, --location=location          only show load balancers in given location
     -N, --no-headers                 do not show headers
-Fields: name id src-port dst-port hostname
+Fields: location name id src-port dst-port hostname

--- a/spec/routes/api/cli/golden-files/lb list.txt
+++ b/spec/routes/api/cli/golden-files/lb list.txt
@@ -1,2 +1,2 @@
-name     id                          src_port  dst_port  hostname      
-test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345     54321     test-lb.dpqe2.
+location       name     id                          src_port  dst_port  hostname      
+eu-central-h1  test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345     54321     test-lb.dpqe2.


### PR DESCRIPTION
This requires changes to the api/serializer so that location is included for load balancers by default.

I think the reason this wasn't included for load balancer but was included for private subnets is that load balancer does not have a location column, it gets the location through the private_subnet it is associated with.

CC @geemus 