### PR TITLE
Add cli/api support for a few previously web-only actions

### DIFF
--- a/cli-commands/fw.rb
+++ b/cli-commands/fw.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("fw") do
   options("ubi fw subcommand [...]")
-  post_options("ubi fw location/(fw-name|_fw-ubid) subcommand [...]")
+  post_options("ubi fw location/(fw-name|_fw-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/fw")

--- a/cli-commands/fw/post/add-rule.rb
+++ b/cli-commands/fw/post/add-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("add-rule") do
-  options("ubi fw location/(fw-name|_fw-ubid) add-rule cidr", key: :fw_add_rule) do
+  options("ubi fw location/(fw-name|_fw-id) add-rule cidr", key: :fw_add_rule) do
     on("-s", "--start-port=port", "starting (or only) port to allow (default: 0)")
     on("-e", "--end-port=port", "ending port to allow (default: 65535)")
   end

--- a/cli-commands/fw/post/attach-subnet.rb
+++ b/cli-commands/fw/post/attach-subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("attach-subnet") do
-  options("ubi fw location/(fw-name|_fw-ubid) attach-subnet subnet-id")
+  options("ubi fw location/(fw-name|_fw-id) attach-subnet subnet-id")
 
   args 1
 

--- a/cli-commands/fw/post/delete-rule.rb
+++ b/cli-commands/fw/post/delete-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("delete-rule") do
-  options("ubi fw location/(fw-name|_fw-ubid) delete-rule rule-id")
+  options("ubi fw location/(fw-name|_fw-id) delete-rule rule-id")
 
   args 1
 

--- a/cli-commands/fw/post/detach-subnet.rb
+++ b/cli-commands/fw/post/detach-subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("detach-subnet") do
-  options("ubi fw location/(fw-name|_fw-ubid) detach-subnet subnet-id")
+  options("ubi fw location/(fw-name|_fw-id) detach-subnet subnet-id")
 
   args 1
 

--- a/cli-commands/fw/post/show.rb
+++ b/cli-commands/fw/post/show.rb
@@ -6,7 +6,7 @@ UbiCli.on("fw").run_on("show") do
   private_subnet_fields = %w[id name state location net4 net6 nics].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi fw location/(fw-name|_fw-ubid) show [options]", key: :fw_show) do
