### PR TITLE
Check that provided locations in routes are valid visible locations

### DIFF
--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -106,6 +106,10 @@ class Clover < Roda
     @current_account = Account[rodauth.session_value]
   end
 
+  def check_visible_location(location = request.params["location"])
+    request.halt unless (@location = LocationNameConverter.to_visible_internal_name(location))
+  end
+
   def validate_request_params(required_keys, allowed_optional_keys = [], ignored_keys = [])
     params = request.params.reject { ignored_keys.include?(_1) }
     params = params.reject { _1 == "_csrf" } unless api?

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -107,7 +107,7 @@ class Clover < Roda
   end
 
   def check_visible_location(location = request.params["location"])
-    request.halt unless (@location = LocationNameConverter.to_visible_internal_name(location))
+    request.halt unless (@location = Location.where(display_name: location, visible: true).get(:name))
   end
 
   def validate_request_params(required_keys, allowed_optional_keys = [], ignored_keys = [])

--- a/lib/location_name_converter.rb
+++ b/lib/location_name_converter.rb
@@ -5,10 +5,6 @@ module LocationNameConverter
     Location.where(display_name:).get(:name)
   end
 
-  def self.to_visible_internal_name(display_name)
-    Location.where(display_name:, visible: true).get(:name)
-  end
-
   def self.to_display_name(internal_name)
     Location.where(name: internal_name).get(:display_name)
   end

--- a/lib/location_name_converter.rb
+++ b/lib/location_name_converter.rb
@@ -5,6 +5,10 @@ module LocationNameConverter
     Location.where(display_name:).get(:name)
   end
 
+  def self.to_visible_internal_name(display_name)
+    Location.where(display_name:, visible: true).get(:name)
+  end
+
   def self.to_display_name(internal_name)
     Location.where(name: internal_name).get(:display_name)
   end

--- a/lib/location_name_converter.rb
+++ b/lib/location_name_converter.rb
@@ -2,10 +2,10 @@
 
 module LocationNameConverter
   def self.to_internal_name(display_name)
-    Location[display_name:]&.name
+    Location.where(display_name:).get(:name)
   end
 
   def self.to_display_name(internal_name)
-    Location[name: internal_name]&.display_name
+    Location.where(name: internal_name).get(:display_name)
   end
 end

--- a/routes/project/firewall.rb
+++ b/routes/project/firewall.rb
@@ -24,7 +24,7 @@ class Clover
       end
 
       r.post true do
-        @location = LocationNameConverter.to_internal_name(r.params["location"])
+        check_visible_location
         firewall_post(r.params["name"])
       end
     end

--- a/routes/project/kubernetes_cluster.rb
+++ b/routes/project/kubernetes_cluster.rb
@@ -10,7 +10,7 @@ class Clover
       end
 
       r.post true do
-        @location = LocationNameConverter.to_internal_name(r.params["location"])
+        check_visible_location
         kubernetes_cluster_post(r.params["name"])
       end
 

--- a/routes/project/location.rb
+++ b/routes/project/location.rb
@@ -3,8 +3,7 @@
 class Clover
   hash_branch(:project_prefix, "location") do |r|
     r.on String do |location_display_name|
-      @location = LocationNameConverter.to_internal_name(location_display_name)
-
+      check_visible_location(location_display_name)
       r.hash_branches(:project_location_prefix)
     end
   end

--- a/routes/project/postgres.rb
+++ b/routes/project/postgres.rb
@@ -8,7 +8,7 @@ class Clover
 
     r.web do
       r.post true do
-        @location = LocationNameConverter.to_internal_name(r.params["location"])
+        check_visible_location
         postgres_post(r.params["name"])
       end
 

--- a/routes/project/private_subnet.rb
+++ b/routes/project/private_subnet.rb
@@ -8,7 +8,7 @@ class Clover
 
     r.web do
       r.post true do
-        @location = LocationNameConverter.to_internal_name(r.params["location"])
+        check_visible_location
         private_subnet_post(r.params["name"])
       end
 

--- a/routes/project/vm.rb
+++ b/routes/project/vm.rb
@@ -15,7 +15,7 @@ class Clover
 
     r.web do
       r.post true do
