### PR TITLE
Postgres Scale Up/Down Frontend

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,6 +3,7 @@ $(function () {
   setupDatePicker();
   setupFormOptionUpdates();
   setupPlayground();
+  setupFormsWithPatchMethod()
 });
 
 $(".toggle-mobile-menu").on("click", function (event) {
@@ -427,4 +428,33 @@ function setupPlayground() {
   };
 
   $('#inference_submit').on("click", generate);
+}
+
+function setupFormsWithPatchMethod() {
+  $("#creation-form.PATCH").on("submit", function (event) {
+    event.preventDefault();
+
+    var form = $(this);
+    var jsonData = {};
+    form.serializeArray().forEach(function(item) {
+        jsonData[item.name] = item.value;
+    });
+
+    $.ajax({
+        url: form.attr('action'),
+        type: 'PATCH',
+        dataType: "html",
+        data: jsonData,
+        success: function (response, status, xhr) {
+          var redirectUrl = xhr.getResponseHeader('Location');
+          if (redirectUrl) {
+              window.location.href = redirectUrl;
+          }
+        },
+        error: function (xhr, ajaxOptions, thrownError) {
+          let message = thrownError;
+          alert(`Error: ${message}`);
+        }
+    });
+  });
 }

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -109,4 +109,33 @@ class Clover
     options.add_option(name: "ha_type", values: [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC], parent: "storage_size")
     options.serialize
   end
+
+  def generate_postgres_configure_options(flavor:, location:)
+    options = OptionTreeGenerator.new
+
+    options.add_option(name: "flavor", values: flavor)
+    options.add_option(name: "location", values: location, parent: "flavor")
+
+    options.add_option(name: "family", values: Option::PostgresSizes.map(&:vm_family).uniq, parent: "location") do |flavor, location, family|
+      available_families = Option.families.map(&:name)
+      available_families.include?(family) && BillingRate.from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", LocationNameConverter.to_internal_name(location))
+    end
+
+    options.add_option(name: "size", values: Option::PostgresSizes.map(&:name).uniq, parent: "family") do |flavor, location, family, size|
+      location = LocationNameConverter.to_internal_name(location)
+      pg_size = Option::PostgresSizes.find { _1.name == size && _1.flavor == flavor && _1.location == location }
+      vm_size = Option::VmSizes.find { _1.name == pg_size.vm_size && _1.arch == "x64" && _1.visible }
+      vm_size.family == family
+    end
+
+    options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096"], parent: "size") do |flavor, location, family, size, storage_size|
+      location = LocationNameConverter.to_internal_name(location)
+      pg_size = Option::PostgresSizes.find { _1.name == size && _1.flavor == flavor && _1.location == location }
+      pg_size.storage_size_options.include?(storage_size.to_i)
+    end
+
+    options.add_option(name: "ha_type", values: [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC], parent: "storage_size")
+
+    options.serialize
+  end
 end

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -45,7 +45,7 @@ class Clover
   end
 
   def postgres_list
-    dataset = dataset_authorize(@project.postgres_resources_dataset, "Postgres:view").eager(:semaphores, :strand)
+    dataset = dataset_authorize(@project.postgres_resources_dataset, "Postgres:view").eager(:semaphores, strand: :children)
     if api?
       dataset = dataset.where(location: @location) if @location
       result = dataset.paginated_result(

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -40,6 +40,7 @@ class PostgresResource < Sequel::Model
 
   def display_state
     return "unavailable" if representative_server&.strand&.label == "unavailable"
+    return "converging" if strand.children.any? { _1.prog == "Postgres::ConvergePostgresResource" }
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
     return "deleting" if destroy_set? || strand.label == "destroy"
     "creating"

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -779,6 +779,33 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
+    patch:
+      operationId: patchPostgresDatabase
+      summary: Update a Postgres Database in a specific location of a project
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ha_type:
+                  description: High availability type
+                  type: string
+                size:
+                  description: Requested size for the underlying VM
+                  type: string
+                storage_size:
+                  description: Requested storage size in GiB
+                  type: integer
+              additionalProperties: false
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_name}/ca-certificates':
     parameters:
       - $ref: '#/components/parameters/project_id'

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -30,6 +30,8 @@ class Clover
           Serializers::Postgres.serialize(pg, {detailed: true})
         else
           @pg = Serializers::Postgres.serialize(pg, {detailed: true, include_path: true})
+          @family = pg.representative_server.vm.family
+          @option_tree, @option_parents = generate_postgres_configure_options(flavor: @pg[:flavor], location: @pg[:location])
           view "postgres/show"
         end
       end
@@ -70,7 +72,13 @@ class Clover
 
         pg.update(target_vm_size: target_vm_size.vm_size, target_storage_size_gib:, ha_type:)
 
-        Serializers::Postgres.serialize(pg, {detailed: true})
+        if api?
+          Serializers::Postgres.serialize(pg, {detailed: true})
+        else
+          flash["notice"] = "'#{pg.name}' will be updated according to requested configuration"
+          response["Location"] = "#{@project.path}#{pg.path}"
+          200
+        end
       end
 
       r.post "restart" do

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -65,13 +65,16 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.display_state).to eq("unavailable")
 
     expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait"))).at_least(:once)
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, children: [instance_double(Strand, prog: "Postgres::ConvergePostgresResource")]))
+    expect(postgres_resource.display_state).to eq("converging")
+
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait", children: [])).twice
     expect(postgres_resource.display_state).to eq("running")
 
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy")).exactly(3).times
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy", children: [])).exactly(3).times
     expect(postgres_resource.display_state).to eq("deleting")
 
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server"))
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server", children: [])).exactly(3).times
     expect(postgres_resource.display_state).to eq("creating")
   end
 

