### PR TITLE
Allow VmHost#download_boot_image with Default Version

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -221,7 +221,7 @@ class VmHost < Sequel::Model
   end
 
   # Introduced for downloading a new boot image via REPL.
-  def download_boot_image(image_name, version:, custom_url: nil)
+  def download_boot_image(image_name, version: nil, custom_url: nil)
     Strand.create_with_id(prog: "DownloadBootImage", label: "start", stack: [{subject_id: id, image_name: image_name, custom_url: custom_url, version: version}])
   end
 

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -10,7 +10,7 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   def version
-    @version ||= frame.fetch("version") { default_boot_image_version(image_name) }
+    @version ||= frame.fetch("version", nil) || default_boot_image_version(image_name)
   end
 
   def download_from_blob_storage?
@@ -133,13 +133,9 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   label def start
-    # YYY: we can remove this once we enforce it in the database layer.
-    # Although the default version is used if version is not passed, adding
-    # a sanity check here to make sure version is not passed as nil.
-    fail "Version can not be passed as nil" if version.nil?
-
     fail "Image already exists on host" if vm_host.boot_images_dataset.where(name: image_name, version: version).count > 0
 
+    # YYY: we should enforce version of boot image in the database layer.
     BootImage.create_with_id(
       vm_host_id: vm_host.id,
       name: image_name,


### PR DESCRIPTION
We have a list of default options in the DownloadBootImage prog, so we can use it to allow default values when initiating download from the console on a host.

We can follow up with making the version in BootImage not null. In prod, we have 6 boot images with version: nil left.