### PR TITLE
Fix InferenceRouter `strand` association

### DIFF
--- a/model/ai/inference_router.rb
+++ b/model/ai/inference_router.rb
@@ -3,7 +3,7 @@
 require_relative "../../model"
 
 class InferenceRouter < Sequel::Model
-  one_to_one :strand
+  one_to_one :strand, key: :id
   many_to_one :project
   one_to_many :replicas, class: :InferenceRouterReplica, key: :inference_router_id
   many_to_one :load_balancer


### PR DESCRIPTION
Set `id` as key for the association between `InferenceRouter` and `Strand`. Without explicitly setting the key, Sequel assumes that `Strand` has a column `inference_router_id`, which is not the case:

```
> InferenceRouter.first.strand

Sequel::DatabaseError: PG::UndefinedColumn: ERROR:  column strand.inference_router_id does not exist
LINE 1: SELECT * FROM "strand" WHERE ("strand"."inference_router_id"...
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `InferenceRouter` to `Strand` association by setting `key: :id` to prevent `Sequel::DatabaseError`.
> 
>   - **Behavior**:
>     - Fixes `one_to_one` association in `InferenceRouter` to `Strand` by setting `key: :id` in `model/ai/inference_router.rb`.
>     - Resolves `Sequel::DatabaseError` due to missing `inference_router_id` column in `Strand`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a033cbd51026578d145ec14a3fd87619e231be5a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->