### PR TITLE
Selectable ch second part

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -53,10 +53,10 @@ r "chmod +x /etc/update-motd.d/99-clover-motd"
 r "timedatectl set-timezone UTC"
 
 # Download cloud hypervisor binaries.
-CloudHypervisor::Version::DEFAULT.download
+CloudHypervisor::Version.download
 
 # Download firmware binaries.
-CloudHypervisor::Firmware::DEFAULT.download
+CloudHypervisor::Firmware.download
 
 # Err towards listing ('l') and not restarting services by default,
 # otherwise a stray keystroke when using "apt install" for unrelated

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -14,7 +14,22 @@ unless (vm_name = ARGV.shift)
   exit 1
 end
 
-vm_setup = VmSetup.new(vm_name)
+params = begin
+  JSON.parse(File.read(VmPath.new(vm_name).prep_json))
+rescue Errno::ENOENT
+  if action.start_with?("delete")
+    # Params were not historically needed for the delete actions,
+    # so handle case where prep file has already been deleted.
+    {}
+  else
+    raise
+  end
+end
+
+vm_setup = VmSetup.new(vm_name,
+  hugepages: params.fetch("hugepages", true),
+  ch_version: params["ch_version"],
+  firmware_version: params["firmware_version"])
 
 if action == "delete"
   vm_setup.purge
@@ -31,8 +46,6 @@ if action == "delete_net"
   vm_setup.purge_user
   exit 0
 end
-
-params = JSON.parse(File.read(VmPath.new(vm_name).prep_json))
 
 begin
   # "Global Unicast" subnet, i.e. a subnet for exchanging packets with

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -118,14 +118,7 @@ module CloudHypervisor
       arm64: new("35.1", "071a0b4918565ce81671ecd36d65b87351c85ea9ca0fbf73d4a67ec810efe606", "355cdb1e2af7653a15912c66f7c76c922ca788fd33d77f6f75846ff41278e249")
     )}
 
-    default = if ubuntu_version >= 24
-      SUPPORTED["45.0"] = Arch.render(
-        x64: new("45.0", "362d42eb464e2980d7b41109a214f8b1518b4e1f8e7d8c227b67c19d4581c250", "11a050087d279f9b5860ddbf2545fda43edf93f9b266440d0981932ee379c6ec"),
-        arm64: new("45.0", "3a8073379d098817d54f7c0ab25a7734b88b070a98e5d820ab39e244b35b5e5e", "a4b736ce82f5e2fc4a92796a9a443f243ef69f4970dad1e1772bd841c76c3301")
-      )
-    else
-      SUPPORTED["35.1"]
-    end
+    default = SUPPORTED["35.1"]
     SUPPORTED.freeze
 
     INSTALLED = SUPPORTED.select { _2.downloaded? }

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -4,13 +4,12 @@ require "fileutils"
 require_relative "../../common/lib/arch"
 
 module CloudHypervisor
-  class Firmware < Struct.new(:version, :sha256)
-    DEFAULT = if Arch.x64?
-      new("202311", "e31738aacd3d68d30f8f9a4d09711cca3dfb414e8910dc3af90c50f36885380a")
-    else
-      new("202211", "482f428f782591d7c2222e0bc8240d25fb200fb21fd984b3339c85979d94b4d8")
-    end
+  # For Firmware and Version:
+  #
+  # SUPPORTED constant is a hash of versions that should be installed by prep_host
+  # INSTALLED constant is a hash of versions that are installed, with a default of the default version
 
+  class Firmware < Struct.new(:version, :sha256)
     def url
       "https://github.com/ubicloud/build-edk2-firmware/releases/download/edk2-stable#{version}-#{Arch.sym}/CLOUDHV-#{Arch.sym}.fd"
     end
@@ -23,8 +22,12 @@ module CloudHypervisor
       "#{firmware_root}/CLOUDHV-#{version}.fd"
     end
 
+    def downloaded?
+      File.exist?(path)
+    end
+
     def download
