### PR TITLE
Add additional project id check for billing entities

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -143,7 +143,7 @@ class Clover
         end
 
         r.is String do |pm_ubid|
-          next unless (payment_method = PaymentMethod.from_ubid(pm_ubid))
+          next unless (payment_method = PaymentMethod.from_ubid(pm_ubid)) && payment_method.billing_info_id == @project.billing_info_id
 
           r.delete true do
             unless payment_method.billing_info.payment_methods.count > 1
@@ -162,7 +162,7 @@ class Clover
         r.is String do |invoice_ubid|
           invoice = (invoice_ubid == "current") ? @project.current_invoice : Invoice.from_ubid(invoice_ubid)
 
-          next unless invoice
+          next unless invoice && invoice.project_id == @project.id
 
           r.get true do
             @invoice_data = Serializers::Invoice.serialize(invoice, {detailed: true})

--- a/routes/project/usage_alert.rb
+++ b/routes/project/usage_alert.rb
@@ -16,7 +16,7 @@ class Clover
       end
 
       r.is String do |usage_alert_ubid|
-        next unless (usage_alert = UsageAlert.from_ubid(usage_alert_ubid))
+        next unless (usage_alert = UsageAlert.from_ubid(usage_alert_ubid)) && usage_alert.project_id == @project.id
 
         r.delete true do
           usage_alert.destroy


### PR DESCRIPTION
We check authorization for all billing-related operations once with
authorize("Project:billing", @project.id).

After that, users can provide any resource ID from other projects to
delete payment method and usage alert, or get invoice details.

It's important that customers can only access their own resources.
