### PR TITLE
Parallelize bootstrapping worker nodes

### DIFF
--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -10,7 +10,7 @@ class KubernetesNodepool < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
 
-  semaphore :destroy
+  semaphore :destroy, :start_bootstrapping
 end
 
 # Table: kubernetes_nodepool

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -75,6 +75,14 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   label def bootstrap_control_plane_vms
     nap 5 unless kubernetes_cluster.endpoint
 
+    # In 1-node control plane setup, we will wait until it's over
+    # In 3-node control plane setup, we start the bootstrapping after
+    # the first CP bootstrap
+    ready_to_bootstrap_workers =
+      kubernetes_cluster.cp_vms.count >= kubernetes_cluster.cp_node_count ||
+      (kubernetes_cluster.cp_node_count == 3 && kubernetes_cluster.cp_vms.count == 1)
+    kubernetes_cluster.nodepools.each(&:incr_start_bootstrapping) if ready_to_bootstrap_workers
+
     hop_wait_nodes if kubernetes_cluster.cp_vms.count >= kubernetes_cluster.cp_node_count
 
     bud Prog::Kubernetes::ProvisionKubernetesNode, {"subject_id" => kubernetes_cluster.id}

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -154,9 +154,22 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect { nx.bootstrap_control_plane_vms }.to nap(5)
     end
 
+    it "incrs start_bootstrapping on KubernetesNodepool on 3 node control plane setup" do
+      expect(kubernetes_cluster).to receive(:cp_vms).and_return([create_vm, create_vm, create_vm]).twice
+      expect(kubernetes_cluster.nodepools.first).to receive(:incr_start_bootstrapping)
+      expect { nx.bootstrap_control_plane_vms }.to hop("wait_nodes")
+    end
+
+    it "incrs start_bootstrapping on KubernetesNodepool on 1 node control plane setup" do
+      kubernetes_cluster.update(cp_node_count: 1)
+      expect(kubernetes_cluster).to receive(:cp_vms).and_return([create_vm]).twice
+      expect(kubernetes_cluster.nodepools.first).to receive(:incr_start_bootstrapping)
+      expect { nx.bootstrap_control_plane_vms }.to hop("wait_nodes")
+    end
+
     it "hops wait_nodes if the target number of CP vms is reached" do
       expect(kubernetes_cluster.api_server_lb).to receive(:hostname).and_return "endpoint"
-      expect(kubernetes_cluster).to receive(:cp_vms).and_return [1, 2, 3]
+      expect(kubernetes_cluster).to receive(:cp_vms).and_return([1, 2, 3]).twice
       expect { nx.bootstrap_control_plane_vms }.to hop("wait_nodes")
     end
 


### PR DESCRIPTION
Previously we would wait for the control-plane bootstrapping to finish before starting the worker bootstrap. From now on, workers will start their bootstrap after the finish of the first CP node, all happening in parallel decreasing the total bootstrap time substantially.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Parallelizes worker node bootstrapping in Kubernetes clusters, reducing total bootstrap time by starting after the first control-plane node finishes.
> 
>   - **Behavior**:
>     - Workers start bootstrapping after the first control-plane node finishes in `kubernetes_cluster_nexus.rb`.
>     - Uses semaphore `start_bootstrapping` to coordinate worker node bootstrapping.
>   - **Concurrency**:
>     - Adds `:start_bootstrapping` semaphore to `KubernetesNodepool` in `kubernetes_nodepool.rb`.
>     - In `kubernetes_cluster_nexus.rb`, checks if workers are ready to bootstrap after the first control-plane node.
>   - **Tests**:
>     - Updates in `kubernetes_cluster_nexus_spec.rb` to test new bootstrapping logic for 1-node and 3-node control-plane setups.
>     - Updates in `kubernetes_nodepool_nexus_spec.rb` to test worker node bootstrapping and semaphore logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6fdb71835c1ac9e17da21674f2255f0b7d9e00d5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->