### PR TITLE
Drop the subnet when a k8s cluster is destroyed

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -139,6 +139,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     kubernetes_cluster.cp_vms.each(&:incr_destroy)
     kubernetes_cluster.remove_all_cp_vms
     kubernetes_cluster.nodepools.each { _1.incr_destroy }
+    kubernetes_cluster.private_subnet.incr_destroy
     nap 5 unless kubernetes_cluster.nodepools.empty?
     kubernetes_cluster.destroy
     pop "kubernetes cluster is deleted"

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -244,6 +244,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect(kubernetes_cluster.cp_vms).to all(receive(:incr_destroy))
       expect(kubernetes_cluster.nodepools).to all(receive(:incr_destroy))
+      expect(kubernetes_cluster.private_subnet).to receive(:incr_destroy)
 
       expect(kubernetes_cluster).not_to receive(:destroy)
       expect { nx.destroy }.to nap(5)


### PR DESCRIPTION
As a bug from the pre-CCM times, we forgot dropping the subnet that's created internally when a k8s cluster is created. This patch adds the incr_destroy call to the destroy label of KubernetesClusterNexus.

Theoretically, a Kubernetes cluster can share a subnet with other resources when an existing subnet is supplied to KubernetesClusterNexus.assemble. However, this is not used in the mainstream routes so we are not worried about the case.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `incr_destroy` call for `private_subnet` in `KubernetesClusterNexus` to ensure subnet is dropped when a cluster is destroyed, with corresponding test update.
> 
>   - **Behavior**:
>     - Adds `incr_destroy` call for `private_subnet` in `destroy` method of `KubernetesClusterNexus` to ensure subnet is dropped when a cluster is destroyed.
>     - Handles case where a subnet is shared with other resources, but not used in mainstream routes.
>   - **Tests**:
>     - Updates `destroy` test in `kubernetes_cluster_nexus_spec.rb` to expect `incr_destroy` on `private_subnet`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0baacee0955034fba804cccfe01b55ea33b5888a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->