### PR TITLE
Add support for respirate partitioning

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -1,9 +1,51 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+num_partitions, partition_num = ARGV
+if num_partitions
+  unless partition_num
+    if ENV["DYNO"]
+      partition_num = ENV["DYNO"].split(".", 2)[1]
+    else
+      warn "must provide number of partitions as second argument"
+      exit 1
+    end
+  end
+
+  num_partitions = Integer(num_partitions)
+  partition_num = Integer(partition_num)
+
+  unless (1..16).cover?(num_partitions)
+    warn "invalid number of partitions: #{num_partitions}"
+    exit 1
+  end
+
+  unless (1..num_partitions).cover?(partition_num)
+    warn "invalid partition number #{partition_num}"
+    exit 1
+  end
+
+  partition_num -= 1
+
+  hex_chars = 1
+  chars = (0...16**hex_chars).map { ("%x" % _1).rjust(hex_chars, "0") }
+  chars_per_partition = chars.size / num_partitions.to_r
+  start_char = chars[(chars_per_partition * partition_num).to_i]
+  uuid_suffix = "-0000-0000-0000-000000000000"
+  start_id = start_char.ljust(8, "0") + uuid_suffix
+
+  partition = if num_partitions == partition_num + 1
+    start_id.."ffffffff-ffff-ffff-ffff-ffffffffffff"
+  else
+    end_char = chars[(chars_per_partition * (partition_num + 1)).to_i]
+    end_id = end_char.ljust(8, "0") + uuid_suffix
+    start_id...end_id
+  end
+end
+
 require_relative "../loader"
 
-d = Scheduling::Dispatcher.new
+d = Scheduling::Dispatcher.new(partition:)
 Signal.trap("TERM") { d.shutdown }
 
 if Config.heartbeat_url
@@ -31,6 +73,12 @@ Strand.dataset.insert_conflict.insert(id: "08200dd2-20ce-833a-de82-10fd5a082bff"
 
 clover_freeze
 
+if partition
+  # Start with a random offset, so that multiple respirate processes are unlikely
+  # to run the old strand scan at the same time.
+  next_old_strand_scan = Time.now + (5 * rand)
+end
+
 DB.synchronize do
   until d.shutting_down
     if d.start_cohort && !d.shutting_down
@@ -40,6 +88,14 @@ DB.synchronize do
       # database (potentially, LISTEN/NOTIFY could be used to reduce this latency)
       duration_slept = sleep 1
       Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
+    end
+
+    if partition && next_old_strand_scan < Time.now
+      next_old_strand_scan = Time.now + 5
+
+      # Check every 5 seconds for strands still not leased by another respirate
+      # process.
+      d.start_cohort(d.scan_old)
     end
   end
 end

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -10,7 +10,12 @@ class Scheduling::Dispatcher
   STRAND_RUNTIME = Strand::LEASE_EXPIRATION / 4
   APOPTOSIS_MUTEX = Mutex.new
 
-  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.db_pool - 2)
+  # Arguments:
+  # apoptosis_timeout :: The number of seconds a strand is allowed to
+  #                      run before causing apoptosis
+  # pool_size :: The number of threads in the thread pool
+  # partition :: A range of UUIDs that this process will operate on.
+  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.db_pool - 2, partition: nil)
     @shutting_down = false
 
     # How long to wait in seconds from the start of strand run
@@ -51,10 +56,9 @@ class Scheduling::Dispatcher
 
     # A prepared statement to get the strands to run.  A prepared statement
     # is used to reduce parsing/planning work in the database.
-    @strand_ps = Strand
+    ds = Strand
       .where(
         Sequel.|({lease: nil}, Sequel[:lease] < Sequel::CURRENT_TIMESTAMP) &
-        (Sequel[:schedule] < Sequel::CURRENT_TIMESTAMP) &
         {exitval: nil}
       )
       .order_by(:schedule)
