### PR TITLE
Check that social login provider provides an email before attempting to save

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -391,6 +391,10 @@ class Clover < Roda
     # :nocov:
 
     before_omniauth_create_account do
+      unless account[:email]
+        flash["error"] = "Social login is only allowed if social login provider provides email"
+        redirect "/login"
+      end
       scope.before_rodauth_create_account(account, omniauth_name)
     end
 

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -472,6 +472,16 @@ RSpec.describe Clover, "auth" do
       OmniAuth.config.test_mode = true
     end
 
+    it "shows error message if attempting to create an account where social login has no email" do
+      mock_provider(:github, nil)
+
+      visit "/login"
+      click_button "GitHub"
+
+      expect(page.title).to eq("Ubicloud - Login")
+      expect(page).to have_flash_error(/Social login is only allowed if social login provider provides email/)
+    end
+
     it "can create new account" do
       mock_provider(:github)
 


### PR DESCRIPTION
If no email is provided, show a nice error message.  This prevents the following unhandled production exception:

Sequel::NotNullConstraintViolation - PG::NotNullViolation: ERROR:  null value in column "email" of relation "accounts" violates not-null constraint