### PR TITLE
Switch period position in multi-line expressions to "trailing"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,3 +95,6 @@ Capybara/ClickLinkOrButtonStyle:
 
 Lint/UselessTimes:
   Enabled: false
+
+Layout/DotPosition:
+  EnforcedStyle: trailing

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 
 group :lint do
   gem "brakeman"
-  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "886cb4e27b099d6f347b950375aa22e638888f95"
+  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "df3174476986706828f7baf3e5e6f5ec8ecd849b"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 
 group :lint do
   gem "brakeman"
-  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "a9ff0001a1eb028e2186b222aeb02b07c04f9808"
+  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "886cb4e27b099d6f347b950375aa22e638888f95"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/ubicloud/erb-formatter.git
-  revision: 886cb4e27b099d6f347b950375aa22e638888f95
-  ref: 886cb4e27b099d6f347b950375aa22e638888f95
+  revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
+  ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
   specs:
     erb-formatter (0.7.3)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,11 +26,10 @@ GIT
 
 GIT
   remote: https://github.com/ubicloud/erb-formatter.git
-  revision: a9ff0001a1eb028e2186b222aeb02b07c04f9808
-  ref: a9ff0001a1eb028e2186b222aeb02b07c04f9808
+  revision: 886cb4e27b099d6f347b950375aa22e638888f95
+  ref: 886cb4e27b099d6f347b950375aa22e638888f95
   specs:
-    erb-formatter (0.4.3)
-      syntax_tree (~> 6.0)
+    erb-formatter (0.7.3)
 
 GEM
   remote: https://rubygems.org/
@@ -277,7 +276,6 @@ GEM
       ttfunk (~> 1.8)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    prettier_print (1.2.1)
     prism (1.4.0)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -402,8 +400,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.24.0)
     stripe (12.6.0)
-    syntax_tree (6.2.0)
-      prettier_print (>= 1.2.0)
     tilt (2.6.0)
     timeout (0.4.3)
     tpm-key_attestation (0.12.1)

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -146,10 +146,10 @@ class Clover < Roda
     # that users won't see higher price in their invoice compared
     # to price calculator and also we charge same amount no matter
     # the number of days in a given month.
-    BillingRate.rates.filter { resource_types.include?(_1["resource_type"]) }
-      .group_by { [_1["resource_type"], _1["resource_family"], _1["location"]] }
-      .map { |_, brs| brs.max_by { _1["active_from"] } }
-      .each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
+    BillingRate.rates.filter { resource_types.include?(_1["resource_type"]) }.
+      group_by { [_1["resource_type"], _1["resource_family"], _1["location"]] }.
+      map { |_, brs| brs.max_by { _1["active_from"] } }.
+      each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
       hash[br["location"]][br["resource_type"]][br["resource_family"]] = {
         hourly: br["unit_price"].to_f * 60,
         monthly: br["unit_price"].to_f * 60 * 672

--- a/lib/access_control_model_tag.rb
+++ b/lib/access_control_model_tag.rb
@@ -34,14 +34,14 @@ module AccessControlModelTag
   end
 
   def currently_included_in
-    DB[:tag]
-      .with_recursive(:tag,
+    DB[:tag].
+      with_recursive(:tag,
         DB[applied_table].where(applied_column => id).select(:tag_id, 0),
-        DB[applied_table].join(:tag, tag_id: applied_column)
-          .select(Sequel[applied_table][:tag_id], Sequel[:level] + 1)
-          .where { level < Config.recursive_tag_limit },
-        args: [:tag_id, :level])
-      .select_map(:tag_id)
+        DB[applied_table].join(:tag, tag_id: applied_column).
+          select(Sequel[applied_table][:tag_id], Sequel[:level] + 1).
+          where { level < Config.recursive_tag_limit },
+        args: [:tag_id, :level]).
+      select_map(:tag_id)
   end
 
   def check_members_to_add(to_add)

--- a/lib/free_quota.rb
+++ b/lib/free_quota.rb
@@ -23,21 +23,21 @@ class FreeQuota
 
   def self.remaining_free_quota(name, project_id)
     free_quota = free_quotas[name]
-    used_amount = BillingRecord
-      .where(project_id:, billing_rate_id: free_quota["billing_rate_ids"])
-      .where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }
-      .sum(:amount) || 0
+    used_amount = BillingRecord.
+      where(project_id:, billing_rate_id: free_quota["billing_rate_ids"]).
+      where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }.
+      sum(:amount) || 0
     [0, free_quota["value"] - used_amount].max
   end
 
   def self.get_exhausted_projects(name)
     free_quota = free_quotas[name]
-    BillingRecord
-      .where(billing_rate_id: free_quota["billing_rate_ids"])
-      .where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }
-      .group(:project_id)
-      .having { sum(:amount) >= free_quota["value"] }
-      .select(:project_id)
+    BillingRecord.
+      where(billing_rate_id: free_quota["billing_rate_ids"]).
+      where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }.
+      group(:project_id).
+      having { sum(:amount) >= free_quota["value"] }.
+      select(:project_id)
   end
 
   def self.begin_of_month

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -59,12 +59,12 @@ module Github
 
     Clog.emit("fetched deliveries") { {deliveries: {total: all_deliveries.count, page: page, since: since}} }
 
-    all_deliveries
-      .reject { _1[:delivered_at] < since }
-      .group_by { _1[:guid] }
-      .values
-      .reject { |group| group.any? { _1[:status] == "OK" } }
-      .map { |group| group.max_by { _1[:delivered_at] } }
+    all_deliveries.
+      reject { _1[:delivered_at] < since }.
+      group_by { _1[:guid] }.
+      values.
+      reject { |group| group.any? { _1[:status] == "OK" } }.
+      map { |group| group.max_by { _1[:delivered_at] } }
   end
 
   def self.redeliver_failed_deliveries(*)

--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -121,11 +121,11 @@ class InvoiceGenerator
         # Free AI tokens WILL be shown on the portal billing page as a separate credit.
         free_inference_tokens_remaining = FreeQuota.free_quotas["inference-tokens"]["value"]
         free_inference_tokens_credit = 0.0
-        project_content[:resources]
-          .flat_map { _1[:line_items] }
-          .select { _1[:resource_type] == "InferenceTokens" }
-          .sort_by { |li| [li[:begin_time].to_date, -li[:unit_price]] }
-          .each do |li|
+        project_content[:resources].
+          flat_map { _1[:line_items] }.
+          select { _1[:resource_type] == "InferenceTokens" }.
+          sort_by { |li| [li[:begin_time].to_date, -li[:unit_price]] }.
+          each do |li|
             used_amount = [li[:amount], free_inference_tokens_remaining].min
             free_inference_tokens_remaining -= used_amount
             free_inference_tokens_credit += used_amount * li[:unit_price]
@@ -184,8 +184,8 @@ class InvoiceGenerator
   end
 
   def active_billing_records
-    active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices])
-      .where { |br| Sequel.pg_range(br.span).overlaps(Sequel.pg_range(@begin_time...@end_time)) }
+    active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices]).
+      where { |br| Sequel.pg_range(br.span).overlaps(Sequel.pg_range(@begin_time...@end_time)) }
     active_billing_records = active_billing_records.where(project_id: @project_ids) unless @project_ids.empty?
     active_billing_records.all.map do |br|
       # We cap the billable duration at 672 hours. In this way, we can

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -11,8 +11,8 @@ module Option
   end
 
   def self.postgres_locations(project_id: nil)
