### PR TITLE
Fix initialization issue when populating StorageDevices and increase error verbosity

### DIFF
--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -30,7 +30,7 @@ class Prog::LearnStorage < Prog::Base
   end
 
   def find_underlying_unix_devices(unix_device)
-    return [unix_device] unless unix_device.start_with?("/dev/md")
+    return [unix_device.delete_prefix("/dev/")] unless unix_device.start_with?("/dev/md")
     SystemParser.extract_underlying_raid_devices_from_mdstat(sshable.cmd("cat /proc/mdstat"), unix_device)
   end
 

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -438,6 +438,25 @@ RSpec.describe VmHost do
     expect(vh.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("down")
   end
 
+  it "checks pulse on a with read/write errors" do
+    session = {
+      ssh_session: instance_double(Net::SSH::Connection::Session)
+    }
+    pulse = {
+      reading: "up",
+      reading_rpt: 5,
+      reading_chg: Time.now - 30
+    }
+    allow(vh).to receive(:disk_devices).and_return(["sda"])
+
+    expect(vh).to receive(:check_storage_smartctl).and_return(true)
+    expect(session[:ssh_session]).to receive(:exec!).with("lsblk --json").and_return(MockStringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
+    expect(session[:ssh_session]).to receive(:exec!).with("sudo bash -c \"head -c 1M </dev/zero > /test-file\"").and_return(MockStringWithExitstatus.new("failed to write file", 1))
+    expect(session[:ssh_session]).to receive(:exec!).with("sha256sum /test-file").and_return(MockStringWithExitstatus.new("30e14955ebf1352266dc2ff8067e68104607e750abb9d3b36582b8af909fcb58  /test-file\n", 0))
+    expect(session[:ssh_session]).to receive(:exec!).with("sudo rm /test-file").and_return(MockStringWithExitstatus.new("could not remove file", 1))
+    expect(vh.check_pulse(session: session, previous_pulse: pulse)[:reading]).to eq("down")
+  end
+
   it "checks pulse with kernel errors" do
     session = {
       ssh_session: instance_double(Net::SSH::Connection::Session)

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -19,8 +19,12 @@ Filesystem     Mounted on                   1B-blocks        Avail
 /dev/sdb       /var/storage/devices/stor2  3331416064   3331276800
 EOS
       expect { ls.start }.to exit({"msg" => "created StorageDevice records"}).and change {
-        StorageDevice.map(&:name).sort
-      }.from([]).to(%w[DEFAULT stor1 stor2])
+        StorageDevice.all.map { |d| [d.name, d.unix_device_list.sort] }.sort
+      }.from([]).to([
+        ["DEFAULT", ["sda"]],
+        ["stor1", ["sdb"]],
+        ["stor2", ["sdc"]]
+      ])
     end
 
     it "exits, updating existing StorageDevice model instances" do


### PR DESCRIPTION
During the write/read/delete check, we faced many failures in Prod and couldn't dig more to see what the issue is. Verbosity is increased to investigate more.

Also the /dev/ prefix is deleted from the StorageDevice creation logic which caused issues when a new VmHost was added.