### PR TITLE
Make thread printer test robust to multithreading

### DIFF
--- a/spec/lib/thread_printer_spec.rb
+++ b/spec/lib/thread_printer_spec.rb
@@ -3,11 +3,17 @@
 RSpec.describe ThreadPrinter do
   describe "#print" do
     it "can dump threads" do
-      expect(described_class).to receive(:puts).with(/--BEGIN THREAD DUMP, .*/)
-      expect(described_class).to receive(:puts).with(/Thread: #<Thread:.*>/)
-      expect(described_class).to receive(:puts).with(/backtrace/)
-      expect(described_class).to receive(:puts).with(/--END THREAD DUMP, .*/)
+      output = []
+      expect(described_class).to receive(:puts) do |str|
+        output << str
+      end.at_least(:once)
+
       described_class.run
+
+      expect(output[0]).to match(/--BEGIN THREAD DUMP, .*/)
+      expect(output[1]).to match(/Thread: #<Thread:.*>/)
+      expect(output[2]).to match(/backtrace/)
+      expect(output[-1]).to match(/--END THREAD DUMP, .*/)
     end
 
     it "can handle threads with a nil backtrace and/or a created_at" do


### PR DESCRIPTION
I saw a case of non-deterministic failure in CI that's almost
certainly caused by multiple threads being present when the thread
printer runs.  In particular, a thread with `puma` in the stack was
present.

Although the test suite is single-threaded, nothing synchronizes the
joining of all threads between tests.  While perhaps chasing such
non-determinism could be fruitful, doing so via the ThreadPrinter test
doesn't make sense; it'd have to be in a before/after/around
arrangement, e.g. in dispatcher_spec.rb:

    describe "#start_cohort" do
      after do
        Thread.list.each { _1.join if _1 != Thread.current }
      end