-      return if File.exist?(path)
+      return if downloaded?
       FileUtils.mkdir_p(firmware_root)
 
       safe_write_to_file(path) do |f|
@@ -35,17 +38,28 @@ module CloudHypervisor
 
       sha256
     end
+
+    default = Arch.render(
+      x64: new("202311", "e31738aacd3d68d30f8f9a4d09711cca3dfb414e8910dc3af90c50f36885380a"),
+      arm64: new("202211", "482f428f782591d7c2222e0bc8240d25fb200fb21fd984b3339c85979d94b4d8")
+    )
+    SUPPORTED = {default.version => default}.freeze
+    INSTALLED = SUPPORTED.select { _2.downloaded? }
+    INSTALLED.default = default if default.downloaded?
+    INSTALLED.freeze
+
+    def self.[](version)
+      INSTALLED[version]
+    end
+
+    def self.download
+      SUPPORTED.each_value(&:download)
+    end
   end
 
   class Version < Struct.new(:version, :sha256_ch_bin, :sha256_ch_remote)
-    DEFAULT = if Arch.x64?
-      new("35.1", "e8426b0733248ed559bea64eb04d732ce8a471edc94807b5e2ecfdfc57136ab4", "337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0")
-    else
-      new("35.1", "071a0b4918565ce81671ecd36d65b87351c85ea9ca0fbf73d4a67ec810efe606", "355cdb1e2af7653a15912c66f7c76c922ca788fd33d77f6f75846ff41278e249")
-    end
-
     def url_for(type)
-      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/#{type}-static#{"-aarch64" if Arch.arm64?}"
+      "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v#{version}/#{type}#{self.class.exe_suffix}"
     end
 
     def ch_remote_url
@@ -68,6 +82,10 @@ module CloudHypervisor
       File.join(dir, "cloud-hypervisor")
     end
 
+    def downloaded?
+      File.exist?(bin) && File.exist?(ch_remote_bin)
+    end
+
     def download
       download_file(ch_remote_url, ch_remote_bin, sha256_ch_remote)
       download_file(cloud_hypervisor_url, bin, sha256_ch_bin)
@@ -84,6 +102,52 @@ module CloudHypervisor
       end
 
       FileUtils.chmod "a+x", path
+    end
+
+    def self.lsb_release
+      `lsb_release -d`
+    end
+
+    def self.ubuntu_version
+      raise "unable to determine Ubuntu version" unless /Ubuntu (\d\d)\./ =~ lsb_release
+      $1.to_i
+    end
+
+    SUPPORTED = {"35.1" => Arch.render(
+      x64: new("35.1", "e8426b0733248ed559bea64eb04d732ce8a471edc94807b5e2ecfdfc57136ab4", "337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0"),
+      arm64: new("35.1", "071a0b4918565ce81671ecd36d65b87351c85ea9ca0fbf73d4a67ec810efe606", "355cdb1e2af7653a15912c66f7c76c922ca788fd33d77f6f75846ff41278e249")
+    )}
+
+    default = if ubuntu_version >= 24
+      SUPPORTED["45.0"] = Arch.render(
+        x64: new("45.0", "362d42eb464e2980d7b41109a214f8b1518b4e1f8e7d8c227b67c19d4581c250", "11a050087d279f9b5860ddbf2545fda43edf93f9b266440d0981932ee379c6ec"),
+        arm64: new("45.0", "3a8073379d098817d54f7c0ab25a7734b88b070a98e5d820ab39e244b35b5e5e", "a4b736ce82f5e2fc4a92796a9a443f243ef69f4970dad1e1772bd841c76c3301")
+      )
+    else
+      SUPPORTED["35.1"]
+    end
+    SUPPORTED.freeze
+
+    INSTALLED = SUPPORTED.select { _2.downloaded? }
+    INSTALLED.default = if default.downloaded?
+      default
+    else
+      INSTALLED.values.first
+    end
+    INSTALLED.freeze
+
+    EXE_SUFFIX = Arch.render(x64: "-static", arm64: "-static-aarch64")
+
+    def self.[](version)
+      INSTALLED[version]
+    end
+
+    def self.download
+      SUPPORTED.each_value(&:download)
+    end
+
+    def self.exe_suffix
+      EXE_SUFFIX
     end
   end
 end

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -104,13 +104,8 @@ module CloudHypervisor
       FileUtils.chmod "a+x", path
     end
 
