### PR TITLE
Show persisted invoices from blob storage

### DIFF
--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -286,6 +286,7 @@ class Invoice < Sequel::Model
       endpoint: Config.invoices_blob_storage_endpoint,
       access_key_id: Config.invoices_blob_storage_access_key,
       secret_access_key: Config.invoices_blob_storage_secret_key,
+      region: "auto",
       request_checksum_calculation: "when_required",
       response_checksum_validation: "when_required"
     )

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe InvoiceGenerator do
   let(:ie1) { InferenceEndpoint.create_with_id(name: "ie1", model_name: "test-model", project_id: p1.id, is_public: true, visible: true, location_id: Location::HETZNER_FSN1_ID, vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, load_balancer_id: lb.id) }
 
   let(:day) { 24 * 60 * 60 }
-  let(:begin_time) { Time.parse("2023-06-01") }
-  let(:end_time) { Time.parse("2023-07-01") }
+  let(:begin_time) { Time.utc(2023, 6) }
+  let(:end_time) { Time.utc(2023, 7) }
 
   it "fails if eur_rate not provided while saving result" do
     expect { described_class.new(begin_time, end_time, save_result: true).run }.to raise_error(ArgumentError, "eur_rate must be provided when save_result is true")

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -3,7 +3,7 @@
 require_relative "spec_helper"
 
 RSpec.describe Invoice do
-  subject(:invoice) { described_class.new(id: "50d5aae4-311c-843b-b500-77fbc7778050", begin_time: Time.parse("2025-03-01"), end_time: Time.parse("2025-04-01"), invoice_number: "2503-4ddfa430e8-0006", created_at: Time.now, content: {"cost" => 10, "subtotal" => 11, "credit" => 1, "discount" => 0, "resources" => [], "billing_info" => {"country" => "NL"}}, status: "unpaid") }
+  subject(:invoice) { described_class.new(id: "50d5aae4-311c-843b-b500-77fbc7778050", begin_time: Time.utc(2025, 3), end_time: Time.utc(2025, 4), invoice_number: "2503-4ddfa430e8-0006", created_at: Time.now, content: {"cost" => 10, "subtotal" => 11, "credit" => 1, "discount" => 0, "resources" => [], "billing_info" => {"country" => "NL"}}, status: "unpaid") }
 
   let(:billing_info) { BillingInfo.create_with_id(stripe_id: "cs_1234567890") }
   let(:client) { instance_double(Aws::S3::Client) }

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
     it "waits if it is not the maintenance window" do
       expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: true)).at_least(:once)
       expect(postgres_resource).to receive(:maintenance_window_start_at).and_return(4)
-      expect(Time).to receive(:now).and_return(Time.parse("2025-01-01 01:00:00 UTC"))
+      expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 1, 1))
       expect(postgres_resource.representative_server).not_to receive(:trigger_failover)
       expect { nx.recycle_representative_server }.to nap(10 * 60)
     end
@@ -105,7 +105,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
     it "triggers failover if maintenance window is not set or if it is the maintenance window" do
       expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: true)).at_least(:once)
       expect(postgres_resource).to receive(:maintenance_window_start_at).and_return(nil, 4)
-      expect(Time).to receive(:now).and_return(Time.parse("2025-01-01 05:00:00 UTC")).at_least(:once)
+      expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 1, 5)).at_least(:once)
       expect(postgres_resource.representative_server).to receive(:trigger_failover).twice
       expect { nx.recycle_representative_server }.to nap(60)
       expect { nx.recycle_representative_server }.to nap(60)

--- a/spec/prog/redeliver_github_failures_spec.rb
+++ b/spec/prog/redeliver_github_failures_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Prog::RedeliverGithubFailures do
   describe "#wait" do
     it "redelivers failed deliveries and naps" do
       expect(Time).to receive(:now).and_return("2023-10-19 23:27:47 +0000").at_least(:once)
-      expect(Github).to receive(:redeliver_failed_deliveries).with(Time.parse("2023-10-19 22:27:47 +0000"))
+      expect(Github).to receive(:redeliver_failed_deliveries).with(Time.utc(2023, 10, 19, 22, 27, 47))
       expect(rgf.strand).to receive(:save_changes)
       expect {
         expect { rgf.wait }.to nap(2 * 60)


### PR DESCRIPTION
- **Set region for the invoice blob storage client**
  It didn't expect a region in the development environment, but Cloudflare
  R2 requires a region to be set in production. Their default region is
  auto.
  

- **Show persisted invoices from blob storage**
  We started persisting invoices as PDFs in blob storage. Since they are
  legal documents, we should always show the same PDF to the customer.
  
  Instead of generating the PDF on the fly, we can display it from the
  saved invoices.

  If the invoice doesn't exist in the blob storage, we will still generate
  it at runtime to fulfill the customer's request.
 
- **Use Time.utc instead of Time.parse in tests**

  It's simpler, and it's better to work in UTC rather than local time
(since `Time.parse` uses local time).

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Invoices are now retrieved from blob storage if available, with a fallback to on-the-fly generation, and the blob storage client is configured with a region for production.
> 
>   - **Behavior**:
>     - In `billing.rb`, invoices are now fetched from blob storage if available, otherwise generated on-the-fly.
>     - In `invoice.rb`, set region to `auto` for blob storage client to support Cloudflare R2.
>   - **Tests**:
>     - Updated tests in `invoice_generator_spec.rb` and `billing_spec.rb` to handle blob storage retrieval and fallback to PDF generation.
>     - Modified time parsing in `invoice_spec.rb` and `converge_postgres_resource_spec.rb` to use `Time.utc` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d0cdf2ee5a22e7aa25b918606f128342fd0c3cda. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->