### PR TITLE
Disallow access to pods GUA ips from internet

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -70,6 +70,27 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     nap 5 unless vm.strand.label == "wait"
 
     vm.sshable.cmd "sudo iptables-nft -t nat -A POSTROUTING -s #{vm.nics.first.private_ipv4} -o ens3 -j MASQUERADE"
+    vm.sshable.cmd("sudo nft --file -", stdin: <<TEMPLATE)
+table ip6 pod_access;
+delete table ip6 pod_access;
+table ip6 pod_access {
+  chain ingress_egress_control {
+    type filter hook forward priority filter; policy drop;
+    # allow access to the vm itself in order to not break the normal functionality of Clover and SSH
+    ip6 daddr #{vm.ephemeral_net6.nth(2)} ct state established,related,new counter accept
+    ip6 saddr #{vm.ephemeral_net6.nth(2)} ct state established,related,new counter accept
+
+    # not allow new connections from internet but allow new connections from inside
+    ip6 daddr #{vm.ephemeral_net6} ct state established,related counter accept
+    ip6 saddr #{vm.ephemeral_net6} ct state established,related,new counter accept
+
+    # used for internal private ipv6 communication between pods
+    ip6 saddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
+    ip6 daddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
+  }
+}
+TEMPLATE
+    vm.ephemeral_net6
     vm.sshable.cmd "sudo systemctl enable --now kubelet"
 
     bud Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => vm.id, "user" => "ubi"}

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -5,9 +5,20 @@ require_relative "../../model/spec_helper"
 RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   subject(:prog) { described_class.new(Strand.new) }
 
+  let(:project) {
+    Project.create(name: "default")
+  }
+  let(:subnet) {
+    Prog::Vnet::SubnetNexus.assemble(Config.kubernetes_service_project_id, name: "test", ipv4_range: "172.19.0.0/16", ipv6_range: "fd40:1a0a:8d48:182a::/64").subject
+  }
+
+  let(:vm) {
+    nic = Prog::Vnet::NicNexus.assemble(subnet.id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
+    vm = Prog::Vm::Nexus.assemble("pub-key", Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
+    vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79")
+  }
+
   let(:kubernetes_cluster) {
-    project = Project.create(name: "default")
-    subnet = PrivateSubnet.create(net6: "0::0/16", net4: "127.0.0.0/8", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
     kc = KubernetesCluster.create(
       name: "k8scluster",
       version: "v1.32",
@@ -21,7 +32,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
     lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
-    kc.add_cp_vm(create_vm)
+    kc.add_cp_vm(vm)
     kc.add_cp_vm(create_vm)
 
     kc.update(api_server_lb_id: lb.id)
@@ -32,7 +43,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
-    allow(prog).to receive_messages(kubernetes_cluster: kubernetes_cluster, frame: {"vm_id" => create_vm.id})
+    allow(prog).to receive_messages(kubernetes_cluster: kubernetes_cluster, frame: {"vm_id" => vm.id})
   end
 
   describe "#before_run" do
@@ -151,9 +162,32 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "enables kubelet and buds a bootstrap rhizome process" do
       sshable = instance_double(Sshable)
       st = instance_double(Strand, label: "wait")
-      expect(prog.vm).to receive_messages(sshable: sshable, strand: st, nics: [instance_double(Nic, private_ipv4: "10.10.20.30/26")])
+      expect(prog.vm).to receive_messages(sshable: sshable, strand: st)
+      expect(sshable).to receive(:cmd).with("sudo iptables-nft -t nat -A POSTROUTING -s 172.19.145.64/26 -o ens3 -j MASQUERADE")
+      expect(sshable).to receive(:cmd).with(
+        "sudo nft --file -",
+        stdin: <<~TEMPLATE
+table ip6 pod_access;
+delete table ip6 pod_access;
+table ip6 pod_access {
+  chain ingress_egress_control {
+    type filter hook forward priority filter; policy drop;
+    # allow access to the vm itself in order to not break the normal functionality of Clover and SSH
+    ip6 daddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept
+    ip6 saddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept
+
+    # not allow new connections from internet but allow new connections from inside
+    ip6 daddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related counter accept
+    ip6 saddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related,new counter accept
+
+    # used for internal private ipv6 communication between pods
+    ip6 saddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept
+    ip6 daddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept
+  }
+}
+        TEMPLATE
+      )
       expect(sshable).to receive(:cmd).with("sudo systemctl enable --now kubelet")
-      expect(sshable).to receive(:cmd).with("sudo iptables-nft -t nat -A POSTROUTING -s 10.10.20.30/26 -o ens3 -j MASQUERADE")
 
       expect(prog).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => prog.vm.id, "user" => "ubi"})
       expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
@@ -203,7 +237,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(prog.vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: "10.0.0.37")])
       expect(prog.vm.sshable).to receive(:cmd).with(
         "common/bin/daemonizer /home/ubi/kubernetes/bin/init-cluster init_kubernetes_cluster",
-        stdin: /{"node_name":"test-vm","cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"127.0.0.0\/8","private_subnet_cidr6":"::\/16","vm_cidr":"10.0.0.37"}/
+        stdin: /{"node_name":"test-vm","cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"172.19.0.0\/16","private_subnet_cidr6":"fd40:1a0a:8d48:182a::\/64","vm_cidr":"10.0.0.37"}/
       )
 
       expect { prog.init_cluster }.to nap(30)


### PR DESCRIPTION
So far pods had both ULA and GUA ipv6 ips and the GUA ip was accessible from the internet. with this change, we add nft rules to each vm to only allow connections to be made from inside the pod and disallow all new connections coming to the GUA ip address.

This change is critical to not expose pods to the internet.