### PR TITLE
Handle additional Octokit exceptions

### DIFF
--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -18,10 +18,10 @@ class Clover < Roda
     end
 
     Clog.emit("Get runner scope from GitHub API") { {get_runner_scope: log_context} }
-    client = Github.installation_client(runner.installation.installation_id)
     begin
+      client = Github.installation_client(runner.installation.installation_id)
       jobs = client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
-    rescue Octokit::ClientError => ex
+    rescue Octokit::ClientError, Octokit::ServerError => ex
       log_context[:expection] = Util.exception_to_hash(ex)
       Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }
       return


### PR DESCRIPTION
Handle exceptions during the Github.installation_client call, and also rescue Octokit::ServerError.