-    Location
-      .where(Sequel.|(
+    Location.
+      where(Sequel.|(
         {name: ["hetzner-fsn1", "leaseweb-wdc02"]},
         {project_id:}
       )).all

--- a/migrate/20241215_authorization_refactor.rb
+++ b/migrate/20241215_authorization_refactor.rb
@@ -56,8 +56,8 @@ Sequel.migration do
         ["ffffffff-ff00-835a-87ff-f06940d85dc0", "ActionTag:view", "ttzzzzzzzz021gzzz0ta0v1ew0"],
         ["ffffffff-ff00-835a-87ff-ff8340029ad0", "ObjectTag:add", "ttzzzzzzzz021gzzzz0t00add0"],
         ["ffffffff-ff00-835a-87c1-a0030ea036e0", "ObjectTag:remove", "ttzzzzzzzz021gz0t00rem0ve1"],
-        ["ffffffff-ff00-835a-87ff-f06800d85dc0", "ObjectTag:view", "ttzzzzzzzz021gzzz0t00v1ew0"]]
-            .each(&:pop))
+        ["ffffffff-ff00-835a-87ff-f06800d85dc0", "ObjectTag:view", "ttzzzzzzzz021gzzz0t00v1ew0"]].
+            each(&:pop))
 
     %w[subject action object].each do |tag_type|
       create_table(:"#{tag_type}_tag") do
@@ -99,22 +99,22 @@ Sequel.migration do
     action_tags.each do |id, name|
       name = name.delete_suffix(":all")
       from(:applied_action_tag).insert([:tag_id, :action_id],
-        from(:action_type)
-          .where(Sequel.like(:name, "#{name}:%"))
-          .select(id, :id))
+        from(:action_type).
+          where(Sequel.like(:name, "#{name}:%")).
+          select(id, :id))
     end
     # Member action tag has Project:{view,github} actions
     from(:applied_action_tag).insert([:tag_id, :action_id],
-      from(:action_type)
-        .where(name: %w[Project:view Project:github])
-        .select(Sequel.cast(member_id, :uuid), :id)
-        .union(
+      from(:action_type).
+        where(name: %w[Project:view Project:github]).
+        select(Sequel.cast(member_id, :uuid), :id).
+        union(
           # and non-Project :all tags
-          from(:action_tag)
-            .where(project_id: nil)
-            .where(Sequel.like(:name, "%:all"))
-            .exclude(name: "Project:all")
-            .select(member_id, :id)
+          from(:action_tag).
+            where(project_id: nil).
+            where(Sequel.like(:name, "%:all")).
+            exclude(name: "Project:all").
+            select(member_id, :id)
         ))
 
     create_table(:access_control_entry) do

--- a/migrate/20250227_id_based_locations.rb
+++ b/migrate/20250227_id_based_locations.rb
@@ -7,17 +7,17 @@ Sequel.migration do
         add_foreign_key :location_id, :location, type: :uuid
       end
 
-      from(table).update(location_id: from(:location)
-        .where(name: Sequel[table][:location])
-        .select(:id))
+      from(table).update(location_id: from(:location).
+        where(name: Sequel[table][:location]).
+        select(:id))
     end
   end
 
   down do
     %i[vm_host vm vm_pool private_subnet firewall postgres_resource minio_cluster inference_endpoint kubernetes_cluster].each do |table|
-      from(table).update(location: from(:location)
-        .where(id: Sequel[table][:location_id])
-        .select(:name))
+      from(table).update(location: from(:location).
+        where(id: Sequel[table][:location_id]).
+        select(:name))
 
       alter_table(table) do
         drop_column :location_id

--- a/migrate/20250324_add_loadbalancer_ports.rb
+++ b/migrate/20250324_add_loadbalancer_ports.rb
@@ -45,14 +45,14 @@ Sequel.migration do
     )
 
     DB[:load_balancer_vm_port].import([:id, :load_balancer_port_id, :load_balancer_vm_id, :state],
-      DB[:load_balancers_vms]
-        .join(:load_balancer_port, load_balancer_id: :load_balancer_id)
-        .select_map([
+      DB[:load_balancers_vms].
+        join(:load_balancer_port, load_balancer_id: :load_balancer_id).
+        select_map([
           Sequel[:load_balancer_port][:id].as(:load_balancer_port_id),
           Sequel[:load_balancers_vms][:id].as(:load_balancer_vm_id),
           Sequel[:load_balancers_vms][:state]
-        ])
-        .each { _1.unshift(UBID.generate("1q").to_uuid) })
+        ]).
+        each { _1.unshift(UBID.generate("1q").to_uuid) })
   end
 
   down do
@@ -65,13 +65,13 @@ Sequel.migration do
       set_column_not_null :dst_port
     end
 
