### PR TITLE
Allow access to objects in internal locations in web/api routes

### DIFF
--- a/routes/project/location.rb
+++ b/routes/project/location.rb
@@ -3,7 +3,7 @@
 class Clover
   hash_branch(:project_prefix, "location") do |r|
     r.on String do |location_display_name|
-      check_visible_location_name(location_display_name)
+      handle_invalid_location unless (@location = Location[display_name: location_display_name])
       r.hash_branches(:project_location_prefix)
     end
   end

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -9,6 +9,7 @@ class Clover
     r.on FIREWALL_NAME_OR_UBID do |firewall_name, firewall_id|
       if firewall_name
         r.post api? do
+          check_visible_location
           firewall_post(firewall_name)
         end
 

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -9,6 +9,7 @@ class Clover
     r.on LOAD_BALANCER_NAME_OR_UBID do |lb_name, lb_id|
       if lb_name
         r.post api? do
+          check_visible_location
           load_balancer_post(lb_name)
         end
 

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -9,6 +9,7 @@ class Clover
     r.on POSTGRES_RESOURCE_NAME_OR_UBID do |pg_name, pg_ubid|
       if pg_name
         r.post api? do
+          check_visible_location
           postgres_post(pg_name)
         end
 

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -9,6 +9,7 @@ class Clover
     r.on PRIVATE_SUBNET_NAME_OR_UBID do |ps_name, ps_id|
       if ps_name
         r.post true do
+          check_visible_location
           private_subnet_post(ps_name)
         end
 

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -9,6 +9,7 @@ class Clover
     r.on VM_NAME_OR_UBID do |vm_name, vm_ubid|
       if vm_name
         r.post api? do
+          check_visible_location
           vm_post(vm_name)
         end
 

--- a/spec/routes/api/cli/vm/ssh_spec.rb
+++ b/spec/routes/api/cli/vm/ssh_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Clover, "cli vm ssh" do
 
   it "handles invalid vm reference" do
     expect(cli(["vm", "#{@vm.display_location}/foo", "ssh"], status: 404)).to eq "! Unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for.\n"
-    expect(cli(["vm", "foo/#{@vm.name}", "ssh"], status: 404)).to eq "! Unexpected response status: 404\nDetails: Sorry, we couldn’t find the resource you’re looking for.\n"
+    expect(cli(["vm", "foo/#{@vm.name}", "ssh"], status: 404)).to eq "! Unexpected response status: 404\nDetails: Validation failed for following path components: location\n  location: Given location is not a valid location. Available locations: eu-central-h1, eu-north-h1, us-east-a2\n"
     expect(cli(["vm", "#{@vm.display_location}/#{@vm.name}/bar", "ssh"], status: 400)).to eq "! Invalid vm reference, should be in location/vm-name or vm-id format\n"
   end
 end

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Clover, "firewall" do
         description: "Firewall description"
       }.to_json
 
-      expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
+      expect(last_response).to have_api_error(404, "Validation failed for following path components: location")
     end
   end
 end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync"
         }.to_json
 
-        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
+        expect(last_response).to have_api_error(404, "Validation failed for following path components: location")
       end
 
       it "invalid name" do

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Clover, "private_subnet" do
       it "location not exist" do
         post "/project/#{project.ubid}/location/not-exist-location/private-subnet/test-ps", {}.to_json
 
-        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
+        expect(last_response).to have_api_error(404, "Validation failed for following path components: location")
       end
     end
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content("31/32 (96%)")
       end
 
+      it "shows 404 page if attempting to create a VM with an invalid location" do
+        visit "#{project.path}/vm/create"
+        fill_in "Name", with: "dummy-vm"
+        choose "Germany"
+
+        Location.where(display_name: "eu-central-h1").destroy
+        click_button "Create"
+        expect(page.status_code).to eq 404
+      end
+
       it "shows vm create page with burstable and location_latitude_fra" do
         project.set_ff_location_latitude_fra true
         visit "#{project.path}/vm/create"


### PR DESCRIPTION
However, do not allow creation of objects in internal locations in web/api routes.
    
Show helpful error message if using an invalid location in the api. This error message shows what the problem is, and the available valid locations the user can use