+  options("ubi fw location/(fw-name|_fw-id) show [options]", key: :fw_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
     on("-p", "--priv-subnet-fields=fields", "show specific private subnet fields (comma separated)")

--- a/cli-commands/lb.rb
+++ b/cli-commands/lb.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("lb") do
   options("ubi lb subcommand [...]")
-  post_options("ubi lb location/(lb-name|_lb-ubid) subcommand [...]")
+  post_options("ubi lb location/(lb-name|_lb-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/lb")

--- a/cli-commands/lb/post/attach-vm.rb
+++ b/cli-commands/lb/post/attach-vm.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("attach-vm") do
-  options("ubi lb location/(lb-name|_lb-ubid) attach-vm vm-id")
+  options("ubi lb location/(lb-name|_lb-id) attach-vm vm-id")
 
   args 1
 

--- a/cli-commands/lb/post/detach-vm.rb
+++ b/cli-commands/lb/post/detach-vm.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("detach-vm") do
-  options("ubi lb location/(lb-name|_lb-ubid) detach-vm vm-id")
+  options("ubi lb location/(lb-name|_lb-id) detach-vm vm-id")
 
   args 1
 

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("update") do
-  options("ubi lb location/(lb-name|_lb-ubid) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]")
+  options("ubi lb location/(lb-name|_lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]")
 
   args(4...)
 

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -3,7 +3,7 @@
 UbiCli.base("pg") do
   options("ubi pg subcommand [...]")
 
-  post_options("ubi pg location/(pg-name|_pg-ubid) [options] subcommand [...]", key: :pg_psql) do
+  post_options("ubi pg location/(pg-name|_pg-id) [options] subcommand [...]", key: :pg_psql) do
     on("-d", "--dbname=name", "override database name")
     on("-U", "--username=name", "override username")
   end

--- a/cli-commands/pg/post/add-firewall-rule.rb
+++ b/cli-commands/pg/post/add-firewall-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("add-firewall-rule") do
-  options("ubi pg location/(pg-name|_pg-ubid) add-firewall-rule cidr")
+  options("ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr")
 
   args 1, invalid_args_message: "cidr is required"
 

--- a/cli-commands/pg/post/add-metric-destination.rb
+++ b/cli-commands/pg/post/add-metric-destination.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("add-metric-destination") do
-  options("ubi pg location/(pg-name|_pg-ubid) add-metric-destination username password url")
+  options("ubi pg location/(pg-name|_pg-id) add-metric-destination username password url")
 
   args 3, invalid_args_message: "username, password, and url arguments are required"
 

--- a/cli-commands/pg/post/delete-firewall-rule.rb
+++ b/cli-commands/pg/post/delete-firewall-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("delete-firewall-rule") do
-  options("ubi pg location/(pg-name|_pg-ubid) delete-firewall-rule id")
+  options("ubi pg location/(pg-name|_pg-id) delete-firewall-rule id")
 
   args 1, invalid_args_message: "rule id is required"
 

--- a/cli-commands/pg/post/delete-metric-destination.rb
+++ b/cli-commands/pg/post/delete-metric-destination.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("delete-metric-destination") do
-  options("ubi pg location/(pg-name|_pg-ubid) delete-metric-destination id")
+  options("ubi pg location/(pg-name|_pg-id) delete-metric-destination id")
 
   args 1, invalid_args_message: "metric destination id is required"
 

--- a/cli-commands/pg/post/failover.rb
+++ b/cli-commands/pg/post/failover.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("failover") do
-  options("ubi pg location/(pg-name|_pg-ubid) failover")
+  options("ubi pg location/(pg-name|_pg-id) failover")
 
   run do
     post(pg_path("/failover")) do |data|

--- a/cli-commands/pg/post/reset-superuser-password.rb
+++ b/cli-commands/pg/post/reset-superuser-password.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("reset-superuser-password") do
-  options("ubi pg location/(pg-name|_pg-ubid) reset-superuser-password new-password")
+  options("ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password")
 
   args 1, invalid_args_message: "password is required"
 

--- a/cli-commands/pg/post/restart.rb
+++ b/cli-commands/pg/post/restart.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("restart") do
-  options("ubi pg location/(pg-name|_pg-ubid) restart")
+  options("ubi pg location/(pg-name|_pg-id) restart")
 
   run do
     post(pg_path("/restart")) do |data|

--- a/cli-commands/pg/post/restart.rb
+++ b/cli-commands/pg/post/restart.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+UbiCli.on("pg").run_on("restart") do
+  options("ubi pg location/(pg-name|_pg-ubid) restart")
+
+  run do
+    post(pg_path("/restart")) do |data|
+      ["Scheduled restart of PostgreSQL database with id #{data["id"]}"]
+    end
+  end
+end

--- a/cli-commands/pg/post/restore.rb
+++ b/cli-commands/pg/post/restore.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("restore") do
-  options("ubi pg location/(pg-name|_pg-ubid) restore new-db-name restore-time")
+  options("ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time")
 
   args 2, invalid_args_message: "name and restore target are required"
 

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -3,7 +3,7 @@
 UbiCli.on("pg").run_on("show") do
   fields = %w[id name state location vm-size storage-size-gib version ha-type flavor connection-string primary earliest-restore-time firewall-rules metric-destinations ca-certificates].freeze.each(&:freeze)
 
-  options("ubi pg location/(pg-name|_pg-ubid) show [options]", key: :pg_show) do
+  options("ubi pg location/(pg-name|_pg-id) show [options]", key: :pg_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     wrap("Fields:", fields)
   end

--- a/cli-commands/ps.rb
+++ b/cli-commands/ps.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("ps") do
   options("ubi ps subcommand [...]")
-  post_options("ubi ps location/(ps-name|_ps-ubid) subcommand [...]")
+  post_options("ubi ps location/(ps-name|_ps-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/ps")

--- a/cli-commands/ps/post/connect.rb
+++ b/cli-commands/ps/post/connect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("ps").run_on("connect") do
-  options("ubi ps location/(ps-name|_ps-ubid) connect ps-id")
+  options("ubi ps location/(ps-name|_ps-id) connect ps-id")
 
   args 1
 

--- a/cli-commands/ps/post/connect.rb
+++ b/cli-commands/ps/post/connect.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+UbiCli.on("ps").run_on("connect") do
+  options("ubi ps location/(ps-name|_ps-ubid) connect ps-id")
+
+  args 1
+
+  run do |ps_id|
+    post(ps_path("/connect"), "connected-subnet-ubid" => ps_id) do |data|
+      ["Connected private subnets with ids #{ps_id} and #{data["id"]}"]
+    end
+  end
+end

--- a/cli-commands/ps/post/disconnect.rb
+++ b/cli-commands/ps/post/disconnect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("ps").run_on("disconnect") do
-  options("ubi ps location/(ps-name|_ps-ubid) disconnect ps-id")
+  options("ubi ps location/(ps-name|_ps-id) disconnect ps-id")
 
   args 1
 

--- a/cli-commands/ps/post/disconnect.rb
+++ b/cli-commands/ps/post/disconnect.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+UbiCli.on("ps").run_on("disconnect") do
+  options("ubi ps location/(ps-name|_ps-ubid) disconnect ps-id")
+
+  args 1
+
+  run do |ps_id|
+    if ps_id.include?("/")
+      raise Rodish::CommandFailure, "invalid private subnet id format"
+    end
+    post(ps_path("/disconnect/#{ps_id}")) do |data|
+      ["Disconnected private subnets with ids #{ps_id} and #{data["id"]}"]
+    end
+  end
+end

--- a/cli-commands/ps/post/show.rb
+++ b/cli-commands/ps/post/show.rb
@@ -6,7 +6,7 @@ UbiCli.on("ps").run_on("show") do
   firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi ps location/(ps-name|_ps-ubid) show [options]", key: :ps_show) do
+  options("ubi ps location/(ps-name|_ps-id) show [options]", key: :ps_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
     on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")

--- a/cli-commands/vm.rb
+++ b/cli-commands/vm.rb
@@ -3,7 +3,7 @@
 UbiCli.base("vm") do
   options("ubi vm subcommand [...]")
 
-  post_options("ubi vm location/(vm-name|_vm-ubid) [options] subcommand [...]", key: :vm_ssh) do
+  post_options("ubi vm location/(vm-name|_vm-id) [options] subcommand [...]", key: :vm_ssh) do
     on("-4", "--ip4", "use IPv4 address")
     on("-6", "--ip6", "use IPv6 address")
     on("-u", "--user user", "override username")

--- a/cli-commands/vm/post/restart.rb
+++ b/cli-commands/vm/post/restart.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("restart") do
-  options("ubi vm location/(vm-name|_vm-ubid) restart")
+  options("ubi vm location/(vm-name|_vm-id) restart")
 
   run do
     post(vm_path("/restart")) do |data|

--- a/cli-commands/vm/post/restart.rb
+++ b/cli-commands/vm/post/restart.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+UbiCli.on("vm").run_on("restart") do
+  options("ubi vm location/(vm-name|_vm-ubid) restart")
+
+  run do
+    post(vm_path("/restart")) do |data|
+      ["Scheduled restart of VM with id #{data["id"]}"]
+    end
+  end
+end

--- a/cli-commands/vm/post/scp.rb
+++ b/cli-commands/vm/post/scp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("scp") do
-  skip_option_parsing("ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
+  skip_option_parsing("ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
 
   args(2..., invalid_args_message: "must provide 2 paths: either 'local-path :remote-path' or ':remote-path local-path'")
 

--- a/cli-commands/vm/post/sftp.rb
+++ b/cli-commands/vm/post/sftp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("sftp") do
-  skip_option_parsing("ubi vm location/(vm-name|_vm-ubid) [options] sftp [sftp-options]")
+  skip_option_parsing("ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]")
 
   args(0...)
 

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -5,7 +5,7 @@ UbiCli.on("vm").run_on("show") do
   firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
   firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
 
-  options("ubi vm location/(vm-name|_vm-ubid) show [options]", key: :vm_show) do
+  options("ubi vm location/(vm-name|_vm-id) show [options]", key: :vm_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
     on("-w", "--firewall-fields=fields", "show specific firewall fields (comma separated)")

--- a/cli-commands/vm/post/ssh.rb
+++ b/cli-commands/vm/post/ssh.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("ssh") do
-  skip_option_parsing("ubi vm location/(vm-name|_vm-ubid) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
+  skip_option_parsing("ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
 
   args(0...)
 

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -68,7 +68,7 @@ class UbiCli
 
       run do |(ref, *argv), opts, command|
         @location, @name, extra = ref.split("/", 3)
-        raise Rodish::CommandFailure, "invalid #{cmd} reference, should be in location/(#{cmd}-name|_#{cmd}-ubid) format" if extra
+        raise Rodish::CommandFailure, "invalid #{cmd} reference, should be in location/(#{cmd}-name|_#{cmd}-id) format" if extra
         command.run(self, opts, argv)
       end
     end
@@ -111,7 +111,7 @@ class UbiCli
     fragment = FRAGMENTS[cmd]
 
     on(cmd).run_on("destroy") do
-      options("ubi #{cmd} location/(#{cmd}-name|_#{cmd}-ubid) destroy [options]", key: :destroy) do
+      options("ubi #{cmd} location/(#{cmd}-name|_#{cmd}-id) destroy [options]", key: :destroy) do
         on("-f", "--force", "do not require confirmation")
       end
 
@@ -136,7 +136,7 @@ class UbiCli
 
   def self.pg_cmd(cmd)
     on("pg").run_on(cmd) do
-      skip_option_parsing("ubi pg location/(pg-name|_pg-ubid) [options] #{cmd} [#{cmd}-options]")
+      skip_option_parsing("ubi pg location/(pg-name|_pg-id) [options] #{cmd} [#{cmd}-options]")
 
       args(0...)
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -832,21 +832,6 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
-  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/restart':
-    parameters:
-      - $ref: '#/components/parameters/project_id'
-      - $ref: '#/components/parameters/location'
-      - $ref: '#/components/parameters/postgres_database_name'
-    post:
-      operationId: restartPostgresDatabase
-      summary: Restart a specific Postgres Database
-      responses:
-        '200':
-          $ref: '#/components/responses/PostgresDatabase'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/ca-certificates':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -1003,6 +988,21 @@ paths:
               additionalProperties: false
               required:
                 - password
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/restart':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_name'
+    post:
+      operationId: restartPostgresDatabase
+      summary: Restart a specific Postgres Database
       responses:
         '200':
           $ref: '#/components/responses/PostgresDatabase'
@@ -1372,13 +1372,6 @@ components:
         type: string
         example: pfmjgkgbktw62k53005jpx8tt7
         pattern: '^pf[0-9a-hj-km-np-tv-z]{24}$'
-    private_subnet_name:
-      description: Private subnet name
-      in: path
-      name: private_subnet_name
-      required: true
-      schema:
-        type: string
     private_subnet_id:
       description: ID of the private subnet
       in: path
@@ -1388,6 +1381,13 @@ components:
         type: string
         example: pskkmx0f2vke4h36nk9cm8v8q0
         pattern: '^ps[0-9a-hj-km-np-tv-z]{24}$'
+    private_subnet_name:
+      description: Private subnet name
+      in: path
+      name: private_subnet_name
+      required: true
+      schema:
+        type: string
     project_id:
       description: ID of the project
       in: path

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -832,6 +832,21 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/restart':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_name'
+    post:
+      operationId: restartPostgresDatabase
+      summary: Restart a specific Postgres Database
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/ca-certificates':
     parameters:
       - $ref: '#/components/parameters/project_id'

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1102,6 +1102,47 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Private Subnet
+  '/project/{project_id}/location/{location}/private-subnet/{private_subnet_name}/connect':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/private_subnet_name'
+    post:
+      operationId: connectPrivateSubnet
+      summary: Connect private subnet to another private subnet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                connected-subnet-ubid:
+                  type: string
+              additionalProperties: false
+      responses:
+        '200':
+          $ref: '#/components/responses/PrivateSubnet'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Private Subnet
+  '/project/{project_id}/location/{location}/private-subnet/{private_subnet_name}/disconnect/{private_subnet_id}':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/private_subnet_name'
+      - $ref: '#/components/parameters/private_subnet_id'
+    post:
+      operationId: disconnectPrivateSubnet
+      summary: Disconnect private subnet from another private subnet
+      responses:
+        '200':
+          $ref: '#/components/responses/PrivateSubnet'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Private Subnet
   '/project/{project_id}/location/{location}/vm':
     get:
       operationId: listLocationVMs
@@ -1338,6 +1379,15 @@ components:
       required: true
       schema:
         type: string
+    private_subnet_id:
+      description: ID of the private subnet
+      in: path
+      name: private_subnet_id
+      required: true
+      schema:
+        type: string
+        example: pskkmx0f2vke4h36nk9cm8v8q0
+        pattern: '^ps[0-9a-hj-km-np-tv-z]{24}$'
     project_id:
       description: ID of the project
       in: path

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1170,6 +1170,21 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Virtual Machine
+  '/project/{project_id}/location/{location}/vm/{vm_name}/restart':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/vm_name'
+    post:
+      operationId: restartVM
+      summary: Restart a specific VM
+      responses:
+        '200':
+          $ref: '#/components/responses/Vm'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Virtual Machine
   '/project/{project_id}/postgres':
     get:
       operationId: listPostgresDatabases

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -40,13 +40,19 @@ class Clover
         204
       end
 
-      r.post web?, "restart" do
+      r.post "restart" do
         authorize("Postgres:edit", pg.id)
         pg.servers.each do |s|
           s.incr_restart
         rescue Sequel::ForeignKeyConstraintViolation
         end
-        r.redirect "#{@project.path}#{pg.path}"
+
+        if api?
+          Serializers::Postgres.serialize(pg, {detailed: true})
+        else
+          flash["notice"] = "'#{pg.name}' will be restarted in a few seconds"
+          r.redirect "#{@project.path}#{pg.path}"
+        end
       end
 
       r.post api?, "failover" do

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -34,11 +34,15 @@ class Clover
         204
       end
 
-      r.post web?, "restart" do
+      r.post "restart" do
         authorize("Vm:edit", vm.id)
         vm.incr_restart
-        flash["notice"] = "'#{vm.name}' will be restarted in a few seconds"
-        r.redirect "#{@project.path}#{vm.path}"
+        if api?
+          Serializers::Vm.serialize(vm, {detailed: true})
+        else
+          flash["notice"] = "'#{vm.name}' will be restarted in a few seconds"
+          r.redirect "#{@project.path}#{vm.path}"
+        end
       end
     end
 

--- a/spec/routes/api/cli/golden-file-commands/error.txt
+++ b/spec/routes/api/cli/golden-file-commands/error.txt
@@ -30,6 +30,9 @@ pg eu-central-h1/test-pg show invalid
 pg eu-central-h1/test-pg -X pg_dump
 pg list -f invalid
 pg list invalid
+ps eu-central-h1/test-ps connect psfzm7e26xky5m9ggetw4dpqe2
+ps eu-central-h1/test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2/foo
+ps eu-central-h1/test-ps disconnect psfzm7e26xky5m9ggetw4dpqe2
 ps eu-central-h1/test2-ps create invalid
 ps eu-central-h1/test-ps destroy invalid
 ps list -f invalid

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -116,6 +116,7 @@ vm eu-central-h1/test2-vm create -S 80 pk
 vm eu-central-h1/test2-vm create -s standard-4 pk
 vm eu-central-h1/test2-vm create -u foo pk
 vm eu-central-h1/test-vm destroy -f
+vm eu-central-h1/test-vm restart
 vm eu-central-h1/test-vm show
 vm eu-central-h1/test-vm show -f firewalls
 vm eu-central-h1/test-vm show -f firewalls -w description,location,path

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -95,6 +95,7 @@ ps eu-central-h1/default-eu-central-h1 show -w description,location,path
 ps eu-central-h1/default-eu-central-h1 show -w firewall-rules
 ps eu-central-h1/default-eu-central-h1 show -w firewall-rules -r id,cidr
 ps eu-central-h1/default-eu-central-h1 show -w firewall-rules -r port-range
+ps eu-central-h1/test-ps connect psfzm9e26xky5m9ggetw4dpqe2
 ps eu-central-h1/test2-ps create
 ps eu-central-h1/test2-ps create -f fw4gj2v4h1fe3q28q0hnf7g8n1
 ps eu-central-h1/test-ps destroy -f

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -68,6 +68,7 @@ pg eu-central-h1/test-pg delete-firewall-rule pfb9g14e5ndt6qf59wfk8109bg
 pg eu-central-h1/test-pg delete-metric-destination et2t1bswsqz21m7j7njfjbp901
 pg eu-central-h1/test-pg destroy -f
 pg eu-central-h1/test-pg reset-superuser-password foo123BAR456
+pg eu-central-h1/test-pg restart
 pg eu-central-h1/test-pg show
 pg eu-central-h1/test-pg show -f firewall-rules,metric-destinations,ca-certificates
 pg eu-central-h1/test-pg show -f ha-type,flavor,connection-string,primary,earliest-restore-time

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for fw destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi fw location/(fw-name|_fw-ubid) destroy [options]
+Usage: ubi fw location/(fw-name|_fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -3,7 +3,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address
@@ -40,22 +40,22 @@ Options:
     -u, --unix-user=username         username (default: ubi)
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
+Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) restart
+Usage: ubi vm location/(vm-name|_vm-id) restart
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) show [options]
+Usage: ubi vm location/(vm-name|_vm-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -67,6 +67,6 @@ Firewall Rule Fields: id cidr port-range
 Firewall Fields: id name description location path firewall-rules
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
 
 

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -10,7 +10,14 @@ Options:
     -6, --ip6                        use IPv6 address
     -u, --user user                  override username
 
-Subcommands: create destroy scp sftp show ssh
+Subcommands:
+  create
+  destroy
+  restart
+  scp
+  sftp
+  show
+  ssh
 
 
 Usage: ubi vm list [options]
@@ -37,6 +44,9 @@ Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
+
+
+Usage: ubi vm location/(vm-name|_vm-ubid) restart
 
 
 Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -280,7 +280,14 @@ Options:
     -6, --ip6                        use IPv6 address
     -u, --user user                  override username
 
-Subcommands: create destroy scp sftp show ssh
+Subcommands:
+  create
+  destroy
+  restart
+  scp
+  sftp
+  show
+  ssh
 
 
 Usage: ubi vm list [options]
@@ -307,6 +314,9 @@ Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
+
+
+Usage: ubi vm location/(vm-name|_vm-ubid) restart
 
 
 Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -13,7 +13,7 @@ Usage: ubi fw subcommand [...]
 Subcommands: list
 
 
-Usage: ubi fw location/(fw-name|_fw-ubid) subcommand [...]
+Usage: ubi fw location/(fw-name|_fw-id) subcommand [...]
 
 Subcommands:
   add-rule
@@ -34,14 +34,14 @@ Options:
 Fields: location name id
 
 
-Usage: ubi fw location/(fw-name|_fw-ubid) add-rule cidr
+Usage: ubi fw location/(fw-name|_fw-id) add-rule cidr
 
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
 
 
-Usage: ubi fw location/(fw-name|_fw-ubid) attach-subnet subnet-id
+Usage: ubi fw location/(fw-name|_fw-id) attach-subnet subnet-id
 
 
 Usage: ubi fw location/fw-name create [options]
@@ -50,19 +50,19 @@ Options:
     -d, --description=desc           description for firewall
 
 
-Usage: ubi fw location/(fw-name|_fw-ubid) delete-rule rule-id
+Usage: ubi fw location/(fw-name|_fw-id) delete-rule rule-id
 
 
-Usage: ubi fw location/(fw-name|_fw-ubid) destroy [options]
+Usage: ubi fw location/(fw-name|_fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi fw location/(fw-name|_fw-ubid) detach-subnet subnet-id
+Usage: ubi fw location/(fw-name|_fw-id) detach-subnet subnet-id
 
 
-Usage: ubi fw location/(fw-name|_fw-ubid) show [options]
+Usage: ubi fw location/(fw-name|_fw-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -87,7 +87,7 @@ Usage: ubi lb subcommand [...]
 Subcommands: list
 
 
-Usage: ubi lb location/(lb-name|_lb-ubid) subcommand [...]
+Usage: ubi lb location/(lb-name|_lb-id) subcommand [...]
 
 Subcommands: attach-vm create destroy detach-vm show update
 
@@ -101,7 +101,7 @@ Options:
 Fields: location name id src-port dst-port hostname
 
 
-Usage: ubi lb location/(lb-name|_lb-ubid) attach-vm vm-id
+Usage: ubi lb location/(lb-name|_lb-id) attach-vm vm-id
 
 
 Usage: ubi lb location/lb-name create [options] private-subnet-id src-port dst-port
@@ -113,13 +113,13 @@ Options:
     -s, --stack=stack                set the stack (dual(default), ipv4, ipv6)
 
 
-Usage: ubi lb location/(lb-name|_lb-ubid) destroy [options]
+Usage: ubi lb location/(lb-name|_lb-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi lb location/(lb-name|_lb-ubid) detach-vm vm-id
+Usage: ubi lb location/(lb-name|_lb-id) detach-vm vm-id
 
 
 Usage: ubi lb location/(lb-name|_lb-ubid) show [options]
@@ -130,7 +130,7 @@ Fields: id name state location hostname algorithm stack health-check-endpoint
         health-check-protocol src-port dst-port subnet vms
 
 
-Usage: ubi lb location/(lb-name|_lb-ubid) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+Usage: ubi lb location/(lb-name|_lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
 
 
 Usage: ubi pg subcommand [...]
@@ -138,7 +138,7 @@ Usage: ubi pg subcommand [...]
 Subcommands: list
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] subcommand [...]
+Usage: ubi pg location/(pg-name|_pg-id) [options] subcommand [...]
 
 Options:
     -d, --dbname=name                override database name
@@ -170,10 +170,10 @@ Options:
 Fields: location name id version flavor
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) add-firewall-rule cidr
+Usage: ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) add-metric-destination username password url
+Usage: ubi pg location/(pg-name|_pg-id) add-metric-destination username password url
 
 
 Usage: ubi pg location/pg-name create [options]
@@ -186,40 +186,40 @@ Options:
     -v, --version=version            PostgreSQL version (16, 17)
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) delete-firewall-rule id
+Usage: ubi pg location/(pg-name|_pg-id) delete-firewall-rule id
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) delete-metric-destination id
+Usage: ubi pg location/(pg-name|_pg-id) delete-metric-destination id
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) destroy [options]
+Usage: ubi pg location/(pg-name|_pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) failover
+Usage: ubi pg location/(pg-name|_pg-id) failover
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] pg_dump [pg_dump-options]
+Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dump [pg_dump-options]
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] pg_dumpall [pg_dumpall-options]
+Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dumpall [pg_dumpall-options]
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] psql [psql-options]
+Usage: ubi pg location/(pg-name|_pg-id) [options] psql [psql-options]
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) reset-superuser-password new-password
+Usage: ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) restart
+Usage: ubi pg location/(pg-name|_pg-id) restart
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) restore new-db-name restore-time
+Usage: ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time
 
 
-Usage: ubi pg location/(pg-name|_pg-ubid) show [options]
+Usage: ubi pg location/(pg-name|_pg-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -233,7 +233,7 @@ Usage: ubi ps subcommand [...]
 Subcommands: list
 
 
-Usage: ubi ps location/(ps-name|_ps-ubid) subcommand [...]
+Usage: ubi ps location/(ps-name|_ps-id) subcommand [...]
 
 Subcommands: connect create destroy disconnect show
 
@@ -247,7 +247,7 @@ Options:
 Fields: location name id net4 net6
 
 
-Usage: ubi ps location/(ps-name|_ps-ubid) connect ps-id
+Usage: ubi ps location/(ps-name|_ps-id) connect ps-id
 
 
 Usage: ubi ps location/ps-name create [options]
@@ -256,16 +256,16 @@ Options:
     -f, --firewall-id=id             add to given firewall
 
 
-Usage: ubi ps location/(ps-name|_ps-ubid) destroy [options]
+Usage: ubi ps location/(ps-name|_ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi ps location/(ps-name|_ps-ubid) disconnect ps-id
+Usage: ubi ps location/(ps-name|_ps-id) disconnect ps-id
 
 
-Usage: ubi ps location/(ps-name|_ps-ubid) show [options]
+Usage: ubi ps location/(ps-name|_ps-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -283,7 +283,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address
@@ -320,22 +320,22 @@ Options:
     -u, --unix-user=username         username (default: ubi)
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
+Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) restart
+Usage: ubi vm location/(vm-name|_vm-id) restart
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) show [options]
+Usage: ubi vm location/(vm-name|_vm-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -347,6 +347,6 @@ Firewall Rule Fields: id cidr port-range
 Firewall Fields: id name description location path firewall-rules
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
 
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -235,7 +235,7 @@ Subcommands: list
 
 Usage: ubi ps location/(ps-name|_ps-ubid) subcommand [...]
 
-Subcommands: create destroy show
+Subcommands: connect create destroy disconnect show
 
 
 Usage: ubi ps list [options]
@@ -245,6 +245,9 @@ Options:
     -l, --location=location          only show private subnets in given location
     -N, --no-headers                 do not show headers
 Fields: location name id net4 net6
+
+
+Usage: ubi ps location/(ps-name|_ps-ubid) connect ps-id
 
 
 Usage: ubi ps location/ps-name create [options]
@@ -257,6 +260,9 @@ Usage: ubi ps location/(ps-name|_ps-ubid) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
+
+
+Usage: ubi ps location/(ps-name|_ps-ubid) disconnect ps-id
 
 
 Usage: ubi ps location/(ps-name|_ps-ubid) show [options]

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -156,6 +156,7 @@ Subcommands:
   pg_dumpall
   psql
   reset-superuser-password
+  restart
   restore
   show
 
@@ -210,6 +211,9 @@ Usage: ubi pg location/(pg-name|_pg-ubid) [options] psql [psql-options]
 
 
 Usage: ubi pg location/(pg-name|_pg-ubid) reset-superuser-password new-password
+
+
+Usage: ubi pg location/(pg-name|_pg-ubid) restart
 
 
 Usage: ubi pg location/(pg-name|_pg-ubid) restore new-db-name restore-time

--- a/spec/routes/api/cli/golden-files/help -ru vm.txt
+++ b/spec/routes/api/cli/golden-files/help -ru vm.txt
@@ -1,8 +1,8 @@
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
-Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
-Usage: ubi vm location/(vm-name|_vm-ubid) restart
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] sftp [sftp-options]
-Usage: ubi vm location/(vm-name|_vm-ubid) show [options]
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
+Usage: ubi vm location/(vm-name|_vm-id) restart
+Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|_vm-id) show [options]
+Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]

