### PR TITLE
Fix required="true" attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ end
 
 group :test do
   gem "capybara"
-  gem "capybara-validate_html5", ">= 2"
+  gem "capybara-validate_html5", ">= 2.1"
   gem "pdf-reader"
   gem "rspec"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-validate_html5 (2.0.0)
+    capybara-validate_html5 (2.1.0)
       capybara
       rack-test (>= 0.6)
     cbor (0.5.9.8)
@@ -466,7 +466,7 @@ DEPENDENCIES
   brakeman
   by (>= 1.1.0)
   capybara
-  capybara-validate_html5 (>= 2)
+  capybara-validate_html5 (>= 2.1)
   committee
   countries
   cuprite

--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -120,6 +120,24 @@ class Clover < Roda
     end
   end
 
+  def html_attrs(attributes)
+    attributes.map do |key, value|
+      case key
+      when :required, :checked
+        case value
+        when true
+          key.name
+        when false
+          ""
+        else
+          "#{key.name}=\"#{h(value)}\""
+        end
+      else
+        "#{h(key)}=\"#{h(value)}\""
+      end
+    end.join(" ")
+  end
+
   def object_tag_membership_label(obj)
     case obj
     when ObjectTag

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -8,7 +8,15 @@ File.write(css_file, "") unless File.file?(css_file)
 
 require "capybara"
 require "capybara/rspec"
-require "capybara/validate_html5" if ENV["CLOVER_FREEZE"] == "1"
+
+if ENV["CLOVER_FREEZE"] == "1"
+  require "capybara/validate_html5"
+
+  Capybara.custom_html_validation do |doc, &block|
+    css = "*[required=true], *[required=false], input[checked=true], input[checked=false]"
+    doc.css(css).map(&block)
+  end
+end
 
 Gem.suffix_pattern
 

--- a/views/components/form/checkbox.erb
+++ b/views/components/form/checkbox.erb
@@ -16,9 +16,7 @@
               type="checkbox"
               value="<%= opt_val %>"
               class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
-              <% (opt_attrs || {}).each do |opt_atr_key, opt_atr_value| %>
-                <%= opt_atr_key %>="<%= opt_atr_value %>"
-              <% end%>
+              <%== html_attrs(opt_attrs || {}) %>
             >
           </div>
           <% if opt_text %>

--- a/views/components/form/datepicker.erb
+++ b/views/components/form/datepicker.erb
@@ -7,11 +7,11 @@
   name: name,
   extra_class: "datepicker",
   attributes: {
-    "required" => true,
-    "placeholder" => "YYYY-MM-DD HH:MM",
-    "data-maxDate" => max_date,
-    "data-minDate" => min_date,
-    "data-defaultDate" => default_date,
-    "hidden" => true
+    required: true,
+    placeholder: "YYYY-MM-DD HH:MM",
+    "data-maxDate": max_date,
+    "data-minDate": min_date,
+    "data-defaultDate": default_date,
+    hidden: true
   }
 ) %>

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -16,9 +16,7 @@ is_content_array = options[0][1].is_a?(Array) %>
             name="<%= name %>"
             value="<%= opt_val %>"
             class="peer sr-only"
-            <% attributes.merge(opt_attrs || {}).each do |atr_key, atr_value| %>
-            <%= atr_key %>="<%= atr_value %>"
-            <% end%>
+            <%== html_attrs(**attributes, **opt_attrs) %>
           >
           <% if is_content_array %>
             <span class="radio-small-card justify-between p-4">

--- a/views/components/form/range_slider.erb
+++ b/views/components/form/range_slider.erb
@@ -20,9 +20,7 @@ extra_class ||= {} %>
       value="<%= value %>"
       <% end %>
       class="w-full range-lg h-2 bg-gray-200 accent-orange-600 rounded-lg appearance-none cursor-pointer border-transparent <%=extra_class %> <%= error ? "text-red-900 ring-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 focus:ring-orange-600"%>"
