### PR TITLE
Simplify current invoice view

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -158,7 +158,7 @@ class Clover
           r.get true do
             @invoice_data = Serializers::Invoice.serialize(invoice, {detailed: true})
 
-            if r.params["pdf"] == "1"
+            unless invoice.status == "current"
               response["Content-Type"] = "application/pdf"
               response["Content-Disposition"] = "filename=\"#{@invoice_data[:filename]}.pdf\""
               next invoice.generate_pdf(@invoice_data)

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -293,8 +293,7 @@ RSpec.describe Clover, "billing" do
         visit "#{project.path}/billing/invoice/current"
 
         expect(page.status_code).to eq(200)
-        expect(page.title).to eq("Ubicloud - #{invoice.name} Invoice")
-        expect(page).to have_content invoice.name
+        expect(page.title).to eq("Ubicloud - Current Usage Summary")
         expect(page).to have_content "Aggregated"
         expect(page.has_css?("#invoice-discount")).to be false
         expect(page.has_css?("#invoice-credit")).to be false
@@ -306,7 +305,6 @@ RSpec.describe Clover, "billing" do
         invoice.this.update(content:)
 
         page.refresh
-        expect(page).to have_content invoice.name
         expect(find_by_id("invoice-discount").text).to eq "-$1.00"
         expect(find_by_id("invoice-credit").text).to eq "-$2.00"
         expect(find_by_id("invoice-free-inference-tokens").text).to eq "-$3.00"

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -108,6 +108,7 @@ module ThawedMock
   allow_mocking(Clog, :emit)
   allow_mocking(CloudflareClient, :new)
   allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :hardware_reset_server, :set_server_name)
+  allow_mocking(InvoiceGenerator, :new)
   allow_mocking(Minio::Client, :new)
   allow_mocking(Minio::Crypto, :new)
   allow_mocking(Scheduling::Allocator, :allocate)

--- a/views/components/table_card.erb
+++ b/views/components/table_card.erb
@@ -1,4 +1,4 @@
-<%# locals: (title: nil, headers: [], rows:, empty_state: nil, right_items: nil) %>
+<%# locals: (title: nil, headers: [], rows:, empty_state: nil, right_items: nil, footer: nil) %>
 
 <div>
   <% if title || right_items %>
@@ -74,5 +74,6 @@
         <% end %>
       </tbody>
     </table>
+    <%== footer %>
   </div>
 </div>

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -1,4 +1,4 @@
-<% @page_title = "#{@invoice_data[:name]} Invoice" %>
+<% @page_title = "Current Usage Summary" %>
 
 <%== part(
   "components/page_header",
@@ -6,83 +6,50 @@
     %w[Projects /project],
     [@project_data[:name], @project_data[:path]],
     ["Billing", "#{@project_data[:path]}/billing"],
-    ["#{@invoice_data[:name]} Invoice", "#"]
-  ],
-  right_items: [
-    part("components/button", text: "View PDF", link: "#{request.url}?pdf=1", attributes: {target: "_blank"})
+    ["Current Usage Summary", "#"]
   ]
 ) %>
 
-<div class="grid gap-6">
-  <!-- Invoice Card -->
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-    <div class="px-4 py-5 sm:p-6">
-      <div class="flex justify-between items-baseline text-gray-800">
-        <div class="text-4xl font-semibold">Current Usage Summary</div>
-        <div class="text-right text-3xl"><%= @invoice_data[:begin_time] %> to <%= @invoice_data[:end_time] %></div>
-      </div>
-      <h3 class="text-lg text-gray-500">
-        This invoice will be finalized on the first day of next month.
-      </h3>
-      <div class="mt-6">
-        <table class="min-w-full divide-y divide-gray-300 border border-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th scope="col" class="py-3 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">RESOURCE</th>
-              <th scope="col" class="px-3 py-3 text-left text-sm font-semibold text-gray-900">DESCRIPTION</th>
-              <th scope="col" class="px-3 py-3 text-right text-sm font-semibold text-gray-900">USAGE</th>
-              <th scope="col" class="py-3 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 sm:pr-6">AMOUNT</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-200 bg-white">
-            <% if @invoice_data[:items].count > 0 %>
-            <% @invoice_data[:items].each do |item| %>
-              <tr>
-                <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= item[:name] %></td>
-                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= item[:description] %></td>
-                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 text-right"><%= item[:usage] %></td>
-                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-right text-sm text-gray-500 sm:pr-6"><%= item[:cost_humanized] %></td>
-              </tr>
-            <% end %>
-            <% else %>
-              <tr>
-                <td colspan="4" class="whitespace-nowrap px-3 py-3 text-center font-medium text-gray-900">No resources</td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+<%
+  footer_content = [
+    ["Subtotal", @invoice_data[:subtotal]],
+    (@invoice_data[:discount] != "$0.00") ? ["Discount", "-#{@invoice_data[:discount]}"] : nil,
+    (@invoice_data[:credit] != "$0.00") ? ["Credit", "-#{@invoice_data[:credit]}"] : nil,
+    (@invoice_data[:free_inference_tokens_credit] != "$0.00") ? ["Free Inference Tokens", "-#{@invoice_data[:free_inference_tokens_credit]}"] : nil,
+    ["Total", @invoice_data[:total]]
+  ].compact.map do |name, value|
+    <<~CONTENT
+      <dl class="grid grid-cols-3 gap-x-3 #{(name == "Total") ? "text-2xl" : nil}">
+        <dt class="text-right font-semibold text-gray-800 col-span-2">#{name}:</dt>
+        <dd class="text-gray-500" id="invoice-#{name.downcase.tr(" ", "-")}">#{value}</dd>
+      </dl>
+    CONTENT
+  end.join
+%>
 
