### PR TITLE
Add CI workflow for the cli/ubi go program

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -54,9 +54,6 @@ jobs:
         CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: bundle exec rake _test_up
 
-    - name: "Run go fmt and check it makes no changes"
-      run: "cd cli && go fmt && git diff --stat --exit-code"
-
     - name: Build cli/ubi
       run: bundle exec rake ubi
 
@@ -67,3 +64,12 @@ jobs:
         CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
         UBI_CMD: ./cli/ubi
       run: bundle exec rspec spec/cli_spec.rb
+
+    - name: Run go fmt and check it makes no changes
+      run: "cd cli && go fmt && git diff --stat --exit-code"
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: v1.64
+        working-directory: cli

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -1,0 +1,69 @@
+name: cli/ubi CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  cli-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubicloud, ubicloud-arm]
+    name: cli/ubi CI - ${{matrix.runs-on}}
+    runs-on: ${{matrix.runs-on}}
+
+    env:
+      DB_USER: clover
+      DB_PASSWORD: nonempty
+      DB_NAME: clover_test
+
+    services:
+      postgres:
+        image: postgres:15.4
+        env:
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+    - name: Perform superuser-only actions, then remove superuser
+      run: |
+        psql "postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}" \
+          -c "CREATE EXTENSION citext; CREATE EXTENSION btree_gist; CREATE ROLE clover_password PASSWORD '${{ env.DB_PASSWORD }}' LOGIN; ALTER ROLE ${{ env.DB_USER }} NOSUPERUSER"
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'cli/go.mod'
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .tool-versions
+        bundler-cache: true
+
+    - name: Apply migrations
+      env:
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+      run: bundle exec rake _test_up
+
+    - name: "Run go fmt and check it makes no changes"
+      run: "cd cli && go fmt && git diff --stat --exit-code"
+
+    - name: Build cli/ubi
+      run: bundle exec rake ubi
+
+    - name: Run cli/ubi tests
+      env:
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+        CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
+        CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
+        UBI_CMD: ./cli/ubi
+      run: bundle exec rspec spec/cli_spec.rb

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -2,7 +2,17 @@ name: cli/ubi CI
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - 'cli/**'
+      - 'bin/ubi'
+      - 'spec/cli_spec.rb'
   pull_request:
+    paths:
+      - 'cli/**'
+      - 'bin/ubi'
+      - 'spec/cli_spec.rb'
 
 jobs:
   cli-ci:

--- a/Rakefile
+++ b/Rakefile
@@ -361,6 +361,11 @@ namespace :linter do
     ERB::Formatter::CommandLine.new(files + ["--write", "--print-width", "120"]).run
   end
 
+  desc "Run golangci-lint"
+  task :go do
+    sh "golangci-lint run cli/ubi.go"
+  end
+
   desc "Validate, lint, format OpenAPI YAML file"
   task :openapi do
     sh "npx redocly lint openapi/openapi.yml --config openapi/redocly.yml"
@@ -370,4 +375,4 @@ namespace :linter do
 end
 
 desc "Run all linters"
-task linter: ["rubocop", "brakeman", "erb_formatter", "openapi"].map { "linter:#{_1}" }
+task linter: ["rubocop", "brakeman", "erb_formatter", "openapi", "go"].map { "linter:#{_1}" }

--- a/Rakefile
+++ b/Rakefile
@@ -278,10 +278,14 @@ task :spec_separate do
   end
 end
 
-desc "Build binary"
+desc "Compile cli/ubi binary for current platform"
 task "ubi" do
+  sh("cd cli && go build -tags osusergo,netgo")
+end
+
+desc "Cross compile cli/ubi binaries for common platforms"
+task "ubi-cross" do
   Dir.chdir("cli") do
-    sh("go build -tags osusergo,netgo")
     os_list = %w[linux windows darwin]
     arch_list = %w[amd64 arm64 386]
     os_list.each do |os|


### PR DESCRIPTION
The `cli/ubi.go` program should not see changes very often, so no need to run the workflow all the time.  The workflow checks three things:

* `go fmt` doesn't make changes (linting)
* `go build` builds successfully
* related cli specs pass when using built `cli/ubi`

The last commit makes it only run if one of the related files is changed.  I split the commit to get a CI run with the workflow (since this PR does not make changes to the related files). That CI run passed: https://github.com/ubicloud/ubicloud/actions/runs/13510171025)

CC @geemus 