### PR TITLE
Change request parameters validation

### DIFF
--- a/bin/production_check
+++ b/bin/production_check
@@ -15,7 +15,7 @@ Open3.popen3({"RACK_ENV" => "production", "PORT" => "8081", "WEB_CONCURRENCY" =>
   pid = wait_thr.pid
 
   timer_thread = Thread.new do
-    queue.pop(timeout: 6)
+    queue.pop(timeout: 12)
     if works.nil?
       error = "Timeout"
       Process.kill(:KILL, pid)

--- a/clover.rb
+++ b/clover.rb
@@ -589,6 +589,7 @@ class Clover < Roda
     end
 
     hash_branch("test-missing-request-params") do |r|
+      no_authorization_needed
       check_required_web_params(%w[foo])
     end
 

--- a/clover.rb
+++ b/clover.rb
@@ -589,7 +589,7 @@ class Clover < Roda
     end
 
     hash_branch("test-missing-request-params") do |r|
-      validate_request_params(%w[foo])
+      check_required_web_params(%w[foo])
     end
 
     hash_branch("test-no-authorization-needed") do |r|

--- a/clover.rb
+++ b/clover.rb
@@ -588,6 +588,10 @@ class Clover < Roda
       raise(r.params["message"] || "test error")
     end
 
+    hash_branch("test-missing-request-params") do |r|
+      validate_request_params(%w[foo])
+    end
+
     hash_branch("test-no-authorization-needed") do |r|
       r.get "once" do
         no_authorization_needed

--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -23,9 +23,7 @@ class Clover
     authorize("Firewall:create", @project.id)
     Validation.validate_name(firewall_name)
 
-    optional_parameters = %w[description]
-    optional_parameters.concat(%w[name location private_subnet_id]) if web?
-    description = validate_request_params([], optional_parameters)["description"] || ""
+    description = request.params["description"] || ""
 
     firewall = Firewall.create_with_id(
       name: firewall_name,

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -152,8 +152,11 @@ class Clover < Roda
   end
 
   def validate_request_params(required_keys, allowed_optional_keys = [], ignored_keys = [])
+    # Committee handles validation for API
+    return request.params if api?
+
     params = request.params.reject { ignored_keys.include?(it) }
-    params = params.reject { it == "_csrf" } unless api?
+    params = params.reject { it == "_csrf" }
 
     Validation.validate_request_params(params, required_keys, allowed_optional_keys)
   end

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -152,13 +152,17 @@ class Clover < Roda
   end
 
   def validate_request_params(required_keys, allowed_optional_keys = [], ignored_keys = [])
+    params = request.params
+
     # Committee handles validation for API
-    return request.params if api?
+    if web?
+      missing_required_keys = required_keys - params.keys
+      unless missing_required_keys.empty?
+        fail Validation::ValidationFailed.new({body: "Request body must include required parameters: #{missing_required_keys.join(", ")}"})
+      end
+    end
 
-    params = request.params.reject { ignored_keys.include?(it) }
-    params = params.reject { it == "_csrf" }
-
-    Validation.validate_request_params(params, required_keys, allowed_optional_keys)
+    params
   end
 
   def fetch_location_based_prices(*resource_types)

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -151,7 +151,7 @@ class Clover < Roda
     request.halt
   end
 
-  def validate_request_params(required_keys)
+  def check_required_web_params(required_keys)
     params = request.params
 
     # Committee handles validation for API

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -151,7 +151,7 @@ class Clover < Roda
     request.halt
   end
 
-  def validate_request_params(required_keys, allowed_optional_keys = [], ignored_keys = [])
+  def validate_request_params(required_keys)
     params = request.params
 
     # Committee handles validation for API

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -5,8 +5,7 @@ class Clover
     authorize("KubernetesCluster:create", @project.id)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
-    required_parameters = ["name", "location", "cp_nodes", "worker_nodes"]
-    request_body_params = validate_request_params(required_parameters)
+    request_body_params = validate_request_params(["name", "location", "cp_nodes", "worker_nodes"])
 
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -5,7 +5,7 @@ class Clover
     authorize("KubernetesCluster:create", @project.id)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
-    params = validate_request_params(["name", "location", "cp_nodes", "worker_nodes"])
+    params = check_required_web_params(["name", "location", "cp_nodes", "worker_nodes"])
 
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -5,19 +5,19 @@ class Clover
     authorize("KubernetesCluster:create", @project.id)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
-    request_body_params = validate_request_params(["name", "location", "cp_nodes", "worker_nodes"])
+    params = validate_request_params(["name", "location", "cp_nodes", "worker_nodes"])
 
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
         name: name,
         project_id: @project.id,
         location_id: @location.id,
-        cp_node_count: request_body_params["cp_nodes"].to_i
+        cp_node_count: params["cp_nodes"].to_i
       ).subject
 
       Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
         name: name + "-np",
-        node_count: request_body_params["worker_nodes"].to_i,
+        node_count: params["worker_nodes"].to_i,
         kubernetes_cluster_id: kc.id
       )
 

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -24,9 +24,9 @@ class Clover
   def load_balancer_post(name)
     authorize("LoadBalancer:create", @project.id)
 
-    request_body_params = validate_request_params(%w[private_subnet_id algorithm src_port dst_port health_check_protocol stack name])
+    params = validate_request_params(%w[private_subnet_id algorithm src_port dst_port health_check_protocol stack name])
 
-    unless (ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"]))
+    unless (ps = PrivateSubnet.from_ubid(params["private_subnet_id"]))
       fail Validation::ValidationFailed.new("private_subnet_id" => "Private subnet not found")
     end
     authorize("PrivateSubnet:view", ps.id)
@@ -34,12 +34,12 @@ class Clover
     lb = Prog::Vnet::LoadBalancerNexus.assemble(
       ps.id,
       name:,
-      algorithm: request_body_params["algorithm"],
-      stack: Validation.validate_load_balancer_stack(request_body_params["stack"]),
-      src_port: Validation.validate_port(:src_port, request_body_params["src_port"]),
-      dst_port: Validation.validate_port(:dst_port, request_body_params["dst_port"]),
-      health_check_endpoint: request_body_params["health_check_endpoint"] || Prog::Vnet::LoadBalancerNexus::DEFAULT_HEALTH_CHECK_ENDPOINT,
-      health_check_protocol: request_body_params["health_check_protocol"]
+      algorithm: params["algorithm"],
+      stack: Validation.validate_load_balancer_stack(params["stack"]),
+      src_port: Validation.validate_port(:src_port, params["src_port"]),
+      dst_port: Validation.validate_port(:dst_port, params["dst_port"]),
+      health_check_endpoint: params["health_check_endpoint"] || Prog::Vnet::LoadBalancerNexus::DEFAULT_HEALTH_CHECK_ENDPOINT,
+      health_check_protocol: params["health_check_protocol"]
     ).subject
 
     if api?

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -24,7 +24,7 @@ class Clover
   def load_balancer_post(name)
     authorize("LoadBalancer:create", @project.id)
 
-    params = validate_request_params(%w[private_subnet_id algorithm src_port dst_port health_check_protocol stack name])
+    params = check_required_web_params(%w[private_subnet_id algorithm src_port dst_port health_check_protocol stack name])
 
     unless (ps = PrivateSubnet.from_ubid(params["private_subnet_id"]))
       fail Validation::ValidationFailed.new("private_subnet_id" => "Private subnet not found")

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -24,10 +24,7 @@ class Clover
   def load_balancer_post(name)
     authorize("LoadBalancer:create", @project.id)
 
-    required_parameters = %w[private_subnet_id algorithm src_port dst_port health_check_protocol stack]
-    required_parameters << "name" if web?
-    optional_parameters = %w[health_check_endpoint]
-    request_body_params = validate_request_params(required_parameters, optional_parameters)
+    request_body_params = validate_request_params(%w[private_subnet_id algorithm src_port dst_port health_check_protocol stack name])
 
     unless (ps = PrivateSubnet.from_ubid(request_body_params["private_subnet_id"]))
       fail Validation::ValidationFailed.new("private_subnet_id" => "Private subnet not found")

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -7,11 +7,7 @@ class Clover
 
     Validation.validate_postgres_location(@location, @project.id)
 
-    required_parameters = ["size"]
-    required_parameters << "name" << "location" if web?
-    allowed_optional_parameters = ["storage_size", "ha_type", "version", "flavor"]
-    ignored_parameters = ["family"]
-    request_body_params = validate_request_params(required_parameters, allowed_optional_parameters, ignored_parameters)
+    request_body_params = validate_request_params(%w[size name location])
     parsed_size = Validation.validate_postgres_size(@location, request_body_params["size"], @project.id)
 
     ha_type = request_body_params["ha_type"] || PostgresResource::HaType::NONE

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -7,7 +7,7 @@ class Clover
 
     Validation.validate_postgres_location(@location, @project.id)
 
-    params = validate_request_params(%w[size name location])
+    params = check_required_web_params(%w[size name location])
     parsed_size = Validation.validate_postgres_size(@location, params["size"], @project.id)
 
     ha_type = params["ha_type"] || PostgresResource::HaType::NONE

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -7,10 +7,10 @@ class Clover
 
     Validation.validate_postgres_location(@location, @project.id)
 
-    request_body_params = validate_request_params(%w[size name location])
-    parsed_size = Validation.validate_postgres_size(@location, request_body_params["size"], @project.id)
+    params = validate_request_params(%w[size name location])
+    parsed_size = Validation.validate_postgres_size(@location, params["size"], @project.id)
 
-    ha_type = request_body_params["ha_type"] || PostgresResource::HaType::NONE
+    ha_type = params["ha_type"] || PostgresResource::HaType::NONE
     requested_standby_count = case ha_type
     when PostgresResource::HaType::ASYNC then 1
     when PostgresResource::HaType::SYNC then 2
@@ -25,10 +25,10 @@ class Clover
       location_id: @location.id,
       name:,
       target_vm_size: parsed_size.vm_size,
-      target_storage_size_gib: request_body_params["storage_size"] || parsed_size.storage_size_options.first,
-      ha_type: request_body_params["ha_type"] || PostgresResource::HaType::NONE,
-      version: request_body_params["version"] || PostgresResource::DEFAULT_VERSION,
-      flavor: request_body_params["flavor"] || PostgresResource::Flavor::STANDARD
+      target_storage_size_gib: params["storage_size"] || parsed_size.storage_size_options.first,
+      ha_type: params["ha_type"] || PostgresResource::HaType::NONE,
+      version: params["version"] || PostgresResource::DEFAULT_VERSION,
+      flavor: params["flavor"] || PostgresResource::Flavor::STANDARD
     )
     send_notification_mail_to_partners(st.subject, current_account.email)
 

--- a/helpers/private_subnet.rb
+++ b/helpers/private_subnet.rb
@@ -25,11 +25,11 @@ class Clover
   def private_subnet_post(name)
     authorize("PrivateSubnet:create", @project.id)
 
-    request_body_params = validate_request_params(%w[name location])
-    firewall_id = if request_body_params["firewall_id"]
-      fw = Firewall.from_ubid(request_body_params["firewall_id"])
+    params = validate_request_params(%w[name location])
+    firewall_id = if params["firewall_id"]
+      fw = Firewall.from_ubid(params["firewall_id"])
       unless fw && fw.location_id == @location.id
-        fail Validation::ValidationFailed.new(firewall_id: "Firewall with id \"#{request_body_params["firewall_id"]}\" and location \"#{@location.display_name}\" is not found")
+        fail Validation::ValidationFailed.new(firewall_id: "Firewall with id \"#{params["firewall_id"]}\" and location \"#{@location.display_name}\" is not found")
       end
       authorize("Firewall:view", fw.id)
       fw.id

--- a/helpers/private_subnet.rb
+++ b/helpers/private_subnet.rb
@@ -25,7 +25,7 @@ class Clover
   def private_subnet_post(name)
     authorize("PrivateSubnet:create", @project.id)
 
-    params = validate_request_params(%w[name location])
+    params = check_required_web_params(%w[name location])
     firewall_id = if params["firewall_id"]
       fw = Firewall.from_ubid(params["firewall_id"])
       unless fw && fw.location_id == @location.id

--- a/helpers/private_subnet.rb
+++ b/helpers/private_subnet.rb
@@ -25,9 +25,7 @@ class Clover
   def private_subnet_post(name)
     authorize("PrivateSubnet:create", @project.id)
 
-    required_parameters = []
-    required_parameters << "name" << "location" if web?
-    request_body_params = validate_request_params(required_parameters, ["firewall_id"])
+    request_body_params = validate_request_params(%w[name location])
     firewall_id = if request_body_params["firewall_id"]
       fw = Firewall.from_ubid(request_body_params["firewall_id"])
       unless fw && fw.location_id == @location.id

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -25,7 +25,7 @@ class Clover
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless project.has_valid_payment_method?
 
     allowed_optional_parameters = ["size", "storage_size", "unix_user", "boot_image", "enable_ip4", "private_subnet_id"]
-    params = validate_request_params(%w[public_key name location])
+    params = check_required_web_params(%w[public_key name location])
     assemble_params = params.slice(*allowed_optional_parameters).compact
 
     # Generally parameter validation is handled in progs while creating resources.

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -24,11 +24,8 @@ class Clover
     authorize("Vm:create", project.id)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless project.has_valid_payment_method?
 
-    required_parameters = ["public_key"]
-    required_parameters << "name" << "location" if web?
     allowed_optional_parameters = ["size", "storage_size", "unix_user", "boot_image", "enable_ip4", "private_subnet_id"]
-    ignored_parameters = ["family"]
-    request_body_params = validate_request_params(required_parameters, allowed_optional_parameters, ignored_parameters)
+    request_body_params = validate_request_params(%w[public_key name location])
     assemble_params = request_body_params.slice(*allowed_optional_parameters).compact
 
     # Generally parameter validation is handled in progs while creating resources.

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -25,8 +25,8 @@ class Clover
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless project.has_valid_payment_method?
 
     allowed_optional_parameters = ["size", "storage_size", "unix_user", "boot_image", "enable_ip4", "private_subnet_id"]
-    request_body_params = validate_request_params(%w[public_key name location])
-    assemble_params = request_body_params.slice(*allowed_optional_parameters).compact
+    params = validate_request_params(%w[public_key name location])
+    assemble_params = params.slice(*allowed_optional_parameters).compact
 
     # Generally parameter validation is handled in progs while creating resources.
     # Since Vm::Nexus both handles VM creation requests from user and also Postgres
@@ -61,7 +61,7 @@ class Clover
     Validation.validate_vcpu_quota(project, "VmVCpu", requested_vm_vcpu_count)
 
     st = Prog::Vm::Nexus.assemble(
-      request_body_params["public_key"],
+      params["public_key"],
       project.id,
       name: name,
       location_id: @location.id,

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -226,21 +226,6 @@ module Validation
     end
   end
 
-  def self.validate_request_params(request_body_params, required_keys, allowed_optional_keys = [])
-    missing_required_keys = required_keys - request_body_params.keys
-    unless missing_required_keys.empty?
-      fail ValidationFailed.new({body: "Request body must include required parameters: #{missing_required_keys.join(", ")}"})
-    end
-
-    allowed_keys = required_keys + allowed_optional_keys
-    unallowed_keys = request_body_params.keys - allowed_keys
-    if unallowed_keys.any?
-      fail ValidationFailed.new({body: "Only following parameters are allowed: #{allowed_keys.join(", ")}"})
-    end
-
-    request_body_params
-  end
-
   def self.validate_usage_limit(limit)
     limit_integer = limit.to_i
     fail ValidationFailed.new({limit: "Limit is not a valid integer."}) if limit_integer.to_s != limit

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -609,6 +609,12 @@ paths:
                   items:
                     type: string
               additionalProperties: false
+              required:
+                - algorithm
+                - dst_port
+                - health_check_endpoint
+                - src_port
+                - vms
       responses:
         '200':
           $ref: '#/components/responses/LoadBalancer'

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -35,8 +35,7 @@ class Clover
         end
       end
 
-      required_parameters = ["name"]
-      request_body_params = validate_request_params(required_parameters)
+      request_body_params = validate_request_params(["name"])
       project = current_account.create_project_with_default_policy(request_body_params["name"])
       no_authorization_needed
 

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -35,8 +35,8 @@ class Clover
         end
       end
 
-      request_body_params = validate_request_params(["name"])
-      project = current_account.create_project_with_default_policy(request_body_params["name"])
+      params = validate_request_params(["name"])
+      project = current_account.create_project_with_default_policy(params["name"])
       no_authorization_needed
 
       if api?

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -35,7 +35,7 @@ class Clover
         end
       end
 
-      params = validate_request_params(["name"])
+      params = check_required_web_params(["name"])
       project = current_account.create_project_with_default_policy(params["name"])
       no_authorization_needed
 

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -47,7 +47,7 @@ class Clover
       r.post %w[attach-subnet detach-subnet] do |action|
         authorize("Firewall:view", firewall.id)
 
-        private_subnet_id = validate_request_params(["private_subnet_id"])["private_subnet_id"]
+        private_subnet_id = check_required_web_params(["private_subnet_id"])["private_subnet_id"]
         private_subnet = PrivateSubnet.from_ubid(private_subnet_id)
 
         unless private_subnet && private_subnet.location_id == @location.id

--- a/routes/project/location/firewall/firewall_rule.rb
+++ b/routes/project/location/firewall/firewall_rule.rb
@@ -7,10 +7,7 @@ class Clover
     r.post true do
       authorize("Firewall:edit", @firewall.id)
 
-      required_parameters = ["cidr"]
-      allowed_optional_parameters = ["port_range"]
-
-      request_body_params = validate_request_params(required_parameters, allowed_optional_parameters)
+      request_body_params = validate_request_params(["cidr"])
 
       parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
       port_range = if request_body_params["port_range"].nil?

--- a/routes/project/location/firewall/firewall_rule.rb
+++ b/routes/project/location/firewall/firewall_rule.rb
@@ -7,7 +7,7 @@ class Clover
     r.post true do
       authorize("Firewall:edit", @firewall.id)
 
-      params = validate_request_params(["cidr"])
+      params = check_required_web_params(["cidr"])
 
       parsed_cidr = Validation.validate_cidr(params["cidr"])
       port_range = if params["port_range"].nil?

--- a/routes/project/location/firewall/firewall_rule.rb
+++ b/routes/project/location/firewall/firewall_rule.rb
@@ -7,13 +7,13 @@ class Clover
     r.post true do
       authorize("Firewall:edit", @firewall.id)
 
-      request_body_params = validate_request_params(["cidr"])
+      params = validate_request_params(["cidr"])
 
-      parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
-      port_range = if request_body_params["port_range"].nil?
+      parsed_cidr = Validation.validate_cidr(params["cidr"])
+      port_range = if params["port_range"].nil?
         [0, 65535]
       else
-        request_body_params["port_range"] = Validation.validate_port_range(request_body_params["port_range"])
+        params["port_range"] = Validation.validate_port_range(params["port_range"])
       end
 
       pg_range = Sequel.pg_range(port_range.first..port_range.last)

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -25,8 +25,7 @@ class Clover
 
       r.post %w[attach-vm detach-vm] do |action|
         authorize("LoadBalancer:edit", lb.id)
-        required_parameters = %w[vm_id]
-        request_body_params = validate_request_params(required_parameters)
+        request_body_params = validate_request_params(%w[vm_id])
 
         unless (vm = Vm.from_ubid(request_body_params["vm_id"]))
           fail Validation::ValidationFailed.new("vm_id" => "VM not found")

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -25,9 +25,9 @@ class Clover
 
       r.post %w[attach-vm detach-vm] do |action|
         authorize("LoadBalancer:edit", lb.id)
-        request_body_params = validate_request_params(%w[vm_id])
+        params = validate_request_params(%w[vm_id])
 
-        unless (vm = Vm.from_ubid(request_body_params["vm_id"]))
+        unless (vm = Vm.from_ubid(params["vm_id"]))
           fail Validation::ValidationFailed.new("vm_id" => "VM not found")
         end
 
@@ -73,17 +73,17 @@ class Clover
 
       r.patch api? do
         authorize("LoadBalancer:edit", lb.id)
-        request_body_params = validate_request_params(%w[algorithm src_port dst_port health_check_endpoint vms])
+        params = validate_request_params(%w[algorithm src_port dst_port health_check_endpoint vms])
         DB.transaction do
           lb.update(
-            algorithm: request_body_params["algorithm"],
-            health_check_endpoint: request_body_params["health_check_endpoint"]
+            algorithm: params["algorithm"],
+            health_check_endpoint: params["health_check_endpoint"]
           )
-          lb.ports.first.update(src_port: Validation.validate_port(:src_port, request_body_params["src_port"]),
-            dst_port: Validation.validate_port(:dst_port, request_body_params["dst_port"]))
+          lb.ports.first.update(src_port: Validation.validate_port(:src_port, params["src_port"]),
+            dst_port: Validation.validate_port(:dst_port, params["dst_port"]))
         end
 
-        new_vms = request_body_params["vms"].map { Vm.from_ubid(it.delete("\"")) }
+        new_vms = params["vms"].map { Vm.from_ubid(it.delete("\"")) }
         new_vms.each do |vm|
           unless vm
             fail Validation::ValidationFailed.new("vms" => "VM not found")

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -25,7 +25,7 @@ class Clover
 
       r.post %w[attach-vm detach-vm] do |action|
         authorize("LoadBalancer:edit", lb.id)
-        params = validate_request_params(%w[vm_id])
+        params = check_required_web_params(%w[vm_id])
 
         unless (vm = Vm.from_ubid(params["vm_id"]))
           fail Validation::ValidationFailed.new("vm_id" => "VM not found")
@@ -73,7 +73,7 @@ class Clover
 
       r.patch api? do
         authorize("LoadBalancer:edit", lb.id)
-        params = validate_request_params(%w[algorithm src_port dst_port health_check_endpoint vms])
+        params = check_required_web_params(%w[algorithm src_port dst_port health_check_endpoint vms])
         DB.transaction do
           lb.update(
             algorithm: params["algorithm"],

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -108,7 +108,7 @@ class Clover
         r.post true do
           authorize("Postgres:edit", pg.id)
 
-          params = validate_request_params(["cidr"])
+          params = check_required_web_params(["cidr"])
           parsed_cidr = Validation.validate_cidr(params["cidr"])
 
           firewall_rule = DB.transaction do
@@ -145,7 +145,7 @@ class Clover
           authorize("Postgres:edit", pg.id)
 
           password_param = (api? ? "password" : "metric-destination-password")
-          params = validate_request_params(["url", "username", password_param])
+          params = check_required_web_params(["url", "username", password_param])
 
           Validation.validate_url(params["url"])
 
@@ -185,7 +185,7 @@ class Clover
         r.post true do
           authorize("Postgres:edit", pg.id)
 
-          params = validate_request_params(["name"])
+          params = check_required_web_params(["name"])
           st = Prog::Postgres::PostgresResourceNexus.assemble(
             project_id: @project.id,
             location_id: pg.location_id,
@@ -235,7 +235,7 @@ class Clover
         authorize("Postgres:create", @project.id)
         authorize("Postgres:view", pg.id)
 
-        params = validate_request_params(["name", "restore_target"])
+        params = check_required_web_params(["name", "restore_target"])
 
         st = Prog::Postgres::PostgresResourceNexus.assemble(
           project_id: @project.id,
@@ -270,7 +270,7 @@ class Clover
           end
         end
 
-        params = validate_request_params(["password", "repeat_password"])
+        params = check_required_web_params(["password", "repeat_password"])
         Validation.validate_postgres_superuser_password(params["password"], params["repeat_password"])
 
         DB.transaction do

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -45,10 +45,7 @@ class Clover
       r.patch do
         authorize("Postgres:edit", pg.id)
 
-        allowed_optional_parameters = ["size", "storage_size", "ha_type"]
-        ignored_parameters = ["family"]
-        request_body_params = validate_request_params([], allowed_optional_parameters, ignored_parameters)
-
+        request_body_params = r.params
         target_vm_size = Validation.validate_postgres_size(pg.location, request_body_params["size"] || pg.target_vm_size, @project.id)
         target_storage_size_gib = Validation.validate_postgres_storage_size(pg.location, target_vm_size.vm_size, request_body_params["storage_size"] || pg.target_storage_size_gib, @project.id)
         ha_type = request_body_params["ha_type"] || PostgresResource::HaType::NONE
@@ -111,8 +108,7 @@ class Clover
         r.post true do
           authorize("Postgres:edit", pg.id)
 
-          required_parameters = ["cidr"]
-          request_body_params = validate_request_params(required_parameters)
+          request_body_params = validate_request_params(["cidr"])
           parsed_cidr = Validation.validate_cidr(request_body_params["cidr"])
 
           firewall_rule = DB.transaction do
@@ -149,8 +145,7 @@ class Clover
           authorize("Postgres:edit", pg.id)
 
           password_param = (api? ? "password" : "metric-destination-password")
-          required_parameters = ["url", "username", password_param]
-          request_body_params = validate_request_params(required_parameters)
+          request_body_params = validate_request_params(["url", "username", password_param])
 
           Validation.validate_url(request_body_params["url"])
 
@@ -190,8 +185,7 @@ class Clover
         r.post true do
           authorize("Postgres:edit", pg.id)
 
-          required_parameters = ["name"]
-          request_body_params = validate_request_params(required_parameters, [], [])
+          request_body_params = validate_request_params(["name"])
           st = Prog::Postgres::PostgresResourceNexus.assemble(
             project_id: @project.id,
             location_id: pg.location_id,
@@ -241,8 +235,7 @@ class Clover
         authorize("Postgres:create", @project.id)
         authorize("Postgres:view", pg.id)
 
-        required_parameters = ["name", "restore_target"]
-        request_body_params = validate_request_params(required_parameters)
+        request_body_params = validate_request_params(["name", "restore_target"])
 
         st = Prog::Postgres::PostgresResourceNexus.assemble(
           project_id: @project.id,
@@ -277,8 +270,7 @@ class Clover
           end
         end
 
-        required_parameters = api? ? ["password"] : ["password", "repeat_password"]
-        request_body_params = validate_request_params(required_parameters)
+        request_body_params = validate_request_params(["password", "repeat_password"])
         Validation.validate_postgres_superuser_password(request_body_params["password"], request_body_params["repeat_password"])
 
         DB.transaction do
@@ -297,9 +289,7 @@ class Clover
       r.post "set-maintenance-window" do
         authorize("Postgres:edit", pg.id)
 
-        allowed_optional_parameters = ["maintenance_window_start_at"]
-        request_body_params = validate_request_params([], allowed_optional_parameters)
-
+        request_body_params = r.params
         pg.update(maintenance_window_start_at: request_body_params["maintenance_window_start_at"])
 
         if api?

--- a/routes/project/private_location.rb
+++ b/routes/project/private_location.rb
@@ -26,7 +26,7 @@ class Clover
 
     r.post true do
       authorize("Location:create", @project.id)
-      params = validate_request_params(["name", "provider_location_name", "access_key", "secret_key"])
+      params = check_required_web_params(["name", "provider_location_name", "access_key", "secret_key"])
 
       Validation.validate_name(params["name"])
       Validation.validate_provider_location_name("aws", params["provider_location_name"])

--- a/routes/project/private_location.rb
+++ b/routes/project/private_location.rb
@@ -26,23 +26,23 @@ class Clover
 
     r.post true do
       authorize("Location:create", @project.id)
-      request_body_params = validate_request_params(["name", "provider_location_name", "access_key", "secret_key"])
+      params = validate_request_params(["name", "provider_location_name", "access_key", "secret_key"])
 
-      Validation.validate_name(request_body_params["name"])
-      Validation.validate_provider_location_name("aws", request_body_params["provider_location_name"])
+      Validation.validate_name(params["name"])
+      Validation.validate_provider_location_name("aws", params["provider_location_name"])
 
       loc = DB.transaction do
         loc = Location.create(
-          display_name: request_body_params["name"],
-          name: request_body_params["provider_location_name"],
-          ui_name: request_body_params["name"],
+          display_name: params["name"],
+          name: params["provider_location_name"],
+          ui_name: params["name"],
           visible: true,
           provider: "aws",
           project_id: @project.id
         )
         LocationCredential.create(
-          access_key: request_body_params["access_key"],
-          secret_key: request_body_params["secret_key"]
+          access_key: params["access_key"],
+          secret_key: params["secret_key"]
         ) { it.id = loc.id }
         loc
       end

--- a/routes/project/private_location.rb
+++ b/routes/project/private_location.rb
@@ -26,8 +26,7 @@ class Clover
 
     r.post true do
       authorize("Location:create", @project.id)
-      required_parameters = ["name", "provider_location_name", "access_key", "secret_key"]
-      request_body_params = validate_request_params(required_parameters)
+      request_body_params = validate_request_params(["name", "provider_location_name", "access_key", "secret_key"])
 
       Validation.validate_name(request_body_params["name"])
       Validation.validate_provider_location_name("aws", request_body_params["provider_location_name"])

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -396,12 +396,6 @@ RSpec.describe Validation do
     end
   end
 
-  describe "#validate_request_params" do
-    it "rejects requests without required params" do
-      expect { described_class.validate_request_params({extra: true}, []) }.to raise_error described_class::ValidationFailed
-    end
-  end
-
   describe "#validate_url" do
     it "valid account names" do
       [

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -164,9 +164,9 @@ RSpec.describe Clover, "load-balancer" do
       end
 
       it "missing required parameters" do
-        patch "/project/#{project.ubid}/location/#{lb.private_subnet.display_location}/load-balancer/#{lb.name}", {}.to_json
-
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: body")
+        expect do
+          patch "/project/#{project.ubid}/location/#{lb.private_subnet.display_location}/load-balancer/#{lb.name}", {}.to_json
+        end.to raise_error(Committee::InvalidRequest, /missing required parameters: algorithm, dst_port, health_check_endpoint, src_port, vms/)
       end
 
       it "updates vms" do

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Clover do
     expect { visit "/webhook/test-error?message=treat+as+unexpected+error" }.to raise_error(RuntimeError, "treat as unexpected error")
   end
 
+  it "raises validation error if a required parameter is not present" do
+    create_account
+    login
+    visit("/test-missing-request-params")
+
+    # Validation error without referrer redirects to /, which redirects to default project dashboard
+    expect(page.title).to eq("Ubicloud - Default Dashboard")
+  end
+
   it "does not have broken links" do
     create_account
     login


### PR DESCRIPTION
For api, rely on committee to validate parameters.  For web, only validate required parameters.  Extra parameters can be ignored for web, and no special handling is needed 

Fix one case where `openapi.yml` wasn't validating required parameters.

Rename `request_body_params` to `params` to make things easier to read.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor request parameter validation by using `Committee` for API and simplifying web validation, with a fix in `openapi.yml` and a variable rename for clarity.
> 
>   - **Behavior**:
>     - API requests now rely on `Committee` for parameter validation.
>     - Web requests validate only required parameters using `check_required_web_params()` in `general.rb`.
>     - Extra parameters in web requests are ignored.
>     - Fixes missing required parameters validation in `openapi.yml` for load balancer updates.
>   - **Refactoring**:
>     - Renames `request_body_params` to `params` across various files for clarity.
>   - **Misc**:
>     - Increases timeout in `production_check` from 6 to 12 seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 12bce856baf367f1e3661e2b1fa7934c8e2d1ccd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->