### PR TITLE
Don't wait to collect telemetry for the runner when for all SSH errors

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -11,6 +11,14 @@ class Sshable < Sequel::Model
     enc.column :raw_private_key_2
   end
 
+  SSH_CONNECTION_ERRORS = [
+    Net::SSH::Disconnect,
+    Net::SSH::ConnectionTimeout,
+    Errno::ECONNRESET,
+    Errno::ECONNREFUSED,
+    IOError
+  ].freeze
+
   class SshError < StandardError
     attr_reader :stdout, :stderr, :exit_code, :exit_signal
 
@@ -138,7 +146,7 @@ class Sshable < Sequel::Model
 
   def available?
     cmd("true") && true
-  rescue Net::SSH::Disconnect, Net::SSH::ConnectionTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, IOError
+  rescue *SSH_CONNECTION_ERRORS
     false
   end
 

--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -82,7 +82,7 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
         # resolution in different states can be handled properly.
         register_deadline("wait", 0)
       end
-    rescue Net::SSH::Disconnect, Net::SSH::ConnectionTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, IOError
+    rescue *Sshable::SSH_CONNECTION_ERRORS
       # Host is likely to be down, which will be handled by HostNexus. No need
       # to create a page for this case.
     end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -553,6 +553,62 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
   end
 
+  describe ".collect_final_telemetry" do
+    it "Logs journalctl and docker limits if workflow_job is not successful" do
+      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "failure"})
+      vmh_sshable = instance_double(Sshable)
+      expect(vm.vm_host).to receive(:sshable).and_return(vmh_sshable)
+      expect(vmh_sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
+      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
+      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
+      COMMAND
+
+      nx.collect_final_telemetry
+    end
+
+    it "Logs journalctl and docker limits if workflow_job is nil" do
+      expect(github_runner).to receive(:workflow_job).and_return(nil)
+      vmh_sshable = instance_double(Sshable)
+      expect(vm.vm_host).to receive(:sshable).and_return(vmh_sshable)
+      expect(vmh_sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
+      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
+      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
+      COMMAND
+
+      nx.collect_final_telemetry
+    end
+
+    it "Logs only docker limits if workflow_job is successful" do
+      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"})
+      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
+      COMMAND
+
+      nx.collect_final_telemetry
+    end
+
+    it "doesn't fail if it failed due to Sshable::SshError" do
+      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"})
+      expect(sshable).to receive(:cmd).and_raise Sshable::SshError.new("bogus", "", "", nil, nil)
+      expect(Clog).to receive(:emit).with("Failed to collect final telemetry").and_call_original
+
+      nx.collect_final_telemetry
+    end
+
+    it "doesn't fail if it failed due to Net::SSH::ConnectionTimeout" do
+      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"})
+      expect(sshable).to receive(:cmd).and_raise Net::SSH::ConnectionTimeout
+      expect(Clog).to receive(:emit).with("Failed to collect final telemetry").and_call_original
+
+      nx.collect_final_telemetry
+    end
+  end
+
   describe "#destroy" do
     it "naps if runner not deregistered yet" do
       expect(client).to receive(:get).and_return(busy: false)
@@ -571,21 +627,12 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)
-
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "failure"}).at_least(:once)
-      vm_host = instance_double(VmHost, sshable: sshable)
-      fws = [instance_double(Firewall)]
-      ps = instance_double(PrivateSubnet, firewalls: fws)
-      expect(fws.first).to receive(:destroy)
+      expect(nx).to receive(:collect_final_telemetry)
+      fw = instance_double(Firewall)
+      ps = instance_double(PrivateSubnet, firewalls: [fw])
+      expect(fw).to receive(:destroy)
       expect(ps).to receive(:incr_destroy)
       expect(vm).to receive(:private_subnets).and_return([ps])
-      expect(vm).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
-      COMMAND
-      expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
       expect(vm).to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")
@@ -594,80 +641,17 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "skip deregistration and destroy vm immediately" do
       expect(nx).to receive(:decr_destroy)
       expect(github_runner).to receive(:skip_deregistration_set?).and_return(true)
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"}).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
-      COMMAND
+      expect(nx).to receive(:collect_final_telemetry)
       expect(vm).to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")
     end
 
-    it "destroys resources and hops if runner deregistered, also, copies serial log if workflow_job is nil" do
+    it "does not collect telemetry if the vm not allocated" do
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
-      expect(client).not_to receive(:delete)
-
-      expect(github_runner).to receive(:workflow_job).and_return(nil)
-      vm_host = instance_double(VmHost, sshable: sshable)
-      expect(vm).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
-      COMMAND
-      expect(sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
-      expect(vm).to receive(:incr_destroy)
-
-      expect { nx.destroy }.to hop("wait_vm_destroy")
-    end
-
-    it "destroys resources and hops if runner deregistered, also, emits log if it couldn't move the serial.log" do
-      expect(nx).to receive(:decr_destroy)
-      expect(client).to receive(:get).and_raise(Octokit::NotFound)
-      expect(client).not_to receive(:delete)
-
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "failure"}).at_least(:once)
-      vm_host = instance_double(VmHost, sshable: sshable)
-      expect(vm).to receive(:vm_host).and_return(vm_host).at_least(:once)
-      expect(sshable).to receive(:cmd).and_raise Sshable::SshError.new("bogus", "", "", nil, nil)
-      expect(Clog).to receive(:emit).with("Failed to move serial.log or running journalctl").and_call_original
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
-      COMMAND
-      expect(vm).to receive(:incr_destroy)
-
-      expect { nx.destroy }.to hop("wait_vm_destroy")
-    end
-
-    it "emits log if it couldn't check Docker Hub rate limit" do
-      expect(nx).to receive(:decr_destroy)
-      expect(client).to receive(:get).and_raise(Octokit::NotFound)
-      expect(client).not_to receive(:delete)
-
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"}).at_least(:once)
-      expect(sshable).to receive(:cmd).and_raise Sshable::SshError.new("bogus", "", "", nil, nil)
-
-      expect(Clog).to receive(:emit).with("Failed to check Docker Hub rate limit").and_call_original
-      expect(vm).to receive(:incr_destroy)
-
-      expect { nx.destroy }.to hop("wait_vm_destroy")
-    end
-
-    it "simply destroys the VM if the workflow_job is there and the conclusion is success" do
-      expect(nx).to receive(:decr_destroy)
-      expect(client).to receive(:get).and_raise(Octokit::NotFound)
-      expect(client).not_to receive(:delete)
-
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"}).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
-        TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
-      COMMAND
-      expect(sshable).not_to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).not_to receive(:cmd).with("journalctl -u runner-script --no-pager | grep -e run-withenv -e systemd | grep -v -e Started")
+      expect(vm).to receive(:vm_host).and_return(nil)
+      expect(nx).not_to receive(:collect_final_telemetry)
       expect(vm).to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")


### PR DESCRIPTION
- **Group SSH connection errors**
  SSH commands might raise different types of exceptions if there’s
  something wrong with the connection. We catch these exceptions in
  multiple places, so I grouped them together.
  

- **Don't wait to collect telemetry for the runner when for all SSH errors**
  We save runner script logs and serial logs if the job isn't successful
  for further investigation. We also collect DockerHub limits to monitor
  usage.
  
  If the host or VM is unavailable, it raises an exception other than
  Sshable::SshError, causing the runner program to get stuck.
  
  If they are down, we shouldn't wait for the runner to collect telemetry.
  
  I also extracted it to a helper method, which made the tests more
  readable.
  