### PR TITLE
Fix ArchClass Render

### DIFF
--- a/rhizome/common/lib/arch_class.rb
+++ b/rhizome/common/lib/arch_class.rb
@@ -23,6 +23,6 @@ ArchClass = Struct.new(:sym) {
   end
 
   def render(x64:, arm64:)
-    {x64:, arm64:}.fetch(sym)
+    {x64: x64, arm64: arm64}.fetch(sym)
   end
 }


### PR DESCRIPTION
Restore Ruby 3.0 compatibility for Ubuntu 22.04 environments

The code is using syntax features only available from Ruby 3.1+, but the
documentation states Rhizome should run on Ubuntu 22.04 by default. Ubuntu 22  ships with Ruby 3.0 only via default apt package. This change reverts the modern syntax to ensure compatibility with the documented minimum supported environment and the current installation method.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `render` method in `arch_class.rb` for Ruby 3.0 compatibility, ensuring Rhizome runs on Ubuntu 22.04.
> 
>   - **Compatibility**:
>     - Fixes `render` method in `arch_class.rb` to restore compatibility with Ruby 3.0 by explicitly naming hash keys.
>   - **Behavior**:
>     - Ensures Rhizome can run on Ubuntu 22.04, which defaults to Ruby 3.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 663e4c51514fea94866de9712ed99d3822af2065. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->