### PR TITLE
Drop support for optional leading underscore for ubids in routes

### DIFF
--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -3,7 +3,7 @@
 class Clover < Roda
   def self.name_or_ubid_for(model)
     # (\z)? to force a nil as first capture
-    [/(\z)?_?(#{model.ubid_type}[a-z0-9]{24})/, /([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)/]
+    [/(\z)?(#{model.ubid_type}[a-tv-z0-9]{24})/, /([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)/]
   end
   [Firewall, KubernetesCluster, LoadBalancer, PostgresResource, PrivateSubnet, Vm].each do |model|
     const_set(:"#{model.table_name.upcase}_NAME_OR_UBID", name_or_ubid_for(model))

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -719,59 +719,6 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
-  '/project/{project_id}/location/{location}/postgres/_{postgres_database_id}/failover':
-    parameters:
-      - $ref: '#/components/parameters/project_id'
-      - $ref: '#/components/parameters/location'
-      - $ref: '#/components/parameters/postgres_database_id'
-    post:
-      operationId: failoverPostgresDatabaseWithID
-      summary: Failover a specific Postgres Database with ID
-      responses:
-        '200':
-          $ref: '#/components/responses/PostgresDatabase'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Postgres Database
-  '/project/{project_id}/location/{location}/postgres/_{postgres_database_id}/firewall-rule':
-    parameters:
-      - $ref: '#/components/parameters/location'
-      - $ref: '#/components/parameters/postgres_database_id'
-      - $ref: '#/components/parameters/project_id'
-    get:
-      operationId: listLocationPostgresFirewallRules
-      summary: List location Postgres firewall rules
-      responses:
-        '200':
-          $ref: '#/components/responses/PostgresFirewallRules'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Postgres Firewall Rule
-    post:
-      operationId: createLocationPostgresFirewallRuleWithId
-      summary: Create a new Postgres firewall rule
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                cidr:
-                  description: CIDR of the firewall rule
-                  type: string
-              additionalProperties: false
-              required:
-                - cidr
-      responses:
-        '200':
-          $ref: '#/components/responses/PostgresFirewallRule'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Postgres Firewall Rule
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -863,8 +810,8 @@ paths:
       - $ref: '#/components/parameters/location'
       - $ref: '#/components/parameters/postgres_database_name'
     post:
-      operationId: failoverPostgresDatabaseWithName
-      summary: Failover a specific Postgres Database with name
+      operationId: failoverPostgresDatabaseWithID
+      summary: Failover a specific Postgres Database with ID
       responses:
         '200':
           $ref: '#/components/responses/PostgresDatabase'
@@ -877,6 +824,16 @@ paths:
       - $ref: '#/components/parameters/location'
       - $ref: '#/components/parameters/postgres_database_name'
       - $ref: '#/components/parameters/project_id'
+    get:
+      operationId: listLocationPostgresFirewallRules
+      summary: List location Postgres firewall rules
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresFirewallRules'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Firewall Rule
     post:
       operationId: createLocationPostgresFirewallRule
       summary: Create a new postgres firewall rule
@@ -1370,15 +1327,6 @@ components:
       schema:
         type: integer
         default: 10
-    postgres_database_id:
-      description: Postgres database ID
-      in: path
-      name: postgres_database_id
-      required: true
-      schema:
-        type: string
-        example: pgn30gjk1d1e2jj34v9x0dq4rp
-        pattern: '^pg[0-9a-hj-km-np-tv-z]{24}$'
     postgres_database_name:
       description: Postgres database name
       in: path

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe Clover, "firewall" do
 
   describe "unauthenticated" do
     it "not post" do
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule"
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not delete" do
-      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
 
     it "not get" do
-      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
       expect(last_response).to have_api_error(401, "Please login to continue")
     end
@@ -37,7 +37,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "create firewall rule" do
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule", {
         cidr: "0.0.0.0/0",
         port_range: "100..101"
       }.to_json
@@ -46,7 +46,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "can not create same firewall rule" do
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule", {
         cidr: firewall_rule.cidr,
         port_range: "80..5432"
       }.to_json
@@ -55,7 +55,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "firewall rule no port range" do
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule", {
         cidr: "0.0.0.0/1"
       }.to_json
 
@@ -63,7 +63,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "firewall rule single port" do
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule", {
         cidr: "0.0.0.0/1",
         port_range: "11111"
       }.to_json
