### PR TITLE
Updates for Inference Endpoints

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -162,7 +162,7 @@ module Config
   override :postgres17_paradedb_ubuntu_2204_version, "20250425.1.1", string
   override :postgres16_lantern_ubuntu_2204_version, "20250103.1.0", string
   override :postgres17_lantern_ubuntu_2204_version, "20250103.1.0", string
-  override :ai_ubuntu_2404_nvidia_version, "20250319.1.0", string
+  override :ai_ubuntu_2404_nvidia_version, "20250505.1.0", string
   override :kubernetes_v1_32_version, "20250320.1.0", string
 
   override :aws_based_postgres_16_ubuntu_2204_ami_version, "ami-030c060f85668b37d", string

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -93,7 +93,7 @@ class Prog::DownloadBootImage < Prog::Base
       ["postgres17-paradedb-ubuntu-2204", "x64", "20250425.1.1"] => "83f8e70b8ad97e781f47d2b8675afeebdcded124a3dc547559635ea7a89b38d9",
       ["postgres16-lantern-ubuntu-2204", "x64", "20250103.1.0"] => "bfb56867513045bc88396d529a3cc186dc44ba4d691acb51dbf45fc5a0eeb7e6",
       ["postgres17-lantern-ubuntu-2204", "x64", "20250103.1.0"] => "a95b2e5d03291783dc1753228d7a87949257a06c7b1eca2c94502ab21ffdecdb",
-      ["ai-ubuntu-2404-nvidia", "x64", "20250319.1.0"] => "354a56a2951859cc2c71c52843bb9fa01c1c99ed4bab0d1016b3f0a73f15ace1",
+      ["ai-ubuntu-2404-nvidia", "x64", "20250505.1.0"] => "8d438d372238d46739ace4337634f3489dc4f18496a970fda6b6e60226307eaa",
       ["ai-model-empty", "x64", "20250317.1.0"] => "24529ea3cfb853c1350153dc3dd30aab62df352b8f46ad35f729cb9948190316",
       ["ai-model-gemma-2-2b-it", "x64", "20240918.1.0"] => "b726ead6d5f48fb8e6de7efb48fb22367c9a7c155cfee71a3a7e5527be5df08e",
       ["ai-model-llama-3-1-8b-it", "x64", "20250118.1.0"] => "7296f70a861c364f59c38b816e1210152ebafbec85ce797888c16b4d48a15e8f",

--- a/rhizome/inference_endpoint/lib/replica_setup.rb
+++ b/rhizome/inference_endpoint/lib/replica_setup.rb
@@ -132,6 +132,7 @@ CERT_DOWNLOAD_TIMER
 [Unit]
 Description=Inference Gateway
 After=network.target
+StartLimitIntervalSec=0
 
 [Service]
 EnvironmentFile=/ie/workdir/inference-gateway.conf
@@ -142,8 +143,6 @@ User=ie
 Group=ie
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=0
-StartLimitBurst=0
 LimitNOFILE=65536
 
 ProtectHome=yes
@@ -168,6 +167,7 @@ Description=Inference Engine
 After=network.target
 After=inference-gateway.service
 Requires=inference-gateway.service
+StartLimitIntervalSec=0
 
 [Service]
 ExecStart=#{engine_start_command}
@@ -182,8 +182,6 @@ User=ie
 Group=ie
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=0
-StartLimitBurst=0
 LimitNOFILE=65536
 ProtectHome=yes
 DynamicUser=yes


### PR DESCRIPTION
- **Move StartLimitIntervalSec to system Unit section**
  StartLimitIntervalSec should go into Unit according to systemd
  documentation. A value of 0 disables rate limiting. RestartSec of
  5s should be enough to prevent a tight restart loop.
  

- **Update AI base image to 20250502.1.0**
  Job producing the image:
  https://github.com/ubicloud/ai-images/actions/runs/14792210050
  
  The image contains
  - Python 3.12
  - vLLM: v0.8.5
  - Inference gateway: v0.1.7
  
  The main difference from the previous ai base image is that it comes
  with the latest version of vLLM.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update systemd configuration for inference endpoints and AI base image version to 20250505.1.0.
> 
>   - **Systemd Configuration**:
>     - Move `StartLimitIntervalSec=0` to `[Unit]` section in `replica_setup.rb` for `inference-gateway.service` and `inference-engine.service`.
>     - Remove `StartLimitBurst=0` from `replica_setup.rb`.
>   - **AI Base Image Update**:
>     - Update `ai_ubuntu_2404_nvidia_version` to `20250505.1.0` in `config.rb`.
>     - Update SHA256 hash for `ai-ubuntu-2404-nvidia` in `download_boot_image.rb`.
>   - **Misc**:
>     - Update AI base image to include Python 3.12, vLLM v0.8.5, and Inference gateway v0.1.7.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 264222e047a339483cecdbdf0116d6d50d667252. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->