### PR TITLE
Fix the GitHub cache table for smaller screens

### DIFF
--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -28,7 +28,7 @@
                   <div class="font-medium text-gray-900"><%= entry[:key] %></div>
                   <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry[:created_at] %>"><%= entry[:created_at_human] %></span></div>
                 </td>
-                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                <td class="px-3 py-3 text-sm text-gray-500">
                   <div><%= entry[:scope] %></div>
                 </td>
                 <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">


### PR DESCRIPTION
I viewed this page without my external monitor for the first time.
Dependabot creates branches with very long names.

This causes the cache table to overflow the page. It's unusable on my
14" MacBook Pro.

| Before | After |
|--------|-------|
| ![cache-before](https://github.com/user-attachments/assets/c6b64c41-de43-49f3-aa38-57524fcc24e8) | ![cache-after](https://github.com/user-attachments/assets/d03f1c71-f4e2-4efd-9d3f-ce9b76feaea7) |