### PR TITLE
Postgres Scale Up/Down Backend

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -21,7 +21,7 @@ class PostgresResource < Sequel::Model
   include SemaphoreMethods
   include ObjectTag::Cleanup
 
-  semaphore :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :destroy
+  semaphore :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -88,6 +88,18 @@ class PostgresResource < Sequel::Model
     target_standby_count + 1
   end
 
+  def has_enough_fresh_servers?
+    servers.count { !_1.needs_recycling? } >= target_server_count
+  end
+
+  def has_enough_ready_servers?
+    servers.count { !_1.needs_recycling? && _1.strand.label == "wait" } >= target_server_count
+  end
+
+  def needs_convergence?
+    servers.any? { _1.needs_recycling? } || servers.count != target_server_count
+  end
+
   def set_firewall_rules
     vm_firewall_rules = firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(5432..5432)} }
     vm_firewall_rules.concat(firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(6432..6432)} })

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -127,8 +127,12 @@ class PostgresServer < Sequel::Model
     !resource.representative_server.primary?
   end
 
+  def storage_size_gib
+    vm.vm_storage_volumes_dataset.first(boot: false)&.size_gib
+  end
+
   def needs_recycling?
-    vm.display_size != resource.target_vm_size || vm.vm_storage_volumes.none? { !_1.boot && _1.size_gib == resource.target_storage_size_gib }
+    vm.display_size != resource.target_vm_size || storage_size_gib != resource.target_storage_size_gib
   end
 
   def failover_target

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/util"
+
+class Prog::Postgres::ConvergePostgresResource < Prog::Base
+  subject_is :postgres_resource
+
+  label def start
+    register_deadline(nil, 2 * 60 * 60)
+    hop_provision_servers
+  end
+
+  label def provision_servers
+    hop_wait_servers_to_be_ready if postgres_resource.has_enough_fresh_servers?
+
+    if postgres_resource.servers.all? { _1.vm.vm_host }
+      exclude_host_ids = (Config.development? || Config.is_e2e) ? [] : postgres_resource.servers.map { _1.vm.vm_host.id }
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: postgres_resource.id, timeline_id: postgres_resource.timeline.id, timeline_access: "fetch", exclude_host_ids: exclude_host_ids)
+    end
+
+    nap 5
+  end
+
+  label def wait_servers_to_be_ready
+    hop_provision_servers unless postgres_resource.has_enough_fresh_servers?
+    hop_recycle_representative_server if postgres_resource.has_enough_ready_servers?
+
+    nap 60
+  end
+
+  label def recycle_representative_server
+    if (rs = postgres_resource.representative_server)
+      hop_prune_servers unless rs.needs_recycling?
+      rs.trigger_failover
+    end
+
+    nap 60
+  end
+
+  label def prune_servers
+    # Below we only keep servers that does not need recycling. If there are
+    # more such servers than required, we prefer ready and recent servers (in that order)
+    servers_to_keep = postgres_resource.servers
+      .reject { _1.representative_at || _1.needs_recycling? }
+      .sort_by { [(_1.strand.label == "wait") ? 0 : 1, Time.now - _1.created_at] }
+      .take(postgres_resource.target_standby_count) + [postgres_resource.representative_server]
+    (postgres_resource.servers - servers_to_keep).each.each(&:incr_destroy)
+
+    pop "postgres resource is converged"
+  end
+end

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -46,6 +46,8 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
       .take(postgres_resource.target_standby_count) + [postgres_resource.representative_server]
     (postgres_resource.servers - servers_to_keep).each.each(&:incr_destroy)
 
+    postgres_resource.incr_update_billing_records
+
     pop "postgres resource is converged"
   end
 end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -160,12 +160,15 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
     postgres_resource.active_billing_records.each(&:finalize)
 
+    flavor = postgres_resource.flavor
     vm_family = representative_server.vm.family
+    vcpu_count = representative_server.vm.vcpus
+    storage_size_gib = representative_server.storage_size_gib
 
     billing_record_parts = []
     postgres_resource.target_server_count.times do |index|
