### PR TITLE
Remove old login-based API authentication

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -12,46 +12,6 @@ info:
 servers:
   - url: 'https://api.ubicloud.com'
 paths:
-  /login:
-    post:
-      operationId: login
-      summary: Login with user information
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                login:
-                  type: string
-                  example: user@mail.com
-                password:
-                  type: string
-                  example: password
-              additionalProperties: false
-              required:
-                - login
-                - password
-      responses:
-        '200':
-          description: Logged in successfully.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: string
-                    example: You have been logged in
-                additionalProperties: false
-                required:
-                  - success
-        default:
-          $ref: '#/components/responses/Error'
-      security: []
-      tags:
-        - Login
   /project:
     get:
       operationId: listProjects

--- a/rodauth/features/personal_access_token.rb
+++ b/rodauth/features/personal_access_token.rb
@@ -1,28 +1,18 @@
 # frozen-string-literal: true
 
+require "rodauth"
+
 module Rodauth
   Feature.define(:personal_access_token, :PersonalAccessToken) do
-    depends :jwt
-
     auth_value_method :pat_authorization_remove, /\ABearer:?\s+pat-/
     session_key :session_pat_key, :pat_id
 
-    def use_pat?
-      pat_authorization_remove.match?(request.env["HTTP_AUTHORIZATION"].to_s)
-    end
-
-    # We override use_jwt? in the rodauth configuration, so this is not used.
-    # def use_jwt?
-    #   super && !use_pat?
-    # end
-
     def session
       return @session if defined?(@session)
-      return super unless use_pat?
 
       @session = s = {}
 
-      token = request.env["HTTP_AUTHORIZATION"].sub(pat_authorization_remove, "")
+      token = request.env["HTTP_AUTHORIZATION"].to_s.sub(pat_authorization_remove, "")
       token_id, key = token.split("-", 2)
 
       return s unless (uuid = UBID.to_uuid(token_id))

--- a/spec/routes/api/auth_spec.rb
+++ b/spec/routes/api/auth_spec.rb
@@ -3,42 +3,16 @@
 require_relative "spec_helper"
 
 RSpec.describe Clover, "auth" do
-  let(:user) { create_account }
-
-  it "wrong email" do
-    post "/login?login=wrong_mail&password=#{TEST_USER_PASSWORD}", nil, {"CONTENT_TYPE" => "application/json"}
-
-    expect(last_response).to have_api_error(401, "There was an error logging in")
-  end
-
-  it "wrong password" do
-    post "/login?login=#{TEST_USER_EMAIL}&password=wrongpassword", nil, {"CONTENT_TYPE" => "application/json"}
-
-    expect(last_response).to have_api_error(401, "There was an error logging in")
-  end
-
-  it "JSON body with array parameters" do
-    post "/login?login=wrong_mail&password=#{TEST_USER_PASSWORD}", [].to_json, {"CONTENT_TYPE" => "application/json"}
-
-    expect(last_response).to have_api_error(401, "There was an error logging in")
-  end
-
-  it "JSON body with invalid JSON" do
-    post "/login?login=wrong_mail&password=#{TEST_USER_PASSWORD}", "'", {"CONTENT_TYPE" => "application/json"}
-
-    expect(last_response).to have_api_error(400, "invalid JSON uploaded")
-  end
-
-  it "wrong jwt" do
+  it "invalid authorization header" do
     header "Authorization", "Bearer wrongjwt"
     get "/project"
 
-    expect(last_response).to have_api_error(400, "invalid JWT format or claim in Authorization header")
+    expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
   end
 
-  it "no login" do
+  it "no authorization header" do
     get "/project"
 
-    expect(last_response).to have_api_error(401, "Please login to continue")
+    expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
   end
 end

--- a/spec/routes/api/committee_spec.rb
+++ b/spec/routes/api/committee_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Clover, "committee infrastructure" do
   let(:project) { project_with_default_policy(user) }
 
   before do
-    login_api(user.email)
+    login_api
   end
 
   it "serializes unexpected nested errors that cannot be converted" do

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -15,25 +15,25 @@ RSpec.describe Clover, "firewall" do
     it "not post" do
       post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
 
     it "not delete" do
       delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
 
     it "not get" do
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
     end
 
     it "create firewall rule" do

--- a/spec/routes/api/project/firewall_spec.rb
+++ b/spec/routes/api/project/firewall_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe Clover, "firewall" do
     it "not list" do
       get "/project/#{project.ubid}/firewall"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
 
     it "not create" do
       post "/project/#{project.ubid}/firewall"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
     end
 
     it "success get all firewalls" do

