### PR TITLE
E2E: wait for VM clean-up before verifying cleanup.

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -136,6 +136,10 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   end
 
   label def verify_cleanup
+    # not all tests will wait for cleanup, so we need to wait here until the
+    # cleanup is done
+    nap 15 unless vm_host.vms.empty?
+
     hop_verify_vm_dir_purged
   end
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -180,6 +180,11 @@ RSpec.describe Prog::Test::HetznerServer do
     it "hops to verify_vm_dir_purged" do
       expect { hs_test.verify_cleanup }.to hop("verify_vm_dir_purged")
     end
+
+    it "naps if vm_host has vms" do
+      expect(vm_host).to receive(:vms).and_return([:vm1, :vm2])
+      expect { hs_test.verify_cleanup }.to nap(15)
+    end
   end
 
   describe "#verify_vm_dir_purged" do


### PR DESCRIPTION
Tests like `Prog::Test::HaPostgresResource` don't wait until their resources have been cleaned-up before popping. So, `HetznerServer::verify_cleanup` sometimes failed because of VMs that were yet to be destroyed.

An example is:
https://github.com/ubicloud/ubicloud/actions/runs/13499869398/job/37715426721

In which I see that the `MinioServerNexus` hops from `wait` to `destroy` after the `verify_cleanup` label.