### PR TITLE
Remove handle_get command from CNI and reorder ipv6 ips in handle_add response

### DIFF
--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -85,8 +85,8 @@ class UbiCNI
       interfaces: [{name: inner_ifname, mac: inner_mac, sandbox: "/var/run/netns/#{cni_netns}"}],
       ips: [
         {address: "#{ipv4_container_ip}/#{ipv4_container_ip.prefix}", gateway: ipv4_gateway_ip.to_s, interface: 0},
-        {address: "#{container_ula_ipv6}/#{container_ula_ipv6.prefix}", gateway: outer_link_local, interface: 0},
-        {address: "#{container_ipv6}/#{container_ipv6.prefix}", gateway: outer_link_local, interface: 0}
+        {address: "#{container_ipv6}/#{container_ipv6.prefix}", gateway: outer_link_local, interface: 0},
+        {address: "#{container_ula_ipv6}/#{container_ula_ipv6.prefix}", gateway: outer_link_local, interface: 0}
       ],
       routes: [{dst: "0.0.0.0/0"}],
       dns: {

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -22,7 +22,6 @@ class UbiCNI
     output = case @cni_command
     when "ADD" then handle_add
     when "DEL" then handle_del
-    when "GET" then handle_get
     else error_exit("Unsupported CNI command: #{@cni_command}")
     end
     puts output
@@ -185,34 +184,6 @@ options ndots:5
     "{}"
   end
 
-  def handle_get
-    check_required_env_vars(["CNI_NETNS", "CNI_IFNAME"])
-    cni_netns = ENV["CNI_NETNS"].sub("/var/run/netns/", "")
-    inner_ifname = ENV["CNI_IFNAME"]
-
-    @logger.info "Retrieving configuration for interface #{inner_ifname} in namespace #{cni_netns}"
-    inner_mac = r("ip -n #{cni_netns} link show #{inner_ifname}").match(/link\/ether ([0-9a-f:]+)/)[1]
-    container_ip = r("ip -n #{cni_netns} -6 addr show dev #{inner_ifname}").match(/inet6 ([0-9a-f:\/]+)/)[1]
-
-    dns_config_path = "/etc/netns/#{cni_netns}/resolv.conf"
-    dns_servers = []
-    search_domains = []
-    if File.exist?(dns_config_path)
-      File.readlines(dns_config_path, chomp: true).each do |line|
-        dns_servers << line.split[1] if line.start_with?("nameserver")
-        search_domains = line.split.drop(1) if line.start_with?("search")
-      end
-    end
-
-    response = {
-      cniVersion: "1.0.0",
-      interfaces: [{name: inner_ifname, mac: inner_mac, sandbox: "/var/run/netns/#{cni_netns}"}],
-      ips: [{address: container_ip, gateway: nil, interface: 0}],
-      dns: {nameservers: dns_servers, search: search_domains, options: ["ndots:5"]}
-    }
-
-    JSON.generate(response)
-  end
 
   def error_exit(message)
     @logger.error message


### PR DESCRIPTION
Return the GUA ip ealier than ULA ip in CNI

In order to see the GUA ipv6 ip in pod's yaml status, we will return the GUA ip sooner than ULA since kubelet will store the first ipv6 as the pods ip and GUA ip is more usable to the customers

Remove handle_get function in CNI

This function is not called at all by kubelet or CRI and is only used by some cni tools. This commit removes the implementation and its tests.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reorder IPv6 addresses in CNI response to prioritize GUA over ULA and remove unused `handle_get` function.
> 
>   - **Behavior**:
>     - Reorder IPv6 addresses in `build_add_response` in `ubi_cni.rb` to return GUA before ULA.
>     - Remove `handle_get` function from `ubi_cni.rb` as it is unused by kubelet or CRI.
>   - **Tests**:
>     - Remove tests for `handle_get` in `ubi_cni_spec.rb`.
>     - Update `run` tests in `ubi_cni_spec.rb` to reflect removal of `handle_get`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3cbcc40903b5f8b9a8dd46d5b6c98b81a40aa1f5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->