### PR TITLE
Remove flow tables to fix load balancer on ipv6

### DIFF
--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -103,17 +103,8 @@ table inet fw_table {
 #{globally_blocked_ipv6s.empty? ? "" : "elements = {#{globally_blocked_ipv6s}}"}
   }
 
-  flowtable ubi_flowtable {
-    hook ingress priority filter
-    devices = { #{vm.nics.map(&:ubid_to_tap_name).join(",")} }
-  }
-
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-
-    # Offload to ubi_flowtable. This is used to offload already filtered
-    # traffic to reduce the latency.
-    meta l4proto { tcp, udp } flow offload @ubi_flowtable
 
     # Destination port 111 is reserved for the portmapper. We block it to
     # prevent abuse.

--- a/spec/prog/vnet/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/update_firewall_rules_spec.rb
@@ -109,17 +109,8 @@ elements = {123.123.123.123/32}
 elements = {2a00:1450:400e:811::200e/128}
   }
 
-  flowtable ubi_flowtable {
-    hook ingress priority filter
-    devices = { tap0 }
-  }
-
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-
-    # Offload to ubi_flowtable. This is used to offload already filtered
-    # traffic to reduce the latency.
-    meta l4proto { tcp, udp } flow offload @ubi_flowtable
 
     # Destination port 111 is reserved for the portmapper. We block it to
     # prevent abuse.
@@ -263,17 +254,8 @@ elements = {123.123.123.123/32}
 elements = {2a00:1450:400e:811::200e/128}
   }
 
-  flowtable ubi_flowtable {
-    hook ingress priority filter
-    devices = { tap0 }
-  }
-
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-
-    # Offload to ubi_flowtable. This is used to offload already filtered
-    # traffic to reduce the latency.
-    meta l4proto { tcp, udp } flow offload @ubi_flowtable
 
     # Destination port 111 is reserved for the portmapper. We block it to
     # prevent abuse.
@@ -424,17 +406,8 @@ elements = {123.123.123.123/32}
 elements = {2a00:1450:400e:811::200e/128}
   }
 
-  flowtable ubi_flowtable {
-    hook ingress priority filter
-    devices = { tap0 }
-  }
-
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-
-    # Offload to ubi_flowtable. This is used to offload already filtered
-    # traffic to reduce the latency.
-    meta l4proto { tcp, udp } flow offload @ubi_flowtable
 
     # Destination port 111 is reserved for the portmapper. We block it to
     # prevent abuse.
@@ -572,17 +545,8 @@ table inet fw_table {
 
   }
 
-  flowtable ubi_flowtable {
-    hook ingress priority filter
-    devices = { tap0 }
-  }
-
   chain forward_ingress {
     type filter hook forward priority filter; policy drop;
-
-    # Offload to ubi_flowtable. This is used to offload already filtered
-    # traffic to reduce the latency.
-    meta l4proto { tcp, udp } flow offload @ubi_flowtable
 
     # Destination port 111 is reserved for the portmapper. We block it to
     # prevent abuse.


### PR DESCRIPTION
We discovered that flow tables cause issues when load balancing on ipv6 with larger packet sizes. For now, the benefits doesn't seem like justifying keeping it around. Removing flow tables fixes the issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove flow tables from firewall rules to fix IPv6 load balancing issues with larger packet sizes.
> 
>   - **Behavior**:
>     - Remove flow tables from `update_firewall_rules.rb` to fix load balancing issues on IPv6 with larger packet sizes.
>     - Remove flow table offloading in `forward_ingress` chain.
>   - **Tests**:
>     - Update `update_firewall_rules_spec.rb` to reflect removal of flow tables in tests for `forward_ingress` chain.
>     - Ensure tests validate the absence of flow table configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4e50761d584fca486dbd79ba22d493126d57b1d6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->