### PR TITLE
Revert "Decrease location preference penalty at allocator"

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -331,8 +331,8 @@ module Scheduling::Allocator
       # penalty of 5 if host has a GPU but VM doesn't require a GPU
       score += 5 unless @request.gpu_count > 0 || @candidate_host[:num_gpus] == 0
 
-      # penalty of 1.5 if location preference is not honored
-      score += 1.5 unless @request.location_preference.empty? || @request.location_preference.include?(@candidate_host[:location_id])
+      # penalty of 10 if location preference is not honored
+      score += 10 unless @request.location_preference.empty? || @request.location_preference.include?(@candidate_host[:location_id])
 
       score
     end


### PR DESCRIPTION
This reverts commit 15345dc020f28786550ac9b69ec9599eebab9eb1.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts location preference penalty in `calculate_score` in `allocator.rb` from 1.5 back to 10.
> 
>   - **Behavior**:
>     - Reverts penalty for not honoring location preference in `calculate_score` in `allocator.rb` from 1.5 back to 10.
>   - **Misc**:
>     - Reverts commit `15345dc020f28786550ac9b69ec9599eebab9eb1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 142308c794678ec47769daaa0f74a3d2700cedbf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->