### PR TITLE
Use `false` cmd directly in cli spec

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "bin/ubi" do
   end
 
   it "uses exit status of executed program" do
-    o, e, s = Open3.capture3(@env.merge("UBI_SSH" => "/bin/false"), @prog, "exec", "ssh", "dash2", "foo")
+    o, e, s = Open3.capture3(@env.merge("UBI_SSH" => "false"), @prog, "exec", "ssh", "dash2", "foo")
     expect(o).to eq ""
     expect(e).to eq ""
     expect(s.exitstatus).to eq 1


### PR DESCRIPTION
macOS doesn't have `/bin/false`; it has `/usr/bin/false`. We can use
`false` directly instead of absolute paths, and the OS will find it
based on the PATH environment variable.
