### PR TITLE
Change rubocop TargetRubyVersion to 3.4

### DIFF
--- a/.by-session-setup.rb
+++ b/.by-session-setup.rb
@@ -263,7 +263,7 @@ lf = $LOADED_FEATURES.dup
 at_exit do
   loaded_features = $LOADED_FEATURES - lf
   dir = __dir__
-  loaded_features.reject! { _1.start_with?(dir) }
+  loaded_features.reject! { it.start_with?(dir) }
 
   unless loaded_features.empty?
     load_paths = $LOAD_PATH.sort_by { |path| -path.length }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ inherit_gem:
   standard: config/base.yml
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.4
   NewCops: enable
   Exclude:
     - public/**/*
@@ -33,6 +33,10 @@ Rake:
 
 Sequel:
   Enabled: true
+
+# Seems to be buggy and flags non-redundant line continuations as redundant
+Style/RedundantLineContinuation:
+  Enabled: false
 
 RSpec/DescribeMethod:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -427,4 +427,4 @@ namespace :linter do
 end
 
 desc "Run all linters"
-task linter: ["rubocop", "brakeman", "erb_formatter", "openapi", "go"].map { "linter:#{_1}" }
+task linter: ["rubocop", "brakeman", "erb_formatter", "openapi", "go"].map { "linter:#{it}" }

--- a/bin/ci
+++ b/bin/ci
@@ -8,8 +8,8 @@ require "optparse"
 @started_at = Time.now
 
 def main(options)
-  all_test_cases = YAML.load_file("config/e2e_test_cases.yml").to_h { [_1["name"], _1] }
-  boot_images = all_test_cases.values_at(*options[:test_cases]).flat_map { _1["images"] }.uniq
+  all_test_cases = YAML.load_file("config/e2e_test_cases.yml").to_h { [it["name"], it] }
+  boot_images = all_test_cases.values_at(*options[:test_cases]).flat_map { it["images"] }.uniq
 
   hetzner_server_st = Prog::Test::HetznerServer.assemble(vm_host_id: options[:vm_host_id], default_boot_images: boot_images)
   wait_until(hetzner_server_st, "wait")
@@ -38,7 +38,7 @@ def main(options)
     tests_to_wait << unencrypted_vms_st
   end
 
-  if (gh_test_cases = all_test_cases.values_at(*options[:test_cases].select { _1.include?("github_runner") }))
+  if (gh_test_cases = all_test_cases.values_at(*options[:test_cases].select { it.include?("github_runner") }))
     tests_to_wait << Prog::Test::GithubRunner.assemble(gh_test_cases)
   end
 
@@ -76,7 +76,7 @@ def log(st, msg)
   when "Test::HetznerServer"
     "VmHost.#{Strand[st.stack.first["vm_host_id"]]&.label}"
   when "Test::VmGroup"
-    st.stack.first["vms"].map { "Vm.#{Strand[_1]&.label}" }.join(", ")
+    st.stack.first["vms"].map { "Vm.#{Strand[it]&.label}" }.join(", ")
   when "Test::Vm"
     "Vm.#{Strand[st.stack.first["subject_id"]]&.label}"
   else

--- a/clover.rb
+++ b/clover.rb
@@ -468,7 +468,7 @@ class Clover < Roda
       account = Account[account_id]
       # Do not allow to close account if the project has resources and
       # the account is the only user
-      if (project = account.projects.find { _1.accounts.count == 1 && _1.has_resources })
+      if (project = account.projects.find { it.accounts.count == 1 && it.has_resources })
         fail DependencyError.new("'#{project.name}' project has some resources. Delete all related resources first.")
       end
     end

--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -52,9 +52,9 @@ class Clover
     options.add_option(name: "location", values: Option.locations)
     subnets = dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map {
       {
-        location_id: _1.location_id,
-        value: _1.ubid,
-        display_name: _1.name
+        location_id: it.location_id,
+        value: it.ubid,
+        display_name: it.name
       }
     }
     options.add_option(name: "private_subnet_id", values: subnets, parent: "location") do |location, private_subnet|

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -133,8 +133,8 @@ class Clover < Roda
   end
 
   def validate_request_params(required_keys, allowed_optional_keys = [], ignored_keys = [])
-    params = request.params.reject { ignored_keys.include?(_1) }
-    params = params.reject { _1 == "_csrf" } unless api?
+    params = request.params.reject { ignored_keys.include?(it) }
+    params = params.reject { it == "_csrf" } unless api?
 
     Validation.validate_request_params(params, required_keys, allowed_optional_keys)
   end
@@ -146,9 +146,9 @@ class Clover < Roda
     # that users won't see higher price in their invoice compared
     # to price calculator and also we charge same amount no matter
     # the number of days in a given month.
-    BillingRate.rates.filter { resource_types.include?(_1["resource_type"]) }
-      .group_by { [_1["resource_type"], _1["resource_family"], _1["location"]] }
-      .map { |_, brs| brs.max_by { _1["active_from"] } }
+    BillingRate.rates.filter { resource_types.include?(it["resource_type"]) }
+      .group_by { [it["resource_type"], it["resource_family"], it["location"]] }
+      .map { |_, brs| brs.max_by { it["active_from"] } }
       .each_with_object(Hash.new { |h, k| h[k] = h.class.new(&h.default_proc) }) do |br, hash|
       hash[br["location"]][br["resource_type"]][br["resource_family"]] = {
         hourly: br["unit_price"].to_f * 60,

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -39,7 +39,7 @@ class Clover
     options.add_option(name: "name")
     options.add_option(name: "location", values: Option.kubernetes_locations)
     options.add_option(name: "cp_nodes", values: Option::KubernetesCPOptions.map(&:cp_node_count), parent: "location")
-    options.add_option(name: "worker_nodes", values: (1..10).map { {value: _1, display_name: "#{_1} Node#{(_1 == 1) ? "" : "s"}"} }, parent: "cp_nodes") do |location, cp_nodes, worker_nodes|
+    options.add_option(name: "worker_nodes", values: (1..10).map { {value: it, display_name: "#{it} Node#{(it == 1) ? "" : "s"}"} }, parent: "cp_nodes") do |location, cp_nodes, worker_nodes|
       worker_nodes[:value] >= cp_nodes
     end
 

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -57,13 +57,13 @@ class Clover
     options = OptionTreeGenerator.new
     options.add_option(name: "name")
     options.add_option(name: "description")
-    options.add_option(name: "private_subnet_id", values: dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map { {value: _1.ubid, display_name: _1.name} })
-    options.add_option(name: "algorithm", values: ["Round Robin", "Hash Based"].map { {value: _1.downcase.tr(" ", "_"), display_name: _1} })
-    options.add_option(name: "stack", values: [LoadBalancer::Stack::IPV4, LoadBalancer::Stack::IPV6, LoadBalancer::Stack::DUAL].map { {value: _1.downcase, display_name: _1.gsub("ip", "IP")} })
+    options.add_option(name: "private_subnet_id", values: dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map { {value: it.ubid, display_name: it.name} })
+    options.add_option(name: "algorithm", values: ["Round Robin", "Hash Based"].map { {value: it.downcase.tr(" ", "_"), display_name: it} })
+    options.add_option(name: "stack", values: [LoadBalancer::Stack::IPV4, LoadBalancer::Stack::IPV6, LoadBalancer::Stack::DUAL].map { {value: it.downcase, display_name: it.gsub("ip", "IP")} })
     options.add_option(name: "src_port")
     options.add_option(name: "dst_port")
     options.add_option(name: "health_check_endpoint")
-    options.add_option(name: "health_check_protocol", values: ["http", "https", "tcp"].map { {value: _1, display_name: _1.upcase} })
+    options.add_option(name: "health_check_protocol", values: ["http", "https", "tcp"].map { {value: it, display_name: it.upcase} })
     options.serialize
   end
 end

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -106,14 +106,14 @@ class Clover
       if location.provider == "aws" && (size.split("-").last.to_i > 16 || size.split("-").first == "burstable")
         false
       else
-        pg_size = all_sizes_for_project.find { _1.name == size && _1.flavor == flavor && _1.location_id == location.id }
-        vm_size = Option::VmSizes.find { _1.name == pg_size.vm_size && _1.arch == "x64" && _1.visible }
+        pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
+        vm_size = Option::VmSizes.find { it.name == pg_size.vm_size && it.arch == "x64" && it.visible }
         vm_size.family == family
       end
     end
 
     options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "118", "237", "475", "950", "1781", "1900", "3562", "3800"], parent: "size") do |flavor, location, family, size, storage_size|
-      pg_size = all_sizes_for_project.find { _1.name == size && _1.flavor == flavor && _1.location_id == location.id }
+      pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
       pg_size.storage_size_options.include?(storage_size.to_i)
     end
 
@@ -143,14 +143,14 @@ class Clover
       if location.provider == "aws" && (size.split("-").last.to_i > 16 || size.split("-").first == "burstable")
         false
       else
-        pg_size = all_sizes_for_project.find { _1.name == size && _1.flavor == flavor && _1.location_id == location.id }
-        vm_size = Option::VmSizes.find { _1.name == pg_size.vm_size && _1.arch == "x64" && _1.visible }
+        pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
+        vm_size = Option::VmSizes.find { it.name == pg_size.vm_size && it.arch == "x64" && it.visible }
         vm_size.family == family
       end
     end
 
     options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "118", "237", "475", "950", "1781", "1900", "3562", "3800"], parent: "size") do |flavor, location, family, size, storage_size|
-      pg_size = all_sizes_for_project.find { _1.name == size && _1.flavor == flavor && _1.location_id == location.id }
+      pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
       pg_size.storage_size_options.include?(storage_size.to_i)
     end
 

--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -26,7 +26,7 @@ class Clover < Roda
       Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }
       return
     end
-    if (job = jobs.find { _1[:runner_name] == runner.ubid })
+    if (job = jobs.find { it[:runner_name] == runner.ubid })
       job[:head_branch]
     else
       Clog.emit("The workflow run does not have given runner") { {runner_scope_failure: log_context} }

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -86,9 +86,9 @@ class Clover
 
     subnets = dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map {
       {
-        location_id: _1.location_id,
-        value: _1.ubid,
-        display_name: _1.name
+        location_id: it.location_id,
+        value: it.ubid,
+        display_name: it.name
       }
     }
     options.add_option(name: "private_subnet_id", values: subnets, parent: "location") do |location, private_subnet|
@@ -99,13 +99,13 @@ class Clover
     options.add_option(name: "family", values: Option.families.map(&:name), parent: "location") do |location, family|
       !!BillingRate.from_resource_properties("VmVCpu", family, location.name)
     end
-    options.add_option(name: "size", values: Option::VmSizes.select { _1.visible }.map { _1.display_name }, parent: "family") do |location, family, size|
-      vm_size = Option::VmSizes.find { _1.display_name == size && _1.arch == "x64" }
+    options.add_option(name: "size", values: Option::VmSizes.select { it.visible }.map { it.display_name }, parent: "family") do |location, family, size|
+      vm_size = Option::VmSizes.find { it.display_name == size && it.arch == "x64" }
       vm_size.family == family
     end
 
     options.add_option(name: "storage_size", values: ["10", "20", "40", "80", "160", "320", "600", "640", "1200", "2400"], parent: "size") do |location, family, size, storage_size|
-      vm_size = Option::VmSizes.find { _1.display_name == size && _1.arch == "x64" }
+      vm_size = Option::VmSizes.find { it.display_name == size && it.arch == "x64" }
       vm_size.storage_size_options.include?(storage_size.to_i)
     end
 

--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -23,7 +23,7 @@ class Clover < Roda
     "deleting" => "bg-red-100 text-red-800"
   )
   ["rebooting", "starting", "waiting for capacity", "restarting"].each do
-    VM_STATE_LABEL_COLOR[_1] = VM_STATE_LABEL_COLOR["creating"]
+    VM_STATE_LABEL_COLOR[it] = VM_STATE_LABEL_COLOR["creating"]
   end
   VM_STATE_LABEL_COLOR["deleted"] = VM_STATE_LABEL_COLOR["deleting"]
   VM_STATE_LABEL_COLOR.freeze

--- a/lib/access_control_model_tag.rb
+++ b/lib/access_control_model_tag.rb
@@ -9,7 +9,7 @@ module AccessControlModelTag
 
       define_method(:applied_table) { table }
       define_method(:applied_column) { column }
-      define_method(:"add_#{base}") { add_member(_1) }
+      define_method(:"add_#{base}") { add_member(it) }
     end
   end
 
@@ -26,7 +26,7 @@ module AccessControlModelTag
   end
 
   def add_members(member_ids)
-    applied_dataset.import([:tag_id, applied_column], member_ids.map { [id, _1] })
+    applied_dataset.import([:tag_id, applied_column], member_ids.map { [id, it] })
   end
 
   def remove_members(member_ids)
@@ -71,17 +71,17 @@ module AccessControlModelTag
     end
 
     proposed_additions = {}
-    to_add.each { proposed_additions[_1] = nil }
+    to_add.each { proposed_additions[it] = nil }
     UBID.resolve_map(proposed_additions)
 
     to_add = []
     # Only allow valid members into the tag
     proposed_additions.each_value do
-      if is_a?(SubjectTag) && _1.is_a?(SubjectTag) && _1.name == "Admin"
+      if is_a?(SubjectTag) && it.is_a?(SubjectTag) && it.name == "Admin"
         issues << "cannot include Admin subject tag in another tag"
         next
       end
-      to_add << _1 if _1 && self.class.valid_member?(project_id, _1)
+      to_add << it if it && self.class.valid_member?(project_id, it)
     end
     if proposed_additions.size != to_add.size
       issues << "#{proposed_additions.size - to_add.size} members not valid"

--- a/lib/authorization.rb
+++ b/lib/authorization.rb
@@ -26,7 +26,7 @@ module Authorization
           .select(Sequel[:applied_action_tag][:action_id], Sequel[:level] + 1)
           .where { level < Config.recursive_tag_limit },
         args: [:action_id, :level])
-      .where(Sequel.or([DB[:action_ids], DB[:rec_action_ids].select(:action_id)].map { [:id, _1] }) | DB[:action_ids].where(action_id: nil).exists)
+      .where(Sequel.or([DB[:action_ids], DB[:rec_action_ids].select(:action_id)].map { [:id, it] }) | DB[:action_ids].where(action_id: nil).exists)
       .select_order_map(:name)
   end
 
@@ -62,11 +62,11 @@ module Authorization
   def self.matched_policies_dataset(project_id, subject_id, actions = nil, object_id = nil)
     dataset = DB[:access_control_entry]
       .where(project_id:)
-      .where(Sequel.or([subject_id, recursive_tag_query(:subject, subject_id)].map { [:subject_id, _1] }))
+      .where(Sequel.or([subject_id, recursive_tag_query(:subject, subject_id)].map { [:subject_id, it] }))
 
     if actions
-      actions = Array(actions).map { ActionType::NAME_MAP.fetch(_1) }
-      dataset = dataset.where(Sequel.or([nil, Sequel.any_uuid(actions), recursive_tag_query(:action, actions, project_id:)].map { [:action_id, _1] }))
+      actions = Array(actions).map { ActionType::NAME_MAP.fetch(it) }
+      dataset = dataset.where(Sequel.or([nil, Sequel.any_uuid(actions), recursive_tag_query(:action, actions, project_id:)].map { [:action_id, it] }))
     end
 
     if object_id
@@ -99,7 +99,7 @@ module Authorization
         false
       end
 
-      dataset = dataset.where(Sequel.or([nil, object_id, recursive_tag_query(:object, object_id)].map { [:object_id, _1] }) & in_project_cond)
+      dataset = dataset.where(Sequel.or([nil, object_id, recursive_tag_query(:object, object_id)].map { [:object_id, it] }) & in_project_cond)
     end
 
     dataset

--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -16,8 +16,8 @@ class BillingRate
 
   def self.from_resource_properties(resource_type, resource_family, location, active_at = Time.now)
     rates.select {
-      _1["resource_type"] == resource_type && _1["resource_family"] == resource_family && _1["location"] == location && _1["active_from"] < active_at
-    }.max_by { _1["active_from"] }
+      it["resource_type"] == resource_type && it["resource_family"] == resource_family && it["location"] == location && it["active_from"] < active_at
+    }.max_by { it["active_from"] }
   end
 
   def self.unit_price_from_resource_properties(resource_type, resource_family, location, active_at = Time.now)
@@ -26,12 +26,12 @@ class BillingRate
 
   def self.from_resource_type(resource_type)
     rates.select {
-      _1["resource_type"] == resource_type
+      it["resource_type"] == resource_type
     }
   end
 
   def self.from_id(billing_rate_id)
-    rates.find { _1["id"] == billing_rate_id }
+    rates.find { it["id"] == billing_rate_id }
   end
 
   def self.line_item_description(resource_type, resource_family, amount)

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -17,7 +17,7 @@ module ContentGenerator
     end
 
     def self.family(location, family)
