### PR TITLE
Wait for vm scheduling before applying LoadBalancer logics

### DIFF
--- a/prog/vnet/cert_server.rb
+++ b/prog/vnet/cert_server.rb
@@ -12,13 +12,14 @@ class Prog::Vnet::CertServer < Prog::Base
   end
 
   label def reshare_certificate
-    put_cert_to_vm
+    put_cert_to_vm if vm.vm_host
 
     pop "certificate is reshared"
   end
 
   label def put_certificate
     nap 5 unless load_balancer.active_cert&.cert
+    nap 5 unless vm.vm_host
 
     put_cert_to_vm
     hop_start_certificate_server
@@ -30,6 +31,8 @@ class Prog::Vnet::CertServer < Prog::Base
   end
 
   label def remove_cert_server
+    pop "certificate resources and server are removed" unless vm.vm_host
+
     vm.vm_host.sshable.cmd("sudo host/bin/setup-cert-server stop_and_remove #{vm.inhost_name}")
     pop "certificate resources and server are removed"
   end

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -25,6 +25,7 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   end
 
   label def remove_load_balancer
+    pop "load balancer is removed" unless vm.vm_host
     vm.vm_host.sshable.cmd("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: generate_nat_rules(vm.ephemeral_net4.to_s, vm.private_ipv4.to_s))
 
     pop "load balancer is removed"

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe Prog::Vnet::CertServer do
   end
 
   describe "#reshare_certificate" do
+    it "doesn't try to put the certificate when Vm is not scheduled to a VmHost" do
+      expect(vm).to receive(:vm_host).and_return(nil)
+      expect { nx.reshare_certificate }.to exit({"msg" => "certificate is reshared"})
+    end
+
     it "puts the certificate and pops" do
       expect(nx).to receive(:put_cert_to_vm)
       expect { nx.reshare_certificate }.to exit({"msg" => "certificate is reshared"})
@@ -63,6 +68,11 @@ RSpec.describe Prog::Vnet::CertServer do
       expect(nx.load_balancer).to receive(:active_cert).and_return(nil)
       expect { nx.put_certificate }.to nap(5)
     end
+
+    it "naps if the vm is not scheduled" do
+      expect(vm).to receive(:vm_host).and_return(nil)
+      expect { nx.put_certificate }.to nap(5)
+    end
   end
 
   describe "#start_certificate_server" do
@@ -76,6 +86,11 @@ RSpec.describe Prog::Vnet::CertServer do
     it "removes the certificate files, server and hops to remove_load_balancer" do
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-cert-server stop_and_remove test-vm")
 
+      expect { nx.remove_cert_server }.to exit({"msg" => "certificate resources and server are removed"})
+    end
+
+    it "does nothing if the vm is not scheduled anywhere" do
+      expect(vm).to receive(:vm_host).and_return(nil)
       expect { nx.remove_cert_server }.to exit({"msg" => "certificate resources and server are removed"})
     end
   end

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -476,6 +476,11 @@ LOAD_BALANCER
   end
 
   describe "#remove_load_balancer" do
+    it "does nothing if the vm is not scheduled anywhere" do
+      expect(vm).to receive(:vm_host).and_return(nil)
+      expect { nx.remove_load_balancer }.to exit({"msg" => "load balancer is removed"})
+    end
+
     it "creates basic nat rules" do
       expect(vmh.sshable).to receive(:cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<REMOVE_LOAD_BALANCER)
 table ip nat;


### PR DESCRIPTION
Logics like applying the nft rules or putting certificates in the Vm's VmHost were not checking whether the vm was scheduled to a VmHost or not. With this commit, we will wait for the Vm's VmHost before proceeding.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure VM operations in `cert_server.rb` and `update_load_balancer_node.rb` only proceed if VM is scheduled to a host, with corresponding tests added.
> 
>   - **Behavior**:
>     - In `cert_server.rb`, `put_cert_to_vm`, `put_certificate`, and `remove_cert_server` now check `vm.vm_host` before proceeding.
>     - In `update_load_balancer_node.rb`, `remove_load_balancer` checks `vm.vm_host` before executing commands.
>   - **Tests**:
>     - Added tests in `cert_server_spec.rb` for `reshare_certificate`, `put_certificate`, and `remove_cert_server` to ensure they handle unscheduled VMs correctly.
>     - Added tests in `update_load_balancer_node_spec.rb` for `remove_load_balancer` to verify behavior when VM is not scheduled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for bd6c89caad6e266854874e9c275f5a106ea50903. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->