### PR TITLE
Put PostgreSQL standbys to different data centers

### DIFF
--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -80,7 +80,7 @@ module ThawedMock
   allow_mocking(StorageKeyEncryptionKey, :create)
   allow_mocking(Strand, :create, :create_with_id)
   allow_mocking(UsageAlert, :where)
-  allow_mocking(VmHost, :[])
+  allow_mocking(VmHost, :[], :where)
   allow_mocking(Vm, :[], :where, :generate_ubid)
   allow_mocking(VmPool, :[], :where)
   allow_mocking(VmHostCpu, :create)


### PR DESCRIPTION
We don't have different availability zones in none of our bare metal providers, but at least, in Hetzner, we have different data centers. This commit ensures that we put PostgreSQL standbys in different data centers if they are using Hetzner as underlying provider.

For LeaseWeb, we don't even have different data centers, but we can place the servers to different racks. Currently all our hosts are already in different racks, so we don't need to do anything special for them.