### PR TITLE
Fix Github Runner user and ssh setup

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -47,6 +47,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     vm_st = Prog::Vm::Nexus.assemble_with_sshable(
       Config.github_runner_service_project_id,
+      unix_user: "runneradmin",
       sshable_unix_user: "runneradmin",
       name: github_runner.ubid.to_s,
       size: label_data["vm_size"],

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       vm = nx.pick_vm
       expect(vm).not_to be_nil
       expect(vm.sshable.unix_user).to eq("runneradmin")
+      expect(vm.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
       expect(vm.vcpus).to eq(4)
       expect(vm.project_id).to eq(Config.github_runner_service_project_id)


### PR DESCRIPTION
fb31111e65c330b3c030f80e244901827c29ef63 had an oversight that blows back very quickly: I didn't adjust Github Runners to set an initial, non-default-named unix user, I only adjusted its Sshable creation. The result is a cascade of authentication errors to `runneradmin` and lack of progress.