### PR TITLE
Add Ruby SDK and reimplement CLI processing using it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /tmp/*
 /assets/css/app.css
 /.auto-parallel-tests
+/sdk/ruby/*.gem
 /sql.log
 /sql_query_parameterization_analysis.txt
 /spec/routes/api/cli/spec-output-files

--- a/Rakefile
+++ b/Rakefile
@@ -325,6 +325,11 @@ task "annotate" do
   Sequel::Annotate.annotate(Dir["model/**/*.rb"])
 end
 
+desc "Build sdk gem"
+task "build-sdk-gem" do
+  sh("cd sdk/ruby && gem build ubicloud.gemspec")
+end
+
 desc "Emit assets before deploying"
 task "assets:precompile" do
   sh("npm", "install")

--- a/cli-commands/fw/post/add-rule.rb
+++ b/cli-commands/fw/post/add-rule.rb
@@ -11,11 +11,8 @@ UbiCli.on("fw").run_on("add-rule") do
   args 1
 
   run do |cidr, opts|
-    range = opts[:fw_add_rule].values_at(:"start-port", :"end-port")
-    range[1] ||= range[0] || 65535
-    range[0] ||= 0
-    post(fw_path("/firewall-rule"), "cidr" => cidr, "port_range" => range.join("..")) do |data|
-      ["Added firewall rule with id: #{data["id"]}"]
-    end
+    start_port, end_port = opts[:fw_add_rule].values_at(:"start-port", :"end-port")
+    id = sdk_object.add_rule(cidr, start_port:, end_port:)[:id]
+    response("Added firewall rule with id: #{id}")
   end
 end

--- a/cli-commands/fw/post/attach-subnet.rb
+++ b/cli-commands/fw/post/attach-subnet.rb
@@ -8,8 +8,7 @@ UbiCli.on("fw").run_on("attach-subnet") do
   args 1
 
   run do |subnet_id|
-    post(fw_path("/attach-subnet"), "private_subnet_id" => subnet_id) do |data|
-      ["Attached private subnet with id #{subnet_id} to firewall with id #{data["id"]}"]
-    end
+    id = sdk_object.attach_subnet(subnet_id).id
+    response("Attached private subnet with id #{subnet_id} to firewall with id #{id}")
   end
 end

--- a/cli-commands/fw/post/create.rb
+++ b/cli-commands/fw/post/create.rb
@@ -9,8 +9,7 @@ UbiCli.on("fw").run_on("create") do
 
   run do |opts|
     params = underscore_keys(opts[:fw_create])
-    post(fw_path, params) do |data|
-      ["Firewall created with id: #{data["id"]}"]
-    end
+    id = sdk.firewall.create(location: @location, name: @name, **params).id
+    response("Firewall created with id: #{id}")
   end
 end

--- a/cli-commands/fw/post/delete-rule.rb
+++ b/cli-commands/fw/post/delete-rule.rb
@@ -8,10 +8,8 @@ UbiCli.on("fw").run_on("delete-rule") do
   args 1
 
   run do |rule_id|
-    raise Rodish::CommandFailure, "invalid rule id format" if rule_id.include?("/")
-
-    delete(fw_path("/firewall-rule/#{rule_id}")) do
-      ["Firewall rule, if it existed, has been deleted"]
-    end
+    check_no_slash(rule_id, "invalid rule id format")
+    sdk_object.delete_rule(rule_id)
+    response("Firewall rule, if it existed, has been deleted")
   end
 end

--- a/cli-commands/fw/post/detach-subnet.rb
+++ b/cli-commands/fw/post/detach-subnet.rb
@@ -8,8 +8,7 @@ UbiCli.on("fw").run_on("detach-subnet") do
   args 1
 
   run do |subnet_id|
-    post(fw_path("/detach-subnet"), "private_subnet_id" => subnet_id) do |data|
-      ["Detached private subnet with id #{subnet_id} from firewall with id #{data["id"]}"]
-    end
+    id = sdk_object.detach_subnet(subnet_id).id
+    response("Detached private subnet with id #{subnet_id} from firewall with id #{id}")
   end
 end

--- a/cli-commands/fw/post/show.rb
+++ b/cli-commands/fw/post/show.rb
@@ -20,48 +20,47 @@ UbiCli.on("fw").run_on("show") do
   help_option_values("Firewall Rule Fields:", firewall_rule_fields)
 
   run do |opts|
-    get(fw_path) do |data|
-      opts = opts[:fw_show]
-      keys = underscore_keys(check_fields(opts[:fields], fields, "fw show -f option"))
-      firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "fw show -r option"))
-      private_subnet_keys = underscore_keys(check_fields(opts[:"priv-subnet-fields"], private_subnet_fields, "fw show -p option"))
-      nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "fw show -n option"))
+    data = sdk_object.info
+    opts = opts[:fw_show]
+    keys = underscore_keys(check_fields(opts[:fields], fields, "fw show -f option"))
+    firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "fw show -r option"))
+    private_subnet_keys = underscore_keys(check_fields(opts[:"priv-subnet-fields"], private_subnet_fields, "fw show -p option"))
+    nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "fw show -n option"))
 
-      body = []
+    body = []
 
-      keys.each do |key|
-        case key
-        when "firewall_rules"
-          body << "rules:\n"
-          data[key].each_with_index do |rule, i|
-            body << "  " << (i + 1).to_s << ": "
-            firewall_rule_keys.each do |fwr_key|
-              body << rule[fwr_key].to_s << "  "
-            end
-            body << "\n"
+    keys.each do |key|
+      case key
+      when :firewall_rules
+        body << "rules:\n"
+        data[key].each_with_index do |rule, i|
+          body << "  " << (i + 1).to_s << ": "
+          firewall_rule_keys.each do |fwr_key|
+            body << rule[fwr_key].to_s << "  "
           end
-        when "private_subnets"
-          data[key].each_with_index do |ps, i|
-            body << "private subnet " << (i + 1).to_s << ":\n"
-            private_subnet_keys.each do |ps_key|
-              if ps_key == "nics"
-                ps[ps_key].each_with_index do |nic, i|
-                  body << "  nic " << (i + 1).to_s << ":\n"
-                  nic_keys.each do |nic_key|
-                    body << "    " << nic_key << ": " << nic[nic_key].to_s << "\n"
-                  end
-                end
-              else
-                body << "  " << ps_key << ": " << ps[ps_key].to_s << "\n"
-              end
-            end
-          end
-        else
-          body << key << ": " << data[key].to_s << "\n"
+          body << "\n"
         end
+      when :private_subnets
+        data[key].each_with_index do |ps, i|
+          body << "private subnet " << (i + 1).to_s << ":\n"
+          private_subnet_keys.each do |ps_key|
+            if ps_key == :nics
+              ps[ps_key].each_with_index do |nic, i|
+                body << "  nic " << (i + 1).to_s << ":\n"
+                nic_keys.each do |nic_key|
+                  body << "    " << nic_key.to_s << ": " << nic[nic_key].to_s << "\n"
+                end
+              end
+            else
+              body << "  " << ps_key.to_s << ": " << ps[ps_key].to_s << "\n"
+            end
+          end
+        end
+      else
+        body << key.to_s << ": " << data[key].to_s << "\n"
       end
-
-      body
     end
+
+    response(body)
   end
 end

--- a/cli-commands/lb/post/attach-vm.rb
+++ b/cli-commands/lb/post/attach-vm.rb
@@ -8,8 +8,7 @@ UbiCli.on("lb").run_on("attach-vm") do
   args 1
 
   run do |vm_id|
-    post(lb_path("/attach-vm"), "vm_id" => vm_id) do |data|
-      ["Attached VM with id #{vm_id} to load balancer with id #{data["id"]}"]
-    end
+    id = sdk_object.attach_vm(vm_id).id
+    response("Attached VM with id #{vm_id} to load balancer with id #{id}")
   end
 end

--- a/cli-commands/lb/post/create.rb
+++ b/cli-commands/lb/post/create.rb
@@ -17,17 +17,14 @@ UbiCli.on("lb").run_on("create") do
 
   run do |private_subnet_id, src_port, dst_port, opts|
     params = underscore_keys(opts[:lb_create])
-    params["algorithm"] ||= "round_robin"
-    if (endpoint = params.delete("check_endpoint"))
-      params["health_check_endpoint"] = endpoint
+    if (endpoint = params.delete(:check_endpoint))
+      params[:health_check_endpoint] = endpoint
     end
-    params["health_check_protocol"] = params.delete("check_protocol") || "http"
-    params["stack"] ||= "dual"
-    params["private_subnet_id"] = private_subnet_id
-    params["src_port"] = src_port
-    params["dst_port"] = dst_port
-    post(lb_path, params) do |data|
-      ["Load balancer created with id: #{data["id"]}"]
-    end
+    params[:health_check_protocol] = params.delete(:check_protocol)
+    params[:private_subnet_id] = private_subnet_id
+    params[:src_port] = src_port
+    params[:dst_port] = dst_port
+    id = sdk.load_balancer.create(location: @location, name: @name, **params).id
+    response("Load balancer created with id: #{id}")
   end
 end

--- a/cli-commands/lb/post/detach-vm.rb
+++ b/cli-commands/lb/post/detach-vm.rb
@@ -8,8 +8,7 @@ UbiCli.on("lb").run_on("detach-vm") do
   args 1
 
   run do |vm_id|
-    post(lb_path("/detach-vm"), "vm_id" => vm_id) do |data|
-      ["Detached VM with id #{vm_id} from load balancer with id #{data["id"]}"]
-    end
+    id = sdk_object.detach_vm(vm_id).id
+    response("Detached VM with id #{vm_id} from load balancer with id #{id}")
   end
 end

