### PR TITLE
Use flash and pre_selected_options to set default values

### DIFF
--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -5,7 +5,7 @@ content_security_policy.add_script_src [:nonce, nonce] %>
 <script nonce="<%==nonce%>">
 let option_tree = <%==JSON.generate(option_tree)%>
 let option_children = <%==JSON.generate(option_parents.each_with_object(Hash.new { |h, k| h[k] = [] }) { |(child, parents), h| h[parents.last] << child if parents.any? })%>
-let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_object(Hash.new { |h, k| h[k] = [] }) { |option, h| h[option] = nil })%>
+let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_object(Hash.new { |h, k| h[k] = [] }) { |option, h| h[option] = flash.dig("old", option) || pre_selected_values[option] })%>
 </script>
 
 <div>

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (action:, form_elements:, option_tree:, option_parents:, method: "POST", form_title: nil, pre_selected_values: [], mode: "create") %>
+<%# locals: (action:, form_elements:, option_tree:, option_parents:, method: "POST", form_title: nil, pre_selected_values: {}, mode: "create") %>
 <% nonce = SecureRandom.base64(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 


### PR DESCRIPTION
**Use empty hash as default value for pre_selected_values**
This was a typo. When pre_selected_values is set, it is set as hash, not array.
So its default value should be an empty hash, not an empty array.

**Use flash and pre_selected_options to set default values**
We already use `option_dirty` hash to remember the values that were selected by
users explicitly. This allows us to keep the selected values as selected even
when user changes the parent option. However, we used to don't remember these
values after the form submission and in resource update forms. We are starting
to populate `option_dirty` from `flash` and `pre_selected_options` hash, so
that we can remember user's selections in more cases.

| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/user-attachments/assets/313bea32-1c47-4fdf-a024-7b6af40b5996) | ![after](https://github.com/user-attachments/assets/92320a2b-f0ce-46d2-b5b9-14de0cf44ebb) |
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects `pre_selected_values` default to a hash and updates `option_dirty` to retain selections using `flash` and `pre_selected_options` in `resource_creation_form.erb`.
> 
>   - **Behavior**:
>     - Corrects default value of `pre_selected_values` from an empty array to an empty hash in `resource_creation_form.erb`.
>     - Updates `option_dirty` to use `flash` and `pre_selected_options` to retain user selections post form submission in `resource_creation_form.erb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 750da764fc7d5be65ddd3b15839e34f962ed29ae. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->