### PR TITLE
Check all requests are appropriately authorized when running non-frozen specs

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -692,7 +692,7 @@ class Clover < Roda
       end
     end
 
-    @need_authorization = true
+    @still_need_authorization = true
     r.hash_branches("")
   end
 
@@ -715,30 +715,30 @@ class Clover < Roda
     # is needed by calling no_authorization_needed
 
     after do |res|
-      if @need_authorization && res && res[0] != 404 && res[0] != 501
+      if @still_need_authorization && res && res[0] != 404 && res[0] != 501
         raise "no authorization check for #{request.request_method} #{request.path_info}"
       end
     end
 
     prepend(Module.new do
       def authorize(actions, object_id)
-        @need_authorization = false
+        @still_need_authorization = false
         super
       end
 
       def has_permission?(actions, object_id)
-        @need_authorization = false
+        @still_need_authorization = false
         super
       end
 
       def dataset_authorize(ds, actions)
-        @need_authorization = false
+        @still_need_authorization = false
         super
       end
 
       def no_authorization_needed
-        raise "called no_authorization_needed when authorization already not needed: #{request.inspect}" unless @need_authorization
-        @need_authorization = false
+        raise "called no_authorization_needed when authorization already not needed: #{request.inspect}" unless @still_need_authorization
+        @still_need_authorization = false
         super
       end
     end)

--- a/clover.rb
+++ b/clover.rb
@@ -572,6 +572,7 @@ class Clover < Roda
 
   hash_branch("after-login") do |r|
     r.get web? do
+      no_authorization_needed
       if (project = current_account.projects_dataset.order(:created_at, :name).first)
         r.redirect "#{project.path}/dashboard"
       else
@@ -588,6 +589,7 @@ class Clover < Roda
     end
 
     hash_branch("clear-last-password-entry") do |r|
+      no_authorization_needed
       session.delete("last_password_entry")
       ""
     end

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -54,6 +54,17 @@ class Clover < Roda
     rodauth.session["pat_id"]
   end
 
+  def check_found_object(obj)
+    unless obj
+      response.status = if request.delete? && request.remaining_path.empty?
+        204
+      else
+        404
+      end
+      request.halt
+    end
+  end
+
   private def each_authorization_id
     return to_enum(:each_authorization_id) unless block_given?
 

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -57,12 +57,20 @@ class Clover < Roda
   def check_found_object(obj)
     unless obj
       response.status = if request.delete? && request.remaining_path.empty?
+        no_authorization_needed
         204
       else
         404
       end
       request.halt
     end
+  end
+
+  def no_authorization_needed
+    # Do nothing, this is a no-op method only used to check in the specs
+    # that all requests have some form of authorization, or an explicit
+    # indication that additional authorization is not needed
+    nil
   end
 
   private def each_authorization_id

--- a/routes/account.rb
+++ b/routes/account.rb
@@ -4,17 +4,20 @@ class Clover
   hash_branch("account") do |r|
     r.web do
       r.get true do
+        no_authorization_needed
         r.redirect "/account/multifactor-manage"
       end
 
       r.on "login-method" do
         r.get true do
+          no_authorization_needed
           @identities = current_account.identities.to_h { [it.provider, it.uid] }
 
           view "account/login_method"
         end
 
         r.post "disconnect" do
+          no_authorization_needed
           provider, uid = typecast_params.nonempty_str(["provider", "uid"])
           identities = current_account.identities
           unless identities.length > (rodauth.has_password? ? 0 : 1)

--- a/routes/cli.rb
+++ b/routes/cli.rb
@@ -3,6 +3,7 @@
 class Clover
   hash_branch("cli") do |r|
     r.post api? do
+      no_authorization_needed
       response["content-type"] = "text/plain"
 
       unless (argv = r.POST["argv"]).is_a?(Array) && argv.all?(String)

--- a/routes/github.rb
+++ b/routes/github.rb
@@ -3,6 +3,7 @@
 class Clover
   hash_branch("github") do |r|
     r.get web?, "callback" do
+      no_authorization_needed
       oauth_code = r.params["code"]
       installation_id = r.params["installation_id"]
       setup_action = r.params["setup_action"]

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -3,6 +3,7 @@
 class Clover
   hash_branch("project") do |r|
     r.get true do
+      no_authorization_needed
       dataset = current_account.projects_dataset.where(visible: true)
 
       if api?
@@ -26,6 +27,7 @@ class Clover
       required_parameters = ["name"]
       request_body_params = validate_request_params(required_parameters)
       project = current_account.create_project_with_default_policy(request_body_params["name"])
+      no_authorization_needed
 
       if api?
         Serializers::Project.serialize(project)
@@ -34,7 +36,10 @@ class Clover
       end
     end
 
-    r.get(web?, "create") { view "project/create" }
+    r.get(web?, "create") do
+      no_authorization_needed
+      view "project/create"
+    end
 
     r.on String do |project_ubid|
       @project = Project.from_ubid(project_ubid)
@@ -80,7 +85,10 @@ class Clover
       end
 
       if web?
-        r.get("dashboard") { view("project/dashboard") }
+        r.get("dashboard") do
+          no_authorization_needed
+          view("project/dashboard")
+        end
 
         r.post true do
           authorize("Project:edit", @project.id)

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -40,7 +40,7 @@ class Clover
       @project = Project.from_ubid(project_ubid)
       @project = nil unless @project&.visible
 
-      next(r.delete? ? 204 : 404) unless @project
+      check_found_object(@project)
 
       if @project.accounts_dataset.where(Sequel[:accounts][:id] => current_account_id).empty?
         fail Authorization::Unauthorized

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -20,8 +20,7 @@ class Clover
 
       filter[:location_id] = @location.id
       firewall = @project.firewalls_dataset.eager(:location).first(filter)
