### PR TITLE
Update pry version to 0.15.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "puma", ">= 6.2.2"
 gem "rack-unreloader", ">= 1.8"
 gem "rake"
 gem "refrigerator", ">= 1"
+gem "reline" # Remove it when pry adds it as a dependency
 gem "roda", ">= 3.89"
 gem "rodauth", github: "jeremyevans/rodauth", ref: "2a72b30136c512ea2853ad9dbc126c067bef89e9"
 gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,7 @@ GEM
     hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.0)
     jmespath (1.6.2)
     json (2.10.2)
     json_schema (0.21.0)
@@ -277,7 +278,7 @@ GEM
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
     prism (1.4.0)
-    pry (0.14.2)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.11.0)
@@ -308,6 +309,8 @@ GEM
     rake (13.2.1)
     refrigerator (1.8.0)
     regexp_parser (2.10.0)
+    reline (0.6.1)
+      io-console (~> 0.5)
     rexml (3.4.1)
     roda (3.89.0)
       rack
@@ -491,6 +494,7 @@ DEPENDENCIES
   rackup
   rake
   refrigerator (>= 1)
+  reline
   roda (>= 3.89)
   rodauth!
   rodauth-omniauth!


### PR DESCRIPTION
After we upgraded Ruby to version 3.4.3, pry started showing the following warnings:

    ./ruby/3.4.3/lib/ruby/gems/3.4.0/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
    You can add ostruct to your Gemfile or gemspec to silence this warning.
    ./ruby/3.4.3/lib/ruby/3.4.0/readline.rb:4: warning: reline was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
    You can add reline to your Gemfile or gemspec to silence this warning.

pry has already removed ostruct usage in the latest version released in December 2024. It's interesting that Dependabot didn't upgrade it automatically.

For the reline warning, pry has already included reline in the Gemfile
but not in the gemspec. I believe pry requires readline, and readline
needs reline. I added to our Gemfile until pry added it.