### PR TITLE
Remove "Install ruby for ARM runners if not cached" step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,19 +40,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Install ruby for ARM runners if not cached
-      if: matrix.runs-on == 'ubicloud-arm'
-      run: |
-        RUBY_VERSION="$(grep -E '^ruby ' .tool-versions | cut -d' ' -f2)"
-        if [ ! -f $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64.complete ]; then
-          git clone https://github.com/rbenv/ruby-build.git
-          sudo ./ruby-build/install.sh
-          sudo ruby-build "$RUBY_VERSION" $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64
-          sudo chown -R runner:runner $RUNNER_TOOL_CACHE/Ruby
-          touch $RUNNER_TOOL_CACHE/Ruby/$RUBY_VERSION/arm64.complete
-          rm -rf ruby-build
-        fi
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This is no longer needed now that setup-ruby provides arm64 runner.