### PR TITLE
Fix LoadBalancer cert renewal empty cert bug

### DIFF
--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -117,11 +117,11 @@ class LoadBalancer < Sequel::Model
   def need_certificates?
     return true if certs_dataset.empty?
 
-    certs_dataset.where { created_at > Time.now - 60 * 60 * 24 * 30 * 2 }.empty?
+    certs_dataset.where { created_at > Time.now - 60 * 60 * 24 * 30 * 2 }.exclude(cert: nil).empty?
   end
 
   def active_cert
-    certs_dataset.where { created_at > Time.now - 60 * 60 * 24 * 30 * 3 }.order(Sequel.desc(:created_at)).first
+    certs_dataset.where { created_at > Time.now - 60 * 60 * 24 * 30 * 3 }.exclude(cert: nil).order(Sequel.desc(:created_at)).first
   end
 
   def ipv4_enabled?

--- a/prog/vnet/cert_server.rb
+++ b/prog/vnet/cert_server.rb
@@ -36,9 +36,11 @@ class Prog::Vnet::CertServer < Prog::Base
 
   def put_cert_to_vm
     cert = load_balancer.active_cert
+    fail "BUG: certificate is nil" unless cert&.cert
 
     cert_payload = cert.cert
     cert_key_payload = OpenSSL::PKey::EC.new(cert.csr_key).to_pem
+
     vm.vm_host.sshable.cmd("sudo host/bin/setup-cert-server put-certificate #{vm.inhost_name}", stdin: JSON.generate({cert_payload: cert_payload.to_s, cert_key_payload: cert_key_payload.to_s}))
   end
 end

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -175,7 +175,14 @@ RSpec.describe LoadBalancer do
     it "returns false if there are certs and they are not expired" do
       cert = Prog::Vnet::CertNexus.assemble(lb.hostname, dns_zone.id).subject
       lb.add_cert(cert)
+      cert.update(cert: "cert")
       expect(lb.need_certificates?).to be(false)
+    end
+
+    it "returns true if there are certs and they are not expired but the cert field is empty" do
+      cert = Prog::Vnet::CertNexus.assemble(lb.hostname, dns_zone.id).subject
+      lb.add_cert(cert)
+      expect(lb.need_certificates?).to be(true)
     end
   end
 
@@ -190,6 +197,8 @@ RSpec.describe LoadBalancer do
       lb.add_cert(cert1)
       lb.add_cert(cert2)
 
+      cert1.update(cert: "cert")
+      cert2.update(cert: "cert")
       cert1.update(created_at: Time.now - 1 * 365 * 24 * 60 * 60)
       expect(lb.active_cert.id).to eq(cert2.id)
     end

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -79,4 +79,18 @@ RSpec.describe Prog::Vnet::CertServer do
       expect { nx.remove_cert_server }.to exit({"msg" => "certificate resources and server are removed"})
     end
   end
+
+  describe ".put_cert_to_vm" do
+    it "fails if certificate is nil" do
+      lb.certs.map { _1.update(cert: nil) }
+      expect { nx.put_cert_to_vm }.to raise_error(RuntimeError, "BUG: certificate is nil")
+    end
+
+    it "fails if certificate payload is nil" do
+      lb.certs.map { _1.update(cert: nil) }
+      expect(nx.load_balancer).to receive(:active_cert).and_return(lb.certs.first)
+
+      expect { nx.put_cert_to_vm }.to raise_error(RuntimeError, "BUG: certificate is nil")
+    end
+  end
 end


### PR DESCRIPTION
Recently we have hit the issue of certificate being empty in inference endpoints. This happened after a cert renewal. The bug is that, the moment we create a new CertNexus, created_at column is set by default but the cert itself is not finalized just yet. Since we forgot to check that column, we thought the cert is finalized and went into broadcasting the new certificate to the metadata-endpoint. Now, checking if the cert column is properly filled, we essentially wait for the new certificate to be finalized before going into distribution mode.