### PR TITLE
Create multiple pgbouncer instances

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -101,7 +101,8 @@ class PostgresServer < Sequel::Model
         }
       },
       identity: resource.identity,
-      hosts: "#{resource.representative_server.vm.private_ipv4} #{resource.identity}"
+      hosts: "#{resource.representative_server.vm.private_ipv4} #{resource.identity}",
+      pgbouncer_instances: (vm.vcpus / 2.0).ceil.clamp(1, 8)
     }
   end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -178,7 +178,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     end
 
     vm.sshable.cmd("sudo -u postgres pg_ctlcluster #{postgres_server.resource.version} main reload")
-    vm.sshable.cmd("sudo systemctl reload pgbouncer")
+    vm.sshable.cmd("sudo systemctl reload pgbouncer@*")
     hop_wait
   end
 
@@ -442,7 +442,7 @@ SQL
   label def restart
     decr_restart
     vm.sshable.cmd("sudo postgres/bin/restart #{postgres_server.resource.version}")
-    vm.sshable.cmd("sudo systemctl restart pgbouncer")
+    vm.sshable.cmd("sudo systemctl restart pgbouncer@*")
     pop "postgres server is restarted"
   end
 

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -3,6 +3,7 @@
 
 require "json"
 require_relative "../../common/lib/util"
+require_relative "../lib/pgbouncer_setup"
 
 if ARGV.count != 1
   fail "Wrong number of arguments. Expected 1, Given #{ARGV.count}"
@@ -96,35 +97,5 @@ safe_write_to_file("/etc/postgresql/#{v}/main/pg_ident.conf", pg_ident_entries)
 # Reload the postmaster to apply changes
 r "pg_ctlcluster #{v} main reload || pg_ctlcluster #{v} main restart"
 
-# PgBouncer config
-pgbouncer_config = <<-PGBOUNCER_CONFIG
-# PgBouncer configuration file
-# ============================
-[databases]
-; any db over Unix socket
-* =
-
-[pgbouncer]
-listen_port = 6432
-listen_addr = 0.0.0.0
-
-unix_socket_dir = /var/run/postgresql
-
-auth_type = hba
-auth_hba_file = /etc/postgresql/#{v}/main/pg_hba.conf
-auth_ident_file = /etc/postgresql/#{v}/main/pg_ident.conf
-auth_user = pgbouncer
-auth_query = SELECT p_user, p_password FROM pgbouncer.get_auth($1)
-
-client_tls_sslmode = require
-client_tls_protocols = tlsv1.3
-client_tls_ca_file = /etc/ssl/certs/ca.crt
-client_tls_cert_file = /etc/ssl/certs/server.crt
-client_tls_key_file = /etc/ssl/certs/server.key
-
-user = postgres
-
-max_client_conn = 5000
-max_db_connections = #{configure_hash["configs"]["max_connections"]}
-PGBOUNCER_CONFIG
-safe_write_to_file("/etc/pgbouncer/pgbouncer.ini", pgbouncer_config)
+pgbouncer_setup = PgBouncerSetup.new(v, configure_hash["configs"]["max_connections"], configure_hash["pgbouncer_instances"])
+pgbouncer_setup.setup

