### PR TITLE
Parse DockerHub rate limit output

### DIFF
--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -560,7 +560,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm.vm_host).to receive(:sshable).and_return(vmh_sshable)
       expect(vmh_sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+      expect(sshable).to receive(:cmd).with(<<~COMMAND, log: false)
         TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
@@ -574,7 +574,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm.vm_host).to receive(:sshable).and_return(vmh_sshable)
       expect(vmh_sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
       expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+      expect(sshable).to receive(:cmd).with(<<~COMMAND, log: false)
         TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
@@ -584,10 +584,13 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "Logs only docker limits if workflow_job is successful" do
       expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"})
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+      expect(sshable).to receive(:cmd).with(<<~COMMAND, log: false).and_return("ratelimit-limit: 100;w=21600\nratelimit-remaining: 98;w=21600\ndocker-ratelimit-source: 192.168.1.1\n")
         TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
+      expect(Clog).to receive(:emit).with("Remaining DockerHub rate limits") do |&blk|
+        expect(blk.call).to eq(dockerhub_rate_limits: {limit: 100, limit_window: 21600, remaining: 98, remaining_window: 21600, source: "192.168.1.1"})
+      end
 
       nx.collect_final_telemetry
     end


### PR DESCRIPTION
We started logging the remaining DockerHub rate limit output to track our usage since DockerHub plans to change its rate limit policy.

Right now, it prints all output as raw text, making it difficult to analyze in our monitoring tool.

It would be better to log it as JSON so we can run basic queries on it.

Example output to parse:

    ratelimit-limit: 100;w=21600
    ratelimit-remaining: 100;w=21600
    docker-ratelimit-source: 192.168.1.1