-    DB[:load_balancers_vms]
-      .update(
+    DB[:load_balancers_vms].
+      update(
         state: Sequel.expr do
-          DB[:load_balancer_vm_port]
-            .where(load_balancer_vm_id: Sequel[:load_balancers_vms][:id])
-            .select(:state)
-            .limit(1)
+          DB[:load_balancer_vm_port].
+            where(load_balancer_vm_id: Sequel[:load_balancers_vms][:id]).
+            select(:state).
+            limit(1)
         end
       )
     alter_table(:load_balancers_vms) do

--- a/model/api_key.rb
+++ b/model/api_key.rb
@@ -44,9 +44,9 @@ class ApiKey < Sequel::Model
 
   def unrestrict_token_for_project(project_id)
     AccessControlEntry.where(project_id:, subject_id: id).destroy
-    DB[:applied_subject_tag]
-      .insert_ignore
-      .insert(subject_id: id, tag_id: SubjectTag.where(project_id:, name: "Admin").select(:id))
+    DB[:applied_subject_tag].
+      insert_ignore.
+      insert(subject_id: id, tag_id: SubjectTag.where(project_id:, name: "Admin").select(:id))
   end
 
   def rotate
@@ -57,8 +57,8 @@ class ApiKey < Sequel::Model
   private
 
   def unrestricted_project_access_dataset(project_id)
-    DB[:applied_subject_tag]
-      .where(subject_id: id, tag_id: SubjectTag.where(project_id:, name: "Admin").select(:id))
+    DB[:applied_subject_tag].
+      where(subject_id: id, tag_id: SubjectTag.where(project_id:, name: "Admin").select(:id))
   end
 end
 

--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -10,11 +10,11 @@ class GithubInstallation < Sequel::Model
   include ResourceMethods
 
   def total_active_runner_vcpus
-    runners_dataset
-      .left_join(:strand, id: :id)
-      .exclude(Sequel[:strand][:label] => ["start", "wait_concurrency_limit"])
-      .select_map(Sequel[:github_runner][:label])
-      .sum do
+    runners_dataset.
+      left_join(:strand, id: :id).
+      exclude(Sequel[:strand][:label] => ["start", "wait_concurrency_limit"]).
+      select_map(Sequel[:github_runner][:label]).
+      sum do
         label = Github.runner_labels[_1]
         Validation.validate_vm_size(label["vm_size"], label["arch"]).vcpus
       end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -136,10 +136,10 @@ class PostgresServer < Sequel::Model
   end
 
   def failover_target
-    target = resource.servers
-      .select { _1.standby? && _1.strand.label == "wait" && !_1.needs_recycling? }
-      .map { {server: _1, lsn: _1.run_query("SELECT pg_last_wal_receive_lsn()").chomp} }
-      .max_by { lsn2int(_1[:lsn]) }
+    target = resource.servers.
+      select { _1.standby? && _1.strand.label == "wait" && !_1.needs_recycling? }.
+      map { {server: _1, lsn: _1.run_query("SELECT pg_last_wal_receive_lsn()").chomp} }.
+      max_by { lsn2int(_1[:lsn]) }
 
     return nil if target.nil?
 
@@ -177,8 +177,8 @@ class PostgresServer < Sequel::Model
     DB.transaction do
       if pulse[:reading] == "up" && pulse[:reading_rpt] % 12 == 1
         begin
-          PostgresLsnMonitor.new(last_known_lsn: last_known_lsn) { _1.postgres_server_id = id }
-            .insert_conflict(
+          PostgresLsnMonitor.new(last_known_lsn: last_known_lsn) { _1.postgres_server_id = id }.
+            insert_conflict(
               target: :postgres_server_id,
               update: {last_known_lsn: last_known_lsn}
             ).save_changes

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -47,9 +47,9 @@ PGHOST=/var/run/postgresql
     return [] if blob_storage.nil?
 
     begin
-      blob_storage_client
-        .list_objects(ubid, "basebackups_005/")
-        .select { _1.key.end_with?("backup_stop_sentinel.json") }
+      blob_storage_client.
+        list_objects(ubid, "basebackups_005/").
+        select { _1.key.end_with?("backup_stop_sentinel.json") }
     rescue => ex
       recoverable_errors = ["The Access Key Id you provided does not exist in our records.", "AccessDenied", "No route to host", "Connection refused"]
       return [] if recoverable_errors.any? { ex.message.include?(_1) }

--- a/model/project.rb
+++ b/model/project.rb
@@ -43,12 +43,12 @@ class Project < Sequel::Model
   end
 
   def default_location
-    location_max_capacity = DB[:vm_host]
-      .join(:location, id: :location_id)
-      .where(allocation_state: "accepting")
-      .select_group(:location_id)
-      .order { sum(Sequel[:total_cores] - Sequel[:used_cores]).desc }
-      .first
+    location_max_capacity = DB[:vm_host].
+      join(:location, id: :location_id).
+      where(allocation_state: "accepting").
+      select_group(:location_id).
+      order { sum(Sequel[:total_cores] - Sequel[:used_cores]).desc }.
+      first
 
     if location_max_capacity.nil?
       Location.find(visible: true).display_name

--- a/model/subject_tag.rb
+++ b/model/subject_tag.rb
@@ -15,11 +15,11 @@ class SubjectTag < Sequel::Model
   end
 
   def self.subject_id_map_for_project_and_accounts(project_id, account_ids)
-    DB[:applied_subject_tag]
-      .join(:subject_tag, id: :tag_id)
-      .where(project_id:, subject_id: Sequel.any_uuid(account_ids))
-      .order(:subject_id, :name)
-      .select_hash_groups(:subject_id, :name)
+    DB[:applied_subject_tag].
+      join(:subject_tag, id: :tag_id).
+      where(project_id:, subject_id: Sequel.any_uuid(account_ids)).
+      order(:subject_id, :name).
+      select_hash_groups(:subject_id, :name)
   end
 
   def self.options_for_project(project)

--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -14,12 +14,12 @@ class VmPool < Sequel::Model
   def pick_vm
     # Find an available VM in the "running" state and not associated with a GitHub runner,
     # and lock it with FOR UPDATE SKIP LOCKED.
-    vms_dataset
-      .where(Sequel[:vm][:display_state] => "running")
-      .exclude(id: DB[:github_runner].exclude(vm_id: nil).select(:vm_id))
-      .for_update
-      .skip_locked
-      .first
+    vms_dataset.
+      where(Sequel[:vm][:display_state] => "running").
+      exclude(id: DB[:github_runner].exclude(vm_id: nil).select(:vm_id)).
+      for_update.
+      skip_locked.
+      first
   end
 end
 

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -136,8 +136,8 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
     elsif actual_replica_count > desired_replica_count
       victims = replicas.select {
                   !(_1.destroy_set? || _1.strand.label == "destroy")
-                }
-        .sort_by { |r|
+                }.
+        sort_by { |r|
         [(r.strand.label == "wait") ? 1 : 0, r.created_at]
       }.take(actual_replica_count - desired_replica_count)
       victims.each(&:incr_destroy)

--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -23,10 +23,10 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
     decr_refresh_dns_servers
 
     dns_zone.dns_servers.each do |dns_server|
-      records_to_rectify = dns_zone.records_dataset
-        .left_join(:seen_dns_records_by_dns_servers, dns_record_id: :id, dns_server_id: dns_server.id)
-        .where(Sequel[:seen_dns_records_by_dns_servers][:dns_record_id] => nil)
-        .order(Sequel.asc(:created_at)).all
+      records_to_rectify = dns_zone.records_dataset.
+        left_join(:seen_dns_records_by_dns_servers, dns_record_id: :id, dns_server_id: dns_server.id).
+        where(Sequel[:seen_dns_records_by_dns_servers][:dns_record_id] => nil).
+        order(Sequel.asc(:created_at)).all
 
       next if records_to_rectify.empty?
 

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -13,8 +13,8 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
         updates[:default_branch] = default_branch if default_branch
         repository.insert_conflict(target: [:installation_id, :name], update: updates).save_changes
       end
-      Strand.new(prog: "Github::GithubRepositoryNexus", label: "wait") { _1.id = repository.id }
-        .insert_conflict(target: :id).save_changes
+      Strand.new(prog: "Github::GithubRepositoryNexus", label: "wait") { _1.id = repository.id }.
+        insert_conflict(target: :id).save_changes
     end
   end
 
@@ -87,10 +87,10 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     # created more than 7 days ago and not accessed yet.
     seven_days_ago = Time.now - 7 * 24 * 60 * 60
     cond = Sequel.expr { (last_accessed_at < seven_days_ago) | ((last_accessed_at =~ nil) & (created_at < seven_days_ago)) }
-    github_repository.cache_entries_dataset
-      .where(cond)
-      .limit(200)
-      .destroy_where(cond)
+    github_repository.cache_entries_dataset.
+      where(cond).
+      limit(200).
+      destroy_where(cond)
 
     # Destroy cache entries if it is created 30 minutes ago
     # but couldn't committed yet. 30 minutes decided as during
@@ -98,11 +98,11 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     # the max size for a single cache entry) takes ~8 minutes at most.
     # To be on the safe side, ~2x buffer is added.
     cond = Sequel.expr(committed_at: nil)
-    github_repository.cache_entries_dataset
-      .where { created_at < Time.now - 30 * 60 }
-      .where(cond)
-      .limit(200)
-      .destroy_where(cond)
+    github_repository.cache_entries_dataset.
+      where { created_at < Time.now - 30 * 60 }.
+      where(cond).
+      limit(200).
+      destroy_where(cond)
 
     # Destroy oldest cache entries if the total usage exceeds the limit.
     dataset = github_repository.cache_entries_dataset.exclude(size: nil)

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -51,10 +51,10 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   label def prune_servers
     # Below we only keep servers that does not need recycling. If there are
     # more such servers than required, we prefer ready and recent servers (in that order)
-    servers_to_keep = postgres_resource.servers
-      .reject { _1.representative_at || _1.needs_recycling? }
-      .sort_by { [(_1.strand.label == "wait") ? 0 : 1, Time.now - _1.created_at] }
-      .take(postgres_resource.target_standby_count) + [postgres_resource.representative_server]
+    servers_to_keep = postgres_resource.servers.
+      reject { _1.representative_at || _1.needs_recycling? }.
+      sort_by { [(_1.strand.label == "wait") ? 0 : 1, Time.now - _1.created_at] }.
+      take(postgres_resource.target_standby_count) + [postgres_resource.representative_server]
     (postgres_resource.servers - servers_to_keep).each.each(&:incr_destroy)
 
     postgres_resource.incr_update_billing_records

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -81,10 +81,10 @@ class Prog::Vm::GithubRunner < Prog::Base
       duration = Time.now - github_runner.ready_at
       used_amount = (duration / 60).ceil
       github_runner.log_duration("runner_completed", duration)
-      today_record = BillingRecord
-        .where(project_id: project.id, resource_id: project.id, billing_rate_id: rate_id)
-        .where { Sequel.pg_range(_1.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
-        .first
+      today_record = BillingRecord.
+        where(project_id: project.id, resource_id: project.id, billing_rate_id: rate_id).
+        where { Sequel.pg_range(_1.span).overlaps(Sequel.pg_range(begin_time...end_time)) }.
+        first
 
       if today_record
         today_record.amount = Sequel[:amount] + used_amount

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -567,9 +567,9 @@ class Prog::Vm::Nexus < Prog::Base
     # the operation succeeded in case some other
     # transaction took over this slice.
     if slice
-      updated = slice.this
-        .where(enabled: true, used_cpu_percent: 0, used_memory_gib: 0)
-        .update(enabled: false)
+      updated = slice.this.
+        where(enabled: true, used_cpu_percent: 0, used_memory_gib: 0).
+        update(enabled: false)
 
       if updated == 1
         slice.incr_destroy

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -31,9 +31,9 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   end
 
   def generate_lb_based_nat_rules
-    active_vm_ports_uniq_by_port = load_balancer.active_vm_ports { |ds| ds.eager(:load_balancer_port, load_balancer_vm: {vm: :nics}) }
-      .uniq(&:load_balancer_port_id)
-      .sort_by { |vm_port| vm_port.load_balancer_port.src_port }
+    active_vm_ports_uniq_by_port = load_balancer.active_vm_ports { |ds| ds.eager(:load_balancer_port, load_balancer_vm: {vm: :nics}) }.
+      uniq(&:load_balancer_port_id).
+      sort_by { |vm_port| vm_port.load_balancer_port.src_port }
     public_ipv4 = vm.ephemeral_net4.to_s
     public_ipv6 = vm.ephemeral_net6.nth(2).to_s
     private_ipv4 = vm.private_ipv4
@@ -133,9 +133,9 @@ TEMPLATE
   end
 
   def generate_lb_map_defs(current_port)
-    items = load_balancer.active_vm_ports
-      .select { |vm_port| vm_port.load_balancer_port.dst_port == current_port.dst_port }
-      .map do |vm_port|
+    items = load_balancer.active_vm_ports.
+      select { |vm_port| vm_port.load_balancer_port.dst_port == current_port.dst_port }.
+      map do |vm_port|
         address = yield vm_port
         port = (vm_port.load_balancer_vm.vm_id == vm.id) ? vm_port.load_balancer_port.dst_port : vm_port.load_balancer_port.src_port
         [address.to_s, port.to_i]

--- a/rhizome/host/bin/delete-old-serial-logs
+++ b/rhizome/host/bin/delete-old-serial-logs
@@ -14,10 +14,10 @@ Dir.glob(File.join(directory_path, "*")).each do |file|
 end
 
 # Reduce the directory size to less than 1GB
-files_with_sizes = Dir.glob(File.join(directory_path, "*"))
-  .select { File.file?(_1) }
-  .map { {file: _1, size: File.size(_1)} }
-  .sort_by { _1[:size] }
+files_with_sizes = Dir.glob(File.join(directory_path, "*")).
+  select { File.file?(_1) }.
+  map { {file: _1, size: File.size(_1)} }.
+  sort_by { _1[:size] }
 while files_with_sizes.sum { _1[:size] } > 1 * 1024 * 1024 * 1024 # 1GB in bytes
   break unless (largest_file = files_with_sizes.pop)
   FileUtils.rm(largest_file[:file])

--- a/routes/project/token.rb
+++ b/routes/project/token.rb
@@ -4,10 +4,10 @@ class Clover
   hash_branch(:project_prefix, "token") do |r|
     r.web do
       authorize("Project:token", @project.id)
-      token_ds = current_account
-        .api_keys_dataset
-        .where(project_id: @project.id)
-        .reverse(:created_at)
+      token_ds = current_account.
+        api_keys_dataset.
+        where(project_id: @project.id).
+        reverse(:created_at)
 
       r.is do
         r.get do

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -78,10 +78,10 @@ class Clover
         DB.transaction do
           allowed_add_tags = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").to_hash(:name)
           allowed_remove_tags = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:remove").to_hash(:name)
-          project_account_ids = @project
-            .accounts_dataset
-            .where(Sequel[:accounts][:id] => Sequel.any_uuid(account_ids))
-            .select_map(Sequel[:accounts][:id])
+          project_account_ids = @project.
+            accounts_dataset.
+            where(Sequel[:accounts][:id] => Sequel.any_uuid(account_ids)).
+            select_map(Sequel[:accounts][:id])
           subject_tag_map = SubjectTag.subject_id_map_for_project_and_accounts(@project.id, project_account_ids)
           project_account_ids.each do |account_id|
             subject_tag_map[account_id] ||= [] # Handle accounts not in any tags
@@ -126,10 +126,10 @@ class Clover
             r.redirect "#{@project.path}/user"
           end
 
-          invitatation_map = @project
-            .invitations_dataset
-            .where(email: invitation_policies.keys)
-            .to_hash(:email)
+          invitatation_map = @project.
+            invitations_dataset.
+            where(email: invitation_policies.keys).
+            to_hash(:email)
           invitation_policy_changes = {}
           invitation_policies.each do |email, policy|
             policy = nil if policy == ""
@@ -149,10 +149,10 @@ class Clover
             (removals[old_policy] ||= []) << 1 if old_policy
           end
           invitation_policy_changes.each do |policy, emails|
-            @project
-              .invitations_dataset
-              .where(email: emails)
-              .update(policy:)
+            @project.
+              invitations_dataset.
+              where(email: emails).
+              update(policy:)
           end
 
           changes = []

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe GithubRunner do
   end
 
   it "provisions a spare runner" do
-    expect(Prog::Vm::GithubRunner).to receive(:assemble)
-      .with(github_runner.installation, repository_name: github_runner.repository_name, label: github_runner.label)
-      .and_return(instance_double(Strand, subject: instance_double(described_class)))
+    expect(Prog::Vm::GithubRunner).to receive(:assemble).
+      with(github_runner.installation, repository_name: github_runner.repository_name, label: github_runner.label).
+      and_return(instance_double(Strand, subject: instance_double(described_class)))
     github_runner.provision_spare_runner
   end
 

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -91,10 +91,10 @@ RSpec.describe Invoice do
       payment_method2 = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_2", order: 2)
 
       # rubocop:disable RSpec/VerifiedDoubles
-      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method1.stripe_id))
-        .and_raise(Stripe::CardError.new("Unsufficient funds", {}))
-      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method2.stripe_id))
-        .and_raise(Stripe::CardError.new("Card declined", {}))
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method1.stripe_id)).
+        and_raise(Stripe::CardError.new("Unsufficient funds", {}))
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method2.stripe_id)).
+        and_raise(Stripe::CardError.new("Card declined", {}))
       # rubocop:enable RSpec/VerifiedDoubles
       expect(Clog).to receive(:emit).with("Invoice couldn't charged.").and_call_original.twice
       expect(Clog).to receive(:emit).with("Invoice couldn't charged with any payment method.").and_call_original