--- a/cli-commands/lb/post/show.rb
+++ b/cli-commands/lb/post/show.rb
@@ -11,23 +11,25 @@ UbiCli.on("lb").run_on("show") do
   help_option_values("Fields:", fields)
 
   run do |opts|
-    get(lb_path) do |data|
-      keys = underscore_keys(check_fields(opts[:lb_show][:fields], fields, "lb show -f option"))
+    data = sdk_object.info
+    keys = underscore_keys(check_fields(opts[:lb_show][:fields], fields, "lb show -f option"))
 
-      body = []
+    body = []
 
-      keys.each do |key|
-        if key == "vms"
-          body << "vms:\n"
-          data[key].each do |vm_ubid|
-            body << "  " << vm_ubid << "\n"
-          end
-        else
-          body << key << ": " << data[key].to_s << "\n"
+    keys.each do |key|
+      case key
+      when :vms
+        body << "vms:\n"
+        data[key].each do |vm|
+          body << "  " << vm.id << "\n"
         end
+      when :subnet
+        body << key.to_s << ": " << data.subnet.name << "\n"
+      else
+        body << key.to_s << ": " << data[key].to_s << "\n"
       end
-
-      body
     end
+
+    response(body)
   end
 end

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -9,8 +9,7 @@ UbiCli.on("lb").run_on("update") do
 
   run do |argv|
     algorithm, src_port, dst_port, health_check_endpoint, *vms = argv
-    patch(lb_path, {algorithm:, src_port:, dst_port:, health_check_endpoint:, vms:}.transform_keys(&:to_s)) do |data|
-      ["Updated load balancer with id #{data["id"]}"]
-    end
+    id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, vms:).id
+    response("Updated load balancer with id #{id}")
   end
 end

--- a/cli-commands/pg/post/add-firewall-rule.rb
+++ b/cli-commands/pg/post/add-firewall-rule.rb
@@ -8,8 +8,7 @@ UbiCli.on("pg").run_on("add-firewall-rule") do
   args 1
 
   run do |cidr|
-    post(pg_path("/firewall-rule"), "cidr" => cidr) do |data|
-      ["Firewall rule added to PostgreSQL database.\n  rule id: #{data["id"]}, cidr: #{data["cidr"]}"]
-    end
+    data = sdk_object.add_firewall_rule(cidr)
+    response("Firewall rule added to PostgreSQL database.\n  rule id: #{data[:id]}, cidr: #{data[:cidr]}")
   end
 end

--- a/cli-commands/pg/post/add-metric-destination.rb
+++ b/cli-commands/pg/post/add-metric-destination.rb
@@ -8,19 +8,13 @@ UbiCli.on("pg").run_on("add-metric-destination") do
   args 3
 
   run do |username, password, url|
-    params = {
-      "username" => username,
-      "password" => password,
-      "url" => url
-    }
-    post(pg_path("/metric-destination"), params) do |data|
-      body = []
-      body << "Metric destination added to PostgreSQL database.\n"
-      body << "Current metric destinations:\n"
-      data["metric_destinations"].each_with_index do |md, i|
-        body << "  " << (i + 1).to_s << ": " << md["id"] << "  " << md["username"].to_s << "  " << md["url"] << "\n"
-      end
-      body
+    data = sdk_object.add_metric_destination(username:, password:, url:)
+    body = []
+    body << "Metric destination added to PostgreSQL database.\n"
+    body << "Current metric destinations:\n"
+    data[:metric_destinations].each_with_index do |md, i|
+      body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
     end
+    response(body)
   end
 end

--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -18,9 +18,7 @@ UbiCli.on("pg").run_on("create") do
 
   run do |opts|
     params = underscore_keys(opts[:pg_create])
-    params["size"] ||= Prog::Vm::Nexus::DEFAULT_SIZE
-    post(pg_path, params) do |data|
-      ["PostgreSQL database created with id: #{data["id"]}"]
-    end
+    id = sdk.postgres.create(location: @location, name: @name, **params).id
+    response("PostgreSQL database created with id: #{id}")
   end
 end

--- a/cli-commands/pg/post/delete-firewall-rule.rb
+++ b/cli-commands/pg/post/delete-firewall-rule.rb
@@ -8,12 +8,8 @@ UbiCli.on("pg").run_on("delete-firewall-rule") do
   args 1
 
   run do |ubid|
-    if ubid.include?("/")
-      raise Rodish::CommandFailure, "invalid firewall rule id format"
-    end
-
-    delete(pg_path("/firewall-rule/#{ubid}")) do |data|
-      ["Firewall rule, if it exists, has been scheduled for deletion"]
-    end
+    check_no_slash(ubid, "invalid firewall rule id format")
+    sdk_object.delete_firewall_rule(ubid)
+    response("Firewall rule, if it exists, has been scheduled for deletion")
   end
 end

--- a/cli-commands/pg/post/delete-metric-destination.rb
+++ b/cli-commands/pg/post/delete-metric-destination.rb
@@ -8,12 +8,8 @@ UbiCli.on("pg").run_on("delete-metric-destination") do
   args 1
 
   run do |ubid|
-    if ubid.include?("/")
-      raise Rodish::CommandFailure, "invalid metric destination id format"
-    end
-
-    delete(pg_path("/metric-destination/#{ubid}")) do |data|
-      ["Metric destination, if it exists, has been scheduled for deletion"]
-    end
+    check_no_slash(ubid, "invalid metric destination id format")
+    sdk_object.delete_metric_destination(ubid)
+    response("Metric destination, if it exists, has been scheduled for deletion")
   end
 end

--- a/cli-commands/pg/post/reset-superuser-password.rb
+++ b/cli-commands/pg/post/reset-superuser-password.rb
@@ -8,8 +8,7 @@ UbiCli.on("pg").run_on("reset-superuser-password") do
   args 1
 
   run do |password|
-    post(pg_path("/reset-superuser-password"), "password" => password) do |data|
-      ["Superuser password reset scheduled for PostgreSQL database with id: #{data["id"]}"]
-    end
+    id = sdk_object.reset_superuser_password(password).id
+    response("Superuser password reset scheduled for PostgreSQL database with id: #{id}")
   end
 end

--- a/cli-commands/pg/post/restart.rb
+++ b/cli-commands/pg/post/restart.rb
@@ -6,8 +6,7 @@ UbiCli.on("pg").run_on("restart") do
   banner "ubi pg (location/pg-name | pg-id) restart"
 
   run do
-    post(pg_path("/restart")) do |data|
-      ["Scheduled restart of PostgreSQL database with id #{data["id"]}"]
-    end
+    id = sdk_object.restart.id
+    response("Scheduled restart of PostgreSQL database with id #{id}")
   end
 end

--- a/cli-commands/pg/post/restore.rb
+++ b/cli-commands/pg/post/restore.rb
@@ -8,12 +8,7 @@ UbiCli.on("pg").run_on("restore") do
   args 2
 
   run do |name, restore_target|
-    params = {
-      "name" => name,
-      "restore_target" => restore_target
-    }
-    post(pg_path("/restore"), params) do |data|
-      ["Restored PostgreSQL database scheduled for creation with id: #{data["id"]}"]
-    end
+    id = sdk_object.restore(name:, restore_target:).id
+    response("Restored PostgreSQL database scheduled for creation with id: #{id}")
   end
 end

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -11,32 +11,31 @@ UbiCli.on("pg").run_on("show") do
   help_option_values("Fields:", fields)
 
   run do |opts|
-    get(pg_path) do |data|
-      opts = opts[:pg_show]
-      keys = check_fields(opts[:fields], fields, "pg show -f option")
+    data = sdk_object.info
+    opts = opts[:pg_show]
+    keys = check_fields(opts[:fields], fields, "pg show -f option")
 
-      body = []
+    body = []
 
-      underscore_keys(keys).each do |key|
-        case key
-        when "firewall_rules"
-          body << "firewall rules:\n"
-          data[key].each_with_index do |rule, i|
-            body << "  " << (i + 1).to_s << ": " << rule["id"] << "  " << rule["cidr"].to_s << "\n"
-          end
-        when "metric_destinations"
-          body << "metric destinations:\n"
-          data[key].each_with_index do |md, i|
-            body << "  " << (i + 1).to_s << ": " << md["id"] << "  " << md["username"].to_s << "  " << md["url"] << "\n"
-          end
-        when "ca_certificates"
-          body << "CA certificates:\n" << data[key].to_s << "\n"
-        else
-          body << key << ": " << data[key].to_s << "\n"
+    underscore_keys(keys).each do |key|
+      case key
+      when :firewall_rules
+        body << "firewall rules:\n"
+        data[key].each_with_index do |rule, i|
+          body << "  " << (i + 1).to_s << ": " << rule[:id] << "  " << rule[:cidr].to_s << "\n"
         end
+      when :metric_destinations
+        body << "metric destinations:\n"
+        data[key].each_with_index do |md, i|
+          body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
+        end
+      when :ca_certificates
+        body << "CA certificates:\n" << data[key].to_s << "\n"
+      else
+        body << key.to_s << ": " << data[key].to_s << "\n"
       end
-
-      body
     end
+
+    response(body)
   end
 end

--- a/cli-commands/ps/post/connect.rb
+++ b/cli-commands/ps/post/connect.rb
@@ -8,8 +8,7 @@ UbiCli.on("ps").run_on("connect") do
   args 1
 
   run do |ps_id|
-    post(ps_path("/connect"), "connected-subnet-ubid" => ps_id) do |data|
-      ["Connected private subnets with ids #{ps_id} and #{data["id"]}"]
-    end
+    id = sdk_object.connect(ps_id).id
+    response("Connected private subnets with ids #{ps_id} and #{id}")
   end
 end

--- a/cli-commands/ps/post/create.rb
+++ b/cli-commands/ps/post/create.rb
@@ -9,8 +9,7 @@ UbiCli.on("ps").run_on("create") do
 
   run do |opts|
     params = underscore_keys(opts[:ps_create])
