### PR TITLE
Rescue Aws::S3::Errors::NoSuchBucket when uploading blobs in runtime github route

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -124,7 +124,7 @@ class Clover
           retries = 0
           begin
             upload_id = repository.blob_storage_client.create_multipart_upload(bucket: repository.bucket_name, key: entry.blob_key).upload_id
-          rescue Aws::S3::Errors::Unauthorized, Aws::S3::Errors::InternalError => ex
+          rescue Aws::S3::Errors::Unauthorized, Aws::S3::Errors::InternalError, Aws::S3::Errors::NoSuchBucket => ex
             retries += 1
             if retries < 3
               # :nocov:

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -172,6 +172,13 @@ RSpec.describe Clover, "github" do
 
         expect(last_response).to have_runtime_error(400, "Could not authorize multipart upload")
       end
+
+      it "fails if the bucket does not yet exist" do
+        expect(blob_storage_client).to receive(:create_multipart_upload).with(hash_including(bucket: repository.bucket_name)).and_raise(Aws::S3::Errors::NoSuchBucket.new("error", "error")).exactly(3)
+        post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100}
+
+        expect(last_response).to have_runtime_error(400, "Could not authorize multipart upload")
+      end
     end
 
     describe "commits cache" do


### PR DESCRIPTION
I suppose it is possible that the bucket has not yet been created, but will be created shortly, so retrying makes sense.  However, if that isn't the case, this will retry multiple times and fail each time.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add handling for `Aws::S3::Errors::NoSuchBucket` in `create_multipart_upload` with retries in `routes/runtime/github.rb`.
> 
>   - **Error Handling**:
>     - Add `Aws::S3::Errors::NoSuchBucket` to rescue block in `create_multipart_upload` in `routes/runtime/github.rb`.
>     - Retries up to 3 times if the bucket does not exist.
>   - **Testing**:
>     - Add test in `github_spec.rb` to verify behavior when `NoSuchBucket` error is raised during `create_multipart_upload`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 79bb442579a8fc8e597d6f5b9709161b74ce12a9. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->