--- a/spec/serializers/postgres_spec.rb
+++ b/spec/serializers/postgres_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Serializers::Postgres do
   let(:pg) { PostgresResource.new(name: "pg-name").tap { _1.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
 
   it "can serialize when no earliest/latest restore times" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start", children: [])).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
     data = described_class.serialize(pg, {detailed: true})
@@ -15,7 +15,7 @@ RSpec.describe Serializers::Postgres do
   end
 
   it "can serialize when earliest_restore_time calculation raises an exception" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start", children: [])).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, latest_restore_time: nil)).exactly(4)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
     expect(pg.timeline).to receive(:earliest_restore_time).and_raise("error")
@@ -26,7 +26,7 @@ RSpec.describe Serializers::Postgres do
 
   it "can serialize when have earliest/latest restore times" do
     time = Time.now
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start", children: [])).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: time, latest_restore_time: time)).exactly(3)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: true, vm: nil, strand: nil)).at_least(:once)
     data = described_class.serialize(pg, {detailed: true})
@@ -35,7 +35,7 @@ RSpec.describe Serializers::Postgres do
   end
 
   it "can serialize when not primary" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start", children: [])).at_least(:once)
     expect(pg).to receive(:representative_server).and_return(instance_double(PostgresServer, primary?: false, vm: nil, strand: nil)).at_least(:once)
     data = described_class.serialize(pg, {detailed: true})
     expect(data[:earliest_restore_time]).to be_nil
@@ -43,7 +43,7 @@ RSpec.describe Serializers::Postgres do
   end
 
   it "can serialize when there is no server" do
-    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start")).at_least(:once)
+    expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start", children: [])).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil))
     expect(pg).to receive(:representative_server).and_return(nil).at_least(:once)
     data = described_class.serialize(pg, {detailed: true})

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (action:, form_elements:, option_tree:, option_parents:) %>
+<%# locals: (action:, form_elements:, option_tree:, option_parents:, form_title: nil) %>
 <% nonce = SecureRandom.base64(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
@@ -7,6 +7,16 @@ let option_tree = <%==JSON.generate(option_tree)%>
 let option_children = <%==JSON.generate(option_parents.each_with_object(Hash.new { |h, k| h[k] = [] }) { |(child, parents), h| h[parents.last] << child if parents.any? })%>
 let option_dirty = <%==JSON.generate(form_elements.map { _1[:name] }.each_with_object(Hash.new { |h, k| h[k] = [] }) { |option, h| h[option] = nil })%>
 </script>
+
+<% if form_title %>
+  <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+    <div class="min-w-0 flex-1">
+      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <%= form_title %>
+      </h3>
+    </div>
+  </div>
+<% end %>
 
 <div class="grid gap-6">
   <form action="<%= action %>" method="POST" id="creation-form">

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (action:, form_elements:, option_tree:, option_parents:, form_title: nil, pre_selected_values: [], mode: "create") %>
+<%# locals: (action:, form_elements:, option_tree:, option_parents:, method: "POST", form_title: nil, pre_selected_values: [], mode: "create") %>
 <% nonce = SecureRandom.base64(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
@@ -19,8 +19,8 @@ let option_dirty = <%==JSON.generate(form_elements.map { _1[:name] }.each_with_o
 <% end %>
 
 <div class="grid gap-6">
-  <form action="<%= action %>" method="POST" id="creation-form">
-    <%== csrf_tag(action) %>
+  <form action="<%= action %>" method="POST" id="creation-form" class="<%= method %>">
+    <%== csrf_tag(action, method) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white">
       <div class="px-4 py-5 sm:p-6">
         <div class="space-y-12">

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (action:, form_elements:, option_tree:, option_parents:, form_title: nil) %>
+<%# locals: (action:, form_elements:, option_tree:, option_parents:, form_title: nil, pre_selected_values: []) %>
 <% nonce = SecureRandom.base64(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
@@ -27,6 +27,8 @@ let option_dirty = <%==JSON.generate(form_elements.map { _1[:name] }.each_with_o
           <div>
             <div class="mt-2 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
               <% selected_options = {}
+pre_selected_values.each { |k, v| selected_options[k] = v.to_s }
+
 form_elements.each do |element|
   container_opening_tag = element[:opening_tag] || "<div class='col-span-full'>"
   container_closing_tag = element[:closing_tag] || "</div>"
@@ -40,9 +42,15 @@ form_elements.each do |element|
     opt_text = content_generator.call(*option.values)
 
     parents = option.reject { |k, v| k == name }
+
     parents_selected = parents.all? { |k, v| selected_options[k] == v }
-    checked = parents_selected && (flash.dig("old", name) == opt_val || (flash.dig("old", name).nil? && selected_options[name].nil?))
+    submitted_value = flash.dig("old", name)
+    selected_in_form_submission = submitted_value == opt_val
+    selected_in_pre_selection = submitted_value.nil? && selected_options[name] == opt_val
+    first_of_its_kind = submitted_value.nil? && selected_options[name].nil?
+    checked = parents_selected && (selected_in_form_submission || selected_in_pre_selection || first_of_its_kind)
     selected_options[name] = opt_val if checked
+  
     opt_classes = (parents.map { |k, v| "form_#{k} form_#{k}_#{v}" } + (parents_selected ? [] : ["hidden"])).join(" ")
 
     opt_attrs = {}

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (action:, form_elements:, option_tree:, option_parents:, form_title: nil, pre_selected_values: []) %>
+<%# locals: (action:, form_elements:, option_tree:, option_parents:, form_title: nil, pre_selected_values: [], mode: "create") %>
 <% nonce = SecureRandom.base64(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
@@ -105,8 +105,12 @@ form_elements.each do |element|
       </div>
       <div class="px-4 py-5 sm:p-6">
         <div class="flex items-center justify-end gap-x-6">
-          <a href="<%= action %>" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>
-          <%== part("components/form/submit_button", text: "Create") %>
+          <% if mode == "create" %>
+            <a href="<%= action %>" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>
+            <%== part("components/form/submit_button", text: "Create") %>
+          <% else %>
+            <%== part("components/form/submit_button", text: "Update") %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -108,6 +108,60 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
       </div>
     <% end %>
   </div>
+  <!-- Update target state of the database resource -->
+  <% form_elements = [
+    {
+      name: "family",
+      type: "radio_small_cards",
+      label: "Server family",
+      required: "required",
+      content_generator: ContentGenerator::Postgres.method(:family)
+    },
+    {
+      name: "size",
+      type: "radio_small_cards",
+      label: "Server size",
+      required: "required",
+      content_generator: ContentGenerator::Postgres.method(:size)
+    },
+    {
+      name: "storage_size",
+      type: "radio_small_cards",
+      label: "Storage size",
+      required: "required",
+      content_generator: ContentGenerator::Postgres.method(:storage_size)
+    },
+    {
+      name: "ha_type",
+      type: "radio_small_cards",
+      label: "High Availability",
+      required: "required",
+      content_generator: ContentGenerator::Postgres.method(:ha_type)
+    }
+  ]
+  
+  pre_selected_values = {
+    "flavor" => @pg[:flavor],
+    "location" => @pg[:location],
+    "family" => @family,
+    "size" => @pg[:vm_size],
+    "storage_size" => @pg[:storage_size_gib],
+    "ha_type" => @pg[:ha_type]
+  } %>
+
+  <%== render(
+    "components/form/resource_creation_form",
+    locals: {
+      action: "#{@project_data[:path]}#{@pg[:path]}",
+      method: "PATCH",
+      form_title: "Configure PostgreSQL database",
+      form_elements:,
+      pre_selected_values:,
+      option_tree: @option_tree,
+      option_parents: @option_parents,
+      mode: "update"
+    }
+  ) %>
   <!-- Fork database -->
   <% if @pg[:earliest_restore_time] && @pg[:latest_restore_time] > @pg[:earliest_restore_time] %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">


### PR DESCRIPTION
**Add form title to resource creation form**

This form can be embedded to resource details page. In such cases, it would be
better to have a title for the form to indicate what the form is for.

**Add pre-selected options to the resource creation form**
These will be used to display forms with some options pre-selected, primarily
to update configurations of existing resources.

**Display different buttons on the resource creation form based on mode**
We are planning to re-use the resource creation form for both creating and
updating resources. This commit adds a new mode attribute to the form and
uses it to display different buttons based on the mode.

**Add PATCH support to resource creation form**
This form can be used to create a new resource or to update an existing one.
To update an existing resource, we need to send a PATCH request to the server.
This commit adds ability to send PATCH requests to the backend.

HTML forms unfortunately do not support PATCH requests. There are 2 common ways
to work around this limitation:
1. Send regular `POST` request with special hidden input and backend can handle
the request as if it is `PATCH` based on the hidden input field.
2. Use JavaScript to change the request method before submitting the form

I opted for the second approach because it fits to RESTful semantics better.
Also the proposal for extending HTML form methods lists additional drawbacks
regarding use of hidden input fields [1].

**Add PATCH endpoint for updating PostgresResource's target state**

**Add UI for PostgresResource update**