### PR TITLE
Fix parallel vm creation issue

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -284,7 +284,7 @@ class Prog::Vm::Nexus < Prog::Base
   label def prep
     case host.sshable.cmd("common/bin/daemonizer --check prep_#{q_vm}")
     when "Succeeded"
-      vm.private_subnets.each(&:incr_add_new_nic)
+      vm.nics.each(&:incr_setup_nic)
       hop_clean_prep
     when "NotStarted", "Failed"
       secrets_json = JSON.generate({

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -53,8 +53,13 @@ class Prog::Vnet::NicNexus < Prog::Base
 
   label def wait_setup
     decr_vm_allocated
+    when_setup_nic_set? do
+      DB.transaction do
+        decr_setup_nic
+        nic.private_subnet.incr_add_new_nic
+      end
+    end
     when_start_rekey_set? do
-      decr_setup_nic
       hop_start_rekey
     end
     nap 5

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -131,10 +131,21 @@ RSpec.describe Prog::Vnet::NicNexus do
       expect { nx.wait_setup }.to nap(5)
     end
 
+    it "incrs add_new_nic when setup_nic is set" do
+      private_subnet = instance_double(PrivateSubnet)
+      nic = instance_double(Nic, private_subnet: private_subnet)
+
+      expect(nx).to receive(:nic).and_return(nic)
+      expect(nx).to receive(:decr_vm_allocated)
+      expect(nx).to receive(:when_setup_nic_set?).and_yield
+      expect(nx).to receive(:decr_setup_nic)
+      expect(private_subnet).to receive(:incr_add_new_nic)
+      expect { nx.wait_setup }.to nap(5)
+    end
+
     it "starts rekeying if setup is triggered" do
       expect(nx).to receive(:decr_vm_allocated)
       expect(nx).to receive(:when_start_rekey_set?).and_yield
-      expect(nx).to receive(:decr_setup_nic)
       expect { nx.wait_setup }.to hop("start_rekey")
     end
   end


### PR DESCRIPTION
An unused semaphore is added to Nic Nexus which allows us to notify the
Subnet to start the rekeying logic through the Nic.

In the former version, Vm would directly call the Subnet Nexus to
start the rekey process but if an unlucky nic didn't get enough CPU
time to reach the wait_setup state, it would miss the start_rekey
semaphore and since when we decr a semaphore, it is set to zero,
Nic strand would get stuck on wait_setup until a manual trigger is done.

Now each nic is used as the bridge between Vm and Subnet and this way,
we make sure Nic strand is in the right state before subnet starts
triggering different semaphores and logics.