### PR TITLE
Bump E2E test timeout and schedule until MinIO is stabilized

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
   schedule:
-    - cron:  '0 */2 * * *'
+    - cron:  '0 */4 * * *'
 
 jobs:
   run-ci:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubicloud
     environment: E2E-CI
     # TODO: Revert it when the internal MinIO cluster is stabilized
-    timeout-minutes: 105
+    timeout-minutes: 180
     concurrency: e2e_environment
 
     env:
@@ -131,7 +131,7 @@ jobs:
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
       run: |
         set -o pipefail
-        timeout 100m foreman start | tee foreman.log | grep "e2e.1"
+        timeout 175m foreman start | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
       if: always()


### PR DESCRIPTION
Image downloads to host from MinIO can take up to 100 minutes in some cases.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Extend E2E test timeout and adjust schedule in `.github/workflows/e2e.yml` due to MinIO issues.
> 
>   - **E2E Test Configuration**:
>     - Increase `timeout-minutes` from 105 to 180 in `.github/workflows/e2e.yml`.
>     - Increase `timeout` in `run tests` step from 100m to 175m.
>     - Change `schedule` cron from every 2 hours to every 4 hours.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 17f1ddfcb097d8872a2b189b22395df3173ae95f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->