@@ -107,8 +107,8 @@ RSpec.describe Invoice do
       payment_method = PaymentMethod.create_with_id(billing_info_id: billing_info.id, stripe_id: "pm_1", order: 1)
 
       # rubocop:disable RSpec/VerifiedDoubles
-      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method.stripe_id))
-        .and_return(double(Stripe::PaymentIntent, id: "payment-intent-id", status: "failed"))
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method.stripe_id)).
+        and_return(double(Stripe::PaymentIntent, id: "payment-intent-id", status: "failed"))
       # rubocop:enable RSpec/VerifiedDoubles
       expect(Clog).to receive(:emit).with("BUG: payment intent should succeed here").and_call_original
       expect(Clog).to receive(:emit).with("Invoice couldn't charged with any payment method.").and_call_original
@@ -122,10 +122,10 @@ RSpec.describe Invoice do
       payment_method2 = PaymentMethod.create(billing_info_id: billing_info.id, stripe_id: "pm_2", created_at: Time.now + 10)
       payment_method3 = PaymentMethod.create(billing_info_id: billing_info.id, stripe_id: "pm_3", created_at: Time.now)
       # rubocop:disable RSpec/VerifiedDoubles
-      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method1.stripe_id))
-        .and_raise(Stripe::CardError.new("Declined", {}))
-      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method2.stripe_id))
-        .and_return(double(Stripe::PaymentIntent, status: "succeeded", id: "pi_1234567890"))
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method1.stripe_id)).
+        and_raise(Stripe::CardError.new("Declined", {}))
+      expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(amount: 1000, customer: billing_info.stripe_id, payment_method: payment_method2.stripe_id)).
+        and_return(double(Stripe::PaymentIntent, status: "succeeded", id: "pi_1234567890"))
       expect(Stripe::PaymentIntent).not_to receive(:create).with(hash_including(payment_method: payment_method3.stripe_id))
       # rubocop:enable RSpec/VerifiedDoubles
       expect(invoice).to receive(:save).with(columns: [:status, :content])

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Page do
   describe "#trigger" do
     before do
       expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)
