### PR TITLE
Do not create a Semaphore if there is no related Strand

### DIFF
--- a/lib/sem_snap.rb
+++ b/lib/sem_snap.rb
@@ -38,7 +38,9 @@ class SemSnap
   end
 
   def incr(name)
-    add_semaphore_instance_to_snapshot(Semaphore.incr(@strand_id, name))
+    if (semaphore = Semaphore.incr(@strand_id, name))
+      add_semaphore_instance_to_snapshot(semaphore)
+    end
   end
 
   private

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -7,8 +7,9 @@ class Semaphore < Sequel::Model
 
   def self.incr(strand_id, name)
     DB.transaction do
-      Strand.dataset.where(id: strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP)
-      Semaphore.create_with_id(strand_id: strand_id, name: name)
+      if Strand.where(id: strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) == 1
+        create(strand_id:, name:)
+      end
     end
   end
 end

--- a/spec/lib/sem_snap_spec.rb
+++ b/spec/lib/sem_snap_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SemSnap do
-  let(:st) { Strand.create_with_id(prog: "Test", label: "start") }
+  let(:st) { Strand.create(prog: "Test", label: "start") }
 
   it "can decrement semaphores" do
     described_class.use(st.id) do |snap|
@@ -38,5 +38,11 @@ RSpec.describe SemSnap do
   it "reads semaphores at initialization" do
     described_class.new(st.id).incr(:test)
     expect(described_class.new(st.id).set?(:test)).to be true
+  end
+
+  it ".incr returns nil if strand no longer exists" do
+    st.destroy
+    snap = described_class.new(st.id)
+    expect(snap.incr(:test)).to be_nil
   end
 end

--- a/spec/model/semaphore_spec.rb
+++ b/spec/model/semaphore_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Semaphore do
+  let(:st) { Strand.create(prog: "Test", label: "start") }
+
+  it ".incr returns nil and does not add Semaphore if there is no related strand" do
+    expect(described_class.all).to be_empty
+    expect(described_class.incr(Vm.generate_uuid, "foo")).to be_nil
+    expect(described_class.all).to be_empty
+  end
+
+  it ".incr raises if invalid name is given" do
+    expect { described_class.incr(st.id, nil) }.to raise_error(Sequel::ValidationFailed)
+  end
+end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -75,7 +75,7 @@ module ThawedMock
   allow_mocking(PostgresResource, :[], :generate_uuid)
   allow_mocking(PostgresServer, :create, :run_query)
   allow_mocking(Project, :[], :from_ubid, :order_by)
-  allow_mocking(Semaphore, :where)
+  allow_mocking(Semaphore, :where, :create)
   allow_mocking(Sshable, :create, :repl?)
   allow_mocking(StorageKeyEncryptionKey, :create)
   allow_mocking(Strand, :create, :create_with_id)


### PR DESCRIPTION
This is designed to handle race conditions, where the strand is deleted between when the object is retrieved and when incr_* is called.

An alternative approach would be raising an exception for this case.  That can potentially alert us to cases that pass invalid strand ids, but it would require more code to handle race conditions.  We couple have separate methods, one that raised by default, and another than can be used in cases where we know the strand id is correct, but want to avoid a race condition.  However, I'm not sure the complexity is worth it.

While here, omit unnecessary hash values, switch from create_with_id to create, and remove explicit dataset call.