### PR TITLE
Increase maximum parallelization from 6 to 10

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,8 @@ ncpu = nil
 nproc = lambda do
   return ncpu if ncpu
   require "etc"
-  # Limit to 6 processes, as higher number results in more time
-  ncpu = Etc.nprocessors.clamp(1, 6).to_s
+  # Limit to 10 processes, as higher number results in more time
+  ncpu = Etc.nprocessors.clamp(1, 10).to_s
 end
 
 clone_test_database = lambda do


### PR DESCRIPTION
We limited parallelization to 6 processes in October 2024 (9c0dc48162ea310d8185ebfd2d2449c737633993), as that provided the best result at the time.

However, we have a lot more specs now than we did then.  According to my testing, 10 processes now provides the best result.

For `rake frozen_spec`:

```
 6 processes: 19.378s
 8 processes: 17.878s
10 processes: 16.527s
12 processes: 16.721s
```

If your CPU has more than 6 logical processors, you will need to run `rake setup_database[test,true]` to create the additional databases, otherwise the specs will fail trying to access a database that doesn't exist.

It would be good to get some testing on arm64 Macs, to see if this also improves performance there.  My recollection is arm64 Macs were slightly faster with 8 processors than with 6 processors even back in October, so I expect they this will improve performance for them as well.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase maximum parallel processes from 6 to 10 in `Rakefile` for improved performance.
> 
>   - **Behavior**:
>     - Increase maximum parallel processes from 6 to 10 in `nproc` lambda in `Rakefile`.
>     - Performance tests show 10 processes provide better results than 6, 8, or 12.
>   - **Setup**:
>     - Users with more than 6 logical processors must run `rake setup_database[test,true]` to create additional databases.
>   - **Testing**:
>     - Suggest testing on arm64 Macs to verify performance improvements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 08a6a74b9405a8d5e82aedb046656644eabca8a1. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->