-    post(ps_path, params) do |data|
-      ["Private subnet created with id: #{data["id"]}"]
-    end
+    id = sdk.private_subnet.create(location: @location, name: @name, **params).id
+    response("Private subnet created with id: #{id}")
   end
 end

--- a/cli-commands/ps/post/disconnect.rb
+++ b/cli-commands/ps/post/disconnect.rb
@@ -8,11 +8,8 @@ UbiCli.on("ps").run_on("disconnect") do
   args 1
 
   run do |ps_id|
-    if ps_id.include?("/")
-      raise Rodish::CommandFailure, "invalid private subnet id format"
-    end
-    post(ps_path("/disconnect/#{ps_id}")) do |data|
-      ["Disconnected private subnets with ids #{ps_id} and #{data["id"]}"]
-    end
+    check_no_slash(ps_id, "invalid private subnet id format")
+    id = sdk_object.disconnect(ps_id).id
+    response("Disconnected private subnets with ids #{ps_id} and #{id}")
   end
 end

--- a/cli-commands/ps/post/show.rb
+++ b/cli-commands/ps/post/show.rb
@@ -20,48 +20,47 @@ UbiCli.on("ps").run_on("show") do
   help_option_values("Firewall Fields:", firewall_fields)
 
   run do |opts|
-    get(ps_path) do |data|
-      opts = opts[:ps_show]
-      keys = underscore_keys(check_fields(opts[:fields], fields, "ps show -f option"))
-      firewall_keys = underscore_keys(check_fields(opts[:"firewall-fields"], firewall_fields, "ps show -w option"))
-      firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "ps show -r option"))
-      nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "ps show -n option"))
+    data = sdk_object.info
+    opts = opts[:ps_show]
+    keys = underscore_keys(check_fields(opts[:fields], fields, "ps show -f option"))
+    firewall_keys = underscore_keys(check_fields(opts[:"firewall-fields"], firewall_fields, "ps show -w option"))
+    firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "ps show -r option"))
+    nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "ps show -n option"))
 
-      body = []
+    body = []
 
-      keys.each do |key|
-        case key
-        when "firewalls"
-          data[key].each_with_index do |firewall, i|
-            body << "firewall " << (i + 1).to_s << ":\n"
-            firewall_keys.each do |fw_key|
-              if fw_key == "firewall_rules"
-                body << "  rules:\n"
-                firewall[fw_key].each_with_index do |rule, i|
-                  body << "   " << (i + 1).to_s << ": "
-                  firewall_rule_keys.each do |fwr_key|
-                    body << rule[fwr_key].to_s << "  "
-                  end
-                  body << "\n"
+    keys.each do |key|
+      case key
+      when :firewalls
+        data[key].each_with_index do |firewall, i|
+          body << "firewall " << (i + 1).to_s << ":\n"
+          firewall_keys.each do |fw_key|
+            if fw_key == :firewall_rules
+              body << "  rules:\n"
+              firewall[fw_key].each_with_index do |rule, i|
+                body << "   " << (i + 1).to_s << ": "
+                firewall_rule_keys.each do |fwr_key|
+                  body << rule[fwr_key].to_s << "  "
                 end
-              else
-                body << "  " << fw_key << ": " << firewall[fw_key].to_s << "\n"
+                body << "\n"
               end
+            else
+              body << "  " << fw_key.to_s << ": " << firewall[fw_key].to_s << "\n"
             end
           end
-        when "nics"
-          data[key].each_with_index do |nic, i|
-            body << "nic " << (i + 1).to_s << ":\n"
-            nic_keys.each do |nic_key|
-              body << "  " << nic_key << ": " << nic[nic_key].to_s << "\n"
-            end
-          end
-        else
-          body << key << ": " << data[key].to_s << "\n"
         end
+      when :nics
+        data[key].each_with_index do |nic, i|
+          body << "nic " << (i + 1).to_s << ":\n"
+          nic_keys.each do |nic_key|
+            body << "  " << nic_key.to_s << ": " << nic[nic_key].to_s << "\n"
+          end
+        end
+      else
+        body << key.to_s << ": " << data[key].to_s << "\n"
       end
-
-      body
     end
+
+    response(body)
   end
 end

--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -20,12 +20,11 @@ UbiCli.on("vm").run_on("create") do
 
   run do |public_key, opts|
     params = underscore_keys(opts[:vm_create])
-    unless params.delete("ipv6_only")
-      params["enable_ip4"] = "1"
+    unless params.delete(:ipv6_only)
+      params[:enable_ip4] = "1"
     end
-    params["public_key"] = public_key.gsub(/(?!\r)\n/, "\r\n")
-    post(vm_path, params) do |data|
-      ["VM created with id: #{data["id"]}"]
-    end
+    params[:public_key] = public_key
+    id = sdk.vm.create(location: @location, name: @name, **params).id
+    response("VM created with id: #{id}")
   end
 end

--- a/cli-commands/vm/post/restart.rb
+++ b/cli-commands/vm/post/restart.rb
@@ -6,8 +6,7 @@ UbiCli.on("vm").run_on("restart") do
   banner "ubi vm (location/vm-name | vm-id) restart"
 
   run do
-    post(vm_path("/restart")) do |data|
-      ["Scheduled restart of VM with id #{data["id"]}"]
-    end
+    id = sdk_object.restart.id
+    response("Scheduled restart of VM with id #{id}")
   end
 end

