### PR TITLE
Fixes and improvements on pgbouncer setup

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -212,7 +212,7 @@ class PostgresServer < Sequel::Model
   end
 
   def self.run_query(vm, query)
-    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv", stdin: query).chomp
+    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: query).chomp
   end
 
   def run_query(query)

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -24,15 +24,9 @@ pgbouncer_setup_query = <<~PGBOUNCER_SETUP
   BEGIN;
 
   /**
-    * Create pgbouncer role if it does not exist.
+    * Create pgbouncer role.
     */
-  DO $$
-  BEGIN
-      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgbouncer') THEN
-          CREATE ROLE pgbouncer LOGIN;
-      END IF;
-  END
-  $$;
+  CREATE ROLE pgbouncer LOGIN;
 
   /**
     * Lock down the privileges of the pgbouncer role.

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -57,4 +57,4 @@ database_init_queries = <<~DATABASE_INIT
   GRANT EXECUTE ON FUNCTION pgbouncer.get_auth(name) TO pgbouncer;
 DATABASE_INIT
 
-r "sudo -u postgres psql -d template1", stdin: database_init_queries
+r "sudo -u postgres psql -d template1 -v 'ON_ERROR_STOP=1'", stdin: database_init_queries

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -68,4 +68,4 @@ pgbouncer_setup_query = <<~PGBOUNCER_SETUP
   COMMIT;
 PGBOUNCER_SETUP
 
-r "sudo -u postgres psql", stdin: pgbouncer_setup_query
+r "sudo -u postgres psql -d template1", stdin: pgbouncer_setup_query

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -17,15 +17,12 @@ r "rm -rf /etc/postgresql/#{v}"
 
 r "pg_createcluster #{v} main --start --locale=C.UTF8"
 
-r "sudo -u postgres psql -c 'CREATE ROLE ubi_replication WITH REPLICATION LOGIN'"
-r "sudo -u postgres psql -c 'CREATE ROLE ubi_monitoring WITH LOGIN IN ROLE pg_monitor'"
-
-pgbouncer_setup_query = <<~PGBOUNCER_SETUP
-  BEGIN;
-
+database_init_queries = <<~DATABASE_INIT
   /**
-    * Create pgbouncer role.
+    * Create system roles.
     */
+  CREATE ROLE ubi_replication WITH REPLICATION LOGIN;
+  CREATE ROLE ubi_monitoring WITH LOGIN IN ROLE pg_monitor;
   CREATE ROLE pgbouncer LOGIN;
 
   /**
@@ -58,8 +55,6 @@ pgbouncer_setup_query = <<~PGBOUNCER_SETUP
 
   REVOKE ALL ON FUNCTION pgbouncer.get_auth(name) FROM PUBLIC, pgbouncer;
   GRANT EXECUTE ON FUNCTION pgbouncer.get_auth(name) TO pgbouncer;
+DATABASE_INIT
 
-  COMMIT;
-PGBOUNCER_SETUP
-
-r "sudo -u postgres psql -d template1", stdin: pgbouncer_setup_query
+r "sudo -u postgres psql -d template1", stdin: database_init_queries

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe PostgresServer do
   end
 
   it "runs query on vm" do
-    expect(postgres_server.vm.sshable).to receive(:cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv", stdin: "SELECT 1").and_return("1\n")
+    expect(postgres_server.vm.sshable).to receive(:cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: "SELECT 1").and_return("1\n")
     expect(postgres_server.run_query("SELECT 1")).to eq("1")
   end
 end

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -222,7 +222,7 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
           <% @pg[:firewall_rules].each do |fwr| %>
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432</td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432, 6432</td>
               <% if edit_perm %>
                 <td
                   id="fwr-delete-<%=fwr[:id]%>"
@@ -248,7 +248,7 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
                 ) %>
               </td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-                5432
+                5432, 6432
               </td>
               <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                 <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST" id="form-pg-fwr-create">


### PR DESCRIPTION
**Show port 6432 along with 5432 in the PostgreSQL firewall rules**

**Configure pgbouncer in template1 database**
This ensures that new databases will automatically have pgbouncer configuration
such as auth_query and pgbouncer schema. Otherwise, without auth_query, it is
not possible to connect to the new database using pgbouncer.

**Don't check existence of pgbouncer role before creating it**
The check is added for the sake of idempotency, but we already delete entire
database cluster few lines above anyway, so it is not needed.

**Combine database initialization commands**
I'm moving replication and monitoring role creations to the same code block
that configures the pgbouncer. I'm also making small improcements such as
removing the unnecessary transaction block and bringing the GRANT/REVOKE
statements to the same place.

**Use ON_ERROR_STOP=1 with psql**
By default, psql always returns 0, even if the command fails. This prevents us
from detecting errors and acting on it (i.e. retrying usually). This commit
adds ON_ERROR_STOP=1 to the psql command, which will cause it to stop
execution and return a non-zero exit code if any command fails.