### PR TITLE
Avoid unnecessary spec subclasses

### DIFF
--- a/spec/model/api_key_spec.rb
+++ b/spec/model/api_key_spec.rb
@@ -3,22 +3,20 @@
 require_relative "spec_helper"
 
 RSpec.describe ApiKey do
-  describe "ApiKey" do
-    let(:prj) {
-      Project.create_with_id(name: "test-project")
-    }
+  let(:prj) {
+    Project.create_with_id(name: "test-project")
+  }
 
-    it "can be created and rotated" do
-      expect(prj.api_keys.count).to eq 0
-      api_key = described_class.create_with_id(owner_table: "project", owner_id: prj.id, used_for: "inference_endpoint", project_id: prj.id)
-      expect(prj.reload.api_keys.count).to eq 1
-      key = api_key.key
-      api_key.rotate
-      expect(api_key.key).not_to eq key
-    end
+  it "can be created and rotated" do
+    expect(prj.api_keys.count).to eq 0
+    api_key = described_class.create_with_id(owner_table: "project", owner_id: prj.id, used_for: "inference_endpoint", project_id: prj.id)
+    expect(prj.reload.api_keys.count).to eq 1
+    key = api_key.key
+    api_key.rotate
+    expect(api_key.key).not_to eq key
+  end
 
-    it "can be created and rotated2" do
-      expect { described_class.create_with_id(owner_table: "invalid-owner", owner_id: "2d1784a8-f70d-48e7-92b1-3f428381d62f", used_for: "inference_endpoint", project_id: prj.id) }.to raise_error("Invalid owner_table: invalid-owner")
-    end
+  it "can be created and rotated2" do
+    expect { described_class.create_with_id(owner_table: "invalid-owner", owner_id: "2d1784a8-f70d-48e7-92b1-3f428381d62f", used_for: "inference_endpoint", project_id: prj.id) }.to raise_error("Invalid owner_table: invalid-owner")
   end
 end

--- a/spec/model/firewall_rule_spec.rb
+++ b/spec/model/firewall_rule_spec.rb
@@ -3,16 +3,14 @@
 require_relative "spec_helper"
 
 RSpec.describe FirewallRule do
-  describe "FirewallRule" do
-    let(:fw) {
-      Firewall.create_with_id(location: "hetzner-fsn1", project_id: Project.create(name: "test").id)
-    }
+  let(:fw) {
+    Firewall.create_with_id(location: "hetzner-fsn1", project_id: Project.create(name: "test").id)
+  }
 
-    it "returns ip6? properly" do
-      fw_rule = described_class.create_with_id(cidr: "::/0", firewall_id: fw.id)
-      expect(fw_rule.ip6?).to be true
-      fw_rule.update(cidr: "0.0.0.0/0")
-      expect(fw_rule.ip6?).to be false
-    end
+  it "returns ip6? properly" do
+    fw_rule = described_class.create_with_id(cidr: "::/0", firewall_id: fw.id)
+    expect(fw_rule.ip6?).to be true
+    fw_rule.update(cidr: "0.0.0.0/0")
+    expect(fw_rule.ip6?).to be false
   end
 end

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -3,90 +3,88 @@
 require_relative "spec_helper"
 
 RSpec.describe Firewall do
-  describe "Firewall" do
-    let(:project_id) { Project.create(name: "test").id }
+  let(:project_id) { Project.create(name: "test").id }
 
-    let(:fw) {
-      described_class.create_with_id(name: "test-fw", description: "test fw desc", location: "hetzner-fsn1", project_id:)
-    }
+  let(:fw) {
+    described_class.create_with_id(name: "test-fw", description: "test fw desc", location: "hetzner-fsn1", project_id:)
+  }
 
-    let(:ps) {
-      PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24", project_id:)
-    }
+  let(:ps) {
+    PrivateSubnet.create_with_id(name: "test-ps", location: "hetzner-fsn1", net6: "2001:db8::/64", net4: "10.0.0.0/24", project_id:)
+  }
 
-    it "inserts firewall rules" do
-      fw.insert_firewall_rule("10.0.0.16/28", Sequel.pg_range(80..5432))
-      expect(fw.firewall_rules.count).to eq(1)
-      expect(fw.firewall_rules.first.cidr.to_s).to eq("10.0.0.16/28")
-      pr = fw.firewall_rules.first.port_range
-      expect(pr.begin).to eq(80)
-      expect(pr.end).to eq(5433)
-    end
+  it "inserts firewall rules" do
+    fw.insert_firewall_rule("10.0.0.16/28", Sequel.pg_range(80..5432))
+    expect(fw.firewall_rules.count).to eq(1)
+    expect(fw.firewall_rules.first.cidr.to_s).to eq("10.0.0.16/28")
+    pr = fw.firewall_rules.first.port_range
+    expect(pr.begin).to eq(80)
+    expect(pr.end).to eq(5433)
+  end
 
-    it "increments VMs update_firewall_rules if there is a VM" do
-      private_subnet = instance_double(PrivateSubnet)
-      expect(fw).to receive(:private_subnets).and_return([private_subnet])
-      expect(private_subnet).to receive(:incr_update_firewall_rules)
-      fw.insert_firewall_rule("0.0.0.0/0", nil)
-    end
+  it "increments VMs update_firewall_rules if there is a VM" do
+    private_subnet = instance_double(PrivateSubnet)
+    expect(fw).to receive(:private_subnets).and_return([private_subnet])
+    expect(private_subnet).to receive(:incr_update_firewall_rules)
+    fw.insert_firewall_rule("0.0.0.0/0", nil)
+  end
 
