### PR TITLE
Exclude /boot/efi from mountpoint healthchecks and fix smartctl flag

### DIFF
--- a/lib/system_parser.rb
+++ b/lib/system_parser.rb
@@ -5,7 +5,7 @@ class SystemParser
 
   def self.get_device_mount_points_from_lsblk_json(json_input, device_name)
     data = JSON.parse(json_input)
-    excluded_mounts = ["[SWAP]", "/boot", nil]
+    excluded_mounts = ["[SWAP]", "/boot", "/boot/efi", nil]
 
     mount_points = {}
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -287,7 +287,10 @@ class VmHost < Sequel::Model
 
   def check_storage_smartctl(ssh_session, devices)
     devices.map do |device_name|
-      passed = ssh_session.exec!("sudo smartctl -j -H /dev/#{device_name} | jq .smart_status.passed").strip == "true"
+      command = "sudo smartctl -j -H /dev/#{device_name}"
+      command << " -d scsi" if device_name.start_with?("sd")
+      command << " | jq .smart_status.passed"
+      passed = ssh_session.exec!(command).strip == "true"
       Clog.emit("Device #{device_name} failed smartctl check on VmHost #{ubid}") unless passed
       passed
     end.all?(true)

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -311,7 +311,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def unavailable
-    Prog::PageNexus.assemble("#{vm_host} is unavailable", ["VmHostUnavailable", vm_host.ubid], vm_host.ubid)
+    Prog::PageNexus.assemble("#{vm_host} disk(s) is unhealthy", ["VmHostUnavailable", vm_host.ubid], vm_host.ubid)
     if available?
       Page.from_tag_parts("VmHostUnavailable", vm_host.ubid)&.incr_resolve
       decr_checkup

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe VmHost do
     }
 
     allow(vh).to receive(:disk_devices).and_return(["sda"])
-    allow(session[:ssh_session]).to receive(:exec!).with("sudo smartctl -j -H /dev/sda | jq .smart_status.passed").and_return(MockStringWithExitstatus.new("true\n", 0))
+    allow(session[:ssh_session]).to receive(:exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(MockStringWithExitstatus.new("true\n", 0))
     allow(session[:ssh_session]).to receive(:exec!).with("lsblk --json").and_return(MockStringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
     allow(session[:ssh_session]).to receive(:exec!).with("sudo bash -c \"head -c 1M </dev/zero > /test-file\"").and_return(MockStringWithExitstatus.new("", 0))
     allow(session[:ssh_session]).to receive(:exec!).with("sha256sum /test-file").and_return(MockStringWithExitstatus.new("30e14955ebf1352266dc2ff8067e68104607e750abb9d3b36582b8af909fcb58  /test-file\n", 0))
@@ -465,9 +465,9 @@ RSpec.describe VmHost do
       reading_rpt: 5,
       reading_chg: Time.now - 30
     }
-    allow(vh).to receive(:disk_devices).and_return(["sda"])
+    allow(vh).to receive(:disk_devices).and_return(["nvme0n1"])
 
-    allow(session[:ssh_session]).to receive(:exec!).with("sudo smartctl -j -H /dev/sda | jq .smart_status.passed").and_return(MockStringWithExitstatus.new("false\n", 0))
+    allow(session[:ssh_session]).to receive(:exec!).with("sudo smartctl -j -H /dev/nvme0n1 | jq .smart_status.passed").and_return(MockStringWithExitstatus.new("false\n", 0))
     expect(vh.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("down")
   end
 


### PR DESCRIPTION
We needed to exclude /boot/efi because VmHost healthchecks will try to write a small file in all mountpoints and we should have excluded there.

Also for scsi devices, we needed to add the -d scsi flag so it would interact right with the device.