### PR TITLE
Add UI for inference router models

### DIFF
--- a/model/ai/inference_router_model.rb
+++ b/model/ai/inference_router_model.rb
@@ -3,6 +3,9 @@
 require_relative "../../model"
 
 class InferenceRouterModel < Sequel::Model
+  one_to_many :inference_router_targets
+  one_through_one :inference_router, join_table: :inference_router_target
+
   include ResourceMethods
 
   def self.from_model_name(name)

--- a/routes/project/inference_endpoint.rb
+++ b/routes/project/inference_endpoint.rb
@@ -3,7 +3,9 @@
 class Clover
   hash_branch(:project_prefix, "inference-endpoint") do |r|
     r.get web? do
-      @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.eager(:location).all)
+      inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.eager(:location).all)
+      inference_router_models = Serializers::InferenceRouterModel.serialize(inference_router_model_ds.all)
+      @inference_models = inference_endpoints + inference_router_models
       @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
       @free_quota_unit = "inference tokens"
       @has_valid_payment_method = @project.has_valid_payment_method?

--- a/routes/project/inference_playground.rb
+++ b/routes/project/inference_playground.rb
@@ -3,7 +3,9 @@
 class Clover
   hash_branch(:project_prefix, "inference-playground") do |r|
     r.get web? do
-      @inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.eager(:location).where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation"))
+      inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.eager(:location).where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation"))
+      inference_router_models = Serializers::InferenceRouterModel.serialize(inference_router_model_ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation").all)
+      @inference_models = inference_endpoints + inference_router_models
       @inference_api_keys = Serializers::InferenceApiKey.serialize(inference_api_key_ds.all)
       @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
       @free_quota_unit = "inference tokens"

--- a/serializers/inference_router_model.rb
+++ b/serializers/inference_router_model.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Serializers::InferenceRouterModel < Serializers::Base
+  def self.million_token_price(resource)
+    (BillingRate.from_resource_properties("InferenceTokens", resource, "global")["unit_price"] * 1_000_000).round(2)
+  end
+
+  def self.serialize_internal(irm, options = {})
+    load_balancer = irm.inference_router.load_balancer
+    {
+      id: irm.ubid,
+      name: irm.model_name,
+      model_name: irm.model_name,
+      tags: irm.tags,
+      url: "#{load_balancer.health_check_protocol}://#{load_balancer.hostname}",
+      input_price_million_tokens: million_token_price(irm.prompt_billing_resource),
+      output_price_million_tokens: million_token_price(irm.completion_billing_resource)
+    }
+  end
+end

--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -410,16 +410,15 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
         "completion_billing_resource", "completion_token_count"
       )
       expect(BillingRecord.count).to eq(2)
-      br = BillingRecord.all[0]
-      expect(br.project_id).to eq(p1.id)
-      expect(br.resource_id).to eq(inference_router.id)
-      expect(br.billing_rate_id).to eq("ba80e171-0c24-4bf9-ac4f-36bdadb259c0")
-      expect(br.amount).to eq(10)
-      br2 = BillingRecord.all[1]
-      expect(br2.project_id).to eq(p1.id)
-      expect(br2.resource_id).to eq(inference_router.id)
-      expect(br2.billing_rate_id).to eq("c8886006-9e15-4046-b46a-163851626f83")
-      expect(br2.amount).to eq(20)
+      brs = BillingRecord.order(:billing_rate_id).all
+      expect(brs[0].project_id).to eq(p1.id)
+      expect(brs[0].resource_id).to eq(inference_router.id)
+      expect(brs[0].billing_rate_id).to eq("ba80e171-0c24-4bf9-ac4f-36bdadb259c0")
+      expect(brs[0].amount).to eq(10)
+      expect(brs[1].project_id).to eq(p1.id)
+      expect(brs[1].resource_id).to eq(inference_router.id)
+      expect(brs[1].billing_rate_id).to eq("c8886006-9e15-4046-b46a-163851626f83")
+      expect(brs[1].amount).to eq(20)
       nx.update_billing_records(
         [{"ubid" => p1.ubid, "model_name" => "test-model", "request_count" => 1, "prompt_token_count" => 1, "completion_token_count" => 2}],
         "prompt_billing_resource", "prompt_token_count"
@@ -429,8 +428,8 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
         "completion_billing_resource", "completion_token_count"
       )
       expect(BillingRecord.count).to eq(2)
