### PR TITLE
Disconnect Sequel::Database instance before fork

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+web: bundle exec puma -C puma_config.rb
 respirate: bin/respirate
 monitor: bin/monitor

--- a/bin/production_check
+++ b/bin/production_check
@@ -4,12 +4,14 @@
 Dir.chdir(File.dirname(__dir__))
 
 require "open3"
+require "net/http"
+require "json"
 
 works = nil
 error = +""
 queue = Queue.new
 
-Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma", "-p", "8081") do |stdin, stdout, stderr, wait_thr|
+Open3.popen3({"RACK_ENV" => "production", "PORT" => "8081", "WEB_CONCURRENCY" => "1"}, "bundle", "exec", "puma", "-C", "puma_config.rb") do |stdin, stdout, stderr, wait_thr|
   pid = wait_thr.pid
 
   timer_thread = Thread.new do
@@ -23,11 +25,15 @@ Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma", "-p", "8081
   stdout_thread = Thread.new do
     while (line = stdout.gets)
       case line
-      when /\A\* Listening on /
-        works = true
+      when /\A\[\d+\] - Worker 0 \(PID: \d+\) booted in \d+.\d+s, phase: 0/
         puts line
+        response = Net::HTTP.post(URI("http://localhost:8081/login"),
+          {"login" => "foo@example.com", "password" => "bar"}.to_json,
+          {"content-type" => "application/json", "host" => "api.localhost"})
+        works = response.is_a?(Net::HTTPUnauthorized)
         queue.push(true)
         Process.kill(:TERM, pid)
+        puts stdout.read
         break
       when /\A! Unable to load application: /
         error << line
@@ -45,9 +51,11 @@ Open3.popen3({"RACK_ENV" => "production"}, "bundle", "exec", "puma", "-p", "8081
     err = stderr.read(1)
     if !err.nil?
       error << err << stderr.read_nonblock(100000)
-      works = false
-      queue.push(true)
-      Process.kill(:TERM, pid)
+      unless /"POST \/login HTTP\/1\.1*" 401 \d+ \d\.\d+\n\z/.match?(error)
+        works = false
+        queue.push(true)
+        Process.kill(:TERM, pid)
+      end
     end
   end
 

--- a/puma_config.rb
+++ b/puma_config.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# :nocov:
+environment ENV["RACK_ENV"] || "development"
+port ENV["PORT"] || "3000"
+threads 5, 5
+
+if @config.options[:workers] > 0
+  silence_single_worker_warning
+  preload_app!
+
+  before_fork do
+    Sequel::DATABASES.each(&:disconnect)
+  end
+end
+# :nocov:


### PR DESCRIPTION
Without this, we are getting exceptions in production shortly after deployment due to multiple processes sharing database connections.

Update bin/production_check to try to use a clustered, preloaded puma, since I assume that is what we must be running in production.