### PR TITLE
Add a restarter program and use it for respirate

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C puma_config.rb
-respirate: bin/respirate
+respirate: bin/restarter bin/respirate
 monitor: bin/monitor

--- a/bin/restarter
+++ b/bin/restarter
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+minimum_time_alive = Integer(ENV.fetch("RESTART_MINIMUM_TIME_ALIVE", "3600"), 10)
+require "json"
+
+command = ARGV.dup.freeze
+start_time = Time.now
+
+iso_start = start_time.utc.strftime("%Y-%m-%dT%H:%M:%S%:z").freeze
+puts JSON.generate(restarter: {
+  start_time: iso_start,
+  startup: {
+    command:,
+    minimum_time_alive:
+  }
+})
+
+loop do
+  system(*command)
+  status = $?
+
+  puts JSON.generate(restarter: {
+    start_time: iso_start,
+    command_exit: {
+      command:,
+      exitstatus: status.exitstatus,
+      pid: status.pid,
+      success: status.success?
+    }
+  })
+
+  sleep(rand(1..10))
+
+  if Time.now - start_time > minimum_time_alive
+    puts JSON.generate(restarter: {start_time: iso_start,
+                                   shutdown: {
+                                     command:,
+                                     minimum_time_alive:
+                                   }})
+    exit
+  end
+end


### PR DESCRIPTION
By default, this prevents the supervisor monitoring `restarter` from seeing that the process it is supervises exited more than once per hour by default.

In the case of Heroku, this is of importance, because after a few consecutive crashes (e.g. from a recalcitrant server causing apoptosis from a `select()` loop without a timeout).  The quantitatively exact Heroku backoff behavior is not documented, so some future tuning will have to take place.

When Heroku elects to no longer start the process again, this pages us or degrades `respirate` throughput for a time.

There's no reason we can't restart more or less right away. So, this patch does this.  There are some secondary/fine considerations:

1. The restarting is randomized to a degree, to prevent too many exactly simultaneous startups.

2. It is desirable to exit sometimes, in case there is a network or computer specific dependency to the failure, to request the process supervisor (e.g. Heroku, Kubernetes) to put the entire process somewhere else...but only once in a while.

3. The log format has some regularity to it: all the `restarter` activity is in the top level key `restarter`.  In it, there is always a `start_time`, which is thought to be unique (along with PID, as often conveyed by syslog) to both identify and convey useful information about the `restarter` session.  In addition to `start_time` there is always a "going concern" key (`startup`, `subprocess_exit`, `shutdown`) with information relevant to that phase in the program's execution in particular.

You can test the basic function of the program like this:

    $ RESTART_MINIMUM_TIME_ALIVE=10 bin/restarter bash -c 'sleep 1; echo hi; exit 1'
    {"restarter":{"start_time":"2025-03-21T17:52:53+00:00","startup":{"subprocess_args":["bash","-c","sleep 1; echo hi; exit 1"],"minimum_time_alive":10}}}
    hi
    {"restarter":{"start_time":"2025-03-21T17:52:53+00:00","subprocess_exit":{"command":["bash","-c","sleep 1; echo hi; exit 1"],"exitstatus":1,"pid":938199,"success":false}}}
    hi
    {"restarter":{"start_time":"2025-03-21T17:52:53+00:00","subprocess_exit":{"command":["bash","-c","sleep 1; echo hi; exit 1"],"exitstatus":1,"pid":938212,"success":false}}}
    {"restarter":{"start_time":"2025-03-21T17:52:53+00:00","shutdown":{"start_time":"2025-03-21T17:52:53+00:00"}}}

[1]: We decline to use the Ruby Timeout class that injects an exception at any point in child thread execution, because it's more or less impossible for us or any library we use, including the standard library, to write a correct program that can have its stack unwound at any point that way.