### PR TITLE
Opt in to profiling examples in the specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,7 +126,7 @@ RSpec.configure do |config|
   # end of the spec run, to help surface which specs are running
   # particularly slow.  However, avoid printing when parallel testing,
   # to avoid output from every process.
-  config.profile_examples = 10 unless ENV["TEST_ENV_NUMBER"]
+  config.profile_examples = 10 if ENV["PROFILE_EXAMPLES"]
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
This information is only helpful if I'm looking at optimizing the specs.  In over 99% of cases, the profiling output just gets in the way and forces me to look into terminal scrollback to find the information I actually need.