### PR TITLE
Require Valid Billing Info Before Creating K8s

### DIFF
--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -3,6 +3,7 @@
 class Clover
   def kubernetes_cluster_post(name)
     authorize("KubernetesCluster:create", @project.id)
+    fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
     required_parameters = ["name", "location", "cp_nodes", "worker_nodes"]
     request_body_params = validate_request_params(required_parameters)

--- a/routes/project/kubernetes_cluster.rb
+++ b/routes/project/kubernetes_cluster.rb
@@ -17,6 +17,7 @@ class Clover
       r.get "create" do
         authorize("KubernetesCluster:create", @project.id)
 
+        @has_valid_payment_method = @project.has_valid_payment_method?
         @option_tree, @option_parents = generate_kubernetes_cluster_options
 
         view "kubernetes-cluster/create"

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -1,5 +1,7 @@
 <% @page_title = "Create Kubernetes Cluster" %>
 
+<%== render("components/billing_warning") %>
+
 <%== part(
   "components/page_header",
   breadcrumbs: [
@@ -9,7 +11,6 @@
     %w[Create #]
   ]
 ) %>
-
 
 <%
   form_elements = [


### PR DESCRIPTION
This commit adds a check to k8s creation form and backend for a valid billing information for a project before creating a cluster.