### PR TITLE
Use prepare_sql_type to avoid unnecessary array allocation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", github: "jeremyevans/sequel", ref: "4b87df31de26683a0204c49f3e759f0fc60fc8b2"
+gem "sequel", github: "jeremyevans/sequel", ref: "4934f70a921395df9241ae4e214e8e9a395b6758"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,10 +18,10 @@ GIT
 
 GIT
   remote: https://github.com/jeremyevans/sequel.git
-  revision: 4b87df31de26683a0204c49f3e759f0fc60fc8b2
-  ref: 4b87df31de26683a0204c49f3e759f0fc60fc8b2
+  revision: 4934f70a921395df9241ae4e214e8e9a395b6758
+  ref: 4934f70a921395df9241ae4e214e8e9a395b6758
   specs:
-    sequel (5.90.0)
+    sequel (5.92.0)
       bigdecimal
 
 GIT


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `take_lease_and_reload` in `strand.rb` using `prepare_sql_type` to avoid unnecessary array allocation and update `sequel` gem reference in `Gemfile`.
> 
>   - **Optimization**:
>     - Use `prepare_sql_type(:update)` in `take_lease_and_reload` in `strand.rb` to avoid unnecessary array allocation.
>   - **Dependencies**:
>     - Update `sequel` gem reference in `Gemfile` to `4934f70a921395df9241ae4e214e8e9a395b6758`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d27175f670873b863557a246ecfa95ec8edd7517. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->