### PR TITLE
Fix Vm#public_key validation

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -260,14 +260,16 @@ class Vm < Sequel::Model
   end
 
   ssh_public_key_line = /(([^# \r\n]|"[^"\r\n]+")+ +)? *[^# \r\n]+ +[A-Za-z0-9+\/]+=*( +[^\r\n]*)?/
-  VALID_SSH_PUBLIC_KEY_LINE = /^#{ssh_public_key_line}$/
+  VALID_SSH_PUBLIC_KEY_LINE = /^#{ssh_public_key_line}\r?$/
   VALID_SSH_AUTHORIZED_KEYS = /\A(([ \t]*|(#[^\r\n]*)?|#{ssh_public_key_line})(\r?\n|\z))+\z/
 
   def validate
     super
-    validates_format(VALID_SSH_AUTHORIZED_KEYS, :public_key, message: "invalid SSH public key format")
-    unless errors.on(:public_key)
-      validates_format(VALID_SSH_PUBLIC_KEY_LINE, :public_key, message: "must contain at least one valid SSH public key")
+    if new?
+      validates_format(VALID_SSH_AUTHORIZED_KEYS, :public_key, message: "invalid SSH public key format")
+      unless errors.on(:public_key)
+        validates_format(VALID_SSH_PUBLIC_KEY_LINE, :public_key, message: "must contain at least one valid SSH public key")
+      end
     end
   end
 end


### PR DESCRIPTION
Need to add \r? before $ to handle \r\n line ending.

Also, only validate for new VMs, not every time the VM is saved.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix SSH public key validation in `Vm` class to handle `\r\n` line endings and apply only to new VMs.
> 
>   - **Validation Changes**:
>     - Update `VALID_SSH_PUBLIC_KEY_LINE` regex in `vm.rb` to handle `\r\n` line endings.
>     - Modify `validate` method in `vm.rb` to apply SSH public key validation only for new VMs using `new?` check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9a0369b083b0a883a14a76b63255bcd3b4ea7d36. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->