### PR TITLE
Removing use_slices_for_allocation flag

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -88,10 +88,10 @@ class Clover
     options.add_option(name: "flavor", values: flavor)
     options.add_option(name: "location", values: Option.postgres_locations.map(&:display_name), parent: "flavor")
     options.add_option(name: "family", values: Option::PostgresSizes.map(&:vm_family).uniq, parent: "location") do |flavor, location, family|
-      available_families = Option.families(use_slices: @project.get_ff_use_slices_for_allocation || false).map { _1.name }
+      available_families = Option.families.map(&:name)
       available_families.include?(family) && BillingRate.from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", LocationNameConverter.to_internal_name(location))
     end
-    options.add_option(name: "size", values: Option::PostgresSizes.map { _1.name }.uniq, parent: "family") do |flavor, location, family, size|
+    options.add_option(name: "size", values: Option::PostgresSizes.map(&:name).uniq, parent: "family") do |flavor, location, family, size|
       location = LocationNameConverter.to_internal_name(location)
       pg_size = Option::PostgresSizes.find { _1.name == size && _1.flavor == flavor && _1.location == location }
       vm_size = Option::VmSizes.find { _1.name == pg_size.vm_size && _1.arch == "x64" && _1.visible }

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -97,7 +97,7 @@ class Clover
     end
 
     options.add_option(name: "enable_ip4", values: ["1"], parent: "location")
-    options.add_option(name: "family", values: Option.families(use_slices: @project.get_ff_use_slices_for_allocation || false).map { _1.name }, parent: "location") do |location, family|
+    options.add_option(name: "family", values: Option.families.map(&:name), parent: "location") do |location, family|
       !!BillingRate.from_resource_properties("VmVCpu", family, LocationNameConverter.to_internal_name(location))
     end
     options.add_option(name: "size", values: Option::VmSizes.select { _1.visible }.map { _1.display_name }, parent: "family") do |location, family, size|

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -18,12 +18,8 @@ module Option
     Location.where(name: ["hetzner-fsn1", "leaseweb-wdc02"]).all
   end
 
-  def self.families(use_slices: false)
-    if use_slices
-      Option::VmFamilies.select { _1.visible }
-    else
-      Option::VmFamilies.select { _1.visible && !_1.require_shared_slice }
-    end
+  def self.families
+    Option::VmFamilies.select { _1.visible }
   end
 
   BootImage = Struct.new(:name, :display_name)

--- a/model/project.rb
+++ b/model/project.rb
@@ -156,7 +156,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :access_all_cache_scopes, :use_slices_for_allocation, :allocator_diagnostics, :kubernetes
+  feature_flag :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :kubernetes
 end
 
 # Table: project

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -25,7 +25,6 @@ class Prog::Test::VmGroup < Prog::Test::Base
   label def setup_vms
     project = Project.create_with_id(name: "project-1")
     test_slices = frame.fetch("test_slices")
-    project.set_ff_use_slices_for_allocation(test_slices)
 
     size_options = test_slices ? ["standard-2", "burstable-1"] : ["standard-2"]
     subnets = Array.new(2) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-#{_1}", location: "hetzner-fsn1") }

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -32,7 +32,7 @@ module Scheduling::Allocator
       location_preference,
       vm.family,
       vm.cpu_percent_limit,
-      vm.project.get_ff_use_slices_for_allocation || false,
+      true, # use slices
       Option::VmFamilies.find { _1.name == vm.family }&.require_shared_slice || false,
       vm.project.get_ff_allocator_diagnostics || false
     )
@@ -68,7 +68,6 @@ module Scheduling::Allocator
   ) do
     def initialize(*args)
       super
-      self.use_slices ||= false
       self.require_shared_slice ||= false
       self.diagnostics ||= false
     end

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -19,12 +19,8 @@ RSpec.describe Option do
   end
 
   describe "#VmFamily options" do
-    it "families include burstables when use slices" do
-      expect(described_class.families(use_slices: true).map(&:name)).to include("burstable")
-    end
-
-    it "families exclude burstables when not using slices" do
-      expect(described_class.families(use_slices: false).map(&:name)).not_to include("burstable")
+    it "families include burstables" do
+      expect(described_class.families.map(&:name)).to include("burstable")
     end
   end
 end

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe Clover, "vm" do
 
       it "shows vm create page with burstable and location_latitude_fra" do
         project.set_ff_location_latitude_fra true
-        project.set_ff_use_slices_for_allocation true
         visit "#{project.path}/vm/create"
         expect(page.title).to eq("Ubicloud - Create Virtual Machine")
       end


### PR DESCRIPTION
Removing the project feature flag `use_slices_for_allocation` and making it the default to use slices. We still keep the `use_slices` parameter in the request to make it easier to turn off the allocation logic for slices if needed. It can be completely removed in the future.