### PR TITLE
Swap params.json generation to use keywords rather than hash-rocket

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -206,27 +206,27 @@ class Vm < Sequel::Model
 
     # we don't write secrets to params_json, because it
     # shouldn't be stored in the host for security reasons.
-    JSON.pretty_generate({
-      "vm_name" => name,
-      "public_ipv6" => ephemeral_net6.to_s,
-      "public_ipv4" => ip4.to_s || "",
-      "local_ipv4" => local_vetho_ip.to_s.shellescape || "",
-      "dns_ipv4" => nics.first.private_subnet.net4.nth(2).to_s,
-      "unix_user" => unix_user,
-      "ssh_public_keys" => [public_key] + project_public_keys,
-      "nics" => nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac, nic.private_ipv4_gateway] },
-      "boot_image" => boot_image,
-      "max_vcpus" => topo.max_vcpus,
-      "cpu_topology" => topo.to_s,
-      "mem_gib" => memory_gib,
-      "ndp_needed" => vm_host.ndp_needed,
-      "storage_volumes" => storage_volumes,
-      "swap_size_bytes" => swap_size_bytes,
-      "pci_devices" => pci_devices.map { [it.slot, it.iommu_group] },
-      "slice_name" => vm_host_slice&.inhost_name || "system.slice",
-      "cpu_percent_limit" => cpu_percent_limit || 0,
-      "cpu_burst_percent_limit" => cpu_burst_percent_limit || 0
-    })
+    JSON.pretty_generate(
+      vm_name: name,
+      public_ipv6: ephemeral_net6.to_s,
+      public_ipv4: ip4.to_s || "",
+      local_ipv4: local_vetho_ip.to_s.shellescape || "",
+      dns_ipv4: nics.first.private_subnet.net4.nth(2).to_s,
+      unix_user:,
+      ssh_public_keys: [public_key] + project_public_keys,
+      nics: nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac, nic.private_ipv4_gateway] },
+      boot_image:,
+      max_vcpus: topo.max_vcpus,
+      cpu_topology: topo.to_s,
+      mem_gib: memory_gib,
+      ndp_needed: vm_host.ndp_needed,
+      storage_volumes:,
+      swap_size_bytes:,
+      pci_devices: pci_devices.map { [it.slot, it.iommu_group] },
+      slice_name: vm_host_slice&.inhost_name || "system.slice",
+      cpu_percent_limit: cpu_percent_limit || 0,
+      cpu_burst_percent_limit: cpu_burst_percent_limit || 0
+    )
   end
 
   def storage_volumes

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -214,7 +214,7 @@ class Vm < Sequel::Model
       dns_ipv4: nics.first.private_subnet.net4.nth(2).to_s,
       unix_user:,
       ssh_public_keys: [public_key] + project_public_keys,
-      nics: nics.map { |nic| [nic.private_ipv6.to_s, nic.private_ipv4.to_s, nic.ubid_to_tap_name, nic.mac, nic.private_ipv4_gateway] },
+      nics: nics.map { [it.private_ipv6.to_s, it.private_ipv4.to_s, it.ubid_to_tap_name, it.mac, it.private_ipv4_gateway] },
       boot_image:,
       max_vcpus: topo.max_vcpus,
       cpu_topology: topo.to_s,


### PR DESCRIPTION
Since `JSON.pretty_generate` treats symbol and string keys the same,
we can use Ruby 3.1’s shorthand hash syntax to simplify the code. This
allows us to omit the value for keys that match local variable names,
making the hash more concise.

Applied the shorthand to `unix_user`, `boot_image`, `storage_volumes`,
and `swap_size_bytes`.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies `params_json` in `model/vm.rb` using Ruby 3.1 shorthand hash syntax for certain keys.
> 
>   - **Code Simplification**:
>     - In `model/vm.rb`, `params_json` method now uses Ruby 3.1 shorthand hash syntax.
>     - Simplifies hash by using keyword arguments for `unix_user`, `boot_image`, `storage_volumes`, and `swap_size_bytes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9d2ccd408f8bb05fd102329f12546cf2c34fe2be. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->