### PR TITLE
Set workflow job permissions explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,7 +6,7 @@ on:
     types: [opened,closed,synchronize]
 permissions:
   actions: write
-  contents: write
+  contents: read
   pull-requests: write
   statuses: write
 jobs:
@@ -28,4 +28,3 @@ jobs:
           remote-repository-name: cla-signers
           create-file-commit-message: 'Creating file for storing CLA Signatures'
           signed-commit-message: '$contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -1,5 +1,8 @@
 name: cli/ubi CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,8 @@
 name: E2E CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
- **Set workflow job permissions explicitly**
  CodeQL has started scanning GitHub Actions workflows as well. It's not a
  major issue, but it's good to follow best practices.
  
  https://github.com/ubicloud/ubicloud/security/code-scanning/11
  
      Workflow does not contain permissions
  
      If a GitHub Actions job or workflow has no explicit permissions set,
      then the repository permissions are used. Repositories created under
      organizations inherit the organization permissions. The
      organizations or repositories created before February 2023 have the
      default permissions set to read-write. Often these permissions do
      not adhere to the principle of least privilege and can be reduced to
      read-only, leaving the write permission only to a specific types as
      issues: write or pull-requests: write.
  

- **Add workflow_dispatch trigger to the workflow jobs**
  I often had to create draft PRs just to trigger the workflow jobs. To
  avoid this, I added a `workflow_dispatch` trigger, allowing us to
  trigger the workflow jobs directly from the GitHub Actions UI for any
  branch.
  