-      vm_family = Option::VmFamilies.find { _1.name == family }
+      vm_family = Option::VmFamilies.find { it.name == family }
       [
         vm_family.display_name,
         vm_family.ui_descriptor
@@ -25,7 +25,7 @@ module ContentGenerator
     end
 
     def self.size(location, family, size)
-      size = Option::VmSizes.find { _1.display_name == size }
+      size = Option::VmSizes.find { it.display_name == size }
       unit_price = BillingRate.unit_price_from_resource_properties("VmVCpu", family, location.name)
 
       [
@@ -49,7 +49,7 @@ module ContentGenerator
     end
 
     def self.boot_image(boot_image)
-      Option::BootImages.find { _1.name == boot_image }.display_name
+      Option::BootImages.find { it.name == boot_image }.display_name
     end
   end
 
@@ -59,7 +59,7 @@ module ContentGenerator
     end
 
     def self.family(flavor, location, family)
-      vm_family = Option::VmFamilies.find { _1.name == family }
+      vm_family = Option::VmFamilies.find { it.name == family }
 
       [
         vm_family.display_name,
@@ -68,7 +68,7 @@ module ContentGenerator
     end
 
     def self.size(flavor, location, family, size)
-      size = Option::PostgresSizes.find { _1.display_name == size }
+      size = Option::PostgresSizes.find { it.display_name == size }
       unit_price = BillingRate.unit_price_from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location.name)
 
       [
@@ -95,8 +95,8 @@ module ContentGenerator
     end
 
     def self.ha_type(flavor, location, family, vm_size, storage_size, ha_type)
-      vcpu = Option::PostgresSizes.find { _1.display_name == vm_size }.vcpu
-      ha_type = Option::PostgresHaOptions.find { _1.name == ha_type }
+      vcpu = Option::PostgresSizes.find { it.display_name == vm_size }.vcpu
+      ha_type = Option::PostgresHaOptions.find { it.name == ha_type }
       compute_unit_price = BillingRate.unit_price_from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location.name)
       storage_unit_price = BillingRate.unit_price_from_resource_properties("PostgresStorage", flavor, location.name)
       standby_count = ha_type.standby_count
@@ -142,7 +142,7 @@ module ContentGenerator
 
     def self.cp_nodes(location, cp_nodes)
       node_price = 2 * BillingRate.unit_price_from_resource_properties("KubernetesControlPlaneVCpu", "standard", location.name)
-      data = Option::KubernetesCPOptions.find { _1.cp_node_count == cp_nodes }
+      data = Option::KubernetesCPOptions.find { it.cp_node_count == cp_nodes }
       [
         data.title,
         data.explanation,

--- a/lib/free_quota.rb
+++ b/lib/free_quota.rb
@@ -14,7 +14,7 @@ class FreeQuota
     @free_quotas ||= begin
       quotas = YAML.load_file("config/free_quotas.yml")
       quotas.each_with_object({}) do |item, hash|
-        item["billing_rate_ids"] = BillingRate.from_resource_type(item["resource_type"]).map { _1["id"] }
+        item["billing_rate_ids"] = BillingRate.from_resource_type(item["resource_type"]).map { it["id"] }
         hash[item["name"]] = item
       end
     end

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -39,7 +39,7 @@ module Github
 
   def self.runner_labels
     @runner_labels ||= begin
-      labels = YAML.load_file("config/github_runner_labels.yml").to_h { [_1["name"], _1] }
+      labels = YAML.load_file("config/github_runner_labels.yml").to_h { [it["name"], it] }
       labels.transform_values { |v| (a = v["alias_for"]) ? labels[a] : v }
     end
   end
@@ -60,11 +60,11 @@ module Github
     Clog.emit("fetched deliveries") { {deliveries: {total: all_deliveries.count, page: page, since: since}} }
 
     all_deliveries
-      .reject { _1[:delivered_at] < since }
-      .group_by { _1[:guid] }
+      .reject { it[:delivered_at] < since }
+      .group_by { it[:guid] }
       .values
-      .reject { |group| group.any? { _1[:status] == "OK" } }
-      .map { |group| group.max_by { _1[:delivered_at] } }
+      .reject { |group| group.any? { it[:status] == "OK" } }
+      .map { |group| group.max_by { it[:delivered_at] } }
   end
 
   def self.redeliver_failed_deliveries(*)

--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -109,7 +109,7 @@ class InvoiceGenerator
 
         # Each project have $1 github runner credit every month
         # 1$ github credit won't be shown on the portal billing page for now.
-        github_usage = project_content[:resources].flat_map { _1[:line_items] }.select { _1[:resource_type] == "GitHubRunnerMinutes" }.sum { _1[:cost] }
+        github_usage = project_content[:resources].flat_map { it[:line_items] }.select { it[:resource_type] == "GitHubRunnerMinutes" }.sum { it[:cost] }
         github_credit = [1.0, github_usage, project_content[:cost]].min
         if github_credit > 0
           project_content[:github_credit] = github_credit
@@ -122,8 +122,8 @@ class InvoiceGenerator
         free_inference_tokens_remaining = FreeQuota.free_quotas["inference-tokens"]["value"]
         free_inference_tokens_credit = 0.0
         project_content[:resources]
-          .flat_map { _1[:line_items] }
-          .select { _1[:resource_type] == "InferenceTokens" }
+          .flat_map { it[:line_items] }
+          .select { it[:resource_type] == "InferenceTokens" }
           .sort_by { |li| [li[:begin_time].to_date, -li[:unit_price]] }
           .each do |li|
             used_amount = [li[:amount], free_inference_tokens_remaining].min

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -4,7 +4,7 @@ require "yaml"
 
 module Option
   ai_models = YAML.load_file("config/ai_models.yml")
-  AI_MODELS = ai_models.select { _1["enabled"] }.freeze
+  AI_MODELS = ai_models.select { it["enabled"] }.freeze
 
   def self.locations(only_visible: true, feature_flags: [])
     Location.where(project_id: nil).all.select { |pl| !only_visible || (pl.visible || feature_flags.include?("location_#{pl.name.tr("-", "_")}")) }
@@ -23,7 +23,7 @@ module Option
   end
 
   def self.families
-    Option::VmFamilies.select { _1.visible }
+    Option::VmFamilies.select { it.visible }
   end
 
   BootImage = Struct.new(:name, :display_name)
@@ -53,21 +53,21 @@ module Option
     alias_method :display_name, :name
   end
   VmSizes = [2, 4, 8, 16, 30, 60].map {
-    storage_size_options = [_1 * 20, _1 * 40]
-    VmSize.new("standard-#{_1}", "standard", _1, _1 * 100, 0, _1 * 4, storage_size_options, NO_IO_LIMITS, true, false, "x64")
+    storage_size_options = [it * 20, it * 40]
+    VmSize.new("standard-#{it}", "standard", it, it * 100, 0, it * 4, storage_size_options, NO_IO_LIMITS, true, false, "x64")
   }.concat([2, 4, 8, 16, 30, 60].map {
-    storage_size_options = [_1 * 20, _1 * 40]
-    VmSize.new("standard-#{_1}", "standard", _1, _1 * 100, 0, (_1 * 3.2).to_i, storage_size_options, NO_IO_LIMITS, false, false, "arm64")
+    storage_size_options = [it * 20, it * 40]
+    VmSize.new("standard-#{it}", "standard", it, it * 100, 0, (it * 3.2).to_i, storage_size_options, NO_IO_LIMITS, false, false, "arm64")
   }).concat([6].map {
-    VmSize.new("standard-gpu-#{_1}", "standard-gpu", _1, _1 * 100, 0, (_1 * 5.34).to_i, [_1 * 30], NO_IO_LIMITS, false, true, "x64")
+    VmSize.new("standard-gpu-#{it}", "standard-gpu", it, it * 100, 0, (it * 5.34).to_i, [it * 30], NO_IO_LIMITS, false, true, "x64")
   }).concat([1, 2].map {
-    storage_size_options = [_1 * 10, _1 * 20]
-    io_limits = IoLimits.new(nil, _1 * 50, _1 * 50)
-    VmSize.new("burstable-#{_1}", "burstable", _1, _1 * 50, _1 * 50, _1 * 2, storage_size_options, io_limits, true, false, "x64")
+    storage_size_options = [it * 10, it * 20]
+    io_limits = IoLimits.new(nil, it * 50, it * 50)
+    VmSize.new("burstable-#{it}", "burstable", it, it * 50, it * 50, it * 2, storage_size_options, io_limits, true, false, "x64")
   }).concat([1, 2].map {
-    storage_size_options = [_1 * 10, _1 * 20]
-    io_limits = IoLimits.new(nil, _1 * 50, _1 * 50)
-    VmSize.new("burstable-#{_1}", "burstable", _1, _1 * 50, _1 * 50, (_1 * 1.6).to_i, storage_size_options, io_limits, false, false, "arm64")
+    storage_size_options = [it * 10, it * 20]
+    io_limits = IoLimits.new(nil, it * 50, it * 50)
+    VmSize.new("burstable-#{it}", "burstable", it, it * 50, it * 50, (it * 1.6).to_i, storage_size_options, io_limits, false, false, "arm64")
   }).freeze
 
   PostgresSize = Struct.new(:location_id, :name, :vm_family, :vm_size, :flavor, :vcpu, :memory, :storage_size_options) do
@@ -98,7 +98,7 @@ module Option
   PostgresHaOptions = [[PostgresResource::HaType::NONE, 0, "No Standbys", "No replication"],
     [PostgresResource::HaType::ASYNC, 1, "1 Standby", "Asynchronous replication"],
     [PostgresResource::HaType::SYNC, 2, "2 Standbys", "Synchronous replication with quorum"]].map {
-    PostgresHaOption.new(*_1)
+    PostgresHaOption.new(*it)
   }.freeze
 
   POSTGRES_VERSION_OPTIONS = {
@@ -112,7 +112,7 @@ module Option
   KubernetesCPOption = Struct.new(:cp_node_count, :title, :explanation)
   KubernetesCPOptions = [[1, "1 Node", "Single control plane node without resilience"],
     [3, "3 Nodes", "Three control plane nodes with resilience"]].map {
-    KubernetesCPOption.new(*_1)
+    KubernetesCPOption.new(*it)
   }.freeze
 
   def self.customer_postgres_sizes_for_project(project_id)

--- a/lib/system_parser.rb
+++ b/lib/system_parser.rb
@@ -70,7 +70,7 @@ class SystemParser
         $1
       end
       unix_device = s.captures.first
-      size_gib, avail_gib = s.captures[2..].map { Integer(_1) / 1073741824 }
+      size_gib, avail_gib = s.captures[2..].map { Integer(it) / 1073741824 }
       out << DfRecord.new(unix_device, optional_name, size_gib, avail_gib)
     end
 

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -14,7 +14,7 @@ class UbiCli
     "vm" => "vm"
   }.freeze
 
-  SDK_METHODS = FRAGMENTS.transform_values { _1.tr("-", "_").freeze }.freeze
+  SDK_METHODS = FRAGMENTS.transform_values { it.tr("-", "_").freeze }.freeze
 
   CAPITALIZED_LABELS = {
     "fw" => "Firewall",
@@ -320,9 +320,9 @@ class UbiCli
 
   def underscore_keys(keys)
     if keys.is_a?(Hash)
-      keys.transform_keys { _1.to_s.tr("-", "_").to_sym }
+      keys.transform_keys { it.to_s.tr("-", "_").to_sym }
     else # when Array
-      keys.map { _1.tr("-", "_").to_sym }
+      keys.map { it.tr("-", "_").to_sym }
     end
   end
 

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -62,8 +62,8 @@ module Validation
   end
 
   def self.validate_vm_size(size, arch, only_visible: false)
-    available_vm_sizes = Option::VmSizes.select { !only_visible || _1.visible }
-    unless (vm_size = available_vm_sizes.find { _1.name == size && _1.arch == arch })
+    available_vm_sizes = Option::VmSizes.select { !only_visible || it.visible }
+    unless (vm_size = available_vm_sizes.find { it.name == size && it.arch == arch })
       fail ValidationFailed.new({size: "\"#{size}\" is not a valid virtual machine size. Available sizes: #{available_vm_sizes.map(&:name)}"})
     end
     vm_size
@@ -77,13 +77,13 @@ module Validation
   end
 
   def self.validate_boot_image(image_name)
-    unless Option::BootImages.find { _1.name == image_name }
+    unless Option::BootImages.find { it.name == image_name }
       fail ValidationFailed.new({boot_image: "\"#{image_name}\" is not a valid boot image name. Available boot image names are: #{Option::BootImages.map(&:name)}"})
     end
   end
 
   def self.validate_postgres_ha_type(ha_type)
-    unless Option::PostgresHaOptions.find { _1.name == ha_type }
+    unless Option::PostgresHaOptions.find { it.name == ha_type }
       fail ValidationFailed.new({ha_type: "\"#{ha_type}\" is not a valid PostgreSQL high availability option. Available options: #{Option::PostgresHaOptions.map(&:name)}"})
     end
   end
@@ -125,7 +125,7 @@ module Validation
 
   def self.validate_postgres_size(location, size, project_id)
     all_sizes_for_project = Option.customer_postgres_sizes_for_project(project_id)
-    unless (postgres_size = all_sizes_for_project.find { _1.location_id == location.id && _1.name == size })
+    unless (postgres_size = all_sizes_for_project.find { it.location_id == location.id && it.name == size })
       fail ValidationFailed.new({size: "\"#{size}\" is not a valid PostgreSQL database size. Available sizes: #{all_sizes_for_project.map(&:name)}"})
     end
     postgres_size

--- a/loader.rb
+++ b/loader.rb
@@ -91,11 +91,11 @@ module Scheduling; end
 module Serializers; end
 
 autoload_normal.call("model", flat: true)
-%w[lib clover.rb].each { autoload_normal.call(_1) }
-%w[scheduling prog serializers].each { autoload_normal.call(_1, include_first: true) }
+%w[lib clover.rb].each { autoload_normal.call(it) }
+%w[scheduling prog serializers].each { autoload_normal.call(it, include_first: true) }
 
 if ENV["LOAD_FILES_SEPARATELY_CHECK"] == "1"
-  files = %w[model lib scheduling prog serializers].flat_map { Dir["#{_1}/**/*.rb"] }
+  files = %w[model lib scheduling prog serializers].flat_map { Dir["#{it}/**/*.rb"] }
   files << "clover.rb"
 
   Sequel::DATABASES.each(&:disconnect)
@@ -119,12 +119,12 @@ Unreloader.record_dependency("lib/resource_methods.rb", "model")
 Unreloader.record_dependency("lib/semaphore_methods.rb", "model")
 
 if force_autoload
-  AUTOLOAD_CONSTANT_VALUES = AUTOLOAD_CONSTANTS.map { Object.const_get(_1) }.freeze
+  AUTOLOAD_CONSTANT_VALUES = AUTOLOAD_CONSTANTS.map { Object.const_get(it) }.freeze
 
   # All classes are already available, so speed up UBID.class_for_ubid using
   # hash of prefixes to class objects
   class UBID
-    TYPE2CLASS = TYPE2CLASSNAME.transform_values { Object.const_get(_1) }.freeze
+    TYPE2CLASS = TYPE2CLASSNAME.transform_values { Object.const_get(it) }.freeze
     private_constant :TYPE2CLASS
 
     singleton_class.remove_method(:class_for_ubid)
@@ -175,7 +175,7 @@ def clover_freeze
 
   # Aws SDK started to autoload modules when used, so we need to load them
   # before freezing. https://github.com/aws/aws-sdk-ruby/pull/3105
-  [:Client, :Presigner, :Errors].each { Aws::S3.const_get(_1) }
+  [:Client, :Presigner, :Errors].each { Aws::S3.const_get(it) }
 
   # A standard library method that edits/creates a module variable as
   # a side effect.  We encountered it when using rubygems for its tar

--- a/migrate/20250324_add_loadbalancer_ports.rb
+++ b/migrate/20250324_add_loadbalancer_ports.rb
@@ -41,7 +41,7 @@ Sequel.migration do
 
     DB[:load_balancer_port].import(
       [:id, :load_balancer_id, :src_port, :dst_port],
-      DB[:load_balancer].select_map([:id, :src_port, :dst_port]).each { _1.unshift(UBID.generate("lp").to_uuid) }
+      DB[:load_balancer].select_map([:id, :src_port, :dst_port]).each { it.unshift(UBID.generate("lp").to_uuid) }
     )
 
     DB[:load_balancer_vm_port].import([:id, :load_balancer_port_id, :load_balancer_vm_id, :state],
@@ -52,7 +52,7 @@ Sequel.migration do
           Sequel[:load_balancers_vms][:id].as(:load_balancer_vm_id),
           Sequel[:load_balancers_vms][:state]
         ])
-        .each { _1.unshift(UBID.generate("1q").to_uuid) })
+        .each { it.unshift(UBID.generate("1q").to_uuid) })
   end
 
   down do

--- a/model/access_control_entry.rb
+++ b/model/access_control_entry.rb
@@ -11,7 +11,7 @@ class AccessControlEntry < Sequel::Model
   def_column_alias :object_id, :object_id
 
   def update_from_ubids(hash)
-    update(hash.transform_values { UBID.to_uuid(_1) if _1 })
+    update(hash.transform_values { UBID.to_uuid(it) if it })
   end
 
   def validate

--- a/model/account.rb
+++ b/model/account.rb
@@ -36,7 +36,7 @@ class Account < Sequel::Model(:accounts)
     update(suspended_at: Time.now)
     DB[:account_active_session_keys].where(account_id: id).delete(force: true)
 
-    projects.each { _1.billing_info&.payment_methods_dataset&.update(fraud: true) }
+    projects.each { it.billing_info&.payment_methods_dataset&.update(fraud: true) }
   end
 end
 

--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -32,7 +32,7 @@ class DnsZone < Sequel::Model
     DB[:dns_record].import(
       [:id, :dns_zone_id, :name, :type, :ttl, :data, :tombstoned],
       records.select_map([:name, :type, :ttl, :data]).map do
-        [DnsRecord.generate_uuid, id, *_1, true]
+        [DnsRecord.generate_uuid, id, *it, true]
       end
     )
 

--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -15,7 +15,7 @@ class GithubInstallation < Sequel::Model
       .exclude(Sequel[:strand][:label] => ["start", "wait_concurrency_limit"])
       .select_map(Sequel[:github_runner][:label])
       .sum do
-        label = Github.runner_labels[_1]
+        label = Github.runner_labels[it]
         Validation.validate_vm_size(label["vm_size"], label["arch"]).vcpus
       end
   end

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -131,7 +131,7 @@ class Invoice < Sequel::Model
     else
       ["The invoice amount of #{ser[:total]} will be debited from your credit card on file."]
     end
-    github_usage = ser[:items].select { _1[:description].include?("GitHub Runner") }.sum { _1[:cost] }
+    github_usage = ser[:items].select { it[:description].include?("GitHub Runner") }.sum { it[:cost] }
     saved_amount = 9 * github_usage
     if saved_amount > 1
       messages << "You saved $#{saved_amount.to_i} this month using managed Ubicloud runners instead of GitHub hosted runners!"
@@ -150,13 +150,13 @@ class Invoice < Sequel::Model
   def send_failure_email(errors)
     ser = Serializers::Invoice.serialize(self, {detailed: true})
     receivers = [ser[:billing_email]]
-    receivers += project.accounts.select { Authorization.has_permission?(project.id, _1.id, "Project:billing", project.id) }.map(&:email)
+    receivers += project.accounts.select { Authorization.has_permission?(project.id, it.id, "Project:billing", project.id) }.map(&:email)
     Util.send_email(receivers.uniq, "Urgent: Action Required to Prevent Service Disruption",
       cc: Config.mail_from,
       greeting: "Dear #{ser[:billing_name]},",
       body: ["We hope this message finds you well.",
         "We've noticed that your credit card on file has been declined with the following errors:",
-        *errors.map { "- #{_1}" },
+        *errors.map { "- #{it}" },
         "The invoice amount of #{ser[:total]} tried be debited from your credit card on file.",
         "To prevent service disruption, please update your payment information within the next two days.",
         "If you have any questions, please send us a support request via support@ubicloud.com."],
@@ -237,7 +237,7 @@ class Invoice < Sequel::Model
     items += if data[:items].empty?
       [[{content: "No resources", colspan: 4, align: :center, font_style: :semibold}]]
     else
-      data[:items].map { [_1[:name], _1[:description], _1[:usage], _1[:cost_humanized]] }
+      data[:items].map { [it[:name], it[:description], it[:usage], it[:cost_humanized]] }
     end
     pdf.table items, header: true, width: pdf.bounds.width, cell_style: {size: 9, border_color: "E5E7EB", borders: [], padding: [5, 6, 12, 6], valign: :center} do
       style(row(0), size: 12, font_style: :semibold, text_color: dark_gray, background_color: "F9FAFB")

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -23,7 +23,7 @@ class MinioServer < Sequel::Model
 
   def generate_etc_hosts_entry
     entries = ["::1 #{hostname}"]
-    entries += cluster.servers.reject { _1.id == id }.map do |server|
+    entries += cluster.servers.reject { it.id == id }.map do |server|
       "#{server.public_ipv6_address} #{server.hostname}"
     end
     entries.join("\n")
@@ -70,8 +70,8 @@ class MinioServer < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      server_data = JSON.parse(session[:minio_client].admin_info.body)["servers"].find { _1["endpoint"] == endpoint }
-      (server_data["state"] == "online" && server_data["drives"].all? { _1["state"] == "ok" }) ? "up" : "down"
+      server_data = JSON.parse(session[:minio_client].admin_info.body)["servers"].find { it["endpoint"] == endpoint }
+      (server_data["state"] == "online" && server_data["drives"].all? { it["state"] == "ok" }) ? "up" : "down"
     rescue
       "down"
     end

--- a/model/object_metatag.rb
+++ b/model/object_metatag.rb
@@ -22,7 +22,7 @@ class ObjectMetatag < DelegateClass(ObjectTag)
 
   # Designed solely for use with UBID.resolve_map
   def self.where(id:)
-    ObjectTag.where(id: Sequel.any_uuid(id.args[0].map { from_meta_uuid(_1) })).map(&:metatag)
+    ObjectTag.where(id: Sequel.any_uuid(id.args[0].map { from_meta_uuid(it) })).map(&:metatag)
   end
 
   # Designed solely for use with UBID.decode

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -43,7 +43,7 @@ class PostgresResource < Sequel::Model
   def display_state
     return "deleting" if destroy_set? || strand.nil? || strand.label == "destroy"
     return "unavailable" if representative_server&.strand&.label == "unavailable"
-    return "converging" if strand.children.any? { _1.prog == "Postgres::ConvergePostgresResource" }
+    return "converging" if strand.children.any? { it.prog == "Postgres::ConvergePostgresResource" }
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
     "creating"
   end
@@ -92,20 +92,20 @@ class PostgresResource < Sequel::Model
   end
 
   def has_enough_fresh_servers?
-    servers.count { !_1.needs_recycling? } >= target_server_count
+    servers.count { !it.needs_recycling? } >= target_server_count
   end
 
   def has_enough_ready_servers?
-    servers.count { !_1.needs_recycling? && _1.strand.label == "wait" } >= target_server_count
+    servers.count { !it.needs_recycling? && it.strand.label == "wait" } >= target_server_count
   end
 
   def needs_convergence?
-    servers.any? { _1.needs_recycling? } || servers.count != target_server_count
+    servers.any? { it.needs_recycling? } || servers.count != target_server_count
   end
 
   def set_firewall_rules
-    vm_firewall_rules = firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(5432..5432)} }
-    vm_firewall_rules.concat(firewall_rules.map { {cidr: _1.cidr.to_s, port_range: Sequel.pg_range(6432..6432)} })
+    vm_firewall_rules = firewall_rules.map { {cidr: it.cidr.to_s, port_range: Sequel.pg_range(5432..5432)} }
+    vm_firewall_rules.concat(firewall_rules.map { {cidr: it.cidr.to_s, port_range: Sequel.pg_range(6432..6432)} })
     vm_firewall_rules.push({cidr: "0.0.0.0/0", port_range: Sequel.pg_range(22..22)})
     vm_firewall_rules.push({cidr: "::/0", port_range: Sequel.pg_range(22..22)})
     vm_firewall_rules.push({cidr: private_subnet.net4.to_s, port_range: Sequel.pg_range(5432..5432)})

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -49,16 +49,16 @@ PGHOST=/var/run/postgresql
     begin
       blob_storage_client
         .list_objects(ubid, "basebackups_005/")
-        .select { _1.key.end_with?("backup_stop_sentinel.json") }
+        .select { it.key.end_with?("backup_stop_sentinel.json") }
     rescue => ex
       recoverable_errors = ["The Access Key Id you provided does not exist in our records.", "AccessDenied", "No route to host", "Connection refused"]
-      return [] if recoverable_errors.any? { ex.message.include?(_1) }
+      return [] if recoverable_errors.any? { ex.message.include?(it) }
       raise
     end
   end
 
   def latest_backup_label_before_target(target:)
-    backup = backups.sort_by(&:last_modified).reverse.find { _1.last_modified < target }
+    backup = backups.sort_by(&:last_modified).reverse.find { it.last_modified < target }
     fail "BUG: no backup found" unless backup
     backup.key.delete_prefix("basebackups_005/").delete_suffix("_backup_stop_sentinel.json")
   end

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -145,7 +145,7 @@ class PrivateSubnet < Sequel::Model
   end
 
   def find_all_connected_nics(excluded_private_subnet_ids = [])
-    nics + connected_subnets.select { |subnet| !excluded_private_subnet_ids.include?(subnet.id) }.flat_map { _1.find_all_connected_nics(excluded_private_subnet_ids + [id]) }.uniq
+    nics + connected_subnets.select { |subnet| !excluded_private_subnet_ids.include?(subnet.id) }.flat_map { it.find_all_connected_nics(excluded_private_subnet_ids + [id]) }.uniq
   end
 end
 

