### PR TITLE
Test tweaks

### DIFF
--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -38,8 +38,9 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
 
       expect(described_class.assemble(ds.id)).to be_a Strand
 
-      expect(Vm.count).to eq 1
-      expect(Vm.first.unix_user).to eq "rhizome"
+      vms = Vm.limit(2).all
+      expect(vms.count).to eq 1
+      expect(vms.first.unix_user).to eq "rhizome"
     end
 
     it "errors out if the dns service project id is not put into config properly" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -64,16 +64,18 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(MinioServer.count).to eq 1
       expect(st.label).to eq "start"
       expect(MinioServer.first.pool).to eq minio_pool
-      expect(Vm.count).to eq 1
-      expect(Vm.first.unix_user).to eq "rhizome"
-      expect(Vm.first.sshable.host).to eq "temp_#{Vm.first.id}"
-      expect(Vm.first.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
+      vms = Vm.all
+      expect(vms.count).to eq 1
+      vm = vms.first
+      expect(vm.unix_user).to eq "rhizome"
+      expect(vm.sshable.host).to eq "temp_#{vm.id}"
+      expect(vm.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
 
-      expect(Vm.first.strand.stack[0]["storage_volumes"].length).to eq 2
-      expect(Vm.first.strand.stack[0]["storage_volumes"][0]["encrypted"]).to be true
-      expect(Vm.first.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 30
-      expect(Vm.first.strand.stack[0]["storage_volumes"][1]["encrypted"]).to be true
-      expect(Vm.first.strand.stack[0]["storage_volumes"][1]["size_gib"]).to eq 100
+      expect(vm.strand.stack[0]["storage_volumes"].length).to eq 2
+      expect(vm.strand.stack[0]["storage_volumes"][0]["encrypted"]).to be true
+      expect(vm.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 30
+      expect(vm.strand.stack[0]["storage_volumes"][1]["encrypted"]).to be true
+      expect(vm.strand.stack[0]["storage_volumes"][1]["size_gib"]).to eq 100
     end
 
     it "fails if pool is not valid" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -70,12 +70,10 @@ RSpec.describe Prog::Minio::MinioServerNexus do
       expect(vm.unix_user).to eq "rhizome"
       expect(vm.sshable.host).to eq "temp_#{vm.id}"
       expect(vm.private_subnets.first.id).to eq minio_pool.cluster.private_subnet_id
-
-      expect(vm.strand.stack[0]["storage_volumes"].length).to eq 2
-      expect(vm.strand.stack[0]["storage_volumes"][0]["encrypted"]).to be true
-      expect(vm.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 30
-      expect(vm.strand.stack[0]["storage_volumes"][1]["encrypted"]).to be true
-      expect(vm.strand.stack[0]["storage_volumes"][1]["size_gib"]).to eq 100
+      expect(vm.strand.stack[0]["storage_volumes"].map { _1.slice("encrypted", "size_gib") }).to eq([
+        {"encrypted" => true, "size_gib" => 30},
+        {"encrypted" => true, "size_gib" => 100}
+      ])
     end
 
     it "fails if pool is not valid" do

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -76,17 +76,19 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).not_to be_nil
-        expect(Vm.first.ip4_enabled).to be_falsey
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).not_to be_nil
+        expect(vm.ip4_enabled).to be_falsey
 
         visit project.path
         expect(page).to have_content("2/32 (6%)")
-        Vm.first.update(vcpus: 25)
+        vm.update(vcpus: 25)
         page.refresh
         expect(page).to have_content("25/32 (78%)")
-        Vm.first.update(vcpus: 31)
+        vm.update(vcpus: 31)
         page.refresh
         expect(page).to have_content("31/32 (96%)")
       end
@@ -182,10 +184,12 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).not_to be_nil
-        expect(Vm.first.ip4_enabled).to be_truthy
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).not_to be_nil
+        expect(vm.ip4_enabled).to be_truthy
       end
 
       it "can create new virtual machine with chosen private subnet" do
@@ -207,9 +211,11 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).to eq(ps.id)
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).to eq(ps.id)
       end
 
       it "can create new virtual machine in default location subnet" do
@@ -231,10 +237,12 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{name}")
         expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
-        expect(Vm.count).to eq(1)
-        expect(Vm.first.project_id).to eq(project.id)
-        expect(Vm.first.private_subnets.first.id).not_to eq(ps.id)
-        expect(Vm.first.private_subnets.first.name).to eq("default-#{LocationNameConverter.to_display_name(ps.location)}")
+        vms = Vm.all
+        expect(vms.count).to eq(1)
+        vm = vms.first
+        expect(vm.project_id).to eq(project.id)
+        expect(vm.private_subnets.first.id).not_to eq(ps.id)
+        expect(vm.private_subnets.first.name).to eq("default-#{LocationNameConverter.to_display_name(ps.location)}")
 
         # can create a second vm in the same location and it will use the same subnet
         visit "#{project.path}/vm/create"


### PR DESCRIPTION
some opportunistic fixes, though I am unsatisfied with the change to `routes/web/vm_spec.rb`, because it seems like the `let(:vm)` fixture should be better scoped. I am wondering what the latest and greatest in route testing organization is (e.g. norms in how to name/nest `describe` and/or `context` blocks), because I'm not sure vm_spec.rb abides it.