### PR TITLE
Increase test timeout for e2e tests to 100 minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubicloud
     environment: E2E-CI
     # TODO: Revert it when the internal MinIO cluster is stabilized
-    timeout-minutes: 85
+    timeout-minutes: 105
     concurrency: e2e_environment
 
     env:
@@ -131,7 +131,7 @@ jobs:
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
       run: |
         set -o pipefail
-        timeout 80m foreman start | tee foreman.log | grep "e2e.1"
+        timeout 100m foreman start | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
       if: always()


### PR DESCRIPTION
Our E2E tests have been timing out due to slow image downloads. This commit increases the timeout to 100 minutes to accommodate these delays.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase E2E test timeout to 100 minutes in `.github/workflows/e2e.yml` to handle slow image downloads.
> 
>   - **Timeout Increase**:
>     - Increases `timeout-minutes` from 85 to 105 in `.github/workflows/e2e.yml` for the `run-ci` job.
>     - Increases `timeout` from 80m to 100m in the `Run tests` step within the same file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 368e0e0778ecce93b6009d91bd698c1e5b64e40b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->