### PR TITLE
Remove unnecessary transaction blocks in progs

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -101,22 +101,20 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   def setup_blob_storage
-    DB.transaction do
-      admin_client = Minio::Client.new(
-        endpoint: postgres_timeline.blob_storage_endpoint,
-        access_key: postgres_timeline.blob_storage.admin_user,
-        secret_key: postgres_timeline.blob_storage.admin_password,
-        ssl_ca_file_data: postgres_timeline.blob_storage.root_certs
-      )
+    admin_client = Minio::Client.new(
+      endpoint: postgres_timeline.blob_storage_endpoint,
+      access_key: postgres_timeline.blob_storage.admin_user,
+      secret_key: postgres_timeline.blob_storage.admin_password,
+      ssl_ca_file_data: postgres_timeline.blob_storage.root_certs
+    )
 
-      # Setup user keys and policy for the timeline
-      admin_client.admin_add_user(postgres_timeline.access_key, postgres_timeline.secret_key)
-      admin_client.admin_policy_add(postgres_timeline.ubid, postgres_timeline.blob_storage_policy)
-      admin_client.admin_policy_set(postgres_timeline.ubid, postgres_timeline.access_key)
+    # Setup user keys and policy for the timeline
+    admin_client.admin_add_user(postgres_timeline.access_key, postgres_timeline.secret_key)
+    admin_client.admin_policy_add(postgres_timeline.ubid, postgres_timeline.blob_storage_policy)
+    admin_client.admin_policy_set(postgres_timeline.ubid, postgres_timeline.access_key)
 
-      # Create bucket for the timeline
-      blob_storage_client.create_bucket(postgres_timeline.ubid)
-      blob_storage_client.set_lifecycle_policy(postgres_timeline.ubid, postgres_timeline.ubid, 8)
-    end
+    # Create bucket for the timeline
+    blob_storage_client.create_bucket(postgres_timeline.ubid)
+    blob_storage_client.set_lifecycle_policy(postgres_timeline.ubid, postgres_timeline.ubid, 8)
   end
 end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -590,13 +590,11 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   def final_clean_up
-    DB.transaction do
-      vm.nics.map do |nic|
-        nic.update(vm_id: nil)
-        nic.incr_destroy
-      end
-      vm.destroy
+    vm.nics.map do |nic|
+      nic.update(vm_id: nil)
+      nic.incr_destroy
     end
+    vm.destroy
   end
 
   label def start_after_host_reboot


### PR DESCRIPTION
Prog label methods are run with an implicit transaction in Strand#unsynchronized_run. If methods are not called directly, and are only called by the normal strand processing, the transaction blocks are unnecessary.

Most transaction blocks in progs are in the `assemble` class methods, where they are needed.  However, I found these three cases where `DB.transaction` was called in other methods, that appear to not be needed.

Best reviewed ignoring whitespace differences.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary transaction blocks from `setup_blob_storage` in `postgres_timeline_nexus.rb` and `write_params_json`, `final_clean_up` in `nexus.rb`.
> 
>   - **Behavior**:
>     - Removed unnecessary `DB.transaction` block from `setup_blob_storage` in `postgres_timeline_nexus.rb`.
>     - Removed unnecessary `DB.transaction` block from `write_params_json` and `final_clean_up` in `nexus.rb`.
>   - **Misc**:
>     - The changes are purely refactoring for code clarity and do not affect the existing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6c78222f0b30dc4852bc422fcf1da03384a17f1c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->