@@ -72,23 +72,23 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "firewall rule delete" do
-      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
       expect(last_response.status).to eq(204)
     end
 
     it "firewall rule delete does not exist" do
-      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/fr000000000000000000000000"
+      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/fr000000000000000000000000"
       expect(last_response.status).to eq(204)
     end
 
     it "success get firewall rule" do
-      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
       expect(last_response.status).to eq(200)
     end
 
     it "get does not exist" do
-      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/firewall-rule/fr000000000000000000000000"
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/fr000000000000000000000000"
 
       expect(last_response.content_type).to eq("application/json")
       expect(last_response).to have_api_error(404)

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -84,13 +84,6 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "success delete with underscore" do
-      delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}"
-
-      expect(last_response.status).to eq(204)
-      expect(firewall).not_to exist
-    end
-
-    it "success delete without underscore" do
       delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}"
 
       expect(last_response.status).to eq(204)
@@ -123,7 +116,7 @@ RSpec.describe Clover, "firewall" do
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
 
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/attach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 
@@ -133,7 +126,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "attach to subnet not exist" do
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/attach-subnet", {
         private_subnet_id: "fooubid"
       }.to_json
 
@@ -145,7 +138,7 @@ RSpec.describe Clover, "firewall" do
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps)
       expect(ps).to receive(:incr_update_firewall_rules)
 
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/detach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 
@@ -153,7 +146,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     it "detach from subnet not exist" do
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/detach-subnet", {
         private_subnet_id: "fooubid"
       }.to_json
 
@@ -165,13 +158,13 @@ RSpec.describe Clover, "firewall" do
       expect(PrivateSubnet).to receive(:from_ubid).and_return(ps).twice
       expect(ps).to receive(:incr_update_firewall_rules).twice
 
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/attach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/attach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 
       expect(firewall.private_subnets.count).to eq(1)
 