--- a/spec/routes/api/cli/golden-files/help -ru vm.txt
+++ b/spec/routes/api/cli/golden-files/help -ru vm.txt
@@ -1,6 +1,7 @@
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
 Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
+Usage: ubi vm location/(vm-name|_vm-ubid) restart
 Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 Usage: ubi vm location/(vm-name|_vm-ubid) [options] sftp [sftp-options]
 Usage: ubi vm location/(vm-name|_vm-ubid) show [options]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -35,6 +35,7 @@ Usage: ubi ps location/(ps-name|_ps-ubid) show [options]
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
 Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
+Usage: ubi vm location/(vm-name|_vm-ubid) restart
 Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 Usage: ubi vm location/(vm-name|_vm-ubid) [options] sftp [sftp-options]
 Usage: ubi vm location/(vm-name|_vm-ubid) show [options]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -26,6 +26,7 @@ Usage: ubi pg location/(pg-name|_pg-ubid) [options] pg_dump [pg_dump-options]
 Usage: ubi pg location/(pg-name|_pg-ubid) [options] pg_dumpall [pg_dumpall-options]
 Usage: ubi pg location/(pg-name|_pg-ubid) [options] psql [psql-options]
 Usage: ubi pg location/(pg-name|_pg-ubid) reset-superuser-password new-password
