### PR TITLE
Increase E2E timeout until the internal MinIO cluster stabilizes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,8 @@ jobs:
     if: vars.RUN_E2E == 'true'
     runs-on: ubicloud
     environment: E2E-CI
-    timeout-minutes: 55
+    # TODO: Revert it when the internal MinIO cluster is stabilized
+    timeout-minutes: 85
     concurrency: e2e_environment
 
     env:
@@ -130,7 +131,7 @@ jobs:
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
       run: |
         set -o pipefail
-        timeout 50m foreman start | tee foreman.log | grep "e2e.1"
+        timeout 80m foreman start | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
       if: always()


### PR DESCRIPTION
Right now, our internal MinIO cluster is facing some performance issues. The E2E suite can't download boot images from it in expected time.

I've increased the timeout to 85 minutes until the internal MinIO cluster stabilizes. We should revert it once the cluster is stable.