@@ -63,6 +67,20 @@ class Scheduling::Dispatcher
       .select(:id)
       .for_update
       .skip_locked
+
+    # If a partition is given, limit the strands to the partition.
+    # Create a separate prepared statement for older strands, not tied to
+    # the current partition, to allow for graceful degradation.
+    if partition
+      @old_strand_ps = ds
+        .where(Sequel[:schedule] < Sequel::CURRENT_TIMESTAMP - Sequel.cast("5 seconds", :interval))
+        .prepare(:select, :get_old_strand_cohort)
+
+      ds = ds.where(id: partition)
+    end
+
+    @strand_ps = ds
+      .where(Sequel[:schedule] < Sequel::CURRENT_TIMESTAMP)
       .prepare(:select, :get_strand_cohort)
   end
 
@@ -130,8 +148,25 @@ class Scheduling::Dispatcher
   # If the process is shutting down, return an empty array.  Otherwise
   # call the database prepared statement to find the strands to run,
   # excluding the strands that are currently running in the thread pool.
+  # If respirate processes are partitioned, this will only return
+  # strands for the current partition.
   def scan
-    @shutting_down ? [] : @strand_ps.call(skip_strands: Sequel.pg_array(@mutex.synchronize { @current_strands.keys }))
+    @shutting_down ? [] : @strand_ps.call(skip_strands:)
+  end
+
+  # Similar to scan, but return older strands which may not be
+  # related to the current partition.  This is to allow for
+  # graceful degradation if a partitioned respirate process
+  # crashes or experiences apoptosis.
+  def scan_old
+    (@old_strand_ps&.call(skip_strands:) unless @shutting_down) || []
+  end
+
+  # A pg_array for the strand ids to skip.  These are the strand
+  # ids that have been enqueued or are currently being processed
+  # by strand threads.
+  def skip_strands
+    Sequel.pg_array(@mutex.synchronize { @current_strands.keys })
   end
 
   # The number of strands the thread pool is currently running.
@@ -216,10 +251,9 @@ class Scheduling::Dispatcher
   # Find strands that need to be run, and push each onto the
   # strand queue.  This can block if the strand queue is full,
   # to allow for backoff in the case of a busy thread pool.
-  def start_cohort
+  def start_cohort(strands = scan)
     strand_queue = @strand_queue
     current_strands = @current_strands
-    strands = scan
     strands.each do |strand|
       break if @shutting_down
       @mutex.synchronize { current_strands[strand.id] = true }


### PR DESCRIPTION
This adds a partition keyword argument to the dispatcher, which accepts a range of UUID strings.  If provided, the dispatcher runs in partitioning mode.  In partitioning mode:

* The default scan query returns only strands inside the partition.

* There is a scan_old method that can be used to return strands where schedule is more than 5 seconds in the past.  Respirate runs this scan every 5 seconds.  This handles failure of one paritioned respirate process gracefully.  Other respirate processes will pick up the slack, just with an additional 5 seconds of latency.

The advantage of partitioning is that multiple respirate processes no longer try to operate on the same strands, so this reduces contention.

For bin/respirate usage, provide 2 arguments to enable partitioning. The first argument is the number of partitions, and the second is the partition number for each partition (1 based). So:

  partition 4 2

Divides the UUID space into 4 partitions, and operates on the 2nd of 4 ("80000000-0000-0000-0000-000000000000"..."c0000000-0000-0000-0000-000000000000").

For Heroku usage, the second argument is optional if the DYNO environment variable is present, in which case it will try to parse the DYNO value to determine the current partition.

Currently, up to 16 partitions are supported, and it is trivial to go from 16 to 256 if needed.

This should be compatible with an index-only scan if we have an index on `strand(schedule, lease, id) WHERE exitval IS NULL`, once the `lease IS NULL` condition is removed.  The scan_old query should also be able to use the same index for an index-only scan.

While here, add a minor spec fix to shutdown the dispatcher when using custom dispatcher options.