--- a/model/project.rb
+++ b/model/project.rb
@@ -67,7 +67,7 @@ class Project < Sequel::Model
   end
 
   def has_resources
-    RESOURCE_ASSOCIATIONS.any? { !send(:"#{_1}_dataset").empty? } || github_installations.flat_map(&:runners).count > 0
+    RESOURCE_ASSOCIATIONS.any? { !send(:"#{it}_dataset").empty? } || github_installations.flat_map(&:runners).count > 0
   end
 
   def soft_delete
@@ -79,7 +79,7 @@ class Project < Sequel::Model
         DB[:"applied_#{tag_type}_tag"].where(tag_id: dataset.select(:id)).delete
         dataset.destroy
       end
-      github_installations.each { Prog::Github::DestroyGithubInstallation.assemble(_1) }
+      github_installations.each { Prog::Github::DestroyGithubInstallation.assemble(it) }
 
       # We still keep the project object for billing purposes.
       # These need to be cleaned up manually once in a while.
@@ -115,7 +115,7 @@ class Project < Sequel::Model
     case resource_type
     when "VmVCpu" then vms.sum(&:vcpus)
     when "GithubRunnerVCpu" then github_installations.sum(&:total_active_runner_vcpus)
-    when "PostgresVCpu" then postgres_resources.flat_map { _1.servers.map { |s| s.vm.vcpus } }.sum
+    when "PostgresVCpu" then postgres_resources.flat_map { it.servers.map { |s| s.vm.vcpus } }.sum
     else
       raise "Unknown resource type: #{resource_type}"
     end

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -33,7 +33,7 @@ class Sshable < Sequel::Model
 
   def keys
     [raw_private_key_1, raw_private_key_2].compact.map {
-      SshKey.from_binary(_1)
+      SshKey.from_binary(it)
     }
   end
 

--- a/model/subject_tag.rb
+++ b/model/subject_tag.rb
@@ -24,7 +24,7 @@ class SubjectTag < Sequel::Model
 
   def self.options_for_project(project)
     {
-      "Tag" => project.subject_tags.reject { _1.name == "Admin" },
+      "Tag" => project.subject_tags.reject { it.name == "Admin" },
       "Account" => project.accounts
     }
   end

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -143,10 +143,10 @@ class Vm < Sequel::Model
   # and use its name as a display name.
   def display_size
     vm_size = Option::VmSizes.find {
-      _1.family == family &&
-        _1.arch == arch &&
-        _1.vcpus == vcpus &&
-        (cpu_percent_limit.nil? || _1.cpu_percent_limit == cpu_percent_limit)
+      it.family == family &&
+        it.arch == arch &&
+        it.vcpus == vcpus &&
+        (cpu_percent_limit.nil? || it.cpu_percent_limit == cpu_percent_limit)
     }
     vm_size.name
   end
@@ -164,7 +164,7 @@ class Vm < Sequel::Model
   end
 
   def storage_size_gib
-    vm_storage_volumes.map { _1.size_gib }.sum
+    vm_storage_volumes.map { it.size_gib }.sum
   end
 
   def init_health_monitor_session
@@ -222,7 +222,7 @@ class Vm < Sequel::Model
       "ndp_needed" => vm_host.ndp_needed,
       "storage_volumes" => storage_volumes,
       "swap_size_bytes" => swap_size_bytes,
-      "pci_devices" => pci_devices.map { [_1.slot, _1.iommu_group] },
+      "pci_devices" => pci_devices.map { [it.slot, it.iommu_group] },
       "slice_name" => vm_host_slice&.inhost_name || "system.slice",
       "cpu_percent_limit" => cpu_percent_limit || 0,
       "cpu_burst_percent_limit" => cpu_burst_percent_limit || 0

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -138,7 +138,7 @@ class VmHost < Sequel::Model
     rand = SecureRandom.random_number(2**(32 - used_subnet.cidr.netmask.prefix_len)).to_i
     picked_subnet = used_subnet.cidr.nth(rand)
     # we check if the picked subnet is used by one of the vms
-    return ip4_random_vm_network if vm_addresses.map { _1.ip.to_s }.include?("#{picked_subnet}/32")
+    return ip4_random_vm_network if vm_addresses.map { it.ip.to_s }.include?("#{picked_subnet}/32")
 
     # For Leaseweb, avoid using the very first and the last ips
     if provider == "leaseweb"
@@ -249,7 +249,7 @@ class VmHost < Sequel::Model
 
   def hetznerify(server_id)
     DB.transaction do
-      HostProvider.create(provider_name: HostProvider::HETZNER_PROVIDER_NAME, server_identifier: server_id) { _1.id = id }
+      HostProvider.create(provider_name: HostProvider::HETZNER_PROVIDER_NAME, server_identifier: server_id) { it.id = id }
       create_addresses
     end
   end
@@ -391,11 +391,11 @@ class VmHost < Sequel::Model
   end
 
   def available_storage_gib
-    storage_devices.sum { _1.available_storage_gib }
+    storage_devices.sum { it.available_storage_gib }
   end
 
   def total_storage_gib
-    storage_devices.sum { _1.total_storage_gib }
+    storage_devices.sum { it.total_storage_gib }
   end
 
   def render_arch(arm64:, x64:)

--- a/prog/ai/inference_router_nexus.rb
+++ b/prog/ai/inference_router_nexus.rb
@@ -39,9 +39,9 @@ class Prog::Ai::InferenceRouterNexus < Prog::Base
 
       inference_router = InferenceRouter.create(
         project_id:, location_id:, name:, vm_size:, replica_count:, load_balancer_id: lb_s.id, private_subnet_id: subnet_s.id
-      ) { _1.id = ubid.to_uuid }
+      ) { it.id = ubid.to_uuid }
       Prog::Ai::InferenceRouterReplicaNexus.assemble(inference_router.id)
-      Strand.create(prog: "Ai::InferenceRouterNexus", label: "start") { _1.id = inference_router.id }
+      Strand.create(prog: "Ai::InferenceRouterNexus", label: "start") { it.id = inference_router.id }
     end
   end
 
@@ -60,7 +60,7 @@ class Prog::Ai::InferenceRouterNexus < Prog::Base
   end
 
   label def wait_replicas
-    nap 5 if replicas.any? { _1.strand.label != "wait" }
+    nap 5 if replicas.any? { it.strand.label != "wait" }
     hop_wait
   end
 
@@ -90,7 +90,7 @@ class Prog::Ai::InferenceRouterNexus < Prog::Base
   end
 
   def reconcile_replicas
-    actual_replica_count = replicas.count { !(_1.destroy_set? || _1.strand.label == "destroy") }
+    actual_replica_count = replicas.count { !(it.destroy_set? || it.strand.label == "destroy") }
     desired_replica_count = inference_router.replica_count
 
     if actual_replica_count < desired_replica_count
@@ -99,7 +99,7 @@ class Prog::Ai::InferenceRouterNexus < Prog::Base
       end
     elsif actual_replica_count > desired_replica_count
       victims = replicas.select {
-                  !(_1.destroy_set? || _1.strand.label == "destroy")
+                  !(it.destroy_set? || it.strand.label == "destroy")
                 }
         .sort_by { |r|
         [(r.strand.label == "wait") ? 1 : 0, r.created_at]

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -32,9 +32,9 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
       replica = InferenceRouterReplica.create(
         inference_router_id: inference_router_id,
         vm_id: vm_st.id
-      ) { _1.id = ubid.to_uuid }
+      ) { it.id = ubid.to_uuid }
 
-      Strand.create(prog: "Ai::InferenceRouterReplicaNexus", label: "start") { _1.id = replica.id }
+      Strand.create(prog: "Ai::InferenceRouterReplicaNexus", label: "start") { it.id = replica.id }
     end
   end
 
@@ -180,7 +180,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
     decr_destroy
 
     resolve_page
-    strand.children.each { _1.destroy }
+    strand.children.each { it.destroy }
     inference_router.load_balancer.evacuate_vm(vm)
     inference_router.load_balancer.remove_vm(vm)
     vm.incr_destroy
@@ -243,8 +243,8 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
       .select(&:active?)
       .map do
       {
-        ubid: _1.ubid,
-        api_keys: _1.api_keys
+        ubid: it.ubid,
+        api_keys: it.api_keys
           .select { |k| k.used_for == "inference_endpoint" && k.is_valid }
           .sort_by { |k| k.id }
           .map { |k| Digest::SHA2.hexdigest(k.key) }
@@ -320,7 +320,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
       begin
         today_record = BillingRecord
           .where(project_id: project.id, resource_id: inference_router.id, billing_rate_id: rate_id)
-          .where { Sequel.pg_range(_1.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
+          .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
           .first
 
         if today_record

--- a/prog/aws/instance.rb
+++ b/prog/aws/instance.rb
@@ -88,7 +88,7 @@ usermod -L ubuntu
       vm.sshable&.update(host: public_ipv4)
       vm.update(cores: vm.vcpus / 2, allocated_at: Time.now, ephemeral_net6: instance_response.dig(:network_interfaces, 0, :ipv_6_addresses, 0, :ipv_6_address))
 
-      if (disk_size = vm.strand.stack.first["storage_volumes"].find { _1["boot"] == false }&.dig("size_gib") || 0) > 0
+      if (disk_size = vm.strand.stack.first["storage_volumes"].find { it["boot"] == false }&.dig("size_gib") || 0) > 0
         VmStorageVolume.create_with_id(
           vm_id: vm.id,
           size_gib: disk_size,

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -198,7 +198,7 @@ end
       child.id
     end.freeze
 
-    strand.children.delete_if { reaped_ids.include?(_1.id) }
+    strand.children.delete_if { reaped_ids.include?(it.id) }
 
     reapable
   end

--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -42,7 +42,7 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
 
       dns_server.run_commands_on_all_vms(commands)
 
-      DB[:seen_dns_records_by_dns_servers].multi_insert(records_to_rectify.map { {dns_record_id: _1.id, dns_server_id: dns_server.id} })
+      DB[:seen_dns_records_by_dns_servers].multi_insert(records_to_rectify.map { {dns_record_id: it.id, dns_server_id: dns_server.id} })
     end
 
     hop_wait

--- a/prog/expire_project_invitations.rb
+++ b/prog/expire_project_invitations.rb
@@ -2,7 +2,7 @@
 
 class Prog::ExpireProjectInvitations < Prog::Base
   label def wait
-    ProjectInvitation.where { _1.expires_at < Time.now }.all.each(&:destroy)
+    ProjectInvitation.where { it.expires_at < Time.now }.all.each(&:destroy)
 
     nap 6 * 60 * 60
   end

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -13,13 +13,13 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
         updates[:default_branch] = default_branch if default_branch
         repository.insert_conflict(target: [:installation_id, :name], update: updates).save_changes
       end
-      Strand.new(prog: "Github::GithubRepositoryNexus", label: "wait") { _1.id = repository.id }
+      Strand.new(prog: "Github::GithubRepositoryNexus", label: "wait") { it.id = repository.id }
         .insert_conflict(target: :id).save_changes
     end
   end
 
   def client
-    @client ||= Github.installation_client(github_repository.installation.installation_id).tap { _1.auto_paginate = true }
+    @client ||= Github.installation_client(github_repository.installation.installation_id).tap { it.auto_paginate = true }
   end
 
   # We dynamically adjust the polling interval based on the remaining rate
@@ -53,7 +53,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
 
       jobs.each do |job|
         next if job[:status] != "queued"
-        next unless (label = job[:labels].find { Github.runner_labels.key?(_1) })
+        next unless (label = job[:labels].find { Github.runner_labels.key?(it) })
         queued_labels[label] += 1
       end
     end

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -23,7 +23,7 @@ class Prog::InstallRhizome < Prog::Base
         elsif stat.file?
           writer.add_file(file, stat.mode) do |tf|
             File.open(full_path, "rb") do
-              IO.copy_stream(_1, tf)
+              IO.copy_stream(it, tf)
             end
           end
 

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -31,9 +31,9 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       # TODO: Validate location
       # TODO: Validate node count
 
-      KubernetesCluster.create(name:, version:, cp_node_count:, location_id:, target_node_size:, target_node_storage_size_gib:, project_id: project.id, private_subnet_id: subnet.id) { _1.id = ubid.to_uuid }
+      KubernetesCluster.create(name:, version:, cp_node_count:, location_id:, target_node_size:, target_node_storage_size_gib:, project_id: project.id, private_subnet_id: subnet.id) { it.id = ubid.to_uuid }
 
-      Strand.create(prog: "Kubernetes::KubernetesClusterNexus", label: "start") { _1.id = ubid.to_uuid }
+      Strand.create(prog: "Kubernetes::KubernetesClusterNexus", label: "start") { it.id = ubid.to_uuid }
     end
   end
 
@@ -90,17 +90,17 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   end
 
   label def wait_nodes
-    nap 10 unless kubernetes_cluster.nodepools.all? { _1.strand.label == "wait" }
+    nap 10 unless kubernetes_cluster.nodepools.all? { it.strand.label == "wait" }
     hop_create_billing_records
   end
 
   label def create_billing_records
     records =
-      kubernetes_cluster.cp_vms.map { {type: "KubernetesControlPlaneVCpu", family: _1.family, amount: _1.vcpus} } +
+      kubernetes_cluster.cp_vms.map { {type: "KubernetesControlPlaneVCpu", family: it.family, amount: it.vcpus} } +
       kubernetes_cluster.nodepools.flat_map(&:vms).flat_map {
         [
-          {type: "KubernetesWorkerVCpu", family: _1.family, amount: _1.vcpus},
-          {type: "KubernetesWorkerStorage", family: "standard", amount: _1.storage_size_gib}
+          {type: "KubernetesWorkerVCpu", family: it.family, amount: it.vcpus},
+          {type: "KubernetesWorkerStorage", family: "standard", amount: it.storage_size_gib}
         ]
       }
 
@@ -138,7 +138,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     kubernetes_cluster.api_server_lb.incr_destroy
     kubernetes_cluster.cp_vms.each(&:incr_destroy)
     kubernetes_cluster.remove_all_cp_vms
-    kubernetes_cluster.nodepools.each { _1.incr_destroy }
+    kubernetes_cluster.nodepools.each { it.incr_destroy }
     kubernetes_cluster.private_subnet.incr_destroy
     nap 5 unless kubernetes_cluster.nodepools.empty?
     kubernetes_cluster.destroy

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
 
       kn = KubernetesNodepool.create(name:, node_count:, kubernetes_cluster_id:, target_node_size:, target_node_storage_size_gib:)
 
-      Strand.create(prog: "Kubernetes::KubernetesNodepoolNexus", label: "start") { _1.id = kn.id }
+      Strand.create(prog: "Kubernetes::KubernetesNodepoolNexus", label: "start") { it.id = kn.id }
     end
   end
 

--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -40,7 +40,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
         root_cert_2: root_cert_2,
         root_cert_key_2: root_cert_key_2,
         project_id:
-      ) { _1.id = ubid.to_uuid }
+      ) { it.id = ubid.to_uuid }
 
       per_pool_server_count = server_count / pool_count
       per_pool_drive_count = drive_count / pool_count
@@ -50,7 +50,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
         Prog::Minio::MinioPoolNexus.assemble(minio_cluster.id, start_index, per_pool_server_count, per_pool_drive_count, per_pool_storage_size, vm_size)
       end
 
-      Strand.create(prog: "Minio::MinioClusterNexus", label: "wait_pools") { _1.id = minio_cluster.id }
+      Strand.create(prog: "Minio::MinioClusterNexus", label: "wait_pools") { it.id = minio_cluster.id }
     end
   end
 
@@ -64,7 +64,7 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
 
   label def wait_pools
     register_deadline("wait", 10 * 60)
-    if minio_cluster.pools.all? { _1.strand.label == "wait" }
+    if minio_cluster.pools.all? { it.strand.label == "wait" }
       # Start all the servers now
       minio_cluster.servers.each(&:incr_restart)
       hop_wait

--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -20,12 +20,12 @@ class Prog::Minio::MinioPoolNexus < Prog::Base
         drive_count: drive_count,
         storage_size_gib: storage_size_gib,
         vm_size: vm_size
-      ) { _1.id = ubid.to_uuid }
+      ) { it.id = ubid.to_uuid }
 
       minio_pool.server_count.times do |i|
         Prog::Minio::MinioServerNexus.assemble(minio_pool.id, minio_pool.start_index + i)
       end
-      Strand.create(prog: "Minio::MinioPoolNexus", label: "wait_servers") { _1.id = minio_pool.id }
+      Strand.create(prog: "Minio::MinioPoolNexus", label: "wait_servers") { it.id = minio_pool.id }
     end
   end
 
@@ -55,7 +55,7 @@ class Prog::Minio::MinioPoolNexus < Prog::Base
   end
 
   label def wait_servers
-    if minio_pool.servers.all? { _1.strand.label == "wait" }
+    if minio_pool.servers.all? { it.strand.label == "wait" }
       when_add_additional_pool_set? do
         decr_add_additional_pool
         cluster.incr_reconfigure

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -8,7 +8,7 @@ class Prog::PageNexus < Prog::Base
       return if Page.from_tag_parts(tag_parts)
 
       pg = Page.create_with_id(summary: summary, details: extra_data.merge({"related_resources" => Array(related_resources)}), tag: Page.generate_tag(tag_parts), severity: severity)
-      Strand.create(prog: "PageNexus", label: "start") { _1.id = pg.id }
+      Strand.create(prog: "PageNexus", label: "start") { it.id = pg.id }
     end
   end
 

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -78,7 +78,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       Prog::Postgres::PostgresServerNexus.assemble(resource_id: postgres_resource.id, timeline_id: timeline_id, timeline_access: timeline_access, representative_at: Time.now)
 
-      Strand.create(prog: "Postgres::PostgresResourceNexus", label: "start") { _1.id = postgres_resource.id }
+      Strand.create(prog: "Postgres::PostgresResourceNexus", label: "start") { it.id = postgres_resource.id }
     end
   end
 
@@ -163,7 +163,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def wait_servers
-    nap 5 if servers.any? { _1.strand.label != "wait" }
+    nap 5 if servers.any? { it.strand.label != "wait" }
     hop_update_billing_records
   end
 
@@ -200,7 +200,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   label def wait
     reap
 
-    if postgres_resource.needs_convergence? && strand.children.none? { _1.prog == "Postgres::ConvergePostgresResource" }
+    if postgres_resource.needs_convergence? && strand.children.none? { it.prog == "Postgres::ConvergePostgresResource" }
       bud Prog::Postgres::ConvergePostgresResource, frame, :start
     end
 
@@ -237,7 +237,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
     decr_destroy
 
-    strand.children.each { _1.destroy }
+    strand.children.each { it.destroy }
     postgres_resource.private_subnet.firewalls.each(&:destroy)
     postgres_resource.private_subnet.incr_destroy
     servers.each(&:incr_destroy)

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -24,7 +24,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
         secret_key: SecureRandom.hex(32),
         blob_storage_id: MinioCluster.first(project_id: Config.postgres_service_project_id, location_id: location.id)&.id
       )
-      Strand.create(prog: "Postgres::PostgresTimelineNexus", label: "start") { _1.id = postgres_timeline.id }
+      Strand.create(prog: "Postgres::PostgresTimelineNexus", label: "start") { it.id = postgres_timeline.id }
     end
   end
 

--- a/prog/setup_nftables.rb
+++ b/prog/setup_nftables.rb
@@ -5,7 +5,7 @@ class Prog::SetupNftables < Prog::Base
 
   label def start
     additional_subnets = vm_host.assigned_subnets.select { |a| a.cidr.version == 4 && a.cidr.network.to_s != vm_host.sshable.host }
-    sshable.cmd("sudo host/bin/setup-nftables.rb #{additional_subnets.map { _1.cidr.to_s }.to_json.shellescape}")
+    sshable.cmd("sudo host/bin/setup-nftables.rb #{additional_subnets.map { it.cidr.to_s }.to_json.shellescape}")
 
     pop "nftables was setup"
   end

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -38,7 +38,7 @@ class Prog::Storage::SetupSpdk < Prog::Base
       vm_host_id: vm_host.id,
       cpu_count: vm_host.spdk_cpu_count,
       hugepages: spdk_hugepages
-    ) { _1.id = SpdkInstallation.generate_uuid }
+    ) { it.id = SpdkInstallation.generate_uuid }
 
     hop_install_spdk
   end

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -23,7 +23,7 @@ class Prog::Test < Prog::Base
   end
 
   label def synchronized
-    th = Thread.list.find { _1.name == "clover_test" }
+    th = Thread.list.find { it.name == "clover_test" }
     w = th[:clover_test_in]
     th.thread_variable_set(:clover_test_out, Thread.current)
     w.close
@@ -31,7 +31,7 @@ class Prog::Test < Prog::Base
   end
 
   label def wait_exit
-    th = Thread.list.find { _1.name == "clover_test" }
+    th = Thread.list.find { it.name == "clover_test" }
     r = th[:clover_test_in]
     r.read
     pop "done"

--- a/prog/test/firewall_rules.rb
+++ b/prog/test/firewall_rules.rb
@@ -171,7 +171,7 @@ ExecStart=nc -l 8080 -6
   end
 
   def vm2
