### PR TITLE
Bump Ruby version to 3.4.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 3.2.8
+ruby 3.4.3
 postgres 15.8
 nodejs 23.6.0
 golang 1.24.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM docker.io/library/ruby:3.2.8-alpine3.21 AS bundler
+FROM docker.io/library/ruby:3.4.3-alpine3.21 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -20,7 +20,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM docker.io/library/ruby:3.2.8-alpine3.21
+FROM docker.io/library/ruby:3.4.3-alpine3.21
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.2.8"
+ruby "3.4.3"
 
 gem "acme-client"
 gem "argon2"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
+
+# Update ruby version in Dockerfile and .tool_versions when updating this
 ruby "3.4.3"
 
 gem "acme-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.8p263
+   ruby 3.4.3p32
 
 BUNDLED WITH
-   2.5.17
+   2.6.8

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -4,6 +4,7 @@ require "net/ssh"
 require "openssl"
 require "erubi"
 require "tilt"
+require "fileutils"
 
 module Util
   # A minimal, non-cached SSH implementation.

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -96,11 +96,11 @@ RSpec.describe PrivateSubnet do
     it "includes ubid if id is available" do
       ubid = described_class.generate_ubid
       private_subnet.id = ubid.to_uuid.to_s
-      expect(private_subnet.inspect).to eq "#<PrivateSubnet[\"#{ubid}\"] @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location_id=>\"10saktg1sprp3mxefj1m3kppq2\", :state=>\"waiting\", :name=>\"ps\", :project_id=>\"#{private_subnet.project.ubid}\"}>"
+      expect(private_subnet.inspect).to eq "#<PrivateSubnet[\"#{ubid}\"] @values={net6: \"fd1b:9793:dcef:cd0a::/64\", net4: \"10.9.39.0/26\", location_id: \"10saktg1sprp3mxefj1m3kppq2\", state: \"waiting\", name: \"ps\", project_id: \"#{private_subnet.project.ubid}\"}>"
     end
 
     it "does not includes ubid if id is missing" do
-      expect(private_subnet.inspect).to eq "#<PrivateSubnet @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location_id=>\"10saktg1sprp3mxefj1m3kppq2\", :state=>\"waiting\", :name=>\"ps\", :project_id=>\"#{private_subnet.project.ubid}\"}>"
+      expect(private_subnet.inspect).to eq "#<PrivateSubnet @values={net6: \"fd1b:9793:dcef:cd0a::/64\", net4: \"10.9.39.0/26\", location_id: \"10saktg1sprp3mxefj1m3kppq2\", state: \"waiting\", name: \"ps\", project_id: \"#{private_subnet.project.ubid}\"}>"
     end
   end
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Prog::Base do
     it "can render exit" do
       expect(described_class::Exit.new(
         Strand.new(prog: "TestProg", label: "exiting_label"), {"msg" => "done"}
-      ).to_s).to eq('Strand exits from TestProg#exiting_label with {"msg"=>"done"}')
+      ).to_s).to eq('Strand exits from TestProg#exiting_label with {"msg" => "done"}')
     end
   end
 

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -30,16 +30,16 @@ RSpec.describe ResourceMethods do
     expect(project.inspect).to eq "#<Project @values={}>"
 
     project.created_at = Time.new(2024, 11, 13, 9, 16, 56.123456, 3600)
-    expect(project.inspect).to eq "#<Project @values={:created_at=>\"2024-11-13 09:16:56\"}>"
+    expect(project.inspect).to eq "#<Project @values={created_at: \"2024-11-13 09:16:56\"}>"
 
     project.id = UBID.parse("pjhahqe5e90j3j6kfjtwtxpsps").to_uuid
-    expect(project.inspect).to eq "#<Project[\"pjhahqe5e90j3j6kfjtwtxpsps\"] @values={:created_at=>\"2024-11-13 09:16:56\"}>"
+    expect(project.inspect).to eq "#<Project[\"pjhahqe5e90j3j6kfjtwtxpsps\"] @values={created_at: \"2024-11-13 09:16:56\"}>"
 
     subject_tag = SubjectTag.new(project_id: project.id, name: nil)
-    expect(subject_tag.inspect).to eq "#<SubjectTag @values={:project_id=>\"pjhahqe5e90j3j6kfjtwtxpsps\", :name=>nil}>"
+    expect(subject_tag.inspect).to eq "#<SubjectTag @values={project_id: \"pjhahqe5e90j3j6kfjtwtxpsps\", name: nil}>"
 
     subject_tag.name = "a"
-    expect(subject_tag.inspect).to eq "#<SubjectTag @values={:project_id=>\"pjhahqe5e90j3j6kfjtwtxpsps\", :name=>\"a\"}>"
+    expect(subject_tag.inspect).to eq "#<SubjectTag @values={project_id: \"pjhahqe5e90j3j6kfjtwtxpsps\", name: \"a\"}>"
   end
 
   it "Model.[] allows lookup using both uuid and ubid" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -895,7 +895,7 @@ RSpec.describe Al do
     }
 
     before do
-      vmh = create_vm_host(total_mem_gib: 64, total_sockets: 2, total_dies: 2, net6: "fd10:9b0b:6b4b:8fbb::/64", total_cpus: 16, total_cores: 8, used_cores: 1, total_hugepages_1g: 54, used_hugepages_1g: 2, accepts_slices: true) { _1.id = Sshable.create_with_id.id }
+      vmh = create_vm_host(total_mem_gib: 64, total_sockets: 2, total_dies: 2, net6: "fd10:9b0b:6b4b:8fbb::/64", total_cpus: 16, total_cores: 8, used_cores: 1, total_hugepages_1g: 54, used_hugepages_1g: 2, accepts_slices: true)
       BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)


### PR DESCRIPTION
Make some minor spec changes to allow specs to pass with new Ruby version.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Bump Ruby version to 3.4.3 and update specs for compatibility.
> 
>   - **Ruby Version Update**:
>     - Bump Ruby version from `3.2.8` to `3.4.3` in `.tool-versions`, `Dockerfile`, and `Gemfile`.
>   - **Spec Adjustments**:
>     - Update hash syntax in `private_subnet_spec.rb`, `base_spec.rb`, and `resource_methods_spec.rb` to use new Ruby syntax.
>     - Remove unnecessary block in `allocator_spec.rb` to fix test setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d7fe4192c4ce1affeaa5ce2701d2db3245e86b11. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->