### PR TITLE
Fix missing Tailwind classes in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY tailwind.config.js package.json package-lock.json ./
 COPY views/ ./views/
 COPY assets/ ./assets/
+COPY helpers/web.rb ./helpers/web.rb
 RUN npm ci
 RUN npm run prod
 


### PR DESCRIPTION
Tailwind generates app.css with only the classes that are used. It
checks three locations to determine which classes to include in the
final CSS file. [^1]

The "helpers/web.rb" file was missing in the frontend-builder layer,
which caused the missing Tailwind classes in Docker.

[^1]: https://github.com/ubicloud/ubicloud/blob/6b9248e3c61340c39401312180118b640cbb3442/tailwind.config.js#L3-L7
