### PR TITLE
Restore Ruby 3.2 syntax to rhizome

### DIFF
--- a/rhizome/.rubocop.yml
+++ b/rhizome/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from: ../.rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 3.2
+  NewCops: enable

--- a/rhizome/common/bin/add_to_fstab
+++ b/rhizome/common/bin/add_to_fstab
@@ -15,8 +15,8 @@ File.open("/etc/fstab", File::RDONLY) do |f|
   f.flock(File::LOCK_EX)
 
   content = f.read
-  rows = content.split("\n").reject { it.start_with?("#") }
-  matches = rows.select { it.match(/\A#{device}\s|\s#{dir}\s/) }
+  rows = content.split("\n").reject { _1.start_with?("#") }
+  matches = rows.select { _1.match(/\A#{device}\s|\s#{dir}\s/) }
   if matches.count == 0
     content += "\n#{device} #{dir} #{type} #{options} #{dump} #{fsck}"
     safe_write_to_file("/etc/fstab", content)

--- a/rhizome/common/lib/network.rb
+++ b/rhizome/common/lib/network.rb
@@ -9,7 +9,7 @@ def mac_to_ipv6_link_local(mac)
   eui[0] ^= 0x02
 
   "fe80::" + eui.each_slice(2).map { |pair|
-    pair.map { format("%02x", it) }.join
+    pair.map { format("%02x", _1) }.join
   }.join(":")
 end
 
@@ -20,6 +20,6 @@ end
 # local address errors out.
 def gen_mac
   ([rand(256) & 0xFE | 0x02] + Array.new(5) { rand(256) }).map {
-    "%0.2X" % it
+    "%0.2X" % _1
   }.join(":").downcase
 end

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -54,7 +54,7 @@ end
 def sync_parent_dir(f)
   parent_dir = Pathname.new(f).parent.to_s
   File.open(parent_dir) {
-    fsync_or_fail(it)
+    fsync_or_fail(_1)
   }
 end
 

--- a/rhizome/host/bin/delete-old-serial-logs
+++ b/rhizome/host/bin/delete-old-serial-logs
@@ -15,10 +15,10 @@ end
 
 # Reduce the directory size to less than 1GB
 files_with_sizes = Dir.glob(File.join(directory_path, "*"))
-  .select { File.file?(it) }
-  .map { {file: it, size: File.size(it)} }
-  .sort_by { it[:size] }
-while files_with_sizes.sum { it[:size] } > 1 * 1024 * 1024 * 1024 # 1GB in bytes
+  .select { File.file?(_1) }
+  .map { {file: _1, size: File.size(_1)} }
+  .sort_by { _1[:size] }
+while files_with_sizes.sum { _1[:size] } > 1 * 1024 * 1024 * 1024 # 1GB in bytes
   break unless (largest_file = files_with_sizes.pop)
   FileUtils.rm(largest_file[:file])
 end

--- a/rhizome/host/lib/slice_setup.rb
+++ b/rhizome/host/lib/slice_setup.rb
@@ -55,7 +55,7 @@ SLICE_CONFIG
     str.split(",").all? do |part|
       if part.include?("-")
         r = part.split("-")
-        r.size == 2 && r.all? { it.to_i.to_s == it } && r[0].to_i <= r[1].to_i
+        r.size == 2 && r.all? { _1.to_i.to_s == _1 } && r[0].to_i <= r[1].to_i
       else
         part.to_i.to_s == part
       end

--- a/rhizome/host/lib/storage_key_encryption.rb
+++ b/rhizome/host/lib/storage_key_encryption.rb
@@ -11,12 +11,12 @@ class StorageKeyEncryption
 
   def write_encrypted_dek(key_file, data_encryption_key)
     File.open(key_file, "w") {
-      it.write(JSON.pretty_generate({
+      _1.write(JSON.pretty_generate({
         cipher: data_encryption_key[:cipher],
         key: wrap_key(data_encryption_key[:key]),
         key2: wrap_key(data_encryption_key[:key2])
       }))
-      fsync_or_fail(it)
+      fsync_or_fail(_1)
     }
   end
 

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -28,7 +28,7 @@ class VmPath
 
   def systemd_service
     File.join("/etc/systemd/system",
-      IO.popen(["systemd-escape", @vm_name + ".service"]) { it.read.chomp })
+      IO.popen(["systemd-escape", @vm_name + ".service"]) { _1.read.chomp })
   end
 
   def write_systemd_service(s)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -187,7 +187,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     storage_roots = []
 
     params = JSON.parse(File.read(vp.prep_json))
-    params["storage_volumes"].reject { it["read_only"] }.each { |params|
+    params["storage_volumes"].reject { _1["read_only"] }.each { |params|
       volume = StorageVolume.new(@vm_name, params)
       volume.purge_spdk_artifacts
       storage_roots.append(volume.storage_root)
@@ -412,7 +412,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def generate_ip6_private_filter_rules(nics)
-    nics.map { "ether saddr #{it.mac} ip6 saddr != #{it.net6} drop" }.join("\n")
+    nics.map { "ether saddr #{_1.mac} ip6 saddr != #{_1.net6} drop" }.join("\n")
   end
 
   def build_nftables_config(gua, nics, ip4)
@@ -484,8 +484,8 @@ dhcp-range=#{nic.tap},#{vm_sub_6.nth(2)},#{vm_sub_6.nth(2)},#{vm_sub_6.netmask.p
 DHCP
     end.join("\n")
 
-    raparams = nics.map { "ra-param=#{it.tap}" }.join("\n")
-    interfaces = nics.map { "interface=#{it.tap}" }.join("\n")
+    raparams = nics.map { "ra-param=#{_1.tap}" }.join("\n")
+    interfaces = nics.map { "interface=#{_1.tap}" }.join("\n")
     dnsmasq_address_ip6 = NetAddr::IPv6.parse("fd00:0b1c:100d:53::")
     runner_config = if boot_image.include?("github")
       <<~ADDRESSES
@@ -582,7 +582,7 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
     ssh_authorized_keys:
-#{public_keys.map { "      - #{yq(it)}" }.join("\n")}
+#{public_keys.map { "      - #{yq(_1)}" }.join("\n")}
 
 ssh_pwauth: False
 
@@ -598,7 +598,7 @@ EOS
   end
 
   def storage(storage_params, storage_secrets, prep)
-    storage_params.reject { it["read_only"] }.map { |params|
+    storage_params.reject { _1["read_only"] }.map { |params|
       device_id = params["device_id"]
       key_wrapping_secrets = storage_secrets[device_id]
       storage_volume = StorageVolume.new(@vm_name, params)
@@ -616,7 +616,7 @@ EOS
   end
 
   def prepare_pci_devices(pci_devices)
-    pci_devices.select { it[0].end_with? ".0" }.each do |pci_dev|
+    pci_devices.select { _1[0].end_with? ".0" }.each do |pci_dev|
       r("echo 1 > /sys/bus/pci/devices/0000:#{pci_dev[0]}/reset")
       r("chown #{@vm_name}:#{@vm_name} /sys/kernel/iommu_groups/#{pci_dev[1]} /dev/vfio/#{pci_dev[1]}")
     end
@@ -625,7 +625,7 @@ EOS
   def install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
     cpu_setting = "boot=#{max_vcpus},topology=#{cpu_topology}"
 
-    tapnames = nics.map { "-i #{it.tap}" }.join(" ")
+    tapnames = nics.map { "-i #{_1.tap}" }.join(" ")
 
     vp.write_dnsmasq_service <<DNSMASQ_SERVICE
 [Unit]
@@ -663,8 +663,8 @@ DNSMASQ_SERVICE
     spdk_after = spdk_services.map { |s| "After=#{s}" }.join("\n")
     spdk_requires = spdk_services.map { |s| "Requires=#{s}" }.join("\n")
 
-    net_params = nics.map { "--net mac=#{it.mac},tap=#{it.tap},ip=,mask=,num_queues=#{max_vcpus * 2 + 1}" }
-    pci_device_params = pci_devices.map { " --device path=/sys/bus/pci/devices/0000:#{it[0]}/" }.join
+    net_params = nics.map { "--net mac=#{_1.mac},tap=#{_1.tap},ip=,mask=,num_queues=#{max_vcpus * 2 + 1}" }
+    pci_device_params = pci_devices.map { " --device path=/sys/bus/pci/devices/0000:#{_1[0]}/" }.join
     limit_memlock = pci_devices.empty? ? "" : "LimitMEMLOCK=#{mem_gib * 1073741824}"
     cpu_quota = (cpu_percent_limit == 0) ? "" : "CPUQuota=#{cpu_percent_limit}%"
 

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -37,17 +37,17 @@ RSpec.describe VmSetup do
     it "templates user YAML with no swap" do
       vs.write_user_data("some_user", ["some_ssh_key"], nil, "")
       expect(vps).to have_received(:write_user_data) {
-        expect(it).to match(/some_user/)
-        expect(it).to match(/some_ssh_key/)
+        expect(_1).to match(/some_user/)
+        expect(_1).to match(/some_ssh_key/)
       }
     end
 
     it "templates user YAML with swap" do
       vs.write_user_data("some_user", ["some_ssh_key"], 123, "")
       expect(vps).to have_received(:write_user_data) {
-        expect(it).to match(/some_user/)
-        expect(it).to match(/some_ssh_key/)
-        expect(it).to match(/size: 123/)
+        expect(_1).to match(/some_user/)
+        expect(_1).to match(/some_ssh_key/)
+        expect(_1).to match(/size: 123/)
       }
     end
 
@@ -281,7 +281,7 @@ RSpec.describe VmSetup do
       nics = [
         %w[fd48:666c:a296:ce4b:2cc6::/79 192.168.5.50/32 ncaka58xyg 3e:bd:a5:96:f7:b9],
         %w[fddf:53d2:4c89:2305:46a0::/79 10.10.10.10/32 ncbbbbbbbb fb:55:dd:ba:21:0a]
-      ].map { VmSetup::Nic.new(*it) }
+      ].map { VmSetup::Nic.new(*_1) }
 
       expect(vps).to receive(:write_nftables_conf).with(<<NFTABLES_CONF)
 table ip raw {

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -32,8 +32,8 @@ safe_write_to_file("/etc/postgresql/#{v}/main/conf.d/001-service.conf", configs)
 # Update pg_hba.conf
 private_subnets = configure_hash["private_subnets"].flat_map {
   [
-    "host    all             all             #{it["net4"]}                     scram-sha-256",
-    "host    all             all             #{it["net6"]}                     scram-sha-256"
+    "host    all             all             #{_1["net4"]}                     scram-sha-256",
+    "host    all             all             #{_1["net6"]}                     scram-sha-256"
   ]
 }.join("\n")
 


### PR DESCRIPTION
Ubuntu 22.04 VmHosts use Ruby 3.0, and Ubunutu 24.04 use Ruby 3.2, so 3.4 syntax would break either.  This was theoretically an issue before, but I'm guessing there were no significant syntax changes between 3.0 and 3.2 that Rubocop's rewriting would break.

This commits a rhizome/.rubocop.yml file that inherits the default configuration, and overrides TargetRubyVersion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores Ruby 3.2 syntax in rhizome for compatibility with Ubuntu 22.04 and 24.04.
> 
>   - **Configuration**:
>     - Adds `rhizome/.rubocop.yml` to set `TargetRubyVersion` to 3.2 and enable `NewCops`.
>   - **Syntax Updates**:
>     - Replaces `it` with `_1` in blocks across multiple files for Ruby 3.2 compatibility, including `add_to_fstab`, `network.rb`, `util.rb`, `delete-old-serial-logs`, `slice_setup.rb`, `storage_key_encryption.rb`, `vm_path.rb`, `vm_setup.rb`, `vm_setup_spec.rb`, and `configure`.
>   - **Compatibility**:
>     - Ensures compatibility with Ubuntu 22.04 and 24.04 by using Ruby 3.2 syntax.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3f05c61e62f011e691247bc1fb3d0e146059f476. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->