### PR TITLE
Use fewer resources for SPDK on smaller hosts.

### DIFF
--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -24,7 +24,9 @@ class Prog::Storage::SetupSpdk < Prog::Base
   label def start
     version = frame["version"]
     arch = vm_host.arch
-    spdk_hugepages = 4
+
+    # Rhizome's spdk_setup.rb uses one 1G hugepage per CPU core
+    spdk_hugepages = vm_host.spdk_cpu_count
 
     fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_SPDK_VERSIONS.include? [version, arch]
 

--- a/rhizome/host/bin/setup-spdk
+++ b/rhizome/host/bin/setup-spdk
@@ -20,17 +20,19 @@ spdk_setup = SpdkSetup.new(version)
 
 case verb
 when "install"
-  unless (cpu_count = ARGV.shift)
-    puts "expected cpu_count as argument"
+  unless (cpu_count = ARGV.shift) && cpu_count.to_i.positive?
+    puts "expected a positive cpu_count as argument"
     exit 1
   end
+  cpu_count = cpu_count.to_i
+
   # YYY: The default is used for backward comaptibility. Make it mandatory after
   # the upgrade.
   os_version = ARGV.shift || "ubuntu-22.04"
   spdk_setup.install_package(os_version: os_version)
-  spdk_setup.create_hugepages_mount
-  spdk_setup.create_conf
-  spdk_setup.create_service(cpu_count: cpu_count.to_i)
+  spdk_setup.create_hugepages_mount(cpu_count: cpu_count)
+  spdk_setup.create_conf(cpu_count: cpu_count)
+  spdk_setup.create_service(cpu_count: cpu_count)
   spdk_setup.enable_services
 when "start"
   spdk_setup.start_services

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe SpdkSetup do
     it "creates the hugepages mount" do
       expect(spdk_setup).to receive(:r).with("sudo --user=spdk mkdir -p /home/spdk/hugepages.#{spdk_version.tr("-", ".")}")
       expect(File).to receive(:write).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount", /.*/)
-      expect { spdk_setup.create_hugepages_mount }.not_to raise_error
+      expect { spdk_setup.create_hugepages_mount(cpu_count: 4) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
Buffer sizes and hugepages for all hosts were the same regardless of a host's capacity. This prevented allocation of Standard-30 on AX102.

This change sets these numbers proportional to cpu_count used for SPDK, which is itself proportional to the host's capacity.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize SPDK resource allocation by making buffer sizes and hugepages proportional to CPU count, improving support for smaller hosts.
> 
>   - **Behavior**:
>     - `spdk_hugepages` in `setup_spdk.rb` now set to `vm_host.spdk_cpu_count` instead of a fixed value.
>     - `create_hugepages_mount`, `create_conf`, and `create_service` in `spdk_setup.rb` now take `cpu_count` as a parameter to adjust resource allocation.
>   - **Validation**:
>     - `setup-spdk` script now checks for positive `cpu_count` argument.
>   - **Configuration**:
>     - `small_pool_count` and `large_pool_count` in `create_conf` are now proportional to `cpu_count`.
>     - Hugepages size in `create_hugepages_mount` is set to `cpu_count` GB.
>   - **Testing**:
>     - Updated `spdk_setup_spec.rb` to test `create_hugepages_mount` with `cpu_count` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4aa511a0d74033ca818de63e59b15b70718a0f44. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->