### PR TITLE
Use rhizome as sshable user and /home/rhizome as script location for service VMs

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -48,6 +48,7 @@ LOGIND
     pop "rhizome user bootstrapped and source installed" if retval&.dig("msg") == "installed rhizome"
 
     key_data = sshable.keys.map(&:private_key)
+    operator_keys = Config.operator_ssh_public_keys || ""
     Util.rootish_ssh(sshable.host, user, key_data, <<SH)
 set -ueo pipefail
 sudo apt update && sudo apt-get -y install ruby-bundler
@@ -60,6 +61,7 @@ sudo mkdir -p /etc/systemd/logind.conf.d
 echo #{LOGIND_CONFIG.shellescape} | sudo tee /etc/systemd/logind.conf.d/rhizome.conf > /dev/null
 echo #{SSHD_CONFIG.shellescape} | sudo tee /etc/ssh/sshd_config.d/10-clover.conf > /dev/null
 echo #{sshable.keys.map(&:public_key).join("\n").shellescape} | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+echo #{operator_keys.shellescape} | sudo tee -a ~/.ssh/authorized_keys > /dev/null
 sync
 SH
 

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -130,7 +130,7 @@ BASH
         private_subnet_cidr6: kubernetes_cluster.private_subnet.net6,
         vm_cidr: vm.nics.first.private_ipv4
       }
-      vm.sshable.cmd("common/bin/daemonizer /home/ubi/kubernetes/bin/init-cluster init_kubernetes_cluster", stdin: JSON.generate(params))
+      vm.sshable.cmd("common/bin/daemonizer /home/rhizome/kubernetes/bin/init-cluster init_kubernetes_cluster", stdin: JSON.generate(params))
       nap 30
     when "InProgress"
       nap 10

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -130,7 +130,7 @@ class Prog::Vm::Nexus < Prog::Base
     ssh_key = SshKey.generate
     kwargs[:unix_user] = unix_user
     st = assemble(ssh_key.public_key, *, **kwargs)
-    Sshable.create(unix_user: unix_user, host: "temp_#{st.id}", raw_private_key_1: ssh_key.keypair) {
+    Sshable.create(unix_user: (unix_user == "runneradmin") ? "runneradmin" : "rhizome", host: "temp_#{st.id}", raw_private_key_1: ssh_key.keypair) {
       _1.id = st.id
     }
     st

--- a/rhizome/inference_endpoint/lib/replica_setup.rb
+++ b/rhizome/inference_endpoint/lib/replica_setup.rb
@@ -122,7 +122,7 @@ CONFIG
 Description=Download loadbalancer SSL cert service
     
 [Service]
-ExecStart=/home/ubi/inference_endpoint/bin/download-lb-cert
+ExecStart=/home/rhizome/inference_endpoint/bin/download-lb-cert
 
 #{common_systemd_settings}
 CERT_DOWNLOAD_SERVICE

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -59,7 +59,7 @@ safe_write_to_file(config_path, config.to_yaml)
 
 r "sudo kubeadm init --config #{config_path}"
 
-r("sudo /home/ubi/kubernetes/bin/setup-cni")
+r("sudo /home/rhizome/kubernetes/bin/setup-cni")
 
 api_server_up = false
 5.times do

--- a/rhizome/kubernetes/bin/join-control-plane-node
+++ b/rhizome/kubernetes/bin/join-control-plane-node
@@ -18,4 +18,4 @@ end
 
 r "kubeadm join #{cluster_endpoint} --control-plane --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash} --certificate-key #{certificate_key}"
 
-r("sudo /home/ubi/kubernetes/bin/setup-cni")
+r("sudo /home/rhizome/kubernetes/bin/setup-cni")

--- a/rhizome/kubernetes/bin/join-worker-node
+++ b/rhizome/kubernetes/bin/join-worker-node
@@ -17,4 +17,4 @@ end
 
 r "kubeadm join #{endpoint} --token #{join_token} --discovery-token-ca-cert-hash #{discovery_token_ca_cert_hash}"
 
-r("sudo /home/ubi/kubernetes/bin/setup-cni")
+r("sudo /home/rhizome/kubernetes/bin/setup-cni")

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Prog::BootstrapRhizome do
 
     it "runs initializing shell with public keys" do
       sshable = instance_double(Sshable, host: "hostname", keys: [instance_double(SshKey, public_key: "test key", private_key: "test private key")])
+      expect(Config).to receive(:operator_ssh_public_keys).and_return("operatorkey")
       expect(br).to receive(:sshable).and_return(sshable).at_least(:once)
       expect(Util).to receive(:rootish_ssh).with "hostname", "root", ["test private key"], <<'FIXTURE'
 set -ueo pipefail
@@ -72,6 +73,7 @@ echo \#\ Supported\ HostKey\ algorithms\ by\ order\ of\ preference.'
 'ClientAliveCountMax\ 4'
 ' | sudo tee /etc/ssh/sshd_config.d/10-clover.conf > /dev/null
 echo test\ key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
+echo operatorkey | sudo tee -a ~/.ssh/authorized_keys > /dev/null
 sync
 FIXTURE
 

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(prog.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check init_kubernetes_cluster").and_return("NotStarted")
       expect(prog.vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: "10.0.0.37")])
       expect(prog.vm.sshable).to receive(:cmd).with(
-        "common/bin/daemonizer /home/ubi/kubernetes/bin/init-cluster init_kubernetes_cluster",
+        "common/bin/daemonizer /home/rhizome/kubernetes/bin/init-cluster init_kubernetes_cluster",
         stdin: /{"cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"127.0.0.0\/8","private_subnet_cidr6":"::\/16","vm_cidr":"10.0.0.37"}/
       )
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Prog::Vm::Nexus do
         expect(kwargs[:size]).to eq("new_size")
         expect(kwargs[:unix_user]).to eq("test_user")
       end.and_return(Strand.new(id: st_id))
-      expect(Sshable).to receive(:create).with({unix_user: "test_user", host: "temp_#{st_id}", raw_private_key_1: "pair"})
+      expect(Sshable).to receive(:create).with({unix_user: "rhizome", host: "temp_#{st_id}", raw_private_key_1: "pair"})
 
       described_class.assemble_with_sshable("test_user", prj.id, size: "new_size")
     end


### PR DESCRIPTION
- **Use rhizome user for service VM sshables**
  As the final step of BootstrapRhizome, update the sshable unix_user from
  the bootstrap user to rhizome.
  
  Additionally, add operator_ssh_public_keys to autorized keys of the
  bootstrap user.
  
  For VM hosts, the operator/bootstrap user is `root`. For service VMs,
  the user used for bootstrapping and operator actions is configurable. By
  convention, that user is `ubi`.
  

- **Update rhizome script location for inference endpoints**
  

- **Update rhizome script location for Kubernetes**
  