-    def self.lsb_release
-      `lsb_release -d`
-    end
-
     def self.ubuntu_version
-      raise "unable to determine Ubuntu version" unless /Ubuntu (\d\d)\./ =~ lsb_release
-      $1.to_i
+      File.read("/etc/os-release")[/VERSION_ID="?(\d\d)/, 1]&.to_i or raise "unable to determine Ubuntu version"
     end
 
     SUPPORTED = {"35.1" => Arch.render(

--- a/rhizome/host/spec/cloud_hypervisor_spec.rb
+++ b/rhizome/host/spec/cloud_hypervisor_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe CloudHypervisor do
     def setup_file_downloads(sha_remote:, sha_ch:)
       f_remote = instance_double(File, path: paths[:remote_tmp])
       f_ch = instance_double(File, path: paths[:ch_tmp])
-      expect(Arch).to receive(:sym).and_return(:x64).at_least(:once)
       expect(ch).to receive(:safe_write_to_file).with(paths[:remote]).and_yield(f_remote)
       expect(ch).to receive(:safe_write_to_file).with(paths[:ch]).and_yield(f_ch)
       expect(ch).to receive(:curl_file).with(gh_ch_remote_url, paths[:remote_tmp]).and_return(sha_remote)
@@ -80,6 +79,7 @@ RSpec.describe CloudHypervisor do
     context "when cloud hypervisor does not exist" do
       before do
         setup_existing_files(remote_exist: false, ch_exist: false)
+        expect(CloudHypervisor::Version).to receive(:exe_suffix).and_return("-static").twice
       end
 
       it "downloads the cloud hypervisor" do

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -5,7 +5,18 @@ require "openssl"
 require "base64"
 
 RSpec.describe VmSetup do
-  subject(:vs) { described_class.new("test") }
+  subject(:vs) {
+    vs = Class.new(described_class) do
+      def no_valid_ch_version
+        nil
+      end
+
+      def no_valid_firmware_version
+        nil
+      end
+    end.new("test")
+    vs
+  }
 
   def key_wrapping_secrets
     key_wrapping_algorithm = "aes-256-gcm"


### PR DESCRIPTION
I just rebased #3180. I think this entire patch progression can be squashed.   But I wanted to save my reconciliation of rebase conflicts to spare others, and comment on the condensed patch.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor VM setup and teardown processes, update cloud hypervisor version handling, and improve test coverage.
> 
>   - **Refactoring**:
>     - Introduced `setup_vm_str(action)` in `nexus.rb` to generate VM setup command strings, replacing repeated command strings.
>     - Replaced `CloudHypervisor::Version::DEFAULT` and `CloudHypervisor::Firmware::DEFAULT` with dynamic version handling in `cloud_hypervisor.rb`.
>     - Updated `VmSetup` initialization to handle `ch_version` and `firmware_version` dynamically in `vm_setup.rb`.
>   - **Behavior Changes**:
>     - VM setup commands in `nexus.rb` now use `setup_vm_str(action)` for consistency.
>     - `prep_host.rb` now downloads cloud hypervisor and firmware using updated methods.
>     - `setup-vm` script now handles missing `prep.json` for delete actions gracefully.
>   - **Testing**:
>     - Updated tests in `cloud_hypervisor_spec.rb` and `vm_setup_spec.rb` to reflect changes in version handling and command generation.
>   - **Misc**:
>     - Removed redundant `DEFAULT` constants in `cloud_hypervisor.rb` and replaced with `SUPPORTED` and `INSTALLED` hashes.
>     - Minor updates to logging and error handling in various scripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ad390ad7f4b2b4d218bcb52719f2fddd0b5f0f76. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->