### PR TITLE
Bandaid fix for LB TCP Health Checks

### DIFF
--- a/model/load_balancers_vms.rb
+++ b/model/load_balancers_vms.rb
@@ -40,7 +40,7 @@ class LoadBalancersVms < Sequel::Model
   def health_check_cmd(type)
     address = (type == :ipv4) ? vm.private_ipv4 : vm.ephemeral_net6.nth(2)
     if load_balancer.health_check_protocol == "tcp"
-      "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{address} #{load_balancer.dst_port} && echo 200 || echo 400"
+      "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{address} #{load_balancer.dst_port} >/dev/null 2>&1 && echo 200 || echo 400"
     else
       "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer.dst_port}:#{(address.version == 6) ? "[#{address}]" : address} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{load_balancer.hostname}:#{load_balancer.dst_port}#{load_balancer.health_check_endpoint}"
     end

--- a/spec/model/load_balancers_vms_spec.rb
+++ b/spec/model/load_balancers_vms_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe LoadBalancersVms do
         expect(lb_vm.health_check_cmd(:ipv6)).to eq("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:[2a01:4f8:10a:128b:814c::2] --max-time 15 --silent --output /dev/null --write-out '%{http_code}' http://#{lb.hostname}:80/up")
 
         lb.update(health_check_protocol: "tcp")
-        expect(lb_vm.health_check_cmd(:ipv4)).to eq("sudo ip netns exec #{vm.inhost_name} nc -z -w 15 192.168.1.1 80 && echo 200 || echo 400")
-        expect(lb_vm.health_check_cmd(:ipv6)).to eq("sudo ip netns exec #{vm.inhost_name} nc -z -w 15 2a01:4f8:10a:128b:814c::2 80 && echo 200 || echo 400")
+        expect(lb_vm.health_check_cmd(:ipv4)).to eq("sudo ip netns exec #{vm.inhost_name} nc -z -w 15 192.168.1.1 80 >/dev/null 2>&1 && echo 200 || echo 400")
+        expect(lb_vm.health_check_cmd(:ipv6)).to eq("sudo ip netns exec #{vm.inhost_name} nc -z -w 15 2a01:4f8:10a:128b:814c::2 80 >/dev/null 2>&1 && echo 200 || echo 400")
 
         lb.update(health_check_protocol: "https")
         expect(lb_vm.health_check_cmd(:ipv4)).to eq("sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{lb.hostname}:80:192.168.1.1 --max-time 15 --silent --output /dev/null --write-out '%{http_code}' https://#{lb.hostname}:80/up")


### PR DESCRIPTION
Load balancer TCP health checks were failing, because the health check command that involve `nc ... | echo "200"` command started returning "Connection to 172.24.128.193 6443 port [tcp/*] succeeded!\n200" instead of just "200", which broke the health checks.

This commit applies a bandaid by suppressing all output of the `nc` command.