-      stub_request(:post, "https://events.pagerduty.com/v2/enqueue")
-        .to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
+      stub_request(:post, "https://events.pagerduty.com/v2/enqueue").
+        to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
     end
 
     it "triggers a page in Pagerduty if key is present" do
@@ -34,8 +34,8 @@ RSpec.describe Page do
   describe "#resolve" do
     it "resolves the page in Pagerduty if key is present" do
       expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)
-      stub_request(:post, "https://events.pagerduty.com/v2/enqueue")
-        .to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
+      stub_request(:post, "https://events.pagerduty.com/v2/enqueue").
+        to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
 
       p.resolve
     end

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -151,8 +151,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     it "creates a pod for runpod" do
       expect(inference_endpoint).to receive(:engine).and_return "runpod"
       expect(Config).to receive(:operator_ssh_public_keys).and_return "operator ssh key"
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"query Pods { myself { pods { id name runtime  { ports { ip isIpPublic privatePort publicPort type } } } } }\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -160,11 +160,11 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: {data: {myself: {pods: []}}}.to_json, headers: {})
+        ).
+        to_return(status: 200, body: {data: {myself: {pods: []}}}.to_json, headers: {})
 
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"mutation {\\n  podFindAndDeployOnDemand(\\n    input: {\\n      cloudType: ALL\\n      dataCenterId: \\\"\\\"\\n      gpuCount: \\n      gpuTypeId: \\\"\\\"\\n      containerDiskInGb: \\n      minVcpuCount: \\n      minMemoryInGb: \\n      imageName: \\\"\\\"\\n      name: \\\"#{replica.ubid}\\\"\\n      volumeInGb: 0\\n      ports: \\\"22/tcp\\\"\\n      env: [\\n        { key: \\\"HF_TOKEN\\\", value: \\\"\\\" },\\n        { key: \\\"HF_HUB_ENABLE_HF_TRANSFER\\\", value: \\\"1\\\"},\\n        { key: \\\"MODEL_PATH\\\", value: \\\"/model\\\"},\\n        { key: \\\"MODEL_NAME_HF\\\", value: \\\"\\\"},\\n        { key: \\\"VLLM_PARAMS\\\", value: \\\"--served-model-name test-model --disable-log-requests --host 127.0.0.1 --some-params\\\"},\\n        { key: \\\"SSH_KEYS\\\", value: \\\"vm ssh key\\\\noperator ssh key\\\" }\\n      ]\\n    }\\n  ) {\\n    id\\n    imageName\\n    env\\n    machineId\\n    machine {\\n      podHostId\\n    }\\n  }\\n}\\n\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -172,8 +172,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: {"data" => {"podFindAndDeployOnDemand" => {"id" => "thepodid"}}}.to_json, headers: {})
+        ).
+        to_return(status: 200, body: {"data" => {"podFindAndDeployOnDemand" => {"id" => "thepodid"}}}.to_json, headers: {})
       expect(replica).to receive(:update).with(external_state: {"pod_id" => "thepodid"})
       expect(sshable).to receive(:cmd).and_return("vm ssh key\n")
       expect { nx.setup_external }.to nap(10)
@@ -181,8 +181,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
 
     it "does not create a pod if one already exists" do
       expect(inference_endpoint).to receive(:engine).and_return "runpod"
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"query Pods { myself { pods { id name runtime  { ports { ip isIpPublic privatePort publicPort type } } } } }\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -190,8 +190,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: {"data" => {"myself" => {"pods" => [{"name" => replica.ubid.to_s, "id" => "thepodid"}]}}}.to_json, headers: {})
+        ).
+        to_return(status: 200, body: {"data" => {"myself" => {"pods" => [{"name" => replica.ubid.to_s, "id" => "thepodid"}]}}}.to_json, headers: {})
 
       expect(replica).to receive(:update).with(external_state: {"pod_id" => "thepodid"})
       expect { nx.setup_external }.to nap(10)
@@ -200,8 +200,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     it "hops to setup for runpod" do
       expect(inference_endpoint).to receive(:engine).and_return "runpod"
       allow(replica).to receive(:external_state).and_return({"pod_id" => "thepodid"})
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"query Pod { pod(input: {podId: \\\"thepodid\\\"}) { id name runtime  { ports { ip isIpPublic privatePort publicPort type } } } }\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -209,8 +209,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: {"data" => {"pod" => {"id" => "thepodid", "runtime" => {"ports" => [{"type" => "tcp", "isIpPublic" => true, "publicPort" => 1234, "ip" => "1.2.3.4"}]}}}}.to_json, headers: {})
+        ).
+        to_return(status: 200, body: {"data" => {"pod" => {"id" => "thepodid", "runtime" => {"ports" => [{"type" => "tcp", "isIpPublic" => true, "publicPort" => 1234, "ip" => "1.2.3.4"}]}}}}.to_json, headers: {})
 
       expect(replica).to receive(:update).with(external_state: {ip: "1.2.3.4", pod_id: "thepodid", port: 1234})
       expect { nx.setup_external }.to hop("setup")
