### PR TITLE
Share the rubocop cache between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
     - name: Run erb-formatter
       run: bundle exec rake linter:erb_formatter
 
+    - name: Cache rubocop
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/.cache/rubocop_cache
+        key: ${{ matrix.runs-on }}-rubocop-cache
+
     - name: Run rubocop
       run: bundle exec rake linter:rubocop
 


### PR DESCRIPTION
As the number of lines in the codebase increases, rubocop has started taking longer than 20 seconds in CI runs. By sharing the cache between runs, it only takes a few seconds if nothing has changed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds caching for `rubocop` in CI to reduce execution time when no changes are detected.
> 
>   - **CI Performance**:
>     - Adds caching for `rubocop` in `.github/workflows/ci.yml` using `actions/cache@v4`.
>     - Cache path set to `/home/runner/.cache/rubocop_cache` with key `${{ matrix.runs-on }}-rubocop-cache`.
>     - Reduces `rubocop` execution time to a few seconds if no changes are detected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9b3ada1028c6a0900c3265e1ede641735f95c807. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->