### PR TITLE
Prioritize AX102 hosts for premium CPU runner testers

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -158,7 +158,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations
+  feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations, :performance_runners
 end
 
 # Table: project

--- a/model/project.rb
+++ b/model/project.rb
@@ -158,7 +158,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :vm_public_ssh_keys, :transparent_cache, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations
+  feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations
 end
 
 # Table: project

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -25,6 +25,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   def pick_vm
     skip_sync = true
+    prefer_performance = github_runner.installation.project.get_ff_performance_runners
     pool = VmPool.where(
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
@@ -35,7 +36,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       arch: label_data["arch"]
     ).first
 
-    if (picked_vm = pool&.pick_vm)
+    if !prefer_performance && (picked_vm = pool&.pick_vm)
       return picked_vm
     end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -207,6 +207,10 @@ class Prog::Vm::Nexus < Prog::Base
           [["accepting"], [vm.location_id], [], []]
         end
 
+      prefer_performance = if vm.location_id == Location::GITHUB_RUNNERS_ID && (runner = GithubRunner.first(vm_id: vm.id))
+        runner.installation.project.get_ff_performance_runners
+      end
+
       Scheduling::Allocator.allocate(
         vm, frame["storage_volumes"],
         distinct_storage_devices: distinct_storage_devices,
@@ -215,7 +219,8 @@ class Prog::Vm::Nexus < Prog::Base
         location_preference: location_preference,
         host_filter: host_filter,
         host_exclusion_filter: host_exclusion_filter,
-        gpu_count: gpu_count
+        gpu_count: gpu_count,
+        prioritize_performance_cpu: !!prefer_performance
       )
     rescue RuntimeError => ex
       raise unless ex.message.include?("no space left on any eligible host")

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     before do
       runner_project = Project.create_with_id(name: "default")
       allow(Config).to receive(:github_runner_service_project_id).and_return(runner_project.id)
+      expect(github_runner).to receive(:installation).and_return(instance_double(GithubInstallation, project:))
     end
 
     it "provisions a VM if the pool is not existing" do

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -434,7 +434,8 @@ RSpec.describe Prog::Vm::Nexus do
         host_exclusion_filter: [],
         location_filter: [Location::HETZNER_FSN1_ID],
         location_preference: [],
-        gpu_count: 0
+        gpu_count: 0,
+        prioritize_performance_cpu: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -449,7 +450,8 @@ RSpec.describe Prog::Vm::Nexus do
         host_exclusion_filter: [],
         location_filter: ["6b9ef786-b842-8420-8c65-c25e3d4bdf3d", Location::HETZNER_FSN1_ID, "1f214853-0bc4-8020-b910-dffb867ef44f"],
         location_preference: ["6b9ef786-b842-8420-8c65-c25e3d4bdf3d"],
-        gpu_count: 0
+        gpu_count: 0,
+        prioritize_performance_cpu: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -465,7 +467,8 @@ RSpec.describe Prog::Vm::Nexus do
         host_exclusion_filter: [],
         location_filter: [],
         location_preference: ["6b9ef786-b842-8420-8c65-c25e3d4bdf3d"],
-        gpu_count: 0
+        gpu_count: 0,
+        prioritize_performance_cpu: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -484,7 +487,8 @@ RSpec.describe Prog::Vm::Nexus do
         host_exclusion_filter: [],
         location_filter: [],
         location_preference: [],
-        gpu_count: 0
+        gpu_count: 0,
+        prioritize_performance_cpu: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -503,7 +507,8 @@ RSpec.describe Prog::Vm::Nexus do
         host_exclusion_filter: [:vm_host_id, "another-vm-host-id"],
         location_filter: [Location::HETZNER_FSN1_ID],
         location_preference: [],
-        gpu_count: 0
+        gpu_count: 0,
+        prioritize_performance_cpu: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -530,7 +535,8 @@ RSpec.describe Prog::Vm::Nexus do
         location_filter: [Location::HETZNER_FSN1_ID],
         host_exclusion_filter: [],
         location_preference: [],
-        gpu_count: 0
+        gpu_count: 0,
+        prioritize_performance_cpu: false
       )
       expect { nx.start }.to hop("create_unix_user")
     end
@@ -549,7 +555,27 @@ RSpec.describe Prog::Vm::Nexus do
         host_exclusion_filter: [],
         location_filter: [Location::HETZNER_FSN1_ID],
         location_preference: [],
-        gpu_count: 3
+        gpu_count: 3,
+        prioritize_performance_cpu: false
+      )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
+    it "prioritize performance CPU if the runner's project has the feature flag" do
+      vm.location_id = Location::GITHUB_RUNNERS_ID
+      prj.set_ff_performance_runners(true)
+      installation_id = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: prj.id).id
+      GithubRunner.create(label: "ubicloud", repository_name: "ubicloud/test", installation_id:, vm_id: vm.id)
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        host_exclusion_filter: [],
+        location_filter: ["6b9ef786-b842-8420-8c65-c25e3d4bdf3d", Location::HETZNER_FSN1_ID, "1f214853-0bc4-8020-b910-dffb867ef44f"],
+        location_preference: ["6b9ef786-b842-8420-8c65-c25e3d4bdf3d"],
+        gpu_count: 0,
+        prioritize_performance_cpu: true
       )
       expect { nx.start }.to hop("create_unix_user")
     end


### PR DESCRIPTION
- **Remove the transparent_cache feature flag**
  We've already added a column to the GithubInstallation model, and it's
  no longer in use.
  

- **Prioritize AX102 hosts for premium CPU runner testers**
  We will introduce a new runner tier soon; I'm working on a PR to enable
  it.
  
  We have some AX102 machines in our fleet. Until the new runner tier is
  launched, we want to give higher priority to some customers to test
  them.
  
  We get the runner object in the VM nexus to check if it’s a preferred
  performance CPU. It’s a bit of an antipattern, but making changes to the
  codebase would require a lot of effort. We need to pass the preference
  from runner nexus to VM nexus to allocator. Additionally, it allocates
  the VM at the `start` label, not in `assemble`, so we need to persist
  the preference in the stack. To avoid all of this, I just try to get the
  runner if the location is "github-runners." This code will be removed
  after the new runner tier is launched.
  
  Since we don't have a VM pool for them, we don't pick from the pool if
  it's a preferred performance CPU.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prioritize AX102 hosts for premium CPU runner testers and remove unused `transparent_cache` feature flag, updating allocation logic and tests accordingly.
> 
>   - **Behavior**:
>     - Prioritize AX102 hosts for premium CPU runner testers by adding `prioritize_performance_cpu` flag in `allocator.rb`.
>     - Remove `transparent_cache` feature flag from `project.rb`.
>   - **Allocation Logic**:
>     - Update `allocate()` in `allocator.rb` to include `prioritize_performance_cpu` parameter.
>     - Modify `calculate_score()` in `allocator.rb` to adjust scoring based on `prioritize_performance_cpu`.
>   - **VM Handling**:
>     - Update `pick_vm()` in `github_runner.rb` to consider `performance_runners` feature flag.
>     - Adjust `before_run()` in `nexus.rb` to handle performance prioritization.
>   - **Tests**:
>     - Add tests in `github_runner_spec.rb`, `nexus_spec.rb`, and `allocator_spec.rb` to verify prioritization logic and removal of `transparent_cache`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7eb9ed6750b6bf4f1759f14c01a36fd34a0e23b8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->