### PR TITLE
Use bdev_ubi-0.3

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -126,7 +126,7 @@ module Config
   override :minio_version, "minio_20240406052602.0.0_amd64"
 
   # Spdk
-  override :spdk_version, "v23.09-ubi-0.2"
+  override :spdk_version, "v23.09-ubi-0.3"
 
   # Boot Images
   override :default_boot_image_name, "ubuntu-jammy", string

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -4,8 +4,8 @@ class Prog::Storage::SetupSpdk < Prog::Base
   subject_is :sshable, :vm_host
 
   SUPPORTED_SPDK_VERSIONS = [
-    ["v23.09-ubi-0.2", "x64"],
-    ["v23.09-ubi-0.2", "arm64"]
+    ["v23.09-ubi-0.3", "x64"],
+    ["v23.09-ubi-0.3", "arm64"]
   ]
 
   def self.assemble(vm_host_id, version, start_service: false, allocation_weight: 0)

--- a/rhizome/host/lib/spdk_path.rb
+++ b/rhizome/host/lib/spdk_path.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-DEFAULT_SPDK_VERSION = "v23.09-ubi-0.2"
+DEFAULT_SPDK_VERSION = "v23.09-ubi-0.3"
 
 module SpdkPath
   def self.user

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -59,8 +59,8 @@ class SpdkSetup
     end
 
     case @spdk_version
-    when "v23.09-ubi-0.2"
-      "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.2b/ubicloud-spdk-#{os_version}-#{arch}.tar.gz"
+    when "v23.09-ubi-0.3"
+      "https://github.com/ubicloud/bdev_ubi/releases/download/spdk-23.09-ubi-0.3/ubicloud-spdk-#{os_version}-#{arch}.tar.gz"
     else
       fail "BUG: unsupported SPDK version"
     end

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Storage::SetupSpdk do
     ))
   }
 
-  let(:spdk_version) { "v23.09-ubi-0.2" }
+  let(:spdk_version) { "v23.09-ubi-0.3" }
   let(:sshable) { vm_host.sshable }
   let(:vm_host) { create_vm_host(used_hugepages_1g: 0, total_hugepages_1g: 20, total_cpus: 96, os_version: "ubuntu-24.04") }
 


### PR DESCRIPTION
bdev_ubi-0.3 fixes several error handling bugs. It also instruments SPDK to log iobuf sizes, which will be helpful if crashes happen.

To install this version on a host and remove the previous version, first drain the host from VMs. And then:

```
setup_st = Prog::Storage::SetupSpdk.assemble(
  vmh.id, "v23.09-ubi-0.3",
  start_service: true, allocation_weight: 100)

remove_st = Prog::Storage::RemoveSpdk.assemble(
  vmh.spdk_installations_dataset.where(
     version:"v23.09-ubi-0.2").first.id)
```