### PR TITLE
Attempt to avoid the 2 most common production Sequel unhandled exceptions

### DIFF
--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -12,9 +12,11 @@ class GithubCacheEntry < Sequel::Model
   include ResourceMethods
 
   dataset_module do
-    def destroy_where(...)
+    # The same as Dataset#destroy, except that it adds the given condition
+    # to the WHERE clause of the DELETE statement for each destroyed row.
+    def destroy_where(cond)
       all do |entry|
-        entry.destroy_where(...)
+        entry.destroy_where(cond)
       end
     end
   end
@@ -23,13 +25,13 @@ class GithubCacheEntry < Sequel::Model
     "cache/#{ubid}"
   end
 
-  def destroy_where(...)
-    instance_filter(...)
+  def destroy_where(cond)
+    instance_filter(cond)
     db.transaction(savepoint: true) do
       destroy
     end
   rescue Sequel::NoExistingObject
-    # DELETE query modified no rows due to filter
+    # DELETE statement modified no rows due to filter
   end
 
   def after_destroy

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -48,7 +48,8 @@ class Clover
 
       fail CloverError.new(204, "NotFound", "No cache entry") if entry.nil?
 
-      entry.update(last_accessed_at: Time.now, last_accessed_by: runner.id)
+      # Entry may no longer exist, use this.update to avoid raising an error in that case
+      entry.this.update(last_accessed_at: Sequel::CURRENT_TIMESTAMP, last_accessed_by: runner.id)
       signed_url = repository.url_presigner.presigned_url(:get_object, bucket: repository.bucket_name, key: entry.blob_key, expires_in: 900)
 
       {

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -79,26 +79,28 @@ class Clover
       return error("A workflow_job without runner_id")
     end
 
-    runner = GithubRunner.first(
-      installation_id: installation.id,
-      repository_name: data["repository"]["full_name"],
-      runner_id: runner_id
-    )
+    DB.transaction do
+      runner = GithubRunner.for_update.first(
+        installation_id: installation.id,
+        repository_name: data["repository"]["full_name"],
+        runner_id: runner_id
+      )
 
-    return error("Unregistered runner") unless runner
+      return error("Unregistered runner") unless runner
 
-    runner.update(workflow_job: job.except("steps"))
+      runner.update(workflow_job: job.except("steps"))
 
-    case data["action"]
-    when "in_progress"
-      runner.log_duration("runner_started", Time.parse(job["started_at"]) - Time.parse(job["created_at"]))
-      success("GithubRunner[#{runner.ubid}] picked job #{job.fetch("id")}")
-    when "completed"
-      runner.incr_destroy
+      case data["action"]
+      when "in_progress"
+        runner.log_duration("runner_started", Time.parse(job["started_at"]) - Time.parse(job["created_at"]))
+        success("GithubRunner[#{runner.ubid}] picked job #{job.fetch("id")}")
+      when "completed"
+        runner.incr_destroy
 
-      success("GithubRunner[#{runner.ubid}] deleted")
-    else
-      error("Unhandled workflow_job action")
+        success("GithubRunner[#{runner.ubid}] deleted")
+      else
+        error("Unhandled workflow_job action")
+      end
     end
   end
 end

--- a/spec/model/github/github_cache_entry_spec.rb
+++ b/spec/model/github/github_cache_entry_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GithubCacheEntry do
 
   let(:repository) { GithubRepository.create_with_id(name: "test") }
 
-  describe ".after_destroy" do
+  describe "#after_destroy" do
     let(:client) { instance_double(Aws::S3::Client) }
 
     before { allow(Aws::S3::Client).to receive(:new).and_return(client) }
@@ -36,6 +36,48 @@ RSpec.describe GithubCacheEntry do
       expect(client).to receive(:abort_multipart_upload).and_raise(Aws::S3::Errors::NoSuchUpload.new(nil, nil))
       expect(client).to receive(:delete_object)
       entry.destroy
+    end
+  end
+
+  describe ".destory_where" do
+    let(:client) { instance_double(Aws::S3::Client) }
+
+    before { allow(Aws::S3::Client).to receive(:new).and_return(client) }
+
+    it "destroy the objects if matched by filter" do
+      archive_count = ArchivedRecord.count
+      entry
+      expect(client).to receive(:abort_multipart_upload).with(bucket: repository.bucket_name, key: entry.blob_key, upload_id: entry.upload_id)
+      expect(client).to receive(:delete_object)
+      described_class.destroy_where(key: "k1")
+      expect(entry).not_to exist
+      expect(ArchivedRecord.count).to eq(archive_count + 1)
+    end
+
+    it "does not destroy the object if it is not matched by the filter" do
+      archive_count = ArchivedRecord.count
+      entry
+      described_class.destroy_where(key: "k2")
+      expect(entry).to exist
+      expect(ArchivedRecord.count).to eq archive_count
+    end
+  end
+
+  describe "#destory_where" do
+    it "destroy the objects if it is matched by the filter" do
+      archive_count = ArchivedRecord.count
+      expect(entry).to receive(:after_destroy).and_return(nil)
+      expect(entry.destroy_where(key: "k1")).to eq entry
+      expect(entry).not_to exist
+      expect(ArchivedRecord.count).to eq(archive_count + 1)
+    end
+
+    it "does not destroy the object if it is not matched by the filter" do
+      archive_count = ArchivedRecord.count
+      expect(entry).not_to receive(:after_destroy)
+      expect(entry.destroy_where(key: "k2")).to be_nil
+      expect(entry).to exist
+      expect(ArchivedRecord.count).to eq archive_count
     end
   end
 end

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -105,8 +105,7 @@ RSpec.describe Clover, "github" do
 
     it "updates job details of runner when receive in_progress action" do
       expect(Clog).to receive(:emit).with("runner_started")
-      expect(runner).to receive(:vm).and_return(instance_double(Vm, ubid: "vm-ubid", arch: "x64", cores: 2, vcpus: 4, vm_host: nil, pool_id: nil)).at_least(:once)
-      expect(GithubRunner).to receive(:first).and_return(runner)
+      runner
       send_webhook("workflow_job", workflow_job_payload(action: "in_progress", workflow_job: workflow_job_object(runner_id: runner.runner_id)))
 
       expect(page.status_code).to eq(200)
@@ -125,7 +124,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "fails if unexpected action" do
-      expect(GithubRunner).to receive(:first).and_return(runner)
+      runner
       send_webhook("workflow_job", workflow_job_payload(action: "approved"))
 
       expect(page.status_code).to eq(200)


### PR DESCRIPTION
This attempts to avoid two cases that raise `Sequel::NoExistingObject` in race conditions.  These cases are similar:

1. Retrieve object in route
2. Concurrent deletion of object (presumably by respirate)
3. Attempt to update object in route, raises as object no longer exists

In one case, this switches from Model#update to Dataset#update to implicitly ignore the case where the object was deleted.  In the other case, this uses a transaction with FOR UPDATE to ensure the object is not deleted between when it was retrieved and when it was updated.