### PR TITLE
Increase the frequency of redeliveries for failed GitHub webhook events

### DIFF
--- a/prog/redeliver_github_failures.rb
+++ b/prog/redeliver_github_failures.rb
@@ -9,6 +9,6 @@ class Prog::RedeliverGithubFailures < Prog::Base
     strand.modified!(:stack)
     strand.save_changes
 
-    nap 5 * 60
+    nap 2 * 60
   end
 end

--- a/spec/prog/redeliver_github_failures_spec.rb
+++ b/spec/prog/redeliver_github_failures_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Prog::RedeliverGithubFailures do
       expect(Github).to receive(:redeliver_failed_deliveries).with(Time.parse("2023-10-19 22:27:47 +0000"))
       expect(rgf.strand).to receive(:save_changes)
       expect {
-        expect { rgf.wait }.to nap(5 * 60)
+        expect { rgf.wait }.to nap(2 * 60)
       }.to change { rgf.strand.stack.first["last_check_at"] }.from("2023-10-19 22:27:47 +0000").to("2023-10-19 23:27:47 +0000")
     end
   end


### PR DESCRIPTION
GitHub’s app delivery API doesn’t have enough filtering options and
allows a maximum of 100 items per page. We have a ‘max_page’ limit to
avoid endless pagination.

As the number of delivered webhook events has increased, we occasionally
hit the max_page limit.

Instead of raising the ‘max_page’ limit, I prefer to check it more
frequently.

Increasing the 'max_page' limit extends the time spent on a single run
and raises the risk of apoptosis. It makes more sense to check more
frequently with less pages rather than less frequently with more pages.
