### PR TITLE
Increase SPDK iobuf sizes.

### DIFF
--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -24,19 +24,20 @@ class Prog::Storage::SetupSpdk < Prog::Base
   label def start
     version = frame["version"]
     arch = vm_host.arch
+    spdk_hugepages = 4
 
     fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_SPDK_VERSIONS.include? [version, arch]
 
     fail "Can't install more than 2 SPDKs on a host" if vm_host.spdk_installations.length > 1
 
-    fail "No available hugepages" if frame["start_service"] && vm_host.used_hugepages_1g > vm_host.total_hugepages_1g - 2
+    fail "No available hugepages" if frame["start_service"] && vm_host.used_hugepages_1g > vm_host.total_hugepages_1g - spdk_hugepages
 
     SpdkInstallation.create(
       version: frame["version"],
       allocation_weight: 0,
       vm_host_id: vm_host.id,
       cpu_count: vm_host.spdk_cpu_count,
-      hugepages: 3
+      hugepages: spdk_hugepages
     ) { _1.id = SpdkInstallation.generate_uuid }
 
     hop_install_spdk


### PR DESCRIPTION
In https://github.com/ubicloud/ubicloud/commit/ab3933bc93b50f9c8fb4633dceeb31e100677b1f we increased iobuf sizes to have enough resources for our current workload. It reduced the error rate across our fleet from 5 times per week to once in every few weeks. This PR further increases the resources to reduce the chance of error even more.

Since we fixed error handling with a previous release of bdev_ubi-0.3, the expected behavior in case of exceeding limits is an error instead of a crash.