### PR TITLE
Remove unnecessary join table for some associations

### DIFF
--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -4,14 +4,10 @@ require_relative "../../model"
 
 class MinioCluster < Sequel::Model
   many_to_one :project
-  one_to_many :pools, key: :cluster_id, class: :MinioPool do |ds|
-    ds.order(:start_index)
-  end
-  many_through_many :servers, [[:minio_pool, :cluster_id, :id], [:minio_server, :minio_pool_id, :id]], class: :MinioServer do |ds|
-    ds.order(:index)
-  end
+  one_to_many :pools, key: :cluster_id, class: :MinioPool, order: :start_index
+  many_to_many :servers, join_table: :minio_pool, left_key: :cluster_id, right_key: :id, right_primary_key: :minio_pool_id, class: :MinioServer, order: :index
   one_to_one :strand, key: :id
-  many_to_one :private_subnet, key: :private_subnet_id
+  many_to_one :private_subnet
 
   include ResourceMethods
   include SemaphoreMethods

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -3,10 +3,8 @@
 require_relative "../../model"
 
 class MinioPool < Sequel::Model
-  many_to_one :cluster, key: :cluster_id, class: :MinioCluster
-  one_to_many :servers, key: :minio_pool_id, class: :MinioServer do |ds|
-    ds.order(:index)
-  end
+  many_to_one :cluster, class: :MinioCluster
+  one_to_many :servers, key: :minio_pool_id, class: :MinioServer, order: :index
   one_to_one :strand, key: :id
 
   include ResourceMethods

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -6,10 +6,10 @@ require_relative "../../model"
 class MinioServer < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :project
-  many_to_one :vm, key: :vm_id, class: :Vm
+  many_to_one :vm
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
   many_to_one :pool, key: :minio_pool_id, class: :MinioPool
-  one_through_many :cluster, [[:minio_server, :id, :minio_pool_id], [:minio_pool, :id, :cluster_id]], class: :MinioCluster
+  one_through_one :cluster, join_table: :minio_pool, left_primary_key: :minio_pool_id, left_key: :id, class: :MinioCluster
 
   include ResourceMethods
   include SemaphoreMethods

--- a/model/project.rb
+++ b/model/project.rb
@@ -7,12 +7,12 @@ class Project < Sequel::Model
   one_to_many :subject_tags, order: :name
   one_to_many :action_tags, order: :name
   one_to_many :object_tags, order: :name
-  one_to_one :billing_info, key: :id, primary_key: :billing_info_id
+  many_to_one :billing_info
   one_to_many :usage_alerts
   one_to_many :github_installations
-  many_through_many :github_runners, [[:github_installation, :project_id, :id], [:github_runner, :installation_id, :id]]
+  many_to_many :github_runners, join_table: :github_installation, right_key: :id, right_primary_key: :installation_id
 
-  many_to_many :accounts, join_table: :access_tag, left_key: :project_id, right_key: :hyper_tag_id
+  many_to_many :accounts, join_table: :access_tag, right_key: :hyper_tag_id
   one_to_many :vms
   one_to_many :minio_clusters
   one_to_many :private_subnets
@@ -25,8 +25,8 @@ class Project < Sequel::Model
   RESOURCE_ASSOCIATIONS = %i[vms minio_clusters private_subnets postgres_resources firewalls load_balancers kubernetes_clusters]
 
   one_to_many :invoices, order: Sequel.desc(:created_at)
-  one_to_many :quotas, class: :ProjectQuota, key: :project_id
-  one_to_many :invitations, class: :ProjectInvitation, key: :project_id
+  one_to_many :quotas, class: :ProjectQuota
+  one_to_many :invitations, class: :ProjectInvitation
   one_to_many :api_keys, key: :owner_id, class: :ApiKey, conditions: {owner_table: "project"}
 
   dataset_module Pagination


### PR DESCRIPTION
Having the associated model's or current model's table as a join table is almost always a bad idea unless the table contains self-referential foreign keys.

While here, use the :order option instead of an association block, and remove unnecessary association options.