-    @vm2 ||= firewall.private_subnets.first.vms.reject { _1.id == vm1.id }.first
+    @vm2 ||= firewall.private_subnets.first.vms.reject { it.id == vm1.id }.first
   end
 
   def vm_outside

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -8,9 +8,9 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   IN_PROGRESS_CONCLUSIONS = ["in_progress", "queued", "requested", "waiting", "pending", "neutral"]
 
   def self.assemble(test_cases)
-    github_service_project = Project.create(name: "Github-Runner-Service-Project") { _1.id = Config.github_runner_service_project_id }
+    github_service_project = Project.create(name: "Github-Runner-Service-Project") { it.id = Config.github_runner_service_project_id }
 
-    vm_pool_service_project = Project.create(name: "Vm-Pool-Service-Project") { _1.id = Config.vm_pool_project_id }
+    vm_pool_service_project = Project.create(name: "Vm-Pool-Service-Project") { it.id = Config.vm_pool_project_id }
 
     github_test_project = Project.create_with_id(name: "Github-Runner-Test-Project")
     GithubInstallation.create_with_id(
@@ -170,7 +170,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   end
 
   def test_runs
-    @test_runs ||= frame["test_cases"].map { _1["details"] }
+    @test_runs ||= frame["test_cases"].map { it["details"] }
   end
 
   def client

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -8,9 +8,9 @@ class Prog::Test::HaPostgresResource < Prog::Test::Base
   def self.assemble
     postgres_test_project = Project.create(name: "Postgres-HA-Test-Project")
     Project[Config.postgres_service_project_id] ||
-      Project.create(name: "Postgres-Service-Project") { _1.id = Config.postgres_service_project_id }
+      Project.create(name: "Postgres-Service-Project") { it.id = Config.postgres_service_project_id }
     Project[Config.minio_service_project_id] ||
-      Project.create(name: "Minio-Service-Project") { _1.id = Config.minio_service_project_id }
+      Project.create(name: "Minio-Service-Project") { it.id = Config.minio_service_project_id }
 
     frame = {
       "postgres_test_project_id" => postgres_test_project.id,
@@ -56,7 +56,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::Base
 
   label def wait_postgres_resource
     server_count = postgres_resource.servers.count
-    nap 10 if server_count != postgres_resource.target_server_count || postgres_resource.servers.filter { _1.strand.label != "wait" }.any?
+    nap 10 if server_count != postgres_resource.target_server_count || postgres_resource.servers.filter { it.strand.label != "wait" }.any?
     hop_test_postgres
   end
 
@@ -70,7 +70,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::Base
   end
 
   label def trigger_failover
-    primary = postgres_resource.servers.find { _1.timeline_access == "push" }
+    primary = postgres_resource.servers.find { it.timeline_access == "push" }
     update_stack({"primary_ubid" => primary.ubid})
 
     primary.vm.sshable.cmd("echo -e '\nfoobar' | sudo tee -a /etc/postgresql/#{postgres_resource.version}/main/conf.d/001-service.conf")

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -153,7 +153,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   label def verify_storage_files_purged
     sshable = vm_host.sshable
 
-    vm_disks = sshable.cmd("sudo ls -1 /var/storage").split("\n").reject { ["vhost", "images"].include? _1 }
+    vm_disks = sshable.cmd("sudo ls -1 /var/storage").split("\n").reject { ["vhost", "images"].include? it }
     fail_test "VM disks not empty: #{vm_disks}" unless vm_disks.empty?
 
     vhost_dir_content = sshable.cmd("sudo ls -1 /var/storage/vhost").split("\n")
@@ -168,10 +168,10 @@ class Prog::Test::HetznerServer < Prog::Test::Base
     rpc_py = "/opt/spdk-#{spdk_version}/scripts/rpc.py"
     rpc_sock = "/home/spdk/spdk-#{spdk_version}.sock"
 
-    bdevs = JSON.parse(sshable.cmd("sudo #{rpc_py} -s #{rpc_sock} bdev_get_bdevs")).map { _1["name"] }
+    bdevs = JSON.parse(sshable.cmd("sudo #{rpc_py} -s #{rpc_sock} bdev_get_bdevs")).map { it["name"] }
     fail_test "SPDK bdevs not empty: #{bdevs}" unless bdevs.empty?
 
-    vhost_controllers = JSON.parse(sshable.cmd("sudo #{rpc_py} -s #{rpc_sock} vhost_get_controllers")).map { _1["ctrlr"] }
+    vhost_controllers = JSON.parse(sshable.cmd("sudo #{rpc_py} -s #{rpc_sock} vhost_get_controllers")).map { it["ctrlr"] }
     fail_test "SPDK vhost controllers not empty: #{vhost_controllers}" unless vhost_controllers.empty?
 
     hop_destroy

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -166,14 +166,14 @@ class Prog::Test::Vm < Prog::Test::Base
   end
 
   def vms_in_same_project
-    vm.project.vms.filter { _1.id != vm.id }
+    vm.project.vms.filter { it.id != vm.id }
   end
 
   def vms_with_same_subnet
-    vms_in_same_project.filter { _1.private_subnets.first.id == vm.private_subnets.first.id }
+    vms_in_same_project.filter { it.private_subnets.first.id == vm.private_subnets.first.id }
   end
 
   def vms_with_different_subnet
-    vms_in_same_project.filter { _1.private_subnets.first.id != vm.private_subnets.first.id }
+    vms_in_same_project.filter { it.private_subnets.first.id != vm.private_subnets.first.id }
   end
 end

--- a/prog/test/vm_host_slices.rb
+++ b/prog/test/vm_host_slices.rb
@@ -37,6 +37,6 @@ class Prog::Test::VmHostSlices < Prog::Test::Base
   end
 
   def slices
-    @slices ||= frame["slices"].map { VmHostSlice[_1] }
+    @slices ||= frame["slices"].map { VmHostSlice[it] }
   end
 end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -19,7 +19,7 @@ class Prog::Vm::GithubRunner < Prog::Base
         label: label
       )
 
-      Strand.create(prog: "Vm::GithubRunner", label: "start") { _1.id = github_runner.id }
+      Strand.create(prog: "Vm::GithubRunner", label: "start") { it.id = github_runner.id }
     end
   end
 
@@ -84,7 +84,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       github_runner.log_duration("runner_completed", duration)
       today_record = BillingRecord
         .where(project_id: project.id, resource_id: project.id, billing_rate_id: rate_id)
-        .where { Sequel.pg_range(_1.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
+        .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
         .first
 
       if today_record
@@ -290,7 +290,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     runners = github_client.paginate("/repos/#{github_runner.repository_name}/actions/runners") do |data, last_response|
       data[:runners].concat last_response.data[:runners]
     end
-    unless (runner = runners[:runners].find { _1[:name] == github_runner.ubid.to_s })
+    unless (runner = runners[:runners].find { it[:name] == github_runner.ubid.to_s })
       fail "BUG: Failed with runner already exists error but couldn't find it"
     end
 

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -11,8 +11,8 @@ class Prog::Vm::HostNexus < Prog::Base
 
       ubid = VmHost.generate_ubid
 
-      Sshable.create(host: sshable_hostname) { _1.id = ubid.to_uuid }
-      vmh = VmHost.create(location_id:, net6: net6, ndp_needed: ndp_needed) { _1.id = ubid.to_uuid }
+      Sshable.create(host: sshable_hostname) { it.id = ubid.to_uuid }
+      vmh = VmHost.create(location_id:, net6: net6, ndp_needed: ndp_needed) { it.id = ubid.to_uuid }
 
       if provider_name == HostProvider::HETZNER_PROVIDER_NAME || provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
         HostProvider.create do |hp|
@@ -28,7 +28,7 @@ class Prog::Vm::HostNexus < Prog::Base
         # Avoid overriding custom server names for development hosts.
         vmh.set_server_name unless Config.development?
       else
-        Address.create(cidr: sshable_hostname, routed_to_host_id: vmh.id) { _1.id = vmh.id }
+        Address.create(cidr: sshable_hostname, routed_to_host_id: vmh.id) { it.id = vmh.id }
         AssignedHostAddress.create_with_id(ip: sshable_hostname, address_id: vmh.id, host_id: vmh.id)
       end
 
@@ -36,7 +36,7 @@ class Prog::Vm::HostNexus < Prog::Base
         prog: "Vm::HostNexus",
         label: "start",
         stack: [{"spdk_version" => spdk_version, "default_boot_images" => default_boot_images}]
-      ) { _1.id = vmh.id }
+      ) { it.id = vmh.id }
     end
   end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -111,7 +111,7 @@ class Prog::Vm::Nexus < Prog::Base
         pool_id: pool_id,
         arch: arch,
         project_id:
-      ) { _1.id = ubid.to_uuid }
+      ) { it.id = ubid.to_uuid }
       nic.update(vm_id: vm.id)
 
       gpu_count = 1 if gpu_count == 0 && vm_size.gpu
@@ -128,7 +128,7 @@ class Prog::Vm::Nexus < Prog::Base
           "exclude_host_ids" => exclude_host_ids,
           "gpu_count" => gpu_count
         }]
-      ) { _1.id = vm.id }
+      ) { it.id = vm.id }
     end
   end
 
@@ -136,7 +136,7 @@ class Prog::Vm::Nexus < Prog::Base
     ssh_key = SshKey.generate
     st = assemble(ssh_key.public_key, *, **kwargs)
     Sshable.create(unix_user: sshable_unix_user, host: "temp_#{st.id}", raw_private_key_1: ssh_key.keypair) {
-      _1.id = st.id
+      it.id = st.id
     }
     st
   end

--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -20,7 +20,7 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
       # This will update the CPU allocation as well as total_cpu_percent and cores values
       vm_host_slice.set_allowed_cpus(allowed_cpus)
 
-      Strand.create(prog: "Vm::VmHostSliceNexus", label: "prep") { _1.id = vm_host_slice.id }
+      Strand.create(prog: "Vm::VmHostSliceNexus", label: "prep") { it.id = vm_host_slice.id }
     end
   end
 

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -18,7 +18,7 @@ class Prog::Vm::VmPool < Prog::Base
         storage_skip_sync:,
         arch:
       )
-      Strand.create(prog: "Vm::VmPool", label: "create_new_vm") { _1.id = vm_pool.id }
+      Strand.create(prog: "Vm::VmPool", label: "create_new_vm") { it.id = vm_pool.id }
     end
   end
 
@@ -72,7 +72,7 @@ class Prog::Vm::VmPool < Prog::Base
 
   label def destroy
     vm_pool.vms.each do |vm|
-      vm.private_subnets.each { _1.incr_destroy }
+      vm.private_subnets.each { it.incr_destroy }
       vm.incr_destroy
     end
     hop_wait_vms_destroy

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -16,7 +16,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     DB.transaction do
       cert = Cert.create_with_id(hostname: hostname, dns_zone_id: dns_zone_id)
 
-      Strand.create(prog: "Vnet::CertNexus", label: "start", stack: [{"restarted" => 0}]) { _1.id = cert.id }
+      Strand.create(prog: "Vnet::CertNexus", label: "start", stack: [{"restarted" => 0}]) { it.id = cert.id }
     end
   end
 

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -38,7 +38,7 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
     public_ipv6 = vm.ephemeral_net6.nth(2).to_s
     private_ipv4 = vm.private_ipv4
     private_ipv6 = vm.private_ipv6
-    neighbor_vms = load_balancer.active_vm_ports.reject { _1.load_balancer_vm.vm_id == vm.id }.uniq { |row| row.load_balancer_vm.id }.map(&:vm)
+    neighbor_vms = load_balancer.active_vm_ports.reject { it.load_balancer_vm.vm_id == vm.id }.uniq { |row| row.load_balancer_vm.id }.map(&:vm)
     neighbor_ips_v4_set, neighbor_ips_v6_set = generate_lb_ip_set_definition(neighbor_vms)
 
     balance_mode_ip4, balance_mode_ip6 = if load_balancer.algorithm == "round_robin"

--- a/rhizome/common/bin/add_to_fstab
+++ b/rhizome/common/bin/add_to_fstab
@@ -15,8 +15,8 @@ File.open("/etc/fstab", File::RDONLY) do |f|
   f.flock(File::LOCK_EX)
 
   content = f.read