--- a/spec/routes/api/project/load_balancer_spec.rb
+++ b/spec/routes/api/project/load_balancer_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Clover, "vm" do
     it "not list" do
       get "/project/#{project.ubid}/load-balancer"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
       lb_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:load_balancer_service_project_id).and_return(lb_project.id)
     end

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -13,31 +13,31 @@ RSpec.describe Clover, "firewall" do
     it "not delete" do
       delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
 
     it "not get" do
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
 
     it "not associate" do
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}/attach-subnet"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
 
     it "not dissociate" do
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.name}/detach-subnet"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
     end
 
     it "success get all location firewalls" do

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe Clover, "load-balancer" do
       ].each do |method, path, body|
         send(method, path, body)
 
-        expect(last_response).to have_api_error(401, "Please login to continue")
+        expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
       end
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
       lb_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:load_balancer_service_project_id).and_return(lb_project.id)
     end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe Clover, "postgres" do
       ].each do |method, path|
         send method, path
 
-        expect(last_response).to have_api_error(401, "Please login to continue")
+        expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
       end
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
       postgres_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe Clover, "private_subnet" do
       ].each do |method, path|
         send method, path
 
-        expect(last_response).to have_api_error(401, "Please login to continue")
+        expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
       end
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
     end
 
     describe "list" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe Clover, "vm" do
       ].each do |method, path|
         send method, path
 
-        expect(last_response).to have_api_error(401, "Please login to continue")
+        expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
       end
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
     end
 
     describe "list" do

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Clover, "vm" do
     it "not list" do
       get "/project/#{project.ubid}/pg"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
       postgres_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end

--- a/spec/routes/api/project/private_subnet_spec.rb
+++ b/spec/routes/api/project/private_subnet_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Clover, "private_subnet" do
     it "not list" do
       get "/project/#{project.ubid}/private-subnet"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
     end
 
     it "success all pss" do

--- a/spec/routes/api/project/vm_spec.rb
+++ b/spec/routes/api/project/vm_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Clover, "vm" do
     it "not list" do
       get "/project/#{project.ubid}/vm"
 
-      expect(last_response).to have_api_error(401, "Please login to continue")
+      expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
     end
   end
 
   describe "authenticated" do
     before do
-      login_api(user.email)
+      login_api
     end
 
     it "success all vms" do

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Clover, "project" do
       ].each do |method, path, body|
         send(method, path, body)
 
-        expect(last_response).to have_api_error(401, "Please login to continue")
+        expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
       end
     end
 
@@ -43,122 +43,115 @@ RSpec.describe Clover, "project" do
     end
   end
 
-  {
-    "with login api" => false,
-    "with personal access token" => true
-  }.each do |desc, use_pat|
-    describe "authenticated #{desc}" do
-      before do
-        login_api(user.email, use_pat:)
+  describe "authenticated" do
+    before do
+      login_api
+    end
+
+    describe "list" do
+      it "success" do
+        project
+        get "/project"
+
+        expect(last_response.status).to eq(200)
+        parsed_body = JSON.parse(last_response.body)
+        expect(parsed_body["count"]).to eq(2)
       end
 
-      describe "list" do
-        it "success" do
-          project
-          get "/project"
+      it "invalid order column" do
+        project
+        get "/project?order_column=name"
 
-          expect(last_response.status).to eq(200)
-          parsed_body = JSON.parse(last_response.body)
-          expect(parsed_body["count"]).to eq(2)
-        end
-
-        it "invalid order column" do
-          project
-          get "/project?order_column=name"
-
-          expect(last_response).to have_api_error(400, "Validation failed for following fields: order_column")
-        end
-
-        it "invalid id" do
-          project
-          get "/project?start_after=invalid_id"
-
-          expect(last_response).to have_api_error(400, "Validation failed for following fields: start_after")
-        end
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: order_column")
       end
 
-      describe "create" do
-        it "success" do
-          project
-          post "/project", {
-            name: "test-project"
-          }.to_json
+      it "invalid id" do
+        project
+        get "/project?start_after=invalid_id"
 
