### PR TITLE
Do not allow model ubid as model name, remove underscore requirement, allow ubid without location in cli

### DIFF
--- a/cli-commands/fw.rb
+++ b/cli-commands/fw.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("fw") do
   options("ubi fw subcommand [...]")
-  post_options("ubi fw location/(fw-name|_fw-id) subcommand [...]")
+  post_options("ubi fw location/(fw-name|fw-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/fw")

--- a/cli-commands/fw.rb
+++ b/cli-commands/fw.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("fw") do
   options("ubi fw subcommand [...]")
-  post_options("ubi fw location/(fw-name|fw-id) subcommand [...]")
+  post_options("ubi fw (location/fw-name|fw-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/fw")

--- a/cli-commands/fw/post/add-rule.rb
+++ b/cli-commands/fw/post/add-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("add-rule") do
-  options("ubi fw location/(fw-name|fw-id) add-rule cidr", key: :fw_add_rule) do
+  options("ubi fw (location/fw-name|fw-id) add-rule cidr", key: :fw_add_rule) do
     on("-s", "--start-port=port", "starting (or only) port to allow (default: 0)")
     on("-e", "--end-port=port", "ending port to allow (default: 65535)")
   end

--- a/cli-commands/fw/post/add-rule.rb
+++ b/cli-commands/fw/post/add-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("add-rule") do
-  options("ubi fw location/(fw-name|_fw-id) add-rule cidr", key: :fw_add_rule) do
+  options("ubi fw location/(fw-name|fw-id) add-rule cidr", key: :fw_add_rule) do
     on("-s", "--start-port=port", "starting (or only) port to allow (default: 0)")
     on("-e", "--end-port=port", "ending port to allow (default: 65535)")
   end

--- a/cli-commands/fw/post/attach-subnet.rb
+++ b/cli-commands/fw/post/attach-subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("attach-subnet") do
-  options("ubi fw location/(fw-name|fw-id) attach-subnet subnet-id")
+  options("ubi fw (location/fw-name|fw-id) attach-subnet subnet-id")
 
   args 1
 

--- a/cli-commands/fw/post/attach-subnet.rb
+++ b/cli-commands/fw/post/attach-subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("attach-subnet") do
-  options("ubi fw location/(fw-name|_fw-id) attach-subnet subnet-id")
+  options("ubi fw location/(fw-name|fw-id) attach-subnet subnet-id")
 
   args 1
 

--- a/cli-commands/fw/post/delete-rule.rb
+++ b/cli-commands/fw/post/delete-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("delete-rule") do
-  options("ubi fw location/(fw-name|fw-id) delete-rule rule-id")
+  options("ubi fw (location/fw-name|fw-id) delete-rule rule-id")
 
   args 1
 

--- a/cli-commands/fw/post/delete-rule.rb
+++ b/cli-commands/fw/post/delete-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("delete-rule") do
-  options("ubi fw location/(fw-name|_fw-id) delete-rule rule-id")
+  options("ubi fw location/(fw-name|fw-id) delete-rule rule-id")
 
   args 1
 

--- a/cli-commands/fw/post/detach-subnet.rb
+++ b/cli-commands/fw/post/detach-subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("detach-subnet") do
-  options("ubi fw location/(fw-name|_fw-id) detach-subnet subnet-id")
+  options("ubi fw location/(fw-name|fw-id) detach-subnet subnet-id")
 
   args 1
 

--- a/cli-commands/fw/post/detach-subnet.rb
+++ b/cli-commands/fw/post/detach-subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("fw").run_on("detach-subnet") do
-  options("ubi fw location/(fw-name|fw-id) detach-subnet subnet-id")
+  options("ubi fw (location/fw-name|fw-id) detach-subnet subnet-id")
 
   args 1
 

--- a/cli-commands/fw/post/show.rb
+++ b/cli-commands/fw/post/show.rb
@@ -6,7 +6,7 @@ UbiCli.on("fw").run_on("show") do
   private_subnet_fields = %w[id name state location net4 net6 nics].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi fw location/(fw-name|_fw-id) show [options]", key: :fw_show) do
