### PR TITLE
Fix missed query parameterization in specs

### DIFF
--- a/spec/prog/dns_zone/dns_zone_nexus_spec.rb
+++ b/spec/prog/dns_zone/dns_zone_nexus_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe Prog::DnsZone::DnsZoneNexus do
       dns_zone.add_record(r2)
       dns_zone.add_record(r3)
 
-      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r1.id}', '#{dns_server.id}')"].insert
+      DB[:seen_dns_records_by_dns_servers].insert(dns_record_id: r1.id, dns_server_id: dns_server.id)
     end
 
     it "does not push anything if there is no unseen records" do
-      DB["INSERT INTO seen_dns_records_by_dns_servers SELECT id, '#{dns_server.id}' FROM dns_record"].insert
+      DB[:seen_dns_records_by_dns_servers].insert(DB[:dns_record].select(:id, dns_server.id))
 
       expect(sshable).not_to receive(:cmd)
       expect { nx.refresh_dns_servers }.to hop("wait")
@@ -90,8 +90,8 @@ COMMANDS
       dns_zone.add_record(r2)
       dns_zone.add_record(r3)
 
-      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r1.id}', '#{dns_server.id}')"].insert
-      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r3.id}', '#{dns_server.id}')"].insert
+      DB[:seen_dns_records_by_dns_servers].insert(dns_record_id: r1.id, dns_server_id: dns_server.id)
+      DB[:seen_dns_records_by_dns_servers].insert(dns_record_id: r3.id, dns_server_id: dns_server.id)
 
       expect { nx.purge_obsolete_records }.to hop("wait")
       expect(dns_zone.reload.records.count).to eq(1)
@@ -107,8 +107,8 @@ COMMANDS
       dns_zone.add_record(r2)
       dns_zone.add_record(r3)
 
-      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r1.id}', '#{dns_server.id}')"].insert
-      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{r2.id}', '#{dns_server.id}')"].insert
+      DB[:seen_dns_records_by_dns_servers].insert(dns_record_id: r1.id, dns_server_id: dns_server.id)
+      DB[:seen_dns_records_by_dns_servers].insert(dns_record_id: r2.id, dns_server_id: dns_server.id)
 
       expect { nx.purge_obsolete_records }.to hop("wait")
       expect(dns_zone.reload.records.count).to eq(2)

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect(nx).to receive(:dns_challenge).and_return(challenge).at_least(:once)
       dns_record = DnsRecord.create_with_id(dns_zone_id: dns_zone.id, name: "test-record-name.cert-hostname.", type: "test-record-type", ttl: 600, data: "content")
-      DB["INSERT INTO seen_dns_records_by_dns_servers(dns_record_id, dns_server_id) VALUES('#{dns_record.id}', NULL)"].insert
+      DB[:seen_dns_records_by_dns_servers].insert(dns_record_id: dns_record.id, dns_server_id: nil)
 
       expect(challenge).to receive(:request_validation)
       expect { nx.wait_dns_update }.to hop("wait_dns_validation")


### PR DESCRIPTION
After these changes, the query parameterization log shows 0 queries with missed parameters.

None of these usages are unsafe, since they are only in the specs and use trusted data, but direct interpolation patterns such as `'#{r1.id}'` are a bad idea in the specs, as it gives the impression to developers that such constructions are safe to use elsewhere in the application.

Bad examples anywhere are a threat to safe usage everywhere.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces direct string interpolation with parameterized queries in test specs to ensure safe database interactions.
> 
>   - **Behavior**:
>     - Replaces direct string interpolation with parameterized queries in `db_spec.rb`, `dns_zone_nexus_spec.rb`, and `cert_nexus_spec.rb`.
>     - Ensures all database interactions in specs use parameterized queries to prevent unsafe patterns.
>   - **Misc**:
>     - Changes in `db_spec.rb` include using `Sequel` methods for query construction.
>     - Updates in `dns_zone_nexus_spec.rb` and `cert_nexus_spec.rb` involve using `DB[:table].insert` with hash arguments for parameterization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for adac989227ffbe15c23ee67b014f57cd33365d2a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->