### PR TITLE
Update postgres image version for E2E

### DIFF
--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -2,5 +2,5 @@
 - { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2404.yml, branch_name: main} }
 - { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2204.yml, branch_name: main} }
 - { name: github_runner_ubuntu_2004, images: ["github-ubuntu-2004"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2004.yml, branch_name: main} }
-- { name: postgres_standard,         images: ["postgres16-ubuntu-2204"] }
-- { name: postgres_ha,               images: ["postgres16-ubuntu-2204", "ubuntu-jammy"] }
+- { name: postgres_standard,         images: ["postgres17-ubuntu-2204"] }
+- { name: postgres_ha,               images: ["postgres17-ubuntu-2204", "ubuntu-jammy"] }


### PR DESCRIPTION
Since the default PG version changed in #3057, E2E fails because the boot image does not exist