-  rows = content.split("\n").reject { _1.start_with?("#") }
-  matches = rows.select { _1.match(/\A#{device}\s|\s#{dir}\s/) }
+  rows = content.split("\n").reject { it.start_with?("#") }
+  matches = rows.select { it.match(/\A#{device}\s|\s#{dir}\s/) }
   if matches.count == 0
     content += "\n#{device} #{dir} #{type} #{options} #{dump} #{fsck}"
     safe_write_to_file("/etc/fstab", content)

--- a/rhizome/common/lib/network.rb
+++ b/rhizome/common/lib/network.rb
@@ -9,7 +9,7 @@ def mac_to_ipv6_link_local(mac)
   eui[0] ^= 0x02
 
   "fe80::" + eui.each_slice(2).map { |pair|
-    pair.map { format("%02x", _1) }.join
+    pair.map { format("%02x", it) }.join
   }.join(":")
 end
 
@@ -20,6 +20,6 @@ end
 # local address errors out.
 def gen_mac
   ([rand(256) & 0xFE | 0x02] + Array.new(5) { rand(256) }).map {
-    "%0.2X" % _1
+    "%0.2X" % it
   }.join(":").downcase
 end

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -54,7 +54,7 @@ end
 def sync_parent_dir(f)
   parent_dir = Pathname.new(f).parent.to_s
   File.open(parent_dir) {
-    fsync_or_fail(_1)
+    fsync_or_fail(it)
   }
 end
 

--- a/rhizome/host/bin/delete-old-serial-logs
+++ b/rhizome/host/bin/delete-old-serial-logs
@@ -15,10 +15,10 @@ end
 
 # Reduce the directory size to less than 1GB
 files_with_sizes = Dir.glob(File.join(directory_path, "*"))
-  .select { File.file?(_1) }
-  .map { {file: _1, size: File.size(_1)} }
-  .sort_by { _1[:size] }
-while files_with_sizes.sum { _1[:size] } > 1 * 1024 * 1024 * 1024 # 1GB in bytes
+  .select { File.file?(it) }
+  .map { {file: it, size: File.size(it)} }
+  .sort_by { it[:size] }
+while files_with_sizes.sum { it[:size] } > 1 * 1024 * 1024 * 1024 # 1GB in bytes
   break unless (largest_file = files_with_sizes.pop)
   FileUtils.rm(largest_file[:file])
 end

--- a/rhizome/host/lib/slice_setup.rb
+++ b/rhizome/host/lib/slice_setup.rb
@@ -55,7 +55,7 @@ SLICE_CONFIG
     str.split(",").all? do |part|
       if part.include?("-")
         r = part.split("-")
-        r.size == 2 && r.all? { _1.to_i.to_s == _1 } && r[0].to_i <= r[1].to_i
+        r.size == 2 && r.all? { it.to_i.to_s == it } && r[0].to_i <= r[1].to_i
       else
         part.to_i.to_s == part
       end

--- a/rhizome/host/lib/storage_key_encryption.rb
+++ b/rhizome/host/lib/storage_key_encryption.rb
@@ -11,12 +11,12 @@ class StorageKeyEncryption
 
   def write_encrypted_dek(key_file, data_encryption_key)
     File.open(key_file, "w") {
-      _1.write(JSON.pretty_generate({
+      it.write(JSON.pretty_generate({
         cipher: data_encryption_key[:cipher],
         key: wrap_key(data_encryption_key[:key]),
         key2: wrap_key(data_encryption_key[:key2])
       }))
-      fsync_or_fail(_1)
+      fsync_or_fail(it)
     }
   end
 

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -28,7 +28,7 @@ class VmPath
 
   def systemd_service
     File.join("/etc/systemd/system",
-      IO.popen(["systemd-escape", @vm_name + ".service"]) { _1.read.chomp })
+      IO.popen(["systemd-escape", @vm_name + ".service"]) { it.read.chomp })
   end
 
   def write_systemd_service(s)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -37,17 +37,17 @@ RSpec.describe VmSetup do
     it "templates user YAML with no swap" do
       vs.write_user_data("some_user", ["some_ssh_key"], nil, "")
       expect(vps).to have_received(:write_user_data) {
-        expect(_1).to match(/some_user/)
-        expect(_1).to match(/some_ssh_key/)
+        expect(it).to match(/some_user/)
+        expect(it).to match(/some_ssh_key/)
       }
     end
 
     it "templates user YAML with swap" do
       vs.write_user_data("some_user", ["some_ssh_key"], 123, "")
       expect(vps).to have_received(:write_user_data) {
-        expect(_1).to match(/some_user/)
-        expect(_1).to match(/some_ssh_key/)
-        expect(_1).to match(/size: 123/)
+        expect(it).to match(/some_user/)
+        expect(it).to match(/some_ssh_key/)
+        expect(it).to match(/size: 123/)
       }
     end
 
@@ -281,7 +281,7 @@ RSpec.describe VmSetup do
       nics = [
         %w[fd48:666c:a296:ce4b:2cc6::/79 192.168.5.50/32 ncaka58xyg 3e:bd:a5:96:f7:b9],
         %w[fddf:53d2:4c89:2305:46a0::/79 10.10.10.10/32 ncbbbbbbbb fb:55:dd:ba:21:0a]
-      ].map { VmSetup::Nic.new(*_1) }
+      ].map { VmSetup::Nic.new(*it) }
 
       expect(vps).to receive(:write_nftables_conf).with(<<NFTABLES_CONF)
 table ip raw {

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -32,8 +32,8 @@ safe_write_to_file("/etc/postgresql/#{v}/main/conf.d/001-service.conf", configs)
 # Update pg_hba.conf
 private_subnets = configure_hash["private_subnets"].flat_map {
   [
-    "host    all             all             #{_1["net4"]}                     scram-sha-256",
-    "host    all             all             #{_1["net6"]}                     scram-sha-256"
+    "host    all             all             #{it["net4"]}                     scram-sha-256",
+    "host    all             all             #{it["net6"]}                     scram-sha-256"
   ]
 }.join("\n")
 

--- a/routes/account.rb
+++ b/routes/account.rb
@@ -9,7 +9,7 @@ class Clover
 
       r.on "login-method" do
         r.get true do
-          @identities = current_account.identities.to_h { [_1.provider, _1.uid] }
+          @identities = current_account.identities.to_h { [it.provider, it.uid] }
 
           view "account/login_method"
         end
@@ -25,7 +25,7 @@ class Clover
             DB[:account_password_hashes].where(id: current_account.id).delete
             DB[:account_previous_password_hashes].where(account_id: current_account.id).delete
             flash[:notice] = "Your password has been deleted"
-          elsif (identity = identities.find { _1.provider == provider && _1.uid == uid })
+          elsif (identity = identities.find { it.provider == provider && it.uid == uid })
             identity.destroy
             flash[:notice] = "Your account has been disconnected from #{provider.capitalize}"
           else

--- a/routes/github.rb
+++ b/routes/github.rb
@@ -36,7 +36,7 @@ class Clover
         r.redirect "#{project.path}/github"
       end
 
-      unless (installation_response = Octokit::Client.new(access_token: access_token).get("/user/installations")[:installations].find { _1[:id].to_s == installation_id })
+      unless (installation_response = Octokit::Client.new(access_token: access_token).get("/user/installations")[:installations].find { it[:id].to_s == installation_id })
         flash["error"] = "GitHub App installation failed. For any questions or assistance, reach out to our team at support@ubicloud.com"
         Clog.emit("GitHub callback failed due to lack of installation") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect "#{project.path}/github"

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -57,9 +57,9 @@ class Clover
         else
           @quotas = ["VmVCpu", "PostgresVCpu"].map {
             {
-              resource_type: _1,
-              current_resource_usage: @project.current_resource_usage(_1),
-              quota: @project.effective_quota_value(_1)
+              resource_type: it,
+              current_resource_usage: @project.current_resource_usage(it),
+              quota: @project.effective_quota_value(it)
             }
           }
 

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -71,7 +71,7 @@ class Clover
         r.get true do
           repository_id_q = @project.github_installations_dataset.join(:github_repository, installation_id: :id).select(Sequel[:github_repository][:id])
           entries = GithubCacheEntry.where(repository_id: repository_id_q).exclude(committed_at: nil).eager(:repository).reverse(:created_at).all
-          @entries_by_repo = Serializers::GithubCacheEntry.serialize(entries).group_by { _1[:repository][:id] }
+          @entries_by_repo = Serializers::GithubCacheEntry.serialize(entries).group_by { it[:repository][:id] }
           @quota_per_repo = "#{@project.effective_quota_value("GithubRunnerCacheStorage")} GB"
 
           view "github/cache"

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -25,7 +25,7 @@ class Clover
 
       r.delete true do
         authorize("Firewall:delete", firewall.id)
-        firewall.private_subnets.map { authorize("PrivateSubnet:edit", _1.id) }
+        firewall.private_subnets.map { authorize("PrivateSubnet:edit", it.id) }
         firewall.destroy
         204
       end

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -84,7 +84,7 @@ class Clover
             dst_port: Validation.validate_port(:dst_port, request_body_params["dst_port"]))
         end
 
-        new_vms = request_body_params["vms"].map { Vm.from_ubid(_1.delete("\"")) }
+        new_vms = request_body_params["vms"].map { Vm.from_ubid(it.delete("\"")) }
         new_vms.each do |vm|
           unless vm
             fail Validation::ValidationFailed.new("vms" => "VM not found")
@@ -99,7 +99,7 @@ class Clover
         end
 
         lb.vms.each do |vm|
-          next if new_vms.any? { _1.id == vm.id }
+          next if new_vms.any? { it.id == vm.id }
           lb.evacuate_vm(vm)
           lb.remove_vm(vm)
         end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -73,7 +73,7 @@ class Clover
 
         DB.transaction do
           pg.update(target_vm_size: target_vm_size.vm_size, target_storage_size_gib:, ha_type:)
-          pg.read_replicas.map { _1.update(target_vm_size: target_vm_size.vm_size, target_storage_size_gib:) }
+          pg.read_replicas.map { it.update(target_vm_size: target_vm_size.vm_size, target_storage_size_gib:) }
         end
 
         if api?

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -83,7 +83,7 @@ class Clover
 
       request.delete true do
         authorize("PrivateSubnet:delete", ps.id)
-        unless ps.vms.all? { _1.destroy_set? || _1.strand.nil? || _1.strand.label == "destroy" }
+        unless ps.vms.all? { it.destroy_set? || it.strand.nil? || it.strand.label == "destroy" }
           fail DependencyError.new("Private subnet '#{ps.name}' has VMs attached, first, delete them.")
         end
 

--- a/routes/project/postgres.rb
+++ b/routes/project/postgres.rb
@@ -21,7 +21,7 @@ class Clover
         @flavor = flavor
         @prices = fetch_location_based_prices("PostgresVCpu", "PostgresStorage")
         @has_valid_payment_method = @project.has_valid_payment_method?
-        @enabled_postgres_sizes = Option::VmSizes.select { @project.quota_available?("PostgresVCpu", _1.vcpus) }.map(&:name)
+        @enabled_postgres_sizes = Option::VmSizes.select { @project.quota_available?("PostgresVCpu", it.vcpus) }.map(&:name)
         @option_tree, @option_parents = generate_postgres_options(flavor: @flavor)
 
         view "postgres/create"

--- a/routes/project/private_location.rb
+++ b/routes/project/private_location.rb
@@ -44,7 +44,7 @@ class Clover
         LocationCredential.create(
           access_key: request_body_params["access_key"],
           secret_key: request_body_params["secret_key"]
-        ) { _1.id = loc.id }
+        ) { it.id = loc.id }
         loc
       end
 

--- a/routes/project/token.rb
+++ b/routes/project/token.rb
@@ -76,7 +76,7 @@ class Clover
           r.post true do
             DB.transaction do
               typecast_params.array!(:Hash, "aces").each do
-                ubid, deleted, action_id, object_id = _1.values_at("ubid", "deleted", "action", "object")
+                ubid, deleted, action_id, object_id = it.values_at("ubid", "deleted", "action", "object")
                 action_id = nil if action_id == ""
                 object_id = nil if object_id == ""
 

--- a/routes/project/vm.rb
+++ b/routes/project/vm.rb
@@ -24,7 +24,7 @@ class Clover
         @prices = fetch_location_based_prices("VmVCpu", "VmStorage", "IPAddress")
         @has_valid_payment_method = @project.has_valid_payment_method?
         @default_location = @project.default_location
-        @enabled_vm_sizes = Option::VmSizes.select { _1.visible && @project.quota_available?("VmVCpu", _1.vcpus) }.map(&:name)
+        @enabled_vm_sizes = Option::VmSizes.select { it.visible && @project.quota_available?("VmVCpu", it.vcpus) }.map(&:name)
         @option_tree, @option_parents = generate_vm_options
 
         view "vm/create"

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -83,10 +83,10 @@ class Clover
           totalCount: entries.count,
           artifactCaches: entries.map do
             {
-              scope: _1.scope,
-              cacheKey: _1.key,
-              cacheVersion: _1.version,
-              creationTime: _1.created_at
+              scope: it.scope,
+              cacheKey: it.key,
+              cacheVersion: it.version,
+              creationTime: it.created_at
             }
           end
         }
@@ -147,7 +147,7 @@ class Clover
 
         max_chunk_size = 32 * 1024 * 1024 # 32MB
         presigned_urls = (1..size.fdiv(max_chunk_size).ceil).map do
-          repository.url_presigner.presigned_url(:upload_part, bucket: repository.bucket_name, key: entry.blob_key, upload_id: upload_id, part_number: _1, expires_in: 900)
+          repository.url_presigner.presigned_url(:upload_part, bucket: repository.bucket_name, key: entry.blob_key, upload_id: upload_id, part_number: it, expires_in: 900)
         end
 
         {

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -59,7 +59,7 @@ class Clover
       return error("No workflow_job in the payload")
     end
 
-    unless (label = job.fetch("labels").find { Github.runner_labels.key?(_1) })
+    unless (label = job.fetch("labels").find { Github.runner_labels.key?(it) })
       return error("Unmatched label")
     end
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -49,7 +49,7 @@ class Scheduling::Dispatcher
       end
 
       ready.first.close
-    end.tap { _1.name = "apoptosis:" + strand_ubid }
+    end.tap { it.name = "apoptosis:" + strand_ubid }
 
     Thread.new do
       Thread.current[:created_at] = Time.now
@@ -66,7 +66,7 @@ class Scheduling::Dispatcher
       # Adequate to unblock IO.select.
       apoptosis_w.close
       notify_w.close
-    end.tap { _1.name = strand_ubid }
+    end.tap { it.name = strand_ubid }
 
     notify_r
   end
@@ -87,7 +87,7 @@ class Scheduling::Dispatcher
     return 0 if @notifiers.empty?
     ready, _, _ = IO.select(@notifiers)
     ready.each(&:close)
-    @notifiers.delete_if { ready.include?(_1) }
+    @notifiers.delete_if { ready.include?(it) }
     ready.count
   end
 end

--- a/sdk/ruby/lib/ubicloud/adapter/rack.rb
+++ b/sdk/ruby/lib/ubicloud/adapter/rack.rb
@@ -32,7 +32,7 @@ module Ubicloud
 
       status, _, rack_body = @app.call(env)
       body = +""
-      rack_body.each { body << _1 }
+      rack_body.each { body << it }
       rack_body.close if rack_body.respond_to?(:close)
 
       handle_response(status, body, missing:)

--- a/sdk/ruby/lib/ubicloud/model.rb
+++ b/sdk/ruby/lib/ubicloud/model.rb
@@ -42,7 +42,7 @@ module Ubicloud
           fragment
         end
 
-        adapter.get(path)[:items].map { new(adapter, _1) }
+        adapter.get(path)[:items].map { new(adapter, it) }
       end
 
       # Resolve associations.  This is called after all models have been loaded.
@@ -234,7 +234,7 @@ module Ubicloud
 
         values[key] = if value.is_a?(Array)
           value.map do
-            convert_to_association(_1, klass)
+            convert_to_association(it, klass)
           end
         else
           convert_to_association(value, klass)

--- a/sdk/ruby/lib/ubicloud/model/firewall.rb
+++ b/sdk/ruby/lib/ubicloud/model/firewall.rb
@@ -33,7 +33,7 @@ module Ubicloud
       check_no_slash(rule_id, "invalid rule id format")
       adapter.delete(_path("/firewall-rule/#{rule_id}"))
 
-      self[:firewall_rules]&.delete_if { _1[:id] == rule_id }
+      self[:firewall_rules]&.delete_if { it[:id] == rule_id }
 
       nil
     end

--- a/sdk/ruby/lib/ubicloud/model/postgres.rb
+++ b/sdk/ruby/lib/ubicloud/model/postgres.rb
@@ -32,7 +32,7 @@ module Ubicloud
       check_no_slash(rule_id, "invalid rule id format")
       adapter.delete(_path("/firewall-rule/#{rule_id}"))
 
-      self[:firewall_rules]&.delete_if { _1[:id] == rule_id }
+      self[:firewall_rules]&.delete_if { it[:id] == rule_id }
 
       nil
     end
@@ -52,7 +52,7 @@ module Ubicloud
       check_no_slash(md_id, "invalid metric destination id format")
       adapter.delete(_path("/metric-destination/#{md_id}"))
 
-      self[:metric_destinations]&.delete_if { _1[:id] == md_id }
+      self[:metric_destinations]&.delete_if { it[:id] == md_id }
 
       nil
     end

--- a/serializers/invoice.rb
+++ b/serializers/invoice.rb
@@ -57,11 +57,11 @@ class Serializers::Invoice < Serializers::Base
                      usage: BillingRate.line_item_usage(line_item["resource_type"], line_item["resource_family"], line_item["amount"], line_item["duration"])
                    }
                  end
-               end.group_by { _1[:description] }.flat_map do |description, line_items|
+               end.group_by { it[:description] }.flat_map do |description, line_items|
                  if line_items.count > 100 && description.end_with?("Address", "Virtual Machine")
-                   duration_sum = line_items.sum { _1[:duration] }
-                   amount_sum = line_items.sum { _1[:amount] }
-                   cost_sum = line_items.sum { _1[:cost] }
+                   duration_sum = line_items.sum { it[:duration] }
+                   amount_sum = line_items.sum { it[:amount] }
+                   cost_sum = line_items.sum { it[:cost] }
                    {
                      name: "#{line_items.count} x #{description} (Aggregated)",
                      description: description,
@@ -74,7 +74,7 @@ class Serializers::Invoice < Serializers::Base
                  else
                    line_items
                  end
-               end.sort_by { _1[:name] }
+               end.sort_by { it[:name] }
       )
     end
 

--- a/serializers/load_balancer.rb
+++ b/serializers/load_balancer.rb
@@ -21,7 +21,7 @@ class Serializers::LoadBalancer < Serializers::Base
 
     if options[:detailed]
       base[:subnet] = lb.private_subnet.name
-      base[:vms] = lb.vms.map { _1.ubid } || []
+      base[:vms] = lb.vms.map { it.ubid } || []
     end
 
     if options[:vms_serialized]

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -27,7 +27,7 @@ class Serializers::Postgres < Serializers::Base
         connection_string: pg.connection_string,
         primary: pg.representative_server&.primary?,
         firewall_rules: Serializers::PostgresFirewallRule.serialize(pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }),
-        metric_destinations: pg.metric_destinations.map { {id: _1.ubid, username: _1.username, url: _1.url} },
+        metric_destinations: pg.metric_destinations.map { {id: it.ubid, username: it.username, url: it.url} },
         read_replicas: Serializers::Postgres.serialize(pg.read_replicas, {include_path: true})
       )
 

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DB do
   it "has no unexpectedly collated columns" do
-    expect(described_class[<<SQL].all.map { _1[:name] }.join(", ")).to eq ""
+    expect(described_class[<<SQL].all.map { it[:name] }.join(", ")).to eq ""
 SELECT quote_ident(nspname) || '.' || quote_ident(relname) || '.' || quote_ident(attname) AS name
 FROM pg_class
 JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid AND

--- a/spec/lib/access_control_model_tag_spec.rb
+++ b/spec/lib/access_control_model_tag_spec.rb
@@ -42,8 +42,8 @@
       column = model.table_name.to_s.sub("tag", "id")
       rows = DB[:archived_record].where(model_name: "applied_#{model.table_name}").select_map(:model_values)
       expect(rows.length).to eq 2
-      expect(rows.map { _1["tag_id"] }.uniq).to eq [tag.id]
-      expect(rows.map { _1[column] }.sort).to eq [tag1.id, tag2.id].sort
+      expect(rows.map { it["tag_id"] }.uniq).to eq [tag.id]
+      expect(rows.map { it[column] }.sort).to eq [tag1.id, tag2.id].sort
     end
 
     it "#currently_included_in returns all tag ids that directly or indirectly include this tag" do

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Authorization do
       Account.create_with_id(email: "auth2@example.com")
     ]
   }
-  let(:projects) { (0..1).map { users[_1].create_project_with_default_policy("project-#{_1}") } }
+  let(:projects) { (0..1).map { users[it].create_project_with_default_policy("project-#{it}") } }
   let(:vms) {
     (0..3).map do |index|
       ps = Prog::Vnet::SubnetNexus.assemble(projects[index / 2].id, name: "vm#{index}-ps", location_id: Location::HETZNER_FSN1_ID).subject

--- a/spec/lib/billing_rate_spec.rb
+++ b/spec/lib/billing_rate_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe BillingRate do
   it "each rate has a unique ID" do
-    expect(described_class.rates.map { _1["id"] }.size).to eq(described_class.rates.map { _1["id"] }.uniq.size)
+    expect(described_class.rates.map { it["id"] }.size).to eq(described_class.rates.map { it["id"] }.uniq.size)
   end
 
   describe "#unit_price_from_resource_properties" do
@@ -58,7 +58,7 @@ RSpec.describe BillingRate do
   end
 
   it "can unambiguously find active rate" do
-    expect(described_class.rates.group_by { [_1["resource_type"], _1["resource_family"], _1["location"], _1["active_from"]] }).not_to be_any { |k, v| v.count != 1 }
+    expect(described_class.rates.group_by { [it["resource_type"], it["resource_family"], it["location"], it["active_from"]] }).not_to be_any { |k, v| v.count != 1 }
   end
 
   it "can find rate for aws locations" do
@@ -76,7 +76,7 @@ RSpec.describe BillingRate do
     LocationCredential.create(
       access_key: "test",
       secret_key: "test"
-    ) { _1.id = loc.id }
+    ) { it.id = loc.id }
 
     expect(described_class.from_resource_properties("VmVCpu", "standard", loc.name, Time.now)).not_to be_nil
     expect(described_class.from_resource_properties("PostgresVCpu", "standard-standard", loc.name, Time.now)).not_to be_nil

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe Clog do
 
   it "returns the key with redacted values for Sequel::Model" do
     expect($stdout).to receive(:write).with('{"vm":{"id":"123"},"message":"model","time":"' + now.to_s + '"}' + "\n")
-    described_class.emit("model") { Vm.new(public_key: "redacted_key").tap { _1.id = "123" } }
+    described_class.emit("model") { Vm.new(public_key: "redacted_key").tap { it.id = "123" } }
   end
 
   it "returns a combined hash when the metadata is an array" do
     expect($stdout).to receive(:write).with('{"vm":{"id":"123"},"field1":"custom","invalid_type":"String","message":"model","time":"' + now.to_s + '"}' + "\n")
-    vm = Vm.new(public_key: "redacted_key").tap { _1.id = "123" }
+    vm = Vm.new(public_key: "redacted_key").tap { it.id = "123" }
     described_class.emit("model") { [vm, {field1: "custom"}, "invalid"] }
   end
 end

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -3,9 +3,9 @@
 require_relative "../model/spec_helper"
 
 RSpec.describe MonitorableResource do
-  let(:postgres_server) { PostgresServer.new { _1.id = "c068cac7-ed45-82db-bf38-a003582b36ee" } }
+  let(:postgres_server) { PostgresServer.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ee" } }
   let(:r_w_event_loop) { described_class.new(postgres_server) }
-  let(:vm_host) { VmHost.new { _1.id = "46683a25-acb1-4371-afe9-d39f303e44b4" } }
+  let(:vm_host) { VmHost.new { it.id = "46683a25-acb1-4371-afe9-d39f303e44b4" } }
   let(:r_without_event_loop) { described_class.new(vm_host) }
 
   describe "#open_resource_session" do

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -6,15 +6,15 @@ require_relative "../../lib/option"
 RSpec.describe Option do
   describe "#VmSize options" do
     it "no burstable cpu allowed for Standard VMs" do
-      expect(Option::VmSizes.map { _1.name.include?("standard-") == (_1.cpu_burst_percent_limit == 0) }.all?(true)).to be true
+      expect(Option::VmSizes.map { it.name.include?("standard-") == (it.cpu_burst_percent_limit == 0) }.all?(true)).to be true
     end
 
     it "no gpu allowed for non-GPU VMs" do
-      expect(Option::VmSizes.map { _1.name.include?("gpu") == _1.gpu }.all?(true)).to be true
+      expect(Option::VmSizes.map { it.name.include?("gpu") == it.gpu }.all?(true)).to be true
     end
 
     it "no odd number of vcpus allowed, except for 1" do
-      expect(Option::VmSizes.all? { _1.vcpus == 1 || _1.vcpus.even? }).to be true
+      expect(Option::VmSizes.all? { it.vcpus == 1 || it.vcpus.even? }).to be true
     end
   end
 

--- a/spec/model/ai/inference_endpoint_spec.rb
+++ b/spec/model/ai/inference_endpoint_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe InferenceEndpoint do
       name: "ie-name",
       location_id: Location::HETZNER_FSN1_ID,
       model_name: "model-name"
-    ) { _1.id = "c76fcd0c-3fb0-40cc-8732-d71869ee1341" }
+    ) { it.id = "c76fcd0c-3fb0-40cc-8732-d71869ee1341" }
   end
 
   describe "#display_states" do

--- a/spec/model/github/github_repository_spec.rb
+++ b/spec/model/github/github_repository_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../spec_helper"
 
 RSpec.describe GithubRepository do
-  subject(:github_repository) { described_class.new(name: "test", access_key: "my-token-id").tap { _1.id = "8823102a-2d5c-8e16-ac04-c60f1b6b9984" } }
+  subject(:github_repository) { described_class.new(name: "test", access_key: "my-token-id").tap { it.id = "8823102a-2d5c-8e16-ac04-c60f1b6b9984" } }
 
   let(:blob_storage_client) { instance_double(Aws::S3::Client) }
   let(:cloudflare_client) { instance_double(CloudflareClient) }

--- a/spec/model/github_installation_spec.rb
+++ b/spec/model/github_installation_spec.rb
@@ -10,23 +10,23 @@ RSpec.describe GithubInstallation do
   }
 
   it "returns sum of used vm cores" do
-    vms = [2, 4, 8].map { create_vm(cores: _1) }
+    vms = [2, 4, 8].map { create_vm(cores: it) }
 
     # let's not create runner for the last vm
     vms[..1].each do |vm|
       gr = GithubRunner.create_with_id(installation_id: installation.id, vm_id: vm.id, repository_name: "test-repo", label: "ubicloud-standard-#{vm.cores}")
-      Strand.create(prog: "Github::RunnerNexus", label: "allocate_vm") { _1.id = gr.id }
+      Strand.create(prog: "Github::RunnerNexus", label: "allocate_vm") { it.id = gr.id }
     end
 
     expect(installation.total_active_runner_vcpus).to eq(6)
   end
 
   it "returns sum of used vm cores for arm64" do
-    vms = [2, 4].map { create_vm(cores: _1, arch: "arm64") }
+    vms = [2, 4].map { create_vm(cores: it, arch: "arm64") }
 
     vms.each do |vm|
       gr = GithubRunner.create_with_id(installation_id: installation.id, vm_id: vm.id, repository_name: "test-repo", label: "ubicloud-standard-#{vm.cores}-arm")
-      Strand.create(prog: "Github::RunnerNexus", label: "allocate_vm") { _1.id = gr.id }
+      Strand.create(prog: "Github::RunnerNexus", label: "allocate_vm") { it.id = gr.id }
     end
 
     expect(installation.total_active_runner_vcpus).to eq(6)

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GithubRunner do
   subject(:github_runner) {
     ins = GithubInstallation.create_with_id(installation_id: 123, name: "test-installation", type: "User")
     vm = create_vm(vm_host: create_vm_host, boot_image: "github-ubuntu-2204")
-    Sshable.create { _1.id = vm.id }
+    Sshable.create { it.id = vm.id }
     described_class.create_with_id(repository_name: "test-repo", label: "ubicloud", vm_id: vm.id, installation_id: ins.id)
   }
 

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Invoice do
   describe ".send_failure_email" do
     it "sends failure email to accounts with billing permissions in addition to the provided billing email" do
       project = Project.create_with_id(name: "cool-project")
-      accounts = (0..2).map { Account.create_with_id(email: "account#{_1}@example.com").tap { |a| a.add_project(project) } }
+      accounts = (0..2).map { Account.create_with_id(email: "account#{it}@example.com").tap { |a| a.add_project(project) } }
       AccessControlEntry.create_with_id(project_id: project.id, subject_id: accounts[0].id)
       AccessControlEntry.create_with_id(project_id: project.id, subject_id: accounts[1].id, action_id: ActionType::NAME_MAP["Vm:view"])
       AccessControlEntry.create_with_id(project_id: project.id, subject_id: accounts[2].id, action_id: ActionType::NAME_MAP["Project:billing"])

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PostgresResource do
     described_class.new(
       name: "pg-name",
       superuser_password: "dummy-password"
-    ) { _1.id = "6181ddb3-0002-8ad0-9aeb-084832c9273b" }
+    ) { it.id = "6181ddb3-0002-8ad0-9aeb-084832c9273b" }
   }
 
   it "returns connection string without ubid qualifier" do
@@ -90,12 +90,12 @@ RSpec.describe PostgresResource do
 
   it "returns target_standby_count correctly" do
     expect(postgres_resource).to receive(:ha_type).and_return(PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC)
-    (0..2).each { expect(postgres_resource.target_standby_count).to eq(_1) }
+    (0..2).each { expect(postgres_resource.target_standby_count).to eq(it) }
   end
 
   it "returns target_server_count correctly" do
     expect(postgres_resource).to receive(:target_standby_count).and_return(0, 1, 2)
