### PR TITLE
Fix race condition on saving CNI datastore file

### DIFF
--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -64,12 +64,11 @@ class UbiCNI
 
     container_id = ENV["CNI_CONTAINERID"]
     cni_netns = ENV["CNI_NETNS"].sub("/var/run/netns/", "")
-
-    inner_mac = gen_mac
-    inner_link_local = mac_to_ipv6_link_local(inner_mac)
     inner_ifname = ENV["CNI_IFNAME"]
 
+    inner_mac = gen_mac
     outer_mac = gen_mac
+    inner_link_local = mac_to_ipv6_link_local(inner_mac)
     outer_link_local = mac_to_ipv6_link_local(outer_mac)
     outer_ifname = "veth_#{container_id[0, 8]}"
 

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -55,6 +55,7 @@ class UbiCNI
   end
 
   def handle_add
+    check_required_env_vars(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
     subnet_ula_ipv6 = @input_data["ranges"]["subnet_ula_ipv6"]
     subnet_ipv6 = @input_data["ranges"]["subnet_ipv6"]
     subnet_ipv4 = @input_data["ranges"]["subnet_ipv4"]
@@ -162,6 +163,7 @@ options ndots:5
   end
 
   def handle_del
+    check_required_env_vars(["CNI_CONTAINERID"])
     container_id = ENV["CNI_CONTAINERID"]
 
     if @ipam_store["allocated_ips"].key?(container_id)
@@ -173,6 +175,7 @@ options ndots:5
   end
 
   def handle_get
+    check_required_env_vars(["CNI_NETNS", "CNI_IFNAME"])
     cni_netns = ENV["CNI_NETNS"].sub("/var/run/netns/", "")
     inner_ifname = ENV["CNI_IFNAME"]
 
@@ -273,6 +276,12 @@ options ndots:5
       2**(32 - subnet.prefix)
     else
       2**(128 - subnet.prefix)
+    end
+  end
+
+  def check_required_env_vars(vars)
+    vars.each do |var|
+      error_exit("Missing required environment variable: #{var}") unless ENV[var]
     end
   end
 end

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -175,12 +175,9 @@ options ndots:5
     dns_servers = []
     search_domains = []
     if File.exist?(dns_config_path)
-      File.readlines(dns_config_path).each do |line|
-        if line.start_with?("nameserver")
-          dns_servers << line.split[1]
-        elsif line.start_with?("search")
-          search_domains = line.split.drop(1)
-        end
+      File.readlines(dns_config_path, chomp: true).each do |line|
+        dns_servers << line.split[1] if line.start_with?("nameserver")
+        search_domains = line.split.drop(1) if line.start_with?("search")
       end
     end
 

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -66,6 +66,7 @@ class UbiCNI
     cni_netns = ENV["CNI_NETNS"].sub("/var/run/netns/", "")
     inner_ifname = ENV["CNI_IFNAME"]
 
+    @logger.info "Generating MAC addresses for container #{container_id}"
     inner_mac = gen_mac
     outer_mac = gen_mac
     inner_link_local = mac_to_ipv6_link_local(inner_mac)
@@ -167,6 +168,7 @@ options ndots:5
     cni_netns = ENV["CNI_NETNS"].sub("/var/run/netns/", "")
     inner_ifname = ENV["CNI_IFNAME"]
 
+    @logger.info "Retrieving configuration for interface #{inner_ifname} in namespace #{cni_netns}"
     inner_mac = r("ip -n #{cni_netns} link show #{inner_ifname}").match(/link\/ether ([0-9a-f:]+)/)[1]
     container_ip = r("ip -n #{cni_netns} -6 addr show dev #{inner_ifname}").match(/inet6 ([0-9a-f:\/]+)/)[1]
 

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -183,25 +183,9 @@ options ndots:5
 
     response = {
       cniVersion: "1.0.0",
-      interfaces: [
-        {
-          name: inner_ifname,
-          mac: inner_mac,
-          sandbox: "/var/run/netns/#{cni_netns}"
-        }
-      ],
-      ips: [
-        {
-          address: container_ip,
-          gateway: nil,
-          interface: 0
-        }
-      ],
-      dns: {
-        nameservers: dns_servers,
-        search: search_domains,
-        options: ["ndots:5"]
-      }
+      interfaces: [{name: inner_ifname, mac: inner_mac, sandbox: "/var/run/netns/#{cni_netns}"}],
+      ips: [{address: container_ip, gateway: nil, interface: 0}],
+      dns: {nameservers: dns_servers, search: search_domains, options: ["ndots:5"]}
     }
 
     JSON.generate(response)

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -31,15 +31,7 @@ class UbiCNI
   end
 
   def run
-    @logger.info "-------------------------------------------------------"
-    @logger.info "Handling new command: #{ENV["CNI_COMMAND"]}"
-    @logger.info "ENV[CNI_CONTAINERID] #{ENV["CNI_CONTAINERID"]}"
-    @logger.info "ENV[CNI_NETNS] #{ENV["CNI_NETNS"]}"
-    @logger.info "ENV[CNI_IFNAME] #{ENV["CNI_IFNAME"]}"
-    @logger.info "ENV[CNI_ARGS] #{ENV["CNI_ARGS"]}"
-    @logger.info "ENV[CNI_PATH] #{ENV["CNI_PATH"]}"
-    @logger.info "-------------------------------------------------------"
-
+    log_environment
     output = case @cni_command
     when "ADD" then handle_add
     when "DEL" then handle_del
@@ -47,6 +39,19 @@ class UbiCNI
     else error_exit("Unsupported CNI command: #{@cni_command}")
     end
     puts output
+  end
+
+  def log_environment
+    @logger.info <<~LOG
+      -------------------------------------------------------
+      Handling new command: #{@cni_command}
+      ENV[CNI_CONTAINERID] #{ENV["CNI_CONTAINERID"]}
+      ENV[CNI_NETNS] #{ENV["CNI_NETNS"]}
+      ENV[CNI_IFNAME] #{ENV["CNI_IFNAME"]}
+      ENV[CNI_ARGS] #{ENV["CNI_ARGS"]}
+      ENV[CNI_PATH] #{ENV["CNI_PATH"]}
+      -------------------------------------------------------
+    LOG
   end
 
   def handle_add

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -56,6 +56,8 @@ class UbiCNI
 
   def handle_add
     check_required_env_vars(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
+    validate_input_ranges
+
     subnet_ula_ipv6 = @input_data["ranges"]["subnet_ula_ipv6"]
     subnet_ipv6 = @input_data["ranges"]["subnet_ipv6"]
     subnet_ipv4 = @input_data["ranges"]["subnet_ipv4"]
@@ -282,6 +284,12 @@ options ndots:5
   def check_required_env_vars(vars)
     vars.each do |var|
       error_exit("Missing required environment variable: #{var}") unless ENV[var]
+    end
+  end
+
+  def validate_input_ranges
+    unless @input_data["ranges"]&.values_at("subnet_ula_ipv6", "subnet_ipv6", "subnet_ipv4")&.all?
+      error_exit("Missing required ranges in input data")
     end
   end
 end

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -76,6 +76,7 @@ class UbiCNI
     @logger.info "Configuring DNS for network namespace #{cni_netns}"
     setup_dns(cni_netns)
 
+    @logger.info "Setting up veth pair for container #{container_id}"
     r "ip link add #{outer_ifname} addr #{outer_mac} type veth peer name #{inner_ifname} addr #{inner_mac} netns #{cni_netns}"
 
     container_ipv6 = setup_ipv6(subnet_ipv6, inner_link_local, outer_link_local, cni_netns, inner_ifname, outer_ifname, setup_default_route: true)

--- a/rhizome/kubernetes/spec/ubi_cni_spec.rb
+++ b/rhizome/kubernetes/spec/ubi_cni_spec.rb
@@ -144,7 +144,6 @@ RSpec.describe UbiCNI do
       allow(File).to receive(:read).with("/opt/cni/bin/ubicni-ipam-store").and_return("{}")
       allow(File).to receive(:exist?).with("/opt/cni/bin/ubicni-ipam-store").and_return(true)
       allow(File).to receive(:exist?).with("/etc/netns/test-ns/resolv.conf").and_return(true)
-      allow(File).to receive(:readlines).and_return(["nameserver 8.8.8.8", "search local"])
       allow(ubicni).to receive(:r).and_return("link/ether 00:11:22:33:44:55", "inet6 fd00::1/64")
     end
 
@@ -165,7 +164,7 @@ RSpec.describe UbiCNI do
 
       dns_config_path = "/etc/netns/test-ns/resolv.conf"
       allow(File).to receive(:exist?).with(dns_config_path).and_return(true)
-      allow(File).to receive(:readlines).with(dns_config_path).and_return([
+      allow(File).to receive(:readlines).with(dns_config_path, chomp: true).and_return([
         "nameserver 10.96.0.10\n",
         "search default.svc.cluster.local svc.cluster.local cluster.local\n",
         "options ndots:5\n"

--- a/rhizome/kubernetes/spec/ubi_cni_spec.rb
+++ b/rhizome/kubernetes/spec/ubi_cni_spec.rb
@@ -294,4 +294,73 @@ RSpec.describe UbiCNI do
       ubicni.check_required_env_vars(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
     end
   end
+
+  describe "#validate_input_ranges" do
+    context "when all required ranges are present" do
+      subject(:ubicni) { described_class.new(input, logger) }
+
+      let(:input) do
+        {
+          "ranges" => {
+            "subnet_ula_ipv6" => "fd00::/64",
+            "subnet_ipv6" => "2001:db8::/64",
+            "subnet_ipv4" => "192.168.1.0/24"
+          }
+        }
+      end
+
+      it "does not call error_exit" do
+        expect(ubicni).not_to receive(:error_exit)
+        ubicni.validate_input_ranges
+      end
+    end
+
+    context "when 'ranges' key is missing" do
+      subject(:ubicni) { described_class.new(input, logger) }
+
+      let(:input) { {} }
+
+      it "calls error_exit with the appropriate message" do
+        expect(ubicni).to receive(:error_exit).with("Missing required ranges in input data")
+        ubicni.validate_input_ranges
+      end
+    end
+
+    context "when one of the required ranges is missing" do
+      subject(:ubicni) { described_class.new(input, logger) }
+
+      let(:input) do
+        {
+          "ranges" => {
+            "subnet_ula_ipv6" => "fd00::/64",
+            "subnet_ipv4" => "192.168.1.0/24"
+          }
+        }
+      end
+
+      it "calls error_exit with the appropriate message" do
+        expect(ubicni).to receive(:error_exit).with("Missing required ranges in input data")
+        ubicni.validate_input_ranges
+      end
+    end
+
+    context "when one of the required ranges is nil" do
+      subject(:ubicni) { described_class.new(input, logger) }
+
+      let(:input) do
+        {
+          "ranges" => {
+            "subnet_ula_ipv6" => "fd00::/64",
+            "subnet_ipv6" => nil,
+            "subnet_ipv4" => "192.168.1.0/24"
+          }
+        }
+      end
+
+      it "calls error_exit with the appropriate message" do
+        expect(ubicni).to receive(:error_exit).with("Missing required ranges in input data")
+        ubicni.validate_input_ranges
+      end
+    end
+  end
 end

--- a/rhizome/kubernetes/spec/ubi_cni_spec.rb
+++ b/rhizome/kubernetes/spec/ubi_cni_spec.rb
@@ -267,4 +267,31 @@ RSpec.describe UbiCNI do
       expect(ubicni.calculate_subnet_size(subnet)).to eq(2**64)
     end
   end
+
+  describe "#check_required_env_vars" do
+    it "does not call error_exit when all required variables are set" do
+      allow(ENV).to receive(:[]).with("CNI_CONTAINERID").and_return("some_value")
+      allow(ENV).to receive(:[]).with("CNI_NETNS").and_return("some_value")
+      allow(ENV).to receive(:[]).with("CNI_IFNAME").and_return("some_value")
+      expect(ubicni).not_to receive(:error_exit)
+      ubicni.check_required_env_vars(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
+    end
+
+    it "calls error_exit when a required variable is missing" do
+      allow(ENV).to receive(:[]).with("CNI_CONTAINERID").and_return("some_value")
+      allow(ENV).to receive(:[]).with("CNI_NETNS").and_return(nil)
+      allow(ENV).to receive(:[]).with("CNI_IFNAME").and_return("some_value")
+      expect(ubicni).to receive(:error_exit).with("Missing required environment variable: CNI_NETNS")
+      ubicni.check_required_env_vars(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
+    end
+
+    it "calls error_exit for each missing variable" do
+      allow(ENV).to receive(:[]).with("CNI_CONTAINERID").and_return(nil)
+      allow(ENV).to receive(:[]).with("CNI_NETNS").and_return(nil)
+      allow(ENV).to receive(:[]).with("CNI_IFNAME").and_return("some_value")
+      expect(ubicni).to receive(:error_exit).with("Missing required environment variable: CNI_CONTAINERID")
+      expect(ubicni).to receive(:error_exit).with("Missing required environment variable: CNI_NETNS")
+      ubicni.check_required_env_vars(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
+    end
+  end
 end


### PR DESCRIPTION
When a pod is created, kubelet will call the CRI to setup the container and its networking and CRI might call the CNI in parallel multiple times.

The code in CNI had no locking mechanism for saving/reading the file and as a result, we could see some inconsistencies across cni datastore file.

This commit fixes the issue by adding locks to the files.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes race condition in CNI datastore by adding file locking and refactoring `UbiCNI` class for safer file operations.
> 
>   - **Behavior**:
>     - Adds file locking to `allocate_ips_for_pod` and `handle_del` in `ubi_cni.rb` to prevent race conditions when accessing the IPAM store.
>     - Refactors `handle_add` and `handle_del` to use `safe_write_to_file` for atomic file operations.
>     - Introduces `check_required_env_vars` and `validate_input_ranges` for input validation.
>   - **Refactoring**:
>     - Extracts logging logic to `log_environment`.
>     - Moves DNS setup to `setup_dns`.
>     - Refactors IP allocation logic into `allocate_ips_for_pod`.
>   - **Testing**:
>     - Updates `ubi_cni_spec.rb` to test new locking behavior and refactored methods.
>     - Adds tests for `check_required_env_vars` and `validate_input_ranges`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2f9747bb368acfd5437ddd151f27a0ba72945594. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->