### PR TITLE
Add a runner force terminate button to the UI

### DIFF
--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -149,6 +149,30 @@ RSpec.describe Clover, "github" do
       expect(page).to have_content runner_wo_strand.ubid
       expect(page).to have_content "not_created"
     end
+
+    it "can terminate runner" do
+      runner = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").subject
+
+      visit "#{project.path}/github/runner"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content runner.ubid
+
+      btn = find "#runner-#{runner.id} .delete-btn"
+      page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+      expect(page.status_code).to eq(204)
+
+      visit "#{project.path}/github/runner"
+      expect(page).to have_flash_notice("Runner '#{runner.ubid}' forcibly terminated")
+    end
+
+    it "raises not found when runner not exists" do
+      visit "#{project.path}/github/runner/grv4tp3wnb7j7jm5d40wv72j0t"
+
+      expect(page.title).to eq("Ubicloud - ResourceNotFound")
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content "ResourceNotFound"
+    end
   end
 
   describe "cache" do

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -7,9 +7,10 @@
 <div class="grid gap-6">
   <%== part(
     "components/table_card",
-    headers: ["Runner", "Repository", "Label", "State", "Branch", "Workflow Job"],
+    headers: ["Runner", "Repository", "Label", "State", "Branch", "Workflow Job", ""],
     rows:
       @runners.map do |runner|
+        destroy_url = "#{@project_data[:path]}/github/runner/#{runner[:ubid]}"
         [
           [
             [runner[:ubid], { link: runner[:runner_url] }],
@@ -25,7 +26,27 @@
               CONTENT
             else
               "Runner doesn't have a job yet"
-            end
+            end,
+            [
+              "button",
+              {
+                component: {
+                  text: nil,
+                  icon: "hero-x-circle",
+                  extra_class: "delete-btn",
+                  type: "danger",
+                  attributes: {
+                    "title" => "Terminate",
+                    "data-url" => destroy_url,
+                    "data-csrf" => csrf_token(destroy_url, "DELETE"),
+                    "data-confirmation-message" => "Are you sure to terminate this runner?\nThis will cancel its current job and permanently delete all its data.",
+                    "data-redirect" => request.path,
+                    "data-method" => "DELETE"
+                  }
+                },
+                extra_class: "text-right"
+              }
+            ]
           ],
           { id: "runner-#{runner[:id]}" }
         ]


### PR DESCRIPTION
We destroy the runner when GitHub sends the workflow job completed webhook event.

Recently, the runner script has gotten stuck a few times due to zombie processes.

This might be related to GitHub incidents, but we don't have enough information to confirm it.

https://github.com/actions/runner/issues/3737

Since GitHub servers think the script is still running, they don't stop it.

Customers can force terminate the runner by clicking the button. This destroys the underlying virtual machine, causing GitHub servers to lose connection to the runner and mark the job as failed.


![CleanShot 2025-03-19 at 12 36 24@2x](https://github.com/user-attachments/assets/b1c69db1-940b-4a38-a62e-ab552e719563)

![CleanShot 2025-03-19 at 12 36 30@2x](https://github.com/user-attachments/assets/21cf5cfa-1374-4fe3-a45e-abc6e1ebe0d7)