--- a/sdk/ruby/MIT-LICENSE
+++ b/sdk/ruby/MIT-LICENSE
@@ -1,0 +1,21 @@
+Ubicloud's Ruby SDK is released under the MIT license (the rest of Ubicloud
+is released under the AGPL license).
+
+Copyright (c) 2025 Ubicloud, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -1,0 +1,432 @@
+# Ubicloud
+
+`Ubicloud` is the official Ruby SDK for accessing Ubicloud. It is designed for
+programmer happiness, just as Ruby itself is.  Methods in this SDK send
+request's to Ubicloud's API.
+
+## Installation
+
+```ruby
+gem install ubicloud
+```
+
+## Usage
+
+`Ubicloud` uses an object-oriented SDK.  The first step is creating an
+appropriate context.  If you are going to use the SDK to manage a single
+Ubicloud project, it is recommended you set the context to a constant:
+
+```ruby
+UBI = Ubicloud.new(:net_http, token: "YOUR_API_TOKEN", project_id: "pj...")
+```
+
+The positional argument to `Ubicloud.new` is the adapter type to use.
+Currently, the `net_http` adapter is recommended.  The `token` keyword
+argument is the Ubicloud API token used for requests.  The `project_id`
+keyword argument is the project that will be accessed. You can also use a
+`base_uri` keyword if you are using a self-hosted version of Ubicloud (or
+any version not hosted by Ubicloud).
+
+The documentation below assumes you are storing the SDK context in the
+`UBI` constant.
+
+### Object Types
+
+`Ubicloud` currently supports manipulating 5 types of objects:
+
+* Firewall (`UBI.firewall`): Firewalls
+* LoadBalancer (`UBI.load_balancer`): Load balancers
+* Postgres (`UBI.postgres`): PostgreSQL databases
+* PrivateSubnet (`UBI.private_subnet`): Private subnets
+* Vm (`UBI.vm`): Virtual machines
+
+### Methods Supported By All Types
+
+`Ubicloud` tries to keep the API consistent across supported types, to make it
+easier to use.  
+
+#### Listing Objects
+
+`UBI.type.list` is used to retrieve a list of objects you have access to
+inside the project:
+
+```ruby
+UBI.firewall.list
+UBI.load_balancer.list
+UBI.postgres.list
+UBI.private_subnet.list
+UBI.vm.list
+```
+
+To only retrieve objects in a specific location, you can use a `location`
+keyword argument:
+
+```ruby
+UBI.vm.list(location: "eu-central-h1")
+```
+
+`UBI.type.list` returns a array of objects.  For example `UBI.vm.list`
+returns an array of `Ubicloud::Vm` objects.  Each of these objects is partially
+populated.  If you need to fully populate the object, you can call `info`
+on the object:
+
+```ruby
+vm = UBI.vm.list.first
+vm.info
+```
+
+#### Creating An Object
+
+`UBI.type.create` is used to create a new object.  It requires the `location`
+and `name` keyword arguments.  Additional parameters, which may be required or
+optional per object type, are also provided as keyword arguments:
+
+```ruby
+UBI.firewall.create(location: "eu-central-h1", name: "my-firewall")
+
+UBI.firewall.create(location: "eu-central-h1", name: "other-firewall",
+  description: "My other firewall")
+
+UBI.vm.create(location: "eu-central-h1", name: "my-vm",
+  public_key: File.read("~/.ssh/authorized_keys"))
+```
+
+Additional required keyword arguments for each type:
+
+* LoadBalancer: `private_subnet_id`, `algorithm`, `src_port`,
+  `dst_port`, `health_check_protocol`, `stack`
+* Vm: `public_key`
+
+Optional keyword arguments for each type:
+
+* Firewall: `description`
+* LoadBalancer: `health_check_endpoint`
+* Postgres: size, `storage_size`, `ha_type`, `version`, `flavor`
+* PrivateSubnet: `firewall_id`
+* Vm: `size`, `storage_size`, `unix_user`, `boot_image`, `enable_ip4`,
+  `private_subnet_id`
+
+#### Retrieving An Object
+
+If you know the object you want to retrieve, instead of picking it out of a
+list, you can retrieve it directly.  If you know the id of the object, you
+can provide that to `UBI.[]`:
+
+```ruby
+UBI["vm345678901234567890123456"]
+```
+
+This instantiates an object of the appropriate class, and checks that the
+object exists and you have access to it.  If you provide an invalid id, or
+you do not have access to the object, the method returns `nil`.
+
+If you know the object already exists, and do not need to check, you can
+call `UBI.new`:
+
+```ruby
+UBI.new("vm345678901234567890123456")
+```
+
+In addition to looking up objects by id, you can look them up by using
+`location/name`.  However, in this case you need to specify the type of
+the object, since it cannot be inferred:
+
+```ruby
+vm = UBI.vm["eu-central-h1/my-vm"]
+```
+
+Like `UBI.[]`, this will check the object exists and you have access to it.
+If you do not want to check, you can use `new`:
+
+```ruby
+vm = UBI.vm.new("eu-central-h1/my-vm")
+```
+
+When using `UBI.new` or `UBI.type.new`, the created object may not
+actually exist in Ubicloud.  You can call `info` on the returned object
+to check that it exists. If it does not exist, an `Ubicloud::Error`
+exception will be raised.
+
+#### Destroying An Object
+
+You can call `destroy` to destroy an object:
+
+```ruby
+vm = UBI["vm345678901234567890123456"]
+vm.destroy
+```
+
+Note that there is no way to recover an object that has been destroyed. You
+should only use this method if you are sure you no longer need the object.
+
+### Type-Specific Methods
+
+In addition to the methods supported for all types, each type also supports
+methods specific to that type.
+
+#### Firewall
+
+##### `add_rule`
+
+`Firewall#add_rule` adds a firewall rule to allow access to the given port(s)
+from a given IP address range:
+
+```ruby
+fw = UBI["fw345678901234567890123456"]
+
+# Allow access to all ports
+fw.add_rule("1.2.3.0/24")
+
+# Allow access to specific port
+fw.add_rule("1.2.0.0/16", start_port: 5432)
+
+# Allow access to port range
+fw.add_rule("1.2.3.0/24", start_port: 10000, end_port: 11000)
+```
+
+##### `delete_rule`
+
+`Firewall#delete_rule` removes a previously added firewall rule.  You must
+provide the firewall rule id (which you can retrieve by inspecting the
+firewall rules):
+
+```ruby
+fw = UBI["fw345678901234567890123456"]
+
+rule_id = fw.firewall_rules.first[:id]
+fw.delete_rule(rule_id)
+```
+
+##### `attach_subnet`
+
+`Firewall#attach_subnet` attaches an existing private subnet to the firewall:
+
+```ruby
+fw = UBI["fw345678901234567890123456"]
+ps = UBI.private_subnet.list.first
+
+# Using PrivateSubnet object
+fw.attach_subnet(ps)
+
+# Using private subnet id
+fw.attach_subnet(ps.id)
+```
+
+##### `detach_subnet`
+
+`Firewall#detach_subnet` detaches an existing private subnet to the firewall:
+
+```ruby
+fw = UBI["fw345678901234567890123456"]
+ps = UBI.private_subnet.list.first
+
+# Using PrivateSubnet object
+fw.detach_subnet(ps)
+
+# Using private subnet id
+fw.detach_subnet(ps.id)
+```
+
+#### LoadBalancer
+
+##### `attach_vm`
+
+`LoadBalancer#attach_vm` attaches an existing virtual machine to the load
+balancer:
+
+```ruby
+lb = UBI["1b345678901234567890123456"]
+vm = UBI.vm.list.first
+
+# Using Vm object
+lb.attach_vm(vm)
+
+# Using virtual machine id
+lb.attach_vm(vm.id)
+```
+
+##### `detach_vm`
+
+`LoadBalancer#detach_vm` detaches an existing virtual machine from the load
+balancer:
+
+```ruby
+lb = UBI["1b345678901234567890123456"]
+vm = UBI.vm.list.first
+
+# Using Vm object
+lb.detach_vm(vm)
+
+# Using virtual machine id
+lb.detach_vm(vm.id)
+```
+
+##### `update`
+
+`LoadBalancer#update` updates a load balancer's parameters. It requires the
+following keyword arguments: `algorithm`, `src_port`, `dst_port`,
+`health_check_endpoint`, `vms`.
+
+The `vms` argument should be an array of virtual machines attached to the load
+balancer.  The method will attach and detach virtual machines to the load
+balancer as needed so that the list of attached virtual machines matches the
+array given.
+
+```ruby
+lb = UBI["1b345678901234567890123456"]
+vm = UBI.vm.list.first
+
+lb.update(algorithm: "https", src_port: 8443, dst_port: 443,
+  health_check_endpoint: "/up", vms: [vm])
+```
+
+#### Postgres
+
+##### `add_firewall_rule`
+
+`Postgres#add_firewall_rule` adds a firewall rule to allow access to the
+PostgreSQL port (5432) from a given IP address range:
+
+```ruby
+pg = UBI["pg345678901234567890123456"]
+pg.add_firewall_rule("1.2.3.0/24")
+```
+
+##### `delete_firewall_rule`
+
+`Postgres#delete_firewall_rule` removes a previously added firewall rule.
+You must provide the firewall rule id (which you can retrieve by inspecting
+the database firewall rules):
+
+```ruby
+pg = UBI["pg345678901234567890123456"]
+
+rule_id = pg.firewall_rules.first[:id]
+pg.delete_firewall_rule(rule_id)
+```
+
+##### `add_metric_destination`
+
+`Postgres#add_metric_destination` adds a destination for the database metrics.
+It requires the following keyword arguments: `username`, `password`, `url`:
+
+```ruby
+pg = UBI["pg345678901234567890123456"]
+pg.add_metric_destination(username: "foo", password: "bar",
+  url: "https://metrics.example.com/add_metric")
+```
+
+##### `delete_metric_destination`
+
+`Postgres#delete_metric_destination` removes a previously added metric
+destination.  You must provide the metric destination id (which you can
+retrieve by inspecting the database metric destinations):
+
+```ruby
+pg = UBI["pg345678901234567890123456"]
+
+md_id = pg.metric_destinations.first[:id]
+pg.delete_metric_destination(md_id)
+```
+
+##### `restart`
+
+`Postgres#restart` schedules a restart of the PostgreSQL database:
+
+```ruby
+pg = UBI["pg345678901234567890123456"]
+pg.restart
+```
+
+##### `reset_superuser_password`
+
+`Postgres#reset_superuser_password` schedules a reset of the superuser
+(`postgres`) password for the PostgreSQL database. 
+
+```ruby
+pg = UBI["pg345678901234567890123456"]
+pg.reset_superuser_password('some-secret-password')
+```
+
+##### `restore`
+
+`Postgres#restore` schedules a restore a previous version of the receiver database to a
+new database at the given restore target.  It requires the following keyword
+arguments: `name` (of restored database), `restore_target`
+
+```ruby
+pg = UBI["pg345678901234567890123456"]
+
+# Create a copy of the database as of 10 minutes ago
+pg.restore(name: "restored-database", restore_target: Time.now - 600)
+```
+
+#### PrivateSubnet
+
+##### `connect`
+
+`PrivateSubnet#connect` connects two private subnets (it does not matter which
+is the receiver and which is the argument):
+
+```ruby
+ps1, ps2 = UBI.private_subnet.list
+
+# Using PrivateSubnet object
+ps1.connect(ps2)
+
+# Using private subnet id
+ps1.connect(ps2.id)
+```
+
+##### `disconnect`
+
+`PrivateSubnet#connect` disconnects two private subnets (it does not matter
+which is the receiver and which is the argument):
+
+```ruby
+ps1, ps2 = UBI.private_subnet.list
+
+# Using PrivateSubnet object
+ps1.disconnect(ps2)
+
+# Using private subnet id
+ps1.disconnect(ps2.id)
+```
+
+#### Vm
+
+##### `restart`
+
+`Vm#restart` schedules a restart of an existing virtual machine:
+
+```ruby
+vm = UBI["vm345678901234567890123456"]
+vm.restart
+```
+
+### Associations
+
+Model instances support associations:
+
+```ruby
+# LoadBalancer instance
+lb = UBI["lb345678901234567890123456"]
+
+# PrivateSubnet instance
+ps = lb.subnet
+
+# Firewall instance
+fw = ps.firewalls.first
+
+# Add a rule to that firewall instance
+fw.add_rule("1.2.3.0/24")
+```
+
+## License
+
+MIT
+
+## Support
+
+For support, please open a GitHub discussion:
+https://github.com/ubicloud/ubicloud/discussions/new?category=q-a

--- a/sdk/ruby/lib/ubicloud.rb
+++ b/sdk/ruby/lib/ubicloud.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "ubicloud/adapter"
+require_relative "ubicloud/model"
+require_relative "ubicloud/model_adapter"
+require_relative "ubicloud/context"
+
+# The Ubicloud module is the namespace for Ubicloud's Ruby SDK,
+# and also the primary entry point.  Even though it is a module,
+# users are expected to call +Ubicloud.new+ to return an appropriate
+# context (Ubicloud::Context) that is used to make requests to
+# Ubicloud's API.
+module Ubicloud
+  # Error class used for errors raised by Ubicloud's Ruby SDK.
+  class Error < StandardError
+    # The integer HTTP status code related to the error.  Can be
+    # nil if the Error is not related to an HTTP request.
+    attr_reader :code
+
+    # Accept the code and body keyword arguments for metadata
+    # related to this error.
+    def initialize(message, code: nil, body: nil)
+      super(message)
+      @code = code
+      @body = body
+    end
+
+    # A hash of parameters.  This is the parsed JSON response body
+    # for the request that resulted in an error.  If an invalid
+    # body is given, or the error is not related to an HTTP request,
+    # returns an empty hash.
+    def params
+      @body ? JSON.parse(@body) : {}
+    rescue
+      {}
+    end
+  end
+
+  # Create a new Ubicloud::Context for the given adapter type
+  # and parameters.  This is the main entry point to the library.
+  # In general, users of the SDK will want to use the :net_http
+  # adapter type:
+  #
+  #   Ubicloud.new(:net_http, token: "YOUR_API_TOKEN", project_id: "pj...")
+  def self.new(adapter_type, **params)
+    Context.new(Adapter.adapter_class(adapter_type).new(**params))
+  end
+end

