### PR TITLE
Use UBIDs in Kubernetes Node Names

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -21,11 +21,11 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
 
   label def start
     name, vm_size, storage_size_gib = if kubernetes_nodepool
-      ["#{kubernetes_nodepool.name}-#{SecureRandom.alphanumeric(5).downcase}",
+      ["#{kubernetes_nodepool.ubid}-#{SecureRandom.alphanumeric(5).downcase}",
         kubernetes_nodepool.target_node_size,
         kubernetes_nodepool.target_node_storage_size_gib]
     else
-      ["#{kubernetes_cluster.name.downcase}-control-plane-#{SecureRandom.alphanumeric(5).downcase}",
+      ["#{kubernetes_cluster.ubid}-#{SecureRandom.alphanumeric(5).downcase}",
         kubernetes_cluster.target_node_size,
         kubernetes_cluster.target_node_storage_size_gib]
     end
@@ -116,6 +116,7 @@ BASH
       hop_install_cni
     when "NotStarted"
       params = {
+        node_name: vm.name,
         cluster_name: kubernetes_cluster.name,
         lb_hostname: kubernetes_cluster.endpoint,
         port: "443",
@@ -143,6 +144,7 @@ BASH
     when "NotStarted"
       cp_sshable = kubernetes_cluster.sshable
       params = {
+        node_name: vm.name,
         cluster_endpoint: "#{kubernetes_cluster.endpoint}:443",
         join_token: cp_sshable.cmd("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).chomp,
         certificate_key: cp_sshable.cmd("sudo kubeadm init phase upload-certs --upload-certs", log: false)[/certificate key:\n(.*)/, 1],
@@ -168,6 +170,7 @@ BASH
     when "NotStarted"
       cp_sshable = kubernetes_cluster.sshable
       params = {
+        node_name: vm.name,
         endpoint: "#{kubernetes_cluster.endpoint}:443",
         join_token: cp_sshable.cmd("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).tr("\n", ""),
         discovery_token_ca_cert_hash: cp_sshable.cmd("sudo kubeadm token create --print-join-command", log: false)[/discovery-token-ca-cert-hash (.*)/, 1]

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -14,6 +14,7 @@ begin
   private_subnet_cidr4 = params.fetch("private_subnet_cidr4")
   private_subnet_cidr6 = params.fetch("private_subnet_cidr6")
   vm_cidr = params.fetch("vm_cidr")
+  node_name = params.fetch("node_name")
 rescue KeyError => e
   puts "Needed #{e.key} in parameters"
   exit 1
@@ -57,7 +58,7 @@ config_path = "/tmp/kubeadm-config.yaml"
 
 safe_write_to_file(config_path, config.to_yaml)
 
-r "sudo kubeadm init --config #{config_path}"
+r "sudo kubeadm init --config #{config_path} --node-name #{node_name}"
 
 r("sudo /home/ubi/kubernetes/bin/setup-cni")
 

--- a/rhizome/kubernetes/bin/join-control-plane-node
+++ b/rhizome/kubernetes/bin/join-control-plane-node
@@ -11,11 +11,12 @@ begin
   join_token = params.fetch("join_token")
   discovery_token_ca_cert_hash = params.fetch("discovery_token_ca_cert_hash")
   certificate_key = params.fetch("certificate_key")
+  node_name = params.fetch("node_name")
 rescue KeyError => e
   puts "Needed #{e.key} in parameters"
   exit 1
 end
 
-r "kubeadm join #{cluster_endpoint} --control-plane --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash} --certificate-key #{certificate_key}"
+r "kubeadm join #{cluster_endpoint} --control-plane --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash} --certificate-key #{certificate_key} --node-name #{node_name}"
 
 r("sudo /home/ubi/kubernetes/bin/setup-cni")

--- a/rhizome/kubernetes/bin/join-worker-node
+++ b/rhizome/kubernetes/bin/join-worker-node
@@ -10,11 +10,12 @@ begin
   endpoint = params.fetch("endpoint")
   join_token = params.fetch("join_token")
   discovery_token_ca_cert_hash = params.fetch("discovery_token_ca_cert_hash")
+  node_name = params.fetch("node_name")
 rescue KeyError => e
   puts "Needed #{e.key} in parameters"
   exit 1
 end
 
-r "kubeadm join #{endpoint} --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash}"
+r "kubeadm join #{endpoint} --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash} --node-name #{node_name}"
 
 r("sudo /home/ubi/kubernetes/bin/setup-cni")

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(kubernetes_cluster.cp_vms.count).to eq(3)
 
       new_vm = kubernetes_cluster.cp_vms.last
-      expect(new_vm.name).to start_with("k8scluster-control-plane-")
+      expect(new_vm.name).to start_with("#{kubernetes_cluster.ubid}-")
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(4)
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq(37)
@@ -101,7 +101,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(kubernetes_nodepool.reload.vms.count).to eq(1)
 
       new_vm = kubernetes_nodepool.vms.last
-      expect(new_vm.name).to start_with("k8stest-np-")
+      expect(new_vm.name).to start_with("#{kubernetes_nodepool.ubid}-")
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(8)
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq(78)
@@ -189,7 +189,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(prog.vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: "10.0.0.37")])
       expect(prog.vm.sshable).to receive(:cmd).with(
         "common/bin/daemonizer /home/ubi/kubernetes/bin/init-cluster init_kubernetes_cluster",
-        stdin: /{"cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"127.0.0.0\/8","private_subnet_cidr6":"::\/16","vm_cidr":"10.0.0.37"}/
+        stdin: /{"node_name":"test-vm","cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"127.0.0.0\/8","private_subnet_cidr6":"::\/16","vm_cidr":"10.0.0.37"}/
       )
 
       expect { prog.init_cluster }.to nap(30)
@@ -229,7 +229,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
       expect(prog.vm.sshable).to receive(:cmd).with(
         "common/bin/daemonizer kubernetes/bin/join-control-plane-node join_control_plane",
-        stdin: /{"cluster_endpoint":"somelb\..*:443","join_token":"jt","certificate_key":"ck","discovery_token_ca_cert_hash":"dtcch"}/,
+        stdin: /{"node_name":"test-vm","cluster_endpoint":"somelb\..*:443","join_token":"jt","certificate_key":"ck","discovery_token_ca_cert_hash":"dtcch"}/,
         log: false
       )
 
@@ -272,7 +272,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
       expect(prog.vm.sshable).to receive(:cmd).with(
         "common/bin/daemonizer kubernetes/bin/join-worker-node join_worker",
-        stdin: /{"endpoint":"somelb\..*:443","join_token":"jt","discovery_token_ca_cert_hash":"dtcch"}/,
+        stdin: /{"node_name":"test-vm","endpoint":"somelb\..*:443","join_token":"jt","discovery_token_ca_cert_hash":"dtcch"}/,
         log: false
       )
 


### PR DESCRIPTION
Previously, we gave names like "clustername-control-plane-something" to k8s cluster nodes in CP side and let them default to VM inhost names in the DP side.

This commit changes the node names to cluster and nodepool UBID based strings in CP and DP. The current format is something like `{(cluster|nodepool).ubid}-{r4nd0}`.

Alternatively, we can provide VM ubids as names to k8s and use them. However, associating VMs with cluster or nodepools in the names seemed more intuitive to me.

One technicality I couldn't figure out was the node name setting during init phase. I initially tried supplying the node name through `nodeRegistration.name` in the kubeadm-config.yaml, but couldn't make it work.