@@ -219,8 +219,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     it "waits until runpod ip and port are available" do
       expect(inference_endpoint).to receive(:engine).and_return "runpod"
       allow(replica).to receive(:external_state).and_return({"pod_id" => "thepodid"})
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"query Pod { pod(input: {podId: \\\"thepodid\\\"}) { id name runtime  { ports { ip isIpPublic privatePort publicPort type } } } }\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -228,16 +228,16 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: {"data" => {"pod" => {"id" => "thepodid", "runtime" => {"ports" => [{"type" => "tcp", "isIpPublic" => false, "publicPort" => 1234, "ip" => "1.2.3.4"}]}}}}.to_json, headers: {})
+        ).
+        to_return(status: 200, body: {"data" => {"pod" => {"id" => "thepodid", "runtime" => {"ports" => [{"type" => "tcp", "isIpPublic" => false, "publicPort" => 1234, "ip" => "1.2.3.4"}]}}}}.to_json, headers: {})
       expect { nx.setup_external }.to nap(10)
     end
 
     it "raises an error if runpod pod id is unexpected" do
       expect(inference_endpoint).to receive(:engine).and_return "runpod"
       allow(replica).to receive(:external_state).and_return({"pod_id" => "thepodid"})
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"query Pod { pod(input: {podId: \\\"thepodid\\\"}) { id name runtime  { ports { ip isIpPublic privatePort publicPort type } } } }\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -245,16 +245,16 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: {"data" => {"pod" => {"id" => "anotherpodid", "runtime" => {"ports" => [{"type" => "tcp", "isIpPublic" => false, "publicPort" => 1234, "ip" => "1.2.3.4"}]}}}}.to_json, headers: {})
+        ).
+        to_return(status: 200, body: {"data" => {"pod" => {"id" => "anotherpodid", "runtime" => {"ports" => [{"type" => "tcp", "isIpPublic" => false, "publicPort" => 1234, "ip" => "1.2.3.4"}]}}}}.to_json, headers: {})
       expect { nx.setup_external }.to raise_error("BUG: unexpected pod id")
     end
 
     it "raises an error if pod cannot be found" do
       expect(inference_endpoint).to receive(:engine).and_return "runpod"
       allow(replica).to receive(:external_state).and_return({"pod_id" => "thepodid"})
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"query Pod { pod(input: {podId: \\\"thepodid\\\"}) { id name runtime  { ports { ip isIpPublic privatePort publicPort type } } } }\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -262,8 +262,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: {"data" => {}}.to_json, headers: {})
+        ).
+        to_return(status: 200, body: {"data" => {}}.to_json, headers: {})
       expect { nx.setup_external }.to raise_error("BUG: pod not found")
     end
   end
@@ -402,8 +402,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
       expect(lb).to receive(:remove_vm).with(vm)
       expect(replica).to receive(:external_state).and_return({"pod_id" => "thepodid"})
 
-      stub_request(:post, "https://api.runpod.io/graphql")
-        .with(
+      stub_request(:post, "https://api.runpod.io/graphql").
+        with(
           body: "{\"query\":\"mutation { podTerminate(input: {podId: \\\"thepodid\\\"}) }\"}",
           headers: {
             "Accept-Encoding" => "deflate, gzip",
@@ -411,8 +411,8 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
             "Content-Type" => "application/json",
             "Host" => "api.runpod.io"
           }
-        )
-        .to_return(status: 200, body: "", headers: {})
+        ).
+        to_return(status: 200, body: "", headers: {})
 
       expect(replica).to receive(:update).with(external_state: "{}")
       expect(vm).to receive(:incr_destroy)

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -214,20 +214,20 @@ zone-flush k8s.ubicloud.com
       expect(prog.ds).to receive(:vms).thrice.and_return([dummy_vm])
       expect(dummy_vm).to receive(:sshable).twice.and_return(dummy_sshable)
 
-      expect(prog.vm.sshable).to receive(:cmd).twice
-        .with("sudo -u knot knotc", stdin: "zone-read --")
-        .and_return("line1\nline2")
+      expect(prog.vm.sshable).to receive(:cmd).twice.
+        with("sudo -u knot knotc", stdin: "zone-read --").
+        and_return("line1\nline2")
 
-      expect(dummy_sshable).to receive(:cmd)
-        .with("sudo -u knot knotc", stdin: "zone-read --")
-        .and_return("line1\nline3")
+      expect(dummy_sshable).to receive(:cmd).
+        with("sudo -u knot knotc", stdin: "zone-read --").
+        and_return("line1\nline3")
 
       # Different outputs
       expect { prog.validate }.to hop("sync_zones")
 
-      expect(dummy_sshable).to receive(:cmd)
-        .with("sudo -u knot knotc", stdin: "zone-read --")
-        .and_return("line2\nline1")
+      expect(dummy_sshable).to receive(:cmd).
+        with("sudo -u knot knotc", stdin: "zone-read --").
+        and_return("line2\nline1")
 
       expect(prog.ds).to receive(:add_vm)
 

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Prog::Test::GithubRunner do
   describe "#create_vm_pool" do
     it "creates pool and hops to wait_vm_pool_to_be_ready" do
       label_data = Github.runner_labels["ubicloud"]
-      expect(Prog::Vm::VmPool).to receive(:assemble)
-        .with(hash_including(size: 1, vm_size: label_data["vm_size"]))
-        .and_return(instance_double(Strand, subject: instance_double(VmPool, id: 12345)))
+      expect(Prog::Vm::VmPool).to receive(:assemble).
+        with(hash_including(size: 1, vm_size: label_data["vm_size"])).
+        and_return(instance_double(Strand, subject: instance_double(VmPool, id: 12345)))
       expect { gr_test.create_vm_pool }.to hop("wait_vm_pool_to_be_ready")
     end
   end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -535,28 +535,28 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "fails if free hugepages couldn't be extracted" do
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo")
-        .and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 5")
+      expect(sshable).to receive(:cmd).with("cat /proc/meminfo").
+        and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 5")
       expect { nx.verify_hugepages }.to raise_error RuntimeError, "Couldn't extract free hugepage count"
     end
 
     it "fails if not enough hugepages for VMs" do
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo")
-        .and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 5\nHugePages_Free: 2")
+      expect(sshable).to receive(:cmd).with("cat /proc/meminfo").
+        and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 5\nHugePages_Free: 2")
       expect { nx.verify_hugepages }.to raise_error RuntimeError, "Not enough hugepages for VMs"
     end
 
     it "fails if used hugepages exceed spdk hugepages" do
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo")
-        .and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 10\nHugePages_Free: 5")
+      expect(sshable).to receive(:cmd).with("cat /proc/meminfo").
+        and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 10\nHugePages_Free: 5")
       expect { nx.verify_hugepages }.to raise_error RuntimeError, "Used hugepages exceed SPDK hugepages"
     end
 
     it "updates vm_host with hugepage stats and hops" do
-      expect(sshable).to receive(:cmd).with("cat /proc/meminfo")
-        .and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 10\nHugePages_Free: 8")
-      expect(vm_host).to receive(:update)
-        .with(total_hugepages_1g: 10, used_hugepages_1g: 7)
+      expect(sshable).to receive(:cmd).with("cat /proc/meminfo").
+        and_return("Hugepagesize: 1048576 kB\nHugePages_Total: 10\nHugePages_Free: 8")
+      expect(vm_host).to receive(:update).
+        with(total_hugepages_1g: 10, used_hugepages_1g: 7)
       expect { nx.verify_hugepages }.to hop("start_slices")
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe Prog::Vm::Nexus do
     it "creates Subnet and Nic if not passed" do
       expect {
         described_class.assemble("some_ssh_key", prj.id)
-      }.to change(PrivateSubnet, :count).from(0).to(1)
-        .and change(Nic, :count).from(0).to(1)
+      }.to change(PrivateSubnet, :count).from(0).to(1).
+        and change(Nic, :count).from(0).to(1)
     end
 
     it "creates Nic if only subnet_id is passed" do

