### PR TITLE
Avoid using absolute and bottom for the terms of service/privacy policy

### DIFF
--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -89,7 +89,7 @@
           </a>
         </div>
         <% if Config.managed_service %>
-          <div class="md:absolute md:bottom-6 md:left-1/2 md:-translate-x-1/2 text-sm text-gray-500 text-center mt-10 w-full">
+          <div class="text-sm text-gray-500 text-center mt-10 w-full">
             By using Ubicloud console you agree to our
             <a
               href="https://www.ubicloud.com/docs/about/terms-of-service"


### PR DESCRIPTION
Using absolute screws things up if the view port is not tall enough, as it makes the text go on top of existing text.