### PR TITLE
Update bin/monitor to export metrics to VictoriaMetrics

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -4,19 +4,32 @@
 require_relative "../loader"
 clover_freeze
 
-resources = {}
-mutex = Mutex.new
-thread_pool_size = (Config.max_monitor_threads - 2).clamp(1, nil)
+health_monitor_resources = {}
+health_monitor_mutex = Mutex.new
+health_monitor_thread_pool_size = (Config.max_health_monitor_threads - 2).clamp(1, nil)
 monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice, LoadBalancerVmPort, KubernetesCluster, VictoriaMetricsServer]
-queue_size = thread_pool_size + (monitorable_resource_types.sum(&:count) * 1.5).round
-queue = SizedQueue.new(queue_size)
+health_monitor_queue_size = health_monitor_thread_pool_size + (monitorable_resource_types.sum(&:count) * 1.5).round
+health_monitor_queue = SizedQueue.new(health_monitor_queue_size)
+
+metrics_target_resources = {}
+metrics_export_mutex = Mutex.new
+metrics_export_thread_pool_size = (Config.max_metrics_export_threads - 2).clamp(1, nil)
+metrics_target_resource_types = [PostgresServer]
+metrics_export_queue_size = metrics_export_thread_pool_size + (metrics_target_resource_types.sum(&:count) * 1.5).round
+metrics_export_queue = SizedQueue.new(metrics_export_queue_size)
 
 resource_scanner = Thread.new do
   loop do
     monitorable_resources = monitorable_resource_types.flat_map(&:all)
-    mutex.synchronize do
+    health_monitor_mutex.synchronize do
       monitorable_resources.each do |r|
-        resources[r.id] ||= MonitorableResource.new(r)
+        health_monitor_resources[r.id] ||= MonitorableResource.new(r)
+      end
+    end
+    metrics_resources = metrics_target_resource_types.flat_map(&:all)
+    metrics_export_mutex.synchronize do
+      metrics_resources.each do |r|
+        metrics_target_resources[r.id] ||= MetricsTargetResource.new(r)
       end
     end
 
@@ -28,9 +41,9 @@ rescue => ex
   Kernel.exit!
 end
 
-thread_pool = Array.new(thread_pool_size) do
+health_monitor_thread_pool = Array.new(health_monitor_thread_pool_size) do
   Thread.new do
-    while (r = queue.pop)
+    while (r = health_monitor_queue.pop)
       r.lock_no_wait do
         r.open_resource_session
         r.process_event_loop
@@ -40,20 +53,36 @@ thread_pool = Array.new(thread_pool_size) do
   end
 end
 
+metrics_export_thread_pool = Array.new(metrics_export_thread_pool_size) do
+  Thread.new do
+    while (r = metrics_export_queue.pop)
+      r.lock_no_wait do
+        r.open_resource_session
+        r.export_metrics
+      end
+    end
+  end
+end
+
 begin
   loop do
     # Since the switch to use a thread pool for monitored resources,
-    # this emits the number of pulse threads, not the number of monitor threads + pulse threads
-    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - thread_pool_size - 2} }
+    # this emits the number of pulse threads + export threads, not the number of monitor threads + pulse threads
+    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - health_monitor_thread_pool_size - metrics_export_thread_pool_size - 2} }
 
-    rs = mutex.synchronize { resources.values }
-
-    rs.each do |r|
+    health_monitor_rs = health_monitor_mutex.synchronize { health_monitor_resources.values }
+    health_monitor_rs.each do |r|
       r.force_stop_if_stuck
-      queue.push(r)
+      health_monitor_queue.push(r)
     end
+    health_monitor_mutex.synchronize { health_monitor_resources.delete_if { |_, r| r.deleted } }
 
-    mutex.synchronize { resources.delete_if { |_, r| r.deleted } }
+    metrics_export_rs = metrics_export_mutex.synchronize { metrics_target_resources.values }
+    metrics_export_rs.each do |r|
+      r.force_stop_if_stuck
+      metrics_export_queue.push(r)
+    end
+    metrics_export_mutex.synchronize { metrics_target_resources.delete_if { |_, r| r.deleted } }
 
     sleep 5
   end
