### PR TITLE
rename connected-subnet-ubid to connected-subnet-id for consistency

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1098,7 +1098,7 @@ paths:
             schema:
               type: object
               properties:
-                connected-subnet-ubid:
+                connected-subnet-id:
                   type: string
               additionalProperties: false
       responses:

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -25,7 +25,7 @@ class Clover
 
       r.post "connect" do
         authorize("PrivateSubnet:connect", ps.id)
-        subnet = PrivateSubnet.from_ubid(r.params["connected-subnet-ubid"])
+        subnet = PrivateSubnet.from_ubid(r.params["connected-subnet-id"])
         unless subnet
           if api?
             response.status = 400

--- a/sdk/ruby/lib/ubicloud/model/private_subnet.rb
+++ b/sdk/ruby/lib/ubicloud/model/private_subnet.rb
@@ -15,7 +15,7 @@ module Ubicloud
     # Connect the given private subnet to the receiver. Accepts either a PrivateSubnet instance
     # or a private subnet id string. Returns self.
     def connect(subnet)
-      merge_into_values(adapter.post(_path("/connect"), "connected-subnet-ubid": to_id(subnet)))
+      merge_into_values(adapter.post(_path("/connect"), "connected-subnet-id": to_id(subnet)))
     end
 
     # Disconnect the given private subnet from the receiver. Accepts either a PrivateSubnet instance

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Clover, "private subnet" do
         expect(private_subnet.connected_subnets.count).to eq(0)
         visit "#{project.path}#{private_subnet.path}"
 
-        select ps2.name, from: "connected-subnet-ubid"
+        select ps2.name, from: "connected-subnet-id"
         click_button "Connect"
 
         expect(private_subnet.reload.connected_subnets.count).to eq(1)
@@ -229,7 +229,7 @@ RSpec.describe Clover, "private subnet" do
         visit "#{project.path}#{private_subnet.path}"
         ps2.strand.destroy
         ps2.destroy
-        select "dummy-ps-2", from: "connected-subnet-ubid"
+        select "dummy-ps-2", from: "connected-subnet-id"
         click_button "Connect"
 
         expect(page).to have_flash_error("Subnet to be connected not found")

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -128,7 +128,7 @@ viewable_fws, viewable_subnets =
           <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
             <%== part(
               "components/form/select",
-              name: "connected-subnet-ubid",
+              name: "connected-subnet-id",
               label: "",
               placeholder: "Pick a subnet to connect",
               options: @connectable_subnets.map { |s| [s[:id], s[:name]] },


### PR DESCRIPTION
I noticed in the openapi that this `ubid` reference snuck in and it appears to be the only place that `ubid` is used, vs `id` everywhere else. This changes it to match other usage throughout for consistency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `connected-subnet-ubid` to `connected-subnet-id` across the codebase for consistency.
> 
>   - **Renaming for Consistency**:
>     - Rename `connected-subnet-ubid` to `connected-subnet-id` in `openapi.yml`.
>     - Update parameter name in `routes/project/location/private_subnet.rb` and `sdk/ruby/lib/ubicloud/model/private_subnet.rb`.
>     - Adjust test cases in `spec/routes/web/private_subnet_spec.rb` to reflect the new parameter name.
>     - Modify form field name in `views/networking/private_subnet/show.erb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b5bcabc2de7fef8f0400bee591d49c53ce9ba8e5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->