+Usage: ubi pg location/(pg-name|_pg-ubid) restart
 Usage: ubi pg location/(pg-name|_pg-ubid) restore new-db-name restore-time
 Usage: ubi pg location/(pg-name|_pg-ubid) show [options]
 Usage: ubi ps list [options]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -30,8 +30,10 @@ Usage: ubi pg location/(pg-name|_pg-ubid) restart
 Usage: ubi pg location/(pg-name|_pg-ubid) restore new-db-name restore-time
 Usage: ubi pg location/(pg-name|_pg-ubid) show [options]
 Usage: ubi ps list [options]
+Usage: ubi ps location/(ps-name|_ps-ubid) connect ps-id
 Usage: ubi ps location/ps-name create [options]
 Usage: ubi ps location/(ps-name|_ps-ubid) destroy [options]
+Usage: ubi ps location/(ps-name|_ps-ubid) disconnect ps-id
 Usage: ubi ps location/(ps-name|_ps-ubid) show [options]
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -1,45 +1,45 @@
 Usage: ubi fw list [options]
-Usage: ubi fw location/(fw-name|_fw-ubid) add-rule cidr
-Usage: ubi fw location/(fw-name|_fw-ubid) attach-subnet subnet-id
+Usage: ubi fw location/(fw-name|_fw-id) add-rule cidr
+Usage: ubi fw location/(fw-name|_fw-id) attach-subnet subnet-id
 Usage: ubi fw location/fw-name create [options]