-          expect(last_response.status).to eq(200)
-          expect(JSON.parse(last_response.body)["name"]).to eq("test-project")
-        end
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: start_after")
+      end
+    end
+
+    describe "create" do
+      it "success" do
+        project
+        post "/project", {
+          name: "test-project"
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq("test-project")
+      end
+    end
+
+    describe "delete" do
+      it "success" do
+        delete "/project/#{project.ubid}"
+
+        expect(last_response.status).to eq(204)
+
+        expect(Project[project.id].visible).to be_falsey
+        expect(DB[:access_tag].where(project_id: project.id).count).to eq(0)
+        expect(SubjectTag.where(project_id: project.id).count).to eq(0)
+        expect(AccessControlEntry.where(project_id: project.id).count).to eq(0)
       end
 
-      describe "delete" do
-        it "success" do
-          delete "/project/#{project.ubid}"
+      it "success with non-existing project" do
+        project_with_default_policy(user)
+        delete "/project/pj000000000000000000000000"
 
-          expect(last_response.status).to eq(204)
-
-          expect(Project[project.id].visible).to be_falsey
-          expect(DB[:access_tag].where(project_id: project.id).count).to eq(0)
-          expect(SubjectTag.where(project_id: project.id).count).to eq(0)
-          expect(AccessControlEntry.where(project_id: project.id).count).to eq(0)
-        end
-
-        it "success with non-existing project" do
-          project_with_default_policy(user)
-          delete "/project/pj000000000000000000000000"
-
-          expect(last_response.status).to eq(204)
-        end
-
-        it "can not delete project when it has resources" do
-          Prog::Vm::Nexus.assemble("key", project.id, name: "vm1")
-
-          delete "/project/#{project.ubid}"
-
-          expect(last_response).to have_api_error(409, "'#{project.name}' project has some resources. Delete all related resources first.")
-        end
-
-        it "not authorized" do
-          project_with_default_policy(user)
-          p = create_account("test@test.com").create_project_with_default_policy("project-1")
-          delete "/project/#{p.ubid}"
-
-          expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
-        end
+        expect(last_response.status).to eq(204)
       end
 
-      describe "show" do
-        it "success" do
-          get "/project/#{project.ubid}"
+      it "can not delete project when it has resources" do
+        Prog::Vm::Nexus.assemble("key", project.id, name: "vm1")
 
-          expect(last_response.status).to eq(200)
-          expect(JSON.parse(last_response.body)["name"]).to eq(project.name)
-        end
+        delete "/project/#{project.ubid}"
 
-        if use_pat
-          it "failure with unauthorized personal access token" do
-            project
-            AccessControlEntry.dataset.destroy
-            AccessControlEntry.create_with_id(project_id: project.id, subject_id: @pat.id, action_id: ActionType::NAME_MAP["Project:edit"])
+        expect(last_response).to have_api_error(409, "'#{project.name}' project has some resources. Delete all related resources first.")
+      end
 
-            get "/project/#{project.ubid}"
-            expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
-          end
-        end
+      it "not authorized" do
+        project_with_default_policy(user)
+        p = create_account("test@test.com").create_project_with_default_policy("project-1")
+        delete "/project/#{p.ubid}"
 
-        it "not found" do
-          project
-          get "/project/pj000000000000000000000000"
+        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
+      end
+    end
 
-          expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
-        end
+    describe "show" do
+      it "success" do
+        get "/project/#{project.ubid}"
 
-        it "not authorized" do
-          project
-          u = create_account("test@test.com")
-          p = u.create_project_with_default_policy("project-1")
-          get "/project/#{p.ubid}"
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["name"]).to eq(project.name)
+      end
 
-          expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
-        end
+      it "failure with unauthorized personal access token" do
+        project
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create_with_id(project_id: project.id, subject_id: @pat.id, action_id: ActionType::NAME_MAP["Project:edit"])
+
+        get "/project/#{project.ubid}"
+        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
+      end
+
+      it "not found" do
+        project
+        get "/project/pj000000000000000000000000"
+
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
+      end
+
+      it "not authorized" do
+        project
+        u = create_account("test@test.com")
+        p = u.create_project_with_default_policy("project-1")
+        get "/project/#{p.ubid}"
+
+        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
       end
     end
   end

--- a/spec/routes/api/show_errors_spec.rb
+++ b/spec/routes/api/show_errors_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Clover do
       ENV["SHOW_ERRORS"] = "1"
     end
     @account = create_account
-    login_api(@account.email)
+    login_api
   end
 
   after do

--- a/spec/routes/api/spec_helper.rb
+++ b/spec/routes/api/spec_helper.rb
@@ -3,13 +3,8 @@
 require_relative "../spec_helper"
 
 RSpec.configure do |config|
-  def login_api(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD, use_pat: true)
-    @use_pat = use_pat
-    unless use_pat
-      post "/login", JSON.generate(login: email, password: password), {"CONTENT_TYPE" => "application/json"}
-      expect(last_response.status).to eq(200)
-      header "Authorization", "Bearer #{last_response.headers["authorization"]}"
-    end
+  def login_api
+    @use_pat = true
   end
 
   def project_with_default_policy(account, name: "project-1")


### PR DESCRIPTION
This makes personal access token the only possible authentication for the API.

For API requests without a personal access token, they get a specific error that the credentials are missing.  I chose to use 401 for this, because that seemed more appropriate than 400.

In the specs, `login_api` now takes no arguments.  It just sets to use personal access tokens for requests.  This was chosen over removing the method completely, because there are a significant number of specs that want to test for unauthenticated access.  I'm not sure whether such specs are actually useful, since they all hit the same condition at the top of the main route block.  We should consider changing the specs in the future to provide an access token that is valid, but does not grant access to the objects, in order to test for specific authorization. We already do this in some cases, but not in others.

With this change, the only error that Rodauth can generate for API requests is for invalid credentials, so simplify the json_response_body method, and generate the response body up front so we don't need to generate it per-request.