-    (0..2).each { expect(postgres_resource.target_server_count).to eq(_1 + 1) }
+    (0..2).each { expect(postgres_resource.target_server_count).to eq(it + 1) }
   end
 
   it "sets firewall rules" do

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper"
 
 RSpec.describe PostgresServer do
   subject(:postgres_server) {
-    described_class.new { _1.id = "c068cac7-ed45-82db-bf38-a003582b36ee" }
+    described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ee" }
   }
 
   let(:resource) {
@@ -155,7 +155,7 @@ RSpec.describe PostgresServer do
 
     it "returns nil if there is no fresh standby" do
       expect(postgres_server).to receive(:representative_at).and_return(Time.now)
-      standby_server = described_class.new { _1.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
+      standby_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
       expect(standby_server).to receive(:resource).and_return(resource)
       expect(standby_server).to receive(:representative_at).and_return(nil).at_least(:once)
       expect(standby_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
@@ -210,7 +210,7 @@ RSpec.describe PostgresServer do
     end
 
     it "returns nil if there is no fresh read_replica" do
-      replica_server = described_class.new { _1.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
+      replica_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
       expect(replica_server).to receive(:resource).and_return(resource)
       expect(replica_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
       expect(replica_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4"))

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -115,14 +115,14 @@ RSpec.describe Project do
 
     it "returns false if any accounts is suspended" do
       project = described_class.create_with_id(name: "test")
-      Account.create_with_id(email: "user1@example.com").tap { _1.add_project(project) }
-      Account.create_with_id(email: "user2@example.com").tap { _1.add_project(project) }.update(suspended_at: Time.now)
+      Account.create_with_id(email: "user1@example.com").tap { it.add_project(project) }
+      Account.create_with_id(email: "user2@example.com").tap { it.add_project(project) }.update(suspended_at: Time.now)
       expect(project.active?).to be false
     end
 
     it "returns true if any condition not match" do
       project = described_class.create_with_id(name: "test")
-      Account.create_with_id(email: "user1@example.com").tap { _1.add_project(project) }
+      Account.create_with_id(email: "user1@example.com").tap { it.add_project(project) }
       expect(project.active?).to be true
     end
   end
@@ -136,7 +136,7 @@ RSpec.describe Project do
         {allocation_state: "accepting", location_id: Location::LEASEWEB_WDC02_ID, total_cores: 100, used_cores: 99},
         {allocation_state: "draining", location_id: Location::HETZNER_HEL1_ID, total_cores: 100, used_cores: 0},
         {allocation_state: "accepting", location_id: Location::GITHUB_RUNNERS_ID, total_cores: 100, used_cores: 0}
-      ].each { create_vm_host(**_1) }
+      ].each { create_vm_host(**it) }
 
       expect(project.default_location).to eq("github-runners")
     end
@@ -161,7 +161,7 @@ RSpec.describe Project do
 
   it "calculates effective quota value" do
     project = described_class.create_with_id(name: "test")
-    project.add_quota(ProjectQuota.new(value: 1000).tap { _1.quota_id = "14fa6820-bf63-41d2-b35e-4a4dcefd1b15" })
+    project.add_quota(ProjectQuota.new(value: 1000).tap { it.quota_id = "14fa6820-bf63-41d2-b35e-4a4dcefd1b15" })
     expect(project.effective_quota_value("VmVCpu")).to eq 32
     expect(project.effective_quota_value("GithubRunnerVCpu")).to eq 1000
     expect(project.effective_quota_value("PostgresVCpu")).to eq 128

--- a/spec/model/storage_device_spec.rb
+++ b/spec/model/storage_device_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StorageDevice do
     context "when finding the disk id from device_name for SSD disks" do
       it "changes the unix_device_list to the device id and saves changes" do
         sa = Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
-        vmh = VmHost.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = sa.id }
+        vmh = VmHost.create(location_id: Location::HETZNER_FSN1_ID) { it.id = sa.id }
         storage_device = described_class.create_with_id(vm_host_id: vmh.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["sda"])
 
         expect(storage_device.vm_host.sshable).to receive(:cmd).with("ls -l /dev/disk/by-id/ | grep 'sda$' | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-random-id")
@@ -21,7 +21,7 @@ RSpec.describe StorageDevice do
     context "when finding the disk id from device_name for NVMe disks" do
       it "changes the unix_device_list to the device id and saves changes" do
         sa = Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
-        vmh = VmHost.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = sa.id }
+        vmh = VmHost.create(location_id: Location::HETZNER_FSN1_ID) { it.id = sa.id }
         storage_device = described_class.create_with_id(vm_host_id: vmh.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["nvme0n1"])
 
         expect(storage_device.vm_host.sshable).to receive(:cmd).with("ls -l /dev/disk/by-id/ | grep 'nvme0n1$' | grep 'nvme-eui' | sed -E 's/.*(nvme-eui[^ ]*).*/\\1/'").and_return("nvme-eui.random-id")

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe VmHost do
   it "requires an Sshable too" do
     expect {
       sa = Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
-      described_class.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = sa.id }
+      described_class.create(location_id: Location::HETZNER_FSN1_ID) { it.id = sa.id }
     }.not_to raise_error
   end
 
@@ -269,8 +269,8 @@ RSpec.describe VmHost do
   it "create_addresses fails if a failover ip of non existent server is being added" do
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
     expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)
-    Sshable.create(host: "test.localhost") { _1.id = vh.id }
-    described_class.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = vh.id }
+    Sshable.create(host: "test.localhost") { it.id = vh.id }
+    described_class.create(location_id: Location::HETZNER_FSN1_ID) { it.id = vh.id }
 
     expect(vh).to receive(:assigned_subnets).and_return([]).at_least(:once)
     expect { vh.create_addresses }.to raise_error(RuntimeError, "BUG: source host 1.1.1.1 isn't added to the database")
@@ -278,10 +278,10 @@ RSpec.describe VmHost do
 
   it "create_addresses creates given addresses and doesn't make an api call when ips given" do
     expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)
-    Sshable.create(host: "1.1.0.0") { _1.id = vh.id }
+    Sshable.create(host: "1.1.0.0") { it.id = vh.id }
     Sshable.create_with_id(host: "1.1.1.1")
 
-    described_class.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = vh.id }
+    described_class.create(location_id: Location::HETZNER_FSN1_ID) { it.id = vh.id }
 
     expect(vh).to receive(:assigned_subnets).and_return([]).at_least(:once)
     vh.create_addresses(ip_records: hetzner_ips)
@@ -292,10 +292,10 @@ RSpec.describe VmHost do
   it "create_addresses creates addresses" do
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
     expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)
-    Sshable.create(host: "1.1.0.0") { _1.id = vh.id }
+    Sshable.create(host: "1.1.0.0") { it.id = vh.id }
     Sshable.create_with_id(host: "1.1.1.1")
 
-    described_class.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = vh.id }
+    described_class.create(location_id: Location::HETZNER_FSN1_ID) { it.id = vh.id }
 
     expect(vh).to receive(:assigned_subnets).and_return([]).at_least(:once)
     vh.create_addresses
@@ -312,9 +312,9 @@ RSpec.describe VmHost do
   it "skips already assigned subnets" do
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
     expect(vh).to receive(:id).and_return("46683a25-acb1-4371-afe9-d39f303e44b4").at_least(:once)
-    Sshable.create(host: "1.1.0.0") { _1.id = vh.id }
+    Sshable.create(host: "1.1.0.0") { it.id = vh.id }
     Sshable.create_with_id(host: "1.1.1.1")
-    described_class.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = vh.id }
+    described_class.create(location_id: Location::HETZNER_FSN1_ID) { it.id = vh.id }
 
     expect(vh).to receive(:assigned_subnets).and_return([Address.new(cidr: NetAddr::IPv4Net.parse("1.1.1.0/30".shellescape))]).at_least(:once)
     vh.create_addresses
@@ -331,8 +331,8 @@ RSpec.describe VmHost do
     expect(vh).to receive(:id).and_return(new_id).at_least(:once)
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
 
-    Sshable.create(host: "1.1.0.0") { _1.id = old_id }
-    described_class.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = old_id }
+    Sshable.create(host: "1.1.0.0") { it.id = old_id }
+    described_class.create(location_id: Location::HETZNER_FSN1_ID) { it.id = old_id }
 
     Sshable.create_with_id(host: "1.1.1.1")
     adr = Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: old_id)
@@ -349,8 +349,8 @@ RSpec.describe VmHost do
     old_id = "4c5dc171-a116-4a05-9e6d-381a4b382b71"
     expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)
 
-    Sshable.create(host: "1.1.0.0") { _1.id = old_id }
-    described_class.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = old_id }
+    Sshable.create(host: "1.1.0.0") { it.id = old_id }
+    described_class.create(location_id: Location::HETZNER_FSN1_ID) { it.id = old_id }
 
     adr = Address.create_with_id(cidr: "1.1.1.0/30", routed_to_host_id: old_id)
     expect(Address).to receive(:where).with(cidr: "1.1.1.0/30").and_return([adr]).once

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Vm do
     end
 
     it "can update spdk version" do
-      spdk_installation = SpdkInstallation.create(version: "b", allocation_weight: 100, vm_host_id: vmh.id) { _1.id = vmh.id }
+      spdk_installation = SpdkInstallation.create(version: "b", allocation_weight: 100, vm_host_id: vmh.id) { it.id = vmh.id }
       volume_dataset = instance_double(Sequel::Dataset)
       expect(vm).to receive(:vm_storage_volumes_dataset).and_return(volume_dataset)
       expect(volume_dataset).to receive(:update).with(spdk_installation_id: spdk_installation.id)

--- a/spec/model/vm_storage_volume_spec.rb
+++ b/spec/model/vm_storage_volume_spec.rb
@@ -4,13 +4,13 @@ require_relative "spec_helper"
 
 RSpec.describe VmStorageVolume do
   it "can render a device_path" do
-    vm = Vm.new(location: Location[Location::HETZNER_FSN1_ID]).tap { _1.id = "eb3dbcb3-2c90-8b74-8fb4-d62a244d7ae5" }
+    vm = Vm.new(location: Location[Location::HETZNER_FSN1_ID]).tap { it.id = "eb3dbcb3-2c90-8b74-8fb4-d62a244d7ae5" }
     expect(described_class.new(disk_index: 7, vm: vm).device_path).to eq("/dev/disk/by-id/virtio-vmxcyvsc_7")
   end
 
   it "can render a device_path for aws" do
     prj = Project.create_with_id(name: "test-project")
-    vm = Vm.new(location: Location.create_with_id(name: "us-east-1", provider: "aws", project_id: prj.id, display_name: "aws-us-east-1", ui_name: "AWS US East 1", visible: true)).tap { _1.id = "eb3dbcb3-2c90-8b74-8fb4-d62a244d7ae5" }
+    vm = Vm.new(location: Location.create_with_id(name: "us-east-1", provider: "aws", project_id: prj.id, display_name: "aws-us-east-1", ui_name: "AWS US East 1", visible: true)).tap { it.id = "eb3dbcb3-2c90-8b74-8fb4-d62a244d7ae5" }
     expect(described_class.new(disk_index: 7, vm: vm).device_path).to eq("/dev/nvme1n1")
   end
 

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
     end
 
     it "the model it is assembled with has unique id" do
-      expect(Option::AI_MODELS.map { _1["id"] }.size).to eq(Option::AI_MODELS.map { _1["id"] }.uniq.size)
+      expect(Option::AI_MODELS.map { it["id"] }.size).to eq(Option::AI_MODELS.map { it["id"] }.uniq.size)
     end
 
     it "raises an error if model is not found" do

--- a/spec/prog/aws/instance_spec.rb
+++ b/spec/prog/aws/instance_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Aws::Instance do
   let(:vm) {
     prj = Project.create_with_id(name: "test-prj")
     loc = Location.create_with_id(name: "us-east-1", provider: "aws", project_id: prj.id, display_name: "aws-us-east-1", ui_name: "AWS US East 1", visible: true)
-    LocationCredential.create_with_id(access_key: "test-access-key", secret_key: "test-secret-key") { _1.id = loc.id }
+    LocationCredential.create_with_id(access_key: "test-access-key", secret_key: "test-secret-key") { it.id = loc.id }
     Prog::Vm::Nexus.assemble("dummy-public key", prj.id, location_id: loc.id, unix_user: "test-user-aws", boot_image: "ami-030c060f85668b37d").subject
   }
 

--- a/spec/prog/aws/nic_spec.rb
+++ b/spec/prog/aws/nic_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Prog::Aws::Nic do
   let(:nic) {
     prj = Project.create_with_id(name: "test-prj")
     loc = Location.create_with_id(name: "us-east-1", provider: "aws", project_id: prj.id, display_name: "aws-us-east-1", ui_name: "AWS US East 1", visible: true)
-    LocationCredential.create_with_id(access_key: "test-access-key", secret_key: "test-secret-key") { _1.id = loc.id }
+    LocationCredential.create_with_id(access_key: "test-access-key", secret_key: "test-secret-key") { it.id = loc.id }
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps", location_id: loc.id).subject
-    PrivateSubnetAwsResource.create(subnet_id: "subnet-0123456789abcdefg", security_group_id: "sg-0123456789abcdefg") { _1.id = ps.id }
+    PrivateSubnetAwsResource.create(subnet_id: "subnet-0123456789abcdefg", security_group_id: "sg-0123456789abcdefg") { it.id = ps.id }
     nic = Prog::Vnet::NicNexus.assemble(ps.id, name: "test-nic").subject
-    NicAwsResource.create { _1.id = nic.id }
+    NicAwsResource.create { it.id = nic.id }
     nic
   }
 

--- a/spec/prog/aws/vpc_spec.rb
+++ b/spec/prog/aws/vpc_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Prog::Aws::Vpc do
   let(:ps) {
     prj = Project.create_with_id(name: "test-prj")
     loc = Location.create_with_id(name: "us-east-1", provider: "aws", project_id: prj.id, display_name: "aws-us-east-1", ui_name: "AWS US East 1", visible: true)
-    LocationCredential.create_with_id(access_key: "test-access-key", secret_key: "test-secret-key") { _1.id = loc.id }
+    LocationCredential.create_with_id(access_key: "test-access-key", secret_key: "test-secret-key") { it.id = loc.id }
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps", location_id: loc.id).subject
-    PrivateSubnetAwsResource.create { _1.id = ps.id }
+    PrivateSubnetAwsResource.create { it.id = ps.id }
     ps
   }
 
@@ -52,7 +52,7 @@ RSpec.describe Prog::Aws::Vpc do
 
       expect(client).to receive(:describe_vpcs).with({filters: [{name: "vpc-id", values: [ps.name]}]}).and_call_original
       expect(client).to receive(:create_security_group).with({group_name: "aws-us-east-1-#{ps.ubid}", description: "Security group for aws-us-east-1-#{ps.ubid}", vpc_id: ps.name, tag_specifications: [{resource_type: "security-group", tags: [{key: "Ubicloud", value: "true"}]}]}).and_call_original
-      ps.firewalls.map { _1.firewall_rules.map { |fw| fw.destroy } }
+      ps.firewalls.map { it.firewall_rules.map { |fw| fw.destroy } }
       FirewallRule.create_with_id(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.1/32", port_range: 22..80)
       ps.reload
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 80, ip_ranges: [{cidr_ip: "0.0.0.1/32"}]}]}).and_call_original
@@ -64,7 +64,7 @@ RSpec.describe Prog::Aws::Vpc do
       client.stub_responses(:create_security_group, Aws::EC2::Errors::InvalidGroupDuplicate.new(nil, nil))
       client.stub_responses(:describe_security_groups, security_groups: [{group_id: "sg-0123456789abcdefg"}])
 
-      ps.firewalls.map { _1.firewall_rules.map { |fw| fw.destroy } }
+      ps.firewalls.map { it.firewall_rules.map { |fw| fw.destroy } }
       FirewallRule.create_with_id(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.1/32", port_range: 22..80)
       FirewallRule.create_with_id(firewall_id: ps.firewalls.first.id, cidr: "::/32", port_range: 22..80)
       ps.reload

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe Prog::Base do
 
     it "can create a page with extra data from a vm" do
       vm = create_vm
-      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { _1.id = vm.id }
+      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { it.id = vm.id }
       st.unsynchronized_run
       page = Page.active.first
       expect(page).not_to be_nil
@@ -308,7 +308,7 @@ RSpec.describe Prog::Base do
 
     it "can create a page with extra data from a vm with a vm host" do
       vm = create_vm(vm_host: create_vm_host(data_center: "FSN1-DC1"))
-      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { _1.id = vm.id }
+      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { it.id = vm.id }
       st.unsynchronized_run
       page = Page.active.first
       expect(page).not_to be_nil
@@ -319,7 +319,7 @@ RSpec.describe Prog::Base do
     it "can create a page with extra data from a vm host" do
       vmh = create_vm_host(data_center: "FSN1-DC1")
       create_vm(vm_host: vmh)
-      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { _1.id = vmh.id }
+      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { it.id = vmh.id }
       st.unsynchronized_run
       page = Page.active.first
       expect(page).not_to be_nil
@@ -330,7 +330,7 @@ RSpec.describe Prog::Base do
     it "can create a page with extra data from a github runner" do
       installation = GithubInstallation.create(installation_id: 123, name: "test-user", type: "User", project: Project.create(name: "test-project"))
       runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "my-repo", installation:)
-      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { _1.id = runner.id }
+      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { it.id = runner.id }
       st.unsynchronized_run
       page = Page.active.first
       expect(page).not_to be_nil
@@ -342,7 +342,7 @@ RSpec.describe Prog::Base do
       vm = create_vm(vm_host: create_vm_host(data_center: "FSN1-DC1"))
       installation = GithubInstallation.create(installation_id: 123, name: "test-user", type: "User", project: Project.create(name: "test-project"))
       runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "my-repo", vm_id: vm.id, installation:)
-      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { _1.id = runner.id }
+      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}]) { it.id = runner.id }
       st.unsynchronized_run
       page = Page.active.first
       expect(page).not_to be_nil

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
   let(:dzs) do
     build_zone = ->(name, neg_ttl) do
       dz = DnsZone.create_with_id(project_id: project.id, name: name, last_purged_at: Time.now, neg_ttl: neg_ttl)
-      Strand.create(prog: "DnsZone::DnsZoneNexus", label: "wait") { _1.id = dz.id }
+      Strand.create(prog: "DnsZone::DnsZoneNexus", label: "wait") { it.id = dz.id }
       dz.add_dns_server ds
       3.times { dz.insert_record(record_name: "#{SecureRandom.alphanumeric(6)}.#{dz.name}", type: "A", ttl: 10, data: IPAddr.new(rand(2**32), Socket::AF_INET).to_s) }
       dz

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Prog::DownloadBootImage do
     end
 
     it "fails if image already exists" do
-      BootImage.create(vm_host_id: vm_host.id, name: "my-image", version: "20230303", size_gib: 3) { _1.id = vm_host.id }
+      BootImage.create(vm_host_id: vm_host.id, name: "my-image", version: "20230303", size_gib: 3) { it.id = vm_host.id }
       expect { dbi.start }.to raise_error RuntimeError, "Image already exists on host"
     end
 

--- a/spec/prog/github/destroy_github_installation_spec.rb
+++ b/spec/prog/github/destroy_github_installation_spec.rb
@@ -6,7 +6,7 @@ require "octokit"
 RSpec.describe Prog::Github::DestroyGithubInstallation do
   subject(:dgi) {
     described_class.new(Strand.new).tap {
-      _1.instance_variable_set(:@github_installation, github_installation)
+      it.instance_variable_set(:@github_installation, github_installation)
     }
   }
 

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -6,13 +6,13 @@ require "octokit"
 RSpec.describe Prog::Github::GithubRepositoryNexus do
   subject(:nx) {
     described_class.new(Strand.new).tap {
-      _1.instance_variable_set(:@github_repository, github_repository)
+      it.instance_variable_set(:@github_repository, github_repository)
     }
   }
 
   let(:github_repository) {
     GithubRepository.new(name: "ubicloud/ubicloud", last_job_at: Time.now).tap {
-      _1.id = "31b9c46a-602a-8616-ae2f-41775cb592dd"
+      it.id = "31b9c46a-602a-8616-ae2f-41775cb592dd"
     }
   }
 

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect(kubernetes_cluster.active_billing_records.length).to eq 4
 
-      expect(kubernetes_cluster.active_billing_records.map { _1.billing_rate["resource_type"] }).to eq ["KubernetesControlPlaneVCpu", "KubernetesControlPlaneVCpu", "KubernetesWorkerVCpu", "KubernetesWorkerStorage"]
+      expect(kubernetes_cluster.active_billing_records.map { it.billing_rate["resource_type"] }).to eq ["KubernetesControlPlaneVCpu", "KubernetesControlPlaneVCpu", "KubernetesWorkerVCpu", "KubernetesWorkerStorage"]
     end
   end
 

