### PR TITLE
Fix Github Runner pool user and ssh setup

### DIFF
--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -44,6 +44,7 @@ class Prog::Vm::VmPool < Prog::Base
 
     Prog::Vm::Nexus.assemble_with_sshable(
       Config.vm_pool_project_id,
+      unix_user: "runneradmin",
       sshable_unix_user: "runneradmin",
       size: vm_pool.vm_size,
       location: vm_pool.location,

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe Prog::Vm::VmPool do
       expect { nx.create_new_vm }.to hop("wait")
       pool = VmPool[st.id]
       expect(pool.vms.count).to eq(1)
-      expect(pool.vms.first.sshable).not_to be_nil
+      vm = pool.vms.first
+      expect(vm.unix_user).to eq("runneradmin")
+      expect(vm.sshable.unix_user).to eq("runneradmin")
     end
   end
 


### PR DESCRIPTION
fd2f6fbc66a48c3ee933c6776b66390d0857bf41 attempted to fix the GitHub action situation, and probably did for fresh allocations, but not for pool allocations, which have a distinct code path for specifying user/VM configuration.