### PR TITLE
Calculate utilization based on github-runners hosts

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -140,7 +140,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     hop_allocate_vm if quota_available?
 
     # check utilization, if it's high, wait for it to go down
-    utilization = VmHost.where(allocation_state: "accepting", arch: label_data["arch"]).select_map {
+    utilization = VmHost.where(allocation_state: "accepting", arch: label_data["arch"], location: "github-runners").select_map {
       sum(:used_cores) * 100.0 / sum(:total_cores)
     }.first.to_f
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
       expect(github_runner.installation).to receive(:project_dataset).and_return(dataset)
       expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
-      VmHost[arch: "x64"].update(used_cores: 4)
+      VmHost[arch: "x64"].update(used_cores: 4, location: "github-runners")
       expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
     end
   end


### PR DESCRIPTION
Instead of including all of the hosts in the calculation, we should limit this to the github-runners location, otherwise, allowing gha users may degrade the provisioning experience for PG or VM customers.