### PR TITLE
Handle Faraday::ConnectionFailed exceptions raised by workflow_run_jobs

### DIFF
--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -21,7 +21,7 @@ class Clover < Roda
     begin
       client = Github.installation_client(runner.installation.installation_id)
       jobs = client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
-    rescue Octokit::ClientError, Octokit::ServerError => ex
+    rescue Octokit::ClientError, Octokit::ServerError, Faraday::ConnectionFailed => ex
       log_context[:expection] = Util.exception_to_hash(ex)
       Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }
       return


### PR DESCRIPTION
Seems reasonable to treat this exception type similar to the Octokit exceptions already rescued.  This addresses a couple of unhandled production exceptions we had this week.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Faraday::ConnectionFailed` to rescued exceptions in `get_scope_from_github` in `helpers/runtime.rb`.
> 
>   - **Exception Handling**:
>     - In `helpers/runtime.rb`, `get_scope_from_github` now rescues `Faraday::ConnectionFailed` in addition to `Octokit::ClientError` and `Octokit::ServerError`.
>     - This change addresses unhandled production exceptions related to connection failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f9f4b83ea9bea66d81fbe5edbfaeaceb93cc6996. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->