--- a/spec/prog/learn_pci_spec.rb
+++ b/spec/prog/learn_pci_spec.rb
@@ -31,7 +31,7 @@ Rev:	a1
 IOMMUGroup:	13
 EOS
       expect { lp.start }.to exit({"msg" => "created PciDevice records"}).and change {
-        PciDevice.map { {vm_host_id: _1.vm_host_id, slot: _1.slot, device_class: _1.device_class, vendor: _1.vendor, device: _1.device, numa_node: _1.numa_node, iommu_group: _1.iommu_group, vm_id: _1.vm_id} }.sort_by { _1[:slot] }
+        PciDevice.map { {vm_host_id: it.vm_host_id, slot: it.slot, device_class: it.device_class, vendor: it.vendor, device: it.device, numa_node: it.numa_node, iommu_group: it.iommu_group, vm_id: it.vm_id} }.sort_by { it[:slot] }
       }.from(
         []
       ).to(
@@ -66,7 +66,7 @@ Rev:	a1
 IOMMUGroup:	13
 EOS
       expect { lp.start }.to exit({"msg" => "created PciDevice records"}).and change {
-        PciDevice.map { {vm_host_id: _1.vm_host_id, slot: _1.slot, device_class: _1.device_class, vendor: _1.vendor, device: _1.device, numa_node: _1.numa_node, iommu_group: _1.iommu_group, vm_id: _1.vm_id} }.sort_by { _1[:slot] }
+        PciDevice.map { {vm_host_id: it.vm_host_id, slot: it.slot, device_class: it.device_class, vendor: it.vendor, device: it.device, numa_node: it.numa_node, iommu_group: it.iommu_group, vm_id: it.vm_id} }.sort_by { it[:slot] }
       }.from(
         [{vm_host_id: vmh.id, slot: "01:00.0", device_class: "dc", vendor: "vd", device: "dv", numa_node: 0, iommu_group: 3, vm_id: nil}]
       ).to(

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -55,7 +55,7 @@ EOS
           sd.values.slice(
             :name, :available_storage_gib, :total_storage_gib
           )
-        }.sort_by { _1[:name] }
+        }.sort_by { it[:name] }
       }.from(
         [{name: "stor1", total_storage_gib: 100, available_storage_gib: 100}]
       ).to(

--- a/spec/prog/page_nexus_spec.rb
+++ b/spec/prog/page_nexus_spec.rb
@@ -5,7 +5,7 @@ require_relative "../model/spec_helper"
 RSpec.describe Prog::PageNexus do
   subject(:pn) {
     described_class.new(Strand.new).tap {
-      _1.instance_variable_set(:@page, pg)
+      it.instance_variable_set(:@page, pg)
     }
   }
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       LocationCredential.create(
         access_key: "access-key-id",
         secret_key: "secret-access-key"
-      ) { _1.id = loc.id }
+      ) { it.id = loc.id }
       loc
     }
 

--- a/spec/prog/rotate_storage_kek_spec.rb
+++ b/spec/prog/rotate_storage_kek_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Prog::RotateStorageKek do
   let(:vm) {
     vm_host = instance_double(VmHost)
     vm = Vm.new.tap {
-      _1.id = Vm.generate_uuid
+      it.id = Vm.generate_uuid
     }
     allow(vm_host).to receive(:sshable).and_return(sshable)
     allow(vm).to receive(:vm_host).and_return(vm_host)
@@ -25,14 +25,14 @@ RSpec.describe Prog::RotateStorageKek do
     StorageKeyEncryptionKey.new(
       algorithm: "aes-256-gcm", key: "key_1",
       init_vector: "iv_1", auth_data: "somedata"
-    ) { _1.id = StorageKeyEncryptionKey.generate_uuid }
+    ) { it.id = StorageKeyEncryptionKey.generate_uuid }
   }
 
   let(:new_kek) {
     StorageKeyEncryptionKey.new(
       algorithm: "aes-256-gcm", key: "key_2",
       init_vector: "iv_2", auth_data: "somedata"
-    ) { _1.id = StorageKeyEncryptionKey.generate_uuid }
+    ) { it.id = StorageKeyEncryptionKey.generate_uuid }
   }
 
   let(:volume) {
@@ -40,7 +40,7 @@ RSpec.describe Prog::RotateStorageKek do
       name: "nvme0",
       total_storage_gib: 100,
       available_storage_gib: 20
-    ) { _1.id = StorageDevice.generate_uuid }
+    ) { it.id = StorageDevice.generate_uuid }
     disk = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0, storage_device: dev)
     disk.key_encryption_key_1 = current_kek
     disk.key_encryption_key_2 = new_kek

--- a/spec/prog/storage/setup_spdk_spec.rb
+++ b/spec/prog/storage/setup_spdk_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe Prog::Storage::SetupSpdk do
   describe "#update_database" do
     it "updates the database and exits" do
       hugepages = 3
-      SpdkInstallation.create(version: spdk_version, vm_host_id: vm_host.id, hugepages: hugepages, allocation_weight: 0) { _1.id = vm_host.id }
+      SpdkInstallation.create(version: spdk_version, vm_host_id: vm_host.id, hugepages: hugepages, allocation_weight: 0) { it.id = vm_host.id }
       expect { setup_spdk.update_database }.to exit({"msg" => "SPDK was setup"})
       expect(vm_host.reload.used_hugepages_1g).to eq(hugepages)
       expect(vm_host.spdk_installations.first.allocation_weight).to eq(50)
     end
 
     it "doesn't reserve a hugepage if service didn't start" do
-      SpdkInstallation.create(version: spdk_version, vm_host_id: vm_host.id, hugepages: 3, allocation_weight: 0) { _1.id = vm_host.id }
+      SpdkInstallation.create(version: spdk_version, vm_host_id: vm_host.id, hugepages: 3, allocation_weight: 0) { it.id = vm_host.id }
       allow(setup_spdk).to receive(:frame).and_return({"version" => spdk_version, "start_service" => false, "allocation_weight" => 50})
       expect { setup_spdk.update_database }.to exit({"msg" => "SPDK was setup"})
       expect(vm_host.reload.used_hugepages_1g).to eq(0)

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Prog::Test::HetznerServer do
                                                "server_id" => "1234",
                                                "additional_boot_images" => [],
                                                "setup_host" => true}, hetzner_api: hetzner_api, vm_host: vm_host)
-    SpdkInstallation.create(version: "1.0", vm_host_id: vm_host.id, allocation_weight: 100) { _1.id = vm_host.id }
+    SpdkInstallation.create(version: "1.0", vm_host_id: vm_host.id, allocation_weight: 100) { it.id = vm_host.id }
   }
 
   describe "#assemble" do

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Prog::Test::VmGroup do
     it "hops to wait_children_ready" do
       expect(vg_test).to receive(:update_stack).and_call_original
       expect { vg_test.setup_vms }.to hop("wait_vms")
-      vm_images = vg_test.strand.stack.first["vms"].map { Vm[_1].boot_image }
+      vm_images = vg_test.strand.stack.first["vms"].map { Vm[it].boot_image }
       expect(vm_images).to eq(["ubuntu-noble", "debian-12", "ubuntu-noble"])
     end
 
@@ -26,7 +26,7 @@ RSpec.describe Prog::Test::VmGroup do
         "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"]
       }).at_least(:once)
       expect { vg_test.setup_vms }.to hop("wait_vms")
-      vm_images = vg_test.strand.stack.first["vms"].map { Vm[_1].boot_image }
+      vm_images = vg_test.strand.stack.first["vms"].map { Vm[it].boot_image }
       expect(vm_images).to eq(["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"])
     end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -7,19 +7,19 @@ require "octokit"
 RSpec.describe Prog::Vm::GithubRunner do
   subject(:nx) {
     described_class.new(Strand.new).tap {
-      _1.instance_variable_set(:@github_runner, github_runner)
+      it.instance_variable_set(:@github_runner, github_runner)
     }
   }
 
   let(:github_runner) {
     GithubRunner.new(installation_id: "", repository_name: "test-repo", label: "ubicloud-standard-4", created_at: Time.now, allocated_at: Time.now + 10, ready_at: Time.now + 20).tap {
-      _1.id = GithubRunner.generate_uuid
+      it.id = GithubRunner.generate_uuid
     }
   }
 
   let(:vm) {
     Vm.new(family: "standard", cores: 1, name: "dummy-vm", location_id: Location[name: "github-runners"].id).tap {
-      _1.id = "788525ed-d6f0-4937-a844-323d4fd91946"
+      it.id = "788525ed-d6f0-4937-a844-323d4fd91946"
     }
   }
   let(:sshable) { instance_double(Sshable) }

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
       expect(st.subject.assigned_subnets.count).to eq(3)
-      expect(st.subject.assigned_subnets.map { _1.cidr.to_s }.sort).to eq(["127.0.0.1/32", "30.30.30.32/29", "2a01:4f8:10a:128b::/64"].sort)
+      expect(st.subject.assigned_subnets.map { it.cidr.to_s }.sort).to eq(["127.0.0.1/32", "30.30.30.32/29", "2a01:4f8:10a:128b::/64"].sort)
 
       expect(st.subject.assigned_host_addresses.count).to eq(1)
       expect(st.subject.assigned_host_addresses.first.ip.to_s).to eq("127.0.0.1/32")
@@ -166,7 +166,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(vm_host).to receive(:net6).and_return(NetAddr.parse_net("2a01:4f9:2b:35a::/64"))
       budded = []
       expect(nx).to receive(:bud) do
-        budded << _1
+        budded << it
       end.at_least(:once)
 
       expect { nx.prep }.to hop("wait_prep")
@@ -188,7 +188,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(vm_host).to receive(:net6).and_return(nil)
       budded_learn_network = false
       expect(nx).to receive(:bud) do
-        budded_learn_network ||= (_1 == Prog::LearnNetwork)
+        budded_learn_network ||= (it == Prog::LearnNetwork)
       end.at_least(:once)
 
       expect { nx.prep }.to hop("wait_prep")

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -6,7 +6,7 @@ require "netaddr"
 RSpec.describe Prog::Vm::Nexus do
   subject(:nx) {
     described_class.new(st).tap {
-      _1.instance_variable_set(:@vm, vm)
+      it.instance_variable_set(:@vm, vm)
     }
   }
 
@@ -15,11 +15,11 @@ RSpec.describe Prog::Vm::Nexus do
     kek = StorageKeyEncryptionKey.new(
       algorithm: "aes-256-gcm", key: "key",
       init_vector: "iv", auth_data: "somedata"
-    ) { _1.id = "04a3fe32-4cf0-48f7-909e-e35822864413" }
-    si = SpdkInstallation.new(version: "v1") { _1.id = SpdkInstallation.generate_uuid }
-    bi = BootImage.new(name: "my-image", version: "20230303") { _1.id = "b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1" }
-    dev1 = StorageDevice.new(name: "nvme0") { _1.id = StorageDevice.generate_uuid }
-    dev2 = StorageDevice.new(name: "DEFAULT") { _1.id = StorageDevice.generate_uuid }
+    ) { it.id = "04a3fe32-4cf0-48f7-909e-e35822864413" }
+    si = SpdkInstallation.new(version: "v1") { it.id = SpdkInstallation.generate_uuid }
+    bi = BootImage.new(name: "my-image", version: "20230303") { it.id = "b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1" }
+    dev1 = StorageDevice.new(name: "nvme0") { it.id = StorageDevice.generate_uuid }
+    dev2 = StorageDevice.new(name: "DEFAULT") { it.id = StorageDevice.generate_uuid }
     disk_1 = VmStorageVolume.new(boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, skip_sync: false)
     disk_1.spdk_installation = si
     disk_1.key_encryption_key_1 = kek
@@ -43,16 +43,16 @@ RSpec.describe Prog::Vm::Nexus do
       location_id: Location::HETZNER_FSN1_ID,
       created_at: Time.now
     ).tap {
-      _1.id = "2464de61-7501-8374-9ab0-416caebe31da"
-      _1.vm_storage_volumes.append(disk_1)
-      _1.vm_storage_volumes.append(disk_2)
-      disk_1.vm = _1
-      disk_2.vm = _1
-      allow(_1).to receive(:active_billing_records).and_return([BillingRecord.new(
+      it.id = "2464de61-7501-8374-9ab0-416caebe31da"
+      it.vm_storage_volumes.append(disk_1)
+      it.vm_storage_volumes.append(disk_2)
+      disk_1.vm = it
+      disk_2.vm = it
+      allow(it).to receive(:active_billing_records).and_return([BillingRecord.new(
         project_id: "50089dcf-b472-8ad2-9ca6-b3e70d12759d",
-        resource_name: _1.name,
-        billing_rate_id: BillingRate.from_resource_properties("VmVCpu", _1.family, "hetzner-fsn1")["id"],
-        amount: _1.vcpus
+        resource_name: it.name,
+        billing_rate_id: BillingRate.from_resource_properties("VmVCpu", it.family, "hetzner-fsn1")["id"],
+        amount: it.vcpus
       )])
     }
     vm
@@ -62,7 +62,7 @@ RSpec.describe Prog::Vm::Nexus do
   describe ".assemble" do
     let(:ps) {
       PrivateSubnet.create(name: "ps", location_id: Location::HETZNER_FSN1_ID, net6: "fd10:9b0b:6b4b:8fbb::/64",
-        net4: "1.1.1.0/26", state: "waiting", project_id: prj.id) { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+        net4: "1.1.1.0/26", state: "waiting", project_id: prj.id) { it.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
     }
     let(:nic) {
       Nic.new(private_subnet_id: ps.id,
@@ -70,7 +70,7 @@ RSpec.describe Prog::Vm::Nexus do
         private_ipv4: "10.0.0.1",
         mac: "00:00:00:00:00:00",
         encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579",
-        name: "default-nic").tap { _1.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
+        name: "default-nic").tap { it.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
     }
 
     it "fails if there is no project" do
@@ -687,7 +687,7 @@ RSpec.describe Prog::Vm::Nexus do
     end
 
     it "create a billing record when host is not nil, too" do
-      host = VmHost.new.tap { _1.id = "46ca6ded-b056-4723-bd91-612959f52f6f" }
+      host = VmHost.new.tap { it.id = "46ca6ded-b056-4723-bd91-612959f52f6f" }
       allow(nx).to receive(:host).and_return(host)
       vm.vm_host = host
       vm.location.provider = "aws"

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
         spdk: i < 2,
         vm_host_slice_id: (i == 2 || i == 3) ? vm_host_slice.id : nil
       ) {
-        _1.vm_host_id = vm_host.id
-        _1.cpu_number = i
+        it.vm_host_id = vm_host.id
+        it.cpu_number = i
       }
     }
   end

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Prog::Vm::VmPool do
       pool.update(size: 1)
 
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
-      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "k y", name: "vm1", location_id: "6b9ef786-b842-8420-8c65-c25e3d4bdf3d", boot_image: "github-ubuntu-2204", family: "standard", arch: "arm64", cores: 2, vcpus: 2, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
+      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "k y", name: "vm1", location_id: "6b9ef786-b842-8420-8c65-c25e3d4bdf3d", boot_image: "github-ubuntu-2204", family: "standard", arch: "arm64", cores: 2, vcpus: 2, memory_gib: 8, project_id:) { it.id = Sshable.create_with_id.id }
 
       expect { nx.wait }.to hop("create_new_vm")
     end
@@ -91,7 +91,7 @@ RSpec.describe Prog::Vm::VmPool do
       pool.update(size: 1)
 
       expect(nx).to receive(:vm_pool).and_return(pool).at_least(:once)
-      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "k y", name: "vm1", location_id: "6b9ef786-b842-8420-8c65-c25e3d4bdf3d", boot_image: "github-ubuntu-2204", family: "standard", arch: "x64", cores: 2, vcpus: 4, memory_gib: 8, project_id:) { _1.id = Sshable.create_with_id.id }
+      Vm.create(vm_host: VmHost.first, unix_user: "ubi", public_key: "k y", name: "vm1", location_id: "6b9ef786-b842-8420-8c65-c25e3d4bdf3d", boot_image: "github-ubuntu-2204", family: "standard", arch: "x64", cores: 2, vcpus: 4, memory_gib: 8, project_id:) { it.id = Sshable.create_with_id.id }
 
       expect { nx.wait }.to nap(30)
     end

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -82,12 +82,12 @@ RSpec.describe Prog::Vnet::CertServer do
 
   describe ".put_cert_to_vm" do
     it "fails if certificate is nil" do
-      lb.certs.map { _1.update(cert: nil) }
+      lb.certs.map { it.update(cert: nil) }
       expect { nx.put_cert_to_vm }.to raise_error(RuntimeError, "BUG: certificate is nil")
     end
 
     it "fails if certificate payload is nil" do
-      lb.certs.map { _1.update(cert: nil) }
+      lb.certs.map { it.update(cert: nil) }
       expect(nx.load_balancer).to receive(:active_cert).and_return(lb.certs.first)
 
       expect { nx.put_cert_to_vm }.to raise_error(RuntimeError, "BUG: certificate is nil")

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
   }
   let(:dns_zone) {
     dz = DnsZone.create_with_id(project_id: ps.project_id, name: "lb.ubicloud.com")
-    Strand.create_with_id(prog: "DnsZone::DnsZoneNexus", label: "wait") { _1.id = dz.id }
+    Strand.create_with_id(prog: "DnsZone::DnsZoneNexus", label: "wait") { it.id = dz.id }
     dz
   }
 
@@ -174,8 +174,8 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
 
   describe "#update_vm_load_balancers" do
     it "updates load balancers for all vms" do
-      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub key", ps.project_id, name: "test-vm#{_1}", private_subnet_id: ps.id).subject }
-      vms.each { st.subject.add_vm(_1) }
+      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub key", ps.project_id, name: "test-vm#{it}", private_subnet_id: ps.id).subject }
+      vms.each { st.subject.add_vm(it) }
       expect { nx.update_vm_load_balancers }.to hop("wait_update_vm_load_balancers")
       # Update progs are budded in update_vm_load_balancers
       expect(st.children_dataset.where(prog: "Vnet::UpdateLoadBalancerNode", label: "update_load_balancer").count).to eq 3
@@ -184,8 +184,8 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
 
   describe "#wait_update_vm_load_balancers" do
     before do
-      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub key", ps.project_id, name: "test-vm#{_1}", private_subnet_id: ps.id).subject }
-      vms.each { st.subject.add_vm(_1) }
+      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub key", ps.project_id, name: "test-vm#{it}", private_subnet_id: ps.id).subject }
+      vms.each { st.subject.add_vm(it) }
       expect { nx.update_vm_load_balancers }.to hop("wait_update_vm_load_balancers")
     end
 
@@ -203,8 +203,8 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
 
   describe "#destroy" do
     before do
-      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub key", ps.project_id, name: "test-vm#{_1}", private_subnet_id: ps.id).subject }
-      vms.each { st.subject.add_vm(_1) }
+      vms = Array.new(3) { Prog::Vm::Nexus.assemble("pub key", ps.project_id, name: "test-vm#{it}", private_subnet_id: ps.id).subject }
+      vms.each { st.subject.add_vm(it) }
       expect { nx.update_vm_load_balancers }.to hop("wait_update_vm_load_balancers")
       st.children.map(&:destroy)
     end

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prog::Vnet::NicNexus do
   let(:st) { Strand.new }
   let(:ps) {
     PrivateSubnet.create_with_id(name: "ps", location_id: Location::HETZNER_FSN1_ID, net6: "fd10:9b0b:6b4b:8fbb::/64",
-      net4: "10.0.0.0/26", state: "waiting", project_id: Project.create(name: "test").id).tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+      net4: "10.0.0.0/26", state: "waiting", project_id: Project.create(name: "test").id).tap { it.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
   }
 
   describe ".assemble" do
