### PR TITLE
Enforce project location access in routes

### DIFF
--- a/model/location.rb
+++ b/model/location.rb
@@ -16,6 +16,20 @@ class Location < Sequel::Model
   GITHUB_RUNNERS_ID = "6b9ef786-b842-8420-8c65-c25e3d4bdf3d"
   LEASEWEB_WDC02_ID = "e0865080-9a3d-8020-a812-f5817c7afe7f"
 
+  dataset_module do
+    def for_project(project_id)
+      where(Sequel[project_id:] | {project_id: nil})
+    end
+
+    def visible_or_for_project(project_id)
+      where(Sequel[project_id:] | {project_id: nil, visible: true})
+    end
+  end
+
+  def visible_or_for_project?(proj_id)
+    (visible && project_id.nil?) || project_id == proj_id
+  end
+
   def path
     "/private-location/#{ui_name}"
   end

--- a/routes/project/location.rb
+++ b/routes/project/location.rb
@@ -3,7 +3,8 @@
 class Clover
   hash_branch(:project_prefix, "location") do |r|
     r.on String do |location_display_name|
-      handle_invalid_location unless (@location = Location[display_name: location_display_name])
+      # Do not allow access to locations tied to other projects
+      handle_invalid_location unless (@location = Location.for_project(@project.id)[display_name: location_display_name])
       r.hash_branches(:project_location_prefix)
     end
   end

--- a/spec/model/location_spec.rb
+++ b/spec/model/location_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Location do
+  subject(:p2_loc) { described_class.create(name: "l2", display_name: "l2", ui_name: "l2", visible: true, provider: "aws", project_id: p2_id) }
+
+  let(:p1_id) { Project.create(name: "pj1").id }
+
+  let(:p2_id) { Project.create(name: "pj2").id }
+
+  let(:p1_loc) { described_class.create(name: "l1", display_name: "l1", ui_name: "l1", visible: true, provider: "aws", project_id: p1_id) }
+
+  it ".for_project filters dataset to given project and non-project-specific locations" do
+    p1_loc
+    p2_loc
+    expect(described_class.for_project(p1_id).select_order_map(:name)).to eq ["github-runners", "hetzner-ai", "hetzner-fsn1", "hetzner-hel1", "l1", "latitude-ai", "latitude-fra", "leaseweb-wdc02"]
+    expect(described_class.for_project(p2_id).select_order_map(:name)).to eq ["github-runners", "hetzner-ai", "hetzner-fsn1", "hetzner-hel1", "l2", "latitude-ai", "latitude-fra", "leaseweb-wdc02"]
+  end
+
+  it ".visible_or_for_project filters dataset to given project and visible non-project-specific locations" do
+    p1_loc
+    p2_loc
+    expect(described_class.visible_or_for_project(p1_id).select_order_map(:name)).to eq ["hetzner-fsn1", "hetzner-hel1", "l1", "leaseweb-wdc02"]
+    expect(described_class.visible_or_for_project(p2_id).select_order_map(:name)).to eq ["hetzner-fsn1", "hetzner-hel1", "l2", "leaseweb-wdc02"]
+  end
+
+  it "#visible_or_for_project? returns whether the location is visible or related to the given project" do
+    expect(p1_loc.visible_or_for_project?(p1_id)).to be true
+    expect(p1_loc.visible_or_for_project?(p2_id)).to be false
+    expect(p2_loc.visible_or_for_project?(p2_id)).to be true
+    expect(p2_loc.visible_or_for_project?(p1_id)).to be false
+    expect(described_class[name: "hetzner-fsn1"].visible_or_for_project?(p1_id)).to be true
+    expect(described_class[name: "github-runners"].visible_or_for_project?(p1_id)).to be false
+  end
+end


### PR DESCRIPTION
In the routes, when a location is given, check that is either available for all projects, or that it is tied to the current project.

This adds:

* Location.for_project: Filters to only locations not tied to projects, and those tied to the given project.

* Location:visible_or_for_project: Filters to only visible locations not tied to projects, and those tied to the given project.

* Location#visible_or_for_project?: Checks whether the location is either visible and not tied to a project, or is tied to the given project.