### PR TITLE
Destroy Child Strands of K8s Provision Prog on Destroy

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -21,6 +21,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
 
   def before_run
     if kubernetes_cluster.strand.label == "destroy" && strand.label != "destroy"
+      strand.children.each(&:destroy)
       pop "provisioning canceled"
     end
   end


### PR DESCRIPTION
This specific case happens if the cluster is destroyed when the Provision prog is in wait_bootstrap_rhizome step. 