@@ -214,7 +214,7 @@ RSpec.describe Prog::Vnet::NicNexus do
   describe "#destroy" do
     let(:ps) {
       PrivateSubnet.create_with_id(name: "ps", location_id: Location::HETZNER_FSN1_ID, net6: "fd10:9b0b:6b4b:8fbb::/64",
-        net4: "1.1.1.0/26", state: "waiting", project_id: Project.create(name: "test").id).tap { _1.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
+        net4: "1.1.1.0/26", state: "waiting", project_id: Project.create(name: "test").id).tap { it.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
     }
     let(:nic) {
       Nic.new(private_subnet_id: ps.id,
@@ -222,7 +222,7 @@ RSpec.describe Prog::Vnet::NicNexus do
         private_ipv4: "10.0.0.1",
         mac: "00:00:00:00:00:00",
         encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579",
-        name: "default-nic").tap { _1.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
+        name: "default-nic").tap { it.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
     }
     let(:ipsec_tunnels) {
       [
@@ -279,7 +279,7 @@ RSpec.describe Prog::Vnet::NicNexus do
         private_ipv4: "10.0.0.1",
         mac: "00:00:00:00:00:00",
         encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579",
-        name: "default-nic").tap { _1.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
+        name: "default-nic").tap { it.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
     }
 
     before do

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
   }
   let(:tunnel) {
     sa = Sshable.create_with_id(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
-    vmh = VmHost.create(location_id: Location::HETZNER_FSN1_ID) { _1.id = sa.id }
+    vmh = VmHost.create(location_id: Location::HETZNER_FSN1_ID) { it.id = sa.id }
     vm_src = create_vm(name: "hellovm", vm_host_id: vmh.id)
     vm_dst = create_vm(name: "hellovm2", vm_host_id: vmh.id)
     n_src = Nic.create_with_id(private_subnet_id: ps.id,
@@ -31,7 +31,7 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       name: "default-nic",
       rekey_payload: {"reqid" => 14329, "spi4" => "0xe0000000", "spi6" => "0xe1111111"},
       vm_id: vm_dst.id)
-    IpsecTunnel.create_with_id(src_nic_id: n_src.id, dst_nic_id: n_dst.id).tap { _1.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
+    IpsecTunnel.create_with_id(src_nic_id: n_src.id, dst_nic_id: n_dst.id).tap { it.id = "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e" }
   }
 
   before do
@@ -40,7 +40,7 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
 
   describe "#before_run" do
     it "pops when destroy is set" do
-      Strand.create(prog: "Vnet:NicNexus", label: "wait_vm") { _1.id = tunnel.src_nic.id }
+      Strand.create(prog: "Vnet:NicNexus", label: "wait_vm") { it.id = tunnel.src_nic.id }
       tunnel.src_nic.incr_destroy
       expect { nx.before_run }.to exit({"msg" => "nic.destroy semaphore is set"})
     end

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe Prog::Vnet::SubnetNexus do
 
     it "extends deadline if a vm prevents destroy" do
       vm = Vm.new(family: "standard", cores: 1, name: "dummy-vm", location_id: Location::HETZNER_FSN1_ID).tap {
-        _1.id = "788525ed-d6f0-4937-a844-323d4fd91946"
+        it.id = "788525ed-d6f0-4937-a844-323d4fd91946"
       }
       expect(ps).to receive(:nics).and_return([nic]).twice
       expect(nic).to receive(:vm_id).and_return("vm-id")

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe Clover, "cli" do
     expect(LoadBalancer).to receive(:generate_uuid).and_return("eb8e0b21-94f2-8c2b-82c8-da57fcfe88c7").at_least(:once)
 
     cli_commands = []
-    cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/success.txt").map { [_1, {}] }
-    cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/error.txt").map { [_1, {status: 400}] }
-    cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/confirm.txt").map { [_1, {confirm_prompt: "Confirmation"}] }
+    cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/success.txt").map { [it, {}] }
+    cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/error.txt").map { [it, {status: 400}] }
+    cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/confirm.txt").map { [it, {confirm_prompt: "Confirmation"}] }
     Dir["spec/routes/api/cli/golden-file-commands/execute/*.txt"].each do |f|
       cmd = File.basename(f).delete_suffix(".txt")
-      cli_commands.concat File.readlines(f).map { [_1, {command_execute: cmd}] }
+      cli_commands.concat File.readlines(f).map { [it, {command_execute: cmd}] }
     end
 
     cli_commands.each do |cmd, kws|

--- a/spec/routes/api/project/private_location_spec.rb
+++ b/spec/routes/api/project/private_location_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Clover, "private-location" do
     LocationCredential.create(
       access_key: "access-key-id",
       secret_key: "secret-access-key"
-    ) { _1.id = loc.id }
+    ) { it.id = loc.id }
     loc
   end
 

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe Clover, "github" do
 
         response = JSON.parse(last_response.body)
         expect(response["totalCount"]).to eq(2)
-        expect(response["artifactCaches"].map { [_1["cacheKey"], _1["cacheVersion"]] }).to eq([["k1", "v1"], ["k1", "v2"]])
+        expect(response["artifactCaches"].map { [it["cacheKey"], it["cacheVersion"]] }).to eq([["k1", "v1"], ["k1", "v2"]])
       end
 
       it "returns the list of cache entries for the default branch" do
@@ -380,7 +380,7 @@ RSpec.describe Clover, "github" do
 
         response = JSON.parse(last_response.body)
         expect(response["totalCount"]).to eq(1)
-        expect(response["artifactCaches"].sort.map { [_1["cacheKey"], _1["cacheVersion"]] }).to eq([["k1", "v2"]])
+        expect(response["artifactCaches"].sort.map { [it["cacheKey"], it["cacheVersion"]] }).to eq([["k1", "v2"]])
       end
     end
   end

--- a/spec/routes/spec_helper.rb
+++ b/spec/routes/spec_helper.rb
@@ -94,7 +94,7 @@ RSpec.configure do |config|
     LocationCredential.create(
       access_key: "access-key-id",
       secret_key: "secret-access-key"
-    ) { _1.id = loc.id }
+    ) { it.id = loc.id }
     loc
   end
 end

--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -592,7 +592,7 @@ RSpec.describe Clover, "access control" do
             expect(page.all("table#tag-membership-add td").map(&:text)).to eq ["Member", "", "test-account", ""]
           when "action"
             expect(page.all("table#tag-membership-add tbody th").map(&:text)).to eq ["Global Tag", "Action"]
-            expect(page.all("table#tag-membership-add td").map(&:text)).to eq (global_tags + action_types).flat_map { [_1, ""] }
+            expect(page.all("table#tag-membership-add td").map(&:text)).to eq (global_tags + action_types).flat_map { [it, ""] }
           else
             expect(page.html).not_to include "Add Members to #{cap_type} Tag"
           end
@@ -608,7 +608,7 @@ RSpec.describe Clover, "access control" do
           expect(page.all("table#tag-membership-add td").map(&:text)).to eq ["Member", "", "other-subject", "", "test-account", ""]
         when "action"
           expect(page.all("table#tag-membership-add tbody th").map(&:text)).to eq ["Global Tag", "Tag", "Action"]
-          expect(page.all("table#tag-membership-add td").map(&:text)).to eq [*global_tags, "other-action", *action_types].flat_map { [_1, ""] }
+          expect(page.all("table#tag-membership-add td").map(&:text)).to eq [*global_tags, "other-action", *action_types].flat_map { [it, ""] }
         else
           expect(page.all("table#tag-membership-add tbody th").map(&:text)).to eq ["Tag (grants access to objects contained in tag)", "Project", "SubjectTag", "ObjectTag (grants access to tag itself)"]
           expect(page.all("table#tag-membership-add td").map(&:text)).to eq ["other-object", "", "Default", "", "Admin", "", "Member", "", "other-object", "", "test-object", ""]
@@ -666,11 +666,11 @@ RSpec.describe Clover, "access control" do
             "", ""]
         when "action"
           ["Global Tag",
-            *ActionTag.where(project_id: nil).select_order_map(:name).flat_map { [_1, ""] },
+            *ActionTag.where(project_id: nil).select_order_map(:name).flat_map { [it, ""] },
             "Tag",
             "test3-action", "",
             "Action",
-            *ActionType.map(&:name).sort.flat_map { [_1, ""] }]
+            *ActionType.map(&:name).sort.flat_map { [it, ""] }]
         else
           ["Tag (grants access to objects contained in tag)",
             "test3-object", "",

--- a/spec/routes/web/private_location_spec.rb
+++ b/spec/routes/web/private_location_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Clover, "location-credential" do
     LocationCredential.create(
       access_key: "access_key",
       secret_key: "secret_key"
-    ) { _1.id = loc.id }
+    ) { it.id = loc.id }
     loc
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Clover, "location-credential" do
     LocationCredential.create(
       access_key: "access_key",
       secret_key: "secret_key"
-    ) { _1.id = loc.id }
+    ) { it.id = loc.id }
     loc
   }
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "destroys runner when receive completed action" do
-      Strand.create(prog: "Vm::GithubRunner", label: "start") { _1.id = runner.id }
+      Strand.create(prog: "Vm::GithubRunner", label: "start") { it.id = runner.id }
 
       send_webhook("workflow_job", workflow_job_payload(action: "completed", workflow_job: workflow_job_object(runner_id: runner.runner_id)))
 

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Scheduling::Dispatcher do
 
   describe "#start_cohort" do
     after do
-      Thread.list.each { _1.join if _1 != Thread.current }
+      Thread.list.each { it.join if it != Thread.current }
     end
 
     it "can create threads" do

--- a/spec/serializers/postgres_spec.rb
+++ b/spec/serializers/postgres_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../spec_helper"
 
 RSpec.describe Serializers::Postgres do
-  let(:pg) { PostgresResource.new(name: "pg-name", location_id: Location::HETZNER_FSN1_ID).tap { _1.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
+  let(:pg) { PostgresResource.new(name: "pg-name", location_id: Location::HETZNER_FSN1_ID).tap { it.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
 
   it "can serialize when no earliest/latest restore times" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start", children: [])).at_least(:once)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -238,8 +238,8 @@ RSpec.configure do |config|
   def create_vm_host(**args)
     args = {location_id: Location::HETZNER_FSN1_ID, allocation_state: "accepting", arch: "x64", total_cores: 48, used_cores: 2}.merge(args)
     ubid = VmHost.generate_ubid
-    Sshable.create { _1.id = ubid.to_uuid }
-    VmHost.create(**args) { _1.id = ubid.to_uuid }
+    Sshable.create { it.id = ubid.to_uuid }
+    VmHost.create(**args) { it.id = ubid.to_uuid }
   end
 
   def create_vm(**args)

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe UBID do
-  let(:all_types) { described_class.constants.select { _1.start_with?("TYPE_") }.map { described_class.const_get(_1) } }
+  let(:all_types) { described_class.constants.select { it.start_with?("TYPE_") }.map { described_class.const_get(it) } }
 
   it ".generate_vanity_action_type supports creating vanity ubids for action types" do
     expect(described_class.generate_vanity_action_type("Project:view").to_s).to eq "ttzzzzzzzz021gzzz0pj0v1ew0"
@@ -33,7 +33,7 @@ RSpec.describe UBID do
       ["0", 0], ["o", 0], ["A", 10], ["e", 14], ["m", 20], ["S", 25], ["z", 31]
     ]
     tests.each {
-      expect(described_class.to_base32(_1[0])).to eq(_1[1])
+      expect(described_class.to_base32(it[0])).to eq(it[1])
     }
   end
 
@@ -57,7 +57,7 @@ RSpec.describe UBID do
       [0, "0"], [12, "c"], [16, "g"], [20, "m"], [26, "t"], [28, "w"], [31, "z"]
     ]
     tests.each {
-      expect(described_class.from_base32(_1[0])).to eq(_1[1])
+      expect(described_class.from_base32(it[0])).to eq(it[1])
     }
   end
 
@@ -137,7 +137,7 @@ RSpec.describe UBID do
       ubids = Array.new(10) do
         described_class.from_uuidish(DB.get { gen_random_ubid_uuid(klass.to_base32_n(type)) })
       end
-      expect(ubids.map { _1.to_s[0..1] }).to eq([type] * 10)
+      expect(ubids.map { it.to_s[0..1] }).to eq([type] * 10)
       ints = ubids.map(&:to_i)
       max_ubid = ints.max
       min_ubid = ints.min
@@ -209,12 +209,12 @@ RSpec.describe UBID do
     expect(sshable.ubid).to start_with UBID::TYPE_SSHABLE
 
     host = create_vm_host
-    si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
+    si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { it.id = host.id }
 
     vm = create_vm
     expect(vm.ubid).to start_with UBID::TYPE_VM
 
-    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
+    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { it.id = host.id }
 
     sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id, storage_device_id: dev.id)
     expect(sv.ubid).to start_with UBID::TYPE_VM_STORAGE_VOLUME
@@ -284,9 +284,9 @@ RSpec.describe UBID do
   it "can decode ids" do
     sshable = Sshable.create_with_id
     host = create_vm_host
-    si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { _1.id = host.id }
+    si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: host.id) { it.id = host.id }
     vm = create_vm
-    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { _1.id = host.id }
+    dev = StorageDevice.create(name: "x", available_storage_gib: 1, total_storage_gib: 1, vm_host_id: host.id) { it.id = host.id }
     sv = VmStorageVolume.create_with_id(vm_id: vm.id, size_gib: 5, disk_index: 0, boot: false, spdk_installation_id: si.id, storage_device_id: dev.id)
     kek = StorageKeyEncryptionKey.create_with_id(algorithm: "x", key: "x", init_vector: "x", auth_data: "x")
     account = Account.create_with_id(email: "x@y.net")

--- a/ubid.rb
+++ b/ubid.rb
@@ -123,7 +123,7 @@ class UBID
   end
 
   # InferenceApiKey does not have a type, and using et (TYPE_ETC) seems like a bad idea
-  ACTION_TYPE_PREFIX_MAP = <<~TYPES.split("\n").map! { _1.split(": ") }.to_h.freeze
+  ACTION_TYPE_PREFIX_MAP = <<~TYPES.split("\n").map! { it.split(": ") }.to_h.freeze
     Project: pj
     Vm: vm
     PrivateSubnet: ps
@@ -169,8 +169,8 @@ class UBID
 
   # Map of prefixes to class name symbols, to avoid autoloading
   # classes until they are referenced by class_for_ubid
-  TYPE2CLASSNAME = constants.select { _1.start_with?("TYPE_") }.reject { _1.to_s == "TYPE_ETC" }
-    .map { [const_get(_1), camelize(_1.to_s).to_sym] }.to_h.freeze
+  TYPE2CLASSNAME = constants.select { it.start_with?("TYPE_") }.reject { it.to_s == "TYPE_ETC" }
+    .map { [const_get(it), camelize(it.to_s).to_sym] }.to_h.freeze
   private_constant :TYPE2CLASSNAME
 
   def self.class_for_ubid(str)
@@ -184,13 +184,13 @@ class UBID
 
   def self.resolve_map(uuids)
     uuids.keys.group_by do
-      ubid = from_uuidish(_1).to_s
+      ubid = from_uuidish(it).to_s
       # Bad hack, needed because ApiKey does not use a fixed ubid type
       ubid.start_with?("et") ? ApiKey : class_for_ubid(ubid)
     end.each do |model, model_uuids|
       next unless model
       model.where(id: Sequel.any_uuid(model_uuids)).each do
-        uuids[_1.id] = _1
+        uuids[it.id] = it
       end
     end
     uuids
@@ -366,7 +366,7 @@ class UBID
   def self.to_base32_n(s)
     result = 0
     s.chars.each {
-      result = result * 32 + to_base32(_1)
+      result = result * 32 + to_base32(it)
     }
     result
   end

--- a/views/components/form/policy_select.erb
+++ b/views/components/form/policy_select.erb
@@ -5,7 +5,7 @@
   name:,
   id:,
   options: [["", "No access", nil, {}]].concat(
-    @allowed_view_tag_names.map { [_1, _1, nil, @allowed_add_tag_names_map.include?(_1) ? {} : { disabled: true }] }
+    @allowed_view_tag_names.map { [it, it, nil, @allowed_add_tag_names_map.include?(it) ? {} : { disabled: true }] }
   ),
   selected:
 ) %>

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -5,7 +5,7 @@ content_security_policy.add_script_src [:nonce, nonce] %>
 <script nonce="<%==nonce%>">
 let option_tree = <%==JSON.generate(option_tree)%>
 let option_children = <%==JSON.generate(option_parents.each_with_object(Hash.new { |h, k| h[k] = [] }) { |(child, parents), h| h[parents.last] << child if parents.any? })%>
-let option_dirty = <%==JSON.generate(form_elements.map { _1[:name] }.each_with_object(Hash.new { |h, k| h[k] = [] }) { |option, h| h[option] = nil })%>
+let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_object(Hash.new { |h, k| h[k] = [] }) { |option, h| h[option] = nil })%>
 </script>
 
 <div>

--- a/views/components/kv_data_card.erb
+++ b/views/components/kv_data_card.erb
@@ -2,7 +2,7 @@
 <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
   <div class="px-4 py-5 sm:p-0">
     <dl class="sm:divide-y sm:divide-gray-200">
-      <% data.reject { !_1 }.each do |name, value, opts| %>
+      <% data.reject { !it }.each do |name, value, opts| %>
         <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
           <dt class="text-sm font-medium text-gray-500"><%= name %></dt>
           <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -19,7 +19,7 @@
                 <%= entries.count %> cache entries
               </th>
               <th scope="colgroup" class="py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50" colspan="2">
-                <%= Serializers::GithubCacheEntry.humanize_size(entries.sum { _1[:size].to_i }) %> used of <%= @quota_per_repo %>
+                <%= Serializers::GithubCacheEntry.humanize_size(entries.sum { it[:size].to_i }) %> used of <%= @quota_per_repo %>
               </th>
             </tr>
             <% entries.each do |entry| %>

--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -23,7 +23,7 @@
     ["Location", @kc.display_location],
     ["Kubernetes Version", @kc.version],
     ["Control Plane Nodes", @kc.cp_node_count],
-    ["Worker Nodes", @kc.nodepools.sum { _1.node_count }]
+    ["Worker Nodes", @kc.nodepools.sum { it.node_count }]
   ]
   
   if @kc.display_state == "running"

--- a/views/layouts/sidebar/group.erb
+++ b/views/layouts/sidebar/group.erb
@@ -1,5 +1,5 @@
 <li>
-  <div class="group <%= items.compact.map { _1[2] }.any? ? "active" : "" %>">
+  <div class="group <%= items.compact.map { it[2] }.any? ? "active" : "" %>">
     <button
       type="button"
       class="sidebar-group-btn w-full text-orange-100 hover:text-white hover:bg-orange-700 flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -1,13 +1,13 @@
 <% @page_title = @ps[:name]
 
 perm_checks = {
-  "Firewall:view" => Firewall.where(id: Sequel.any_uuid(@ps[:firewalls].map { UBID.to_uuid(_1[:id]) })),
-  "PrivateSubnet:view" => PrivateSubnet.where(id: Sequel.any_uuid(@connected_subnets.map { UBID.to_uuid(_1[:id]) }))
+  "Firewall:view" => Firewall.where(id: Sequel.any_uuid(@ps[:firewalls].map { UBID.to_uuid(it[:id]) })),
+  "PrivateSubnet:view" => PrivateSubnet.where(id: Sequel.any_uuid(@connected_subnets.map { UBID.to_uuid(it[:id]) }))
 }
 
 viewable_fws, viewable_subnets =
   perm_checks.map do |perm, ds|
-    dataset_authorize(ds, perm).select_hash(:id, Sequel.as(true, :v)).transform_keys! { UBID.from_uuidish(_1).to_s }
+    dataset_authorize(ds, perm).select_hash(:id, Sequel.as(true, :v)).transform_keys! { UBID.from_uuidish(it).to_s }
   end %>
 
 <%== part(

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -362,7 +362,7 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
                     placeholder: "No Maintenance Window",
                     options:
                       (0..23).map do
-                        [_1, "#{"%02d" % _1}:00 - #{"%02d" % ((_1 + PostgresResource::MAINTENANCE_DURATION_IN_HOURS) % 24)}:00 (UTC)"]
+                        [it, "#{"%02d" % it}:00 - #{"%02d" % ((it + PostgresResource::MAINTENANCE_DURATION_IN_HOURS) % 24)}:00 (UTC)"]
                       end,
                     label: "Maintenance Window:",
                     selected: @pg[:maintenance_window_start_at]

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -78,7 +78,7 @@
                     options:
                       ISO3166::Country
                         .all
-                        .reject { Config.sanctioned_countries.include?(_1.alpha2) }
+                        .reject { Config.sanctioned_countries.include?(it.alpha2) }
                         .sort_by(&:common_name)
                         .map { |c| [c.alpha2, c.common_name] }
                         .to_h

--- a/views/project/tag.erb
+++ b/views/project/tag.erb
@@ -8,11 +8,11 @@ removal_allowed = has_permission?("#{@tag_model}:remove", @authorize_id)
 
 add_groups = @tag_model.options_for_project(@project)
 avoid = @current_members.dup
-@tag.currently_included_in.each { avoid[_1] = true }
+@tag.currently_included_in.each { avoid[it] = true }
 avoid[@tag.id] = true
 add_groups.transform_values! do |v|
-  v = v.reject { avoid.include?(_1.id) }
-  v.map! { [_1.name.to_s, _1.ubid] }
+  v = v.reject { avoid.include?(it.id) }
+  v.map! { [it.name.to_s, it.ubid] }
   v.sort!
 end
 add_groups.reject! { _2.empty? }

--- a/views/vm/show.erb
+++ b/views/vm/show.erb
@@ -1,9 +1,9 @@
 <% @page_title = @vm[:name]
 
 viewable_fws =
-  dataset_authorize(Firewall.where(id: @vm[:firewalls].map { UBID.to_uuid(_1[:id]) }), "Firewall:view")
+  dataset_authorize(Firewall.where(id: @vm[:firewalls].map { UBID.to_uuid(it[:id]) }), "Firewall:view")
     .select_hash(:id, Sequel.as(true, :v))
-    .transform_keys! { UBID.from_uuidish(_1).to_s } %>
+    .transform_keys! { UBID.from_uuidish(it).to_s } %>
 
 <% if @vm[:state] != "running" %>
   <div class="auto-refresh hidden" data-interval="10"></div>


### PR DESCRIPTION
Disable Style/RedundantLineContinuation, as it incorrectly removes line continutations in rhizome/host/lib/vm_setup.rb that are not redundant.

All code changes are for _1 => it in blocks.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updates block parameter syntax from `_1` to `it` across multiple files and disables a RuboCop style check for line continuations.
> 
>   - **Behavior**:
>     - Disables `Style/RedundantLineContinuation` in RuboCop configuration to prevent incorrect removal of line continuations in `vm_setup.rb`.
>   - **Syntax Changes**:
>     - Replaces `_1` with `it` in block parameters in `content_generator.rb`, `loader.rb`, and `project.rb`.
>     - Similar replacements in `dns_zone_nexus.rb`, `hetzner_server.rb`, and `vm_group.rb`.
>     - Updates in `util.rb`, `vm_setup.rb`, and `user.rb`.
>     - Changes in `dispatcher.rb` and `kv_data_card.erb` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7b2e7ee5f3387d501b8882d819c2c7feb7555100. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->