### PR TITLE
Change the "Tax ID" label to "VAT ID" for EU customers

### DIFF
--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -123,14 +123,14 @@ RSpec.describe Clover, "billing" do
       expect(page.title).to eq("Ubicloud - Project Billing")
       fill_in "Billing Name", with: "New Inc."
       select "United States", from: "Country"
-      fill_in "Tax ID (Optional)", with: "456789"
+      fill_in "VAT ID", with: "456789"
 
       click_button "Update"
 
       expect(page.status_code).to eq(200)
       expect(page).to have_field("Billing Name", with: "New Inc.")
       expect(page).to have_field("Country", with: "US")
-      expect(page).to have_field("Tax ID (Optional)", with: "456789")
+      expect(page).to have_field("Tax ID", with: "456789")
     end
 
     it "shows error if billing info update failed" do

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -134,15 +134,15 @@
                   ) %>
                 </div>
                 <div class="sm:col-span-4">
-                  <%== part("components/form/text", name: "tax_id", label: "Tax ID (Optional)", value: @billing_info_data[:tax_id]) %>
-                </div>
-                <div class="sm:col-span-4">
                   <%== part(
                     "components/form/text",
-                    name: "company_name",
-                    label: "Company Name (Optional)",
-                    value: @billing_info_data[:company_name]
+                    name: "tax_id",
+                    label: ISO3166::Country.new(@billing_info_data[:country])&.in_eu_vat? ? "VAT ID" : "Tax ID",
+                    value: @billing_info_data[:tax_id]
                   ) %>
+                </div>
+                <div class="sm:col-span-4">
+                  <%== part("components/form/text", name: "company_name", label: "Company Name", value: @billing_info_data[:company_name]) %>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Next month, we will start charging VAT and will email all customers to inform them about the new VAT ID requirement.

To clarify, we display the text input's label as "VAT ID" for EU customers.

Additionally, the `(Optional)` suffix is confusing, so I removed it.