-        <div class="mt-8 flex justify-end">
-            <div class="grid gap-2 text-right">
-              <dl class="grid grid-cols-3 gap-x-3">
-                <dt class="text-right font-semibold text-gray-800 col-span-2">Subtotal:</dt>
-                <dd class="text-gray-500"><%= @invoice_data[:subtotal] %></dd>
-              </dl>
-              <% if @invoice_data[:discount] != "$0.00" %>
-                <dl class="grid grid-cols-3 gap-x-3">
-                  <dt class="text-right font-semibold text-gray-800 col-span-2">Discount:</dt>
-                  <dd class="text-gray-500" id="invoice-discount">-<%= @invoice_data[:discount] %></dd>
-                </dl>
-              <% end %>
-              <% if @invoice_data[:credit] != "$0.00" %>
-                <dl class="grid grid-cols-3 gap-x-3">
-                  <dt class="text-right font-semibold text-gray-800 col-span-2">Credit:</dt>
-                  <dd class="text-gray-500" id="invoice-credit">-<%= @invoice_data[:credit] %></dd>
-                </dl>
-              <% end %>
-              <% if @invoice_data[:free_inference_tokens_credit] != "$0.00" %>
-                <dl class="grid grid-cols-3 gap-x-3">
-                  <dt class="text-right font-semibold text-gray-800 col-span-2">Free Inference Tokens:</dt>
-                  <dd class="text-gray-500" id="invoice-free-inference-tokens">-<%= @invoice_data[:free_inference_tokens_credit] %></dd>
-                </dl>
-              <% end %>
-              <dl class="grid grid-cols-3 gap-x-3 text-2xl">
-                <dt class="text-right font-semibold text-gray-800 col-span-2">Total:</dt>
-                <dd class="text-gray-500"><%= @invoice_data[:total] %></dd>
-              </dl>
-            </div>
-        </div>
-      </div>
-    </div>
+<div class="grid gap-6">
+  <div class="md:flex md:items-center md:justify-between text-2xl">
+    <div class="min-w-0 flex-1">This invoice will be finalized on the first day of next month</div>
+    <div class="text-right"><%= @invoice_data[:begin_time] %> to <%= @invoice_data[:end_time] %></div>
   </div>
