### PR TITLE
Extend the runner's destroy deadline if it's still running a job

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -351,6 +351,8 @@ class Prog::Vm::GithubRunner < Prog::Base
         response = github_client.get("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")
         if response[:busy]
           Clog.emit("The runner is still running a job") { github_runner }
+          register_deadline(nil, 15 * 60, allow_extension: true)
+          register_deadline("wait_vm_destroy", 2 * 60 * 60)
           nap 15
         end
         github_client.delete("/repos/#{github_runner.repository_name}/actions/runners/#{github_runner.runner_id}")


### PR DESCRIPTION
Before destroying the runner, we also deregister it from GitHub to
ensure it's not running any jobs.

Sometimes, GitHub assigns a job to the runner at the last minute when we
decide to recycle it.

There's nothing we can do about it, so we just wait for the job to
finish.

We simply extend the existing 15-minute deadline and set a new deadline
for 2 hours.
