### PR TITLE
Handle display_state generation during resource deletion

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -40,10 +40,10 @@ class PostgresResource < Sequel::Model
   end
 
   def display_state
+    return "deleting" if destroy_set? || strand.nil? || strand.label == "destroy"
     return "unavailable" if representative_server&.strand&.label == "unavailable"
     return "converging" if strand.children.any? { _1.prog == "Postgres::ConvergePostgresResource" }
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
-    return "deleting" if destroy_set? || strand.label == "destroy"
     "creating"
   end
 


### PR DESCRIPTION
During the resource deletion, it is possible to have a short time where the strand is nil, which causes the display_state to throw and exception. This commits fixes that by moving delete state check to the beginning. It also refactors the display_state tests, because over the time display state got move complex and testing all possible display_state outputs using a single test is not very feasible anymore.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `display_state` in `PostgresResource` to handle `nil` strand and refactor tests for clarity.
> 
>   - **Behavior**:
>     - Fix `display_state` in `postgres_resource.rb` to handle `nil` strand by checking for deletion state first.
>   - **Tests**:
>     - Refactor `display_state` tests in `postgres_resource_spec.rb` to separate cases for each possible state output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7b5884fdc5320f56bbb52ffd840644d29bc25c29. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->