### PR TITLE
Add golang to .tool-versions to compile ubi cli

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 ruby 3.2.7
 postgres 15.8
 nodejs 23.6.0
+golang 1.24.0

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -59,13 +59,14 @@ asdf plugin add <name> [<git-url>]      Add a plugin from the plugin repo OR,
 [...]
 ```
 
-We like to have these four plugins (you can paste these commands):
+We like to have these plugins (you can paste these commands):
 
 ```sh
 $ asdf plugin add ruby
 $ asdf plugin add direnv
 $ asdf plugin add postgres
 $ asdf plugin add nodejs
+$ asdf plugin add golang
 ```
 
 Once you have the plugins, you can start to install the software the

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,3 +1,3 @@
 module ubi
 
-go 1.22.2
+go 1.24.0


### PR DESCRIPTION
Otherwise, this fails if one has the asdf golang plugin installed.  An alternative would be to tell .tool-versions to use the "system" golang if we think forcing people who don't work with the CLI to get new versions of Go from time to time is too invasive.

On the other hand, bringing golang into asdf's purview means it's very easy for everyone working with the project to instrument or alter the cli.