-      expect(Integer(br.reload.amount)).to eq(11)
-      expect(Integer(br2.reload.amount)).to eq(22)
+      expect(Integer(brs[0].reload.amount)).to eq(11)
+      expect(Integer(brs[1].reload.amount)).to eq(22)
     end
 
     it "does not update for zero tokens" do

--- a/spec/routes/web/inference_endpoint_spec.rb
+++ b/spec/routes/web/inference_endpoint_spec.rb
@@ -47,6 +47,111 @@ RSpec.describe Clover, "inference-endpoint" do
       expect(page).to have_no_content("unknown-capability")
     end
 
+    it "shows the right inference router models" do
+      private_subnet = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location_id: Location::HETZNER_FSN1_ID).subject
+      load_balancer = LoadBalancer.create_with_id(
+        private_subnet_id: private_subnet.id, name: "dummy-lb-1", health_check_endpoint: "/up", project_id: project.id
+      )
+      LoadBalancerPort.create(load_balancer_id: load_balancer.id, src_port: 80, dst_port: 8000)
+      inference_router = InferenceRouter.create(
+        name: "ir-name", location_id: Location::HETZNER_FSN1_ID, vm_size: "standard-2", replica_count: 1,
+        project_id: project.id, load_balancer_id: load_balancer.id, private_subnet_id: private_subnet.id
+      )
+      [
+        ["meta-llama/Llama-3.2-1B-Instruct", "llama-3-2-1b-it-input", "llama-3-2-1b-it-output", true, {capability: "Text Generation", hf_model: "foo/bar"}],
+        ["Invisible Model", "test-model-input", "test-model-output", false, {capability: "Text Generation"}],
+        ["Unknown Capability", "test-model2-input", "test-model2-output", true, {capability: "Unknown"}]
+      ].each do |model_name, prompt_billing, completion_billing, visible, tags|
+        model = InferenceRouterModel.create(
+          model_name:, prompt_billing_resource: prompt_billing, completion_billing_resource: completion_billing,
+          project_inflight_limit: 100, project_prompt_tps_limit: 10_000, project_completion_tps_limit: 10_000,
+          visible:, tags:
+        )
+        InferenceRouterTarget.create(
+          name: "test-target", host: "test-host", api_key: "test-key", inflight_limit: 10, priority: 1,
+          inference_router_model_id: model.id, inference_router_id: inference_router.id, enabled: true
+        )
+      end
+      InferenceRouterModel.create(
+        model_name: "Model without Target", prompt_billing_resource: "test-model2-input", completion_billing_resource: "test-model2-output",
+        project_inflight_limit: 100, project_prompt_tps_limit: 10_000, project_completion_tps_limit: 10_000,
+        visible: true, tags: {capability: "Text Generation"}
+      )
+
+      expect(BillingRate).to receive(:from_resource_properties)
+        .with("InferenceTokens", "llama-3-2-1b-it-input", "global")
+        .and_return({"unit_price" => 0.0000001})
+      expect(BillingRate).to receive(:from_resource_properties)
+        .with("InferenceTokens", "llama-3-2-1b-it-output", "global")
+        .and_return({"unit_price" => 0.0000002})
+      visit "#{project.path}/inference-endpoint"
+
+      expect(page.title).to eq("Ubicloud - Inference Endpoints")
+      expect(page).to have_content("meta-llama/Llama-3.2-1B-Instruct")
+      expect(page).to have_link(href: "https://huggingface.co/foo/bar")
+      expect(page).to have_content("Input: $0.10 / 1M tokens")
+      expect(page).to have_content("Output: $0.20 / 1M tokens")
+      expect(page).to have_no_content("Invisible Model")
+      expect(page).to have_no_content("Unknown Capability")
+      expect(page).to have_no_content("Model without Target")
+    end
+
+    it "shows both inference endpoints and router models when both are present" do
+      private_subnet = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location_id: Location::HETZNER_FSN1_ID).subject
+      load_balancer = LoadBalancer.create_with_id(private_subnet_id: private_subnet.id, name: "dummy-lb-1", health_check_endpoint: "/up", project_id: project.id)
+      LoadBalancerPort.create(load_balancer_id: load_balancer.id, src_port: 80, dst_port: 8000)
+      InferenceEndpoint.create_with_id(
+        name: "mistral-small-3",
+        model_name: "mistral-small-3",
+        project_id: project.id,
+        is_public: true,
+        visible: true,
+        load_balancer_id: load_balancer.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        vm_size: "size",
+        replica_count: 1,
+        boot_image: "image",
+        storage_volumes: [],
+        engine_params: "",
+        engine: "vllm",
+        private_subnet_id: private_subnet.id,
+        tags: {capability: "Text Generation"}
+      )
+      inference_router = InferenceRouter.create(
+        name: "ir-name",
+        location_id: Location::HETZNER_FSN1_ID,
+        vm_size: "standard-2",
+        replica_count: 1,
+        project_id: project.id,
+        load_balancer_id: load_balancer.id,
+        private_subnet_id: private_subnet.id
+      )
+      inference_router_model = InferenceRouterModel.create(
+        model_name: "meta-llama/Llama-3.2-1B-Instruct",
+        prompt_billing_resource: "llama-3-2-1b-it-input",
+        completion_billing_resource: "llama-3-2-1b-it-output",
+        project_inflight_limit: 100,
+        project_prompt_tps_limit: 1000,
+        project_completion_tps_limit: 1000,
+        visible: true,
+        tags: {capability: "Text Generation"}
+      )
+      InferenceRouterTarget.create(
+        name: "test-target",
+        host: "test-host",
+        api_key: "test-key",
+        inflight_limit: 10,
+        priority: 1,
+        inference_router_model_id: inference_router_model.id,
+        inference_router_id: inference_router.id,
+        enabled: true
+      )
+      visit "#{project.path}/inference-endpoint"
+      expect(page.title).to eq("Ubicloud - Inference Endpoints")
+      expect(page).to have_content("mistral-small-3")
+      expect(page).to have_content("meta-llama/Llama-3.2-1B-Instruct")
+    end
+
     it "does not show inference endpoints without permissions" do
       ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location_id: Location::HETZNER_FSN1_ID).subject
       lb = LoadBalancer.create_with_id(private_subnet_id: ps.id, name: "dummy-lb-1", health_check_endpoint: "/up", project_id: project.id)

