### PR TITLE
Pin rubocop-capybara to 2.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :development do
 end
 
 group :rubocop do
-  gem "rubocop-capybara"
+  gem "rubocop-capybara", "~> 2.21.0"
   gem "rubocop-erb"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,7 +484,7 @@ DEPENDENCIES
   rotp
   rqrcode
   rspec
-  rubocop-capybara
+  rubocop-capybara (~> 2.21.0)
   rubocop-erb
   rubocop-performance
   rubocop-rake


### PR DESCRIPTION
The new version has at least one erroneous rewrite in `Capybara/FindAllFirst` and need to resolve a question as to whether we want to keep the `Capybara/NegationMatcherAfterVisit` cop by expressing the invariant we want differently.

However, while deliberating on this, I don't want to break dependabot making usable upgrade pull requests.

See https://github.com/ubicloud/ubicloud/pull/2974#issuecomment-2719528107