### PR TITLE
Fix logged delay for "obtained lease"

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -42,12 +42,12 @@ class Strand < Sequel::Model
     end
     affected = ps.call(id:).first
     return false unless affected
-    # Also operate as reload query
-    @values = affected
     lease_time = affected.fetch(:lease)
     verbose_logging = rand(1000) == 0
 
     Clog.emit("obtained lease") { {lease_acquired: {time: lease_time, delay: Time.now - schedule}} } if verbose_logging
+    # Also operate as reload query
+    @values = affected
 
     begin
       yield


### PR DESCRIPTION
Move the updating of @values (simulating a reload) until after the Clog.emit, since that was where the reload call was previously.

This should fix the negative delays that were logged.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes negative delay logging in `take_lease_and_reload` in `strand.rb` by adjusting `@values` assignment timing.
> 
>   - **Behavior**:
>     - Fixes negative delay logging in `take_lease_and_reload` in `strand.rb` by moving `@values` assignment after `Clog.emit` call.
>   - **Misc**:
>     - No other changes or refactors were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3b296111b91653800a3902ff1c3c59b1f8d310fb. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->