--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Clover, "access control" do
     # Show the displayed access control entries, except for the Admin one
     def displayed_access_control_entries
       page.all("table#access-control-entries .existing-aces-view td.values").map(&:text) +
-        page.all("table#access-control-entries .existing-aces select")
-          .map { |select| select.all("option[selected]")[0] || select.first("option") }
-          .map(&:text)
+        page.all("table#access-control-entries .existing-aces select").
+          map { |select| select.all("option[selected]")[0] || select.first("option") }.
+          map(&:text)
     end
 
     before do

--- a/spec/routes/web/token_spec.rb
+++ b/spec/routes/web/token_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Clover, "personal access token management" do
   # Show the displayed access control entries, except for the Admin one
   def displayed_access_control_entries
     page.all("table#access-control-entries .existing-aces-view td.values").map(&:text) +
-      page.all("table#access-control-entries .existing-aces select")
-        .map { |select| select.all("option[selected]")[0] || select.first("option") }
-        .map(&:text)
+      page.all("table#access-control-entries .existing-aces select").
+        map { |select| select.all("option[selected]")[0] || select.first("option") }.
+        map(&:text)
   end
 
   before do

--- a/spec/ruby_sdk_spec.rb
+++ b/spec/ruby_sdk_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe Ubicloud do
     let(:adapter) { described_class.new(token: "foo", project_id: "pj", base_uri: "http://localhost") }
 
     it "sends expected headers for GET requests" do
-      stub_request(:get, "http://localhost/project/pj/headers")
-        .with(
+      stub_request(:get, "http://localhost/project/pj/headers").
+        with(
           headers: {
             "Accept" => "text/plain",
             "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
@@ -199,14 +199,14 @@ RSpec.describe Ubicloud do
             "Connection" => "close",
             "User-Agent" => "Ruby"
           }
-        )
-        .to_return(status: 200, body: "{}", headers: {})
+        ).
+        to_return(status: 200, body: "{}", headers: {})
       expect(adapter.get("headers")).to eq({})
     end
 
     it "sends expected headers for POST requests" do
-      stub_request(:post, "http://localhost/project/pj/headers")
-        .with(
+      stub_request(:post, "http://localhost/project/pj/headers").
+        with(
           body: "{\"foo\":\"bar\"}",
           headers: {
             "Accept" => "text/plain",
@@ -216,14 +216,14 @@ RSpec.describe Ubicloud do
             "Content-Type" => "application/json",
             "User-Agent" => "Ruby"
           }
-        )
-        .to_return(status: 200, body: "{}", headers: {})
+        ).
+        to_return(status: 200, body: "{}", headers: {})
       expect(adapter.post("headers", foo: "bar")).to eq({})
     end
 
     it "sends expected headers and body for POST requests" do
-      stub_request(:post, "http://localhost/project/pj/headers")
-        .with(
+      stub_request(:post, "http://localhost/project/pj/headers").
+        with(
           headers: {
             "Accept" => "text/plain",
             "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
@@ -232,14 +232,14 @@ RSpec.describe Ubicloud do
             "Content-Type" => "application/json",
             "User-Agent" => "Ruby"
           }
-        )
-        .to_return(status: 200, body: "{}", headers: {})
+        ).
+        to_return(status: 200, body: "{}", headers: {})
       expect(adapter.post("headers")).to eq({})
     end
 
     it "sends expected headers for DELETE requests" do
-      stub_request(:delete, "http://localhost/project/pj/headers")
-        .with(
+      stub_request(:delete, "http://localhost/project/pj/headers").
+        with(
           headers: {
             "Accept" => "text/plain",
             "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
@@ -248,8 +248,8 @@ RSpec.describe Ubicloud do
             "Content-Type" => "application/json",
             "User-Agent" => "Ruby"
           }
-        )
-        .to_return(status: 200, body: "{}", headers: {})
+        ).
+        to_return(status: 200, body: "{}", headers: {})
       expect(adapter.delete("headers")).to eq({})
     end
   end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Al do
 
     it "persists valid allocation" do
       al = instance_double(Al::Allocation)