--- a/rhizome/postgres/lib/pgbouncer_setup.rb
+++ b/rhizome/postgres/lib/pgbouncer_setup.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+class PgBouncerSetup
+  def initialize(version, max_connections, num_instances)
+    @version = version
+    @max_connections = max_connections
+    @num_instances = num_instances
+  end
+
+  def service_template_name
+    "pgbouncer@"
+  end
+
+  def pgbouncer_service_file_path
+    "/etc/systemd/system/#{service_template_name}.service"
+  end
+
+  def socket_service_file_path
+    "/etc/systemd/system/#{service_template_name}.socket"
+  end
+
+  def create_service_templates
+    File.write(pgbouncer_service_file_path, <<PGBOUNCER_SERVICE
+[Unit]
+Description="connection pooler for PostgreSQL (%i)"
+After=network.target
+Requires=pgbouncer@%i.socket
+
+[Service]
+Type=notify
+User=postgres
+ExecStart=/usr/sbin/pgbouncer /etc/pgbouncer/pgbouncer_%i.ini
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target
+PGBOUNCER_SERVICE
+    )
+
+    File.write(socket_service_file_path, <<PGBOUNCER_SOCKET
+[Unit]
+Description=Sockets for PgBouncer
+
+[Socket]
+ListenStream=6432
+ListenStream=%i
+ListenStream=/tmp/.s.PGSQL.%i
+
+ReusePort=true
+
+[Install]
+WantedBy=sockets.target
+PGBOUNCER_SOCKET
+    )
+
+    r "systemctl daemon-reload"
+  end
+
+  def port_num(id)
+    50000 + id
+  end
+
+  def peer_config
+    peers = (1..@num_instances.to_i).map do |i|
+      "#{i} = host=/tmp/.s.PGSQL.#{port_num(i)}"
+    end.join("\n")
+
+    <<PGBOUNCER_PEER
+[peers]
+#{peers}
+PGBOUNCER_PEER
+  end
+
+  def create_pgbouncer_config
+    (1..@num_instances.to_i).each do |i|
+      File.write("/etc/pgbouncer/pgbouncer_#{port_num(i)}.ini", <<PGBOUNCER_CONFIG
+# PgBouncer configuration file
+# ============================
+[databases]
+; any db over Unix socket
+* =
+
+[pgbouncer]
+listen_port = 6432
+listen_addr = 0.0.0.0
+
+unix_socket_dir = /var/run/postgresql
+so_reuseport = 1
+peer_id = #{i}
+
+auth_type = hba
+auth_hba_file = /etc/postgresql/#{@version}/main/pg_hba.conf
+auth_ident_file = /etc/postgresql/#{@version}/main/pg_ident.conf
+auth_user = pgbouncer
+auth_query = SELECT p_user, p_password FROM pgbouncer.get_auth($1)
+
+client_tls_sslmode = require
+client_tls_protocols = tlsv1.3
+client_tls_ca_file = /etc/ssl/certs/ca.crt
+client_tls_cert_file = /etc/ssl/certs/server.crt
+client_tls_key_file = /etc/ssl/certs/server.key
+
+user = postgres
+
+max_client_conn = #{5000 / @num_instances.to_i}
+max_db_connections = #{@max_connections.to_i / @num_instances.to_i}
+
+; Peer configuration, to correctly forward cancellation requests.
+#{peer_config}
+PGBOUNCER_CONFIG
+      )
+    end
+  end
+
+  def disable_default_pgbouncer
+    r "systemctl disable --now pgbouncer"
+  end
+
+  def enable_and_start_service
+    (1..@num_instances.to_i).each do |i|
+      r "systemctl enable --now #{service_template_name}#{port_num(i)}"
+    end
+  end
+
+  def setup
+    create_service_templates
+    create_pgbouncer_config
+    disable_default_pgbouncer
+    enable_and_start_service
+  end
+end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe PostgresServer do
     instance_double(
       Vm,
       sshable: instance_double(Sshable),
+      vcpus: 4,
       memory_gib: 8,
       ephemeral_net4: "1.2.3.4",
       ip6: "fdfa:b5aa:14a3:4a3d::2",

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -329,7 +329,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:cmd).with("sudo chgrp cert_readers /etc/ssl/certs/server.crt && sudo chmod 640 /etc/ssl/certs/server.crt")
       expect(sshable).to receive(:cmd).with("sudo chgrp cert_readers /etc/ssl/certs/server.key && sudo chmod 640 /etc/ssl/certs/server.key")
       expect(sshable).to receive(:cmd).with("sudo -u postgres pg_ctlcluster 16 main reload")
-      expect(sshable).to receive(:cmd).with("sudo systemctl reload pgbouncer")
+      expect(sshable).to receive(:cmd).with("sudo systemctl reload pgbouncer@*")
       expect(nx).to receive(:refresh_walg_credentials)
       expect { nx.refresh_certificates }.to hop("wait")
     end
@@ -680,7 +680,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#restart" do
     it "restarts and exits" do
       expect(sshable).to receive(:cmd).with("sudo postgres/bin/restart 16")
-      expect(sshable).to receive(:cmd).with("sudo systemctl restart pgbouncer")
+      expect(sshable).to receive(:cmd).with("sudo systemctl restart pgbouncer@*")
       expect { nx.restart }.to exit({"msg" => "postgres server is restarted"})
     end
   end


### PR DESCRIPTION
Create multiple pgbouncer instances

Configure a systemd template to create multiple pgbouncer instances, to
avoid bottlenecks created due to it being single-threaded.

To have pgbouncer connect to PG via a domain socket, we need to specify
a unix_socket_dir in the pgbouncer config. But this config value cannot
be shared between different pgbouncer instances, thus we use systemd
socket activation to have pgbouncer use the same server connection
socket but separate listening sockets. [1]

This change also adds a [peers] section to the pgbouncer config, to
allow processing cancellation requests correctly. Since this needs a
unique `peer_id` to be set for each process, we create separate config
files for each process here. [2]

[1]: https://github.com/pgbouncer/pgbouncer/blob/a980f572d537f43216d4ac2ea4550cbbfa4c31b7/src/pooler.c#L510
[2]: https://www.pgbouncer.org/config.html#section-peers