### PR TITLE
Small CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
       - 'main'
     tags:
       - 'v*'
+  pull_request:
 
 env:
   IMAGE_NAME: ubicloud/ubicloud

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15.4
+        image: postgres:15.8
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -36,7 +36,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15.4
+        image: postgres:15.8
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -85,7 +85,7 @@ jobs:
       run: "cd cli && go fmt && git diff --stat --exit-code"
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.64
         working-directory: cli

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -12,11 +12,13 @@ on:
       - 'cli/**'
       - 'bin/ubi'
       - 'spec/cli_spec.rb'
+      - '.github/workflows/cli-ci.yml'
   pull_request:
     paths:
       - 'cli/**'
       - 'bin/ubi'
       - 'spec/cli_spec.rb'
+      - '.github/workflows/cli-ci.yml'
 
 jobs:
   cli-ci:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15.4
+        image: postgres:15.8
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -202,7 +202,7 @@ direnv: Creating env file /home/ubicloud/.cache/asdf-direnv/env/2363097900-47841
 direnv: loading ~/.cache/asdf-direnv/env/2363097900-478416608-196231759-3753665172
 direnv: using asdf direnv 2.34.0
 direnv: using asdf nodejs 22.9.0
-direnv: using asdf postgres 15.4
+direnv: using asdf postgres 15.8
 direnv: loading ~/.asdf/plugins/postgres/bin/exec-env
 direnv: using asdf ruby 3.2.5
 direnv: loading ~/.asdf/plugins/ruby/bin/exec-env
@@ -215,14 +215,14 @@ Note that `$PGDATA` is exported.  Thus, we can start Postgres:
 
 ```sh
 $ postgres -D $PGDATA
-2024-10-15 13:22:43.682 PST [36002] LOG:  starting PostgreSQL 15.4 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4), 64-bit
+2024-10-15 13:22:43.682 PST [36002] LOG:  starting PostgreSQL 15.8 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4), 64-bit
 ```
 
 Also note `LD_LIBRARY_PATH`:
 
 ```sh
 $ printenv LD_LIBRARY_PATH
-/home/ubicloud/.asdf/installs/postgres/15.4/lib
+/home/ubicloud/.asdf/installs/postgres/15.8/lib
 ```
 
 This is important to be able to compile client drivers against the

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:15.4
+    image: postgres:15.8
     container_name: ubicloud-postgres
     env_file: .env
     ports:


### PR DESCRIPTION
- **Run the docker build workflow for each pull request**
  We run our Ruby CI for each pull request, but we only run our Docker
  build workflow for the main branch.
  
  Sometimes, a PR is merged and breaks the Docker build workflow. It's
  important to see if it's failing before merging the PR.
  
  At first, we didn't run it for each pull request because it took too
  long.
  
  But with the help of caching, it's now fast enough to run for each pull
  request.
  

- **Run the CLI CI if the workflow file has changed as well**
  We run the CLI CI if any CLI file changes. However, sometimes the
  workflow itself changes, so it’s a good idea to run it if the workflow
  file has changed too.
  

- **Update the PG version to 15.8 in the CI workflows**
  We are already using 15.8 in development as specified in
  `.tool_versions`. It's a good practice to keep the same version across
  all environments, including CI.
  
  By the way, production is using 15.10, so we might upgrade development
  to 15.10 as well. I’m not doing it now because I don’t want to break
  anyone’s local development environments.

- **Downgrade golangci/golangci-lint-action to v6**

  I merged https://github.com/ubicloud/ubicloud/pull/3047, but it seems to have broken the CI. The
  golangci/golangci-lint-action@v7 requires using golangci-lint v2, but v2
  raises the following error. I didn't notice it because cli-ci didn't run
  on that PR. Thanks to the previous commit, cli-ci will run when there
  are changes.

      Error: cli/ubi.go:74:23: Error return value of `resp.Body.Close` is not checked (errcheck)
      	defer resp.Body.Close()
      	                     ^
      1 issues:
      * errcheck: 1
  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve CI by running Docker builds on PRs, updating PostgreSQL to 15.8, and fixing Golang linter version.
> 
>   - **CI Workflows**:
>     - Run Docker build workflow on pull requests in `build.yml` to catch failures before merging.
>     - Run CLI CI when `.github/workflows/cli-ci.yml` changes in `cli-ci.yml`.
>   - **PostgreSQL Version**:
>     - Update PostgreSQL image to 15.8 in `ci.yml`, `cli-ci.yml`, `e2e.yml`, and `demo/docker-compose.yml`.
>     - Update PostgreSQL version in `DEVELOPERS.md`.
>   - **Golang Linter**:
>     - Downgrade `golangci/golangci-lint-action` to v6 in `cli-ci.yml` due to compatibility issues with v7.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for cf6964df6ba175b189e2a4b346260eaabd55aa04. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->