--- a/sdk/ruby/lib/ubicloud/adapter.rb
+++ b/sdk/ruby/lib/ubicloud/adapter.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Ubicloud
+  # Ubicloud::Adapter is the base class for adapters used in Ubicloud's Ruby SDK.
+  # Ubicloud's Ruby SDK uses adapters to allow for separate ways to access
+  # Ubicloud's API.  Currently, the :net_http adapter is the recommended adapter.
+  #
+  # Ubicloud::Adapter subclasses must implement +call+ to handle sending the
+  # request.  They should call +handle_response+ to handle responses to the
+  # request.
+  class Adapter
+    ADAPTERS = {
+      net_http: :NetHttp,
+      rack: :Rack
+    }.freeze
+    private_constant :ADAPTERS
+
+    # Require the related adapter file, and return the related adapter.
+    def self.adapter_class(adapter_type)
+      require_relative "adapter/#{adapter_type}"
+      const_get(ADAPTERS.fetch(adapter_type))
+    end
+
+    # Issue a GET request to the API for the given path.
+    def get(path, missing: :raise)
+      call("GET", path, missing:)
+    end
+
+    # Issue a GET request to the API for the given path and parameters.
+    def post(path, params = nil)
+      call("POST", path, params:)
+    end
+
+    # Issue a DELETE request to the API for the given path.
+    def delete(path)
+      call("DELETE", path)
+    end
+
+    # Issue a PATCH request to the API for the given path and parameters.
+    def patch(path, params = nil)
+      call("PATCH", path, params:)
+    end
+
+    private
+
+    # Handle responses to the requests made the library.  Non-200/204
+    # are treated as errors and result in an Ubicloud::Error being raised.
+    def handle_response(code, body, missing: :raise)
+      case code
+      when 204
+        nil
+      when 200
+        JSON.parse(body, symbolize_names: true)
+      else
+        return if code == 404 && missing.nil?
+        raise Error.new("unsuccessful response", code:, body:)
+      end
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/adapter/net_http.rb
+++ b/sdk/ruby/lib/ubicloud/adapter/net_http.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "uri"
+require "net/http"
+
+module Ubicloud
+  # Ubicloud::Adapter::NetHttp is the recommended adapter for general use.
+  # It uses the net/http standard library to make requests to the Ubicloud API.
+  class Adapter::NetHttp < Adapter
+    # Set the token and project_id to use for requests.  The base_uri argument
+    # can be used to access a self-hosted Ubicloud instance (or other Ubicloud
+    # instance not hosted by Ubicloud).
+    def initialize(token:, project_id:, base_uri: "https://api.ubicloud.com/")
+      @base_uri = URI.join(URI(base_uri), "project/#{project_id}/")
+      @headers = {
+        "authorization" => "Bearer: #{token}",
+        "content-type" => "application/json",
+        "accept" => "text/plain",
+        "connection" => "close"
+      }.freeze
+      @get_headers = @headers.dup
+      @get_headers.delete("content-type")
+      @get_headers.freeze
+    end
+
+    METHOD_MAP = {
+      "GET" => :get,
+      "POST" => :post,
+      "DELETE" => :delete,
+      "PATCH" => :patch
+    }.freeze
+
+    private_constant :METHOD_MAP
+
+    private
+
+    # Use Net::HTTP to submit a request to the Ubicloud API.
+    def call(method, path, params: nil, missing: :raise)
+      Net::HTTP.start(@base_uri.hostname, @base_uri.port, use_ssl: @base_uri.scheme == "https") do |http|
+        path = URI.join(@base_uri, path).path
+
+        response = case method
+        when "GET"
+          http.get(path, @get_headers)
+        when "DELETE"
+          http.delete(path, @headers)
+        else
+          http.send(METHOD_MAP.fetch(method), path, params&.to_json, @headers)
+        end
+
+        handle_response(response.code.to_i, response.body, missing:)
+      end
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/adapter/rack.rb
+++ b/sdk/ruby/lib/ubicloud/adapter/rack.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  # Ubicloud::Adapter::Rack is designed for internal use of the
+  # Ruby SDK by Ubicloud itself.  It is used inside Ubicloud to
+  # issue internal requests when handling CLI commands.  A new
+  # instance of Ubicloud::Adapter::Rack is created for each
+  # CLI command.
+  class Adapter::Rack < Adapter
+    # Accept the rack application (Clover), request env of the CLI request,
+    # and related project id.
+    def initialize(app:, env:, project_id:)
+      @app = app
+      @env = env
+      @project_id = project_id
+    end
+
+    private
+
+    # Create a new rack request enviroment hash for the internal
+    # request, and call the rack application with it.
+    def call(method, path, params: nil, missing: :raise)
+      env = @env.merge(
+        "REQUEST_METHOD" => method,
+        "PATH_INFO" => "/project/#{@project_id}/#{path}",
+        "rack.request.form_input" => nil,
+        "rack.request.form_hash" => nil
+      )
+      params &&= params.to_json.force_encoding(Encoding::BINARY)
+      env["rack.input"] = StringIO.new(params || "".b)
+      env.delete("roda.json_params")
+
+      status, _, rack_body = @app.call(env)
+      body = +""
+      rack_body.each { body << _1 }
+      rack_body.close if rack_body.respond_to?(:close)
+
+      handle_response(status, body, missing:)
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/context.rb
+++ b/sdk/ruby/lib/ubicloud/context.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  # Ubicloud::Context instances are the root object used in Ubicloud's Ruby
+  # SDK.  They provide access to the models, using the configured adapter.
+  #
+  # The following instance methods are defined via metaprogramming.  All
+  # return instances of Ubicloud::ModelAdapter, for the related model.
+  #
+  # +firewall+ :: Ubicloud::Firewall
+  # +load_balancer+ :: Ubicloud::LoadBalancer
+  # +postgres+ :: Ubicloud::Postgres
+  # +private_subnet+ :: Ubicloud::PrivateSubnet
+  # +vm+ :: Ubicloud::Vm
+  class Context
+    def initialize(adapter)
+      @adapter = adapter
+      @models = {}
+    end
+
+    {
+      vm: Vm,
+      postgres: Postgres,
+      firewall: Firewall,
+      private_subnet: PrivateSubnet,
+      load_balancer: LoadBalancer
+    }.each do |meth, model|
+      define_method(meth) { @models[meth] ||= ModelAdapter.new(model, @adapter) }
+    end
+
+    MODEL_PREFIX_MAP = {
+      "vm" => Vm,
+      "pg" => Postgres,
+      "fw" => Firewall,
+      "ps" => PrivateSubnet,
+      "1b" => LoadBalancer
+    }.freeze
+
+    # Return a new model instance for the given id, assuming the id is properly
+    # formatted.  Returns nil if the id is not properly formatted.  Does not
+    # check with \Ubicloud to determine whether the object actually exists.
+    def new(id)
+      if id.is_a?(String) && (model = MODEL_PREFIX_MAP[id[0, 2]]) && model.id_regexp.match?(id)
+        model.new(@adapter, id)
+      end
+    end
+
+    # The same as #new, but checks that the object exists and you have access to it.
+    def [](id)
+      new(id)&.check_exists
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/model.rb
+++ b/sdk/ruby/lib/ubicloud/model.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  # Ubicloud::Model is the abstract base class for model classes.  There is a
+  # separate model class for each primary object type in Ubicloud's API.
+  class Model
+    class << self
+      # A hash of associations for the model.  This is used by instances
+      # to automatically wrap returned objects in model instances.
+      attr_reader :associations
+
+      # The path fragment for this model in the Ubicloud API.
+      attr_reader :fragment
+
+      # A regexp for valid id format for instances of this model.
+      attr_reader :id_regexp
+
+      # Return a new model instance for the given values, tied to the
+      # related adapter, if the model instance exists and is accessible.
+      # Return nil if the model instance does not exist or is not
+      # accessible.  +values+ can be:
+      #
+      # * a string in a valid id format for the model
+      # * a string in location/name format
+      # * a hash of values (must contain either :id key or :location and :name keys)
+      def [](adapter, values)
+        new(adapter, values).check_exists
+      end
+
+      # Create a new model object in Ubicloud with the given location, name, and params.
+      def create(adapter, location:, name:, **params)
+        new(adapter, adapter.post("location/#{location}/#{fragment}/#{name}", _create_params(params)))
+      end
+
+      # Return an array of all model instances you have access to in Ubicloud. If the
+      # +location+ keyword argument is given, only return model instances for that location.
+      def list(adapter, location: nil)
+        path = if location
+          raise Error, "invalid location: #{location.inspect}" if location.include?("/")
+          "location/#{location}/#{fragment}"
+        else
+          fragment
+        end
+
+        adapter.get(path)[:items].map { new(adapter, _1) }
+      end
+
+      # Resolve associations.  This is called after all models have been loaded.
+      # This approach is taken to avoid the need for autoload or const_get.
+      def resolve_associations # :nodoc:
+        @associations = @association_block&.call || {}
+      end
+
+      private
+
+      # Used by models to set defaults for parameters.  Overrides the _create_params
+      # method using the given block.  The block should mutate the parameter hash.
+      def set_create_param_defaults
+        singleton_class.send(:private, define_singleton_method(:_create_params) do |params|
+          params = params.dup || {}
+          yield params
+          params
+        end)
+      end
+
+      # The parameters to use when creating an object.  Uses only the given parameters
+      # by default.
+      def _create_params(params)
+        params
+      end
+
+      # Register the assocation block that will be used for resolving associations.
+      def set_associations(&block)
+        @association_block = block
+      end
+
+      # Create methods for each of the model's columns (unless the method is already defined).
+      # These methods will fully populate the object if the related key is not already present
+      # in the model.
+      def set_columns(*columns)
+        columns.each do |column|
+          next if method_defined?(column)
+          define_method(column) do
+            info unless @values.has_key?(column)
+            @values[column]
+          end
+        end
+      end
+
+      # Use the given regexp to set the valid id_regexp format for the model.
+      def set_prefix(prefix)
+        @id_regexp = %r{\A#{prefix}[a-tv-z0-9]{24}\z}
+      end
+
+      # Set the path fragment that this model uses in the Ubicloud API.
+      def set_fragment(fragment)
+        @fragment = fragment
+      end
+    end
+
+    # Return the adapter used for this model instance.  Each model instance is tied to a
+    # specific adapter, and requests to the Ubicloud API are made through the adapter.
+    attr_reader :adapter
+
+    # A hash of values for the model instance.
+    attr_reader :values
+
+    # Create a new model instance, which should represent an object that already exists
+    # in Ubicloud. +values+ can be:
+    #
+    # * a string in a valid id format for the model
+    # * a string in location/name format
+    # * a hash with symbol keys (must contain either :id key or :location and :name keys)
+    def initialize(adapter, values)
+      @adapter = adapter
+
+      case values
+      when String
+        @values = if self.class.id_regexp.match?(values)
+          {id: values}
+        else
+          location, name, extra = values.split("/", 3)
+          raise Error, "invalid #{self.class.fragment} location/name: #{values.inspect}" if extra || !name
+          {location:, name:}
+        end
+      when Hash
+        if !values[:id] && !(values[:location] && values[:name])
+          raise Error, "hash must have :id key or :location and :name keys"
+        end
+        @values = {}
+        merge_into_values(values)
+      else
+        raise Error, "unsupported value initializing #{self.class}: #{values.inspect}"
+      end
+    end
+
+    # Return hash of data for this model instance.
+    def to_h
+      @values
+    end
+
+    # Return the value of a specific key for the model instance.
+    def [](key)
+      @values[key]
+    end
+
+    # Destroy the given model instance in Ubicloud.  It is not possible to restore
+    # objects that have been destroyed, so only use this if you are sure you want
+    # to destroy the object.
+    def destroy
+      adapter.delete(_path)
+    end
+
+    # The model's id, which will be a 26 character string.  This will load the
+    # id from Ubicloud if the model instance doesn't currently store the id
+    # (such as when it was initialized with a location and name).
+    def id
+      unless (id = @values[:id])
+        info
+        id = @values[:id]
+      end
+
+      id
+    end
+
+    # The model's location, as a string.  This will load the location from Ubicloud
+    # if the model instance does not currently store it (such as when it was
+    # initialized with an id).
+    def location
+      unless (location = @values[:location])
+        load_object_info_from_id
+        location = @values[:location]
+      end
+
+      location
+    end
+
+    # The model's name.  This will load the name from Ubicloud if the model instance
+    # does not currently store it (such as when it was initialized with an id).
+    def name
+      unless (name = @values[:name])
+        load_object_info_from_id
+        name = @values[:name]
+      end
+
+      name
+    end
+
+    # Fully populate the model instance by making a request to the Ubicloud API.
+    # This can also be used to refresh an already populated instance.
+    def info
+      _info
+    end
+
+    # Show the class name and values hash.
+    def inspect
+      "#<#{self.class.name} #{@values.inspect}>"
+    end
+
+    # Check whether the current instance exists in Ubicloud.  Returns nil if the
+    # object does not exist.
+    def check_exists
+      @values[:name] ? _info(missing: nil) : load_object_info_from_id(missing: nil)
+    end
+
+    private
+
+    def _info(missing: :raise)
+      if (hash = adapter.get(_path, missing:))
+        merge_into_values(hash)
+      end
+    end
+
+    # Raise an error if the given string contains a slash.  This is used for strings
+    # used as path fragments when making requests, to raise an error before issuing
+    # an HTTP request in the case where you know the path would not be valid.
+    def check_no_slash(string, error_message)
+      raise Error, error_message if string.include?("/")
+    end
+
+    # If the given id is not already a string, call id on it to get a string.
+    # This is used in methods that can accept either a model instance or an id.
+    def to_id(id)
+      (String === id) ? id : id.id
+    end
+
+    # For each of the model's associations, convert the related entry in the values
+    # hash to an associated object.
+    def check_associations
+      values = @values
+
+      self.class.associations.each do |key, klass|
+        next unless (value = values[key])
+
+        values[key] = if value.is_a?(Array)
+          value.map do
+            convert_to_association(_1, klass)
+          end
+        else
+          convert_to_association(value, klass)
+        end
+      end
+    end
+
+    # Convert the given value to an instance of the given klass.
+    def convert_to_association(value, klass)
+      case value
+      when Hash, klass.id_regexp
+        klass.new(adapter, value)
+      when String
+        # The object is given by name and not by id, assume that
+        # it must be in the same location as the receiver.
+        klass.new(adapter, "#{location}/#{value}")
+      else
+        value
+      end
+    end
+
+    # Given only the object's id, find the location and name of the object
+    # and merge them into the values hash.
+    def load_object_info_from_id(missing: :raise)
+      if (hash = adapter.get("object-info/#{values[:id]}", missing:))
+        hash.delete("type")
+        merge_into_values(hash)
+      end
+    end
+
+    # Merge the given values into the values hash, and convert any entries in
+    # the values hash to associated objects.
+    def merge_into_values(values)
+      @values.merge!(values)
+      check_associations
+      self
+    end
+
+    # The path to use for requests for the model instance.  If +rest+ is given,
+    # it is appended to the path.
+    def _path(rest = "")
+      "location/#{location}/#{self.class.fragment}/#{name}#{rest}"
+    end
+  end
+end
+
+# Require each model subclass, and then resolve associations after
+# all subclasses have been loaded.
+Dir.open(File.join(__dir__, "model")) do |dir|
+  dir.each_child do |file|
+    if file.end_with?(".rb")
+      require_relative "model/#{file}"
+    end
+  end
+end
+Ubicloud::Model.subclasses.each(&:resolve_associations)

--- a/sdk/ruby/lib/ubicloud/model/firewall.rb
+++ b/sdk/ruby/lib/ubicloud/model/firewall.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  class Firewall < Model
+    set_prefix "fw"
+
+    set_fragment "firewall"
+
+    set_columns :id, :name, :description, :location, :firewall_rules, :path, :private_subnets
+
+    set_associations do
+      {private_subnets: PrivateSubnet}
+    end
+
+    # Allow the given cidr (ip address range) access to the given port range.
+    #
+    # * If +start_port+ and +end_port+ are both given, they specify the port range.
+    # * If only +start_port+ is given, only that single port is allowed.
+    # * If only +end_port+ is given, all ports up to that end port are allowed.
+    # * If neither +start_port+ and +end_port+ are given, all ports are allowed.
+    #
+    # Returns a hash for the firewall rule.
+    def add_rule(cidr, start_port: nil, end_port: nil)
+      rule = adapter.post(_path("/firewall-rule"), cidr:, port_range: "#{start_port || 0}..#{end_port || start_port || 65535}")
+
+      self[:firewall_rules]&.<<(rule)
+
+      rule
+    end
+
+    # Delete the firewall rule with the given id.  Returns nil.
+    def delete_rule(rule_id)
+      check_no_slash(rule_id, "invalid rule id format")
+      adapter.delete(_path("/firewall-rule/#{rule_id}"))
+
+      self[:firewall_rules]&.delete_if { _1[:id] == rule_id }
+
+      nil
+    end
+
+    # Attach the given private subnet to the firewall. Accepts either a PrivateSubnet instance
+    # or a private subnet id string.  Returns a PrivateSubnet instance.
+    def attach_subnet(subnet)
+      subnet_action(subnet, "/attach-subnet")
+    end
+
+    # Detach the given private subnet from the firewall. Accepts either a PrivateSubnet instance
+    # or a private subnet id string.  Returns a PrivateSubnet instance.
+    def detach_subnet(subnet)
+      subnet_action(subnet, "/detach-subnet")
+    end
+
+    private
+
+    # Internals of attach_subnet/detach_subnet.
+    def subnet_action(subnet, action)
+      PrivateSubnet.new(adapter, adapter.post(_path(action), private_subnet_id: to_id(subnet)))
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/model/load_balancer.rb
+++ b/sdk/ruby/lib/ubicloud/model/load_balancer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  class LoadBalancer < Model
+    set_prefix "1b"
+
+    set_fragment "load-balancer"
+
+    set_columns :id, :name, :location, :hostname, :algorithm, :stack, :health_check_endpoint, :health_check_protocol, :src_port, :dst_port, :subnet, :vms
+
+    set_associations do
+      {
+        subnet: PrivateSubnet,
+        vms: Vm
+      }
+    end
+
+    set_create_param_defaults do |params|
+      params[:algorithm] ||= "round_robin"
+      params[:stack] ||= "dual"
+      params[:health_check_protocol] ||= "http"
+    end
+
+    # Update the receiver with new parameters. Returns self.
+    #
+    # The +vms+ argument should be an array of virtual machines attached to the load
+    # balancer.  The method will attach and detach virtual machines to the load
+    # balancer as needed so that the list of attached virtual machines matches the
+    # array given.
+    def update(algorithm:, src_port:, dst_port:, health_check_endpoint:, vms:)
+      merge_into_values(adapter.patch(_path, algorithm:, src_port:, dst_port:, health_check_endpoint:, vms:))
+    end
+
+    # Attach the given virtual machine to the firewall. Accepts either a Vm instance
+    # or a virtual machine id string.  Returns a Vm instance.
+    def attach_vm(vm)
+      vm_action(vm, "/attach-vm")
+    end
+
+    # Detach the given virtual machine from the firewall. Accepts either a Vm instance
+    # or a virtual machine id string.  Returns a Vm instance.
+    def detach_vm(vm)
+      vm_action(vm, "/detach-vm")
+    end
+
+    private
+
+    # Internals of attach_vm/detach_vm
+    def vm_action(vm, action)
+      Vm.new(adapter, adapter.post(_path(action), vm_id: to_id(vm)))
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/model/postgres.rb
+++ b/sdk/ruby/lib/ubicloud/model/postgres.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  class Postgres < Model
+    set_prefix "pg"
+
+    set_fragment "postgres"
+
+    set_columns :id, :name, :state, :location, :vm_size, :storage_size_gib, :version, :ha_type, :flavor, :ca_certificates, :connection_string, :primary, :firewall_rules, :metric_destinations
+
+    set_create_param_defaults do |params|
+      params[:size] ||= "standard-2"
+    end
+
+    # Schedule a restart of the PostgreSQL server. Returns self.
+    def restart
+      merge_into_values(adapter.post(_path("/restart")))
+    end
+
+    # Allow the given cidr (ip address range) access to the PostgreSQL database port (5432)
+    # for this database. Returns a hash for the firewall rule.
+    def add_firewall_rule(cidr)
+      rule = adapter.post(_path("/firewall-rule"), cidr:)
+
+      self[:firewall_rules]&.<<(rule)
+
+      rule
+    end
+
+    # Delete the firewall rule with the given id.  Returns nil.
+    def delete_firewall_rule(rule_id)
+      check_no_slash(rule_id, "invalid rule id format")
+      adapter.delete(_path("/firewall-rule/#{rule_id}"))
+
+      self[:firewall_rules]&.delete_if { _1[:id] == rule_id }
+
+      nil
+    end
+
+    # Add a metric destination for this database with the given username, password,
+    # and URL. Returns a hash for the metric destination.
+    def add_metric_destination(username:, password:, url:)
+      md = adapter.post(_path("/metric-destination"), username:, password:, url:)
+
+      self[:metric_destinations]&.<<(md)
+
+      md
+    end
+
+    # Delete the metric destination with the given id.  Returns nil.
+    def delete_metric_destination(md_id)
+      check_no_slash(md_id, "invalid metric destination id format")
+      adapter.delete(_path("/metric-destination/#{md_id}"))
+
+      self[:metric_destinations]&.delete_if { _1[:id] == md_id }
+
+      nil
+    end
+
+    # Schedule a password reset for the database superuser (postgres) for the database.
+    # Returns self.
+    def reset_superuser_password(password)
+      merge_into_values(adapter.post(_path("/reset-superuser-password"), password:))
+    end
+
+    # Schedule a restore of the database at the given restore_target time, to a new
+    # database with the given name.  Returns a Postgres instance for the restored
+    # database.
+    def restore(name:, restore_target:)
+      Postgres.new(adapter, adapter.post(_path("/restore"), name:, restore_target:))
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/model/private_subnet.rb
+++ b/sdk/ruby/lib/ubicloud/model/private_subnet.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  class PrivateSubnet < Model
+    set_prefix "ps"
+
+    set_fragment "private-subnet"
+
+    set_columns :id, :name, :state, :location, :net4, :net6, :firewalls, :nics
+
+    set_associations do
+      {firewalls: Firewall}
+    end
+
+    # Connect the given private subnet to the receiver. Accepts either a PrivateSubnet instance
+    # or a private subnet id string. Returns self.
+    def connect(subnet)
+      merge_into_values(adapter.post(_path("/connect"), "connected-subnet-ubid": to_id(subnet)))
+    end
+
+    # Disconnect the given private subnet from the receiver. Accepts either a PrivateSubnet instance
+    # or a private subnet id string. Returns self.
+    def disconnect(subnet)
+      subnet = to_id(subnet)
+      check_no_slash(subnet, "invalid private subnet id format")
+      merge_into_values(adapter.post(_path("/disconnect/#{subnet}")))
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/model/vm.rb
+++ b/sdk/ruby/lib/ubicloud/model/vm.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  class Vm < Model
+    set_prefix "vm"
+
+    set_fragment "vm"
+
+    set_columns :id, :name, :state, :location, :size, :unix_user, :storage_size_gib, :ip6, :ip4_enabled, :ip4, :firewalls, :private_ipv4, :private_ipv6, :subnet
+
+    set_associations do
+      {
+        firewalls: Firewall,
+        subnet: PrivateSubnet
+      }
+    end
+
+    set_create_param_defaults do |params|
+      params[:public_key] = params[:public_key]&.gsub(/(?<!\r)\n/, "\r\n")
+    end
+
+    # Schedule a restart of the virtual machine. Returns self.
+    def restart
+      merge_into_values(adapter.post(_path("/restart")))
+    end
+  end
+end

--- a/sdk/ruby/lib/ubicloud/model_adapter.rb
+++ b/sdk/ruby/lib/ubicloud/model_adapter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Ubicloud
+  # Ubicloud::ModelAdapter instances represents a model class
+  # that is tied to a adapter.  Methods called on instances
+  # of this class are forwarded to the related model, with
+  # the adapter as the first argument.
+  class ModelAdapter
+    def initialize(model, adapter)
+      @model = model
+      @adapter = adapter
+    end
+
+    # Forward methods to the model class, but include the
+    # adapter as the first argument.
+    def method_missing(meth, ...)
+      @model.public_send(meth, @adapter, ...)
+    end
+
+    # Respond to the method if the model class responds to it.
+    def respond_to_missing?(...)
+      @model.respond_to?(...)
+    end
+  end
+end

--- a/sdk/ruby/ubicloud.gemspec
+++ b/sdk/ruby/ubicloud.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name = "ubicloud"
+  s.version = "0.1.0"
+  s.summary = "Ubicloud Ruby SDK"
+  s.authors = ["Ubicloud, Inc."]
+  s.email = ["ruby-gem-owner@ubicloud.com"]
+  s.homepage = "https://github.com/ubicloud/ubicloud/tree/main/sdk/ruby"
+  s.license = "MIT"
+  s.required_ruby_version = ">= 3.1"
+
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/ubicloud/ubicloud/issues",
+    "mailing_list_uri" => "https://github.com/ubicloud/ubicloud/discussions/new?category=q-a",
+    "source_code_uri" => "https://github.com/ubicloud/ubicloud/tree/main/sdk/ruby"
+  }
+
+  s.files = %w[MIT-LICENSE] + Dir["lib/**/*.rb"]
+  s.extra_rdoc_files = %w[MIT-LICENSE]
+end

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
@@ -1,2 +1,1 @@
-! Unexpected response status: 404
-Details: Sorry, we couldn’t find the resource you’re looking for.
+! No virtual machine with id vmdzyppz6j166jh5e9t0dwrfas exists

