### PR TITLE
Persist invoices as PDFs in blob storage

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -205,4 +205,8 @@ module Config
   optional :stripe_secret_key, string, clear: true
   override :annual_non_dutch_eu_sales_exceed_threshold, false, bool
   optional :invalid_vat_notification_email, string
+  override :invoices_bucket_name, "ubicloud-invoices", string
+  optional :invoices_blob_storage_endpoint, string
+  optional :invoices_blob_storage_access_key, string, clear: true
+  optional :invoices_blob_storage_secret_key, string, clear: true
 end

--- a/serializers/invoice.rb
+++ b/serializers/invoice.rb
@@ -8,7 +8,6 @@ class Serializers::Invoice < Serializers::Base
       ubid: inv.id ? inv.ubid : "current",
       path: inv.path,
       name: inv.name,
-      filename: "Ubicloud-#{inv.begin_time.strftime("%Y-%m")}-#{inv.invoice_number}",
       date: inv.created_at.strftime("%B %d, %Y"),
       begin_time: inv.begin_time.strftime("%b %d, %Y"),
       end_time: inv.end_time.strftime("%b %d, %Y"),


### PR DESCRIPTION
Invoices are legal documents and should not be changed. Currently, we
generate the PDFs in real-time using the content of the invoices. We try
to keep it backward compatible and not change the format of the PDFs,
but that might happen over time. It's important to save the version of
the invoice that was sent to the customer.

I will also show the PDF invoice to the customer from blob storage, but
I will do that in a future PR after persisting all existing invoices.

We also need to share our generated invoices with our accountants for
VAT purposes. To make sharing easier, I place them in separate
directories.
