### PR TITLE
Postgres Read Replica promote feature

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -23,7 +23,7 @@ class PostgresResource < Sequel::Model
   include SemaphoreMethods
   include ObjectTag::Cleanup
 
-  semaphore :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy
+  semaphore :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy, :promote
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -17,7 +17,7 @@ class PostgresServer < Sequel::Model
   include HealthMonitorMethods
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
-  semaphore :restart, :configure, :take_over, :configure_prometheus, :destroy, :recycle
+  semaphore :restart, :configure, :take_over, :configure_prometheus, :destroy, :recycle, :promote
 
   def configure_hash
     configs = {

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -897,6 +897,21 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Metric Destination
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/promote':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_reference'
+    post:
+      operationId: promotePostgresDatabase
+      summary: Promote a specific Postgres Read Replica Database
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/read-replica':
     post:
       operationId: createPostgresDatabaseReadReplica

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -221,6 +221,14 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       postgres_resource.set_firewall_rules
     end
 
+    when_promote_set? do
+      if postgres_resource.read_replica?
+        postgres_resource.servers.each(&:incr_promote)
+        postgres_resource.update(parent_id: nil)
+      end
+      decr_promote
+    end
+
     nap 30
   end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -364,6 +364,22 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(postgres_resource).to receive(:set_firewall_rules)
       expect { nx.wait }.to nap(30)
     end
+
+    it "if read_replica and promote is set, promotes and naps" do
+      expect(nx).to receive(:when_promote_set?).and_yield
+      expect(postgres_resource).to receive(:read_replica?).and_return(true)
+      expect(postgres_resource).to receive(:servers).and_return([])
+      expect(postgres_resource).to receive(:update).with(parent_id: nil)
+      expect(nx).to receive(:decr_promote)
+      expect { nx.wait }.to nap(30)
+    end
+
+    it "if not read_replica and promote is set, just naps" do
+      expect(nx).to receive(:when_promote_set?).and_yield
+      expect(postgres_resource).to receive(:read_replica?).and_return(false)
+      expect(nx).to receive(:decr_promote)
+      expect { nx.wait }.to nap(30)
+    end
   end
 
   describe "#destroy" do

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -455,6 +455,27 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
         </div>
       </div>
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+        <% if @pg[:read_replica] %>
+          <div class="px-4 py-5 sm:p-6">
+            <form action="<%= "#{@project_data[:path]}#{@pg[:path]}/promote" %>" role="form" method="POST">
+              <%== csrf_tag("#{@project_data[:path]}#{@pg[:path]}/promote") %>
+              <div class="sm:flex sm:items-center sm:justify-between">
+                <div>
+                  <h3 class="text-base font-semibold leading-6 text-gray-900">Promote PostgreSQL read replica database</h3>
+                  <div class="mt-2 text-sm text-gray-500">
+                    <p>This action will promote and restart the PostgreSQL database. The database will stop replicating
+                      permanently. It will be offline momentarily, and all connections will be dropped.</p>
+                  </div>
+                </div>
+                <div id="postgres-replica-promote-<%=@pg[:id]%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                  <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                    <%== part("components/form/submit_button", text: "Promote", extra_class: "promote-btn") %>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        <% end %>
         <!-- Reset password -->
         <% if @pg[:primary] %>
           <div class="px-4 py-5 sm:p-6">


### PR DESCRIPTION
## Postgres Read Replica promote feature
This simply adds both the backend and UI components to promote a read
replica. We make use of the existing take_over code path.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add feature to promote Postgres read replicas to primary databases, including backend logic, API routes, UI components, and tests.
> 
>   - **Behavior**:
>     - Adds `promote` semaphore to `PostgresResource` and `PostgresServer` classes.
>     - Implements promotion logic in `prog/postgres/postgres_resource_nexus.rb` and `prog/postgres/postgres_server_nexus.rb`.
>     - Updates `openapi.yml` to include `/promote` endpoint for promoting a read replica.
>   - **Routes**:
>     - Adds POST `/promote` route in `routes/project/location/postgres.rb` to handle promotion requests.
>     - Validates that only read replicas can be promoted.
>   - **UI**:
>     - Updates `views/postgres/show.erb` to include a "Promote" button for read replicas.
>     - Displays a message indicating the promotion process has started.
>   - **Tests**:
>     - Adds tests in `spec/prog/postgres/postgres_resource_nexus_spec.rb` and `spec/prog/postgres/postgres_server_nexus_spec.rb` for promotion logic.
>     - Adds API tests in `spec/routes/api/project/location/postgres_spec.rb` for the promote endpoint.
>     - Adds web tests in `spec/routes/web/project/postgres_spec.rb` for UI interactions related to promotion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8140d884ae3b03939bbd74402ff06af193c10d3f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->