-Usage: ubi fw location/(fw-name|_fw-ubid) delete-rule rule-id
-Usage: ubi fw location/(fw-name|_fw-ubid) destroy [options]
-Usage: ubi fw location/(fw-name|_fw-ubid) detach-subnet subnet-id
-Usage: ubi fw location/(fw-name|_fw-ubid) show [options]
+Usage: ubi fw location/(fw-name|_fw-id) delete-rule rule-id
+Usage: ubi fw location/(fw-name|_fw-id) destroy [options]
+Usage: ubi fw location/(fw-name|_fw-id) detach-subnet subnet-id
+Usage: ubi fw location/(fw-name|_fw-id) show [options]
 Usage: ubi help [options] [command [subcommand]]
 Usage: ubi lb list [options]
-Usage: ubi lb location/(lb-name|_lb-ubid) attach-vm vm-id
+Usage: ubi lb location/(lb-name|_lb-id) attach-vm vm-id
 Usage: ubi lb location/lb-name create [options] private-subnet-id src-port dst-port
-Usage: ubi lb location/(lb-name|_lb-ubid) destroy [options]
-Usage: ubi lb location/(lb-name|_lb-ubid) detach-vm vm-id
+Usage: ubi lb location/(lb-name|_lb-id) destroy [options]
+Usage: ubi lb location/(lb-name|_lb-id) detach-vm vm-id
 Usage: ubi lb location/(lb-name|_lb-ubid) show [options]
