### PR TITLE
Use a thread pool + shared queue for monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -6,10 +6,12 @@ clover_freeze
 
 resources = {}
 mutex = Mutex.new
+thread_pool_size = (Config.max_monitor_threads - 2).clamp(1, nil)
+monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice, LoadBalancerVmPort, KubernetesCluster]
+queue_size = thread_pool_size + (monitorable_resource_types.sum(&:count) * 1.5).round
+queue = SizedQueue.new(queue_size)
 
 resource_scanner = Thread.new do
-  monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice, LoadBalancerVmPort, KubernetesCluster]
-
   loop do
     monitorable_resources = monitorable_resource_types.flat_map(&:all)
     mutex.synchronize do
@@ -26,27 +28,33 @@ rescue => ex
   Kernel.exit!
 end
 
+thread_pool = Array.new(thread_pool_size) do
+  Thread.new do
+    while (r = queue.pop)
+      r.lock_no_wait do
+        r.open_resource_session
+        r.process_event_loop
+        r.check_pulse
+      end
+    end
+  end
+end
+
 begin
   loop do
-    mutex.synchronize do
-      # Deduct 2 for the threads that are always running: main, resource_scanner
-      Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - 2} }
-      resources.each do |r_id, r|
-        sleep 1 while Thread.list.count + 1 > Config.max_monitor_threads
+    # Since the switch to use a thread pool for monitored resources,
+    # this emits the number of pulse threads, not the number of monitor threads + pulse threads
+    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - thread_pool_size - 2} }
 
-        r.force_stop_if_stuck
+    rs = mutex.synchronize { resources.values }
 
-        Thread.new do
-          r.lock_no_wait do
-            r.open_resource_session
-            r.process_event_loop
-            r.check_pulse
-          end
-        end
-      end
-
-      resources.select { |r_id, r| r.deleted }.each { |r_id, r| resources.delete(r_id) }
+    rs.each do |r|
+      r.force_stop_if_stuck
+      queue.push(r)
     end
+
+    mutex.synchronize { resources.delete_if { |_, r| r.deleted } }
+
     sleep 5
   end
 rescue => ex
@@ -56,3 +64,5 @@ rescue => ex
 end
 
 resource_scanner.join
+thread_pool.each { queue.push(nil) }
+thread_pool.each(&:join)

--- a/bin/monitor
+++ b/bin/monitor
@@ -25,13 +25,13 @@ rescue => ex
   Kernel.exit!
 end
 
-pulse_checker = Thread.new do
+begin
   loop do
     mutex.synchronize do
-      # Deduct 3 for the threads that are always running: main, resource_scanner, pulse_checker
-      Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - 3} }
+      # Deduct 2 for the threads that are always running: main, resource_scanner
+      Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - 2} }
       resources.each do |r_id, r|
-        sleep 1 while Thread.list.count + 2 > Config.max_monitor_threads
+        sleep 1 while Thread.list.count + 1 > Config.max_monitor_threads
 
         r.force_stop_if_stuck
 
@@ -55,4 +55,3 @@ rescue => ex
 end
 
 resource_scanner.join
-pulse_checker.join

--- a/bin/monitor
+++ b/bin/monitor
@@ -11,8 +11,9 @@ resource_scanner = Thread.new do
   monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice, LoadBalancerVmPort, KubernetesCluster]
 
   loop do
+    monitorable_resources = monitorable_resource_types.flat_map(&:all)
     mutex.synchronize do
-      Enumerator::Chain.new(*monitorable_resource_types).each do |r|
+      monitorable_resources.each do |r|
         resources[r.id] ||= MonitorableResource.new(r)
       end
     end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -194,7 +194,7 @@ class PostgresServer < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, user: "postgres", connect_timeout: 4)
+      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, user: "postgres", connect_timeout: 4, keep_reference: false)
       last_known_lsn = session[:db_connection]["SELECT #{lsn_function} AS lsn"].first[:lsn]
       "up"
     rescue


### PR DESCRIPTION
Because the pulse threads for PostgresServer and MinioServer instances
were counted by the thread calculation, it appears as though if the
number of PostgresServer and MinioServer instances to monitor exceeded
Config.max_monitor_threads - 2, that the monitor would sleep
indefinitely previously (at least, until one of the pulse threads
exited). This change eliminates that possibility.  However, the
tradeoff is the number of threads in the process can exceed
Config.max_monitor_threads.  Config.max_monitor_threads now is only
used to set the size of the monitor thread pool.

To prevent arbitrarily large memory usage if the thread pool is not
able to process jobs fast enough, the queue size is limited to
the thread pool size plus 1.5 times the number of monitored objects.
Once that limit is hit, pushing to the queue will block.  However,
if this happens, this will lead to a greater than 5 second delay
between pulse checks.

Reduce scope of mutex.synchronize calls in the main monitor loop and
resource scanner thread.

Prevent Sequel::Database object leakage in PostgresServer#check_pulse.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a thread pool and shared queue for resource monitoring in `bin/monitor`, preventing potential deadlocks and database object leakage.
> 
>   - **Behavior**:
>     - Replaces individual threads with a thread pool and shared queue in `bin/monitor` to manage resource monitoring.
>     - Queue size is set to thread pool size plus 1.5 times the number of monitored objects to prevent memory overflow.
>     - If queue limit is reached, pushing to the queue blocks, potentially delaying pulse checks by over 5 seconds.
>   - **Concurrency**:
>     - Reduces scope of `mutex.synchronize` in main monitor loop and resource scanner thread in `bin/monitor`.
>   - **Database**:
>     - Prevents `Sequel::Database` object leakage in `PostgresServer#check_pulse` by setting `keep_reference: false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2e2be8fead2e7f4fd5666c5cecdcbb9108083c35. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->