### PR TITLE
Fix reasoning output of ds-r1-qwen-32b

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -104,7 +104,7 @@ class Prog::DownloadBootImage < Prog::Base
       ["ai-model-llama-3-3-70b-turbo", "x64", "20250221.1.0"] => "833e62b949c4eb8aeccabaac4c14a8af525db30c490b2eea53b33093676c7d44",
       ["ai-model-qwen-2-5-14b-it", "x64", "20250118.1.0"] => "51a7fe8c520f39b8197c88426c8f37199bd3bd2afdae579b8877a604cd474021",
       ["ai-model-qwq-32b-preview", "x64", "20241209.1.0"] => "38ca4912134ed9b115726eff258666d68ce6df92330a3585d47494099821f9b1",
-      ["ai-model-ds-r1-qwen-32b", "x64", "20250225.1.0"] => "12135bc78697bd242d4925f53bfd46337b40a5b8fe1c86db5871f71f56e5a3ea",
+      ["ai-model-ds-r1-qwen-32b", "x64", "20250227.1.0"] => "16269ce8660413718c58b60c649042cca6cef2429f59f59e4c70bb5e951ebe74",
       ["ai-model-ds-r1-qwen-1-5b", "x64", "20250129.1.0"] => "9135a2e81fc6129d6d12bd633b5a30d4bfe2fd219ec5e370404758dda1159001",
       ["ai-model-ms-phi-4", "x64", "20250213.1.0"] => "0e998c4916c837c0992c4546404ecb51d0c5d5923f998f7cff0a9cddc5bf1689",
       ["ai-model-mistral-small-3", "x64", "20250217.1.0"] => "01ce8d1d0b7b0f717c51c26590234f4cb7971a9a5276de92b6cb4dc2c7a085e5"


### PR DESCRIPTION
The following commit broke the reasoning output of ds-r1-qwen-32b: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B/commit/3865e12a1eb7cbd641ab3f9dfc28c588c6b0c1e9

That issue is not specific to Ubicloud but to vLLM, see https://github.com/vllm-project/vllm/issues/13375

Github job creating this image:
https://github.com/ubicloud/ai-images/actions/runs/13563355592

The image is identical to `20250225.1.0` but with the commit mentioned above reverted.