### PR TITLE
Fixes for starting slices after host reboot

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -128,8 +128,8 @@ class Sshable < Sequel::Model
     sess
   end
 
-  def start_fresh_session
-    Net::SSH.start(host, unix_user, **COMMON_SSH_ARGS.merge(key_data: keys.map(&:private_key)))
+  def start_fresh_session(&block)
+    Net::SSH.start(host, unix_user, **COMMON_SSH_ARGS.merge(key_data: keys.map(&:private_key)), &block)
   end
 
   def invalidate_cache_entry

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -253,6 +253,14 @@ class Prog::Vm::HostNexus < Prog::Base
       used_hugepages_1g: spdk_hugepages + total_vm_mem_gib
     )
 
+    hop_start_slices
+  end
+
+  label def start_slices
+    vm_host.slices.each { |slice|
+      slice.incr_start_after_host_reboot
+    }
+
     hop_start_vms
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -435,6 +435,15 @@ RSpec.describe Prog::Vm::HostNexus do
       expect { nx.verify_spdk }.to hop("verify_hugepages")
     end
 
+    it "start_slices starts slices" do
+      slice1 = instance_double(VmHostSlice)
+      slice2 = instance_double(VmHostSlice)
+      expect(vm_host).to receive(:slices).and_return([slice1, slice2])
+      expect(slice1).to receive(:incr_start_after_host_reboot)
+      expect(slice2).to receive(:incr_start_after_host_reboot)
+      expect { nx.start_slices }.to hop("start_vms")
+    end
+
     it "start_vms starts vms & becomes accepting & hops to wait if unprepared" do
       expect(vms).to all receive(:incr_start_after_host_reboot)
       expect(vm_host).to receive(:allocation_state).and_return("unprepared")
@@ -542,7 +551,7 @@ RSpec.describe Prog::Vm::HostNexus do
         .and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 10\nHugePages_Free: 8")
       expect(vm_host).to receive(:update)
         .with(total_hugepages_1g: 10, used_hugepages_1g: 7)
-      expect { nx.verify_hugepages }.to hop("start_vms")
+      expect { nx.verify_hugepages }.to hop("start_slices")
     end
   end
 


### PR DESCRIPTION
## Execute the block passed to Sshable.start_fresh_session

In `Prog::Vm::VmHostSliceNexus.available?` we relied on the block passed to `Sshable.start_fresh_session` being executed. But it wasn't executed previously.

This change fixes that by passing it to `Net::SSH.start` which accepts a block:

```
.start(host, user = nil, options = {}, &block)
```

## Start slices after host reboot.

We need to start slices after host reboot. Otherwise, `cpuset.cpus.partition` might not be in the correct state.