-
-      next (r.delete? ? 204 : 404) unless firewall
+      check_found_object(firewall)
 
       r.delete true do
         authorize("Firewall:delete", firewall.id)

--- a/routes/project/location/firewall/firewall_rule.rb
+++ b/routes/project/location/firewall/firewall_rule.rb
@@ -28,21 +28,17 @@ class Clover
 
     r.is String do |firewall_rule_ubid|
       firewall_rule = FirewallRule.from_ubid(firewall_rule_ubid)
+      check_found_object(firewall_rule)
 
-      request.delete true do
-        if firewall_rule
-          authorize("Firewall:edit", @firewall.id)
-          @firewall.remove_firewall_rule(firewall_rule)
-        end
-
+      r.delete true do
+        authorize("Firewall:edit", @firewall.id)
+        @firewall.remove_firewall_rule(firewall_rule)
         204
       end
 
-      request.get true do
-        if firewall_rule
-          authorize("Firewall:view", @firewall.id)
-          Serializers::FirewallRule.serialize(firewall_rule)
-        end
+      r.get true do
+        authorize("Firewall:view", @firewall.id)
+        Serializers::FirewallRule.serialize(firewall_rule)
       end
     end
   end

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -21,7 +21,7 @@ class Clover
       filter[:private_subnet_id] = @project.private_subnets_dataset.where(location_id: @location.id).select(Sequel[:private_subnet][:id])
       lb = LoadBalancer.first(filter)
 
-      next (r.delete? ? 204 : 404) unless lb
+      check_found_object(lb)
 
       r.post %w[attach-vm detach-vm] do |action|
         authorize("LoadBalancer:edit", lb.id)

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -20,8 +20,7 @@ class Clover
 
       filter[:location_id] = @location.id
       pg = @project.postgres_resources_dataset.first(filter)
-
-      next (r.delete? ? 204 : 404) unless pg
+      check_found_object(pg)
 
       r.get true do
         authorize("Postgres:view", pg.id)

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -189,6 +189,8 @@ class Clover
 
       r.on "read-replica" do
         r.post true do
+          authorize("Postgres:edit", pg.id)
+
           required_parameters = ["name"]
           request_body_params = validate_request_params(required_parameters, [], [])
           st = Prog::Postgres::PostgresResourceNexus.assemble(

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -20,8 +20,7 @@ class Clover
 
       filter[:location_id] = @location.id
       ps = @project.private_subnets_dataset.eager(:location).first(filter)
-
-      next (r.delete? ? 204 : 404) unless ps
+      check_found_object(ps)
 
       r.post "connect" do
         authorize("PrivateSubnet:connect", ps.id)

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -20,8 +20,7 @@ class Clover
 
       filter[:location_id] = @location.id
       vm = @project.vms_dataset.eager(:location).first(filter)
-
-      next(r.delete? ? 204 : 404) unless vm
+      check_found_object(vm)
 
       r.get true do
         authorize("Vm:view", vm.id)

--- a/routes/project/private_location.rb
+++ b/routes/project/private_location.rb
@@ -70,8 +70,7 @@ class Clover
 
     r.is String do |name|
       @location = @project.locations.find { |loc| loc.ui_name == name }
-
-      next(r.delete? ? 204 : 404) unless @location
+      check_found_object(@location)
 
       r.get do
         authorize("Location:view", @project.id)

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe Clover do
     expect(page.title).to end_with("Dashboard")
   end
 
+  if ENV["CLOVER_FREEZE"] != "1"
+    it "raises error if no_authorization_needed called when not needed or already authorized" do
+      create_account.create_project_with_default_policy("project-1")
+      login
+
+      visit "/test-no-authorization-needed/once"
+      expect(page.status_code).to eq(200)
+
+      expect { visit "/test-no-authorization-needed/twice" }.to raise_error(RuntimeError)
+      expect { visit "/test-no-authorization-needed/after-authorization" }.to raise_error(RuntimeError)
+    end
+  end
+
   it "handles expected errors" do
     expect(Clog).to receive(:emit).with("route exception").and_call_original
 


### PR DESCRIPTION
This adds a needs_authorization flag before the main hash branch dispatch.

When running non-frozen specs, if that flag is not cleared before a response
is returned, an exception is raised.  The flag can be cleared by:

* Calling an authorization method
* Calling no_authorization_needed to explicit indicate authorization is not needed

This adds no_authorization_needed to routes I believe do not need additional
authorization.

To find incorrect usage of no_authorization_needed, it also raises if the
request is already authorizated or does not require authorization.

This support found a missing postgres read-replica authorization (which is
fixed in the first commit), and should prevent missing authorization in the future.

This also fixes an issue where Clover was returning 204 responses for DELETE
requests where the path had garbage at the end.  This changes handling so that
204 is only used if the DELETE request is fully routed.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces authorization checks for all requests in `clover.rb` and fixes DELETE request handling for invalid paths.
> 
>   - **Authorization**:
>     - Introduces `@still_need_authorization` flag in `clover.rb` to ensure all requests are authorized or explicitly marked with `no_authorization_needed`.
>     - Raises error if `no_authorization_needed` is called when not needed or already authorized.
>     - Adds `no_authorization_needed` to routes in `clover.rb`, `account.rb`, `cli.rb`, `github.rb`, `project.rb`, and others.
>   - **Bug Fix**:
>     - Fixes issue in `general.rb` where DELETE requests returned 204 for invalid paths by using `check_found_object()`.
>   - **Testing**:
>     - Adds test in `clover_web_spec.rb` to ensure `no_authorization_needed` raises errors when misused.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4e90227d715f576288e8671b0c06bba623edc69f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->