-Usage: ubi lb location/(lb-name|_lb-ubid) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+Usage: ubi lb location/(lb-name|_lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
 Usage: ubi pg list [options]
-Usage: ubi pg location/(pg-name|_pg-ubid) add-firewall-rule cidr
-Usage: ubi pg location/(pg-name|_pg-ubid) add-metric-destination username password url
+Usage: ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr
+Usage: ubi pg location/(pg-name|_pg-id) add-metric-destination username password url
 Usage: ubi pg location/pg-name create [options]
-Usage: ubi pg location/(pg-name|_pg-ubid) delete-firewall-rule id
-Usage: ubi pg location/(pg-name|_pg-ubid) delete-metric-destination id
-Usage: ubi pg location/(pg-name|_pg-ubid) destroy [options]
-Usage: ubi pg location/(pg-name|_pg-ubid) failover
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] pg_dump [pg_dump-options]
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] pg_dumpall [pg_dumpall-options]
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] psql [psql-options]
-Usage: ubi pg location/(pg-name|_pg-ubid) reset-superuser-password new-password
-Usage: ubi pg location/(pg-name|_pg-ubid) restart
-Usage: ubi pg location/(pg-name|_pg-ubid) restore new-db-name restore-time
-Usage: ubi pg location/(pg-name|_pg-ubid) show [options]
+Usage: ubi pg location/(pg-name|_pg-id) delete-firewall-rule id
+Usage: ubi pg location/(pg-name|_pg-id) delete-metric-destination id
+Usage: ubi pg location/(pg-name|_pg-id) destroy [options]
+Usage: ubi pg location/(pg-name|_pg-id) failover
+Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dump [pg_dump-options]
+Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dumpall [pg_dumpall-options]
+Usage: ubi pg location/(pg-name|_pg-id) [options] psql [psql-options]
+Usage: ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password
+Usage: ubi pg location/(pg-name|_pg-id) restart
+Usage: ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time
+Usage: ubi pg location/(pg-name|_pg-id) show [options]
 Usage: ubi ps list [options]
