### PR TITLE
Fix NoMethodError when viewing VM create page with burstables and location_latitude_fra feature flags enabled

### DIFF
--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -20,6 +20,10 @@ class BillingRate
     }.max_by { _1["active_from"] }
   end
 
+  def self.unit_price_from_resource_properties(resource_type, resource_family, location, active_at = Time.now)
+    from_resource_properties(resource_type, resource_family, location, active_at)&.[]("unit_price")&.to_f
+  end
+
   def self.from_resource_type(resource_type)
     rates.select {
       _1["resource_type"] == resource_type

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -12,13 +12,17 @@ module ContentGenerator
 
     def self.enable_ipv4(location, value)
       location = LocationNameConverter.to_internal_name(location)
-      unit_price = BillingRate.from_resource_properties("IPAddress", "IPv4", location)["unit_price"].to_f
+      unit_price = BillingRate.unit_price_from_resource_properties("IPAddress", "IPv4", location)
 
       "Enable Public IPv4 ($#{"%.2f" % (unit_price * 60 * 672)}/mo)"
     end
 
     def self.family(location, family)
       vm_family = Option::VmFamilies.find { _1.name == family }
+
+      # Do not include a family for a location that has no valid sizes at the location
+      return unless BillingRate.unit_price_from_resource_properties("VmVCpu", family, LocationNameConverter.to_internal_name(location))
+
       [
         vm_family.display_name,
         vm_family.ui_descriptor
@@ -28,7 +32,7 @@ module ContentGenerator
     def self.size(location, family, size)
       location = LocationNameConverter.to_internal_name(location)
       size = Option::VmSizes.find { _1.display_name == size }
-      unit_price = BillingRate.from_resource_properties("VmVCpu", family, location)["unit_price"].to_f
+      return unless (unit_price = BillingRate.unit_price_from_resource_properties("VmVCpu", family, location))
 
       [
         size.display_name,
@@ -41,7 +45,7 @@ module ContentGenerator
     def self.storage_size(location, family, vm_size, storage_size)
       storage_size = storage_size.to_i
       location = LocationNameConverter.to_internal_name(location)
-      unit_price = BillingRate.from_resource_properties("VmStorage", family, location)["unit_price"].to_f
+      return unless (unit_price = BillingRate.unit_price_from_resource_properties("VmStorage", family, location))
 
       [
         "#{storage_size}GB",
@@ -73,7 +77,7 @@ module ContentGenerator
     def self.size(flavor, location, family, size)
       location = LocationNameConverter.to_internal_name(location)
       size = Option::PostgresSizes.find { _1.display_name == size }
-      unit_price = BillingRate.from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location)["unit_price"].to_f
+      unit_price = BillingRate.unit_price_from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location)
 
       [
         size.display_name,
@@ -85,7 +89,7 @@ module ContentGenerator
 
     def self.storage_size(flavor, location, family, vm_size, storage_size)
       location = LocationNameConverter.to_internal_name(location)
-      unit_price = BillingRate.from_resource_properties("PostgresStorage", flavor, location)["unit_price"].to_f
+      unit_price = BillingRate.unit_price_from_resource_properties("PostgresStorage", flavor, location)
 
       [
         "#{storage_size}GB",
@@ -104,7 +108,7 @@ module ContentGenerator
       vcpu = Option::PostgresSizes.find { _1.display_name == vm_size }.vcpu
       ha_type = Option::PostgresHaOptions.find { _1.name == ha_type }
       compute_unit_price = BillingRate.from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location)["unit_price"].to_f
-      storage_unit_price = BillingRate.from_resource_properties("PostgresStorage", flavor, location)["unit_price"].to_f
+      storage_unit_price = BillingRate.unit_price_from_resource_properties("PostgresStorage", flavor, location)
       standby_count = ha_type.standby_count
 
       [

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content("31/32 (96%)")
       end
 
+      it "shows vm create page with burstable and location_latitude_fra" do
+        project.set_ff_location_latitude_fra true
+        project.set_ff_use_slices_for_allocation true
+        visit "#{project.path}/vm/create"
+        expect(page.title).to eq("Ubicloud - Create Virtual Machine")
+      end
+
       it "shows expected information on index page" do
         project
 

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -27,7 +27,7 @@ form_elements.each do |element|
   options = OptionTreeGenerator.generate_allowed_options(name, option_tree, option_parents).map do |option|
     opt_val = (type == "select") ? option[name][:value] : option[name]
 
-    opt_text = content_generator.call(*option.values)
+    next unless opt_text = content_generator.call(*option.values)
 
     parents = option.reject { |k, v| k == name }
     parents_selected = parents.all? { |k, v| selected_options[k] == v }
@@ -41,6 +41,7 @@ form_elements.each do |element|
 
     [opt_val, opt_text, opt_classes, opt_attrs]
   end if has_option
+  options&.compact!
 
   if has_option && selected_options[name].nil?
     options.find{ |_, _, _, opt_attrs| opt_attrs[:disabled].nil? }&.tap do |opt_val, _, _, opt_attrs|


### PR DESCRIPTION
This issue occurred because there is no billing rate for a burstable size for the latitude_fra location.

Add a BillingRate.unit_price_from_resource_properties that returns nil instead of raising a NoMethodError if there is no matching resource property.  Use it to DRY up code in ContentGenerator::{Vm,Postgres}.

Make ContentGenerator::Vm.family not return an array if there are no valid sizes at the requested location for the family.

This issue affects VMs and not PostgreSQL databases because Option.postgres_locations does not include the latitude_fra location.