### PR TITLE
Rewrite first part of DEVELOPERS.md to use mise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 # CLI binary
 /cli/ubi
 /cli/ubi-*
+
+# mise "local" dependency specification that shouldn't be committed
+mise.local.toml

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -600,7 +600,7 @@ $ rake linter:erb_formatter
 
 ### Cloudifying a Host for Development
 
-We show cloudifying a host from Hetzner, but the principles should work everywhere. Make sure that the Hetzner instance has at least one `One additional subnet /29` ordered and `Ubuntu 22.04 LTS base` is installed.
+We show cloudifying a host from Hetzner, but the principles should work everywhere. Make sure that the Hetzner instance has at least one `One additional subnet /29` ordered and `Ubuntu 24.04 LTS base` is installed.
 
 1. Set the environment variables in `.env.rb`;
     ```ruby

--- a/mise.local.toml.template
+++ b/mise.local.toml.template
@@ -1,0 +1,2 @@
+[tools]
+postgres = "15.8"


### PR DESCRIPTION

Note: We should delete `.envrc` after a transition period. If `asdf`
is uninstalled but `direnv` remains active, it will complain that `use
asdf` doesn't work. This emits an annoying message, but has no other
harmful effects.

Motivation for this rewrite:

`asdf-direnv` has not been updated for the Go-rewritten version of
`asdf`. This creates problems for anyone following these
instructions. I originally used `asdf-direnv` because some programs
(if memory serves, the `pq` gem compilation running `pg_config`) don't
work when shimmed. I also preferred the speed of `$PATH` manipulation
over using shim programs.

The author of `asdf-direnv` stopped maintaining it months ago, since
`mise` offers a similar model to `asdf` but is based on `$PATH` rather
than shims. As a result, he switched to `mise`, and now so are we.

There are generally fewer steps when using `mise`, but I made
`DEVELOPERS.md` a bit longer to include shell activation instructions
and system dependencies, so the instructions have grown slightly
overall. Hopefully, this will speed up the process, since it is less
necessary to visit other manual pages.

Another major difference is that `mise install` tries to download and
install *every* dependency, so it’s necessary to set up system
dependencies first. This required some reordering and restructuring.

Finally, while it was theoretically possible to manage Postgres by
other means, having it in `.tool-versions` made this awkward and often
painful in practice—even though the previous manual implied it should
be easy. This has now been changed to use the `mise.local.toml`
feature as an opt-in.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Rewrites `DEVELOPERS.md` to use `mise` for software version management, adding detailed setup instructions and a `mise.local.toml.template` for Postgres.
> 
>   - **Behavior**:
>     - Rewrites `DEVELOPERS.md` to replace `asdf` with `mise` for managing software versions.
>     - Adds detailed instructions for installing and setting up `mise`, including shell integration and autocompletion.
>     - Introduces `mise.local.toml.template` for Postgres configuration.
>   - **Installation**:
>     - Provides system dependency installation instructions for Ruby and Postgres on macOS and Ubuntu.
>     - Describes `mise install` process to install all required dependencies.
>   - **Environment**:
>     - Details how to check `mise`-set environment variables using `mise env`.
>     - Explains how to manage Postgres with `mise` and the use of `mise.local.toml`.
>   - **Misc**:
>     - Updates Postgres setup instructions to use `mise` instead of `asdf`.
>     - Updates Node.js installation and verification steps to reflect `mise` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 76dd8715fffee7f9dfd31c3d66f8bdfec798137c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->