-      <% attributes.each do |atr_key, atr_value| %>
-      <%= atr_key %>="<%= atr_value %>"
-      <% end%>
+      <%== html_attrs(attributes) %>
     >
     <ul class="flex justify-between w-full px-[10px] pt-2 sm:pt-8">
       <% range_labels.each do |lbl| %>

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -64,20 +64,19 @@ let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_o
 
       opt_attrs = {}
       opt_attrs[:disabled] = "disabled" unless parents_selected
-      opt_attrs[:checked] = "checked" if checked
+      opt_attrs[:checked] = checked
 
       [opt_val, opt_text, opt_classes, opt_attrs]
     end if has_option
 
     if has_option && selected_options[name].nil?
       options.find{ |_, _, _, opt_attrs| opt_attrs[:disabled].nil? }&.tap do |opt_val, _, _, opt_attrs|
-        opt_attrs[:checked] = "checked"
+        opt_attrs[:checked] = true
         selected_options[name] = opt_val
       end
     end
 
-    attributes = {}
-    attributes[:required] = "" if required
+    attributes = {required:}
 
     case type
     when "radio_small_cards"

--- a/views/components/form/select.erb
+++ b/views/components/form/select.erb
@@ -10,9 +10,7 @@ error ||= flash.dig("errors", name) %>
     id="<%= id %>"
     name="<%= name %>"
     class="<%= classes %> block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%>"
-    <% attributes.each do |atr_key, atr_value| %>
-    <%= atr_key %>="<%= atr_value %>"
-    <% end%>
+    <%== html_attrs(attributes) %>
   >
     <% if placeholder %>
       <option class="always-visible" value>
@@ -24,20 +22,14 @@ error ||= flash.dig("errors", name) %>
       <% next if opts.empty? %>
       <% if group_name %>
         <% opt_group_attributes = group_name.is_a?(Hash) ? group_name : {"label" => group_name}  %>
-        <optgroup
-          <% opt_group_attributes.each do |opt_atr_key, opt_atr_value| %>
-            <%= opt_atr_key %>="<%= opt_atr_value %>"
-          <% end %>
-        >
+        <optgroup <%== html_attrs(opt_group_attributes) %>>
       <% end %>
       <% opts.each do |opt_val, opt_text, opt_classes, opt_attrs| %>
         <option
           value="<%= opt_val %>"
           class="<%= opt_classes %>"
           <%= (opt_val == selected) ? "selected" : "" %>
-          <% (opt_attrs || {}).each do |opt_atr_key, opt_atr_value| %>
-          <%= opt_atr_key %>="<%= opt_atr_value %>"
-          <% end%>
+          <%== html_attrs(opt_attrs || {}) %>
         >
           <%= opt_text %>
         </option>

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -15,9 +15,7 @@ error = rodauth.field_error(name) || flash.dig("errors", name) %>
       value="<%= value %>"
       <% end %>
       class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%> <%= extra_class %>"
-      <% attributes.each do |atr_key, atr_value| %>
-      <%= atr_key %>="<%= atr_value %>"
-      <% end%>
+      <%== html_attrs(attributes) %>
     >
     <% if button_title %>
       <%== part("components/form/submit_button", text: button_title) %>

--- a/views/components/form/textarea.erb
+++ b/views/components/form/textarea.erb
@@ -9,9 +9,7 @@
     id="<%= name %>"
     name="<%= name %>"
     class="block w-full rounded-md border-0 sm:py-1.5 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"
-    <% attributes.each do |atr_key, atr_value| %>
-    <%= atr_key %>="<%= atr_value %>"
-    <% end%>
+    <%== html_attrs(attributes) %>
   ><%= value %></textarea>
   <% if description %>
     <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%= description %></p>


### PR DESCRIPTION
Add a custom validator looking for {required,checked}={true,false} attributes. This found numerous cases.

Add an html_attrs method that handles required/checked attributes properly, skipping them if the value is false, and using them without a value if the value is true.

Change all attribute handling to use html_attrs to fix the issue.