@@ -64,5 +93,7 @@ rescue => ex
 end
 
 resource_scanner.join
-thread_pool.each { queue.push(nil) }
-thread_pool.each(&:join)
+health_monitor_thread_pool.each { health_monitor_queue.push(nil) }
+health_monitor_thread_pool.each(&:join)
+metrics_export_thread_pool.each { metrics_export_queue.push(nil) }
+metrics_export_thread_pool.each(&:join)

--- a/config.rb
+++ b/config.rb
@@ -47,7 +47,8 @@ module Config
   optional :clover_column_encryption_key, base64, clear: true
   optional :heartbeat_url, string
   optional :clover_database_root_certs, string
-  override :max_monitor_threads, 32, int
+  override :max_health_monitor_threads, 32, int
+  override :max_metrics_export_threads, 32, int
   optional :omniauth_github_id, string, clear: true
   optional :omniauth_github_secret, string, clear: true
   optional :omniauth_google_id, string, clear: true

--- a/lib/metrics_target_methods.rb
+++ b/lib/metrics_target_methods.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+module MetricsTargetMethods
+  MAX_SCRAPE_FETCH_COUNT = 4
+  FILENAME_FORMAT = "%Y-%m-%dT%H-%M-%S-%N"
+
+  def metrics_config
+    {
+      # Array of endpoints to collect metrics from
+      endpoints: [],
+
+      # Maximum number of files to retain on disk buffer
+      max_file_retention: 120,
+
+      # Interval for collecting metrics in seconds or as a time span string
+      interval: "15s",
+
+      # Additional label names and values to be added to the collected metrics
+      additional_labels: {foo: "bar"},
+
+      # Directory to store the collected metrics
+      metrics_dir: "/home/ubi/metrics"
+    }
+  end
+
+  def export_metrics(session:, tsdb_client:)
+    scrape_results = scrape_endpoints(session)
+
+    if scrape_results.empty?
+      return
+    end
+
+    if tsdb_client.nil?
+      Clog.emit("VictoriaMetrics server is not configured.")
+      return
+    end
+
+    scrape_results.each do |scrape|
+      tsdb_client.import_prometheus(scrape, metrics_config[:additional_labels])
+    end
+
+    mark_pending_scrapes_as_done(session, scrape_results[-1].time)
+    scrape_results.count
+  end
+
+  def scrape_endpoints(session)
+    scrape_files = session[:ssh_session].exec!("ls #{metrics_dir}/done | sort | head -n #{MAX_SCRAPE_FETCH_COUNT}").split("\n")
+
+    scrape_files.filter_map do |file|
+      time_str = file.split(".").first
+      time = Time.strptime(time_str, FILENAME_FORMAT)
+      status = {}
+
+      samples = session[:ssh_session].exec!("cat #{metrics_dir}/done/#{file.shellescape}", status: status)
+
+      VictoriaMetrics::Client::Scrape.new(time:, samples:) if status[:exit_code] == 0
+    end
+  end
+
+  def mark_pending_scrapes_as_done(session, time)
+    marker = time.strftime(FILENAME_FORMAT)
+    session[:ssh_session].exec!("ls #{metrics_dir}/done | sort | awk '$0 <= \"#{marker}\"' | xargs -I{} rm #{metrics_dir}/done/{}")
+  end
+
+  def metrics_dir
+    metrics_config[:metrics_dir].shellescape
+  end
+end

