### PR TITLE
Nap longer while waiting for the semaphore to increase

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -120,7 +120,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   end
 
   label def wait
-    nap 65536
+    nap 6 * 60 * 60
   end
 
   label def destroy

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -42,7 +42,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   end
 
   label def wait
-    nap 65536
+    nap 6 * 60 * 60
   end
 
   label def destroy

--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -68,7 +68,7 @@ class Prog::Minio::MinioPoolNexus < Prog::Base
   end
 
   label def wait
-    nap 30
+    nap 6 * 60 * 60
   end
 
   label def destroy

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -24,6 +24,6 @@ class Prog::PageNexus < Prog::Base
       pop "page is resolved"
     end
 
-    nap 30
+    nap 6 * 60 * 60
   end
 end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -377,7 +377,7 @@ SQL
       push self.class, frame, "restart"
     end
 
-    nap 30
+    nap 6 * 60 * 60
   end
 
   label def unavailable

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -315,7 +315,7 @@ class Prog::Vm::HostNexus < Prog::Base
       decr_checkup
     end
 
-    nap 30
+    nap 6 * 60 * 60
   end
 
   label def unavailable

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -378,7 +378,7 @@ class Prog::Vm::Nexus < Prog::Base
       hop_unavailable
     end
 
-    nap 30
+    nap 6 * 60 * 60
   end
 
   label def update_firewall_rules

--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -62,7 +62,7 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
       hop_unavailable
     end
 
-    nap 30
+    nap 6 * 60 * 60
   end
 
   label def unavailable

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -52,7 +52,7 @@ class Prog::Vnet::NicNexus < Prog::Base
       hop_start_rekey
     end
 
-    nap 30
+    nap 6 * 60 * 60
   end
 
   label def start_rekey

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -67,7 +67,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       private_subnet.incr_refresh_keys
     end
 
-    nap 30
+    nap 10 * 60
   end
 
   def gen_encryption_key

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -203,8 +203,8 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   end
 
   describe "#wait" do
-    it "naps forever for now" do
-      expect { nx.wait }.to nap(65536)
+    it "naps for 6 hours" do
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   end
 
   describe "#wait" do
-    it "just naps for long time for now" do
-      expect { nx.wait }.to nap(65536)
+    it "naps for 6 hours" do
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
   end
 

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
 
   describe "#wait" do
     it "naps" do
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
   end
 

--- a/spec/prog/page_nexus_spec.rb
+++ b/spec/prog/page_nexus_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Prog::PageNexus do
     end
 
     it "naps" do
-      expect { pn.wait }.to nap(30)
+      expect { pn.wait }.to nap(6 * 60 * 60)
     end
   end
 end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#wait" do
     it "naps" do
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
     it "hops to prepare_for_take_over if take_over is set" do
@@ -544,7 +544,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "naps if checkup is set but the server is available" do
       expect(nx).to receive(:when_checkup_set?).and_yield
       expect(nx).to receive(:available?).and_return(true)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
     it "hops to configure_prometheus if configure_prometheus is set" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#wait" do
     it "naps" do
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
     it "hops to prep_graceful_reboot when needed" do
@@ -319,7 +319,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
       expect(nx).to receive(:when_checkup_set?).and_yield
       expect(nx).to receive(:available?).and_return(true)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -655,7 +655,7 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe "#wait" do
     it "naps when nothing to do" do
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
     it "hops to start_after_host_reboot when needed" do
@@ -694,7 +694,7 @@ RSpec.describe Prog::Vm::Nexus do
 
       expect(nx).to receive(:when_checkup_set?).and_yield
       expect(nx).to receive(:available?).and_return(true)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
   end
 

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
   end
 
   describe "#wait" do
-    it "naps for 30 seconds" do
-      expect { nx.wait }.to nap(30)
+    it "naps for 6 hours" do
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
     it "hops to start_after_host_reboot when signaled" do
@@ -139,7 +139,7 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
 
       expect(nx).to receive(:when_checkup_set?).and_yield
       expect(nx).to receive(:available?).and_return(true)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
   end
 

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#wait" do
     it "naps if nothing to do" do
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
     it "hops to start rekey if needed" do
@@ -105,7 +105,7 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect(nx).to receive(:when_repopulate_set?).and_yield
       ps = instance_double(PrivateSubnet, incr_refresh_keys: true)
       expect(nx).to receive(:nic).and_return(instance_double(Nic, private_subnet: ps))
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(6 * 60 * 60)
     end
   end
 

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "increments refresh_keys if it passed more than a day" do
       expect(ps).to receive(:last_rekey_at).and_return(Time.now - 60 * 60 * 24 - 1)
       expect(ps).to receive(:incr_refresh_keys).and_return(true)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(10 * 60)
     end
 
     it "triggers update_firewall_rules if when_update_firewall_rules_set?" do
@@ -155,11 +155,11 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(ps).to receive(:vms).and_return([instance_double(Vm, id: "vm1")]).at_least(:once)
       expect(ps.vms.first).to receive(:incr_update_firewall_rules).and_return(true)
       expect(nx).to receive(:decr_update_firewall_rules).and_return(true)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(10 * 60)
     end
 
     it "naps if nothing to do" do
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(10 * 60)
     end
   end
 


### PR DESCRIPTION
- **Nap 6 hours while waiting for the semaphore to increase**
  When we increase the semaphore, we have already scheduled the strand for
  now.
  
  If the label is just waiting for the semaphore to increase, there's no
  need for short naps.
  
  Most of our wait labels are just waiting for the semaphore to increase,
  so I extended their naps to 6 hours.
  
  It will help decrease the load on the respirate on production
  
  [^1]: https://github.com/ubicloud/ubicloud/blob/28dacb968b9222e72bdc829c240ad3d272fb80c8/model/semaphore.rb#L10
  

- **Increase the subnet nap time to 10 minutes**
  The subnet nexus waits for the semaphore to increase or checks if 24
  hours have passed since the last rekeying.
  
  It is already scheduled for now when the semaphore increased.
  
  For the last rekeying, there's no need to check every 30 seconds; 10
  minutes is more than enough.
  