-      billing_record_parts.push({resource_type: index.zero? ? "PostgresVCpu" : "PostgresStandbyVCpu", resource_family: "#{postgres_resource.flavor}-#{vm_family}", amount: representative_server.vm.vcpus})
-      billing_record_parts.push({resource_type: index.zero? ? "PostgresStorage" : "PostgresStandbyStorage", resource_family: postgres_resource.flavor, amount: postgres_resource.target_storage_size_gib})
+      billing_record_parts.push({resource_type: index.zero? ? "PostgresVCpu" : "PostgresStandbyVCpu", resource_family: "#{flavor}-#{vm_family}", amount: vcpu_count})
+      billing_record_parts.push({resource_type: index.zero? ? "PostgresStorage" : "PostgresStandbyStorage", resource_family: flavor, amount: storage_size_gib})
     end
 
     billing_record_parts.each do |brp|

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -230,8 +230,6 @@ CONFIG
   end
 
   label def configure
-    decr_configure
-
     case vm.sshable.cmd("common/bin/daemonizer --check configure_postgres")
     when "Succeeded"
       vm.sshable.cmd("common/bin/daemonizer --clean configure_postgres")
@@ -370,6 +368,7 @@ SQL
     end
 
     when_configure_set? do
+      decr_configure
       hop_configure
     end
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -36,6 +36,30 @@ RSpec.describe PostgresResource do
     expect(s).to include("ubi_replication@pgc60xvcr00a5kbnggj1js4kkq.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/server.crt")
   end
 