--- a/lib/metrics_target_resource.rb
+++ b/lib/metrics_target_resource.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class MetricsTargetResource
+  EXPORT_TIMEOUT = 100
+
+  attr_reader :deleted
+
+  def initialize(resource)
+    @resource = resource
+    @session = nil
+    @mutex = Mutex.new
+    @last_export_success = false
+    @export_started_at = Time.now
+    @deleted = false
+
+    vmr = VictoriaMetricsResource.first(project_id: Config.victoria_metrics_service_project_id)
+    vms = vmr&.servers&.first
+    @tsdb_client = vms&.client
+  end
+
+  def open_resource_session
+    return if @session && @last_export_success
+
+    @session = @resource.reload.init_metrics_export_session
+  rescue => ex
+    if ex.is_a?(Sequel::NoExistingObject)
+      Clog.emit("Resource is deleted.") { {resource_deleted: {ubid: @resource.ubid}} }
+      @session = nil
+      @deleted = true
+    end
+  end
+
+  def export_metrics
+    @export_started_at = Time.now
+    begin
+      count = @resource.export_metrics(session: @session, tsdb_client: @tsdb_client)
+      Clog.emit("Metrics export has finished.") { {metrics_export_success: {ubid: @resource.ubid, count: count}} }
+      @last_export_success = true
+    rescue => ex
+      @last_export_success = false
+      close_resource_session
+      Clog.emit("Metrics export has failed.") { {metrics_export_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
+    end
+  end
+
+  def close_resource_session
+    return if @session.nil?
+
+    @session[:ssh_session].shutdown!
+    begin
+      @session[:ssh_session].close
+    rescue
+    end
+    @session = nil
+  end
+
+  def force_stop_if_stuck
+    if @mutex.locked?
+      Clog.emit("Resource is locked.") { {resource_locked: {ubid: @resource.ubid}} }
+      if @export_started_at + EXPORT_TIMEOUT < Time.now
+        Clog.emit("Metrics export has stuck.") { {metrics_export_stuck: {ubid: @resource.ubid}} }
+      end
+    end
+  end
+
+  def lock_no_wait
+    return unless @mutex.try_lock
+
+    begin
+      yield
+    ensure
+      @mutex.unlock
+    end
+  end
+end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -15,6 +15,7 @@ class PostgresServer < Sequel::Model
   include ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
+  include MetricsTargetMethods
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
   semaphore :restart, :configure, :take_over, :configure_prometheus, :configure_metrics, :destroy, :recycle, :promote
@@ -190,6 +191,13 @@ class PostgresServer < Sequel::Model
     {
       ssh_session: ssh_session,
       db_connection: nil
+    }
+  end
+
+  def init_metrics_export_session
+    ssh_session = vm.sshable.start_fresh_session
+    {
+      ssh_session: ssh_session
     }
   end
 

--- a/spec/lib/metrics_target_methods_spec.rb
+++ b/spec/lib/metrics_target_methods_spec.rb
@@ -1,0 +1,126 @@
+# spec/lib/metrics_target_methods_spec.rb
+# frozen_string_literal: true
+
+require "spec_helper"
+require "metrics_target_methods"
+
+class TestClass
+  include MetricsTargetMethods
+end
+
+RSpec.describe MetricsTargetMethods do
+  let(:test_instance) { TestClass.new }
+  let(:mock_ssh_session) { instance_double(Net::SSH::Connection::Session) }
+  let(:session) { {ssh_session: mock_ssh_session} }
+  let(:mock_tsdb_client) { instance_double(VictoriaMetrics::Client) }
+  let(:metrics_dir) { "/home/ubi/metrics" }
+
+  describe "#metrics_config" do
+    it "returns the default configuration" do
+      config = test_instance.metrics_config
+      expect(config).to be_a(Hash)
+      expect(config[:endpoints]).to eq([])
+      expect(config[:max_file_retention]).to eq(120)
+      expect(config[:interval]).to eq("15s")
+      expect(config[:additional_labels]).to eq({foo: "bar"})
+      expect(config[:metrics_dir]).to eq("/home/ubi/metrics")
+    end
+  end
+
+  describe "#export_metrics" do
+    context "when scrape results are empty" do
+      before do
+        allow(test_instance).to receive(:scrape_endpoints).and_return([])
+        allow(Clog).to receive(:emit)
+      end
+
+      it "does not call import_prometheus or mark_pending_scrapes_as_done" do
+        expect(mock_tsdb_client).not_to receive(:import_prometheus)
+        expect(test_instance).not_to receive(:mark_pending_scrapes_as_done)
+
+        test_instance.export_metrics(session: session, tsdb_client: mock_tsdb_client)
+      end
+    end
+
+    context "when scrape results exist" do
+      let(:time) { Time.now }
+      let(:scrape_result_a) { VictoriaMetrics::Client::Scrape.new(time: time - 10, samples: "metric1{} 1") }
+      let(:scrape_result_b) { VictoriaMetrics::Client::Scrape.new(time: time, samples: "metric2{} 2") }
+      let(:scrape_results) { [scrape_result_a, scrape_result_b] }
+
+      before do
+        allow(test_instance).to receive(:scrape_endpoints).and_return(scrape_results)
+        allow(Clog).to receive(:emit)
+        allow(test_instance).to receive(:mark_pending_scrapes_as_done)
+      end
+
+      it "does not call import_prometheus or mark_pending_scrapes_as_done if tsdb_client is nil" do
+        expect(mock_tsdb_client).not_to receive(:import_prometheus)
+        expect(test_instance).not_to receive(:mark_pending_scrapes_as_done)
+        test_instance.export_metrics(session: session, tsdb_client: nil)
+      end
+
+      it "imports all scrapes and marks them as done" do
+        expect(mock_tsdb_client).to receive(:import_prometheus).with(scrape_result_a, {foo: "bar"})
+        expect(mock_tsdb_client).to receive(:import_prometheus).with(scrape_result_b, {foo: "bar"})
+        expect(test_instance).to receive(:mark_pending_scrapes_as_done).with(session, time)
+
+        test_instance.export_metrics(session: session, tsdb_client: mock_tsdb_client)
+      end
+    end
+  end
+
+  describe "#scrape_endpoints" do
+    let(:file_list) { "2023-01-01T12-00-00-000000000.prom\n2023-01-01T12-15-00-000000000.prom" }
+    let(:file_content) { "metric{} 1" }
+    let(:status_hash) { {exit_code: 0} }
+
+    before do
+      allow(mock_ssh_session).to receive(:exec!).with(/ls.*done/).and_return(file_list)
+      allow(mock_ssh_session).to receive(:exec!).with(/cat.*done/, status: anything) do |_, options|
+        options[:status][:exit_code] = status_hash[:exit_code]
+        file_content
+      end
+    end
+
+    context "when files can be read successfully" do
+      it "returns the expected scrapes" do
+        results = test_instance.scrape_endpoints(session)
+
+        expect(results.length).to eq(2)
+        expect(results[0]).to be_a(VictoriaMetrics::Client::Scrape)
+        expect(results[0].samples).to eq(file_content)
+        expect(results[1]).to be_a(VictoriaMetrics::Client::Scrape)
+        expect(results[1].samples).to eq(file_content)
+      end
+    end
+
+    context "when files cannot be read" do
+      let(:status_hash) { {exit_code: 1} }
+
+      it "filters out failed scrapes" do
+        results = test_instance.scrape_endpoints(session)
+        expect(results).to be_empty
+      end
+    end
+  end
+
+  describe "#mark_pending_scrapes_as_done" do
+    let(:time) { Time.new(2023, 1, 1, 12, 0, 0) }
+    let(:time_marker) { "2023-01-01T12-00-00-000000000" }
+
+    it "executes the correct command to move files" do
+      expected_command = "ls #{metrics_dir}/done | sort | awk '$0 <= \"#{time_marker}\"' | xargs -I{} rm #{metrics_dir}/done/{}"
+      expect(mock_ssh_session).to receive(:exec!).with(expected_command)
+
+      test_instance.mark_pending_scrapes_as_done(session, time)
+    end
+  end
+
+  describe "#metrics_dir" do
+    it "returns the escaped metrics directory path" do
+      allow(test_instance).to receive(:metrics_config).and_return({metrics_dir: "/path with spaces"})
+      expect(test_instance.metrics_dir).to eq("/path\\ with\\ spaces")
+    end
+  end
+end

--- a/spec/lib/metrics_target_resource_spec.rb
+++ b/spec/lib/metrics_target_resource_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MetricsTargetResource do
+  let(:postgres_server) { PostgresServer.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ee" } }
+  let(:resource) { described_class.new(postgres_server) }
+
+  describe "#initialize" do
+    it "initializes with a resource and nil tsdb client when VictoriaMetrics is not found" do
+      expect(resource.instance_variable_get(:@resource)).to eq(postgres_server)
+    end
+
+    it "initializes with a resource and a tsdb client when VictoriaMetrics is found" do
+      prj = Project.create_with_id(name: "vm-project") { it.id = "4d8f9896-26a3-4784-8f52-2ed5d5e55c0e" }
+      expect(Config).to receive(:victoria_metrics_service_project_id).and_return(prj.id)
+      vmr = instance_double(VictoriaMetricsResource, project_id: prj.id)
+      expect(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
+      expect(vmr).to receive(:servers).and_return([instance_double(VictoriaMetricsServer, client: "tsdb_client")])
+
+      expect(resource.instance_variable_get(:@resource)).to eq(postgres_server)
+      expect(resource.instance_variable_get(:@tsdb_client)).to eq("tsdb_client")
+    end
+  end
+
+  describe "#open_resource_session" do
+    it "opens a resource session if not already open" do
+      expect(postgres_server).to receive(:reload).and_return(postgres_server)
+      expect(postgres_server).to receive(:init_metrics_export_session).and_return("session")
+      resource.open_resource_session
+      expect(resource.instance_variable_get(:@session)).to eq("session")
+    end
+
+    it "doesn't reopen a session if already open and last export was successful" do
+      resource.instance_variable_set(:@session, "session")
+      resource.instance_variable_set(:@last_export_success, true)
+
+      # Ensure postgres_server doesn't receive init_metrics_export_session again
+      expect(postgres_server).not_to receive(:reload)
+      expect(postgres_server).not_to receive(:init_metrics_export_session)
+
+      resource.open_resource_session
+      expect(resource.instance_variable_get(:@session)).to eq("session")
+    end
+
+    it "marks resource as deleted when Sequel::NoExistingObject is raised" do
+      expect(postgres_server).to receive(:reload).and_raise(Sequel::NoExistingObject)
+
+      expect(Clog).to receive(:emit).with("Resource is deleted.").and_yield
+
+      resource.open_resource_session
+      expect(resource.deleted).to be true
+      expect(resource.instance_variable_get(:@session)).to be_nil
+    end
+
+    it "ignores other exceptions" do
+      expect(postgres_server).to receive(:reload).and_raise(StandardError)
+      expect { resource.open_resource_session }.not_to raise_error
+    end
+  end
+
+  describe "#export_metrics" do
+    before do
+      prj = Project.create_with_id(name: "vm-project") { it.id = "4d8f9896-26a3-4784-8f52-2ed5d5e55c0d" }
+      expect(Config).to receive(:victoria_metrics_service_project_id).and_return(prj.id)
+      vmr = instance_double(VictoriaMetricsResource, project_id: prj.id)
+      expect(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
+      expect(vmr).to receive(:servers).and_return([instance_double(VictoriaMetricsServer, client: "tsdb_client")])
+    end
+
+    it "calls export_metrics on the resource and updates last_export_success" do
+      resource.instance_variable_set(:@session, "session")
+      expect(postgres_server).to receive(:export_metrics).with(session: "session", tsdb_client: "tsdb_client")
+      expect { resource.export_metrics }.to change { resource.instance_variable_get(:@last_export_success) }.from(false).to(true)
+    end
+
+    it "swallows exceptions and logs them" do
+      expect(postgres_server).to receive(:export_metrics).and_raise(StandardError.new("Export failed"))
+      expect(Clog).to receive(:emit)
+      expect { resource.export_metrics }.not_to raise_error
+    end
+  end
+
+  describe "#close_resource_session" do
+    it "returns if session is nil" do
+      resource.instance_variable_set(:@session, nil)
+      expect { resource.close_resource_session }.not_to raise_error
+    end
+
+    it "closes the session and sets it to nil" do
+      session = instance_double(Net::SSH::Connection::Session)
+      resource.instance_variable_set(:@session, {ssh_session: session})
+      expect(session).to receive(:shutdown!)
+      expect(session).to receive(:close)
+      expect { resource.close_resource_session }.to change { resource.instance_variable_get(:@session) }.from({ssh_session: session}).to(nil)
+    end
+  end
+
+  describe "#force_stop_if_stuck" do
+    it "does nothing if pulse check is not stuck" do
+      expect(Kernel).not_to receive(:exit!)
+
+      # not locked
+      resource.force_stop_if_stuck
+
+      # not timed out
+      resource.instance_variable_get(:@mutex).lock
+      resource.instance_variable_set(:@export_started_at, Time.now)
+      resource.force_stop_if_stuck
+      resource.instance_variable_get(:@mutex).unlock
+    end
+
+    it "triggers Kernel.exit if pulse check is stuck" do
+      resource.instance_variable_get(:@mutex).lock
+      resource.instance_variable_set(:@export_started_at, Time.now - 200)
+      expect(Clog).to receive(:emit).at_least(:once)
+      resource.force_stop_if_stuck
+      resource.instance_variable_get(:@mutex).unlock
+    end
+  end
+
+  describe "#lock_no_wait" do
+    it "does not yield if mutex is locked" do
+      resource.instance_variable_get(:@mutex).lock
+      expect { |b| resource.lock_no_wait(&b) }.not_to yield_control
+      resource.instance_variable_get(:@mutex).unlock
+    end
+
+    it "yields if mutex is not locked" do
+      expect { |b| resource.lock_no_wait(&b) }.to yield_control
+    end
+  end
+end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -278,6 +278,12 @@ RSpec.describe PostgresServer do
     postgres_server.init_health_monitor_session
   end
 
+  it "initiates a new metrics export session" do
+    session = instance_double(Net::SSH::Connection::Session)
+    expect(postgres_server.vm.sshable).to receive(:start_fresh_session).and_return(session)
+    postgres_server.init_metrics_export_session
+  end
+
   it "checks pulse" do
     session = {
       ssh_session: instance_double(Net::SSH::Connection::Session),

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -87,7 +87,7 @@ module ThawedMock
   allow_mocking(VmHostCpu, :create)
   allow_mocking(VmHostSlice, :[], :dataset)
   allow_mocking(VictoriaMetricsServer, :[])
-  allow_mocking(VictoriaMetricsResource, :[])
+  allow_mocking(VictoriaMetricsResource, :[], :first)
 
   # Progs
   allow_mocking(Prog::Ai::InferenceEndpointNexus, :assemble, :model_for_id)


### PR DESCRIPTION
## Description
This commit updates bin/monitor to scan for resources which have metrics
export capability (currently only PG servers) and periodically export
metrics out store them in VictoriaMetrics.

Each resource which exports metrics provides `MetricsTargetMethods`,
which contain the config and a commmon algorithm to fetch scraped data
from a given list of endpoints. Roghly the logic looks like this:

Producer side (PG server):
A systemd-backed timer executes `postgres/bin/metrics-collector`, which
scrapes the list of endpoints and stores them on disk, every 15s
(default interval). This location is the `pending` buffer, which can
grow upto a 120 entries by default, providing recovery for 30
minutes of outages in other parts of the system.

Consumer side (bin/monitor):
Monitor periodically connects to each metrics target resource to fetch
upto 4 scrapes at a time and write them to VictoriaMetrics, and move the
successfully exported scrapes to the `done` buffer, which is cleand up
periodically by the `metrics-collector`.  Currently, we only create a
single global VictoriaMetrics instance for simplicity, although it can
be configured to be location-aware.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add functionality to export metrics from Postgres servers to VictoriaMetrics, including new classes, methods, and tests.
> 
>   - **Behavior**:
>     - `bin/monitor` updated to export metrics from `PostgresServer` to VictoriaMetrics using `MetricsTargetMethods`.
>     - New `MetricsTargetResource` class handles metric export sessions and manages resource state.
>     - `VictoriaMetrics::Client` updated with `import_prometheus()` to send gzipped data.
>   - **Configuration**:
>     - `config.rb` updated with `max_metrics_export_threads` and `victoria_metrics_service_project_id`.
>   - **Models**:
>     - `PostgresServer` includes `MetricsTargetMethods` for metric configuration and session initiation.
>   - **Tests**:
>     - New tests in `metrics_target_methods_spec.rb`, `metrics_target_resource_spec.rb`, and `client_spec.rb` for metric export functionality.
>     - `postgres_server_spec.rb` updated to test metric session initiation.
>   - **Misc**:
>     - `metrics_target_methods.rb` and `metrics_target_resource.rb` added for metric export logic.
>     - `client.rb` updated to handle gzipped data and authentication for VictoriaMetrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3832f833f772bcdf0ce3889b54094b522035a80a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->