### PR TITLE
Handle Excon::Error::HTTPStatus raised by setup_blob_storage

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -6,7 +6,11 @@ class Clover
       fail CloverError.new(400, "InvalidRequest", "invalid JWT format or claim in Authorization header")
     end
 
-    repository.setup_blob_storage unless repository.access_key
+    begin
+      repository.setup_blob_storage unless repository.access_key
+    rescue Excon::Error::HTTPStatus
+      fail CloverError.new(400, "InvalidRequest", "unable to setup blob storage")
+    end
 
     # getCacheEntry
     r.get "cache" do

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -8,7 +8,8 @@ class Clover
 
     begin
       repository.setup_blob_storage unless repository.access_key
-    rescue Excon::Error::HTTPStatus
+    rescue Excon::Error::HTTPStatus => ex
+      Clog.emit("Unable to setup blob storage") { {failed_blob_storage_setup: {ubid: runner.ubid, repository_ubid: repository.ubid, response: ex.response.body}} }
       fail CloverError.new(400, "InvalidRequest", "unable to setup blob storage")
     end
 

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -49,8 +49,11 @@ RSpec.describe Clover, "github" do
     vm = create_vm
     login_runtime(vm)
     repository = instance_double(GithubRepository, access_key: nil)
-    expect(GithubRunner).to receive(:[]).with(vm_id: vm.id).and_return(instance_double(GithubRunner, repository: repository))
-    expect(repository).to receive(:setup_blob_storage).and_raise(Excon::Error::HTTPStatus, "Expected(200) <=> Actual(520 Unknown)")
+    runner = instance_double(GithubRunner, repository: repository)
+    expect(GithubRunner).to receive(:[]).with(vm_id: vm.id).and_return(runner)
+    expect(runner).to receive(:ubid).and_return(nil)
+    expect(repository).to receive(:ubid).and_return(nil)
+    expect(repository).to receive(:setup_blob_storage).and_raise(Excon::Error::HTTPStatus.new("Expected(200) <=> Actual(520 Unknown)", nil, Excon::Response.new(body: "foo")))
 
     post "/runtime/github/caches"
 


### PR DESCRIPTION
Fixes an unhandled production exception.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add error handling for `Excon::Error::HTTPStatus` in `setup_blob_storage` and test it in `github_spec.rb`.
> 
>   - **Error Handling**:
>     - Add `begin-rescue` block in `routes/runtime/github.rb` to handle `Excon::Error::HTTPStatus` during `repository.setup_blob_storage`.
>     - Log error details and raise `CloverError` with message "unable to setup blob storage".
>   - **Testing**:
>     - Add test case in `github_spec.rb` to verify error handling when `setup_blob_storage` raises `Excon::Error::HTTPStatus`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1941bd94eb99681534643bad68997d96dc26872a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->