### PR TITLE
Remove asdf-direnv .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use asdf


### PR DESCRIPTION
This emits an annoying message if `asdf-direnv` is not installed but `direnv` is installed.  I'm leaving this patch outstanding for a couple of weeks while people get their toolchains adjusted, but after it is applied, `asdf-direnv` won't work anymore.