### PR TITLE
Add ubid types for 4 models, do not leak TYPE_ETC ubid values

### DIFF
--- a/model/api_key.rb
+++ b/model/api_key.rb
@@ -13,10 +13,6 @@ class ApiKey < Sequel::Model
     enc.column :key
   end
 
-  def self.ubid_type
-    UBID::TYPE_ETC
-  end
-
   def name
     ubid
   end

--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -9,10 +9,6 @@ class GithubCacheEntry < Sequel::Model
 
   include ResourceMethods
 
-  def self.ubid_type
-    UBID::TYPE_ETC
-  end
-
   def blob_key
     "cache/#{ubid}"
   end

--- a/model/postgres/postgres_metric_destination.rb
+++ b/model/postgres/postgres_metric_destination.rb
@@ -10,10 +10,6 @@ class PostgresMetricDestination < Sequel::Model
   plugin :column_encryption do |enc|
     enc.column :password
   end
-
-  def self.ubid_type
-    UBID::TYPE_ETC
-  end
 end
 
 # Table: postgres_metric_destination

--- a/model/usage_alert.rb
+++ b/model/usage_alert.rb
@@ -8,10 +8,6 @@ class UsageAlert < Sequel::Model
 
   include ResourceMethods
 
-  def self.ubid_type
-    UBID::TYPE_ETC
-  end
-
   def trigger
     send_email
     update(last_triggered_at: Time.now)

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1330,7 +1330,7 @@ components:
       schema:
         type: string
         example: et7ekmf54nae5nya9s6vebg43f
-        pattern: '^et[0-9a-hj-km-np-tv-z]{24}$'
+        pattern: '^(et|md)[0-9a-hj-km-np-tv-z]{24}$'
     order_column:
       description: Pagination - Order column
       in: query

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -135,7 +135,11 @@ RSpec.describe Authorization do
       AccessControlEntry.dataset.destroy
       project_id = projects[0].id
 
+      # Backwards compatibility for old TYPE_ETC ubid (etkjnpyp1dst3n9d2mct7s71rh in this example)
+      api_key_id = ApiKey.create_with_id(owner_table: "project", owner_id: project_id, used_for: "inference_endpoint", project_id:) { |api_key| api_key.id = "9cab6f58-2dce-85da-aa5a-2a3347c9c388" }.id
+
       [
+        [{subjects: [users[0].id], actions: ["Vm:view"], objects: api_key_id}, users[0].id, "Vm:view", api_key_id, 1],
         [{}, SecureRandom.uuid, "Vm:view", UBID.from_uuidish(SecureRandom.uuid).to_s.sub(/\A../, "00"), 0],
         [{}, SecureRandom.uuid, ["Vm:view"], UBID.from_uuidish(SecureRandom.uuid).to_s.sub(/\A../, "00"), 0],
         [{}, SecureRandom.uuid, ["Vm:view"], vms[0].id, 0],

--- a/spec/model/access_control_entry_spec.rb
+++ b/spec/model/access_control_entry_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe AccessControlEntry do
     ace.subject_id = ApiKey.create_personal_access_token(account, project:).id
     expect(ace.valid?).to be true
 
+    # Backwards compatibility for old TYPE_ETC ubid (etkjnpyp1dst3n9d2mct7s71rh in this example)
+    ace.subject_id = ApiKey.create_with_id(owner_table: "accounts", owner_id: account.id, used_for: "api", project_id: project.id) { |api_key| api_key.id = "9cab6f58-2dce-85da-aa5a-2a3347c9c388" }.id
+    expect(ace.valid?).to be true
+
     project2 = Project.create_with_id(name: "Test-2")
     ace.subject_id = ApiKey.create_personal_access_token(account2, project: project2).id
     expect(ace.valid?).to be false

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination foo bar https:__md.example.com.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination foo bar https:__md.example.com.txt
@@ -1,4 +1,4 @@
 Metric destination added to PostgreSQL database.
 Current metric destinations:
-  1: et2t1bswsqz21m7j7njfjbp901  foo  https://baz.example.com
-  2: etqhb3wgwvge5pepd72pcgzyp6  foo  https://md.example.com
+  1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
+  2: md8vck86dbsj5g8x5bvz6c1s7z  foo  https://md.example.com

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f firewall-rules,metric-destinations,ca-certificates.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f firewall-rules,metric-destinations,ca-certificates.txt
@@ -1,6 +1,6 @@
 firewall rules:
   1: pfb9g14e5ndt6qf59wfk8109bg  0.0.0.0/0
 metric destinations:
-  1: et2t1bswsqz21m7j7njfjbp901  foo  https://baz.example.com
+  1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
 CA certificates:
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
@@ -13,6 +13,6 @@ earliest_restore_time:
 firewall rules:
   1: pfb9g14e5ndt6qf59wfk8109bg  0.0.0.0/0
 metric destinations:
-  1: et2t1bswsqz21m7j7njfjbp901  foo  https://baz.example.com
+  1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
 CA certificates:
 

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Clover, "cli" do
     expect(FirewallRule).to receive(:generate_uuid).and_return("51e5bc7d-245b-8df8-bf91-7c5d150cb160", "3b367895-7f18-89f8-a295-ff247e9d5192", "305d838d-a3cd-85f8-aa08-9a66e71a5877", "5aa5b086-37bd-81f8-8d03-dd4b0e09a436", "20c360fa-bc06-8df8-b067-33f4a1ebdbbd", "2b628450-25bd-8df8-8b42-fb5cc5d01ad1", "da42e2ef-b5f1-8df8-966d-1387afb1b2f4", "bc9b093a-0e00-89f8-991a-5e0cd15a7942", "b5e13849-a04f-89f8-b564-ab8ad37298aa", "e46b8b76-88e2-89f8-972b-692232699d16", "e0804078-98cf-85f8-bf74-702ec92c91e8", "d62c8465-7f9b-85f8-a548-5a8772352988")
     expect(PostgresResource).to receive(:generate_uuid).and_return("dd0375a6-1c66-82d0-a5e8-af1e8527a8a2")
     expect(PostgresFirewallRule).to receive(:generate_uuid).and_return("5a601238-b56e-8ecf-bbca-9e3e680812b8")
-    expect(PostgresMetricDestination).to receive(:generate_uuid).and_return("1682bcf3-37f8-81da-a1e4-7ac9f25d9200")
+    expect(PostgresMetricDestination).to receive(:generate_uuid).and_return("45754ea1-c139-8a8d-af18-7b24e0dbc7de")
     cli(%w[vm eu-central-h1/test-vm create a])
     @vm = Vm.first
     add_ipv4_to_vm(@vm, "128.0.0.1")
@@ -56,7 +56,7 @@ RSpec.describe Clover, "cli" do
     expect(FirewallRule).to receive(:generate_uuid).and_invoke(-> { fwr_uuids.next }).at_least(:once)
     expect(PostgresResource).to receive(:generate_uuid).and_return("97eb0a77-7869-86d0-9dcb-a46416ddc5c9").at_least(:once)
     expect(PostgresFirewallRule).to receive(:generate_uuid).and_return("6d674a31-e1c1-8ecf-b5ac-363abb5b9185").at_least(:once)
-    expect(PostgresMetricDestination).to receive(:generate_uuid).and_return("bc563e43-9b83-89da-b3ac-d38acc87fd63").at_least(:once)
+    expect(PostgresMetricDestination).to receive(:generate_uuid).and_return("46d93419-abcc-8a8d-823a-55efe660727f").at_least(:once)
     expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("nc186qw3d23j1kzsgjqg2t811r")).at_least(:once)
     expect(LoadBalancer).to receive(:generate_uuid).and_return("eb8e0b21-94f2-8c2b-82c8-da57fcfe88c7").at_least(:once)
 

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -17,6 +17,21 @@ RSpec.configure do |config|
     Clover.app
   end
 