+
+  <!-- Invoice Card -->
+  <%== part(
+      "components/table_card",
+      headers: ["Resource", "Description", "Usage", "Amount"],
+      rows: @invoice_data[:items].map do |item|
+         [
+           [
+             item[:name],
+             item[:description],
+             [item[:usage], { extra_class: "text-right"}],
+             [item[:cost_humanized], { extra_class: "text-right"}],
+           ],
+           { id: "item-#{item[:name]}" }
+         ]
+      end,
+      empty_state: "No resources",
+      footer: "<div class=\"px-4 py-5 sm:p-6 flex justify-end\"><div class=\"grid gap-2 text-right\">#{footer_content}</div></div>"
+    )
+  %>
 </div>

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -17,71 +17,13 @@
   <!-- Invoice Card -->
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <div class="px-4 py-5 sm:p-6">
-      <% if @invoice_data[:status] == "current" %>
-        <div class="flex justify-between items-baseline text-gray-800">
-          <div class="text-4xl font-semibold">Current Usage Summary</div>
-          <div class="text-right text-3xl"><%= @invoice_data[:begin_time] %> to <%= @invoice_data[:end_time] %></div>
-        </div>
-        <h3 class="text-lg text-gray-500">
-          This invoice will be finalized on the first day of next month.
-        </h3>
-      <% else %>
-        <div class="flex justify-between">
-          <div>
-            <img class="h-8 w-auto" src="/logo-primary.png" alt="Ubicloud">
-            <address class="mt-4 not-italic text-gray-800">
-              <% if @invoice_data[:issuer_name] %>
-                <span class="font-semibold"><%= @invoice_data[:issuer_name] %></span><br>
-              <% end %>
-              <%= @invoice_data[:issuer_address] %>,<br>
-              <%= @invoice_data[:issuer_city] %>,
-              <%= @invoice_data[:issuer_state] %>
-              <%= @invoice_data[:issuer_postal_code] %>,<br>
-              <%= @invoice_data[:issuer_country] %><br>
-            </address>
-          </div>
-          <div class="text-right">
-            <h2 class="text-3xl font-semibold text-gray-800">
-              Invoice for <%= @invoice_data[:name] %>
-            </h2>
-            <span class="mt-1 block text-gray-500">#<%= @invoice_data[:invoice_number] %></span>
-          </div>
-        </div>
-        <div class="mt-8 grid grid-cols-2 gap-3">
-          <div>
-            <h3 class="text-lg font-semibold text-gray-800">Bill to:</h3>
-            <h3 class="text-lg font-semibold text-gray-800">
-              <%= @invoice_data[:billing_name] %>
-              <% if @invoice_data[:company_name] %>
-                - <%= @invoice_data[:company_name] %>
-              <% end %>
-            </h3>
-            <address class="mt-2 not-italic text-gray-500">
-              <% if @invoice_data[:tax_id] %>
-                Tax ID: <%= @invoice_data[:tax_id] %> <br>
-              <% end %>
-              <%= @invoice_data[:billing_address] %>,<br>
-              <%= @invoice_data[:billing_city] %>,
-              <%= @invoice_data[:billing_state] %>
-              <%= @invoice_data[:billing_postal_code] %>,<br>
-              <%= @invoice_data[:billing_country] %><br>
-            </address>
-          </div>
-
-          <div class="text-right space-y-2">
-            <div class="grid grid-cols-1 gap-2">
-              <dl class="grid grid-cols-5 gap-x-3">
-                <dt class="col-span-3 font-semibold text-gray-800">Invoice date:</dt>
-                <dd class="col-span-2 text-gray-500"><%= @invoice_data[:date] %></dd>
-              </dl>
-              <dl class="grid grid-cols-5 gap-x-3">
-                <dt class="col-span-3 font-semibold text-gray-800">Due date:</dt>
-                <dd class="col-span-2 text-gray-500"><%= @invoice_data[:date] %></dd>
-              </dl>
-            </div>
-          </div>
-        </div>
-      <% end %>
+      <div class="flex justify-between items-baseline text-gray-800">
+        <div class="text-4xl font-semibold">Current Usage Summary</div>
+        <div class="text-right text-3xl"><%= @invoice_data[:begin_time] %> to <%= @invoice_data[:end_time] %></div>
+      </div>
+      <h3 class="text-lg text-gray-500">
+        This invoice will be finalized on the first day of next month.
+      </h3>
       <div class="mt-6">
         <table class="min-w-full divide-y divide-gray-300 border border-gray-200">
           <thead class="bg-gray-50">


### PR DESCRIPTION
We will add VAT details to the invoices. I simplified the current invoice view, so we don't have to apply the same VAT changes in both places.

One of the biggest simplifications for invoices is removing Invoice serializer, but it requires too much effort for now.

- **Add footer to the table card component**
  

- **Show finalized invoices as PDF**
  We used to display both current and finalized invoices in HTML format,
  allowing customers to convert HTML to PDF. Now, we generate PDF invoices
  directly using pure Ruby, so there's no need to show finalized invoices
  in HTML anymore. This change reduces maintenance since we no longer have
  to update both HTML and PDF views for invoice updates. The view now only
  shows current usage so no need to show billing details.
  

- **Use the table component in the current usage view**
  Since it's only for current usage, we can simplify it by using the table
  card component.
  