--- a/spec/ruby_sdk_spec.rb
+++ b/spec/ruby_sdk_spec.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+require_relative "../sdk/ruby/lib/ubicloud"
+require_relative "../sdk/ruby/lib/ubicloud/adapter"
+require_relative "../sdk/ruby/lib/ubicloud/adapter/net_http"
+
+# rubocop:disable RSpec/SpecFilePathFormat
+RSpec.describe Ubicloud do
+  # rubocop:enable RSpec/SpecFilePathFormat
+  let(:ubi) { described_class.new(:rack, app: Clover, env: {}, project_id: nil) }
+
+  it "ModelAdapter#respond_to? works as expected" do
+    expect(ubi.vm).to respond_to(:create)
+    expect(ubi.vm).to respond_to(:list)
+    expect(ubi.vm).not_to respond_to(:invalid_meth)
+  end
+
+  it "Error#params returns empty hash for no body" do
+    expect(Ubicloud::Error.new("foo").params).to eq({})
+  end
+
+  it "Error#params returns empty hash for invalid JSON" do
+    expect(Ubicloud::Error.new("foo", code: 444, body: "x").params).to eq({})
+  end
+
+  it "Adapter::Rack closes response bodies" do
+    o = ["{\"items\": []}"]
+    closed = false
+    o.define_singleton_method(:close) { closed = true }
+    expect(Clover).to receive(:call).and_return([200, {}, o])
+    expect(ubi.vm.list).to eq([])
+    expect(closed).to be true
+  end
+
+  it "Model.new raises for invalid hash" do
+    expect(Clover).not_to receive(:call)
+    expect { ubi.vm.new({}) }.to raise_error(Ubicloud::Error, "hash must have :id key or :location and :name keys")
+    expect { ubi.vm.new({name: "foo"}) }.to raise_error(Ubicloud::Error, "hash must have :id key or :location and :name keys")
+    expect { ubi.vm.new({location: "foo"}) }.to raise_error(Ubicloud::Error, "hash must have :id key or :location and :name keys")
+    expect(ubi.vm.new({name: "foo", location: "foo"})).to be_a(Ubicloud::Vm)
+  end
+
+  it "Model.[] raises for invalid id or location/name format" do
+    expect(Clover).not_to receive(:call)
+    expect { ubi.vm["test-vm"] }.to raise_error(Ubicloud::Error, "invalid vm location/name: \"test-vm\"")
+  end
+
+  it "Model.[] assumes location/name for invalid id format" do
+    expect(Clover).to receive(:call).and_return([404, {}, []])
+    expect(ubi.vm["eu-north-h1/test-vm"]).to be_nil
+  end
+
+  it "Model.[] returns nil for valid id format but missing object" do
+    expect(Clover).to receive(:call).and_return([404, {}, []])
+    expect(ubi.vm["vm345678901234567890123456"]).to be_nil
+  end
+
+  it "Context#[] returns nil for invalid format" do
+    expect(ubi["foo"]).to be_nil
+  end
+
+  it "Context#[] returns nil for valid format but missing object" do
+    expect(Clover).to receive(:call).and_return([404, {}, []])
+    expect(ubi["vm345678901234567890123456"]).to be_nil
+  end
+
+  it "Context#new returns nil for invalid format" do
+    expect(ubi.new("foo")).to be_nil
+  end
+
+  it "Context#new returns object for valid format but missing object" do
+    expect(Clover).not_to receive(:call)
+    expect(ubi.new("vm345678901234567890123456")).to be_a(Ubicloud::Vm)
+  end
+
+  it "Firewall#attach/detach_subnet supports PrivateSubnet instances" do
+    fw = ubi.firewall.new("eu-central-h1/test-fw")
+    ps = ubi.private_subnet.new("ps345678901234567890123456")
+    path = params = nil
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      path = env["PATH_INFO"]
+      params = JSON.parse(env["rack.input"].read, symbolize_names: true)
+      [200, {}, ["{\"id\": \"ps345678901234567890123456\"}"]]
+    end)
+
+    fw.attach_subnet(ps)
+    expect(path).to eq "/project//location/eu-central-h1/firewall/test-fw/attach-subnet"
+    expect(params).to eq({private_subnet_id: "ps345678901234567890123456"})
+
+    fw.detach_subnet(ps)
+    expect(path).to eq "/project//location/eu-central-h1/firewall/test-fw/detach-subnet"
+    expect(params).to eq({private_subnet_id: "ps345678901234567890123456"})
+  end
+
+  it "Vm.create converts LF to CRLF in public_keys" do
+    public_key = nil
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      public_key = JSON.parse(env["rack.input"].read, symbolize_names: true)[:public_key]
+      [200, {}, ["{\"id\": \"vm345678901234567890123456\"}"]]
+    end)
+
+    expect(ubi.vm.create(location: "eu-central-h1", name: "test-vm", public_key: "foo\nbar\r\nbaz")).to be_a(Ubicloud::Vm)
+    expect(public_key).to eq "foo\r\nbar\r\nbaz"
+
+    expect(ubi.vm.create(location: "eu-central-h1", name: "test-vm")).to be_a(Ubicloud::Vm)
+    expect(public_key).to be_nil
+  end
+
+  it "Firewall#add_rule and #delete_rule work without firewall rules loaded" do
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      [200, {}, ["{}"]]
+    end)
+
+    fw = ubi.firewall.new("foo/bar")
+    expect(fw.values[:firewall_rules]).to be_nil
+    fw.add_rule("1.2.3.0/24")
+    expect(fw.values[:firewall_rules]).to be_nil
+    fw.delete_rule("fr345678901234567890123456")
+    expect(fw.values[:firewall_rules]).to be_nil
+  end
+
+  it "Postgres#add_firewall_rule and #delete_firewall_rule work without firewall rules loaded" do
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      [200, {}, ["{}"]]
+    end)
+
+    pg = ubi.postgres.new("foo/bar")
+    expect(pg.values[:firewall_rules]).to be_nil
+    pg.add_firewall_rule("1.2.3.0/24")
+    expect(pg.values[:firewall_rules]).to be_nil
+    pg.delete_firewall_rule("fr345678901234567890123456")
+    expect(pg.values[:firewall_rules]).to be_nil
+  end
+
+  it "Postgres#add_metric_destination and #delete_metric_destination work without firewall rules loaded" do
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      [200, {}, ["{}"]]
+    end)
+
+    pg = ubi.postgres.new("foo/bar")
+    expect(pg.values[:metric_destinations]).to be_nil
+    pg.add_metric_destination(username: "foo", password: "bar", url: "https://baz.example.com")
+    expect(pg.values[:metric_destinations]).to be_nil
+    pg.delete_metric_destination("md345678901234567890123456")
+    expect(pg.values[:metric_destinations]).to be_nil
+  end
+
+  it "Firewall#add_rule and #delete_rule modify firewall rules if loaded" do
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      [200, {}, ["{\"id\": \"fr345678901234567890123456\"}"]]
+    end)
+
+    fw = ubi.firewall.new(location: "foo", name: "bar", firewall_rules: [])
+    expect(fw.values[:firewall_rules]).to eq([])
+    fw.add_rule("1.2.3.0/24")
+    expect(fw.values[:firewall_rules]).to eq([{id: "fr345678901234567890123456"}])
+    fw.delete_rule("fr345678901234567890123456")
+    expect(fw.values[:firewall_rules]).to eq([])
+  end
+
+  it "Postgres#add_firewall_rule and #delete_firewall_rule modify firewall rules if loaded" do
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      [200, {}, ["{\"id\": \"fr345678901234567890123456\"}"]]
+    end)
+
+    pg = ubi.postgres.new(location: "foo", name: "bar", firewall_rules: [])
+    expect(pg.values[:firewall_rules]).to eq([])
+    pg.add_firewall_rule("1.2.3.0/24")
+    expect(pg.values[:firewall_rules]).to eq([{id: "fr345678901234567890123456"}])
+    pg.delete_firewall_rule("fr345678901234567890123456")
+    expect(pg.values[:firewall_rules]).to eq([])
+  end
+
+  it "Postgres#add_metric_destination and #delete_metric_destination modify metric destinations if loaded" do
+    expect(Clover).to receive(:call).twice.and_invoke(proc do |env|
+      [200, {}, ["{\"id\": \"md345678901234567890123456\"}"]]
+    end)
+
+    pg = ubi.postgres.new(location: "foo", name: "bar", metric_destinations: [])
+    expect(pg.values[:metric_destinations]).to eq([])
+    pg.add_metric_destination(username: "foo", password: "bar", url: "https://baz.example.com")
+    expect(pg.values[:metric_destinations]).to eq([{id: "md345678901234567890123456"}])
+    pg.delete_metric_destination("md345678901234567890123456")
+    expect(pg.values[:metric_destinations]).to eq([])
+  end
+
+  describe Ubicloud::Adapter::NetHttp do
+    let(:adapter) { described_class.new(token: "foo", project_id: "pj", base_uri: "http://localhost") }
+
+    it "sends expected headers for GET requests" do
+      stub_request(:get, "http://localhost/project/pj/headers")
+        .with(
+          headers: {
+            "Accept" => "text/plain",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => "Bearer: foo",
+            "Connection" => "close",
+            "User-Agent" => "Ruby"
+          }
+        )
+        .to_return(status: 200, body: "{}", headers: {})
+      expect(adapter.get("headers")).to eq({})
+    end
+
+    it "sends expected headers for POST requests" do
+      stub_request(:post, "http://localhost/project/pj/headers")
+        .with(
+          body: "{\"foo\":\"bar\"}",
+          headers: {
+            "Accept" => "text/plain",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => "Bearer: foo",
+            "Connection" => "close",
+            "Content-Type" => "application/json",
+            "User-Agent" => "Ruby"
+          }
+        )
+        .to_return(status: 200, body: "{}", headers: {})
+      expect(adapter.post("headers", foo: "bar")).to eq({})
+    end
+
+    it "sends expected headers and body for POST requests" do
+      stub_request(:post, "http://localhost/project/pj/headers")
+        .with(
+          headers: {
+            "Accept" => "text/plain",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => "Bearer: foo",
+            "Connection" => "close",
+            "Content-Type" => "application/json",
+            "User-Agent" => "Ruby"
+          }
+        )
+        .to_return(status: 200, body: "{}", headers: {})
+      expect(adapter.post("headers")).to eq({})
+    end
+
+    it "sends expected headers for DELETE requests" do
+      stub_request(:delete, "http://localhost/project/pj/headers")
+        .with(
+          headers: {
+            "Accept" => "text/plain",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => "Bearer: foo",
+            "Connection" => "close",
+            "Content-Type" => "application/json",
+            "User-Agent" => "Ruby"
+          }
+        )
+        .to_return(status: 200, body: "{}", headers: {})
+      expect(adapter.delete("headers")).to eq({})
+    end
+  end
+end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -107,6 +107,7 @@ module ThawedMock
   allow_mocking(BillingRate, :from_resource_properties)
   allow_mocking(Clog, :emit)
   allow_mocking(CloudflareClient, :new)