-      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/_#{firewall.ubid}/detach-subnet", {
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/detach-subnet", {
         private_subnet_id: ps.ubid
       }.to_json
 

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Clover, "load-balancer" do
         [:get, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"],
         [:post, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: "vm-1"}],
         [:post, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/detach-vm", {vm_id: "vm-1"}],
-        [:get, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_#{lb.ubid}"]
+        [:get, "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.ubid}"]
       ].each do |method, path, body|
         send(method, path, body)
 
@@ -71,7 +71,7 @@ RSpec.describe Clover, "load-balancer" do
 
     describe "id" do
       it "success" do
-        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_#{lb.ubid}"
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("lb-1")

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -26,16 +26,16 @@ RSpec.describe Clover, "postgres" do
         [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres"],
         [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/test-postgres"],
         [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"],
-        [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"],
+        [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}"],
         [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"],
-        [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"],
+        [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}"],
         [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule"],
         [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"],
         [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore"],
-        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/restore"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/restore"],
         [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password"],
-        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/reset-superuser-password"],
-        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/reset-superuser-password"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/failover"],
         [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/ca-certificates"]
       ].each do |method, path|
         send method, path
@@ -150,7 +150,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule pg ubid" do
-        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/firewall-rule", {
           cidr: "0.0.0.0/24"
         }.to_json
 
@@ -237,7 +237,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "reset password ubid" do
-        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/reset-superuser-password", {
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/reset-superuser-password", {
           password: "DummyPassword123"
         }.to_json
 
@@ -253,7 +253,7 @@ RSpec.describe Clover, "postgres" do
         st.update(label: "wait")
         expect(PostgresServer).to receive(:run_query).and_return "16/B374D848"
 
-        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/failover"
 
         expect(last_response.status).to eq(200)
       end
@@ -262,7 +262,7 @@ RSpec.describe Clover, "postgres" do
         pg.save_changes
         pg.representative_server.update(timeline_access: "fetch")
 
-        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/failover"
 
         expect(last_response).to have_api_error(400, "Failover cannot be triggered during restore!")
       end
@@ -270,7 +270,7 @@ RSpec.describe Clover, "postgres" do
       it "failover no ff base image" do
         pg.save_changes
 
-        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/failover"
 
         expect(last_response).to have_api_error(400, "Failover cannot be triggered for this resource!")
       end
@@ -279,7 +279,7 @@ RSpec.describe Clover, "postgres" do
         pg.flavor = PostgresResource::Flavor::PARADEDB
         pg.save_changes
 
-        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/failover"
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/failover"
 
         expect(last_response).to have_api_error(400, "There is not a suitable standby server to failover!")
       end
@@ -305,7 +305,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "success ubid" do
-        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(pg.name)
@@ -318,7 +318,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "show firewall" do
-        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule"
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/firewall-rule"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["items"][0]["cidr"]).to eq("0.0.0.0/0")
@@ -352,7 +352,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "success ubid" do
-        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be true
@@ -373,7 +373,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "not exist ubid in location" do
-        delete "/project/#{project.ubid}/location/foo_location/postgres/_#{pg.ubid}"
+        delete "/project/#{project.ubid}/location/foo_location/postgres/#{pg.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
@@ -386,7 +386,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "firewall-rule ubid" do
-        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/_#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 
         expect(last_response.status).to eq(204)
       end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Clover, "private_subnet" do
         [:get, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet"],
         [:post, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"],
         [:delete, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
-        [:delete, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"],
+        [:delete, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.ubid}"],
         [:get, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.name}"],
-        [:get, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"]
+        [:get, "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.ubid}"]
       ].each do |method, path|
         send method, path
 
@@ -137,7 +137,7 @@ RSpec.describe Clover, "private_subnet" do
       end
 
       it "success id" do
-        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"
+        get "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(ps.name)
@@ -166,14 +166,14 @@ RSpec.describe Clover, "private_subnet" do
       end
 
       it "success id" do
-        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_#{ps.ubid}"
+        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/#{ps.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
       end
 
       it "not exist ubid in location" do
-        delete "/project/#{project.ubid}/location/foo_location/private-subnet/_#{ps.ubid}"
+        delete "/project/#{project.ubid}/location/foo_location/private-subnet/#{ps.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be false

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Clover, "vm" do
         [:get, "/project/#{project.ubid}/location/#{vm.display_location}/vm"],
         [:post, "/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"],
         [:delete, "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"],
-        [:delete, "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"],
+        [:delete, "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.ubid}"],
         [:get, "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"],
-        [:get, "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"]
+        [:get, "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.ubid}"]
       ].each do |method, path|
         send method, path
 
@@ -207,7 +207,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success ubid" do
-        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.ubid}"
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq(vm.name)
@@ -229,7 +229,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "success ubid" do
-        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/_#{vm.ubid}"
+        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be true
@@ -250,7 +250,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "not exist ubid in location" do
-        delete "/project/#{project.ubid}/location/foo_location/vm/_#{vm.ubid}"
+        delete "/project/#{project.ubid}/location/foo_location/vm/#{vm.ubid}"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Clover, "Kubernetes" do
       end
 
       it "works with ubid" do
-        visit "#{project.path}/location/#{kc.display_location}/kubernetes-cluster/_#{kc.ubid}"
+        visit "#{project.path}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}"
 
         expect(page.title).to eq("Ubicloud - #{kc.name}")
         expect(page).to have_content kc.name


### PR DESCRIPTION
Also, do not allow `u` as a character, since ubids cannot include it.

Some of this overlaps with #2907, but this handles the actual route support and updates all related specs.

CC @geemus 