### PR TITLE
Add hugepage, cloud-hypervisor, and firmware fields to params.json

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -199,7 +199,7 @@ class Vm < Sequel::Model
     super + [:public_key]
   end
 
-  def params_json(swap_size_bytes)
+  def params_json(swap_size_bytes: nil, ch_version: nil, firmware_version: nil, hugepages: nil)
     topo = cloud_hypervisor_cpu_topology
 
     project_public_keys = project.get_ff_vm_public_ssh_keys || []
@@ -225,7 +225,10 @@ class Vm < Sequel::Model
       pci_devices: pci_devices.map { [it.slot, it.iommu_group] },
       slice_name: vm_host_slice&.inhost_name || "system.slice",
       cpu_percent_limit: cpu_percent_limit || 0,
-      cpu_burst_percent_limit: cpu_burst_percent_limit || 0
+      cpu_burst_percent_limit: cpu_burst_percent_limit || 0,
+      ch_version:,
+      firmware_version:,
+      hugepages:
     )
   end
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -278,51 +278,59 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.prep }.to hop("clean_prep")
     end
 
-    it "generates and passes a params json if prep command is not started yet" do
-      vm = nx.vm
-      vm.ephemeral_net6 = "fe80::/64"
-      vm.unix_user = "test_user"
-      vm.public_key = "test_ssh_key"
-      vm.local_vetho_ip = "169.254.0.0"
-      ps = instance_double(PrivateSubnet, location_id: Location::HETZNER_FSN1_ID, net4: NetAddr::IPv4Net.parse("10.0.0.0/26"))
-      nic = Nic.new(private_ipv6: "fd10:9b0b:6b4b:8fbb::/64", private_ipv4: "10.0.0.3/32", mac: "5a:0f:75:80:c3:64")
-      pci = PciDevice.new(slot: "01:00.0", iommu_group: 23)
-      expect(nic).to receive(:ubid_to_tap_name).and_return("tap4ncdd56m")
-      expect(vm).to receive(:nics).and_return([nic]).at_least(:once)
-      expect(nic).to receive(:private_subnet).and_return(ps).at_least(:once)
-      expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(2, 1, 1, 1))
-      expect(vm).to receive(:pci_devices).and_return([pci]).at_least(:once)
-      prj.set_ff_vm_public_ssh_keys(["operator_ssh_key"])
-      expect(vm).to receive(:project).and_return(prj).at_least(:once)
+    [
+      {"swap_size_bytes" => nil},
+      {"swap_size_bytes" => nil, "hugepages" => false, "ch_version" => "45.0", "firmware_version" => "202311"}
+    ].each do |frame_update|
+      it "generates and passes a params json if prep command is not started yet (with frame opts: #{frame_update.inspect})" do
+        nx.strand.stack.first.update(frame_update)
+        nx.instance_variable_set(:@frame, nil)
+        vm = nx.vm
+        vm.ephemeral_net6 = "fe80::/64"
+        vm.unix_user = "test_user"
+        vm.public_key = "test_ssh_key"
+        vm.local_vetho_ip = "169.254.0.0"
+        ps = instance_double(PrivateSubnet, location_id: Location::HETZNER_FSN1_ID, net4: NetAddr::IPv4Net.parse("10.0.0.0/26"))
+        nic = Nic.new(private_ipv6: "fd10:9b0b:6b4b:8fbb::/64", private_ipv4: "10.0.0.3/32", mac: "5a:0f:75:80:c3:64")
+        pci = PciDevice.new(slot: "01:00.0", iommu_group: 23)
+        expect(nic).to receive(:ubid_to_tap_name).and_return("tap4ncdd56m")
+        expect(vm).to receive(:nics).and_return([nic]).at_least(:once)
+        expect(nic).to receive(:private_subnet).and_return(ps).at_least(:once)
+        expect(vm).to receive(:cloud_hypervisor_cpu_topology).and_return(Vm::CloudHypervisorCpuTopo.new(2, 1, 1, 1))
+        expect(vm).to receive(:pci_devices).and_return([pci]).at_least(:once)
+        prj.set_ff_vm_public_ssh_keys(["operator_ssh_key"])
+        expect(vm).to receive(:project).and_return(prj).at_least(:once)
 
-      sshable = instance_spy(Sshable)
-      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
-      vmh = instance_double(VmHost, sshable: sshable,
-        total_cpus: 80, total_cores: 80, total_sockets: 10, ndp_needed: false, arch: "arm64")
-      expect(vm).to receive(:vm_host).and_return(vmh).at_least(:once)
+        sshable = instance_double(Sshable)
+        expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
+        vmh = instance_double(VmHost, sshable: sshable,
+          total_cpus: 80, total_cores: 80, total_sockets: 10, ndp_needed: false, arch: "arm64")
+        expect(vm).to receive(:vm_host).and_return(vmh).at_least(:once)
 
