### PR TITLE
Pin rubocop-capybara to < 2.22 redux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :development do
 end
 
 group :rubocop do
-  gem "rubocop-capybara", "~> 2.21.0"
+  gem "rubocop-capybara", "< 2.22"
   gem "rubocop-erb"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -490,7 +490,7 @@ DEPENDENCIES
   rotp
   rqrcode
   rspec
-  rubocop-capybara (~> 2.21.0)
+  rubocop-capybara (< 2.22)
   rubocop-erb
   rubocop-performance
   rubocop-rake


### PR DESCRIPTION
I want to table this upgrade while upstream figures out `Capybara/FindAllFirst`, or, failing that, stop using `rubocopy-capybara`.

d03a9e516c83095f73637cb392dbe9e50d1c2d41 was not effective, as Dependabot takes it upon itself not only to satisfy the Gemfile, but to update it as well when people use the `~>` operator.  I suppose this comes from a long history of people using `~>` without a plan to be notified about new releases that do not satisfy it.

I filed the `FindAllFirst` as an issue:
https://github.com/rubocop/rubocop-capybara/issues/150

Using a `<` operator ought to be more prescriptive.  I am not sure how to conveniently test dependabot's behavior without a merge, though.