### PR TITLE
Update aws-sdk-s3 from 1.177 to 1.182

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ end
 
 gem "webauthn", "~> 3.2"
 
-gem "aws-sdk-s3", "~> 1.177"
+gem "aws-sdk-s3", "~> 1.182"
 
 gem "acme-client", "~> 2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,21 +61,22 @@ GEM
       fiddle
     ast (2.4.2)
     awesome_print (1.9.2)
-    aws-eventstream (1.3.0)
-    aws-partitions (1.1031.0)
-    aws-sdk-core (3.214.1)
+    aws-eventstream (1.3.1)
+    aws-partitions (1.1059.0)
+    aws-sdk-core (3.219.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
+      base64
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.96.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-kms (1.99.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.177.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-s3 (1.182.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.10.1)
+    aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
@@ -443,7 +444,7 @@ DEPENDENCIES
   argon2
   argon2-kdf
   awesome_print
-  aws-sdk-s3 (~> 1.177)
+  aws-sdk-s3 (~> 1.182)
   bcrypt_pbkdf
   brakeman
   by (>= 1.1.0)


### PR DESCRIPTION
Actually, the "aws-sdk-s3" gem releases a new version every week, and generally these updates are harmless, auto-generated packages. However, version "1.177" has different content.

They changed the client's default checksum validation to CRC32, which Cloudflare R2 doesn't support. This change breaks many applications. [^1]

Cloudflare recommends either pinning to version 1.177 or passing the parameters `request_checksum_calculation: "when_required"` and `response_checksum_validation: "when_required"` to the S3 client [^2]. Since we'll need to update the version eventually, it's a good idea to do it now.

[^1]: https://www.cloudflarestatus.com/incidents/t5nrjmpxc1cj
[^2]: https://developers.cloudflare.com/r2/examples/aws/aws-sdk-ruby/