+  it "returns has_enough_fresh_servers correctly" do
+    expect(postgres_resource.servers).to receive(:count).and_return(1, 1)
+    expect(postgres_resource).to receive(:target_server_count).and_return(1, 2)
+    expect(postgres_resource.has_enough_fresh_servers?).to be(true)
+    expect(postgres_resource.has_enough_fresh_servers?).to be(false)
+  end
+
+  it "returns has_enough_ready_servers correctly" do
+    expect(postgres_resource.servers).to receive(:count).and_return(1, 1)
+    expect(postgres_resource).to receive(:target_server_count).and_return(1, 2)
+    expect(postgres_resource.has_enough_ready_servers?).to be(true)
+    expect(postgres_resource.has_enough_ready_servers?).to be(false)
+  end
+
+  it "returns needs_convergence correctly" do
+    expect(postgres_resource.servers).to receive(:any?).and_return(true, false, false)
+    expect(postgres_resource.servers).to receive(:count).and_return(1, 2)
+    expect(postgres_resource).to receive(:target_server_count).and_return(2, 2)
+
+    expect(postgres_resource.needs_convergence?).to be(true)
+    expect(postgres_resource.needs_convergence?).to be(true)
+    expect(postgres_resource.needs_convergence?).to be(false)
+  end
+
   it "returns display state correctly" do
     expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "unavailable")))
     expect(postgres_resource.display_state).to eq("unavailable")

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -179,6 +179,22 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "storage_size_gib" do
+    it "returns the storage size in GiB" do
+      volume_dataset = instance_double(Sequel::Dataset)
+      expect(volume_dataset).to receive(:first).and_return(instance_double(VmStorageVolume, boot: false, size_gib: 64))
+      expect(vm).to receive(:vm_storage_volumes_dataset).and_return(volume_dataset)
+      expect(postgres_server.storage_size_gib).to eq(64)
+    end
+
+    it "returns nil if there is no storage volume" do
+      volume_dataset = instance_double(Sequel::Dataset)
+      expect(volume_dataset).to receive(:first).and_return(nil)
+      expect(vm).to receive(:vm_storage_volumes_dataset).and_return(volume_dataset)
+      expect(postgres_server.storage_size_gib).to be_nil
+    end
+  end
+
   it "initiates a new health monitor session" do
     forward = instance_double(Net::SSH::Service::Forward)
     expect(forward).to receive(:local_socket)

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Postgres::ConvergePostgresResource do
+  subject(:nx) { described_class.new(Strand.new(id: "8148ebdf-66b8-8ed0-9c2f-8cfe93f5aa77")) }
+
+  let(:postgres_resource) {
+    instance_double(
+      PostgresResource,
+      id: "8148ebdf-66b8-8ed0-9c2f-8cfe93f5aa77",
+      servers: [
+        instance_double(PostgresServer),
+        instance_double(PostgresServer)
+      ],
+      timeline: instance_double(PostgresTimeline, id: "timeline-id")
+    )
+  }
+
+  before do
+    allow(nx).to receive(:postgres_resource).and_return(postgres_resource)
+  end
+
+  describe "#start" do
+    it "registers a deadline" do
+      expect(nx).to receive(:register_deadline).with(nil, 2 * 60 * 60)
+      expect { nx.start }.to hop("provision_servers")
+    end
+  end
+
+  describe "#provision_servers" do
+    before do
+      allow(postgres_resource).to receive(:has_enough_fresh_servers?).and_return(false)
+      allow(postgres_resource.servers[0]).to receive(:vm).and_return(instance_double(Vm, vm_host: instance_double(VmHost, id: "vmh-id-1")))
+      allow(postgres_resource.servers[1]).to receive(:vm).and_return(instance_double(Vm, vm_host: instance_double(VmHost, id: "vmh-id-2")))
+    end
+
+    it "hops to wait_servers_to_be_ready if there are enough fresh servers" do
+      expect(postgres_resource).to receive(:has_enough_fresh_servers?).and_return(true)
+      expect { nx.provision_servers }.to hop("wait_servers_to_be_ready")
+    end
+
+    it "does not provision a new server if there is a server that is not assigned to a vm_host" do
+      expect(postgres_resource.servers[0]).to receive(:vm).and_return(instance_double(Vm, vm_host: nil))
+      expect(Prog::Postgres::PostgresServerNexus).not_to receive(:assemble)
+      expect { nx.provision_servers }.to nap
+    end
+
+    it "provisions a new server without excluding hosts in development environment" do
+      allow(Config).to receive(:development?).and_return(true)
+      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(exclude_host_ids: []))
+      expect { nx.provision_servers }.to nap
+    end
+
+    it "provisions a new server if there is no server with vm_host" do
+      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(exclude_host_ids: ["vmh-id-1", "vmh-id-2"]))
+      expect { nx.provision_servers }.to nap
+    end
+  end
+
+  describe "#wait_servers_to_be_ready" do
+    it "hops to provision_servers if there is not enough fresh servers" do
+      expect(postgres_resource).to receive(:has_enough_fresh_servers?).and_return(false)
+      expect { nx.wait_servers_to_be_ready }.to hop("provision_servers")
+    end
+
+    it "hops to recycle_representative_server if there are enough ready servers" do
+      expect(postgres_resource).to receive(:has_enough_fresh_servers?).and_return(true)
+      expect(postgres_resource).to receive(:has_enough_ready_servers?).and_return(true)
+      expect { nx.wait_servers_to_be_ready }.to hop("recycle_representative_server")
+    end
+
+    it "waits if there are not enough ready servers" do
+      expect(postgres_resource).to receive(:has_enough_fresh_servers?).and_return(true)
+      expect(postgres_resource).to receive(:has_enough_ready_servers?).and_return(false)
+      expect { nx.wait_servers_to_be_ready }.to nap
+    end
+  end
+
+  describe "#recycle_representative_server" do
+    it "waits until there is a representative server to act on it" do
+      expect(postgres_resource).to receive(:representative_server).and_return(nil)
+      expect { nx.recycle_representative_server }.to nap
+    end
+
+    it "hops to prune_servers if the representative server does not need recycling" do
+      expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: false)).at_least(:once)
+      expect { nx.recycle_representative_server }.to hop("prune_servers")
+    end
+
+    it "triggers failover on the representative server" do
+      expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: true)).at_least(:once)
+      expect(postgres_resource.representative_server).to receive(:trigger_failover)
+      expect { nx.recycle_representative_server }.to nap
+    end
+  end
+
+  describe "#prune_servers" do
+    it "destroys extra servers" do
+      expect(postgres_resource).to receive(:servers).and_return([
+        instance_double(PostgresServer, representative_at: "yesterday", needs_recycling?: false, created_at: 1, strand: instance_double(Strand, label: "wait")),
+        instance_double(PostgresServer, representative_at: nil, needs_recycling?: true, created_at: 5, strand: instance_double(Strand, label: "wait")),
+        instance_double(PostgresServer, representative_at: nil, needs_recycling?: false, created_at: 4, strand: instance_double(Strand, label: "unavailable")),
+        instance_double(PostgresServer, representative_at: nil, needs_recycling?: false, created_at: 3, strand: instance_double(Strand, label: "wait")),
+        instance_double(PostgresServer, representative_at: nil, needs_recycling?: false, created_at: 2, strand: instance_double(Strand, label: "wait"))
+      ]).at_least(:once)
+      expect(postgres_resource).to receive(:representative_server).and_return(postgres_resource.servers[0])
+      expect(postgres_resource).to receive(:target_standby_count).and_return(1).at_least(:once)
+
+      expect(postgres_resource.servers[1]).to receive(:incr_destroy)
+      expect(postgres_resource.servers[2]).to receive(:incr_destroy)
+      expect(postgres_resource.servers[4]).to receive(:incr_destroy)
+
+      expect { nx.prune_servers }.to exit
+    end
+  end
+end

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -111,6 +111,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(postgres_resource.servers[2]).to receive(:incr_destroy)
       expect(postgres_resource.servers[4]).to receive(:incr_destroy)
 