-    it "bulk sets firewall rules" do
-      fw.insert_firewall_rule("10.0.0.16/28", Sequel.pg_range(80..5432))
-      fw.insert_firewall_rule("0.0.0.0/32", Sequel.pg_range(5432..5432))
-      fw.replace_firewall_rules([{cidr: "0.0.0.0/32", port_range: Sequel.pg_range(5432..5432)}])
-      expect(fw.reload.firewall_rules.count).to eq(1)
-      expect(fw.reload.firewall_rules.first.cidr.to_s).to eq("0.0.0.0/32")
-    end
+  it "bulk sets firewall rules" do
+    fw.insert_firewall_rule("10.0.0.16/28", Sequel.pg_range(80..5432))
+    fw.insert_firewall_rule("0.0.0.0/32", Sequel.pg_range(5432..5432))
+    fw.replace_firewall_rules([{cidr: "0.0.0.0/32", port_range: Sequel.pg_range(5432..5432)}])
+    expect(fw.reload.firewall_rules.count).to eq(1)
+    expect(fw.reload.firewall_rules.first.cidr.to_s).to eq("0.0.0.0/32")
+  end
 
-    it "associates with a private subnet" do
-      expect(ps).to receive(:incr_update_firewall_rules)
-      fw.associate_with_private_subnet(ps)
+  it "associates with a private subnet" do
+    expect(ps).to receive(:incr_update_firewall_rules)
+    fw.associate_with_private_subnet(ps)
 
-      expect(fw.private_subnets.count).to eq(1)
-      expect(fw.private_subnets.first.id).to eq(ps.id)
-    end
+    expect(fw.private_subnets.count).to eq(1)
+    expect(fw.private_subnets.first.id).to eq(ps.id)
+  end
 
-    it "disassociates from a private subnet" do
-      fw.associate_with_private_subnet(ps, apply_firewalls: false)
-      expect(fw.private_subnets.count).to eq(1)
+  it "disassociates from a private subnet" do
+    fw.associate_with_private_subnet(ps, apply_firewalls: false)
+    expect(fw.private_subnets.count).to eq(1)
 
-      expect(ps).to receive(:incr_update_firewall_rules)
-      fw.disassociate_from_private_subnet(ps)
-      expect(fw.reload.private_subnets.count).to eq(0)
-      expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(0)
-    end
+    expect(ps).to receive(:incr_update_firewall_rules)
+    fw.disassociate_from_private_subnet(ps)
+    expect(fw.reload.private_subnets.count).to eq(0)
+    expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(0)
+  end
 
-    it "disassociates from a private subnet without applying firewalls" do
-      fw.associate_with_private_subnet(ps, apply_firewalls: false)
-      expect(fw.private_subnets.count).to eq(1)
+  it "disassociates from a private subnet without applying firewalls" do
+    fw.associate_with_private_subnet(ps, apply_firewalls: false)
+    expect(fw.private_subnets.count).to eq(1)
 
-      expect(ps).not_to receive(:incr_update_firewall_rules)
-      fw.disassociate_from_private_subnet(ps, apply_firewalls: false)
-      expect(fw.reload.private_subnets.count).to eq(0)
-      expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(0)
-    end
+    expect(ps).not_to receive(:incr_update_firewall_rules)
+    fw.disassociate_from_private_subnet(ps, apply_firewalls: false)
+    expect(fw.reload.private_subnets.count).to eq(0)
+    expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(0)
+  end
 
-    it "destroys firewall" do
-      fw.associate_with_private_subnet(ps, apply_firewalls: false)
-      expect(fw.reload.private_subnets.count).to eq(1)
-      expect(fw.private_subnets).to receive(:each).and_return([ps])
-      expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(1)
-      fw.destroy
-      expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(0)
-      expect(described_class[fw.id]).to be_nil
-    end
+  it "destroys firewall" do
+    fw.associate_with_private_subnet(ps, apply_firewalls: false)
+    expect(fw.reload.private_subnets.count).to eq(1)
+    expect(fw.private_subnets).to receive(:each).and_return([ps])
+    expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(1)
+    fw.destroy
+    expect(FirewallsPrivateSubnets.where(firewall_id: fw.id).count).to eq(0)
+    expect(described_class[fw.id]).to be_nil
+  end
 
-    it "removes referencing access control entries and object tag memberships" do
-      account = Account.create_with_id(email: "test@example.com")
-      project = account.create_project_with_default_policy("project-1", default_policy: false)
-      tag = ObjectTag.create_with_id(project_id: project.id, name: "t")
-      tag.add_member(fw.id)
-      fw.update(project_id: project.id)
-      ace = AccessControlEntry.create_with_id(project_id: project.id, subject_id: account.id, object_id: fw.id)
+  it "removes referencing access control entries and object tag memberships" do
+    account = Account.create_with_id(email: "test@example.com")
+    project = account.create_project_with_default_policy("project-1", default_policy: false)
+    tag = ObjectTag.create_with_id(project_id: project.id, name: "t")
+    tag.add_member(fw.id)
+    fw.update(project_id: project.id)
+    ace = AccessControlEntry.create_with_id(project_id: project.id, subject_id: account.id, object_id: fw.id)
 
-      fw.destroy
-      expect(tag.member_ids).to be_empty
-      expect(ace).not_to be_exists
-    end
+    fw.destroy
+    expect(tag.member_ids).to be_empty
+    expect(ace).not_to be_exists
   end
 end


### PR DESCRIPTION
These three specs files use the pattern:

```ruby
RSpec.describe ClassName do
  describe "ClassName" do
```

This is redundant and unnecessary.  Drop the `describe "ClassName" do`.

There are many other cases where we could drop unnecessary spec subclasses (any nested describe/context blocks not using before/after/let/etc. can be folded into the containing block), but as those could potentially be useful for grouping (even if I don't think the tradeoff is worth it), I am not modifying those.

Best reviewed when ignoring whitespace differences.