--- a/spec/routes/web/inference_playground_spec.rb
+++ b/spec/routes/web/inference_playground_spec.rb
@@ -35,6 +35,30 @@ RSpec.describe Clover, "inference-playground" do
       ].each do |name, model_name, project, is_public, visible, load_balancer_id, tags|
         InferenceEndpoint.create_with_id(name:, model_name:, project_id: project.id, is_public:, visible:, load_balancer_id:, location_id: Location::HETZNER_FSN1_ID, vm_size: "size", replica_count: 1, boot_image: "image", storage_volumes: [], engine_params: "", engine: "vllm", private_subnet_id: ps.id, tags:)
       end
+      inference_router = InferenceRouter.create(
+        name: "ir-name",
+        location_id: Location::HETZNER_FSN1_ID,
+        vm_size: "standard-2",
+        replica_count: 1,
+        project_id: project.id,
+        load_balancer_id: lb.id,
+        private_subnet_id: ps.id
+      )
+      [
+        ["meta-llama/Llama-3.2-1B-Instruct", "llama-3-2-1b-it-input", "llama-3-2-1b-it-output", true, {capability: "Text Generation", hf_model: "foo/bar"}],
+        ["Invisible Model", "test-model-input", "test-model-output", false, {capability: "Text Generation"}],
+        ["Embedding Model", "test-model2-input", "test-model2-output", true, {capability: "Embeddings"}]
+      ].each do |model_name, prompt_billing, completion_billing, visible, tags|
+        model = InferenceRouterModel.create(
+          model_name:, prompt_billing_resource: prompt_billing, completion_billing_resource: completion_billing,
+          project_inflight_limit: 100, project_prompt_tps_limit: 10_000, project_completion_tps_limit: 10_000,
+          visible:, tags:
+        )
+        InferenceRouterTarget.create(
+          name: "test-target", host: "test-host", api_key: "test-key", inflight_limit: 10, priority: 1,
+          inference_router_model_id: model.id, inference_router_id: inference_router.id, enabled: true
+        )
+      end
       visit "#{project.path}/inference-playground"
 
       expect(page.title).to eq("Ubicloud - Playground")
