### PR TITLE
Do not allow to disrupt GitHub resources for other projects

### DIFF
--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -42,7 +42,7 @@ class Clover
         end
 
         r.on String do |installation_id|
-          next unless (installation = GithubInstallation.from_ubid(installation_id))
+          next unless (installation = GithubInstallation.from_ubid(installation_id)) && installation.project_id == @project.id
 
           r.post true do
             cache_enabled = r.params["cache_enabled"] == "true"
@@ -65,7 +65,7 @@ class Clover
         end
 
         r.is String do |entry_ubid|
-          next unless (entry = GithubCacheEntry.from_ubid(entry_ubid))
+          next unless (entry = GithubCacheEntry.from_ubid(entry_ubid)) && entry.repository.installation.project_id == @project.id
 
           r.delete true do
             entry.destroy


### PR DESCRIPTION
We check authorization for all GitHub-related operations once with
`authorize("Project:github", @project.id)`.

After that, users can provide any resource ID from other projects to
update GitHub installation settings or delete cache entry.

It's important that customers can only access their own resources.

The current bug allows updating GitHub installation settings or deleting
cache data, but it does not provide access to sensitive information.
