### PR TITLE
Show only the company name on the invoice if it's provided

### DIFF
--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -212,7 +212,7 @@ class Invoice < Sequel::Model
     row = pdf.bounding_box([0, row_y], width: column_width) do
       if data[:billing_name]
         pdf.text "Bill to:", style: :semibold, color: dark_gray, size: 14
-        pdf.text [data[:billing_name], data[:company_name]].compact.join(" - "), style: :semibold, color: dark_gray, size: 14
+        pdf.text data[:company_name].to_s.strip.empty? ? data[:billing_name] : data[:company_name], style: :semibold, color: dark_gray, size: 14
         pdf.move_down 5
         pdf.text "#{data[:billing_address]},"
         pdf.text "#{data[:billing_city]}, #{data[:billing_state]} #{data[:billing_postal_code]},"


### PR DESCRIPTION
In the past, we didn't have a separate field for the company name, so
customers used the billing name as the company name.

Now that we've added a company name field, it appears on the invoice
twice. In addition, some customers have requested that only the company
name be shown on the invoice, not the person's name.

Therefore, if the company name is provided, there's no need to include
the person's name.

We didn't do this before because we were generating invoice PDFs on the
fly, which would have altered already generated invoices. However, we
have started to persist the invoices in blob storage and display them
from there, so these changes won't affect old invoices.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Show only the company name on invoices if provided, updating `generate_pdf` in `invoice.rb` and tests in `billing_spec.rb`.
> 
>   - **Behavior**:
>     - In `generate_pdf` in `invoice.rb`, show only `company_name` if provided, otherwise show `billing_name`.
>     - Ensures invoices display only the company name when available, avoiding duplication.
>   - **Tests**:
>     - Update `billing_spec.rb` to check for presence of `company_name` and absence of `billing_name` in invoice PDFs.
>     - Modify test data to reflect new behavior, ensuring correct invoice display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 34f89be31e6c8162a826f67463503033827eb7e7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->