@@ -42,7 +66,7 @@ RSpec.describe Clover, "inference-playground" do
       expect(page).to have_no_content("e5-mistral-8b-it")
       expect(page).to have_no_content("llama-guard-3-8b")
       expect(page).to have_no_content("llama-3-2-3b-it")
-      expect(page).to have_select("inference_endpoint", selected: "mistral-small-3", with_options: ["mistral-small-3", "test-model"])
+      expect(page).to have_select("inference_endpoint", selected: "mistral-small-3", with_options: ["mistral-small-3", "test-model", "meta-llama/Llama-3.2-1B-Instruct"])
     end
 
     it "gives choice of inference api keys" do

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -3,7 +3,7 @@
 <%== render("inference/tabbar") %>
 
 <div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">
-  <% @inference_endpoints.each_with_index do | ie, index |
+  <% @inference_models.each_with_index do | ie, index |
     path, model_icon, curl_message = case ie[:tags]["capability"]
       when "Text Generation"
         [

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -12,8 +12,8 @@
           locals: {
             name: "inference_endpoint",
             placeholder: "Pick an endpoint",
-            options: @inference_endpoints.map { |ie| [ie[:url], ie[:model_name]] },
-            selected: @inference_endpoints.any? ? @inference_endpoints.first[:url] : nil
+            options: @inference_models.map { |ie| [ie[:url], ie[:model_name]] },
+            selected: @inference_models.any? ? @inference_models.first[:url] : nil
           }
         ) %>
       </div>


### PR DESCRIPTION
Create model cards for the visible inference router models alongside the inference endpoints.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add UI support for inference router models, integrating them with existing inference endpoints and updating views and tests accordingly.
> 
>   - **Behavior**:
>     - Adds `visible_capable_models()` in `helpers/inference.rb` to filter visible models with specific capabilities.
>     - Updates `inference_endpoint_ds()` and `inference_router_model_ds()` in `helpers/inference.rb` to use `visible_capable_models()`.
>     - Combines inference endpoints and router models in `inference_endpoint.rb` and `inference_playground.rb` routes.
>   - **Models**:
>     - Adds associations `one_to_many :inference_router_targets` and `one_through_one :inference_router` in `InferenceRouterModel`.
>   - **Serializers**:
>     - Adds `serializers/inference_router_model.rb` to serialize router models with pricing and URL information.
>   - **Views**:
>     - Updates `index.erb` and `playground.erb` to display combined inference models.
>   - **Tests**:
>     - Adds tests in `inference_endpoint_spec.rb` and `inference_playground_spec.rb` to verify UI displays correct models and handles various scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 53f2120f5b9b13092367797b791ca83ee3ddb606. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->