### PR TITLE
Fix index continuation when assembling additional MinIO pools

### DIFF
--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -31,7 +31,12 @@ class Prog::Minio::MinioPoolNexus < Prog::Base
 
   def self.assemble_additional_pool(cluster_id, server_count, drive_count, storage_size_gib, vm_size)
     DB.transaction do
-      st = assemble(cluster_id, MinioCluster[cluster_id]&.server_count, server_count, drive_count, storage_size_gib, vm_size)
+      unless MinioCluster[cluster_id]
+        fail "No existing cluster"
+      end
+
+      start_index = MinioCluster[cluster_id].servers.max_by(&:index).index + 1
+      st = assemble(cluster_id, start_index, server_count, drive_count, storage_size_gib, vm_size)
       st.subject.incr_add_additional_pool
       st
     end

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
         described_class.assemble_additional_pool(SecureRandom.uuid, 0, 1, 100, "standard-2")
       }.to raise_error RuntimeError, "No existing cluster"
     end
+
+    it "correctly calculates start index for additional pool for a cluster with decommissioned pools" do
+      described_class.assemble(minio_cluster.id, 2, 2, 2, 100, "standard-2")
+      st = described_class.assemble_additional_pool(minio_cluster.id, 1, 1, 100, "standard-2")
+      expect(st.subject.start_index).to eq 4
+    end
   end
 
   describe "#wait_servers" do


### PR DESCRIPTION
## Description

Before this change, calling `assemble_additional_pool` on a MinIO cluster with decommissioned pools would break the cluster configuration because the code assumed that the node indices would always start from 0. This is fixed by calculating the start index of the new pool to continue from the current maximum node index + 1.

## Test
- [x] Unit test
- [ ] Local dev run