-Usage: ubi ps location/(ps-name|_ps-ubid) connect ps-id
+Usage: ubi ps location/(ps-name|_ps-id) connect ps-id
 Usage: ubi ps location/ps-name create [options]
-Usage: ubi ps location/(ps-name|_ps-ubid) destroy [options]
-Usage: ubi ps location/(ps-name|_ps-ubid) disconnect ps-id
-Usage: ubi ps location/(ps-name|_ps-ubid) show [options]
+Usage: ubi ps location/(ps-name|_ps-id) destroy [options]
+Usage: ubi ps location/(ps-name|_ps-id) disconnect ps-id
+Usage: ubi ps location/(ps-name|_ps-id) show [options]
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
-Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
-Usage: ubi vm location/(vm-name|_vm-ubid) restart
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] sftp [sftp-options]
-Usage: ubi vm location/(vm-name|_vm-ubid) show [options]
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
+Usage: ubi vm location/(vm-name|_vm-id) restart
+Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|_vm-id) show [options]
+Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]

--- a/spec/routes/api/cli/golden-files/help -u vm.txt
+++ b/spec/routes/api/cli/golden-files/help -u vm.txt
@@ -1,2 +1,2 @@
 Usage: ubi vm subcommand [...]
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]

--- a/spec/routes/api/cli/golden-files/help vm.txt
+++ b/spec/routes/api/cli/golden-files/help vm.txt
@@ -3,7 +3,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/help vm.txt
+++ b/spec/routes/api/cli/golden-files/help vm.txt
@@ -10,4 +10,11 @@ Options:
     -6, --ip6                        use IPv6 address
     -u, --user user                  override username
 
-Subcommands: create destroy scp sftp show ssh
+Subcommands:
+  create
+  destroy
+  restart
+  scp
+  sftp
+  show
+  ssh

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
@@ -18,5 +18,6 @@ Subcommands:
   pg_dumpall
   psql
   reset-superuser-password
+  restart
   restore
   show

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
@@ -1,6 +1,6 @@
 ! Invalid option: -X
 
-Usage: ubi pg location/(pg-name|_pg-ubid) [options] subcommand [...]
+Usage: ubi pg location/(pg-name|_pg-id) [options] subcommand [...]
 
 Options:
     -d, --dbname=name                override database name

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg add-firewall-rule subcommand (cidr is required)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) add-firewall-rule cidr
+Usage: ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg add-metric-destination subcommand (username, password, and url arguments are required)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) add-metric-destination username password url
+Usage: ubi pg location/(pg-name|_pg-id) add-metric-destination username password url

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-firewall-rule.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-firewall-rule.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg delete-firewall-rule subcommand (rule id is required)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) delete-firewall-rule id
+Usage: ubi pg location/(pg-name|_pg-id) delete-firewall-rule id

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-metric-destination.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-metric-destination.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg delete-metric-destination subcommand (metric destination id is required)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) delete-metric-destination id
+Usage: ubi pg location/(pg-name|_pg-id) delete-metric-destination id

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for pg destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) destroy [options]
+Usage: ubi pg location/(pg-name|_pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg reset-superuser-password.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg reset-superuser-password.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg reset-superuser-password subcommand (password is required)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) reset-superuser-password new-password
+Usage: ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restart.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restart.txt
@@ -1,0 +1,1 @@
+Scheduled restart of PostgreSQL database with id pgvm1qb9gwct1mqmay7m54yma5

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restore.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restore.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg restore subcommand (name and restore target are required)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) restore new-db-name restore-time
+Usage: ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for pg show subcommand (accepts: 0, given: 1)
 
