### PR TITLE
Introduce LoadBalancer management functionality of CloudControllerManager

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -8,7 +8,7 @@ resources = {}
 mutex = Mutex.new
 
 resource_scanner = Thread.new do
-  monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice, LoadBalancerVmPort]
+  monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice, LoadBalancerVmPort, KubernetesCluster]
 
   loop do
     mutex.synchronize do

--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class Kubernetes::Client
+  def initialize(kubernetes_cluster, session)
+    @session = session
+    @kubernetes_cluster = kubernetes_cluster
+    @load_balancer = LoadBalancer.where(name: kubernetes_cluster.services_load_balancer_name).first
+  end
+
+  def service_deleted?(svc)
+    !!svc.dig("metadata", "deletionTimestamp")
+  end
+
+  # Returns a flat array of [port, nodePort] pairs from all services
+  # Format: [[src_port_0, dst_port_0], [src_port_1, dst_port_1], ...]
+  def lb_desired_ports(svc_list)
+    svc_list.flat_map do |svc|
+      svc.dig("spec", "ports")&.map { |port| [port["port"], port["nodePort"]] } || []
+    end
+  end
+
+  def load_balancer_hostname_missing?(svc)
+    svc.dig("status", "loadBalancer", "ingress")&.first&.dig("hostname").to_s.empty?
+  end
+
+  def kubectl(cmd)
+    @session.exec!("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf #{cmd}")
+  end
+
+  def set_load_balancer_hostname(svc, hostname)
+    patch_data = JSON.generate({
+      "status" => {
+        "loadBalancer" => {
+          "ingress" => [{"hostname" => hostname}]
+        }
+      }
+    })
+    kubectl("-n #{svc.dig("metadata", "namespace")} patch service #{svc.dig("metadata", "name")} --type=merge -p '#{patch_data}' --subresource=status")
+  end
+
+  def sync_kubernetes_services
+    k8s_svc_raw = kubectl("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson")
+    svc_list = JSON.parse(k8s_svc_raw)["items"]
+
+    if @load_balancer.nil?
+      raise "services load balancer does not exist."
+    end
+
+    extra_vms, missing_vms = @kubernetes_cluster.vm_diff_for_lb(@load_balancer)
+    missing_vms.each { |missing_vm| @load_balancer.add_vm(missing_vm) }
+    extra_vms.each { |extra_vm| @load_balancer.detach_vm(extra_vm) }
+
+    extra_ports, missing_ports = @kubernetes_cluster.port_diff_for_lb(@load_balancer, lb_desired_ports(svc_list))
+    extra_ports.each { |port| @load_balancer.remove_port(port) }
+    missing_ports.each { |port| @load_balancer.add_port(port[0], port[1]) }
+
+    return unless @load_balancer.strand.label == "wait"
+    svc_list.each { |svc| set_load_balancer_hostname(svc, @load_balancer.hostname) }
+  end
+
+  def any_lb_services_modified?
+    k8s_svc_raw = kubectl("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson")
+    svc_list = JSON.parse(k8s_svc_raw)["items"]
+
+    return true if svc_list.empty? && !@load_balancer.ports.empty?
+
+    extra_vms, missing_vms = @kubernetes_cluster.vm_diff_for_lb(@load_balancer)
+    return true unless extra_vms.empty? && missing_vms.empty?
+
+    extra_ports, missing_ports = @kubernetes_cluster.port_diff_for_lb(@load_balancer, lb_desired_ports(svc_list))
+    return true unless extra_ports.empty? && missing_ports.empty?
+
+    svc_list.any? { |svc| load_balancer_hostname_missing?(svc) }
+  end
+end

--- a/loader.rb
+++ b/loader.rb
@@ -62,6 +62,8 @@ module Hosting; end
 
 module Minio; end
 
