### PR TITLE
Update erb-formatter version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 
 group :lint do
   gem "brakeman"
-  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "a9ff0001a1eb028e2186b222aeb02b07c04f9808"
+  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "df3174476986706828f7baf3e5e6f5ec8ecd849b"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,11 +26,10 @@ GIT
 
 GIT
   remote: https://github.com/ubicloud/erb-formatter.git
-  revision: a9ff0001a1eb028e2186b222aeb02b07c04f9808
-  ref: a9ff0001a1eb028e2186b222aeb02b07c04f9808
+  revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
+  ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
   specs:
-    erb-formatter (0.4.3)
-      syntax_tree (~> 6.0)
+    erb-formatter (0.7.3)
 
 GEM
   remote: https://rubygems.org/
@@ -277,7 +276,6 @@ GEM
       ttfunk (~> 1.8)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    prettier_print (1.2.1)
     prism (1.4.0)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -402,8 +400,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.24.0)
     stripe (12.6.0)
-    syntax_tree (6.2.0)
-      prettier_print (>= 1.2.0)
     tilt (2.6.0)
     timeout (0.4.3)
     tpm-key_attestation (0.12.1)

--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -4,7 +4,7 @@
 <% if link %>
   <a
     href="<%= link %>"
-    class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
+    class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
     <% attributes.each do |atr_key, atr_value| %>
     <%= atr_key %>="<%= atr_value %>"
     <% end%>


### PR DESCRIPTION
I was investigating changing how we formatted some code, and found that `erb-formatter` also formatted embedded code in disagreement with how `rubocop-erb` does.

Such differences in formatting interpretation can cause failure in CI, where committing code produced by `erb-formatter` can fail rubocop.

To have investigated this so closely is a lot of effort to achieve nearly nothing.  Originally, I intended to change the `Layout/DotPosition` rubocop rule to `trailing`, but where the `syntax_tree` gem used by `erb-formatter` would produce code that *always* format code that would fail Rubocop; however, I changed my mind late in the process.

By then I had made those enhancements to `erb-formatter` and decided to keep them: there's no reason to redundantly format code or expose ourselves to the `syntax_tree` dependency.