### PR TITLE
Install rhizome programs in all Vm based services to /home/rhizome

### DIFF
--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -16,7 +16,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
 
       inference_endpoint = InferenceEndpoint[inference_endpoint_id]
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
+        "rhizome",
         Config.inference_endpoint_service_project_id,
         location: inference_endpoint.location,
         name: ubid.to_s,

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -20,7 +20,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
 
     DB.transaction do
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
+        "rhizome",
         Config.dns_service_project_id,
         location: location,
         name: name,

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -39,7 +39,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     storage_volumes = [{encrypted: true, size_gib: storage_size_gib}] if storage_size_gib
 
     vm = Prog::Vm::Nexus.assemble_with_sshable(
-      "ubi",
+      "rhizome",
       kubernetes_cluster.project.id,
       name: name,
       location: kubernetes_cluster.location,

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -19,7 +19,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       ubid = MinioServer.generate_ubid
 
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
+        "rhizome",
         Config.minio_service_project_id,
         location: minio_pool.cluster.location,
         name: ubid.to_s,

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -23,7 +23,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       end
 
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
+        "rhizome",
         Config.postgres_service_project_id,
         location: postgres_resource.location,
         name: ubid.to_s,

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -38,8 +38,9 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
 
       expect(described_class.assemble(ds.id)).to be_a Strand
 
-      expect(Vm.count).to eq 1
-      expect(Vm.first.unix_user).to eq "rhizome"
+      vms = Vm.limit(2).all
+      expect(vms.count).to eq 1
+      expect(vms.first.unix_user).to eq "rhizome"
     end
 
     it "errors out if the dns service project id is not put into config properly" do

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       expect(described_class.assemble(ds.id)).to be_a Strand
 
       expect(Vm.count).to eq 1
-      expect(Vm.first.unix_user).to eq "ubi"
+      expect(Vm.first.unix_user).to eq "rhizome"
     end
 
     it "errors out if the dns service project id is not put into config properly" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -64,16 +64,18 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(MinioServer.count).to eq 1
       expect(st.label).to eq "start"
       expect(MinioServer.first.pool).to eq minio_pool
-      expect(Vm.count).to eq 1
-      expect(Vm.first.unix_user).to eq "rhizome"
-      expect(Vm.first.sshable.host).to eq "temp_#{Vm.first.id}"
-      expect(Vm.first.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
+      vms = Vm.all
+      expect(vms.count).to eq 1
+      vm = vms.first
+      expect(vm.unix_user).to eq "rhizome"
+      expect(vm.sshable.host).to eq "temp_#{vm.id}"
+      expect(vm.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
 
-      expect(Vm.first.strand.stack[0]["storage_volumes"].length).to eq 2
-      expect(Vm.first.strand.stack[0]["storage_volumes"][0]["encrypted"]).to be true
-      expect(Vm.first.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 30
-      expect(Vm.first.strand.stack[0]["storage_volumes"][1]["encrypted"]).to be true
-      expect(Vm.first.strand.stack[0]["storage_volumes"][1]["size_gib"]).to eq 100
+      expect(vm.strand.stack[0]["storage_volumes"].length).to eq 2
+      expect(vm.strand.stack[0]["storage_volumes"][0]["encrypted"]).to be true
+      expect(vm.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 30
+      expect(vm.strand.stack[0]["storage_volumes"][1]["encrypted"]).to be true
+      expect(vm.strand.stack[0]["storage_volumes"][1]["size_gib"]).to eq 100
     end
 
     it "fails if pool is not valid" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -70,12 +70,10 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(vm.unix_user).to eq "rhizome"
       expect(vm.sshable.host).to eq "temp_#{vm.id}"
       expect(vm.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
-
-      expect(vm.strand.stack[0]["storage_volumes"].length).to eq 2
-      expect(vm.strand.stack[0]["storage_volumes"][0]["encrypted"]).to be true
-      expect(vm.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 30
-      expect(vm.strand.stack[0]["storage_volumes"][1]["encrypted"]).to be true
-      expect(vm.strand.stack[0]["storage_volumes"][1]["size_gib"]).to eq 100
+      expect(vm.strand.stack[0]["storage_volumes"].map { _1.slice("encrypted", "size_gib") }).to eq([
+        {"encrypted" => true, "size_gib" => 30},
+        {"encrypted" => true, "size_gib" => 100}
+      ])
     end
 
     it "fails if pool is not valid" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(st.label).to eq "start"
       expect(MinioServer.first.pool).to eq minio_pool
       expect(Vm.count).to eq 1
-      expect(Vm.first.unix_user).to eq "ubi"
+      expect(Vm.first.unix_user).to eq "rhizome"
       expect(Vm.first.sshable.host).to eq "temp_#{Vm.first.id}"
       expect(Vm.first.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -76,17 +76,19 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).not_to be_nil
-        expect(Vm.first.ip4_enabled).to be_falsey
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).not_to be_nil
+        expect(vm.ip4_enabled).to be_falsey
 
         visit project.path
         expect(page).to have_content("2/32 (6%)")
-        Vm.first.update(vcpus: 25)
+        vm.update(vcpus: 25)
         page.refresh
         expect(page).to have_content("25/32 (78%)")
-        Vm.first.update(vcpus: 31)
+        vm.update(vcpus: 31)
         page.refresh
         expect(page).to have_content("31/32 (96%)")
       end
@@ -182,10 +184,12 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).not_to be_nil
-        expect(Vm.first.ip4_enabled).to be_truthy
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).not_to be_nil
+        expect(vm.ip4_enabled).to be_truthy
       end
 
       it "can create new virtual machine with chosen private subnet" do
@@ -207,9 +211,11 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).to eq(ps.id)
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).to eq(ps.id)
       end
 
       it "can create new virtual machine in default location subnet" do
@@ -231,10 +237,12 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).not_to eq(ps.id)
-        expect(Vm.first.private_subnets.first.name).to eq("default-#{LocationNameConverter.to_display_name(ps.location)}")
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).not_to eq(ps.id)
+        expect(vm.private_subnets.first.name).to eq("default-#{LocationNameConverter.to_display_name(ps.location)}")
 
         # can create a second vm in the same location and it will use the same subnet
         visit "#{project.path}/vm/create"


### PR DESCRIPTION
Every managed service was going through the motions of creating a
rhizome user, and then not using it, instead installing into
/home/ubi, which is our default non-root, sudo-capable virtual machine
user.

This is bad for management of `authorized_keys` between machine and
personnel login, a future auditing system (separating administrative
and automated activity), it's bad for parity (on VmHosts, the concerns
were split as designed between `root` [which is bad for other reasons]
and rhizome, and finally, it renders 22f3aa5c, which will terminate
sessions from abandoned connections in a timely manner, but only does
so for the user name `rhizome` (via the configuration
`KillOnlyUsers=rhizome`)

