### PR TITLE
Avoid **hash.merge(other_hash) constructions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,7 @@ SQL
     # NB: this grant/revoke cannot be transaction-isolated, so, in
     # sensitive settings, it would be good to check role access.
     DB["GRANT CREATE ON SCHEMA public TO ?", ph_user.to_sym].get
-    Sequel.postgres(**DB.opts.merge(user: ph_user)) do |ph_db|
+    Sequel.postgres(**DB.opts, user: ph_user) do |ph_db|
       ph_db.loggers << Logger.new($stdout) if ph_db.loggers.empty?
       Sequel::Migrator.run(ph_db, "migrate/ph", table: "schema_migrations_password")
     end

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -149,7 +149,7 @@ class Sshable < Sequel::Model
   end
 
   def start_fresh_session(&block)
-    Net::SSH.start(host, unix_user, **COMMON_SSH_ARGS.merge(key_data: keys.map(&:private_key)), &block)
+    Net::SSH.start(host, unix_user, **COMMON_SSH_ARGS, key_data: keys.map(&:private_key), &block)
   end
 
   def invalidate_cache_entry

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -162,7 +162,7 @@ SQL
       stack.first["last_label_changed_at"] = Time.now.to_s
       modified!(:stack)
 
-      update(**hp.strand_update_args.merge(try: 0))
+      update(**hp.strand_update_args, try: 0)
 
       hp
     rescue Prog::Base::Exit => ext

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -176,9 +176,8 @@ RSpec.describe Clover, "github" do
   end
 
   describe "cache" do
-    def create_cache_entry(**args)
-      defaults = {key: "k#{Random.rand}", version: "v1", scope: "main", repository_id: repository.id, created_by: "3c9a861c-ab14-8218-a175-875ebb652f7b", committed_at: Time.now}
-      GithubCacheEntry.create_with_id(**defaults.merge(args))
+    def create_cache_entry(**)
+      GithubCacheEntry.create(key: "k#{Random.rand}", version: "v1", scope: "main", repository_id: repository.id, created_by: "3c9a861c-ab14-8218-a175-875ebb652f7b", committed_at: Time.now, **)
     end
 
     it "can list caches" do


### PR DESCRIPTION
While this works, it's less efficient than alternatives.  If the method accepts an options hash, the `**` can be dropped, avoiding a hash allocation. If the method accepts keywords, `**hash, **other_hash` can be used.

However, in the cases where we are using these constructions, one of the hashes is a literal hash, so these constructions result in 2-3 hash allocations:

* 1 for the literal hash
* 1 for the Hash#merge
* 1 if the keyword splat is converted to a positional hash

using `**hash, kw: value` reduces this to a single hash allocation, in addition to being simpler.

For the create_cache_entry change in the specs, use an anonymous keyword splat parameter.  This is done for simplicity, it doesn't save allocations in this case (as all callers are providing literal keywords).