### PR TITLE
Fix cloudify_server script, adapting to Location being moved to DB

### DIFF
--- a/demo/cloudify_server
+++ b/demo/cloudify_server
@@ -6,7 +6,7 @@ REPL = true
 require_relative "../loader"
 require "timeout"
 
-LOCATIONS = Option::LOCATIONS.map { |l| [l, "#{l.provider.display_name} #{l.display_name}"] }.to_h
+LOCATIONS = Location.where(visible: true).map { |l| [l, "#{l.provider} #{l.name} (#{l.display_name})"] }.to_h
 
 def get_input(msg, default = nil)
   prompt = "#{msg}#{default.nil? ? "" : " [default: #{default}]"}: "
@@ -54,7 +54,7 @@ puts "\n\nCloudifying '#{hostname}' server for '#{LOCATIONS[location]}' \n\n"
 
 strand = Prog::Vm::HostNexus.assemble(
   hostname,
-  provider_name: location.provider.name,
+  provider_name: location.provider,
   server_identifier: host_id,
   location: location.name,
   default_boot_images: ["ubuntu-jammy"]


### PR DESCRIPTION
 This patch fixes the cloudify_server script, which was broken with
    recent changes that move Locations from hard-coded files to the
    database.

While doing so, this patch also makes some UI changes, by including
    the native names of the locations alongside their Ubicloud names, and
    hiding some internal-only locations for simplicity.
    
Fixes the issue discussed in #2948, thanks @chgaviria