### PR TITLE
Fix web pages error handling for payment method and usage alert

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -139,7 +139,7 @@ class Clover
           r.delete true do
             unless payment_method.billing_info.payment_methods.count > 1
               response.status = 400
-              next {message: "You can't delete the last payment method of a project."}
+              next {error: {message: "You can't delete the last payment method of a project."}}
             end
 
             payment_method.destroy

--- a/routes/project/usage_alert.rb
+++ b/routes/project/usage_alert.rb
@@ -16,15 +16,12 @@ class Clover
       end
 
       r.is String do |usage_alert_ubid|
-        usage_alert = UsageAlert.from_ubid(usage_alert_ubid)
-        unless usage_alert
-          response.status = 404
-          next {message: "Usage alert is not found."}
-        end
+        next unless (usage_alert = UsageAlert.from_ubid(usage_alert_ubid))
 
         r.delete true do
           usage_alert.destroy
-          {message: "Usage alert #{usage_alert.name} is deleted."}
+          flash["notice"] = "Usage alert #{usage_alert.name} is deleted."
+          204
         end
       end
     end

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Clover, "billing" do
 
     describe "usage alerts" do
       before do
-        UsageAlert.create_with_id(project_id: project.id, user_id: user.id, name: "alert-1", limit: 100)
+        UsageAlert.create_with_id(project_id: project.id, user_id: user.id, name: "alert-1", limit: 101)
         UsageAlert.create_with_id(project_id: project_wo_permissions.id, user_id: user.id, name: "alert-2", limit: 100)
       end
 
@@ -402,9 +402,12 @@ RSpec.describe Clover, "billing" do
         expect(page).to have_content "alert-1"
 
         # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
-        # UI tests run without a JavaScript enginer.
+        # UI tests run without a JavaScript engine.
         btn = find "#alert-#{project.usage_alerts.first.ubid} .delete-btn"
         page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+
+        visit "#{project.path}/billing"
+        expect(page).to have_flash_notice "Usage alert alert-1 is deleted."
 
         visit "#{project.path}/billing"
         expect(page).to have_no_content "alert-1"

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Clover, "billing" do
       page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
 
       expect(page.status_code).to eq(400)
-      expect(page.body).to eq({message: "You can't delete the last payment method of a project."}.to_json)
+      expect(page.body).to eq({error: {message: "You can't delete the last payment method of a project."}}.to_json)
       expect(billing_info.reload.payment_methods.count).to eq(1)
     end
 


### PR DESCRIPTION
## Fix last payment method delete error
Without specifying "error" in the "next" block, our error messages are
shown as "Error: undefined".

## Usage alert delete message handling fix

before:
![CleanShot 2025-02-25 at 11 26 21@2x](https://github.com/user-attachments/assets/ae3da635-34cb-4aa5-bdfb-27f7e4e4d128)

after:
![CleanShot 2025-02-25 at 11 26 59@2x](https://github.com/user-attachments/assets/c3a8ecbe-5b89-41d9-a922-b48a19de110d)
