### PR TITLE
Penalize non-premium runner requests more for AX102

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -320,7 +320,7 @@ module Scheduling::Allocator
 
       # prioritize AX102 for our premium CPU testers.
       # penalize other customers since the allocator is eager to use smaller hosts first
-      score += @request.prioritize_performance_cpu ? -1 : 1 if @candidate_host[:total_cores] == 16
+      score += @request.prioritize_performance_cpu ? -1 : 5 if @candidate_host[:total_cores] == 16
 
       # penalty for AX161, TODO: remove after migration to AX162
       score += 0.5 if @candidate_host[:total_cores] == 32

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe Al do
       expect(Al::StorageAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
       vmhds[:location_id] = "6b9ef786-b842-8420-8c65-c25e3d4bdf3d"
       vmhds[:total_cores] = 16
-      expect(Al::Allocation.new(vmhds, req).score).to eq(1)
+      expect(Al::Allocation.new(vmhds, req).score).to eq(5)
     end
 
     it "respects location preferences" do


### PR DESCRIPTION
Our allocator selects smaller hosts first. Since AX102 is three times
smaller than AX162, it tends to choose AX102. However, we want to
reserve AX102 for customers who want premium runners. Until we launch
premium runners, we should penalize non-premium runner requests more to
keep AX102 available for premium runners.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase penalty for non-premium requests on AX102 hosts to reserve them for premium requests.
> 
>   - **Behavior**:
>     - Increase penalty for non-premium requests on AX102 hosts in `calculate_score` in `allocator.rb` from 1 to 5.
>     - Ensures AX102 is reserved for premium requests by default.
>   - **Tests**:
>     - Update test in `allocator_spec.rb` to expect a score of 5 for non-premium requests on AX102.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7d5b2aa624dee3fe695883a158672b8a6a028613. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->