### PR TITLE
Fix the issue with missing billing info on invoices

### DIFF
--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe Invoice do
     end
   end
 
+  describe ".send_success_email" do
+    it "does not send the invoice if it has no billing information" do
+      project = Project.create_with_id(name: "cool-project")
+      invoice = described_class.create_with_id(project_id: project.id, invoice_number: "001", begin_time: Time.now, end_time: Time.now, content: {
+        "resources" => [],
+        "subtotal" => 0.0,
+        "credit" => 0.0,
+        "discount" => 0.0,
+        "cost" => 0.0
+      })
+      expect(Clog).to receive(:emit).with("Couldn't send the invoice because it has no billing information").and_call_original
+      invoice.send_success_email
+      expect(Mail::TestMailer.deliveries.length).to eq 0
+    end
+  end
+
   describe ".charge" do
     it "not charge if Stripe not enabled" do
       allow(Config).to receive(:stripe_secret_key).and_return(nil)


### PR DESCRIPTION
We used to think that every invoice for a project had to have valid billing info because users can't create resources without it.

However, we now allow users to access some of our services, like AI inference endpoints, up to certain limits without needing billing information.

We generate invoices for them more appropriately instead of just a bunch of commas with empty strings. Also, we don't attempt to send the invoice since it doesn't have a billing email.

![CleanShot 2025-03-12 at 14 43 07@2x](https://github.com/user-attachments/assets/fbe466d4-18de-4b56-976c-a09ae5d365f4)