### PR TITLE
Fix PostgresResource#display_state when there is no associated strand

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -42,6 +42,7 @@ class PostgresResource < Sequel::Model
 
   def display_state
     return "unavailable" if representative_server&.strand&.label == "unavailable"
+    return "deleting" unless (strand = self.strand)
     return "converging" if strand.children.any? { _1.prog == "Postgres::ConvergePostgresResource" }
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
     return "deleting" if destroy_set? || strand.label == "destroy"

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -68,14 +68,18 @@ RSpec.describe PostgresResource do
     expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, children: [instance_double(Strand, prog: "Postgres::ConvergePostgresResource")]))
     expect(postgres_resource.display_state).to eq("converging")
 
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait", children: [])).twice
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait", children: []))
     expect(postgres_resource.display_state).to eq("running")
 
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy", children: [])).exactly(3).times
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy", children: []))
     expect(postgres_resource.display_state).to eq("deleting")
 
-    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server", children: [])).exactly(3).times
+    expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait_server", children: []))
     expect(postgres_resource.display_state).to eq("creating")
+  end
+
+  it "returns display state correctly when there is no associated strand" do
+    expect(postgres_resource.display_state).to eq("deleting")
   end
 
   it "returns target_standby_count correctly" do


### PR DESCRIPTION
Have the display_state return deleting in this case, since the assumption is if the strand is destroyed, the PostgresResource has already been destroyed or will be destroyed shortly.

While here, cache the result of the strand method to simplify the mocking.

Fixes a couple of unhandled production exceptions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `display_state` in `PostgresResource` to return "deleting" when no `strand` is associated, preventing unhandled exceptions.
> 
>   - **Behavior**:
>     - `display_state` in `postgres_resource.rb` now returns "deleting" if there is no associated `strand`.
>     - Fixes unhandled exceptions in production related to missing `strand`.
>   - **Tests**:
>     - Adds test in `postgres_resource_spec.rb` to verify `display_state` returns "deleting" when no `strand` is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8247b8374d20aebe0422acf005ea9ba69494ff6d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->