### PR TITLE
Refactor K8S Progs, Allow Delete During Create

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -79,7 +79,15 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
 
     hop_wait if kubernetes_cluster.cp_vms.count >= kubernetes_cluster.cp_node_count
 
-    push Prog::Kubernetes::ProvisionKubernetesNode
+    bud Prog::Kubernetes::ProvisionKubernetesNode, {"subject_id" => kubernetes_cluster.id}
+
+    hop_wait_control_plane_node
+  end
+
+  label def wait_control_plane_node
+    reap
+    hop_bootstrap_control_plane_vms if leaf?
+    donate
   end
 
   label def wait

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -95,6 +95,9 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   end
 
   label def destroy
+    reap
+    donate unless leaf?
+    decr_destroy
     kubernetes_cluster.api_server_lb.incr_destroy
     kubernetes_cluster.cp_vms.each(&:incr_destroy)
     kubernetes_cluster.remove_all_cp_vms

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -46,6 +46,9 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   end
 
   label def destroy
+    reap
+    donate unless leaf?
+    decr_destroy
     kubernetes_nodepool.vms.each(&:incr_destroy)
     kubernetes_nodepool.remove_all_vms
     kubernetes_nodepool.destroy

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -35,7 +35,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   end
 
   label def wait
-    nap 30
+    nap 65536
   end
 
   label def destroy

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -31,7 +31,14 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
 
   label def bootstrap_worker_vms
     hop_wait if kubernetes_nodepool.vms.count >= kubernetes_nodepool.node_count
-    push Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kubernetes_nodepool.id, "subject_id" => kubernetes_nodepool.kubernetes_cluster_id}
+    bud Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kubernetes_nodepool.id, "subject_id" => kubernetes_nodepool.kubernetes_cluster_id}
+    hop_wait_worker_node
+  end
+
+  label def wait_worker_node
+    reap
+    hop_bootstrap_worker_vms if leaf?
+    donate
   end
 
   label def wait

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -77,6 +77,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   containerd config default | sudo tee /etc/containerd/config.toml
   sudo sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
   sudo systemctl restart containerd
+  sudo rm -f '/etc/apt/keyrings/kubernetes-apt-keyring.gpg'
   curl -fsSL https://pkgs.k8s.io/core:/stable:/#{kubernetes_cluster.version}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/#{kubernetes_cluster.version}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
   sudo apt update

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -19,6 +19,12 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     vm.sshable.cmd("sudo tee -a /etc/hosts", stdin: "#{ip} #{kubernetes_cluster.endpoint}\n")
   end
 
+  def before_run
+    if kubernetes_cluster.strand.label == "destroy" && strand.label != "destroy"
+      pop "provisioning canceled"
+    end
+  end
+
   label def start
     name, vm_size, storage_size_gib = if kubernetes_nodepool
       ["#{kubernetes_nodepool.name}-#{SecureRandom.alphanumeric(5).downcase}",

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -182,6 +182,15 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   end
 
   describe "#destroy" do
+    before { expect(nx).to receive(:reap) }
+
+    it "donates if there are sub-programs running (Provision...)" do
+      expect(nx).to receive(:leaf?).and_return false
+      expect(nx).to receive(:donate).and_call_original
+
+      expect { nx.destroy }.to nap(1)
+    end
+
     it "triggers deletion of associated resources and naps until all nodepools are gone" do
       expect(kubernetes_cluster.api_server_lb).to receive(:incr_destroy)
 

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   end
 
   describe "#wait" do
-    it "just naps for 30 seconds for now" do
-      expect { nx.wait }.to nap(30)
+    it "just naps for long time for now" do
+      expect { nx.wait }.to nap(65536)
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   end
 
   describe "#destroy" do
+    before { expect(nx).to receive(:reap) }
+
+    it "donates if there are sub-programs running (Provision...)" do
+      expect(nx).to receive(:leaf?).and_return false
+      expect(nx).to receive(:donate).and_call_original
+
+      expect { nx.destroy }.to nap(1)
+    end
+
     it "destroys the nodepool and its vms" do
       vms = [create_vm, create_vm]
       expect(kn).to receive(:vms).and_return(vms)


### PR DESCRIPTION
### Make ProvisionKubernetesNode  cancel itself if cluster is dropped

Add a `before_run` check to ProvisionKubernetesNode prog
    so that it drops itself if the cluster is destroyed. The cleanup of the
    vm is handled by cluster and nodepool nexus progs.

The nexuses also get a check for waiting for any possible child progs
    before continuing with the destroy procedure.

###     Convert `push` to `bud` in ProvisionKubernetesNode calls

We have been using push for ProvisionKubernetesNode in
    KubernetesClusterNexus and KubernetesNodepoolNexus FSMs. As it works
    in theory, this makes it harder to debug and untangle the stuck
    workflows as well as blocking some future improvements such as parallel
    execution of provisions and destroying mid-create sequence.

###     Increase nap time of k8s nodepool nexus

###     Fix idempotency issue on k8s software install step
