### PR TITLE
Use spaces around | in destroy usage banners in the CLI

### DIFF
--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -153,7 +153,7 @@ class UbiCli
     on(cmd).run_on("destroy") do
       desc "Destroy a #{LOWERCASE_LABELS[cmd]}"
 
-      options("ubi #{cmd} (location/#{cmd}-name|#{cmd}-id) destroy [options]", key: :destroy) do
+      options("ubi #{cmd} (location/#{cmd}-name | #{cmd}-id) destroy [options]", key: :destroy) do
         on("-f", "--force", "do not require confirmation")
       end
 

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default destroy invalid.txt
@@ -3,7 +3,7 @@
 Destroy a firewall
 
 Usage:
-    ubi fw (location/fw-name|fw-id) destroy [options]
+    ubi fw (location/fw-name | fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -51,7 +51,7 @@ Options:
 Destroy a virtual machine
 
 Usage:
-    ubi vm (location/vm-name|vm-id) destroy [options]
+    ubi vm (location/vm-name | vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -86,7 +86,7 @@ Usage:
 Destroy a firewall
 
 Usage:
-    ubi fw (location/fw-name|fw-id) destroy [options]
+    ubi fw (location/fw-name | fw-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
@@ -175,7 +175,7 @@ Options:
 Destroy a load balancer
 
 Usage:
-    ubi lb (location/lb-name|lb-id) destroy [options]
+    ubi lb (location/lb-name | lb-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
@@ -285,7 +285,7 @@ Usage:
 Destroy a PostgreSQL database
 
 Usage:
-    ubi pg (location/pg-name|pg-id) destroy [options]
+    ubi pg (location/pg-name | pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
@@ -386,7 +386,7 @@ Options:
 Destroy a private subnet
 
 Usage:
-    ubi ps (location/ps-name|ps-id) destroy [options]
+    ubi ps (location/ps-name | ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation
@@ -467,7 +467,7 @@ Options:
 Destroy a virtual machine
 
 Usage:
-    ubi vm (location/vm-name|vm-id) destroy [options]
+    ubi vm (location/vm-name | vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/help -ru vm.txt
+++ b/spec/routes/api/cli/golden-files/help -ru vm.txt
@@ -2,7 +2,7 @@ ubi vm command [...]
 ubi vm (location/vm-name | vm-id) [post-options] post-command [...]
 ubi vm list [options]
 ubi vm location/vm-name create [options] public_key
-ubi vm (location/vm-name|vm-id) destroy [options]
+ubi vm (location/vm-name | vm-id) destroy [options]
 ubi vm (location/vm-name | vm-id) restart
 ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -6,7 +6,7 @@ ubi fw (location/fw-name | fw-id) add-rule cidr
 ubi fw (location/fw-name | fw-id) attach-subnet ps-id
 ubi fw location/fw-name create [options]
 ubi fw (location/fw-name | fw-id) delete-rule rule-id
-ubi fw (location/fw-name|fw-id) destroy [options]
+ubi fw (location/fw-name | fw-id) destroy [options]
 ubi fw (location/fw-name | fw-id) detach-subnet ps-id
 ubi fw (location/fw-name | fw-id) show [options]
 ubi help [options] [command [subcommand]]
@@ -15,7 +15,7 @@ ubi lb (location/lb-name | lb-id) post-command [...]
 ubi lb list [options]
 ubi lb (location/lb-name | lb-id) attach-vm vm-id
 ubi lb location/lb-name create [options] ps-id src-port dst-port
-ubi lb (location/lb-name|lb-id) destroy [options]
+ubi lb (location/lb-name | lb-id) destroy [options]
 ubi lb (location/lb-name | lb-id) detach-vm vm-id
 ubi lb (location/lb-name | lb-id) show [options]
 ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
@@ -27,7 +27,7 @@ ubi pg (location/pg-name | pg-id) add-metric-destination username password url
 ubi pg location/pg-name create [options]
 ubi pg (location/pg-name | pg-id) delete-firewall-rule rule-id
 ubi pg (location/pg-name | pg-id) delete-metric-destination md-id
-ubi pg (location/pg-name|pg-id) destroy [options]
+ubi pg (location/pg-name | pg-id) destroy [options]
 ubi pg (location/pg-name | pg-id) [options] pg_dump [pg_dump-options]
 ubi pg (location/pg-name | pg-id) [options] pg_dumpall [pg_dumpall-options]
 ubi pg (location/pg-name | pg-id) [options] psql [psql-options]
@@ -40,14 +40,14 @@ ubi ps (location/ps-name | ps-id) post-command [...]
 ubi ps list [options]
 ubi ps (location/ps-name | ps-id) connect ps-id
 ubi ps location/ps-name create [options]
-ubi ps (location/ps-name|ps-id) destroy [options]
+ubi ps (location/ps-name | ps-id) destroy [options]
 ubi ps (location/ps-name | ps-id) disconnect ps-id
 ubi ps (location/ps-name | ps-id) show [options]
 ubi vm command [...]
 ubi vm (location/vm-name | vm-id) [post-options] post-command [...]
 ubi vm list [options]
 ubi vm location/vm-name create [options] public_key
-ubi vm (location/vm-name|vm-id) destroy [options]
+ubi vm (location/vm-name | vm-id) destroy [options]
 ubi vm (location/vm-name | vm-id) restart
 ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg destroy invalid.txt
@@ -3,7 +3,7 @@
 Destroy a PostgreSQL database
 
 Usage:
-    ubi pg (location/pg-name|pg-id) destroy [options]
+    ubi pg (location/pg-name | pg-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps destroy invalid.txt
@@ -3,7 +3,7 @@
 Destroy a private subnet
 
 Usage:
-    ubi ps (location/ps-name|ps-id) destroy [options]
+    ubi ps (location/ps-name | ps-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm destroy invalid.txt
@@ -3,7 +3,7 @@
 Destroy a virtual machine
 
 Usage:
-    ubi vm (location/vm-name|vm-id) destroy [options]
+    ubi vm (location/vm-name | vm-id) destroy [options]
 
 Options:
     -f, --force                      do not require confirmation


### PR DESCRIPTION
This was missed when they were added to the other commands.

CC @geemus 