+  options("ubi fw location/(fw-name|fw-id) show [options]", key: :fw_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
     on("-p", "--priv-subnet-fields=fields", "show specific private subnet fields (comma separated)")

--- a/cli-commands/fw/post/show.rb
+++ b/cli-commands/fw/post/show.rb
@@ -6,7 +6,7 @@ UbiCli.on("fw").run_on("show") do
   private_subnet_fields = %w[id name state location net4 net6 nics].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi fw location/(fw-name|fw-id) show [options]", key: :fw_show) do
+  options("ubi fw (location/fw-name|fw-id) show [options]", key: :fw_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
     on("-p", "--priv-subnet-fields=fields", "show specific private subnet fields (comma separated)")

--- a/cli-commands/lb.rb
+++ b/cli-commands/lb.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("lb") do
   options("ubi lb subcommand [...]")
-  post_options("ubi lb location/(lb-name|lb-id) subcommand [...]")
+  post_options("ubi lb (location/lb-name|lb-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/lb")

--- a/cli-commands/lb.rb
+++ b/cli-commands/lb.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("lb") do
   options("ubi lb subcommand [...]")
-  post_options("ubi lb location/(lb-name|_lb-id) subcommand [...]")
+  post_options("ubi lb location/(lb-name|lb-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/lb")

--- a/cli-commands/lb/post/attach-vm.rb
+++ b/cli-commands/lb/post/attach-vm.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("attach-vm") do
-  options("ubi lb location/(lb-name|_lb-id) attach-vm vm-id")
+  options("ubi lb location/(lb-name|lb-id) attach-vm vm-id")
 
   args 1
 

--- a/cli-commands/lb/post/attach-vm.rb
+++ b/cli-commands/lb/post/attach-vm.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("attach-vm") do
-  options("ubi lb location/(lb-name|lb-id) attach-vm vm-id")
+  options("ubi lb (location/lb-name|lb-id) attach-vm vm-id")
 
   args 1
 

--- a/cli-commands/lb/post/detach-vm.rb
+++ b/cli-commands/lb/post/detach-vm.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("detach-vm") do
-  options("ubi lb location/(lb-name|lb-id) detach-vm vm-id")
+  options("ubi lb (location/lb-name|lb-id) detach-vm vm-id")
 
   args 1
 

--- a/cli-commands/lb/post/detach-vm.rb
+++ b/cli-commands/lb/post/detach-vm.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("detach-vm") do
-  options("ubi lb location/(lb-name|_lb-id) detach-vm vm-id")
+  options("ubi lb location/(lb-name|lb-id) detach-vm vm-id")
 
   args 1
 

--- a/cli-commands/lb/post/show.rb
+++ b/cli-commands/lb/post/show.rb
@@ -3,7 +3,7 @@
 UbiCli.on("lb").run_on("show") do
   fields = %w[id name state location hostname algorithm stack health-check-endpoint health-check-protocol src-port dst-port subnet vms].freeze.each(&:freeze)
 
-  options("ubi lb location/(lb-name|lb-id) show [options]", key: :lb_show) do
+  options("ubi lb (location/lb-name|lb-id) show [options]", key: :lb_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     wrap("Fields:", fields)
   end

--- a/cli-commands/lb/post/show.rb
+++ b/cli-commands/lb/post/show.rb
@@ -3,7 +3,7 @@
 UbiCli.on("lb").run_on("show") do
   fields = %w[id name state location hostname algorithm stack health-check-endpoint health-check-protocol src-port dst-port subnet vms].freeze.each(&:freeze)
 
-  options("ubi lb location/(lb-name|_lb-ubid) show [options]", key: :lb_show) do
+  options("ubi lb location/(lb-name|lb-id) show [options]", key: :lb_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     wrap("Fields:", fields)
   end

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("update") do
-  options("ubi lb location/(lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]")
+  options("ubi lb (location/lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]")
 
   args(4...)
 

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("lb").run_on("update") do
-  options("ubi lb location/(lb-name|_lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]")
+  options("ubi lb location/(lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]")
 
   args(4...)
 

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -3,7 +3,7 @@
 UbiCli.base("pg") do
   options("ubi pg subcommand [...]")
 
-  post_options("ubi pg location/(pg-name|_pg-id) [options] subcommand [...]", key: :pg_psql) do
+  post_options("ubi pg location/(pg-name|pg-id) [options] subcommand [...]", key: :pg_psql) do
     on("-d", "--dbname=name", "override database name")
     on("-U", "--username=name", "override username")
   end

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -3,7 +3,7 @@
 UbiCli.base("pg") do
   options("ubi pg subcommand [...]")
 
-  post_options("ubi pg location/(pg-name|pg-id) [options] subcommand [...]", key: :pg_psql) do
+  post_options("ubi pg (location/pg-name|pg-id) [options] subcommand [...]", key: :pg_psql) do
     on("-d", "--dbname=name", "override database name")
     on("-U", "--username=name", "override username")
   end

--- a/cli-commands/pg/post/add-firewall-rule.rb
+++ b/cli-commands/pg/post/add-firewall-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("add-firewall-rule") do
-  options("ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr")
+  options("ubi pg location/(pg-name|pg-id) add-firewall-rule cidr")
 
   args 1, invalid_args_message: "cidr is required"
 

--- a/cli-commands/pg/post/add-firewall-rule.rb
+++ b/cli-commands/pg/post/add-firewall-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("add-firewall-rule") do
-  options("ubi pg location/(pg-name|pg-id) add-firewall-rule cidr")
+  options("ubi pg (location/pg-name|pg-id) add-firewall-rule cidr")
 
   args 1, invalid_args_message: "cidr is required"
 

--- a/cli-commands/pg/post/add-metric-destination.rb
+++ b/cli-commands/pg/post/add-metric-destination.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("add-metric-destination") do
-  options("ubi pg location/(pg-name|pg-id) add-metric-destination username password url")
+  options("ubi pg (location/pg-name|pg-id) add-metric-destination username password url")
 
   args 3, invalid_args_message: "username, password, and url arguments are required"
 

--- a/cli-commands/pg/post/add-metric-destination.rb
+++ b/cli-commands/pg/post/add-metric-destination.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("add-metric-destination") do
-  options("ubi pg location/(pg-name|_pg-id) add-metric-destination username password url")
+  options("ubi pg location/(pg-name|pg-id) add-metric-destination username password url")
 
   args 3, invalid_args_message: "username, password, and url arguments are required"
 

--- a/cli-commands/pg/post/delete-firewall-rule.rb
+++ b/cli-commands/pg/post/delete-firewall-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("delete-firewall-rule") do
-  options("ubi pg location/(pg-name|pg-id) delete-firewall-rule id")
+  options("ubi pg (location/pg-name|pg-id) delete-firewall-rule id")
 
   args 1, invalid_args_message: "rule id is required"
 

--- a/cli-commands/pg/post/delete-firewall-rule.rb
+++ b/cli-commands/pg/post/delete-firewall-rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("delete-firewall-rule") do
-  options("ubi pg location/(pg-name|_pg-id) delete-firewall-rule id")
+  options("ubi pg location/(pg-name|pg-id) delete-firewall-rule id")
 
   args 1, invalid_args_message: "rule id is required"
 

--- a/cli-commands/pg/post/delete-metric-destination.rb
+++ b/cli-commands/pg/post/delete-metric-destination.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("delete-metric-destination") do
-  options("ubi pg location/(pg-name|_pg-id) delete-metric-destination id")
+  options("ubi pg location/(pg-name|pg-id) delete-metric-destination id")
 
   args 1, invalid_args_message: "metric destination id is required"
 

--- a/cli-commands/pg/post/delete-metric-destination.rb
+++ b/cli-commands/pg/post/delete-metric-destination.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("delete-metric-destination") do
-  options("ubi pg location/(pg-name|pg-id) delete-metric-destination id")
+  options("ubi pg (location/pg-name|pg-id) delete-metric-destination id")
 
   args 1, invalid_args_message: "metric destination id is required"
 

--- a/cli-commands/pg/post/failover.rb
+++ b/cli-commands/pg/post/failover.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("failover") do
-  options("ubi pg location/(pg-name|_pg-id) failover")
+  options("ubi pg location/(pg-name|pg-id) failover")
 
   run do
     post(pg_path("/failover")) do |data|

--- a/cli-commands/pg/post/failover.rb
+++ b/cli-commands/pg/post/failover.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("failover") do
-  options("ubi pg location/(pg-name|pg-id) failover")
+  options("ubi pg (location/pg-name|pg-id) failover")
 
   run do
     post(pg_path("/failover")) do |data|

--- a/cli-commands/pg/post/reset-superuser-password.rb
+++ b/cli-commands/pg/post/reset-superuser-password.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("reset-superuser-password") do
-  options("ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password")
+  options("ubi pg location/(pg-name|pg-id) reset-superuser-password new-password")
 
   args 1, invalid_args_message: "password is required"
 

--- a/cli-commands/pg/post/reset-superuser-password.rb
+++ b/cli-commands/pg/post/reset-superuser-password.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("reset-superuser-password") do
-  options("ubi pg location/(pg-name|pg-id) reset-superuser-password new-password")
+  options("ubi pg (location/pg-name|pg-id) reset-superuser-password new-password")
 
   args 1, invalid_args_message: "password is required"
 

--- a/cli-commands/pg/post/restart.rb
+++ b/cli-commands/pg/post/restart.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("restart") do
-  options("ubi pg location/(pg-name|pg-id) restart")
+  options("ubi pg (location/pg-name|pg-id) restart")
 
   run do
     post(pg_path("/restart")) do |data|

--- a/cli-commands/pg/post/restart.rb
+++ b/cli-commands/pg/post/restart.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("restart") do
-  options("ubi pg location/(pg-name|_pg-id) restart")
+  options("ubi pg location/(pg-name|pg-id) restart")
 
   run do
     post(pg_path("/restart")) do |data|

--- a/cli-commands/pg/post/restore.rb
+++ b/cli-commands/pg/post/restore.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("restore") do
-  options("ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time")
+  options("ubi pg location/(pg-name|pg-id) restore new-db-name restore-time")
 
   args 2, invalid_args_message: "name and restore target are required"
 

--- a/cli-commands/pg/post/restore.rb
+++ b/cli-commands/pg/post/restore.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("pg").run_on("restore") do
-  options("ubi pg location/(pg-name|pg-id) restore new-db-name restore-time")
+  options("ubi pg (location/pg-name|pg-id) restore new-db-name restore-time")
 
   args 2, invalid_args_message: "name and restore target are required"
 

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -3,7 +3,7 @@
 UbiCli.on("pg").run_on("show") do
   fields = %w[id name state location vm-size storage-size-gib version ha-type flavor connection-string primary earliest-restore-time firewall-rules metric-destinations ca-certificates].freeze.each(&:freeze)
 
-  options("ubi pg location/(pg-name|pg-id) show [options]", key: :pg_show) do
+  options("ubi pg (location/pg-name|pg-id) show [options]", key: :pg_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     wrap("Fields:", fields)
   end

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -3,7 +3,7 @@
 UbiCli.on("pg").run_on("show") do
   fields = %w[id name state location vm-size storage-size-gib version ha-type flavor connection-string primary earliest-restore-time firewall-rules metric-destinations ca-certificates].freeze.each(&:freeze)
 
-  options("ubi pg location/(pg-name|_pg-id) show [options]", key: :pg_show) do
+  options("ubi pg location/(pg-name|pg-id) show [options]", key: :pg_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     wrap("Fields:", fields)
   end

--- a/cli-commands/ps.rb
+++ b/cli-commands/ps.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("ps") do
   options("ubi ps subcommand [...]")
-  post_options("ubi ps location/(ps-name|ps-id) subcommand [...]")
+  post_options("ubi ps (location/ps-name|ps-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/ps")

--- a/cli-commands/ps.rb
+++ b/cli-commands/ps.rb
@@ -2,7 +2,7 @@
 
 UbiCli.base("ps") do
   options("ubi ps subcommand [...]")
-  post_options("ubi ps location/(ps-name|_ps-id) subcommand [...]")
+  post_options("ubi ps location/(ps-name|ps-id) subcommand [...]")
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/ps")

--- a/cli-commands/ps/post/connect.rb
+++ b/cli-commands/ps/post/connect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("ps").run_on("connect") do
-  options("ubi ps location/(ps-name|_ps-id) connect ps-id")
+  options("ubi ps location/(ps-name|ps-id) connect ps-id")
 
   args 1
 

--- a/cli-commands/ps/post/connect.rb
+++ b/cli-commands/ps/post/connect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("ps").run_on("connect") do
-  options("ubi ps location/(ps-name|ps-id) connect ps-id")
+  options("ubi ps (location/ps-name|ps-id) connect ps-id")
 
   args 1
 

--- a/cli-commands/ps/post/disconnect.rb
+++ b/cli-commands/ps/post/disconnect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("ps").run_on("disconnect") do
-  options("ubi ps location/(ps-name|_ps-id) disconnect ps-id")
+  options("ubi ps location/(ps-name|ps-id) disconnect ps-id")
 
   args 1
 

--- a/cli-commands/ps/post/disconnect.rb
+++ b/cli-commands/ps/post/disconnect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("ps").run_on("disconnect") do
-  options("ubi ps location/(ps-name|ps-id) disconnect ps-id")
+  options("ubi ps (location/ps-name|ps-id) disconnect ps-id")
 
   args 1
 

--- a/cli-commands/ps/post/show.rb
+++ b/cli-commands/ps/post/show.rb
@@ -6,7 +6,7 @@ UbiCli.on("ps").run_on("show") do
   firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi ps location/(ps-name|ps-id) show [options]", key: :ps_show) do
+  options("ubi ps (location/ps-name|ps-id) show [options]", key: :ps_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
     on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")

--- a/cli-commands/ps/post/show.rb
+++ b/cli-commands/ps/post/show.rb
@@ -6,7 +6,7 @@ UbiCli.on("ps").run_on("show") do
   firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi ps location/(ps-name|_ps-id) show [options]", key: :ps_show) do
+  options("ubi ps location/(ps-name|ps-id) show [options]", key: :ps_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
     on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")

--- a/cli-commands/vm.rb
+++ b/cli-commands/vm.rb
@@ -3,7 +3,7 @@
 UbiCli.base("vm") do
   options("ubi vm subcommand [...]")
 
-  post_options("ubi vm location/(vm-name|_vm-id) [options] subcommand [...]", key: :vm_ssh) do
+  post_options("ubi vm location/(vm-name|vm-id) [options] subcommand [...]", key: :vm_ssh) do
     on("-4", "--ip4", "use IPv4 address")
     on("-6", "--ip6", "use IPv6 address")
     on("-u", "--user user", "override username")

--- a/cli-commands/vm.rb
+++ b/cli-commands/vm.rb
@@ -3,7 +3,7 @@
 UbiCli.base("vm") do
   options("ubi vm subcommand [...]")
 
-  post_options("ubi vm location/(vm-name|vm-id) [options] subcommand [...]", key: :vm_ssh) do
+  post_options("ubi vm (location/vm-name|vm-id) [options] subcommand [...]", key: :vm_ssh) do
     on("-4", "--ip4", "use IPv4 address")
     on("-6", "--ip6", "use IPv6 address")
     on("-u", "--user user", "override username")

--- a/cli-commands/vm/post/restart.rb
+++ b/cli-commands/vm/post/restart.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("restart") do
-  options("ubi vm location/(vm-name|_vm-id) restart")
+  options("ubi vm location/(vm-name|vm-id) restart")
 
   run do
     post(vm_path("/restart")) do |data|

--- a/cli-commands/vm/post/restart.rb
+++ b/cli-commands/vm/post/restart.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("restart") do
-  options("ubi vm location/(vm-name|vm-id) restart")
+  options("ubi vm (location/vm-name|vm-id) restart")
 
   run do
     post(vm_path("/restart")) do |data|

--- a/cli-commands/vm/post/scp.rb
+++ b/cli-commands/vm/post/scp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("scp") do
-  skip_option_parsing("ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
+  skip_option_parsing("ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
 
   args(2..., invalid_args_message: "must provide 2 paths: either 'local-path :remote-path' or ':remote-path local-path'")
 

--- a/cli-commands/vm/post/scp.rb
+++ b/cli-commands/vm/post/scp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("scp") do
-  skip_option_parsing("ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
+  skip_option_parsing("ubi vm (location/vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
 
   args(2..., invalid_args_message: "must provide 2 paths: either 'local-path :remote-path' or ':remote-path local-path'")
 

--- a/cli-commands/vm/post/sftp.rb
+++ b/cli-commands/vm/post/sftp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("sftp") do
-  skip_option_parsing("ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]")
+  skip_option_parsing("ubi vm (location/vm-name|vm-id) [options] sftp [sftp-options]")
 
   args(0...)
 

--- a/cli-commands/vm/post/sftp.rb
+++ b/cli-commands/vm/post/sftp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("sftp") do
-  skip_option_parsing("ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]")
+  skip_option_parsing("ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]")
 
   args(0...)
 

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -5,7 +5,7 @@ UbiCli.on("vm").run_on("show") do
   firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
   firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
 
-  options("ubi vm location/(vm-name|_vm-id) show [options]", key: :vm_show) do
+  options("ubi vm location/(vm-name|vm-id) show [options]", key: :vm_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
     on("-w", "--firewall-fields=fields", "show specific firewall fields (comma separated)")

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -5,7 +5,7 @@ UbiCli.on("vm").run_on("show") do
   firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
   firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
 
-  options("ubi vm location/(vm-name|vm-id) show [options]", key: :vm_show) do
+  options("ubi vm (location/vm-name|vm-id) show [options]", key: :vm_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
     on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
     on("-w", "--firewall-fields=fields", "show specific firewall fields (comma separated)")

--- a/cli-commands/vm/post/ssh.rb
+++ b/cli-commands/vm/post/ssh.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("ssh") do
-  skip_option_parsing("ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
+  skip_option_parsing("ubi vm (location/vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
 
   args(0...)
 

--- a/cli-commands/vm/post/ssh.rb
+++ b/cli-commands/vm/post/ssh.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 UbiCli.on("vm").run_on("ssh") do
-  skip_option_parsing("ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
+  skip_option_parsing("ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
 
   args(0...)
 

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class Clover < Roda
-  NAME_OR_UBID = /([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)|_([a-z0-9]{26})/
+  def self.name_or_ubid_for(model)
+    # (\z)? to force a nil as first capture
+    [/(\z)?_?(#{model.ubid_type}[a-z0-9]{24})/, /([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)/]
+  end
+  [Firewall, KubernetesCluster, LoadBalancer, PostgresResource, PrivateSubnet, Vm].each do |model|
+    const_set(:"#{model.table_name.upcase}_NAME_OR_UBID", name_or_ubid_for(model))
+  end
 
   class RodaResponse
     API_DEFAULT_HEADERS = DEFAULT_HEADERS.merge("content-type" => "application/json").freeze

--- a/lib/resource_methods.rb
+++ b/lib/resource_methods.rb
@@ -3,12 +3,7 @@
 module ResourceMethods
   def self.included(base)
     base.extend(ClassMethods)
-    ubid_type = begin
-      base.ubid_type
-    rescue NameError
-      "et"
-    end
-    base.instance_variable_set(:@ubid_format, /\A#{ubid_type}[a-z0-9]{24}\z/)
+    base.instance_variable_set(:@ubid_format, /\A#{base.ubid_type}[a-z0-9]{24}\z/)
   end
 
   def freeze

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -111,7 +111,7 @@ class UbiCli
     fragment = FRAGMENTS[cmd]
 
     on(cmd).run_on("destroy") do
-      options("ubi #{cmd} location/(#{cmd}-name|_#{cmd}-id) destroy [options]", key: :destroy) do
+      options("ubi #{cmd} location/(#{cmd}-name|#{cmd}-id) destroy [options]", key: :destroy) do
         on("-f", "--force", "do not require confirmation")
       end
 
@@ -136,7 +136,7 @@ class UbiCli
 
   def self.pg_cmd(cmd)
     on("pg").run_on(cmd) do
-      skip_option_parsing("ubi pg location/(pg-name|_pg-id) [options] #{cmd} [#{cmd}-options]")
+      skip_option_parsing("ubi pg location/(pg-name|pg-id) [options] #{cmd} [#{cmd}-options]")
 
       args(0...)
 

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -131,7 +131,7 @@ class UbiCli
     fragment = FRAGMENTS[cmd]
 
     on(cmd).run_on("destroy") do
-      options("ubi #{cmd} location/(#{cmd}-name|#{cmd}-id) destroy [options]", key: :destroy) do
+      options("ubi #{cmd} (location/#{cmd}-name|#{cmd}-id) destroy [options]", key: :destroy) do
         on("-f", "--force", "do not require confirmation")
       end
 
@@ -156,7 +156,7 @@ class UbiCli
 
   def self.pg_cmd(cmd)
     on("pg").run_on(cmd) do
-      skip_option_parsing("ubi pg location/(pg-name|pg-id) [options] #{cmd} [#{cmd}-options]")
+      skip_option_parsing("ubi pg (location/pg-name|pg-id) [options] #{cmd} [#{cmd}-options]")
 
       args(0...)
 

--- a/model/boot_image.rb
+++ b/model/boot_image.rb
@@ -6,11 +6,11 @@ class BootImage < Sequel::Model
   many_to_one :vm_host, key: :vm_host_id, class: :VmHost
   one_to_many :vm_storage_volumes, key: :boot_image_id, class: :VmStorageVolume
 
-  include ResourceMethods
-
   def self.ubid_type
     UBID::TYPE_ETC
   end
+
+  include ResourceMethods
 
   # Introduced for removing a boot image via REPL.
   def remove_boot_image

--- a/model/certs_load_balancers.rb
+++ b/model/certs_load_balancers.rb
@@ -4,6 +4,11 @@ require_relative "../model"
 
 class CertsLoadBalancers < Sequel::Model
   many_to_one :cert
+
+  def self.ubid_type
+    UBID::TYPE_ETC
+  end
+
   include ResourceMethods
 
   def destroy

--- a/model/connected_subnet.rb
+++ b/model/connected_subnet.rb
@@ -3,11 +3,11 @@
 require_relative "../model"
 
 class ConnectedSubnet < Sequel::Model
-  include ResourceMethods
-
   def self.ubid_type
     UBID::TYPE_ETC
   end
+
+  include ResourceMethods
 end
 
 # Table: connected_subnet

--- a/model/firewalls_private_subnets.rb
+++ b/model/firewalls_private_subnets.rb
@@ -3,6 +3,10 @@
 require_relative "../model"
 
 class FirewallsPrivateSubnets < Sequel::Model
+  def self.ubid_type
+    UBID::TYPE_ETC
+  end
+
   include ResourceMethods
 end
 

--- a/model/globally_blocked_dnsname.rb
+++ b/model/globally_blocked_dnsname.rb
@@ -3,11 +3,11 @@
 require_relative "../model"
 
 class GloballyBlockedDnsname < Sequel::Model
-  include ResourceMethods
-
   def self.ubid_type
     UBID::TYPE_ETC
   end
+
+  include ResourceMethods
 end
 
 # Table: globally_blocked_dnsname

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -22,6 +22,10 @@ class LoadBalancer < Sequel::Model
   dataset_module Pagination
   semaphore :destroy, :update_load_balancer, :rewrite_dns_records, :refresh_cert
 
+  def display_location
+    private_subnet.display_location
+  end
+
   def path
     "/location/#{private_subnet.display_location}/load-balancer/#{name}"
   end

--- a/model/pci_device.rb
+++ b/model/pci_device.rb
@@ -3,14 +3,14 @@
 require_relative "../model"
 
 class PciDevice < Sequel::Model
-  include ResourceMethods
-
   many_to_one :vm_host
   many_to_one :vm
 
   def self.ubid_type
     UBID::TYPE_ETC
   end
+
+  include ResourceMethods
 
   def is_gpu
     ["0300", "0302"].include? device_class

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -4,13 +4,13 @@ require_relative "../model"
 require_relative "../lib/system_parser"
 
 class StorageDevice < Sequel::Model
-  include ResourceMethods
-
   many_to_one :vm_host
 
   def self.ubid_type
     UBID::TYPE_ETC
   end
+
+  include ResourceMethods
 
   def set_underlying_unix_devices
     df_command_path = (name == "DEFAULT") ? "/var/storage" : "/var/storage/devices/#{name}"

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1241,6 +1241,20 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Virtual Machine
+  '/project/{project_id}/object-info/{object_id}':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/object_id'
+    get:
+      operationId: getObjectInfo
+      summary: 'Return information on object type, location, and name'
+      responses:
+        '200':
+          $ref: '#/components/responses/ObjectInfo'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Project
   '/project/{project_id}/postgres':
     get:
       operationId: listPostgresDatabases
@@ -1331,6 +1345,15 @@ components:
         type: string
         example: et7ekmf54nae5nya9s6vebg43f
         pattern: '^(et|md)[0-9a-hj-km-np-tv-z]{24}$'
+    object_id:
+      description: ID of a supported object
+      in: path
+      name: object_id
+      required: true
+      schema:
+        type: string
+        example: fwkkmx0f2vke4h36nk9cm8v8q0
+        pattern: '^(fw|1b|pg|ps|vm)[0-9a-hj-km-np-tv-z]{24}$'
     order_column:
       description: Pagination - Order column
       in: query
@@ -1838,6 +1861,27 @@ components:
             required:
               - count
               - items
+    ObjectInfo:
+      description: 'Type, location, and name information for object'
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              type:
+                description: Type of object
+                type: string
+              location:
+                description: Location of object
+                type: string
+              name:
+                description: Name of object
+                type: string
+            additionalProperties: false
+            required:
+              - type
+              - location
+              - name
     PostgresDatabase:
       description: A Postgres Database
       content:

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -6,7 +6,7 @@ class Clover
       firewall_list_api_response(firewall_list_dataset)
     end
 
-    r.on NAME_OR_UBID do |firewall_name, firewall_id|
+    r.on FIREWALL_NAME_OR_UBID do |firewall_name, firewall_id|
       if firewall_name
         r.post api? do
           firewall_post(firewall_name)

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -3,7 +3,7 @@
 class Clover
   hash_branch(:project_location_prefix, "kubernetes-cluster") do |r|
     r.web do
-      r.on NAME_OR_UBID do |kc_name, kc_ubid|
+      r.on KUBERNETES_CLUSTER_NAME_OR_UBID do |kc_name, kc_ubid|
         filter = if kc_name
           {Sequel[:kubernetes_cluster][:name] => kc_name}
         else

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -6,7 +6,7 @@ class Clover
       load_balancer_list
     end
 
-    r.on NAME_OR_UBID do |lb_name, lb_id|
+    r.on LOAD_BALANCER_NAME_OR_UBID do |lb_name, lb_id|
       if lb_name
         r.post api? do
           load_balancer_post(lb_name)

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -6,7 +6,7 @@ class Clover
       postgres_list
     end
 
-    r.on NAME_OR_UBID do |pg_name, pg_ubid|
+    r.on POSTGRES_RESOURCE_NAME_OR_UBID do |pg_name, pg_ubid|
       if pg_name
         r.post api? do
           postgres_post(pg_name)

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -6,7 +6,7 @@ class Clover
       private_subnet_list
     end
 
-    r.on NAME_OR_UBID do |ps_name, ps_id|
+    r.on PRIVATE_SUBNET_NAME_OR_UBID do |ps_name, ps_id|
       if ps_name
         r.post true do
           private_subnet_post(ps_name)

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -6,7 +6,7 @@ class Clover
       vm_list_api_response(vm_list_dataset)
     end
 
-    r.on NAME_OR_UBID do |vm_name, vm_ubid|
+    r.on VM_NAME_OR_UBID do |vm_name, vm_ubid|
       if vm_name
         r.post api? do
           vm_post(vm_name)

--- a/routes/project/object_info.rb
+++ b/routes/project/object_info.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Clover
+  type_ds_perm_map = {
+    "fw" => [:firewalls_dataset, "Firewall:view"],
+    "1b" => [:load_balancers_dataset, "LoadBalancer:view"],
+    "pg" => [:postgres_resources_dataset, "Postgres:view"],
+    "ps" => [:private_subnets_dataset, "PrivateSubnet:view"],
+    "vm" => [:vms_dataset, "Vm:view"]
+  }.freeze
+  type_ds_perm_map.each_value(&:freeze)
+
+  hash_branch(:project_prefix, "object-info") do |r|
+    r.get(api?, UbiCli::OBJECT_INFO_REGEXP) do |ubid, type|
+      ds_method, perm = type_ds_perm_map[type]
+
+      if (object = dataset_authorize(@project.send(ds_method), perm).first(id: UBID.to_uuid(ubid)))
+        {
+          "type" => object.class.table_name.to_s.tr("_", " "),
+          "location" => object.display_location,
+          "name" => object.name
+        }
+      end
+    end
+  end
+end

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe LoadBalancer do
     Prog::Vm::Nexus.assemble("pub-key", prj.id, name: "test-vm1", private_subnet_id: lb.private_subnet.id).subject
   }
 
+  it "disallows VM ubid format as name" do
+    ps = described_class.new(name: described_class.generate_ubid.to_s)
+    ps.validate
+    expect(ps.errors[:name]).to eq ["cannot be exactly 26 numbers/lowercase characters starting with 1b to avoid overlap with id format"]
+  end
+
+  it "allows inference endpoint ubid format as name" do
+    ps = described_class.new(name: InferenceEndpoint.generate_ubid.to_s)
+    ps.validate
+    expect(ps.errors[:name]).to be_nil
+  end
+
   describe "util funcs" do
     before do
       allow(Config).to receive(:load_balancer_service_hostname).and_return("lb.ubicloud.com")

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe PrivateSubnet do
       private_ipv6: "fd1b:9793:dcef:cd0a:c::/79")
   }
 
+  it "disallows VM ubid format as name" do
+    ps = described_class.new(name: described_class.generate_ubid.to_s)
+    ps.validate
+    expect(ps.errors[:name]).to eq ["cannot be exactly 26 numbers/lowercase characters starting with ps to avoid overlap with id format"]
+  end
+
+  it "allows inference endpoint ubid format as name" do
+    ps = described_class.new(name: InferenceEndpoint.generate_ubid.to_s)
+    ps.validate
+    expect(ps.errors[:name]).to be_nil
+  end
+
   describe "random ip generation" do
     it "returns random private ipv4" do
       private_subnet

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -246,6 +246,18 @@ RSpec.describe Vm do
     vm.init_health_monitor_session
   end
 
+  it "disallows VM ubid format as name" do
+    vm = described_class.new(name: described_class.generate_ubid.to_s)
+    vm.validate
+    expect(vm.errors[:name]).to eq ["cannot be exactly 26 numbers/lowercase characters starting with vm to avoid overlap with id format"]
+  end
+
+  it "allows postgres server ubid format as name" do
+    vm = described_class.new(name: PostgresServer.generate_ubid.to_s)
+    vm.validate
+    expect(vm.errors[:name]).to be_nil
+  end
+
   it "checks pulse" do
     session = {
       ssh_session: instance_double(Net::SSH::Connection::Session)

--- a/spec/routes/api/cli/golden-file-commands/error.txt
+++ b/spec/routes/api/cli/golden-file-commands/error.txt
@@ -43,3 +43,5 @@ vm eu-central-h1/test-vm show -f invalid
 vm eu-central-h1/test-vm -u foo scp :remote-path local-path invalid
 vm eu-central-h1/test-vm -X sftp
 vm list invalid
+vm vmdzyppz6j166jh5e9t0dwrfas show
+vm vmdzyppz6j166jh5e9t0dwrfa show

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -128,6 +128,7 @@ vm eu-central-h1/test-vm show -f firewalls -w firewall-rules -r port-range
 vm eu-central-h1/test-vm show -f firewalls -w id,name
 vm eu-central-h1/test-vm show -f id,name,state,location,size,unix-user,storage-size-gib
 vm eu-central-h1/test-vm show -f ip6,ip4-enabled,ip4,private-ipv4,private-ipv6,subnet
+vm eu-central-h1/vmdzyppz6j166jh5e9t2dwrfas show
 vm list
 vm list -f location
 vm list -f name,id,ip4,ip6

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -18,6 +18,7 @@ fw eu-central-h1/test2-fw create
 fw eu-central-h1/test2-fw create -d test2-fw-description
 fw eu-central-h1/test-ps-default attach-subnet psfzm9e26xky5m9ggetw4dpqe2
 fw eu-central-h1/test-ps-default destroy -f
+fw fw4gj2v4h1fe3q28q0hnf7g8n1 show
 fw list
 fw list -f location
 fw list -l eu-central-h1
@@ -38,6 +39,7 @@ help -u
 help -u vm
 help vm
 help vm list
+lb 1bvp8yk1karj4ngwhtgrfh6esd show
 lb eu-central-h1/test2-lb create psfzm9e26xky5m9ggetw4dpqe2 12345 54321
 lb eu-central-h1/test-lb show
 lb eu-central-h1/test-lb show -f id,name,state,location,hostname,algorithm
@@ -84,6 +86,7 @@ pg list -l eu-north-h1
 pg list -l eu-north-h1 -f name,id
 pg list -l eu-north-h1 -N -f name,id
 pg list -N
+pg pgvm1qb9gwct1mqmay7m54yma5 show
 ps eu-central-h1/default-eu-central-h1 show
 ps eu-central-h1/default-eu-central-h1 show -f firewalls
 ps eu-central-h1/default-eu-central-h1 show -f firewalls,nics
@@ -109,6 +112,7 @@ ps list -l eu-north-h1
 ps list -l eu-north-h1 -f name,id
 ps list -l eu-north-h1 -N -f name,id
 ps list -N
+ps psfzm9e26xky5m9ggetw4dpqe2 show
 --version
 vm eu-central-h1/test2-vm create -6 pk
 vm eu-central-h1/test2-vm create -b debian-12 pk
@@ -138,3 +142,4 @@ vm list -l eu-central-h1 -N -f name,id
 vm list -l eu-north-h1
 vm list -l eu-north-h1 -f name,id
 vm list -N
+vm vmdzyppz6j166jh5e9t2dwrfas show

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for fw destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi fw location/(fw-name|_fw-id) destroy [options]
+Usage: ubi fw location/(fw-name|fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for fw destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi fw location/(fw-name|fw-id) destroy [options]
+Usage: ubi fw (location/fw-name|fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/fw fw4gj2v4h1fe3q28q0hnf7g8n1 show.txt
+++ b/spec/routes/api/cli/golden-files/fw fw4gj2v4h1fe3q28q0hnf7g8n1 show.txt
@@ -1,0 +1,20 @@
+id: fw4gj2v4h1fe3q28q0hnf7g8n1
+name: default-eu-central-h1-default
+location: eu-central-h1
+description: Default firewall
+rules:
+  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
+  2: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
+private subnet 1:
+  id: psfzm9e26xky5m9ggetw4dpqe2
+  name: default-eu-central-h1
+  state: available
+  location: eu-central-h1
+  net4: 172.27.99.128/26
+  net6: fdd9:1ea7:125d:5fa4::/64
+  nic 1:
+    id: nc69z0cda8jt0g5b120hamn4vf
+    name: test-vm-nic
+    private_ipv4: 10.67.141.133
+    private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+    vm_name: test-vm

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -3,7 +3,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address
@@ -40,22 +40,22 @@ Options:
     -u, --unix-user=username         username (default: ubi)
 
 
-Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
+Usage: ubi vm location/(vm-name|vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi vm location/(vm-name|_vm-id) restart
+Usage: ubi vm location/(vm-name|vm-id) restart
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
 
 
-Usage: ubi vm location/(vm-name|_vm-id) show [options]
+Usage: ubi vm location/(vm-name|vm-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -67,6 +67,6 @@ Firewall Rule Fields: id cidr port-range
 Firewall Fields: id name description location path firewall-rules
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
 
 

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -3,7 +3,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
+Usage: ubi vm (location/vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address
@@ -40,22 +40,22 @@ Options:
     -u, --unix-user=username         username (default: ubi)
 
 
-Usage: ubi vm location/(vm-name|vm-id) destroy [options]
+Usage: ubi vm (location/vm-name|vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi vm location/(vm-name|vm-id) restart
+Usage: ubi vm (location/vm-name|vm-id) restart
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm (location/vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
+Usage: ubi vm (location/vm-name|vm-id) [options] sftp [sftp-options]
 
 
-Usage: ubi vm location/(vm-name|vm-id) show [options]
+Usage: ubi vm (location/vm-name|vm-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -67,6 +67,6 @@ Firewall Rule Fields: id cidr port-range
 Firewall Fields: id name description location path firewall-rules
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm (location/vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
 
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -13,7 +13,7 @@ Usage: ubi fw subcommand [...]
 Subcommands: list
 
 
-Usage: ubi fw location/(fw-name|fw-id) subcommand [...]
+Usage: ubi fw (location/fw-name|fw-id) subcommand [...]
 
 Subcommands:
   add-rule
@@ -34,14 +34,14 @@ Options:
 Fields: location name id
 
 
-Usage: ubi fw location/(fw-name|fw-id) add-rule cidr
+Usage: ubi fw (location/fw-name|fw-id) add-rule cidr
 
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
 
 
-Usage: ubi fw location/(fw-name|fw-id) attach-subnet subnet-id
+Usage: ubi fw (location/fw-name|fw-id) attach-subnet subnet-id
 
 
 Usage: ubi fw location/fw-name create [options]
@@ -50,19 +50,19 @@ Options:
     -d, --description=desc           description for firewall
 
 
-Usage: ubi fw location/(fw-name|fw-id) delete-rule rule-id
+Usage: ubi fw (location/fw-name|fw-id) delete-rule rule-id
 
 
-Usage: ubi fw location/(fw-name|fw-id) destroy [options]
+Usage: ubi fw (location/fw-name|fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi fw location/(fw-name|fw-id) detach-subnet subnet-id
+Usage: ubi fw (location/fw-name|fw-id) detach-subnet subnet-id
 
 
-Usage: ubi fw location/(fw-name|fw-id) show [options]
+Usage: ubi fw (location/fw-name|fw-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -87,7 +87,7 @@ Usage: ubi lb subcommand [...]
 Subcommands: list
 
 
-Usage: ubi lb location/(lb-name|lb-id) subcommand [...]
+Usage: ubi lb (location/lb-name|lb-id) subcommand [...]
 
 Subcommands: attach-vm create destroy detach-vm show update
 
@@ -101,7 +101,7 @@ Options:
 Fields: location name id src-port dst-port hostname
 
 
-Usage: ubi lb location/(lb-name|lb-id) attach-vm vm-id
+Usage: ubi lb (location/lb-name|lb-id) attach-vm vm-id
 
 
 Usage: ubi lb location/lb-name create [options] private-subnet-id src-port dst-port
@@ -113,16 +113,16 @@ Options:
     -s, --stack=stack                set the stack (dual(default), ipv4, ipv6)
 
 
-Usage: ubi lb location/(lb-name|lb-id) destroy [options]
+Usage: ubi lb (location/lb-name|lb-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi lb location/(lb-name|lb-id) detach-vm vm-id
+Usage: ubi lb (location/lb-name|lb-id) detach-vm vm-id
 
 
-Usage: ubi lb location/(lb-name|lb-id) show [options]
+Usage: ubi lb (location/lb-name|lb-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -130,7 +130,7 @@ Fields: id name state location hostname algorithm stack health-check-endpoint
         health-check-protocol src-port dst-port subnet vms
 
 
-Usage: ubi lb location/(lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+Usage: ubi lb (location/lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
 
 
 Usage: ubi pg subcommand [...]
@@ -138,7 +138,7 @@ Usage: ubi pg subcommand [...]
 Subcommands: list
 
 
-Usage: ubi pg location/(pg-name|pg-id) [options] subcommand [...]
+Usage: ubi pg (location/pg-name|pg-id) [options] subcommand [...]
 
 Options:
     -d, --dbname=name                override database name
@@ -170,10 +170,10 @@ Options:
 Fields: location name id version flavor
 
 
-Usage: ubi pg location/(pg-name|pg-id) add-firewall-rule cidr
+Usage: ubi pg (location/pg-name|pg-id) add-firewall-rule cidr
 
 
-Usage: ubi pg location/(pg-name|pg-id) add-metric-destination username password url
+Usage: ubi pg (location/pg-name|pg-id) add-metric-destination username password url
 
 
 Usage: ubi pg location/pg-name create [options]
@@ -186,40 +186,40 @@ Options:
     -v, --version=version            PostgreSQL version (16, 17)
 
 
-Usage: ubi pg location/(pg-name|pg-id) delete-firewall-rule id
+Usage: ubi pg (location/pg-name|pg-id) delete-firewall-rule id
 
 
-Usage: ubi pg location/(pg-name|pg-id) delete-metric-destination id
+Usage: ubi pg (location/pg-name|pg-id) delete-metric-destination id
 
 
-Usage: ubi pg location/(pg-name|pg-id) destroy [options]
+Usage: ubi pg (location/pg-name|pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi pg location/(pg-name|pg-id) failover
+Usage: ubi pg (location/pg-name|pg-id) failover
 
 
-Usage: ubi pg location/(pg-name|pg-id) [options] pg_dump [pg_dump-options]
+Usage: ubi pg (location/pg-name|pg-id) [options] pg_dump [pg_dump-options]
 
 
-Usage: ubi pg location/(pg-name|pg-id) [options] pg_dumpall [pg_dumpall-options]
+Usage: ubi pg (location/pg-name|pg-id) [options] pg_dumpall [pg_dumpall-options]
 
 
-Usage: ubi pg location/(pg-name|pg-id) [options] psql [psql-options]
+Usage: ubi pg (location/pg-name|pg-id) [options] psql [psql-options]
 
 
-Usage: ubi pg location/(pg-name|pg-id) reset-superuser-password new-password
+Usage: ubi pg (location/pg-name|pg-id) reset-superuser-password new-password
 
 
-Usage: ubi pg location/(pg-name|pg-id) restart
+Usage: ubi pg (location/pg-name|pg-id) restart
 
 
-Usage: ubi pg location/(pg-name|pg-id) restore new-db-name restore-time
+Usage: ubi pg (location/pg-name|pg-id) restore new-db-name restore-time
 
 
-Usage: ubi pg location/(pg-name|pg-id) show [options]
+Usage: ubi pg (location/pg-name|pg-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -233,7 +233,7 @@ Usage: ubi ps subcommand [...]
 Subcommands: list
 
 
-Usage: ubi ps location/(ps-name|ps-id) subcommand [...]
+Usage: ubi ps (location/ps-name|ps-id) subcommand [...]
 
 Subcommands: connect create destroy disconnect show
 
@@ -247,7 +247,7 @@ Options:
 Fields: location name id net4 net6
 
 
-Usage: ubi ps location/(ps-name|ps-id) connect ps-id
+Usage: ubi ps (location/ps-name|ps-id) connect ps-id
 
 
 Usage: ubi ps location/ps-name create [options]
@@ -256,16 +256,16 @@ Options:
     -f, --firewall-id=id             add to given firewall
 
 
-Usage: ubi ps location/(ps-name|ps-id) destroy [options]
+Usage: ubi ps (location/ps-name|ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi ps location/(ps-name|ps-id) disconnect ps-id
+Usage: ubi ps (location/ps-name|ps-id) disconnect ps-id
 
 
-Usage: ubi ps location/(ps-name|ps-id) show [options]
+Usage: ubi ps (location/ps-name|ps-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -283,7 +283,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
+Usage: ubi vm (location/vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address
@@ -320,22 +320,22 @@ Options:
     -u, --unix-user=username         username (default: ubi)
 
 
-Usage: ubi vm location/(vm-name|vm-id) destroy [options]
+Usage: ubi vm (location/vm-name|vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi vm location/(vm-name|vm-id) restart
+Usage: ubi vm (location/vm-name|vm-id) restart
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm (location/vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
+Usage: ubi vm (location/vm-name|vm-id) [options] sftp [sftp-options]
 
 
-Usage: ubi vm location/(vm-name|vm-id) show [options]
+Usage: ubi vm (location/vm-name|vm-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -347,6 +347,6 @@ Firewall Rule Fields: id cidr port-range
 Firewall Fields: id name description location path firewall-rules
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm (location/vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
 
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -13,7 +13,7 @@ Usage: ubi fw subcommand [...]
 Subcommands: list
 
 
-Usage: ubi fw location/(fw-name|_fw-id) subcommand [...]
+Usage: ubi fw location/(fw-name|fw-id) subcommand [...]
 
 Subcommands:
   add-rule
@@ -34,14 +34,14 @@ Options:
 Fields: location name id
 
 
-Usage: ubi fw location/(fw-name|_fw-id) add-rule cidr
+Usage: ubi fw location/(fw-name|fw-id) add-rule cidr
 
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
 
 
-Usage: ubi fw location/(fw-name|_fw-id) attach-subnet subnet-id
+Usage: ubi fw location/(fw-name|fw-id) attach-subnet subnet-id
 
 
 Usage: ubi fw location/fw-name create [options]
@@ -50,19 +50,19 @@ Options:
     -d, --description=desc           description for firewall
 
 
-Usage: ubi fw location/(fw-name|_fw-id) delete-rule rule-id
+Usage: ubi fw location/(fw-name|fw-id) delete-rule rule-id
 
 
-Usage: ubi fw location/(fw-name|_fw-id) destroy [options]
+Usage: ubi fw location/(fw-name|fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi fw location/(fw-name|_fw-id) detach-subnet subnet-id
+Usage: ubi fw location/(fw-name|fw-id) detach-subnet subnet-id
 
 
-Usage: ubi fw location/(fw-name|_fw-id) show [options]
+Usage: ubi fw location/(fw-name|fw-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -87,7 +87,7 @@ Usage: ubi lb subcommand [...]
 Subcommands: list
 
 
-Usage: ubi lb location/(lb-name|_lb-id) subcommand [...]
+Usage: ubi lb location/(lb-name|lb-id) subcommand [...]
 
 Subcommands: attach-vm create destroy detach-vm show update
 
@@ -101,7 +101,7 @@ Options:
 Fields: location name id src-port dst-port hostname
 
 
-Usage: ubi lb location/(lb-name|_lb-id) attach-vm vm-id
+Usage: ubi lb location/(lb-name|lb-id) attach-vm vm-id
 
 
 Usage: ubi lb location/lb-name create [options] private-subnet-id src-port dst-port
@@ -113,16 +113,16 @@ Options:
     -s, --stack=stack                set the stack (dual(default), ipv4, ipv6)
 
 
-Usage: ubi lb location/(lb-name|_lb-id) destroy [options]
+Usage: ubi lb location/(lb-name|lb-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi lb location/(lb-name|_lb-id) detach-vm vm-id
+Usage: ubi lb location/(lb-name|lb-id) detach-vm vm-id
 
 
-Usage: ubi lb location/(lb-name|_lb-ubid) show [options]
+Usage: ubi lb location/(lb-name|lb-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -130,7 +130,7 @@ Fields: id name state location hostname algorithm stack health-check-endpoint
         health-check-protocol src-port dst-port subnet vms
 
 
-Usage: ubi lb location/(lb-name|_lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+Usage: ubi lb location/(lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
 
 
 Usage: ubi pg subcommand [...]
@@ -138,7 +138,7 @@ Usage: ubi pg subcommand [...]
 Subcommands: list
 
 
-Usage: ubi pg location/(pg-name|_pg-id) [options] subcommand [...]
+Usage: ubi pg location/(pg-name|pg-id) [options] subcommand [...]
 
 Options:
     -d, --dbname=name                override database name
@@ -170,10 +170,10 @@ Options:
 Fields: location name id version flavor
 
 
-Usage: ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr
+Usage: ubi pg location/(pg-name|pg-id) add-firewall-rule cidr
 
 
-Usage: ubi pg location/(pg-name|_pg-id) add-metric-destination username password url
+Usage: ubi pg location/(pg-name|pg-id) add-metric-destination username password url
 
 
 Usage: ubi pg location/pg-name create [options]
@@ -186,40 +186,40 @@ Options:
     -v, --version=version            PostgreSQL version (16, 17)
 
 
-Usage: ubi pg location/(pg-name|_pg-id) delete-firewall-rule id
+Usage: ubi pg location/(pg-name|pg-id) delete-firewall-rule id
 
 
-Usage: ubi pg location/(pg-name|_pg-id) delete-metric-destination id
+Usage: ubi pg location/(pg-name|pg-id) delete-metric-destination id
 
 
-Usage: ubi pg location/(pg-name|_pg-id) destroy [options]
+Usage: ubi pg location/(pg-name|pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi pg location/(pg-name|_pg-id) failover
+Usage: ubi pg location/(pg-name|pg-id) failover
 
 
-Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dump [pg_dump-options]
+Usage: ubi pg location/(pg-name|pg-id) [options] pg_dump [pg_dump-options]
 
 
-Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dumpall [pg_dumpall-options]
+Usage: ubi pg location/(pg-name|pg-id) [options] pg_dumpall [pg_dumpall-options]
 
 
-Usage: ubi pg location/(pg-name|_pg-id) [options] psql [psql-options]
+Usage: ubi pg location/(pg-name|pg-id) [options] psql [psql-options]
 
 
-Usage: ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password
+Usage: ubi pg location/(pg-name|pg-id) reset-superuser-password new-password
 
 
-Usage: ubi pg location/(pg-name|_pg-id) restart
+Usage: ubi pg location/(pg-name|pg-id) restart
 
 
-Usage: ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time
+Usage: ubi pg location/(pg-name|pg-id) restore new-db-name restore-time
 
 
-Usage: ubi pg location/(pg-name|_pg-id) show [options]
+Usage: ubi pg location/(pg-name|pg-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -233,7 +233,7 @@ Usage: ubi ps subcommand [...]
 Subcommands: list
 
 
-Usage: ubi ps location/(ps-name|_ps-id) subcommand [...]
+Usage: ubi ps location/(ps-name|ps-id) subcommand [...]
 
 Subcommands: connect create destroy disconnect show
 
@@ -247,7 +247,7 @@ Options:
 Fields: location name id net4 net6
 
 
-Usage: ubi ps location/(ps-name|_ps-id) connect ps-id
+Usage: ubi ps location/(ps-name|ps-id) connect ps-id
 
 
 Usage: ubi ps location/ps-name create [options]
@@ -256,16 +256,16 @@ Options:
     -f, --firewall-id=id             add to given firewall
 
 
-Usage: ubi ps location/(ps-name|_ps-id) destroy [options]
+Usage: ubi ps location/(ps-name|ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi ps location/(ps-name|_ps-id) disconnect ps-id
+Usage: ubi ps location/(ps-name|ps-id) disconnect ps-id
 
 
-Usage: ubi ps location/(ps-name|_ps-id) show [options]
+Usage: ubi ps location/(ps-name|ps-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -283,7 +283,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address
@@ -320,22 +320,22 @@ Options:
     -u, --unix-user=username         username (default: ubi)
 
 
-Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
+Usage: ubi vm location/(vm-name|vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
 
 
-Usage: ubi vm location/(vm-name|_vm-id) restart
+Usage: ubi vm location/(vm-name|vm-id) restart
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
 
 
-Usage: ubi vm location/(vm-name|_vm-id) show [options]
+Usage: ubi vm location/(vm-name|vm-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
@@ -347,6 +347,6 @@ Firewall Rule Fields: id cidr port-range
 Firewall Fields: id name description location path firewall-rules
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
 
 

--- a/spec/routes/api/cli/golden-files/help -ru vm.txt
+++ b/spec/routes/api/cli/golden-files/help -ru vm.txt
@@ -1,8 +1,8 @@
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
-Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
-Usage: ubi vm location/(vm-name|_vm-id) restart
-Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
-Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
-Usage: ubi vm location/(vm-name|_vm-id) show [options]
-Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|vm-id) destroy [options]
+Usage: ubi vm location/(vm-name|vm-id) restart
+Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|vm-id) show [options]
+Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]

--- a/spec/routes/api/cli/golden-files/help -ru vm.txt
+++ b/spec/routes/api/cli/golden-files/help -ru vm.txt
@@ -1,8 +1,8 @@
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
-Usage: ubi vm location/(vm-name|vm-id) destroy [options]
-Usage: ubi vm location/(vm-name|vm-id) restart
-Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
-Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
-Usage: ubi vm location/(vm-name|vm-id) show [options]
-Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm (location/vm-name|vm-id) destroy [options]
+Usage: ubi vm (location/vm-name|vm-id) restart
+Usage: ubi vm (location/vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm (location/vm-name|vm-id) [options] sftp [sftp-options]
+Usage: ubi vm (location/vm-name|vm-id) show [options]
+Usage: ubi vm (location/vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -1,45 +1,45 @@
 Usage: ubi fw list [options]
-Usage: ubi fw location/(fw-name|_fw-id) add-rule cidr
-Usage: ubi fw location/(fw-name|_fw-id) attach-subnet subnet-id
+Usage: ubi fw location/(fw-name|fw-id) add-rule cidr
+Usage: ubi fw location/(fw-name|fw-id) attach-subnet subnet-id
 Usage: ubi fw location/fw-name create [options]
-Usage: ubi fw location/(fw-name|_fw-id) delete-rule rule-id
-Usage: ubi fw location/(fw-name|_fw-id) destroy [options]
-Usage: ubi fw location/(fw-name|_fw-id) detach-subnet subnet-id
-Usage: ubi fw location/(fw-name|_fw-id) show [options]
+Usage: ubi fw location/(fw-name|fw-id) delete-rule rule-id
+Usage: ubi fw location/(fw-name|fw-id) destroy [options]
+Usage: ubi fw location/(fw-name|fw-id) detach-subnet subnet-id
+Usage: ubi fw location/(fw-name|fw-id) show [options]
 Usage: ubi help [options] [command [subcommand]]
 Usage: ubi lb list [options]
-Usage: ubi lb location/(lb-name|_lb-id) attach-vm vm-id
+Usage: ubi lb location/(lb-name|lb-id) attach-vm vm-id
 Usage: ubi lb location/lb-name create [options] private-subnet-id src-port dst-port
-Usage: ubi lb location/(lb-name|_lb-id) destroy [options]
-Usage: ubi lb location/(lb-name|_lb-id) detach-vm vm-id
-Usage: ubi lb location/(lb-name|_lb-ubid) show [options]
-Usage: ubi lb location/(lb-name|_lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+Usage: ubi lb location/(lb-name|lb-id) destroy [options]
+Usage: ubi lb location/(lb-name|lb-id) detach-vm vm-id
+Usage: ubi lb location/(lb-name|lb-id) show [options]
+Usage: ubi lb location/(lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
 Usage: ubi pg list [options]
-Usage: ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr
-Usage: ubi pg location/(pg-name|_pg-id) add-metric-destination username password url
+Usage: ubi pg location/(pg-name|pg-id) add-firewall-rule cidr
+Usage: ubi pg location/(pg-name|pg-id) add-metric-destination username password url
 Usage: ubi pg location/pg-name create [options]
-Usage: ubi pg location/(pg-name|_pg-id) delete-firewall-rule id
-Usage: ubi pg location/(pg-name|_pg-id) delete-metric-destination id
-Usage: ubi pg location/(pg-name|_pg-id) destroy [options]
-Usage: ubi pg location/(pg-name|_pg-id) failover
-Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dump [pg_dump-options]
-Usage: ubi pg location/(pg-name|_pg-id) [options] pg_dumpall [pg_dumpall-options]
-Usage: ubi pg location/(pg-name|_pg-id) [options] psql [psql-options]
-Usage: ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password
-Usage: ubi pg location/(pg-name|_pg-id) restart
-Usage: ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time
-Usage: ubi pg location/(pg-name|_pg-id) show [options]
+Usage: ubi pg location/(pg-name|pg-id) delete-firewall-rule id
+Usage: ubi pg location/(pg-name|pg-id) delete-metric-destination id
+Usage: ubi pg location/(pg-name|pg-id) destroy [options]
+Usage: ubi pg location/(pg-name|pg-id) failover
+Usage: ubi pg location/(pg-name|pg-id) [options] pg_dump [pg_dump-options]
+Usage: ubi pg location/(pg-name|pg-id) [options] pg_dumpall [pg_dumpall-options]
+Usage: ubi pg location/(pg-name|pg-id) [options] psql [psql-options]
+Usage: ubi pg location/(pg-name|pg-id) reset-superuser-password new-password
+Usage: ubi pg location/(pg-name|pg-id) restart
+Usage: ubi pg location/(pg-name|pg-id) restore new-db-name restore-time
+Usage: ubi pg location/(pg-name|pg-id) show [options]
 Usage: ubi ps list [options]
-Usage: ubi ps location/(ps-name|_ps-id) connect ps-id
+Usage: ubi ps location/(ps-name|ps-id) connect ps-id
 Usage: ubi ps location/ps-name create [options]
-Usage: ubi ps location/(ps-name|_ps-id) destroy [options]
-Usage: ubi ps location/(ps-name|_ps-id) disconnect ps-id
-Usage: ubi ps location/(ps-name|_ps-id) show [options]
+Usage: ubi ps location/(ps-name|ps-id) destroy [options]
+Usage: ubi ps location/(ps-name|ps-id) disconnect ps-id
+Usage: ubi ps location/(ps-name|ps-id) show [options]
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
-Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
-Usage: ubi vm location/(vm-name|_vm-id) restart
-Usage: ubi vm location/(vm-name|_vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
-Usage: ubi vm location/(vm-name|_vm-id) [options] sftp [sftp-options]
-Usage: ubi vm location/(vm-name|_vm-id) show [options]
-Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm location/(vm-name|vm-id) destroy [options]
+Usage: ubi vm location/(vm-name|vm-id) restart
+Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
+Usage: ubi vm location/(vm-name|vm-id) show [options]
+Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -1,45 +1,45 @@
 Usage: ubi fw list [options]
-Usage: ubi fw location/(fw-name|fw-id) add-rule cidr
-Usage: ubi fw location/(fw-name|fw-id) attach-subnet subnet-id
+Usage: ubi fw (location/fw-name|fw-id) add-rule cidr
+Usage: ubi fw (location/fw-name|fw-id) attach-subnet subnet-id
 Usage: ubi fw location/fw-name create [options]
-Usage: ubi fw location/(fw-name|fw-id) delete-rule rule-id
-Usage: ubi fw location/(fw-name|fw-id) destroy [options]
-Usage: ubi fw location/(fw-name|fw-id) detach-subnet subnet-id
-Usage: ubi fw location/(fw-name|fw-id) show [options]
+Usage: ubi fw (location/fw-name|fw-id) delete-rule rule-id
+Usage: ubi fw (location/fw-name|fw-id) destroy [options]
+Usage: ubi fw (location/fw-name|fw-id) detach-subnet subnet-id
+Usage: ubi fw (location/fw-name|fw-id) show [options]
 Usage: ubi help [options] [command [subcommand]]
 Usage: ubi lb list [options]
-Usage: ubi lb location/(lb-name|lb-id) attach-vm vm-id
+Usage: ubi lb (location/lb-name|lb-id) attach-vm vm-id
 Usage: ubi lb location/lb-name create [options] private-subnet-id src-port dst-port
-Usage: ubi lb location/(lb-name|lb-id) destroy [options]
-Usage: ubi lb location/(lb-name|lb-id) detach-vm vm-id
-Usage: ubi lb location/(lb-name|lb-id) show [options]
-Usage: ubi lb location/(lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+Usage: ubi lb (location/lb-name|lb-id) destroy [options]
+Usage: ubi lb (location/lb-name|lb-id) detach-vm vm-id
+Usage: ubi lb (location/lb-name|lb-id) show [options]
+Usage: ubi lb (location/lb-name|lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
 Usage: ubi pg list [options]
-Usage: ubi pg location/(pg-name|pg-id) add-firewall-rule cidr
-Usage: ubi pg location/(pg-name|pg-id) add-metric-destination username password url
+Usage: ubi pg (location/pg-name|pg-id) add-firewall-rule cidr
+Usage: ubi pg (location/pg-name|pg-id) add-metric-destination username password url
 Usage: ubi pg location/pg-name create [options]
-Usage: ubi pg location/(pg-name|pg-id) delete-firewall-rule id
-Usage: ubi pg location/(pg-name|pg-id) delete-metric-destination id
-Usage: ubi pg location/(pg-name|pg-id) destroy [options]
-Usage: ubi pg location/(pg-name|pg-id) failover
-Usage: ubi pg location/(pg-name|pg-id) [options] pg_dump [pg_dump-options]
-Usage: ubi pg location/(pg-name|pg-id) [options] pg_dumpall [pg_dumpall-options]
-Usage: ubi pg location/(pg-name|pg-id) [options] psql [psql-options]
-Usage: ubi pg location/(pg-name|pg-id) reset-superuser-password new-password
-Usage: ubi pg location/(pg-name|pg-id) restart
-Usage: ubi pg location/(pg-name|pg-id) restore new-db-name restore-time
-Usage: ubi pg location/(pg-name|pg-id) show [options]
+Usage: ubi pg (location/pg-name|pg-id) delete-firewall-rule id
+Usage: ubi pg (location/pg-name|pg-id) delete-metric-destination id
+Usage: ubi pg (location/pg-name|pg-id) destroy [options]
+Usage: ubi pg (location/pg-name|pg-id) failover
+Usage: ubi pg (location/pg-name|pg-id) [options] pg_dump [pg_dump-options]
+Usage: ubi pg (location/pg-name|pg-id) [options] pg_dumpall [pg_dumpall-options]
+Usage: ubi pg (location/pg-name|pg-id) [options] psql [psql-options]
+Usage: ubi pg (location/pg-name|pg-id) reset-superuser-password new-password
+Usage: ubi pg (location/pg-name|pg-id) restart
+Usage: ubi pg (location/pg-name|pg-id) restore new-db-name restore-time
+Usage: ubi pg (location/pg-name|pg-id) show [options]
 Usage: ubi ps list [options]
-Usage: ubi ps location/(ps-name|ps-id) connect ps-id
+Usage: ubi ps (location/ps-name|ps-id) connect ps-id
 Usage: ubi ps location/ps-name create [options]
-Usage: ubi ps location/(ps-name|ps-id) destroy [options]
-Usage: ubi ps location/(ps-name|ps-id) disconnect ps-id
-Usage: ubi ps location/(ps-name|ps-id) show [options]
+Usage: ubi ps (location/ps-name|ps-id) destroy [options]
+Usage: ubi ps (location/ps-name|ps-id) disconnect ps-id
+Usage: ubi ps (location/ps-name|ps-id) show [options]
 Usage: ubi vm list [options]
 Usage: ubi vm location/vm-name create [options] public_key
-Usage: ubi vm location/(vm-name|vm-id) destroy [options]
-Usage: ubi vm location/(vm-name|vm-id) restart
-Usage: ubi vm location/(vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
-Usage: ubi vm location/(vm-name|vm-id) [options] sftp [sftp-options]
-Usage: ubi vm location/(vm-name|vm-id) show [options]
-Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+Usage: ubi vm (location/vm-name|vm-id) destroy [options]
+Usage: ubi vm (location/vm-name|vm-id) restart
+Usage: ubi vm (location/vm-name|vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
+Usage: ubi vm (location/vm-name|vm-id) [options] sftp [sftp-options]
+Usage: ubi vm (location/vm-name|vm-id) show [options]
+Usage: ubi vm (location/vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]

--- a/spec/routes/api/cli/golden-files/help -u vm.txt
+++ b/spec/routes/api/cli/golden-files/help -u vm.txt
@@ -1,2 +1,2 @@
 Usage: ubi vm subcommand [...]
-Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]

--- a/spec/routes/api/cli/golden-files/help -u vm.txt
+++ b/spec/routes/api/cli/golden-files/help -u vm.txt
@@ -1,2 +1,2 @@
 Usage: ubi vm subcommand [...]
-Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
+Usage: ubi vm (location/vm-name|vm-id) [options] subcommand [...]

--- a/spec/routes/api/cli/golden-files/help vm.txt
+++ b/spec/routes/api/cli/golden-files/help vm.txt
@@ -3,7 +3,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/help vm.txt
+++ b/spec/routes/api/cli/golden-files/help vm.txt
@@ -3,7 +3,7 @@ Usage: ubi vm subcommand [...]
 Subcommands: list
 
 
-Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
+Usage: ubi vm (location/vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/lb 1bvp8yk1karj4ngwhtgrfh6esd show.txt
+++ b/spec/routes/api/cli/golden-files/lb 1bvp8yk1karj4ngwhtgrfh6esd show.txt
@@ -1,0 +1,14 @@
+id: 1bvp8yk1karj4ngwhtgrfh6esd
+name: test-lb
+state: 
+location: eu-central-h1
+hostname: test-lb.dpqe2.
+algorithm: round_robin
+stack: dual
+health_check_endpoint: /up
+health_check_protocol: http
+src_port: 12345
+dst_port: 54321
+subnet: default-eu-central-h1
+vms:
+  vmdzyppz6j166jh5e9t2dwrfas

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
@@ -1,6 +1,6 @@
 ! Invalid option: -X
 
-Usage: ubi pg location/(pg-name|_pg-id) [options] subcommand [...]
+Usage: ubi pg location/(pg-name|pg-id) [options] subcommand [...]
 
 Options:
     -d, --dbname=name                override database name

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
@@ -1,6 +1,6 @@
 ! Invalid option: -X
 
-Usage: ubi pg location/(pg-name|pg-id) [options] subcommand [...]
+Usage: ubi pg (location/pg-name|pg-id) [options] subcommand [...]
 
 Options:
     -d, --dbname=name                override database name

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg add-firewall-rule subcommand (cidr is required)
 
-Usage: ubi pg location/(pg-name|_pg-id) add-firewall-rule cidr
+Usage: ubi pg location/(pg-name|pg-id) add-firewall-rule cidr

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg add-firewall-rule subcommand (cidr is required)
 
-Usage: ubi pg location/(pg-name|pg-id) add-firewall-rule cidr
+Usage: ubi pg (location/pg-name|pg-id) add-firewall-rule cidr

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg add-metric-destination subcommand (username, password, and url arguments are required)
 
-Usage: ubi pg location/(pg-name|pg-id) add-metric-destination username password url
+Usage: ubi pg (location/pg-name|pg-id) add-metric-destination username password url

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-metric-destination.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg add-metric-destination subcommand (username, password, and url arguments are required)
 
-Usage: ubi pg location/(pg-name|_pg-id) add-metric-destination username password url
+Usage: ubi pg location/(pg-name|pg-id) add-metric-destination username password url

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-firewall-rule.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-firewall-rule.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg delete-firewall-rule subcommand (rule id is required)
 
-Usage: ubi pg location/(pg-name|pg-id) delete-firewall-rule id
+Usage: ubi pg (location/pg-name|pg-id) delete-firewall-rule id

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-firewall-rule.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-firewall-rule.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg delete-firewall-rule subcommand (rule id is required)
 
-Usage: ubi pg location/(pg-name|_pg-id) delete-firewall-rule id
+Usage: ubi pg location/(pg-name|pg-id) delete-firewall-rule id

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-metric-destination.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-metric-destination.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg delete-metric-destination subcommand (metric destination id is required)
 
-Usage: ubi pg location/(pg-name|_pg-id) delete-metric-destination id
+Usage: ubi pg location/(pg-name|pg-id) delete-metric-destination id

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-metric-destination.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg delete-metric-destination.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg delete-metric-destination subcommand (metric destination id is required)
 
-Usage: ubi pg location/(pg-name|pg-id) delete-metric-destination id
+Usage: ubi pg (location/pg-name|pg-id) delete-metric-destination id

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for pg destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi pg location/(pg-name|pg-id) destroy [options]
+Usage: ubi pg (location/pg-name|pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for pg destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi pg location/(pg-name|_pg-id) destroy [options]
+Usage: ubi pg location/(pg-name|pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg reset-superuser-password.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg reset-superuser-password.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg reset-superuser-password subcommand (password is required)
 
-Usage: ubi pg location/(pg-name|pg-id) reset-superuser-password new-password
+Usage: ubi pg (location/pg-name|pg-id) reset-superuser-password new-password

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg reset-superuser-password.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg reset-superuser-password.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg reset-superuser-password subcommand (password is required)
 
-Usage: ubi pg location/(pg-name|_pg-id) reset-superuser-password new-password
+Usage: ubi pg location/(pg-name|pg-id) reset-superuser-password new-password

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restore.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restore.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg restore subcommand (name and restore target are required)
 
-Usage: ubi pg location/(pg-name|pg-id) restore new-db-name restore-time
+Usage: ubi pg (location/pg-name|pg-id) restore new-db-name restore-time

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restore.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg restore.txt
@@ -1,3 +1,3 @@
 ! Invalid arguments for pg restore subcommand (name and restore target are required)
 
-Usage: ubi pg location/(pg-name|_pg-id) restore new-db-name restore-time
+Usage: ubi pg location/(pg-name|pg-id) restore new-db-name restore-time

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for pg show subcommand (accepts: 0, given: 1)
 
-Usage: ubi pg location/(pg-name|_pg-id) show [options]
+Usage: ubi pg location/(pg-name|pg-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for pg show subcommand (accepts: 0, given: 1)
 
-Usage: ubi pg location/(pg-name|pg-id) show [options]
+Usage: ubi pg (location/pg-name|pg-id) show [options]
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)

--- a/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
+++ b/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
@@ -1,0 +1,18 @@
+id: pgvm1qb9gwct1mqmay7m54yma5
+name: test-pg
+state: creating
+location: eu-central-h1
+vm_size: standard-2
+storage_size_gib: 64
+version: 16
+ha_type: none
+flavor: standard
+connection_string: postgres://postgres:bar456FOO123@test-pg.pgvm1qb9gwct1mqmay7m54yma5.pg.example.com?channel_binding=require
+primary: true
+earliest_restore_time: 
+firewall rules:
+  1: pfb9g14e5ndt6qf59wfk8109bg  0.0.0.0/0
+metric destinations:
+  1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
+CA certificates:
+

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for ps destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi ps location/(ps-name|ps-id) destroy [options]
+Usage: ubi ps (location/ps-name|ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for ps destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi ps location/(ps-name|_ps-id) destroy [options]
+Usage: ubi ps location/(ps-name|ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/ps psfzm9e26xky5m9ggetw4dpqe2 show.txt
+++ b/spec/routes/api/cli/golden-files/ps psfzm9e26xky5m9ggetw4dpqe2 show.txt
@@ -1,0 +1,21 @@
+id: psfzm9e26xky5m9ggetw4dpqe2
+name: default-eu-central-h1
+state: available
+location: eu-central-h1
+net4: 172.27.99.128/26
+net6: fdd9:1ea7:125d:5fa4::/64
+firewall 1:
+  id: fw4gj2v4h1fe3q28q0hnf7g8n1
+  name: default-eu-central-h1-default
+  description: Default firewall
+  location: eu-central-h1
+  path: 
+  rules:
+   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
+   2: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
+nic 1:
+  id: nc69z0cda8jt0g5b120hamn4vf
+  name: test-vm-nic
+  private_ipv4: 10.67.141.133
+  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm_name: test-vm

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
@@ -1,6 +1,6 @@
 ! Invalid option: -X
 
-Usage: ubi vm location/(vm-name|_vm-id) [options] subcommand [...]
+Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
@@ -1,6 +1,6 @@
 ! Invalid option: -X
 
-Usage: ubi vm location/(vm-name|vm-id) [options] subcommand [...]
+Usage: ubi vm (location/vm-name|vm-id) [options] subcommand [...]
 
 Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for vm destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi vm location/(vm-name|_vm-id) destroy [options]
+Usage: ubi vm location/(vm-name|vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
@@ -1,6 +1,6 @@
 ! Invalid number of arguments for vm destroy subcommand (accepts: 0, given: 1)
 
-Usage: ubi vm location/(vm-name|vm-id) destroy [options]
+Usage: ubi vm (location/vm-name|vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -1,0 +1,22 @@
+id: vmdzyppz6j166jh5e9t2dwrfas
+name: test-vm
+state: creating
+location: eu-central-h1
+size: standard-2
+unix_user: ubi
+storage_size_gib: 0
+ip6: 
+ip4_enabled: true
+ip4: 128.0.0.1
+private_ipv4: 10.67.141.133
+private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+subnet: default-eu-central-h1
+firewall 1:
+  id: fw4gj2v4h1fe3q28q0hnf7g8n1
+  name: default-eu-central-h1-default
+  description: Default firewall
+  location: eu-central-h1
+  path: /location/eu-central-h1/firewall/default-eu-central-h1-default
+  rules:
+    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
+    2: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfa show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfa show.txt
@@ -1,0 +1,1 @@
+! Invalid vm reference, should be in location/vm-name or vm-id format

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
@@ -1,0 +1,2 @@
+! Unexpected response status: 404
+Details: Sorry, we couldn’t find the resource you’re looking for.

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -1,0 +1,22 @@
+id: vmdzyppz6j166jh5e9t2dwrfas
+name: test-vm
+state: creating
+location: eu-central-h1
+size: standard-2
+unix_user: ubi
+storage_size_gib: 0
+ip6: 
+ip4_enabled: true
+ip4: 128.0.0.1
+private_ipv4: 10.67.141.133
+private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+subnet: default-eu-central-h1
+firewall 1:
+  id: fw4gj2v4h1fe3q28q0hnf7g8n1
+  name: default-eu-central-h1-default
+  description: Default firewall
+  location: eu-central-h1
+  path: /location/eu-central-h1/firewall/default-eu-central-h1-default
+  rules:
+    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
+    2: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  

--- a/spec/routes/api/cli/help_spec.rb
+++ b/spec/routes/api/cli/help_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Clover, "cli help" do
 
   it "shows help for specific subcommand if given" do
     expect(cli(%w[help vm ssh])).to eq <<~OUTPUT
-      Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+      Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
     OUTPUT
   end
 
@@ -45,7 +45,7 @@ RSpec.describe Clover, "cli help" do
     expect(cli(%w[help vm ssh foo], status: 400)).to eq <<~OUTPUT
       ! Invalid command: vm ssh foo
 
-      Usage: ubi vm location/(vm-name|_vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+      Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
     OUTPUT
   end
 end

--- a/spec/routes/api/cli/help_spec.rb
+++ b/spec/routes/api/cli/help_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Clover, "cli help" do
 
   it "shows help for specific subcommand if given" do
     expect(cli(%w[help vm ssh])).to eq <<~OUTPUT
-      Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+      Usage: ubi vm (location/vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
     OUTPUT
   end
 
@@ -45,7 +45,7 @@ RSpec.describe Clover, "cli help" do
     expect(cli(%w[help vm ssh foo], status: 400)).to eq <<~OUTPUT
       ! Invalid command: vm ssh foo
 
-      Usage: ubi vm location/(vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+      Usage: ubi vm (location/vm-name|vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
     OUTPUT
   end
 end

--- a/spec/routes/api/cli/vm/ssh_spec.rb
+++ b/spec/routes/api/cli/vm/ssh_spec.rb
@@ -80,6 +80,6 @@ RSpec.describe Clover, "cli vm ssh" do
   it "handles invalid vm reference" do
     expect(cli(["vm", "#{@vm.display_location}/foo", "ssh"], status: 404)).to eq "! Unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for.\n"
     expect(cli(["vm", "foo/#{@vm.name}", "ssh"], status: 404)).to eq "! Unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for.\n"
-    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh"], status: 400)).to eq "! Invalid vm reference, should be in location/(vm-name|_vm-id) format\n"
+    expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh"], status: 400)).to eq "! Invalid vm reference, should be in location/vm-name or vm-id format\n"
   end
 end

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -83,22 +83,39 @@ RSpec.describe Clover, "firewall" do
       expect(last_response).to have_api_error(400, "Validation failed for following fields: name")
     end
 
-    it "success delete" do
+    it "success delete with underscore" do
       delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}"
 
       expect(last_response.status).to eq(204)
+      expect(firewall).not_to exist
     end
 
-    it "delete not exist for valid ubid format" do
-      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{"0" * 26}"
+    it "success delete without underscore" do
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}"
 
       expect(last_response.status).to eq(204)
+      expect(firewall).not_to exist
     end
 
-    it "delete not exist for invalid ubid format" do
+    it "delete for not valid ubid format" do
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{"0" * 26}"
+
+      expect(last_response.status).to eq(204)
+      expect(firewall).to exist
+    end
+
+    it "delete for non-existant ubid" do
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{Firewall.generate_ubid}"
+
+      expect(last_response.status).to eq(204)
+      expect(firewall).to exist
+    end
+
+    it "delete for invalid ubid format" do
       delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_foo_ubid"
 
       expect(last_response.status).to eq(204)
+      expect(firewall).to exist
     end
 
     it "attach to subnet" do


### PR DESCRIPTION
This is a series of commits that:

* Disallows setting a name for a model that matches the model's ubid format
* Removes the leading underscore requirement for ubids in route segments (no longer needed for disambiguation, underscore allowed for backwards compatibility)
* Adds object-info api endpoint that accepts a ubid and returns type/location/name information for it
* Updates the cli to accept ubid without location, using the object-info api endpoint to get the location

I'm currently basing this on top of #2873 to avoid conflicts, but if that isn't accepted, I can adjust this.