### PR TITLE
Update to Ruby 3.2.8

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 3.2.7
+ruby 3.2.8
 postgres 15.8
 nodejs 23.6.0
 golang 1.24.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM docker.io/library/ruby:3.2.7-alpine3.21 AS bundler
+FROM docker.io/library/ruby:3.2.8-alpine3.21 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -20,7 +20,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM docker.io/library/ruby:3.2.7-alpine3.21
+FROM docker.io/library/ruby:3.2.8-alpine3.21
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.2.7"
+ruby "3.2.8"
 
 gem "acme-client"
 gem "argon2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,7 +521,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.7p253
+   ruby 3.2.8p263
 
 BUNDLED WITH
    2.5.17


### PR DESCRIPTION
Heroku shows the following warning:

    remote: ###### WARNING:
    remote:
    remote:        There is a more recent Ruby version available for you to use:
    remote:
    remote:        3.2.8
    remote:
    remote:        The latest version will include security and bug fixes. We always recommend
    remote:        running the latest version of your minor release.
    remote:
    remote:        Please upgrade your Ruby version.
    remote:
    remote:        For all available Ruby versions see:
    remote:          https://devcenter.heroku.com/articles/ruby-support#supported-runtimes

We don't have any reason to not upgrade
https://github.com/ruby/ruby/releases/tag/v3_2_8
