### PR TITLE
bin/respirate improvements

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -31,14 +31,16 @@ Strand.dataset.insert_conflict.insert(id: "08200dd2-20ce-833a-de82-10fd5a082bff"
 
 clover_freeze
 
-until d.shutting_down
-  if d.start_cohort && !d.shutting_down
-    # Only sleep if not shutting down and there were no strands in previous scan
-    # Note that this results in an up to a 1 second delay to pick up new strands,
-    # but that is an accept tradeoff, because we do not want to busy loop the
-    # database (potentially, LISTEN/NOTIFY could be used to reduce this latency)
-    duration_slept = sleep 1
-    Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
+DB.synchronize do
+  until d.shutting_down
+    if d.start_cohort && !d.shutting_down
+      # Only sleep if not shutting down and there were no strands in previous scan
+      # Note that this results in an up to a 1 second delay to pick up new strands,
+      # but that is an accept tradeoff, because we do not want to busy loop the
+      # database (potentially, LISTEN/NOTIFY could be used to reduce this latency)
+      duration_slept = sleep 1
+      Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
+    end
   end
 end
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -61,6 +61,8 @@ class Scheduling::Dispatcher
       .limit(pool_size)
       .exclude(id: Sequel.function(:ANY, Sequel.cast(:$skip_strands, "uuid[]")))
       .select(:id)
+      .for_update
+      .skip_locked
       .prepare(:select, :get_strand_cohort)
   end
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -120,7 +120,7 @@ class Scheduling::Dispatcher
       start_queue:,
       finish_queue:,
       apoptosis_thread: Thread.new { apoptosis_thread(start_queue, finish_queue) },
-      strand_thread: Thread.new { strand_thread(strand_queue, start_queue, finish_queue) }
+      strand_thread: Thread.new { DB.synchronize { strand_thread(strand_queue, start_queue, finish_queue) } }
     }
   end
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -60,6 +60,7 @@ class Scheduling::Dispatcher
       .order_by(:schedule)
       .limit(pool_size)
       .exclude(id: Sequel.function(:ANY, Sequel.cast(:$skip_strands, "uuid[]")))
+      .select(:id)
       .prepare(:select, :get_strand_cohort)
   end
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -10,7 +10,7 @@ class Scheduling::Dispatcher
   STRAND_RUNTIME = Strand::LEASE_EXPIRATION / 4
   APOPTOSIS_MUTEX = Mutex.new
 
-  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.db_pool - 1)
+  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.db_pool - 2)
     @shutting_down = false
 
     # How long to wait in seconds from the start of strand run
@@ -26,7 +26,7 @@ class Scheduling::Dispatcher
     # The thread pool size.  By default, set to one less than the number of database
     # connections, to ensure there is a connection always available for the
     # main thread, for the query to find strands to run.
-    pool_size = pool_size.clamp(1, Config.db_pool - 1)
+    pool_size = pool_size.clamp(1, Config.db_pool - 2)
 
     # The Queue that all threads in the thread pool pull from.  This is a
     # SizedQueue to allow for backoff in the case that the thread pool cannot

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -10,7 +10,7 @@ class Scheduling::Dispatcher
   STRAND_RUNTIME = Strand::LEASE_EXPIRATION / 4
   APOPTOSIS_MUTEX = Mutex.new
 
-  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29)
+  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.db_pool - 1)
     @shutting_down = false
 
     # How long to wait in seconds from the start of strand run
@@ -23,10 +23,10 @@ class Scheduling::Dispatcher
     # Mutex for current strands
     @mutex = Mutex.new
 
-    # The thread pool size.  Set to one less than the number of database
+    # The thread pool size.  By default, set to one less than the number of database
     # connections, to ensure there is a connection always available for the
     # main thread, for the query to find strands to run.
-    pool_size = Config.db_pool - 1
+    pool_size = pool_size.clamp(1, Config.db_pool - 1)
 
     # The Queue that all threads in the thread pool pull from.  This is a
     # SizedQueue to allow for backoff in the case that the thread pool cannot

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Scheduling::Dispatcher do
       exited = false
       expect(ThreadPrinter).to receive(:run)
       expect(Kernel).to receive(:exit!).and_invoke(-> { exited = true })
-      di = described_class.new(apoptosis_timeout: 0.05)
+      di = described_class.new(apoptosis_timeout: 0.05, pool_size: 1)
       start_queue = di.instance_variable_get(:@thread_data).dig(0, :start_queue)
       start_queue.push(true)
       t = Time.now
@@ -80,7 +80,7 @@ RSpec.describe Scheduling::Dispatcher do
       exited = false
       expect(ThreadPrinter).to receive(:run)
       expect(Kernel).to receive(:exit!).and_invoke(-> { exited = true })
-      di = described_class.new(apoptosis_timeout: 0.05)
+      di = described_class.new(apoptosis_timeout: 0.05, pool_size: 1)
       thread_data = di.instance_variable_get(:@thread_data)
       start_queue = thread_data.dig(0, :start_queue)
       finish_queue = thread_data.dig(0, :finish_queue)


### PR DESCRIPTION
* Fix default thread pool size
* Allow custom thread pool sizes
* Checkout connection per thread
* Only select strand.id in scan query
* Use FOR UPDATE SKIP LOCKED in scan query