### PR TITLE
Add cli-sync rake task to sync cli folder to cli repository

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,30 @@
+# ubi
+
+`ubi` the command line program for interacting with Ubicloud.
+
+# Building
+
+With `make`:
+
+```
+$ make
+```
+
+Directly with `go build`:
+
+```
+$ go build -ldflags "-s -w -X main.version=`cat version.txt`" -tags osusergo,netgo
+```
+
+# Running
+
+First, make sure `UBI_TOKEN` in the environment is set to your Ubicloud personal
+access token. Then run it:
+
+```
+$ ubi
+```
+
+# License
+
+APGL


### PR DESCRIPTION
The cli repository should be checked out in ../cli.  We'll be using the cli repository only to publish releases, actual development will still occur in the ubicloud repository.

While here, add a basic README for the cli repository, which will also be synced.