### PR TITLE
Start listening on ipv6 ip of nodes in control plane nodes

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -65,8 +65,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       health_check_endpoint: "/healthz",
       health_check_protocol: "tcp",
       custom_hostname_dns_zone_id:,
-      custom_hostname_prefix:,
-      stack: LoadBalancer::Stack::IPV4
+      custom_hostname_prefix:
     ).subject
     kubernetes_cluster.update(api_server_lb_id: load_balancer.id)
 

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -44,7 +44,17 @@ cluster_config = {
   "clusterName" => cluster_name,
   "controlPlaneEndpoint" => "#{lb_hostname}:#{port}",
   "apiServer" => {
-    "certSANs" => [lb_hostname]
+    "certSANs" => [lb_hostname],
+    "extraArgs" => [
+      {
+        "name" => "bind-address",
+        "value" => "::"
+      },
+      {
+        "name" => "advertise-address",
+        "value" => node_ipv4
+      }
+    ]
   },
   "networking" => {
     "podSubnet" => "#{private_subnet_cidr4},#{private_subnet_cidr6}",

--- a/rhizome/kubernetes/bin/join-node
+++ b/rhizome/kubernetes/bin/join-node
@@ -46,7 +46,23 @@ config = {
 
 if is_control_plane
   config["controlPlane"] = {
-    "certificateKey" => certificate_key
+    "certificateKey" => certificate_key,
+    "localAPIEndpoint" => {
+      "advertiseAddress" => node_ipv4,
+      "bindPort" => 6443
+    },
+    "apiServer" => {
+      "extraArgs" => [
+        {
+          "name" => "bind-address",
+          "value" => "::"
+        },
+        {
+          "name" => "advertise-address",
+          "value" => node_ipv4
+        }
+      ]
+    }
   }
 end
 

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kubernetes_cluster.api_server_lb.ports.first.dst_port).to eq 6443
       expect(kubernetes_cluster.api_server_lb.health_check_endpoint).to eq "/healthz"
       expect(kubernetes_cluster.api_server_lb.health_check_protocol).to eq "tcp"
-      expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::IPV4
+      expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::DUAL
       expect(kubernetes_cluster.api_server_lb.private_subnet_id).to eq subnet.id
       expect(kubernetes_cluster.api_server_lb.custom_hostname_dns_zone_id).to eq dns_zone.id
       expect(kubernetes_cluster.api_server_lb.custom_hostname).to eq "k8scluster-apiserver-#{kubernetes_cluster.ubid[-5...]}.k8s.ubicloud.com"
@@ -142,7 +142,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kubernetes_cluster.api_server_lb.ports.first.dst_port).to eq 6443
       expect(kubernetes_cluster.api_server_lb.health_check_endpoint).to eq "/healthz"
       expect(kubernetes_cluster.api_server_lb.health_check_protocol).to eq "tcp"
-      expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::IPV4
+      expect(kubernetes_cluster.api_server_lb.stack).to eq LoadBalancer::Stack::DUAL
       expect(kubernetes_cluster.api_server_lb.private_subnet_id).to eq subnet.id
       expect(kubernetes_cluster.api_server_lb.custom_hostname).to be_nil
     end


### PR DESCRIPTION
So far, we only listened on the IPv4 IP of nodes, creating the k8s apiserver load balancer in IPv4 mode. From now on, we will also listen on the IPv6 IP, making the LB dual stack.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable dual-stack (IPv4 and IPv6) support for Kubernetes control plane nodes by updating load balancer and node configuration.
> 
>   - **Behavior**:
>     - Update `kubernetes_cluster_nexus.rb` to configure load balancer as `LoadBalancer::Stack::DUAL` instead of `IPV4`.
>     - Modify `init-cluster` and `join-node` scripts to bind API server to IPv6 (`::`) and advertise IPv4 address.
>   - **Tests**:
>     - Update `kubernetes_cluster_nexus_spec.rb` to expect `LoadBalancer::Stack::DUAL` for load balancer stack.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 75a796928f431c1644a857f6847b56391d579f87. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->