### PR TITLE
Add -W:strict_unused_block when running specs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 3.2.8
+ruby 3.4.3
 postgres 15.8
 nodejs 23.6.0
 golang 1.24.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.2.8"
+ruby "3.4.3"
 
 gem "acme-client"
 gem "argon2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.8p263
+   ruby 3.4.3p32
 
 BUNDLED WITH
-   2.5.17
+   2.6.8

--- a/Rakefile
+++ b/Rakefile
@@ -185,11 +185,11 @@ desc "Run specs in with coverage in unfrozen mode, and without coverage in froze
 task default: [:coverage, :frozen_spec]
 
 rspec = lambda do |env|
-  sh(env.merge("RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "rspec", "spec")
+  sh(env.merge("RUBYOPT" => "-w -W:strict_unused_block", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "rspec", "spec")
 end
 
 turbo_tests = lambda do |env|
-  sh(env.merge("RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "turbo_tests", "-n", nproc.call)
+  sh(env.merge("RUBYOPT" => "-w -W:strict_unused_block", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"), "bundle", "exec", "turbo_tests", "-n", nproc.call)
 end
 
 spec = lambda do |env|
@@ -236,7 +236,7 @@ task "coverage_pspec" do
   output_file = "coverage/output.txt"
   coverage_setup.call
   command = "bundle exec turbo_tests -n #{nproc.call} 2>&1 | tee #{output_file}"
-  sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "COVERAGE" => "1", "RODA_RENDER_COMPILED_METHOD_SUPPORT" => "no"}, command)
+  sh({"RUBYOPT" => "-w -W:strict_unused_block", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "COVERAGE" => "1", "RODA_RENDER_COMPILED_METHOD_SUPPORT" => "no"}, command)
   command_output = File.binread(output_file)
   unless command_output.include?("Line Coverage: 100.0%") && command_output.include?("Branch Coverage: 100.0%")
     warn "SimpleCov failed with exit 2 due to a coverage related error"
@@ -273,7 +273,7 @@ task :spec_separate do
 
   failures = []
   Dir["spec/**/*_spec.rb"].each do |file|
-    failures << file unless system(RbConfig.ruby, "-w", "-S", "rspec", file)
+    failures << file unless system(RbConfig.ruby, "-w -W:strict_unused_block", "-S", "rspec", file)
   end
 
   if failures.empty?

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -4,6 +4,7 @@ require "net/ssh"
 require "openssl"
 require "erubi"
 require "tilt"
+require "fileutils"
 
 module Util
   # A minimal, non-cached SSH implementation.

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -96,11 +96,11 @@ RSpec.describe PrivateSubnet do
     it "includes ubid if id is available" do
       ubid = described_class.generate_ubid
       private_subnet.id = ubid.to_uuid.to_s
-      expect(private_subnet.inspect).to eq "#<PrivateSubnet[\"#{ubid}\"] @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location_id=>\"10saktg1sprp3mxefj1m3kppq2\", :state=>\"waiting\", :name=>\"ps\", :project_id=>\"#{private_subnet.project.ubid}\"}>"
+      expect(private_subnet.inspect).to eq "#<PrivateSubnet[\"#{ubid}\"] @values={net6: \"fd1b:9793:dcef:cd0a::/64\", net4: \"10.9.39.0/26\", location_id: \"10saktg1sprp3mxefj1m3kppq2\", state: \"waiting\", name: \"ps\", project_id: \"#{private_subnet.project.ubid}\"}>"
     end
 
     it "does not includes ubid if id is missing" do
-      expect(private_subnet.inspect).to eq "#<PrivateSubnet @values={:net6=>\"fd1b:9793:dcef:cd0a::/64\", :net4=>\"10.9.39.0/26\", :location_id=>\"10saktg1sprp3mxefj1m3kppq2\", :state=>\"waiting\", :name=>\"ps\", :project_id=>\"#{private_subnet.project.ubid}\"}>"
+      expect(private_subnet.inspect).to eq "#<PrivateSubnet @values={net6: \"fd1b:9793:dcef:cd0a::/64\", net4: \"10.9.39.0/26\", location_id: \"10saktg1sprp3mxefj1m3kppq2\", state: \"waiting\", name: \"ps\", project_id: \"#{private_subnet.project.ubid}\"}>"
     end
   end
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Prog::Base do
     it "can render exit" do
       expect(described_class::Exit.new(
         Strand.new(prog: "TestProg", label: "exiting_label"), {"msg" => "done"}
-      ).to_s).to eq('Strand exits from TestProg#exiting_label with {"msg"=>"done"}')
+      ).to_s).to eq('Strand exits from TestProg#exiting_label with {"msg" => "done"}')
     end
   end
 

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -30,16 +30,16 @@ RSpec.describe ResourceMethods do
     expect(project.inspect).to eq "#<Project @values={}>"
 
     project.created_at = Time.new(2024, 11, 13, 9, 16, 56.123456, 3600)
-    expect(project.inspect).to eq "#<Project @values={:created_at=>\"2024-11-13 09:16:56\"}>"
+    expect(project.inspect).to eq "#<Project @values={created_at: \"2024-11-13 09:16:56\"}>"
 
     project.id = UBID.parse("pjhahqe5e90j3j6kfjtwtxpsps").to_uuid
-    expect(project.inspect).to eq "#<Project[\"pjhahqe5e90j3j6kfjtwtxpsps\"] @values={:created_at=>\"2024-11-13 09:16:56\"}>"
+    expect(project.inspect).to eq "#<Project[\"pjhahqe5e90j3j6kfjtwtxpsps\"] @values={created_at: \"2024-11-13 09:16:56\"}>"
 
     subject_tag = SubjectTag.new(project_id: project.id, name: nil)
-    expect(subject_tag.inspect).to eq "#<SubjectTag @values={:project_id=>\"pjhahqe5e90j3j6kfjtwtxpsps\", :name=>nil}>"
+    expect(subject_tag.inspect).to eq "#<SubjectTag @values={project_id: \"pjhahqe5e90j3j6kfjtwtxpsps\", name: nil}>"
 
     subject_tag.name = "a"
-    expect(subject_tag.inspect).to eq "#<SubjectTag @values={:project_id=>\"pjhahqe5e90j3j6kfjtwtxpsps\", :name=>\"a\"}>"
+    expect(subject_tag.inspect).to eq "#<SubjectTag @values={project_id: \"pjhahqe5e90j3j6kfjtwtxpsps\", name: \"a\"}>"
   end
 
   it "Model.[] allows lookup using both uuid and ubid" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -895,7 +895,7 @@ RSpec.describe Al do
     }
 
     before do
-      vmh = create_vm_host(total_mem_gib: 64, total_sockets: 2, total_dies: 2, net6: "fd10:9b0b:6b4b:8fbb::/64", total_cpus: 16, total_cores: 8, used_cores: 1, total_hugepages_1g: 54, used_hugepages_1g: 2, accepts_slices: true) { _1.id = Sshable.create_with_id.id }
+      vmh = create_vm_host(total_mem_gib: 64, total_sockets: 2, total_dies: 2, net6: "fd10:9b0b:6b4b:8fbb::/64", total_cpus: 16, total_cores: 8, used_cores: 1, total_hugepages_1g: 54, used_hugepages_1g: 2, accepts_slices: true)
       BootImage.create_with_id(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create_with_id(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)


### PR DESCRIPTION
This can find more cases where unused blocks are present.

I'm marking this as a draft, because it currently shows warnings in rspec.  There is a pull request to fix rspec, but it hasn't been merged yet: https://github.com/rspec/rspec/issues/175