### PR TITLE
Check authorization performed even for raised exceptions

### DIFF
--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe Clover do
       visit "/test-no-authorization-needed/once"
       expect(page.status_code).to eq(200)
 
-      expect { visit "/test-no-authorization-needed/twice" }.to raise_error(RuntimeError)
-      expect { visit "/test-no-authorization-needed/after-authorization" }.to raise_error(RuntimeError)
+      re = /called no_authorization_needed when authorization already not needed: /
+      expect { visit "/test-no-authorization-needed/twice" }.to raise_error(RuntimeError, re)
+      expect { visit "/test-no-authorization-needed/after-authorization" }.to raise_error(RuntimeError, re)
+      expect { visit "/test-no-authorization-needed/runtime-error" }.to raise_error(RuntimeError, /no authorization check for /)
     end
   end
 


### PR DESCRIPTION
Otherwise, we could miss cases that raised an exception after doing something that should have required authorization but did not have any authorization.  In general, authorization checks should be done as early as possible.

Ignore cases where Authorization::Unauthorized is raised, since that certainly indicates an authorization check was performed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure authorization checks in `clover.rb` even when exceptions are raised, except for `Authorization::Unauthorized`, and update tests accordingly.
> 
>   - **Behavior**:
>     - Ensure authorization checks in `clover.rb` even when exceptions are raised, except for `Authorization::Unauthorized`.
>     - Modify `after` block to handle `res` being `nil` and `$!` being `Authorization::Unauthorized`.
>   - **Tests**:
>     - Update `clover_web_spec.rb` to test for raised exceptions without authorization checks, specifically for `/test-no-authorization-needed/runtime-error`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4407d9b958483d0c068d90c77630799b03b1d91f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->