### PR TITLE
Limit projects to 10 per account

### DIFF
--- a/routes/project.rb
+++ b/routes/project.rb
@@ -24,6 +24,17 @@ class Clover
     end
 
     r.post true do
+      if current_account.projects_dataset.count >= 10
+        err_msg = "Project limit exceeded. You can create up to 10 projects. Contact support@ubicloud.com if you need more."
+        no_authorization_needed
+        if api?
+          fail CloverError.new(400, "InvalidRequest", err_msg)
+        else
+          flash["error"] = err_msg
+          r.redirect "/project"
+        end
+      end
+
       required_parameters = ["name"]
       request_body_params = validate_request_params(required_parameters)
       project = current_account.create_project_with_default_policy(request_body_params["name"])

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -83,6 +83,27 @@ RSpec.describe Clover, "project" do
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-project")
       end
+
+      it "creates up to 10 projects per account" do
+        project
+        (10 - user.projects_dataset.count).times do |i|
+          post "/project", {
+            name: "test-project-#{i}"
+          }.to_json
+
+          expect(last_response.status).to eq(200)
+          expect(JSON.parse(last_response.body)["name"]).to eq("test-project-#{i}")
+        end
+
+        expect(user.projects_dataset.count).to eq(10)
+
+        post "/project", {
+          name: "test-project"
+        }.to_json
+
+        expect(last_response).to have_api_error(400, "Project limit exceeded. You can create up to 10 projects. Contact support@ubicloud.com if you need more.")
+        expect(user.projects_dataset.count).to eq(10)
+      end
     end
 
     describe "delete" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -77,6 +77,25 @@ RSpec.describe Clover, "project" do
         expect(project.subject_tags.map(&:name).sort).to eq %w[Admin Member]
         expect(user.projects).to include project
       end
+
+      it "limits number of projects per account to 10" do
+        visit "/project/create"
+
+        (10 - user.projects_dataset.count).times do |i|
+          user.create_project_with_default_policy("project-#{i}")
+        end
+
+        expect(user.projects_dataset.count).to eq 10
+        expect(page.title).to eq("Ubicloud - Create Project")
+
+        fill_in "Name", with: "new-project-10"
+
+        click_button "Create"
+
+        expect(page).to have_flash_error("Project limit exceeded. You can create up to 10 projects. Contact support@ubicloud.com if you need more.")
+        expect(page.title).to eq("Ubicloud - Projects")
+        expect(user.projects_dataset.count).to eq 10
+      end
     end
 
     describe "dashboard" do


### PR DESCRIPTION
Enforce a maximum of 10 projects per account through API and web routes. This restriction is not applied at the data model level, allowing for manual creation of additional projects if necessary.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enforces a limit of 10 projects per account via API and web routes, with tests added for verification.
> 
>   - **Behavior**:
>     - Enforces a limit of 10 projects per account in `routes/project.rb`.
>     - Displays error message and prevents project creation if limit is exceeded.
>     - Allows manual creation of additional projects beyond the limit.
>   - **API**:
>     - Adds test in `spec/routes/api/project_spec.rb` to verify project limit enforcement and error handling.
>   - **Web**:
>     - Adds test in `spec/routes/web/project_spec.rb` to verify project limit enforcement and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3b749f40b5e1da7c82f8723d93122d0d11fffe02. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->