+module Kubernetes; end
+
 module Prog; end
 
 module Prog::Ai; end

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+RSpec.describe Kubernetes::Client do
+  let(:project) { Project.create(name: "test") }
+  let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: Location::HETZNER_FSN1_ID, net6: "fe80::/64", net4: "192.168.0.0/24") }
+  let(:kubernetes_cluster) {
+    KubernetesCluster.create(
+      name: "test",
+      version: "v1.32",
+      cp_node_count: 3,
+      private_subnet_id: private_subnet.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      project_id: project.id,
+      target_node_size: "standard-2"
+    )
+  }
+  let(:session) { instance_double(Net::SSH::Connection::Session) }
+  let(:kubernetes_client) { described_class.new(kubernetes_cluster, session) }
+
+  describe "service_deleted?" do
+    it "detects deleted service" do
+      svc = {
+        "metadata" => {
+          "deletionTimestamp" => "asdf"
+        }
+      }
+      expect(kubernetes_client.service_deleted?(svc)).to be(true)
+    end
+
+    it "detects not deleted service" do
+      svc = {
+        "metadata" => {}
+      }
+      expect(kubernetes_client.service_deleted?(svc)).to be(false)
+    end
+  end
+
+  describe "lb_desired_ports" do
+    it "returns desired ports" do
+      svc_list = [
+        {
+          "spec" => {
+            "ports" => [
+              {"port" => 80, "nodePort" => 31942},
+              {"port" => 443, "nodePort" => 33212}
+            ]
+          }
+        },
+        {
+          "spec" => {
+            "ports" => [
+              {"port" => 800, "nodePort" => 32942}
+            ]
+          }
+        }
+      ]
+      expect(kubernetes_client.lb_desired_ports(svc_list)).to eq([[80, 31942], [443, 33212], [800, 32942]])
+    end
+  end
+
+  describe "load_balancer_hostname_missing?" do
+    it "returns false when hostname is present" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => [
+              {"hostname" => "asdf.com"}
+            ]
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(false)
+    end
+
+    it "returns true when ingress is an empty hash" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => {}
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+
+    it "returns true when ingress is nil" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => nil
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+
+    it "returns true when ingress is an empty array" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => []
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+
+    it "returns true when hostname key is missing" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => [{}]
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+
+    it "returns true when hostname is nil" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => [{"hostname" => nil}]
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+
+    it "returns true when hostname is empty string" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => [{"hostname" => ""}]
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+
+    it "returns false when hostname is present in the first ingress even if others are missing" do
+      svc = {
+        "status" => {
+          "loadBalancer" => {
+            "ingress" => [
+              {"hostname" => "example.com"},
+              {"hostname" => nil}
+            ]
+          }
+        }
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(false)
+    end
+
+    it "returns true when loadBalancer key is missing" do
+      svc = {
+        "status" => {}
+      }
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+
+    it "returns true when status key is missing" do
+      svc = {}
+      expect(kubernetes_client.load_balancer_hostname_missing?(svc)).to be(true)
+    end
+  end
+
+  describe "kubectl" do
+    it "runs kubectl command in the right format" do
+      expect(session).to receive(:exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes")
+      kubernetes_client.kubectl("get nodes")
+    end
+  end
+
+  describe "set_load_balancer_hostname" do
+    it "calls kubectl function with right inputs" do
+      svc = {
+        "metadata" => {
+          "namespace" => "default",
+          "name" => "test-svc"
+        }
+      }
+      expect(kubernetes_client).to receive(:kubectl).with("-n default patch service test-svc --type=merge -p '{\"status\":{\"loadBalancer\":{\"ingress\":[{\"hostname\":\"asdf.com\"}]}}}' --subresource=status")
+      kubernetes_client.set_load_balancer_hostname(svc, "asdf.com")
+    end
+  end
+
+  describe "any_lb_services_modified?" do
+    before do
+      @lb = Prog::Vnet::LoadBalancerNexus.assemble(private_subnet.id, name: kubernetes_cluster.services_load_balancer_name, src_port: 80, dst_port: 8000).subject
+      @response = {
+        "items" => [{}]
+      }.to_json
+      allow(kubernetes_client).to receive(:kubectl).with("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(@response)
+    end
+
+    it "returns true early since there are no LoadBalancer services but there is a port" do
+      response = {
+        "items" => []
+      }.to_json
+      expect(kubernetes_client).to receive(:kubectl).with("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
+      expect(kubernetes_client.any_lb_services_modified?).to be(true)
+    end
+
+    it "determines lb_service is modified because vm_diff is not empty" do
+      expect(kubernetes_cluster).to receive(:vm_diff_for_lb).and_return([[instance_double(Vm)], []])
+      expect(kubernetes_client.any_lb_services_modified?).to be(true)
+
+      expect(kubernetes_cluster).to receive(:vm_diff_for_lb).and_return([[], [instance_double(Vm)]])
+      expect(kubernetes_client.any_lb_services_modified?).to be(true)
+    end
+
+    it "determines lb_service is modified because port_diff is not empty" do
+      allow(kubernetes_cluster).to receive(:vm_diff_for_lb).and_return([[], []])
+
+      expect(kubernetes_cluster).to receive(:port_diff_for_lb).and_return([[], [instance_double(LoadBalancerPort)]])
+      expect(kubernetes_client.any_lb_services_modified?).to be(true)
+
+      expect(kubernetes_cluster).to receive(:port_diff_for_lb).and_return([[instance_double(LoadBalancerPort)], []])
+      expect(kubernetes_client.any_lb_services_modified?).to be(true)
+    end
+
+    it "determintes the modification because hostname is not set" do
+      response = {
+        "items" => [
+          {
+            "status" => {
+              "loadBalancer" => {
+                "ingress" => [
+                  {}
+                ]
+              }
+            }
+          }
+        ]
+      }.to_json
+      expect(kubernetes_client).to receive(:kubectl).with("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
+
+      allow(kubernetes_cluster).to receive_messages(
+        vm_diff_for_lb: [[], []],
+        port_diff_for_lb: [[], []]
+      )
+      expect(kubernetes_client.any_lb_services_modified?).to be(true)
+    end
+  end
+
+  describe "sync_kubernetes_services" do
+    before do
+      @lb = Prog::Vnet::LoadBalancerNexus.assemble(private_subnet.id, name: kubernetes_cluster.services_load_balancer_name, src_port: 443, dst_port: 8443).subject
+      @response = {
+        "items" => [{}]
+      }.to_json
+      allow(kubernetes_client).to receive(:kubectl).with("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(@response)
+    end
+
+    it "reconciles with pre existing lb with not ready loadbalancer" do
+      @lb.strand.update(label: "not waiting")
+      missing_port = [80, 8000]
+      missing_vm = create_vm
+      extra_vm = create_vm
+      allow(kubernetes_client).to receive(:lb_desired_ports).and_return([[30122, 80]])
+      allow(kubernetes_cluster).to receive_messages(
+        vm_diff_for_lb: [[extra_vm], [missing_vm]],
+        port_diff_for_lb: [[@lb.ports.first], [missing_port]]
+      )
+      expect(kubernetes_client).not_to receive(:set_load_balancer_hostname)
+      kubernetes_client.sync_kubernetes_services
+    end
+
+    it "reconciles with pre existing lb with ready loadbalancer" do
+      missing_port = [80, 8000]
+      missing_vm = create_vm
+      extra_vm = create_vm
+      allow(kubernetes_client).to receive(:lb_desired_ports).and_return([[30122, 80]])
+      allow(kubernetes_cluster).to receive_messages(
+        vm_diff_for_lb: [[extra_vm], [missing_vm]],
+        port_diff_for_lb: [[@lb.ports.first], [missing_port]]
+      )
+      expect(kubernetes_client).to receive(:set_load_balancer_hostname)
+      kubernetes_client.sync_kubernetes_services
+    end
+
+    it "raises error with non existing lb" do
+      kubernetes_client = described_class.new(instance_double(KubernetesCluster, services_load_balancer_name: "random_name"), instance_double(Net::SSH::Connection::Session))
+      allow(kubernetes_client).to receive(:kubectl).with("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return({"items" => [{}]}.to_json)
+      expect { kubernetes_client.sync_kubernetes_services }.to raise_error("services load balancer does not exist.")
+    end
+  end
+end


### PR DESCRIPTION
For kubernetes clusters, we will watch the Services with type set to 'LoadBalancer' and create corresponding Ubicloud loadbalancers and also react to port/vm removals or additions.