### PR TITLE
Separate Sshable user and initial unix user in assemble_with_sshable

### DIFF
--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -17,8 +17,8 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
 
       inference_endpoint = InferenceEndpoint[inference_endpoint_id]
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
         Config.inference_endpoint_service_project_id,
+        sshable_unix_user: "ubi",
         location: inference_endpoint.location,
         name: ubid.to_s,
         size: inference_endpoint.vm_size,

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -20,8 +20,8 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
 
     DB.transaction do
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
         Config.dns_service_project_id,
+        sshable_unix_user: "ubi",
         location: location,
         name: name,
         size: vm_size,

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -39,8 +39,8 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     storage_volumes = [{encrypted: true, size_gib: storage_size_gib}] if storage_size_gib
 
     vm = Prog::Vm::Nexus.assemble_with_sshable(
-      "ubi",
       kubernetes_cluster.project.id,
+      sshable_unix_user: "ubi",
       name: name,
       location: kubernetes_cluster.location,
       size: vm_size,

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -19,8 +19,8 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       ubid = MinioServer.generate_ubid
 
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
         Config.minio_service_project_id,
+        sshable_unix_user: "ubi",
         location: minio_pool.cluster.location,
         name: ubid.to_s,
         size: minio_pool.vm_size,

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -23,8 +23,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       end
 
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi",
         Config.postgres_service_project_id,
+        sshable_unix_user: "ubi",
         location: postgres_resource.location,
         name: ubid.to_s,
         size: postgres_resource.target_vm_size,

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -37,14 +37,13 @@ class Prog::Test::VmGroup < Prog::Test::Base
     ]
     vm_count = [boot_images.size, storage_options.size, size_options.size].max
     vms = Array.new(vm_count) do |index|
-      Prog::Vm::Nexus.assemble_with_sshable(
-        "ubi", project.id,
+      Prog::Vm::Nexus.assemble_with_sshable(project.id,
+        sshable_unix_user: "ubi",
         size: size_options[index % size_options.size],
         private_subnet_id: subnets[index % subnets.size].id,
         storage_volumes: storage_options[index % storage_options.size],
         boot_image: boot_images[index % boot_images.size],
-        enable_ip4: true
-      )
+        enable_ip4: true)
     end
 
     update_stack({

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -46,8 +46,8 @@ class Prog::Vm::GithubRunner < Prog::Base
     ).subject
 
     vm_st = Prog::Vm::Nexus.assemble_with_sshable(
-      "runneradmin",
       Config.github_runner_service_project_id,
+      sshable_unix_user: "runneradmin",
       name: github_runner.ubid.to_s,
       size: label_data["vm_size"],
       location: label_data["location"],

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -126,11 +126,10 @@ class Prog::Vm::Nexus < Prog::Base
     end
   end
 
-  def self.assemble_with_sshable(unix_user, *, **kwargs)
+  def self.assemble_with_sshable(*, sshable_unix_user: "rhizome", **kwargs)
     ssh_key = SshKey.generate
-    kwargs[:unix_user] = unix_user
     st = assemble(ssh_key.public_key, *, **kwargs)
-    Sshable.create(unix_user: unix_user, host: "temp_#{st.id}", raw_private_key_1: ssh_key.keypair) {
+    Sshable.create(unix_user: sshable_unix_user, host: "temp_#{st.id}", raw_private_key_1: ssh_key.keypair) {
       _1.id = st.id
     }
     st

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -43,8 +43,8 @@ class Prog::Vm::VmPool < Prog::Base
     ).subject
 
     Prog::Vm::Nexus.assemble_with_sshable(
-      "runneradmin",
       Config.vm_pool_project_id,
+      sshable_unix_user: "runneradmin",
       size: vm_pool.vm_size,
       location: vm_pool.location,
       boot_image: vm_pool.boot_image,

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "picks correct base image for Lantern" do
       expect(PostgresResource).to receive(:[]).and_return(postgres_resource)
       expect(postgres_resource).to receive(:flavor).and_return(PostgresResource::Flavor::LANTERN).at_least(:once)
-      expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).with(anything, anything, hash_including(boot_image: "postgres16-lantern-ubuntu-2204")).and_return(instance_double(Strand, id: "62c62ddb-5b5a-4e9e-b534-e73c16f86bcb"))
+      expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).with(anything, hash_including(boot_image: "postgres16-lantern-ubuntu-2204")).and_return(instance_double(Strand, id: "62c62ddb-5b5a-4e9e-b534-e73c16f86bcb"))
       expect(PostgresServer).to receive(:create).and_return(instance_double(PostgresServer, id: "5c13fd6a-25c2-4fa4-be48-2846f127526a"))
       described_class.assemble(resource_id: postgres_resource.id, timeline_id: "91588cda-7122-4d6a-b01c-f33c30cb17d8", timeline_access: "push", representative_at: Time.now)
     end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -209,11 +209,10 @@ RSpec.describe Prog::Vm::Nexus do
         expect(project_id).to eq(prj.id)
         expect(kwargs[:name]).to be_nil
         expect(kwargs[:size]).to eq("new_size")
-        expect(kwargs[:unix_user]).to eq("test_user")
       end.and_return(Strand.new(id: st_id))
-      expect(Sshable).to receive(:create).with({unix_user: "test_user", host: "temp_#{st_id}", raw_private_key_1: "pair"})
+      expect(Sshable).to receive(:create).with(host: "temp_#{st_id}", raw_private_key_1: "pair", unix_user: "rhizome")
 
-      described_class.assemble_with_sshable("test_user", prj.id, size: "new_size")
+      described_class.assemble_with_sshable(prj.id, size: "new_size")
     end
   end
 


### PR DESCRIPTION
This patch is intended to be a semantic no-op as applied, but once
managed services have been adapted to install their `rhizome` programs
into the `rhizome` home directory and use the `rhizome` user to
execute them (like `VmHost`s), the call sites currently specifying
`sshable_unix_user: "ubi"` can stop specifying `sshable_unix_user` and
rely on the default value `rhizome`.

`Sshable` was originally designed exclusively for the `rhizome` user
to support running its programs. This changed in commit
51ee43807c172f42312773fc10ce9cd6750b3843 to support E2E test cases
requiring standard cached SSH access without needing rhizome
installation (initially introduced in
68f0c7a8595318822e0b2877291dce66cd61ecf5).

It was later adapted for GitHub Actions, which learned to bypass the
`rhizome` upload phase for performance gains and meeting specific unix
user naming requirements for parity with first-party GitHub Action
Runners.  We saw firsthand that minor deviations here could lead to
confusion, including an inconsistency seen in the GitHub Actions
product: see e2329cc1ad27e2cd1e9e9183835fa429d7a52312.

It so happens both of these use cases involve using a single,
bootstrapped user as the only user clover is aware of or needs to be
aware of.  But, it was incorrectly extended to services with full
`rhizome` directories and upload steps.  This was an oversight.
Despite creating a separate `rhizome` user, `rhizome` programs were
loaded into the home directory of `ubi`, and both automation and
personnel used the same unix user to log in and `authorized_keys` file
to log in, which made `authorized_keys` more awkward to update than
the arrangement seen on VM Hosts, which was intended to be the default
arrangement.

Although both Sshable and Vm have parameters and database fields named
`unix_user`, they originated independently for distinct purposes. I
think their shared naming, while typically a useful heuristic for
coupling in Clover's codebase, contributed to this repeated oversight.

