### PR TITLE
Add auto_validations skip_invalid option

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -7,7 +7,7 @@ if ENV["RACK_ENV"] == "development"
   Sequel::Model.cache_associations = false
 end
 
-Sequel::Model.plugin :auto_validations
+Sequel::Model.plugin :auto_validations, skip_invalid: true
 Sequel::Model.plugin :require_valid_schema
 Sequel::Model.plugin :singular_table_names
 Sequel::Model.plugin :subclasses unless ENV["RACK_ENV"] == "development"

--- a/spec/lib/access_control_model_tag_spec.rb
+++ b/spec/lib/access_control_model_tag_spec.rb
@@ -107,7 +107,7 @@
       error = "must only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number"
       tag = model.new(project_id: project.id)
       expect(tag.valid?).to be false
-      expect(tag.errors[:name]).to eq([error, "is not present"])
+      expect(tag.errors[:name]).to eq([error])
 
       tag.name = "@"
       expect(tag.valid?).to be false


### PR DESCRIPTION
`skip_invalid` skips auto validations on a column if the column is already invalid for other reasons.  This can prevent the display of multiple error message for a column, where only one is needed. This affects one spec, which had both a detailed custom error message, as well as a generic "is not present" error message.

I tried using `not_null: :presence`, which validates that NOT NULL string columns do not have empty string values, but Ubicloud has a lot of cases where NOT NULL string columns are allowed to have empty string values, so it doesn't make sense to use that.