### PR TITLE
Expand destroy guard of VM Nexus to all 3 states

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -165,7 +165,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if strand.label != "destroy"
+      unless ["destroy", "wait_lb_expiry", "destroy_slice"].include? strand.label
         vm.active_billing_records.each(&:finalize)
         vm.assigned_vm_address&.active_billing_record&.finalize
         register_deadline(nil, 5 * 60)

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -607,8 +607,14 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
+      expect(nx).to receive(:when_destroy_set?).and_yield.at_least(:once)
       expect(nx.strand).to receive(:label).and_return("destroy")
+      expect { nx.before_run }.not_to hop("destroy")
+
+      expect(nx.strand).to receive(:label).and_return("destroy_slice")
+      expect { nx.before_run }.not_to hop("destroy")
+
+      expect(nx.strand).to receive(:label).and_return("wait_lb_expiry")
       expect { nx.before_run }.not_to hop("destroy")
     end
 


### PR DESCRIPTION
I managed to stuck a few Nexus progs in dev env with double `incr_destroy` calls to vms, then realized that we prevent the double delete cycle for the initial `destroy` label, but not for the following labels.