### PR TITLE
Allow location preferences for GitHub runners

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -158,7 +158,7 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations, :performance_runners
+  feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations, :performance_runners, :preferred_runner_locations
 end
 
 # Table: project

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -200,7 +200,7 @@ class Prog::Vm::Nexus < Prog::Base
       allocation_state_filter, location_filter, location_preference, host_filter =
         if frame["force_host_id"]
           [[], [], [], [frame["force_host_id"]]]
-        elsif Location[vm.location_id].name == "github-runners"
+        elsif vm.location_id == Location::GITHUB_RUNNERS_ID
           runner_locations = (vm.vcpus == 60) ? [] : [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID]
           [["accepting"], runner_locations, [Location::GITHUB_RUNNERS_ID], []]
         else

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -331,8 +331,8 @@ module Scheduling::Allocator
       # penalty of 5 if host has a GPU but VM doesn't require a GPU
       score += 5 unless @request.gpu_count > 0 || @candidate_host[:num_gpus] == 0
 
-      # penalty of 10 if location preference is not honored
-      score += 10 unless @request.location_preference.empty? || @request.location_preference.include?(@candidate_host[:location_id])
+      # penalty of 1.5 if location preference is not honored
+      score += 1.5 unless @request.location_preference.empty? || @request.location_preference.include?(@candidate_host[:location_id])
 
       score
     end


### PR DESCRIPTION
- **Do not send a database query to check the location of vm**
  Since we already have the location ID, there’s no need to query the
  database. We can just compare the ID.
  

- **Allow location preferences for GitHub runners**
  Right now, we provision runners in any European location, and
  standard-60 runners in the US as well.
  
  Some of our customers want runners from specific locations.
  
  We can't guarantee allocation at that location, but we can prioritize
  those requests if there is enough capacity.
  
  Our allocator already accepts location preferences. We just need to pass
  the value from the feature flag to the allocator if it's set. It accepts
  a list of location IDs.
  
  ```ruby
  project.set_ff_preferred_runner_locations([Location::LEASEWEB_WDC02_ID])
  ```
  

- **Decrease location preference penalty at allocator**
  GitHub runners can technically be allocated on any host, but we use a
  special “github-runners” location for incubating new hosts to ensure
  reliability before moving them to their actual location. Over time,
  mature hosts are moved out, and the “github-runners” location will
  eventually be phased out.
  
  Previously, location preference had a high penalty (10), which caused a
  few issues:
  - Hosts became unbalanced, overloading “github-runners” while other
    hosts stayed underutilized. Half of our fleet is on the other side.
  - AX102 machines prioritized for premium customers were unintentionally
    filled by non-premium users because they were still under
    “github-runners” with lower penalties elsewhere.
  - Special location preferences (like US priority) became too aggressive,
    risking overfilling dedicated regions.
  
  Reduced the penalty to 1.5, which is lower than the AX102 penalty (5)
  and fits within the host utilization penalty range (0–2), aiming for
  more balanced allocation.
  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce location preferences for GitHub runners and reduce location preference penalty to improve resource allocation balance.
> 
>   - **Behavior**:
>     - Allow location preferences for GitHub runners by passing feature flag values to the allocator in `nexus.rb`.
>     - Reduce location preference penalty from 10 to 1.5 in `allocator.rb` to improve host utilization balance.
>   - **Feature Flags**:
>     - Add `preferred_runner_locations` feature flag in `project.rb`.
>   - **Tests**:
>     - Update tests in `nexus_spec.rb` to cover new location preference logic and reduced penalty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b44dec34a6fbe4d6e728fda82a02457c8104b4e0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->