### PR TITLE
Bump maximum pagination page size to 1000, and make that the default

### DIFF
--- a/lib/pagination.rb
+++ b/lib/pagination.rb
@@ -3,11 +3,11 @@
 module Pagination
   def paginated_result(start_after: nil, page_size: nil, order_column: nil)
     model = @opts[:model]
-    page_size ||= 10
+    page_size ||= 1000
     order_column_sym = (order_column || "id").to_sym
 
     begin
-      page_size = Integer(page_size).clamp(1, 100)
+      page_size = Integer(page_size).clamp(1, 1000)
     rescue ArgumentError
       fail Validation::ValidationFailed.new(page_size: "#{page_size} is not an integer")
     end

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -48,14 +48,14 @@ RSpec.describe Pagination do
         expect(result[:records].length).to eq(1)
       end
 
-      it "big page size" do
-        101.times do |index|
+      it "more objects than requested page size" do
+        3.times do |index|
           ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "additional-ps-#{index}", location_id: Location::HETZNER_FSN1_ID).subject
           Prog::Vm::Nexus.assemble("dummy-public-key", project.id, name: "additional-vm-#{index}", private_subnet_id: ps.id).subject
         end
 
-        result = project.vms_dataset.paginated_result(page_size: 1000)
-        expect(result[:records].length).to eq(100)
+        result = project.vms_dataset.paginated_result(page_size: 2)
+        expect(result[:records].length).to eq(2)
       end
 
       it "empty page" do


### PR DESCRIPTION
Actually testing over 1000 results in the specs is way too slow, so just test that a page_size lower than the number of objects is respected.  This doesn't test the upper clamp, but it's not necessary to do so for coverage, and I don't think the benefit of such testing is worth the large performance hit.

CC @geemus 