+  def last_response
+    lr = super
+
+    if lr && !lr.instance_variable_get(:@body_checked)
+      lr.instance_variable_set(:@body_checked, true)
+      if (match = lr.body.match(/(?<=(.{50}\W))(et[a-z0-9]{24})(?=(\W.{50}))/m))
+        unless match[1].match?(/otp_raw_secret|csrf/)
+          raise "response body contains TYPE_ETC ubid: #{match.captures.inspect}"
+        end
+      end
+    end
+
+    lr
+  end
+
   def error_response_matcher(expected_state, expected_message, expected_details, nested_error)
     message_path = nested_error ? ["error", "message"] : ["message"]
     details_path = nested_error ? ["error", "details"] : ["details"]

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -321,13 +321,18 @@ RSpec.describe UBID do
     page = Page.create_with_id(summary: "x", tag: "y")
     project = Project.create(name: "test")
     a_type = ActionType.first
+
     api_key = ApiKey.create(owner_table: "project", owner_id: project.id, used_for: "inference_endpoint", key: "1", project_id: project.id)
+    # Backwards compatibility for old TYPE_ETC ubid (etkjnpyp1dst3n9d2mct7s71rh in this example)
+    old_api_key = ApiKey.create_with_id(owner_table: "project", owner_id: project.id, used_for: "inference_endpoint", project_id: project.id) { |ak| ak.id = "9cab6f58-2dce-85da-aa5a-2a3347c9c388" }
+
     invalid = described_class.to_uuid("han2sefsk4f61k91z77vn0y978")
-    hash = {page.id => nil, a_type.id => nil, api_key.id => nil, invalid => nil}
+    hash = {page.id => nil, a_type.id => nil, api_key.id => nil, invalid => nil, old_api_key.id => nil}
     described_class.resolve_map(hash)
     expect(hash[page.id]).to eq page
     expect(hash[a_type.id]).to eq a_type
     expect(hash[api_key.id]).to eq api_key
+    expect(hash[old_api_key.id]).to eq old_api_key
     expect(hash[invalid]).to be_nil
   end
 

--- a/ubid.rb
+++ b/ubid.rb
@@ -84,6 +84,11 @@ class UBID
   TYPE_KUBERNETES_CLUSTER = "kc"
   TYPE_KUBERNETES_NODEPOOL = "kn"
   TYPE_LOCATION = "10"
+  TYPE_API_KEY = "ak"
+  TYPE_USAGE_ALERT = "va"
+  TYPE_POSTGRES_METRIC_DESTINATION = "md"
+  TYPE_GITHUB_CACHE_ENTRY = "ge"
+
   # Common entropy-based type for everything else
   TYPE_ETC = "et"
 


### PR DESCRIPTION
This adds a check in the route specs that TYPE_ETC ubid values are not present in responses.  It then changes four models to use model-specific ubid types instead of TYPE_ETC.

The original impetus for this change is to eventually remove authorization code that explicitly checks for TYPE_ETC and assumes ApiKey, which will cause problems in the future if we ever have another model using TYPE_ETC that the authorization system needs to deal with.

This keeps current support for TYPE_ETC ApiKey values in the authorization system, because we don't want to break existing tokens. This requires adding a few tests to keep 100% coverage.  However, we may want to eventually phase out such support.