-      expect(sshable).to receive(:cmd).with(/sudo -u vm[0-9a-z]+ tee/, stdin: String) do |**kwargs|
-        require "json"
-        params = JSON(kwargs.fetch(:stdin))
-        expect(params).to include({
-          "public_ipv6" => "fe80::/64",
-          "unix_user" => "test_user",
-          "ssh_public_keys" => ["test_ssh_key", "operator_ssh_key"],
-          "max_vcpus" => 2,
-          "cpu_topology" => "2:1:1:1",
-          "mem_gib" => 8,
-          "local_ipv4" => "169.254.0.0",
-          "nics" => [["fd10:9b0b:6b4b:8fbb::/64", "10.0.0.3/32", "tap4ncdd56m", "5a:0f:75:80:c3:64", "10.0.0.1/26"]],
-          "swap_size_bytes" => nil,
-          "pci_devices" => [["01:00.0", 23]],
-          "slice_name" => "system.slice",
-          "cpu_percent_limit" => 200,
-          "cpu_burst_percent_limit" => 0
-        })
+        expect(sshable).to receive(:cmd).with(/sudo -u vm[0-9a-z]+ tee/, stdin: String) do |**kwargs|
+          require "json"
+          params = JSON(kwargs.fetch(:stdin))
+          expect(params).to include(
+            "public_ipv6" => "fe80::/64",
+            "unix_user" => "test_user",
+            "ssh_public_keys" => ["test_ssh_key", "operator_ssh_key"],
+            "max_vcpus" => 2,
+            "cpu_topology" => "2:1:1:1",
+            "mem_gib" => 8,
+            "local_ipv4" => "169.254.0.0",
+            "nics" => [["fd10:9b0b:6b4b:8fbb::/64", "10.0.0.3/32", "tap4ncdd56m", "5a:0f:75:80:c3:64", "10.0.0.1/26"]],
+            "swap_size_bytes" => nil,
+            "pci_devices" => [["01:00.0", 23]],
+            "slice_name" => "system.slice",
+            "cpu_percent_limit" => 200,
+            "cpu_burst_percent_limit" => 0,
+            **frame_update
+          )
+        end
+        expect(sshable).to receive(:cmd).with(/sudo host\/bin\/setup-vm prep #{nx.vm_name}/, {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/})
+
+        expect { nx.prep }.to nap(1)
       end
-      expect(sshable).to receive(:cmd).with(/sudo host\/bin\/setup-vm prep #{nx.vm_name}/, {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/})
-
-      expect { nx.prep }.to nap(1)
     end
 
     it "naps if prep command is in progress" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -968,7 +968,7 @@ RSpec.describe Al do
       expect(nic).to receive(:mac).and_return("")
       expect(nic).to receive(:private_ipv4_gateway).and_return("")
       expect(vm).to receive(:nics).and_return([nic]).at_least(1)
-      expect(JSON.parse(vm.params_json("")).fetch("slice_name")).to eq(expected_slice_name + ".slice")
+      expect(JSON.parse(vm.params_json).fetch("slice_name")).to eq(expected_slice_name + ".slice")
 
       # Validate the slice properties
       expect(slice.name).to eq(expected_slice_name)


### PR DESCRIPTION
These fields are not yet read by `rhizome`.

The firmware and cloud-hypervisor version fields allow control over the versions used at provisioning time, enabling gradual rollout and testing of new versions and combinations. This is the main motivation. `nil` values for all of these are acceptable, a near-future version of `rhizome` will apply a default in that case.

The hugepage field is for skipping VM allocation using hugepages, to speed up some aspects of development iteration: hugepages cost an extra reboot in `prep_host` and slows down every reboot as Linux searches for contiguous memory.  Alone, this does not complete the objective, but it's also necessary to move towards it.

Commit message by Daniel Farina <daniel@ubicloud.com>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `ch_version`, `firmware_version`, and `hugepages` fields to VM parameters and update related methods and tests.
> 
>   - **Behavior**:
>     - Add `ch_version`, `firmware_version`, and `hugepages` fields to `params_json` in `model/vm.rb`.
>     - Update `assemble` method in `prog/vm/nexus.rb` to accept `ch_version`, `firmware_version`, and `hugepages` parameters.
>     - Modify `write_params_json` in `prog/vm/nexus.rb` to include new fields in JSON.
>   - **Tests**:
>     - Update tests in `nexus_spec.rb` to verify `params_json` includes `ch_version`, `firmware_version`, and `hugepages` fields.
>     - Add test cases for `assemble` method to handle new parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 100e66b696b87c7269c4604d365481200015b4a9. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->