### PR TITLE
Fix rhizome issues with Ruby 3.0

### DIFF
--- a/.github/workflows/rhizome.yml
+++ b/.github/workflows/rhizome.yml
@@ -1,0 +1,41 @@
+name: Rhizome CI
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'rhizome/**'
+      - '.github/workflows/rhizome.yml'
+  pull_request:
+    paths:
+      - 'rhizome/**'
+      - '.github/workflows/rhizome.yml'
+
+jobs:
+  ruby-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ "3.0", 3.2 ]
+        runs-on: [ubicloud, ubicloud-arm]
+    name: Ruby ${{matrix.ruby}} - ${{matrix.runs-on}}
+    runs-on: ${{matrix.runs-on}}
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+      env:
+        BUNDLE_GEMFILE: rhizome/Gemfile
+
+    - name: Run dataplane tests
+      run: (cd rhizome && bundle exec rspec -O /dev/null .)

--- a/rhizome/.rubocop.yml
+++ b/rhizome/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from: ../.rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.0
   NewCops: enable

--- a/rhizome/Gemfile
+++ b/rhizome/Gemfile
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+# Use __dir__ to make sure that
+# `BUNDLE_GEMFILE=rhizome/Gemfile bundle install` works from repository root,
+# as that is what rhizome CI uses.
+
 # Load Gemfiles
-Dir.glob("*/Gemfile") do |file|
-  instance_eval File.read(file)
+Dir.glob("*/Gemfile", base: __dir__) do |file|
+  instance_eval File.read(File.join(__dir__, file))
 end

--- a/rhizome/common/lib/arch_class.rb
+++ b/rhizome/common/lib/arch_class.rb
@@ -23,6 +23,6 @@ ArchClass = Struct.new(:sym) {
   end
 
   def render(x64:, arm64:)
-    {x64:, arm64:}.fetch(sym)
+    {x64: x64, arm64: arm64}.fetch(sym)
   end
 }

--- a/rhizome/inference_endpoint/bin/setup-replica
+++ b/rhizome/inference_endpoint/bin/setup-replica
@@ -20,10 +20,10 @@ rescue KeyError => e
 end
 
 replica_setup.prep(
-  engine_start_cmd:,
-  replica_ubid:,
-  ssl_crt_path:,
-  ssl_key_path:,
-  gateway_port:,
-  max_requests:
+  engine_start_cmd: engine_start_cmd,
+  replica_ubid: replica_ubid,
+  ssl_crt_path: ssl_crt_path,
+  ssl_key_path: ssl_key_path,
+  gateway_port: gateway_port,
+  max_requests: max_requests
 )


### PR DESCRIPTION
Both are related to hash value omission.

Change  TargetRubyVersion to 3.0, so that rubocop fails if you use syntax not supported by Ruby 3.0.

Additionally, add a workflow for running rhizome tests on 3.0 and 3.2, to ensure it runs correctly with those Ruby versions.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Ruby 3.0 compatibility issues and adds CI testing for Ruby 3.0 and 3.2.
> 
>   - **CI Workflow**:
>     - Adds `rhizome.yml` to `.github/workflows` to run tests on Ruby 3.0 and 3.2.
>     - Configures matrix strategy for `ubicloud` and `ubicloud-arm`.
>   - **Rubocop Configuration**:
>     - Changes `TargetRubyVersion` to 3.0 in `rhizome/.rubocop.yml`.
>   - **Code Adjustments**:
>     - Updates hash syntax in `arch_class.rb` and `setup-replica` to explicitly include keys and values.
>     - Modifies `Gemfile` to use `__dir__` for loading Gemfiles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f141dead16363bf997375de859b11c381cbf1f26. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->