+  allow_mocking(Clover, :call)
   allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :hardware_reset_server, :set_server_name)
   allow_mocking(InvoiceGenerator, :new)
   allow_mocking(Minio::Client, :new)


### PR DESCRIPTION
This adds a custom (i.e. not-autogenerated) Ruby SDK, designed specifically
around Ubicloud.  Examples of use:

```ruby
require "ubicloud"

# Setup SDK context
UBI = Ubicloud.new(:net_http, token: "YOUR_API_TOKEN", project_id: "pj...")

# Get list of VMs
UBI.vm.list

# Create a firewall
UBI.firewall.create(location: "eu-central-h1", name: "my-fw")

# Retrieive a load balancer,
lb = UBI["1b345678901234567890123456"]

# then destroy it
lb.destroy

# Schedule a PostgreSQL database restart
UBI.postgres.new("eu-central-h1/my-fw").restart
```

The SDK comes with two adapters, net_http and rack. net_http uses the
net/http standard library to submit HTTP requests.  rack directly calls
rack applications.  Users are expected to use net_http. UbiCli uses the
rack adapter to directly submit internal requests to Clover.

This changes the custom code in UbiCli and the cli-commands files to use
the Ruby SDK for all changes.  This is slightly slower, but allows for
testing Ruby SDK using the existing tests for the CLI.

The only spec change is to an error message, and the error message is now
more helpful.

As the Ruby SDK uses symbol keys instead of string keys, this switches
UbiCli and the cli-commands files to also use symbol keys.

This adds an UbiCli#check_no_slash helper method to DRY up code that
checks for slashes in strings used as path fragments.

CC @geemus 