-      expect(Al::Allocation).to receive(:best_allocation)
-        .with(Al::Request.new(
+      expect(Al::Allocation).to receive(:best_allocation).
+        with(Al::Request.new(
           "2464de61-7501-8374-9ab0-416caebe31da", 2, 8, 33,
           [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
             [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
@@ -151,26 +151,26 @@ RSpec.describe Al do
       sd2 = StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 12, total_storage_gib: 99)
       BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
 
-      expect(Al::Allocation.candidate_hosts(req))
-        .to eq([{location_id: vmh.location_id,
-                 num_storage_devices: 2,
-                 storage_devices: [{"available_storage_gib" => sd2.available_storage_gib, "id" => sd2.id, "total_storage_gib" => sd2.total_storage_gib},
-                   {"available_storage_gib" => sd1.available_storage_gib, "id" => sd1.id, "total_storage_gib" => sd1.total_storage_gib}],
-                 total_cpus: vmh.total_cpus,
-                 total_cores: vmh.total_cores,
-                 total_hugepages_1g: vmh.total_hugepages_1g,
-                 total_storage_gib: sd1.total_storage_gib + sd2.total_storage_gib,
-                 available_storage_gib: sd1.available_storage_gib + sd2.available_storage_gib,
-                 used_cores: vmh.used_cores,
-                 used_hugepages_1g: vmh.used_hugepages_1g,
-                 vm_host_id: vmh.id,
-                 total_ipv4: 4,
-                 num_gpus: 0,
-                 available_gpus: 0,
-                 available_iommu_groups: nil,
-                 used_ipv4: 1,
-                 vm_provisioning_count: 0,
-                 accepts_slices: false}])
+      expect(Al::Allocation.candidate_hosts(req)).
+        to eq([{location_id: vmh.location_id,
+                num_storage_devices: 2,
+                storage_devices: [{"available_storage_gib" => sd2.available_storage_gib, "id" => sd2.id, "total_storage_gib" => sd2.total_storage_gib},
+                  {"available_storage_gib" => sd1.available_storage_gib, "id" => sd1.id, "total_storage_gib" => sd1.total_storage_gib}],
+                total_cpus: vmh.total_cpus,
+                total_cores: vmh.total_cores,
+                total_hugepages_1g: vmh.total_hugepages_1g,
+                total_storage_gib: sd1.total_storage_gib + sd2.total_storage_gib,
+                available_storage_gib: sd1.available_storage_gib + sd2.available_storage_gib,
+                used_cores: vmh.used_cores,
+                used_hugepages_1g: vmh.used_hugepages_1g,
+                vm_host_id: vmh.id,
+                total_ipv4: 4,
+                num_gpus: 0,
+                available_gpus: 0,
+                available_iommu_groups: nil,
+                used_ipv4: 1,
+                vm_provisioning_count: 0,
+                accepts_slices: false}])
     end
 
     it "retrieves provisioning count" do
@@ -181,25 +181,25 @@ RSpec.describe Al do
       create_vm(vm_host_id: vmh.id, location_id: vmh.location_id, boot_image: "ubuntu-jammy", display_state: "creating")
       BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
 
-      expect(Al::Allocation.candidate_hosts(req))
-        .to eq([{location_id: vmh.location_id,
-                 num_storage_devices: 1,
-                 storage_devices: [{"available_storage_gib" => sd1.available_storage_gib, "id" => sd1.id, "total_storage_gib" => sd1.total_storage_gib}],
-                 total_cpus: vmh.total_cpus,
-                 total_cores: vmh.total_cores,
-                 total_hugepages_1g: vmh.total_hugepages_1g,
-                 total_storage_gib: sd1.total_storage_gib,
-                 available_storage_gib: sd1.available_storage_gib,
-                 used_cores: vmh.used_cores,
-                 used_hugepages_1g: vmh.used_hugepages_1g,
-                 vm_host_id: vmh.id,
-                 total_ipv4: 4,
-                 num_gpus: 0,
-                 available_gpus: 0,
-                 available_iommu_groups: nil,
-                 used_ipv4: 1,
-                 vm_provisioning_count: 2,
-                 accepts_slices: false}])
+      expect(Al::Allocation.candidate_hosts(req)).
+        to eq([{location_id: vmh.location_id,
+                num_storage_devices: 1,
+                storage_devices: [{"available_storage_gib" => sd1.available_storage_gib, "id" => sd1.id, "total_storage_gib" => sd1.total_storage_gib}],
+                total_cpus: vmh.total_cpus,
+                total_cores: vmh.total_cores,
+                total_hugepages_1g: vmh.total_hugepages_1g,
+                total_storage_gib: sd1.total_storage_gib,
+                available_storage_gib: sd1.available_storage_gib,
+                used_cores: vmh.used_cores,
+                used_hugepages_1g: vmh.used_hugepages_1g,
+                vm_host_id: vmh.id,
+                total_ipv4: 4,
+                num_gpus: 0,
+                available_gpus: 0,
+                available_iommu_groups: nil,
+                used_ipv4: 1,
+                vm_provisioning_count: 2,
+                accepts_slices: false}])
     end
 
     it "applies host filter" do
@@ -1061,12 +1061,12 @@ RSpec.describe Al do
 
     it "prefers a host with available slice for burstables" do
       vh1 = VmHost.first
-      Prog::Vm::VmHostSliceNexus.assemble_with_host("sl1", vh1, family: "standard", allowed_cpus: (2..5), memory_gib: 16, is_shared: false)
-        .subject
-        .update(used_cpu_percent: 400, used_memory_gib: 16, enabled: true) # Full
-      Prog::Vm::VmHostSliceNexus.assemble_with_host("sl2", vh1, family: "burstable", allowed_cpus: (6..7), memory_gib: 8, is_shared: true)
-        .subject
-        .update(used_cpu_percent: 100, used_memory_gib: 4, enabled: true)  # Partially filled in
+      Prog::Vm::VmHostSliceNexus.assemble_with_host("sl1", vh1, family: "standard", allowed_cpus: (2..5), memory_gib: 16, is_shared: false).
+        subject.
+        update(used_cpu_percent: 400, used_memory_gib: 16, enabled: true) # Full
+      Prog::Vm::VmHostSliceNexus.assemble_with_host("sl2", vh1, family: "burstable", allowed_cpus: (6..7), memory_gib: 8, is_shared: true).
+        subject.
+        update(used_cpu_percent: 100, used_memory_gib: 4, enabled: true)  # Partially filled in
       vh1.update(total_cores: 4, total_cpus: 8, used_cores: 4, total_hugepages_1g: 27, used_hugepages_1g: 26)
       vh1.reload
 

--- a/ubid.rb
+++ b/ubid.rb
@@ -165,8 +165,8 @@ class UBID
 
   # Map of prefixes to class name symbols, to avoid autoloading
   # classes until they are referenced by class_for_ubid
-  TYPE2CLASSNAME = constants.select { _1.start_with?("TYPE_") }.reject { _1.to_s == "TYPE_ETC" }
-    .map { [const_get(_1), camelize(_1.to_s).to_sym] }.to_h.freeze
+  TYPE2CLASSNAME = constants.select { _1.start_with?("TYPE_") }.reject { _1.to_s == "TYPE_ETC" }.
+    map { [const_get(_1), camelize(_1.to_s).to_sym] }.to_h.freeze
   private_constant :TYPE2CLASSNAME
 
   def self.class_for_ubid(str)

--- a/views/account/multifactor/webauthn_remove.erb
+++ b/views/account/multifactor/webauthn_remove.erb
@@ -22,9 +22,9 @@
                 <div class="col-span-6 sm:col-span-6">
                   <fieldset>
                     <div class="space-y-5">
-                      <% (usage = DB[rodauth.webauthn_keys_table]
-                          .where(rodauth.webauthn_keys_account_id_column => rodauth.session_value)
-                          .select_hash(rodauth.webauthn_keys_webauthn_id_column, [rodauth.webauthn_keys_last_use_column, :name])
+                      <% (usage = DB[rodauth.webauthn_keys_table].
+                          where(rodauth.webauthn_keys_account_id_column => rodauth.session_value).
+                          select_hash(rodauth.webauthn_keys_webauthn_id_column, [rodauth.webauthn_keys_last_use_column, :name])
                         ).map do |id, (last_use, name)| %>
                         <div class="relative flex items-start">
                           <div class="flex h-6 items-center">

--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -4,7 +4,7 @@
 <% if link %>
   <a
     href="<%= link %>"
-    class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
+    class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
     <% attributes.each do |atr_key, atr_value| %>
     <%= atr_key %>="<%= atr_value %>"
     <% end%>

--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -43,10 +43,10 @@
     end
   
   @nodes +=
-    @kc
-      .nodepools_dataset
-      .eager(:vms)
-      .flat_map do |np|
+    @kc.
+      nodepools_dataset.
+      eager(:vms).
+      flat_map do |np|
         np.vms.map { |vm| { name: vm.name, role: "Worker", state: vm.display_state, hostname: vm.ephemeral_net4.to_s } }
       end %>
 

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -76,13 +76,13 @@
                     placeholder: "Select a Country",
                     selected: stripe_data["country"],
                     options:
-                      ISO3166::Country
-                        .all
-                        .reject { Config.sanctioned_countries.include?(_1.alpha2) }
-                        .sort_by(&:common_name)
-                        .map { |c| [c.alpha2, c.common_name] }
-                        .to_h
-                        .to_a,
+                      ISO3166::Country.
+                        all.
+                        reject { Config.sanctioned_countries.include?(_1.alpha2) }.
+                        sort_by(&:common_name).
+                        map { |c| [c.alpha2, c.common_name] }.
+                        to_h.
+                        to_a,
                     attributes: {
                       required: true
                     }

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -1,9 +1,9 @@
 <% @page_title = @vm[:name]
 
 viewable_fws =
-  dataset_authorize(Firewall.where(id: @vm[:firewalls].map { UBID.to_uuid(_1[:id]) }), "Firewall:view")
-    .select_hash(:id, Sequel.as(true, :v))
-    .transform_keys! { UBID.from_uuidish(_1).to_s } %>
+  dataset_authorize(Firewall.where(id: @vm[:firewalls].map { UBID.to_uuid(_1[:id]) }), "Firewall:view").
+    select_hash(:id, Sequel.as(true, :v)).
+    transform_keys! { UBID.from_uuidish(_1).to_s } %>
 
 <% if @vm[:state] != "running" %>
   <div class="auto-refresh hidden" data-interval="10"></div>


### PR DESCRIPTION
This is particularly dire in `pry` where the idiomatic/default `.` starts a runs a command, e.g. `.ls` runs the `ls` command.  Using trailing dots solves this problem, it's also the common code style in Jeremy Evans software libraries.