### PR TITLE
ConvergePostgresResource deadline change for maintenance windows

### DIFF
--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
   describe "#start" do
     it "registers a deadline" do
-      expect(nx).to receive(:register_deadline).with(nil, 2 * 60 * 60)
+      expect(nx).to receive(:register_deadline).with("recycle_representative_server", 2 * 60 * 60)
       expect { nx.start }.to hop("provision_servers")
     end
   end


### PR DESCRIPTION
With the introduction of maintenance windows, the refresh of a PG instance may simply wait for a while until the maintenance window comes. At the start of the ConvergePostgresResource, we are setting the deadline to 2 hours. This simply triggers a page if the preparation of a server was quick but still we are waiting because we are not yet at the maintenance window. With this commit, we are fixing that.