-        @location = LocationNameConverter.to_internal_name(r.params["location"])
+        check_visible_location
         vm_post(r.params["name"])
       end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "not exist" do
-        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/foo_name"
+        delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/foo-name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
@@ -334,7 +334,7 @@ RSpec.describe Clover, "postgres" do
       it "not exist ubid in location" do
         delete "/project/#{project.ubid}/location/foo_location/postgres/#{pg.ubid}"
 
-        expect(last_response.status).to eq(204)
+        expect(last_response.status).to eq(404)
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -331,13 +331,6 @@ RSpec.describe Clover, "postgres" do
         expect(SemSnap.new(pg.id).set?("destroy")).to be false
       end
 
-      it "not exist ubid in location" do
-        delete "/project/#{project.ubid}/location/foo_location/postgres/#{pg.ubid}"
-
-        expect(last_response.status).to eq(404)
-        expect(SemSnap.new(pg.id).set?("destroy")).to be false
-      end
-
       it "firewall-rule" do
         delete "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}"
 

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Clover, "private_subnet" do
 
       it "not authorized" do
         project
-        post "/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.location}/private-subnet/foo_subnet"
+        post "/project/#{project_wo_permissions.ubid}/location/#{ps_wo_permission.display_location}/private-subnet/foo_subnet"
 
         expect(last_response.content_type).to eq("application/json")
         expect(last_response).to have_api_error(403)
@@ -175,12 +175,12 @@ RSpec.describe Clover, "private_subnet" do
       it "not exist ubid in location" do
         delete "/project/#{project.ubid}/location/foo_location/private-subnet/#{ps.ubid}"
 
-        expect(last_response.status).to eq(204)
+        expect(last_response.status).to eq(404)
         expect(SemSnap.new(ps.id).set?("destroy")).to be false
       end
 
       it "not exist ubid" do
-        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/_foo_ubid"
+        delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo-name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(ps.id).set?("destroy")).to be false

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -172,13 +172,6 @@ RSpec.describe Clover, "private_subnet" do
         expect(SemSnap.new(ps.id).set?("destroy")).to be true
       end
 
-      it "not exist ubid in location" do
-        delete "/project/#{project.ubid}/location/foo_location/private-subnet/#{ps.ubid}"
-
-        expect(last_response.status).to eq(404)
-        expect(SemSnap.new(ps.id).set?("destroy")).to be false
-      end
-
       it "not exist ubid" do
         delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo-name"
 

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "not exist" do
-        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/foo_name"
+        delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/foo-name"
 
         expect(last_response.status).to eq(204)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
@@ -252,7 +252,7 @@ RSpec.describe Clover, "vm" do
       it "not exist ubid in location" do
         delete "/project/#{project.ubid}/location/foo_location/vm/#{vm.ubid}"
 
-        expect(last_response.status).to eq(204)
+        expect(last_response.status).to eq(404)
         expect(SemSnap.new(vm.id).set?("destroy")).to be false
       end
     end

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Clover, "firewall" do
       end
 
       it "raises not found when firewall not exists" do
-        visit "#{project.path}/location/hetzner-fsn1/firewall/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/eu-central-h1/firewall/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Clover, "private subnet" do
       end
 
       it "raises not found when private subnet not exists" do
-        visit "#{project.path}/location/hetzner-fsn1/private-subnet/08s56d4kaj94xsmrnf5v5m3mav"
+        visit "#{project.path}/location/eu-central-h1/private-subnet/08s56d4kaj94xsmrnf5v5m3mav"
 
         expect(page.title).to eq("Ubicloud - ResourceNotFound")
         expect(page.status_code).to eq(404)


### PR DESCRIPTION
Add LocationNameConverter.to_visible_internal_name to check that a
given location is a valid visible location.

Add Clover#check_visible_location, which calls to_visible_internal_name
and halts route processing if a location is not a valid visible location.
Use this in the routes in all cases where @location was being set
manually.

Change delete specs that use invalid locations to expect 404 instead of
204.  204 is not needed, as the deletion could never have succeeded with
an invalid location.