### PR TITLE
Configure Octokit timeouts

### DIFF
--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -21,7 +21,7 @@ class Clover < Roda
     begin
       client = Github.installation_client(runner.installation.installation_id)
       jobs = client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
-    rescue Octokit::ClientError, Octokit::ServerError, Faraday::ConnectionFailed => ex
+    rescue Octokit::ClientError, Octokit::ServerError, Faraday::ConnectionFailed, Faraday::TimeoutError => ex
       log_context[:expection] = Util.exception_to_hash(ex)
       Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }
       return

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -4,6 +4,15 @@ require "octokit"
 require "jwt"
 require "yaml"
 
+Octokit.configure do |c|
+  c.connection_options = {
+    request: {
+      open_timeout: 10,
+      timeout: 10
+    }
+  }
+end
+
 module Github
   def self.oauth_client
     Octokit::Client.new(client_id: Config.github_app_client_id, client_secret: Config.github_app_client_secret)


### PR DESCRIPTION
This uses 10 seconds for both open_timeout and timeout, which should ensure no more than 20 seconds total, assuming there is a single Octokit request per Clover request.  That leaves 10 seconds for Clover's processing before exceeding Heroku's 30 second limit.

Add Faraday::TimeoutError to the list of errors to rescue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Configure Octokit timeouts to 10 seconds each and handle `Faraday::TimeoutError` in `get_scope_from_github()`.
> 
>   - **Timeout Configuration**:
>     - Set `open_timeout` and `timeout` to 10 seconds each in `lib/github.rb` for Octokit requests.
>   - **Error Handling**:
>     - Add `Faraday::TimeoutError` to rescue block in `get_scope_from_github()` in `helpers/runtime.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for af0efc77aa8c1c12491b2bc9d3e9b158577370d0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->