### PR TITLE
Postgres Read Replicas

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -60,7 +60,11 @@ class Clover
       }
     else
       dataset = dataset.eager(:representative_server, :timeline)
-      @postgres_databases = Serializers::Postgres.serialize(dataset.all, {include_path: true})
+      resources = dataset.all
+        .group_by { |r| r.read_replica? ? r[:parent_id] : r[:id] }
+        .flat_map { |group_id, rs| rs.sort_by { |r| r[:created_at] } }
+
+      @postgres_databases = Serializers::Postgres.serialize(resources, {include_path: true})
       view "postgres/index"
     end
   end

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -14,6 +14,7 @@ class PostgresResource < Sequel::Model
   one_to_many :metric_destinations, class: :PostgresMetricDestination, key: :postgres_resource_id
   many_to_one :private_subnet
   many_to_one :location, key: :location_id, class: :Location
+  one_to_many :read_replicas, class: :PostgresResource, key: :parent_id, conditions: {restore_target: nil}
 
   plugin :association_dependencies, firewall_rules: :destroy, metric_destinations: :destroy
   dataset_module Pagination
@@ -121,6 +122,10 @@ class PostgresResource < Sequel::Model
   def validate
     super
     validates_includes(0..23, :maintenance_window_start_at, allow_nil: true, message: "must be between 0 and 23")
+  end
+
+  def read_replica?
+    parent_id && restore_target.nil?
   end
 
   module HaType

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -897,6 +897,33 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Metric Destination
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/read-replica':
+    post:
+      operationId: createPostgresDatabaseReadReplica
+      summary: Create a read replica of the Postgres database
+      parameters:
+        - $ref: '#/components/parameters/project_id'
+        - $ref: '#/components/parameters/location'
+        - $ref: '#/components/parameters/postgres_database_reference'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              additionalProperties: false
+              required:
+                - name
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/reset-superuser-password':
     post:
       operationId: resetSuperuserPassword
@@ -1722,6 +1749,13 @@ components:
           description: Maintenance window start time
           type: integer
           nullable: true
+        read_replica:
+          description: If the database is a read replica or not
+          type: boolean
+        parent:
+          description: Parent Postgres database
+          type: string
+          nullable: true
       additionalProperties: false
       required:
         - flavor
@@ -1734,6 +1768,7 @@ components:
         - version
         - vm_size
         - maintenance_window_start_at
+        - read_replica
     PostgresFirewallRule:
       type: object
       properties:

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -48,10 +48,15 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
           target_storage_size_gib = Validation.validate_postgres_storage_size(location, target_vm_size, target_storage_size_gib, project_id)
         end
 
-        restore_target = Validation.validate_date(restore_target, "restore_target")
-        unless (earliest_restore_time = parent.timeline.earliest_restore_time) && earliest_restore_time <= restore_target &&
-            parent.timeline.latest_restore_time && restore_target <= parent.timeline.latest_restore_time
-          fail Validation::ValidationFailed.new({restore_target: "Restore target must be between #{earliest_restore_time} and #{parent.timeline.latest_restore_time}"})
+        if restore_target
+          restore_target = Validation.validate_date(restore_target, "restore_target")
+          earliest_restore_time = parent.timeline.earliest_restore_time
+          latest_restore_time = parent.timeline.latest_restore_time
+
+          unless earliest_restore_time && earliest_restore_time <= restore_target &&
+              latest_restore_time && restore_target <= latest_restore_time
+            fail Validation::ValidationFailed.new({restore_target: "Restore target must be between #{earliest_restore_time} and #{latest_restore_time}"})
+          end
         end
         [parent.superuser_password, parent.timeline.id, "fetch", parent.version]
       end

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -13,7 +13,9 @@ class Serializers::Postgres < Serializers::Base
       ha_type: pg.ha_type,
       flavor: pg.flavor,
       ca_certificates: pg.ca_certificates,
-      maintenance_window_start_at: pg.maintenance_window_start_at
+      maintenance_window_start_at: pg.maintenance_window_start_at,
+      read_replica: !!pg.read_replica?,
+      parent: pg.parent&.path
     }
 
     if options[:include_path]
@@ -25,7 +27,8 @@ class Serializers::Postgres < Serializers::Base
         connection_string: pg.connection_string,
         primary: pg.representative_server&.primary?,
         firewall_rules: Serializers::PostgresFirewallRule.serialize(pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }),
