### PR TITLE
Fix division by zero in progress bar calculation

### DIFF
--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Clover, "project" do
 
     describe "details" do
       it "can show project details" do
-        project
+        project.add_quota(quota_id: ProjectQuota.default_quotas["VmVCpu"]["id"], value: 0)
         visit "/project"
 
         expect(page.title).to eq("Ubicloud - Projects")
@@ -176,6 +176,10 @@ RSpec.describe Clover, "project" do
 
         expect(page.title).to eq("Ubicloud - #{project.name} Dashboard")
         expect(page).to have_content project.name
+
+        find_by_id("desktop-menu").click_link "Settings"
+
+        expect(page.title).to eq("Ubicloud - #{project.name}")
       end
 
       it "raises forbidden when does not have permissions" do

--- a/views/components/progress_bar.erb
+++ b/views/components/progress_bar.erb
@@ -1,5 +1,5 @@
 <%# locals: (numerator:, denominator:, title:) %>
-<% progress = [100, 100 * numerator / denominator].min
+<% progress = [100, denominator.zero? ? 100 : 100 * numerator / denominator].min
 color = (progress < 60) ? "bg-blue-500" : (progress < 80) ? "bg-yellow-500" : "bg-red-500" %>
 
 <div class="flex justify-between mb-1">


### PR DESCRIPTION
When we set the project quota to zero, the denominator becomes zero,
which breaks the project detail page.