-Usage: ubi pg location/(pg-name|_pg-ubid) show [options]
+Usage: ubi pg location/(pg-name|_pg-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps connect psfzm7e26xky5m9ggetw4dpqe2.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps connect psfzm7e26xky5m9ggetw4dpqe2.txt
@@ -1,0 +1,2 @@
+! Unexpected response status: 400
+Details: Subnet to be connected not found

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps connect psfzm9e26xky5m9ggetw4dpqe2.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps connect psfzm9e26xky5m9ggetw4dpqe2.txt
@@ -1,0 +1,1 @@
+Connected private subnets with ids psfzm9e26xky5m9ggetw4dpqe2 and pshfgpzvs0t20gpezmz2kkk8e4

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for ps destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi ps location/(ps-name|_ps-ubid) destroy [options]
+Usage: ubi ps location/(ps-name|_ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps disconnect psfzm7e26xky5m9ggetw4dpqe2.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps disconnect psfzm7e26xky5m9ggetw4dpqe2.txt
@@ -1,0 +1,2 @@
+! Unexpected response status: 400
+Details: Subnet to be disconnected not found

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2_foo.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2_foo.txt
@@ -1,0 +1,1 @@
+! Invalid private subnet id format

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
@@ -1,6 +1,6 @@
 ! Invalid option: -X
 
-Usage: ubi vm location/(vm-name|_vm-ubid) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
@@ -7,4 +7,11 @@ Options:
     -6, --ip6                        use IPv6 address
     -u, --user user                  override username
 
-Subcommands: create destroy scp sftp show ssh
+Subcommands:
+  create
+  destroy
+  restart
+  scp
+  sftp
+  show
+  ssh

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for vm destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi vm location/(vm-name|_vm-ubid) destroy [options]
+Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm restart.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm restart.txt
@@ -1,0 +1,1 @@
+Scheduled restart of VM with id vmdzyppz6j166jh5e9t2dwrfas

--- a/spec/routes/api/cli/help_spec.rb
+++ b/spec/routes/api/cli/help_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Clover, "cli help" do
 
   it "shows help for specific subcommand if given" do
     expect(cli(%w[help vm ssh])).to eq <<~OUTPUT
-      Usage: ubi vm location/(vm-name|_vm-ubid) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+      Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
     OUTPUT
   end
 
@@ -45,7 +45,7 @@ RSpec.describe Clover, "cli help" do
     expect(cli(%w[help vm ssh foo], status: 400)).to eq <<~OUTPUT
       ! Invalid command: vm ssh foo
 
-      Usage: ubi vm location/(vm-name|_vm-ubid) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+      Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
     OUTPUT
   end
 end

--- a/spec/routes/api/cli/pg/restart_spec.rb
+++ b/spec/routes/api/cli/pg/restart_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg restart" do
+  before do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+    cli(%w[pg eu-central-h1/test-pg create])
+    @pg = PostgresResource.first
+  end
+
+  it "restarts postgres database" do
+    expect(Semaphore.where(strand_id: @pg.servers.first.id, name: "restart")).to be_empty
+    expect(cli(%w[pg eu-central-h1/test-pg restart])).to eq "Scheduled restart of PostgreSQL database with id #{@pg.ubid}\n"
+    expect(Semaphore.where(strand_id: @pg.servers.first.id, name: "restart")).not_to be_empty
+  end
+end

--- a/spec/routes/api/cli/ps/connect_spec.rb
+++ b/spec/routes/api/cli/ps/connect_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli ps connect" do
+  before do
+    cli(%w[ps eu-central-h1/test-ps create])
+    cli(%w[ps eu-central-h1/test-ps2 create])
+    @ps1, @ps2 = PrivateSubnet.all
+  end
+
+  it "connects requested private subnet to this subnet" do
+    expect(ConnectedSubnet.count).to eq 0
+    expect(cli(%W[ps eu-central-h1/#{@ps1.name} connect #{@ps2.ubid}])).to eq "Connected private subnets with ids #{@ps2.ubid} and #{@ps1.ubid}\n"
+    expect(ConnectedSubnet.count).to eq 1
+  end
+end

--- a/spec/routes/api/cli/ps/disconnect_spec.rb
+++ b/spec/routes/api/cli/ps/disconnect_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli ps connect" do
+  before do
+    cli(%w[ps eu-central-h1/test-ps create])
+    cli(%w[ps eu-central-h1/test-ps2 create])
+    @ps1, @ps2 = PrivateSubnet.all
+    cli(%W[ps eu-central-h1/#{@ps1.name} connect #{@ps2.ubid}])
+  end
+
+  it "disconnects requested private subnet from this subnet" do
+    expect(ConnectedSubnet.count).to eq 1
+    expect(cli(%W[ps eu-central-h1/#{@ps1.name} disconnect #{@ps2.ubid}])).to eq "Disconnected private subnets with ids #{@ps2.ubid} and #{@ps1.ubid}\n"
+    expect(ConnectedSubnet.count).to eq 0
+  end
+end

--- a/spec/routes/api/cli/vm/restart_spec.rb
+++ b/spec/routes/api/cli/vm/restart_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli vm restart" do
+  before do
+    cli(%w[vm eu-central-h1/test-vm create a])
+    @vm = Vm.first
+  end
+
+  it "restarts vm" do
+    expect(Semaphore.where(strand_id: @vm.id, name: "restart")).to be_empty
+    expect(cli(%w[vm eu-central-h1/test-vm restart])).to eq "Scheduled restart of VM with id #{@vm.ubid}\n"
+    expect(Semaphore.where(strand_id: @vm.id, name: "restart")).not_to be_empty
+  end
+end

--- a/spec/routes/api/cli/vm/ssh_spec.rb
+++ b/spec/routes/api/cli/vm/ssh_spec.rb
@@ -80,6 +80,6 @@ RSpec.describe Clover, "cli vm ssh" do
   it "handles invalid vm reference" do
     expect(cli(["vm", "#{@vm.display_location}/foo", "ssh"], status: 404)).to eq "! Unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for.\n"
     expect(cli(["vm", "foo/#{@vm.name}", "ssh"], status: 404)).to eq "! Unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for.\n"
-    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh"], status: 400)).to eq "! Invalid vm reference, should be in location/(vm-name|_vm-ubid) format\n"
+    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh"], status: 400)).to eq "! Invalid vm reference, should be in location/(vm-name|_vm-id) format\n"
   end
 end

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Clover, "private subnet" do
         page.driver.post btn["data-url"], {_csrf: btn["data-csrf"]}
 
         expect(page.status_code).to eq(400)
-        expect(page.body).to eq({error: {message: "Subnet to be disconnected not found"}}.to_json)
+        expect(page.body).to eq({error: {code: 400, type: "InvalidRequest", message: "Subnet to be disconnected not found"}}.to_json)
       end
     end
 


### PR DESCRIPTION
This adds the following cli commands:

* vm restart
* pg restart
* ps connect
* ps disconnect

All of these were previously web-only, and the cli can only implement what the api exposes, so this adds api support for all of these.

This also changes usage lines to say `id` instead of `ubid`, as ubids are internal things that users consider to be ids (we don't generally expose the uuid directly to users).

CC @geemus 