-        metric_destinations: pg.metric_destinations.map { {id: _1.ubid, username: _1.username, url: _1.url} }
+        metric_destinations: pg.metric_destinations.map { {id: _1.ubid, username: _1.username, url: _1.url} },
+        read_replicas: Serializers::Postgres.serialize(pg.read_replicas, {include_path: true})
       )
 
       if pg.timeline && pg.representative_server&.primary?

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Clover, "postgres" do
         [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}"],
         [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"],
         [:get, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}"],
+        [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/read-replica"],
         [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule"],
         [:delete, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/foo_ubid"],
         [:post, "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore"],
@@ -195,6 +196,17 @@ RSpec.describe Clover, "postgres" do
 
         expect(pg.reload.target_storage_size_gib).to eq(128)
         expect(last_response).to have_api_error(400, "Database is not ready for update")
+      end
+
+      it "read-replica" do
+        expect(Project).to receive(:from_ubid).and_return(project)
+        expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
+
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/#{pg.name}/read-replica", {
+          name: "my-read-replica"
+        }.to_json
+
+        expect(last_response.status).to eq(200)
       end
 
       it "firewall-rule" do

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -35,12 +35,16 @@
   <div class="grid gap-6">
     <%== part(
       "components/table_card",
-      headers: ["Name", "Managed by", "Location", "State"],
+      headers: ["Name", "Compute", "Storage", "Version", "Parent", "Managed by", "Location", "State"],
       rows: @postgres_databases.map do |pg|
         brand, = flavors[pg[:flavor]]
         [
           [
             [pg[:name], {link: @project_data[:path] + pg[:path]}],
+            [pg[:vm_size]],
+            [pg[:storage_size_gib]],
+            [pg[:version]],
+            [pg[:parent] ? pg[:parent].split("/").last : "", {link: pg[:parent] ? @project_data[:path] + pg[:parent] : ""}],
             ["<div class='inline-flex gap-x-1 items-center'><img src='/icons/pg-#{brand.downcase}.png' class='object-cover rounded-lg overflow-hidden w-6 h-6'/><p>#{brand}</p></div>", {escape: false}],
             pg[:location],
             ["pg_state_label", {component: { state: pg[:state] }}]

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -24,13 +24,13 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
     ["Version", "Postgres #{@pg[:version]}"],
     ["High Availability", PG_HA_DATA[@pg[:ha_type]]]
   ]
-  
+
   if @pg[:connection_string]
     data.push(["Connection String", @pg[:connection_string], { copyable: true, revealable: true }])
   else
     data.push(["Connection String", "Waiting for host to be ready..."])
   end
-  
+
   if @pg[:ca_certificates]
     data.push(
       ["CA Certificates", part("components/download_button", link: "#{request.path}/ca-certificates"), { escape: false }]
@@ -108,100 +108,170 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
       </div>
     <% end %>
   </div>
-  <!-- Update target state of the database resource -->
-  <% form_elements = [
-    {
-      name: "family",
-      type: "radio_small_cards",
-      label: "Server family",
-      required: "required",
-      content_generator: ContentGenerator::Postgres.method(:family)
-    },
-    {
-      name: "size",
-      type: "radio_small_cards",
-      label: "Server size",
-      required: "required",
-      content_generator: ContentGenerator::Postgres.method(:size)
-    },
-    {
-      name: "storage_size",
-      type: "radio_small_cards",
-      label: "Storage size",
-      required: "required",
-      content_generator: ContentGenerator::Postgres.method(:storage_size)
-    },
-    {
-      name: "ha_type",
-      type: "radio_small_cards",
-      label: "High Availability",
-      required: "required",
-      content_generator: ContentGenerator::Postgres.method(:ha_type)
-    },
-    {
-      name: "failover_time_notice",
-      type: "section",
-      content:
-        "If a maintenance window is configured, failover to the new server with the desired configuration will occur during the first available maintenance window after the new server is ready. Otherwise, failover will take place as soon as the new server becomes ready. Depending on the size of the data, it may take several hours for the new server to become ready.",
-      separator: false
-    }
-  ]
-  
-  pre_selected_values = {
-    "flavor" => @pg[:flavor],
-    "location" => @location.id,
-    "family" => @family,
-    "size" => @pg[:vm_size],
-    "storage_size" => @pg[:storage_size_gib],
-    "ha_type" => @pg[:ha_type]
-  } %>
+  <% if !@pg[:read_replica] %>
+    <!-- Update target state of the database resource -->
+    <% form_elements = [
+      {
+        name: "family",
+        type: "radio_small_cards",
+        label: "Server family",
+        required: "required",
+        content_generator: ContentGenerator::Postgres.method(:family)
+      },
+      {
+        name: "size",
+        type: "radio_small_cards",
+        label: "Server size",
+        required: "required",
+        content_generator: ContentGenerator::Postgres.method(:size)
+      },
+      {
+        name: "storage_size",
+        type: "radio_small_cards",
+        label: "Storage size",
+        required: "required",
+        content_generator: ContentGenerator::Postgres.method(:storage_size)
+      },
+      {
+        name: "ha_type",
+        type: "radio_small_cards",
+        label: "High Availability",
+        required: "required",
+        content_generator: ContentGenerator::Postgres.method(:ha_type)
+      },
+      {
+        name: "failover_time_notice",
+        type: "section",
+        content:
+          "If a maintenance window is configured, failover to the new server with the desired configuration will occur during the first available maintenance window after the new server is ready. Otherwise, failover will take place as soon as the new server becomes ready. Depending on the size of the data, it may take several hours for the new server to become ready.",
+        separator: false
+      }
+    ]
 
-  <%== render(
-    "components/form/resource_creation_form",
-    locals: {
-      action: "#{@project_data[:path]}#{@pg[:path]}",
-      method: "PATCH",
-      form_title: "Configure PostgreSQL database",
-      form_elements:,
-      pre_selected_values:,
-      option_tree: @option_tree,
-      option_parents: @option_parents,
-      mode: "update"
-    }
-  ) %>
-  <!-- Fork database -->
-  <% if @pg[:earliest_restore_time] && @pg[:latest_restore_time] > @pg[:earliest_restore_time] %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-      <div class="px-4 py-5 sm:p-6">
-        <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restore" %>" role="form" method="POST">
-          <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restore") %>
-          <div class="space-y-4">
-            <div>
-              <h2 class="text-lg font-medium leading-6 text-gray-900">Fork PostgreSQL database</h2>
-              <p class="mt-1 text-sm text-gray-500">
-                When you fork your existing PostgreSQL database, a new server will be provisioned.
-              </p>
+    pre_selected_values = {
+      "flavor" => @pg[:flavor],
+      "location" => @location.id,
+      "family" => @family,
+      "size" => @pg[:vm_size],
+      "storage_size" => @pg[:storage_size_gib],
+      "ha_type" => @pg[:ha_type]
+    } %>
+
+    <%== render(
+      "components/form/resource_creation_form",
+      locals: {
+        action: "#{@project_data[:path]}#{@pg[:path]}",
+        method: "PATCH",
+        form_title: "Configure PostgreSQL database",
+        form_elements:,
+        pre_selected_values:,
+        option_tree: @option_tree,
+        option_parents: @option_parents,
+        mode: "update"
+      }
+    ) %>
+    <!-- Fork database -->
+    <% if @pg[:earliest_restore_time] && @pg[:latest_restore_time] > @pg[:earliest_restore_time] %>
+      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+        <div class="px-4 py-5 sm:p-6">
+          <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/restore" %>" role="form" method="POST">
+            <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/restore") %>
+            <div class="space-y-4">
+              <div>
+                <h2 class="text-lg font-medium leading-6 text-gray-900">Fork PostgreSQL database</h2>
+                <p class="mt-1 text-sm text-gray-500">
+                  When you fork your existing PostgreSQL database, a new server will be provisioned.
+                </p>
+              </div>
+              <div class="grid grid-cols-12 gap-6">
+                <div class="col-span-12 sm:col-span-5">
+                  <%== part(
+                    "components/form/text",
+                    label: "New server name",
+                    name: "name",
+                    attributes: {
+                      placeholder: @pg[:name] + "-fork",
+                      required: true
+                    }
+                  ) %>
+                </div>
+                <div class="col-span-12 sm:col-span-5">
+                  <%== part(
+                    "components/form/datepicker",
+                    label: "Target Time (UTC)",
+                    name: "restore_target",
+                    default_date: @pg[:latest_restore_time],
+                    max_date: @pg[:latest_restore_time],
+                    min_date: @pg[:earliest_restore_time]
+                  ) %>
+                </div>
+                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                  <%== part("components/form/submit_button", text: "Fork") %>
+                </div>
+              </div>
             </div>
-            <div class="grid grid-cols-12 gap-6">
-              <div class="col-span-12 sm:col-span-5">
-                <%== part("components/form/text", label: "New server name", name: "name", attributes: { required: true }) %>
-              </div>
-              <div class="col-span-12 sm:col-span-5">
-                <%== part(
-                  "components/form/datepicker",
-                  label: "Target Time (UTC)",
-                  name: "restore_target",
-                  default_date: @pg[:latest_restore_time],
-                  max_date: @pg[:latest_restore_time],
-                  min_date: @pg[:earliest_restore_time]
-                ) %>
-              </div>
-              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                <%== part("components/form/submit_button", text: "Fork") %>
-              </div>
-            </div>
-          </div>
-        </form>
+          </form>
+        </div>
+      </div>
+    <% end %>
+    <!-- Read Replicas -->
+    <div>
+      <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+        <div class="min-w-0 flex-1">
+          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+            Read Replicas
+          </h3>
+        </div>
+      </div>
+      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+        <table class="min-w-full divide-y divide-gray-300">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% @pg[:read_replicas].each do |read_replica| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  <a href="<%= @project_data[:path] + read_replica[:path] %>" class="text-orange-600 hover:text-orange-700">
+                    <%= read_replica[:name] %>
+                  </a>
+                </td>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  <%== part("components/pg_state_label", state: read_replica[:state], extra_class: "text-md") %>
+                </td>
+              </tr>
+            <% end %>
+            <% if edit_perm %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  <%== part(
+                    "components/form/text",
+                    name: "name",
+                    attributes: {
+                      placeholder: @pg[:name] + "-read-replica",
+                      required: true,
+                      form: "form-pg-read-replica-create"
+                    }
+                  ) %>
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <form
+                    action="<%= "#{@project_data[:path]}#{@pg[:path]}/read-replica" %>"
+                    role="form"
+                    method="POST"
+                    id="form-pg-read-replica-create"
+                  >
+                    <%== csrf_tag("#{request.path}/read-replica") %>
+                    <%== part("components/form/submit_button", text: "Create", extra_class: "pg-read-replica-create-btn") %>
+                  </form>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
## Postgres backend support to provision read replicas
We start supporting read replica provisioning at the backend. Basically,
we need to pass a parent_id and nil restore target to
PostgresResourceNexus.assemble. It handles the pg configuration and
setting up the replication.

## Read replica lag detection and server recycling
Even if we setup replication, it is possible that the replication would
fail and we might need to recycle the server. To detect that, we are
continuously checking the lag between a read replica and its parent. If
the applied wal difference is greater than 80 MB and the replica does
not apply new wal files in the upcoming 15 minutes, we decide to recycle
the server.
We also implement the read replica failover mechanism in this commit
which is essentially refreshing dns records marking the new server as
the representative.

## Postgres read replicas web and API support
With this commit, read replicas are available in the UI. We can
provision a read replica basically by entering a name and clicking to
the create button. We are not allowing customers to pick different spec
for read replicas because it opens up a bunch of options for scale
operations.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for PostgreSQL read replicas, including provisioning, lag detection, failover, and UI/API integration.
> 
>   - **Behavior**:
>     - Add support for PostgreSQL read replicas in `postgres_resource.rb` and `postgres_server.rb`.
>     - Implement read replica lag detection and recycling in `postgres_server.rb` and `postgres_server_nexus.rb`.
>     - Add read replica failover mechanism in `postgres_server.rb`.
>   - **API**:
>     - Add `createPostgresDatabaseReadReplica` endpoint in `openapi.yml`.
>     - Update `routes/project/location/postgres.rb` to handle read replica creation.
>   - **UI**:
>     - Update `views/postgres/index.erb` and `views/postgres/show.erb` to display read replicas.
>   - **Tests**:
>     - Add tests for read replica functionality in `postgres_server_spec.rb` and `postgres_server_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e29fb8a2afbac74662ece5cbef1ec8feda72ec8c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->