### PR TITLE
Wait for a github runner job up to 7 minutes, instead of 5 minutes, 10 seconds

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -323,9 +323,9 @@ class Prog::Vm::GithubRunner < Prog::Base
     # JIT tokens are valid for 5 minutes. If the runner doesn't pick a job
     # within that time, the job may have been cancelled prior to assignment,
     # so we destroy the runner. We check if the runner is busy or not with
-    # GitHub API, but sometimes GitHub assigns a job at the last second.
-    # Therefore, we wait a few extra seconds beyond the 5 minute mark.
-    if github_runner.workflow_job.nil? && Time.now > github_runner.ready_at + 5 * 60 + 10
+    # GitHub API, but sometimes GitHub assigns a job after that (sometimes
+    # over 6 minutes). So wait for 7 minutes.
+    if github_runner.workflow_job.nil? && Time.now > github_runner.ready_at + 7 * 60
       response = github_client.get("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")
       unless response[:busy]
         Clog.emit("The runner does not pick a job") { github_runner }

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#wait" do
     it "does not destroy runner if it does not pick a job in five minutes, and busy" do
-      expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
+      expect(Time).to receive(:now).and_return(github_runner.ready_at + 8 * 60)
       expect(client).to receive(:get).and_return({busy: true})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect(github_runner).not_to receive(:incr_destroy)
@@ -512,7 +512,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "destroys runner if it does not pick a job in five minutes and not busy" do
       expect(github_runner).to receive(:workflow_job).and_return(nil)
-      expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
+      expect(Time).to receive(:now).and_return(github_runner.ready_at + 8 * 60)
       expect(client).to receive(:get).and_return({busy: false})
       expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect(github_runner).to receive(:incr_destroy)


### PR DESCRIPTION
We've had two cases today where the github runner did not get assigned a job until a little over 6 minutes.