### PR TITLE
[openapi] remove obvious/explicit _id usage in openapi schema

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1446,19 +1446,17 @@ components:
         type: string
     postgres_database_reference:
       description: Postgres database ID or name
+      examples:
+        id:
+          value: pgn30gjk1d1e2jj34v9x0dq4rp
+        name:
+          value: postgres-database-name
       in: path
       name: postgres_database_reference
       required: true
       schema:
-        oneOf:
-          - type: string
-            example: pgn30gjk1d1e2jj34v9x0dq4rp
-            pattern: '^pg[0-9a-tv-z]{24}$'
-          - type: string
-            example: postgres-database-name
-            not:
-              pattern: '^pg[0-9a-tv-z]{24}$'
-            pattern: '^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$'
+        type: string
+        pattern: '^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$'
     postgres_firewall_rule_id:
       description: ID of the postgres firewall rule
       in: path

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -831,44 +831,6 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
-  '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/firewall-rule':
-    parameters:
-      - $ref: '#/components/parameters/location'
-      - $ref: '#/components/parameters/postgres_database_name'
-      - $ref: '#/components/parameters/project_id'
-    get:
-      operationId: listLocationPostgresFirewallRules
-      summary: List location Postgres firewall rules
-      responses:
-        '200':
-          $ref: '#/components/responses/PostgresFirewallRules'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Postgres Firewall Rule
-    post:
-      operationId: createLocationPostgresFirewallRule
-      summary: Create a new postgres firewall rule
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                cidr:
-                  description: CIDR of the firewall rule
-                  type: string
-              additionalProperties: false
-              required:
-                - cidr
-      responses:
-        '200':
-          $ref: '#/components/responses/PostgresFirewallRule'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Postgres Firewall Rule
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/firewall-rule/{firewall_rule_id}':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -1009,6 +971,44 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/firewall-rule':
+    parameters:
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_reference'
+      - $ref: '#/components/parameters/project_id'
+    get:
+      operationId: listLocationPostgresFirewallRules
+      summary: List location Postgres firewall rules
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresFirewallRules'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Firewall Rule
+    post:
+      operationId: createLocationPostgresFirewallRule
+      summary: Create a new Postgres firewall rule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cidr:
+                  description: CIDR of the firewall rule
+                  type: string
+              additionalProperties: false
+              required:
+                - cidr
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresFirewallRule'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Firewall Rule
   '/project/{project_id}/location/{location}/private-subnet':
     get:
       operationId: listLocationPrivateSubnets
@@ -1444,6 +1444,19 @@ components:
       required: true
       schema:
         type: string
+    postgres_database_reference:
+      description: Postgres database ID or name
+      in: path
+      name: postgres_database_reference
+      required: true
+      schema:
+        oneOf:
+          - type: string
+            example: pgn30gjk1d1e2jj34v9x0dq4rp
+            pattern: '^pg[0-9a-tv-z]{24}$'
+          - type: string
+            example: postgres-database-name
+            pattern: '^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$'
     postgres_firewall_rule_id:
       description: ID of the postgres firewall rule
       in: path

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1456,6 +1456,8 @@ components:
             pattern: '^pg[0-9a-tv-z]{24}$'
           - type: string
             example: postgres-database-name
+            not:
+              pattern: '^pg[0-9a-tv-z]{24}$'
             pattern: '^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$'
     postgres_firewall_rule_id:
       description: ID of the postgres firewall rule


### PR DESCRIPTION
This removes the obvious/explicit _id api routes and makes associated fixes in the main schema.

A couple points of note:

1. The name regex seems overly broad, but I was having a hard time finding in the code what it should be exactly. Happy to change it if someone can tell me what it should be specifically.
2. I was surprised just how few _id paths there were in the schema. I think a bunch of additional stuff needs to be updated to allow name or id (but just never was updated/accurate in the schema to begin with), but I'm certainly willing to be corrected/wrong.