### PR TITLE
Log runner vcpus instead of cores

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -36,7 +36,7 @@ class GithubRunner < Sequel::Model
   end
 
   def log_duration(message, duration)
-    values = {ubid: ubid, label: label, repository_name: repository_name, duration: duration, conclusion: workflow_job&.dig("conclusion")}
+    values = {ubid:, label:, repository_name:, duration:, conclusion: workflow_job&.dig("conclusion")}
     if vm
       values.merge!(vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores, vcpus: vm.vcpus)
       if vm.vm_host

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -38,7 +38,7 @@ class GithubRunner < Sequel::Model
   def log_duration(message, duration)
     values = {ubid: ubid, label: label, repository_name: repository_name, duration: duration, conclusion: workflow_job&.dig("conclusion")}
     if vm
-      values.merge!(vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores)
+      values.merge!(vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores, vcpus: vm.vcpus)
       if vm.vm_host
         values[:vm_host_ubid] = vm.vm_host.ubid
         values[:data_center] = vm.vm_host.data_center

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Clover, "github" do
 
     it "updates job details of runner when receive in_progress action" do
       expect(Clog).to receive(:emit).with("runner_started")
-      expect(runner).to receive(:vm).and_return(instance_double(Vm, ubid: "vm-ubid", arch: "x64", cores: 2, vm_host: nil, pool_id: nil)).at_least(:once)
+      expect(runner).to receive(:vm).and_return(instance_double(Vm, ubid: "vm-ubid", arch: "x64", cores: 2, vcpus: 4, vm_host: nil, pool_id: nil)).at_least(:once)
       expect(GithubRunner).to receive(:first).and_return(runner)
       send_webhook("workflow_job", workflow_job_payload(action: "in_progress", workflow_job: workflow_job_object(runner_id: runner.runner_id)))
 


### PR DESCRIPTION
- **Log runner vcpus instead of cores**
  With the burstable feature, we set VM cores to 0 and then set the actual
  values during provisioning. So, it's 0 for runner allocated logs if it's
  provisioned on a VM host with slices enabled. Therefore, we should use
  vcpus instead of cores in the logs. I'm keeping the cores since they
  have actual values after provisioning, and I don't want to break all the
  views in our monitoring tool.
  

- **Omit unnecessary hash values in runner log**
  