### PR TITLE
Do not login to DockerHub if not pushing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Log in to Docker Hub
+        if: ${{ inputs.push_image }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -66,7 +67,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=ubicloud-${{ matrix.runner }}
           cache-to: type=gha,mode=max,scope=ubicloud-${{ matrix.runner }}
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ inputs.push_image && 'true' || 'false' }}
 
       - name: Export digest
         run: |


### PR DESCRIPTION
There is no need to login to DockerHub if we are not publishing new image.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Conditionally log in to DockerHub and push images in `build.yml` based on `push_image` input.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/build.yml`, DockerHub login step now conditional on `inputs.push_image`.
>     - Modify `outputs` in `docker/build-push-action` to conditionally push images based on `inputs.push_image`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 61ab3dce5c0c58b292cdc1d136bdb554965746c4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->