+      expect(postgres_resource).to receive(:incr_update_billing_records)
+
       expect { nx.prune_servers }.to exit
     end
   end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -269,8 +269,9 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
   describe "#update_billing_records" do
     it "creates billing record for cores and storage then hops" do
+      expect(postgres_resource).to receive(:flavor).and_return("standard")
+      expect(postgres_resource.representative_server).to receive(:storage_size_gib).and_return(128)
       expect(postgres_resource).to receive(:target_server_count).and_return(2)
-      expect(postgres_resource).to receive(:flavor).and_return("standard").at_least(:once)
 
       expect(BillingRecord).to receive(:create_with_id).with(
         project_id: postgres_resource.project_id,
@@ -293,7 +294,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         resource_id: postgres_resource.id,
         resource_name: postgres_resource.name,
         billing_rate_id: BillingRate.from_resource_properties("PostgresStorage", "standard", postgres_resource.location)["id"],
-        amount: postgres_resource.target_storage_size_gib
+        amount: 128
       )
 
       expect(BillingRecord).to receive(:create_with_id).with(
@@ -301,7 +302,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         resource_id: postgres_resource.id,
         resource_name: postgres_resource.name,
         billing_rate_id: BillingRate.from_resource_properties("PostgresStandbyStorage", "standard", postgres_resource.location)["id"],
-        amount: postgres_resource.target_storage_size_gib
+        amount: 128
       )
 
       expect { nx.update_billing_records }.to hop("wait")


### PR DESCRIPTION
This is actually more than just scale up/down. It is E2E convergence logic. With
that, it automatically implements enable/disable HA.

Convergence is the process of converging from an arbitrary physical state of
PostgresResource to its target state, which is combination of target vm size,
target storage size and target server count.

Convergence logic is implemented in 4 steps:
1. Provision enough `fresh` servers to meet the target server count.
2. Wait until new servers are `ready` (i.e. in wait state).
3. Recycle representative_server to match resource's target.
4. Prune extra servers that are possibly left over from pre-convergence time.

At the end of the convergence, we ensure that the representative_server is in
the desired state and there are enough fresh standby servers that are ready to
take over the primary role if it becomes necessary.

Since the convergence is long running operation, it is possible that the target
changes during the convergence, especially during second step as other steps
are relatively quick. To ensure converging to correct target, second step can
decide to hop back to first step for course correction.