### PR TITLE
GPU billing meters

### DIFF
--- a/config/billing_rates.yml
+++ b/config/billing_rates.yml
@@ -92,6 +92,7 @@
 - { id: a3abe656-6ca2-4f17-a911-169c51a4a77a, resource_type: GitHubRunnerMinutes,     resource_family: standard-60-arm,     location: global,         unit_price: 0.0240000000, billed_by: amount,   active_from: 2023-01-01T00:00:00Z }
 - { id: 27d84309-e39d-8d78-b603-7632dafe374e, resource_type: GitHubRunnerMinutes,     resource_family: standard-gpu-6,      location: global,         unit_price: 0.0320000000, billed_by: amount,   active_from: 2023-01-01T00:00:00Z }
 - { id: c31b3640-92fa-49c3-bae8-c1011cc5f917, resource_type: GitHubRunnerConcurrency, resource_family: standard,            location: global,         unit_price: 0.0000248016, billed_by: duration, active_from: 2023-01-01T00:00:00Z }
+- { id: e7ba2b8f-3503-4086-bca6-241f05966419, resource_type: Gpu,                     resource_family: 20b5,                location: latitude-ai,    unit_price: 0.0204350000, billed_by: duration, active_from: 2025-03-07T00:00:00Z } #A100
 
 # Deprecated billing rates
 - { id: c62a5b1d-0ed8-493c-89a5-d19db075d3c2, resource_type: PostgresVCpu,            resource_family: standard,            location: hetzner-fsn1,   unit_price: 0.0005518353, billed_by: duration, active_from: 2025-01-01T00:00:00Z }

--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -62,6 +62,8 @@ class BillingRate
       "Additional GitHub Runner Concurrency"
     when "InferenceTokens"
       "#{resource_family} Inference Tokens"
+    when "Gpu"
+      "#{amount.to_i}x #{PciDevice.device_name(resource_family)}"
     else
       fail "BUG: Unknown resource type for line item description"
     end

--- a/model/pci_device.rb
+++ b/model/pci_device.rb
@@ -10,10 +10,26 @@ class PciDevice < Sequel::Model
     UBID::TYPE_ETC
   end
 
+  def self.device_name(device_id)
+    # https://download.nvidia.com/XFree86/Linux-x86_64/535.98/README/supportedchips.html
+    case device_id
+    when "20b5"
+      "NVIDIA A100 80GB PCIe"
+    when "27b0"
+      "NVIDIA RTX 4000 SFF Ada Generation"
+    else
+      "PCI device"
+    end
+  end
+
   include ResourceMethods
 
   def is_gpu
     ["0300", "0302"].include? device_class
+  end
+
+  def name
+    PciDevice.device_name(device)
   end
 end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -329,6 +329,19 @@ class Prog::Vm::Nexus < Prog::Base
       )
     end
 
+    if vm.pci_devices.any? { |dev| dev.is_gpu }
+      gpu_count = vm.pci_devices.count { |dev| dev.is_gpu }
+      gpu = vm.pci_devices.find { |dev| dev.is_gpu }
+
+      BillingRecord.create_with_id(
+        project_id: project.id,
+        resource_id: vm.id,
+        resource_name: "GPUs of #{vm.name}",
+        billing_rate_id: BillingRate.from_resource_properties("Gpu", gpu.device, vm.location)["id"],
+        amount: gpu_count
+      )
+    end
+
     hop_wait
   end
 

--- a/spec/lib/billing_rate_spec.rb
+++ b/spec/lib/billing_rate_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe BillingRate do
       expect(described_class.line_item_description("VmVCpu", "standard", 8)).to eq("standard-8 Virtual Machine")
     end
 
+    it "returns for gpu" do
+      expect(described_class.line_item_description("Gpu", "20b5", 2)).to eq("2x NVIDIA A100 80GB PCIe")
+    end
+
     it "returns for IPAddress" do
       expect(described_class.line_item_description("IPAddress", "IPv4", 1)).to eq("IPv4 Address")
     end
@@ -46,6 +50,10 @@ RSpec.describe BillingRate do
 
     it "returns usage by token" do
       expect(described_class.line_item_usage("InferenceTokens", "test-model", 10, 1)).to eq("10 tokens")
+    end
+
+    it "returns usage by duration for gpu" do
+      expect(described_class.line_item_usage("gpu", "20b5", 10, 2)).to eq("2 minutes")
     end
   end
 

--- a/spec/model/pci_device_spec.rb
+++ b/spec/model/pci_device_spec.rb
@@ -17,4 +17,10 @@ RSpec.describe PciDevice do
     d = described_class.new(device_class: "0403")
     expect(d.is_gpu).to be_falsy
   end
+
+  it "returns correct names" do
+    expect(described_class.new(device_class: "0302", vendor: "10de", device: "20b5").name).to equal("NVIDIA A100 80GB PCIe")
+    expect(described_class.new(device_class: "0300", vendor: "10de", device: "27b0").name).to equal("NVIDIA RTX 4000 SFF Ada Generation")
+    expect(described_class.new(device_class: "0302", vendor: "10de", device: "????").name).to equal("PCI device")
+  end
 end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -585,6 +585,14 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.create_billing_record }.to hop("wait")
     end
 
+    it "creates billing records when gpu is present" do
+      vm.location = "latitude-ai"
+      expect(vm).to receive(:pci_devices).and_return([PciDevice.new(slot: "01:00.0", iommu_group: 23, device_class: "0302", vendor: "10de", device: "20b5")]).at_least(:once)
+      expect(BillingRecord).to receive(:create_with_id).exactly(4).times
+      expect(vm).to receive(:project).and_return(prj).at_least(:once)
+      expect { nx.create_billing_record }.to hop("wait")
+    end
+
     it "creates billing records when ip4 is not enabled" do
       expect(vm).to receive(:ip4_enabled).and_return(false)
       expect(BillingRecord).to receive(:create_with_id).exactly(3).times


### PR DESCRIPTION
**Create billing records for GPUs**
    
For billable projects, billing records are created for GPUs that are
attached to VMs. These billing records are created based on the number
and type of GPUs attached to the VM instances. At the moment we do not
support attaching GPUs of different type to a single VM.

---

**Add GPUs as new billing resource type**
    
Support GPUs as new billing resource type. The GPU's PCI device id is
used as resource family.

A billing rate of type `Gpu` is added for A100 GPUs, which have PCI
device id `20b5`.

---

**Get name of PCI device**
    
This commit adds new methods to get the name of known PCI devices.

For NVIDIA devices, the mapping of pci ids to names can be found at
https://download.nvidia.com/XFree86/Linux-x86_64/535.98/README/supportedchips.html

---

This is how GPUs are showing up on invoices:
![Screenshot 2025-03-07 at 17 46 54](https://github.com/user-attachments/assets/663aa599-5ced-4df5-b1f3-223ec3fff9e9)

