### PR TITLE
Add Kubernetes v1.33 image config

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -169,6 +169,7 @@ module Config
   override :postgres17_lantern_ubuntu_2204_version, "20250103.1.0", string
   override :ai_ubuntu_2404_nvidia_version, "20250505.1.0", string
   override :kubernetes_v1_32_version, "20250320.1.0", string
+  override :kubernetes_v1_33_version, "20250506.1.0", string
 
   override :aws_based_postgres_16_ubuntu_2204_ami_version, "ami-030c060f85668b37d", string
   override :aws_based_postgres_17_ubuntu_2204_ami_version, "ami-095e7210597188ca5", string

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -110,7 +110,8 @@ class Prog::DownloadBootImage < Prog::Base
       ["ai-model-ds-r1-qwen-1-5b", "x64", "20250129.1.0"] => "9135a2e81fc6129d6d12bd633b5a30d4bfe2fd219ec5e370404758dda1159001",
       ["ai-model-ms-phi-4", "x64", "20250213.1.0"] => "0e998c4916c837c0992c4546404ecb51d0c5d5923f998f7cff0a9cddc5bf1689",
       ["ai-model-mistral-small-3", "x64", "20250217.1.0"] => "01ce8d1d0b7b0f717c51c26590234f4cb7971a9a5276de92b6cb4dc2c7a085e5",
-      ["kubernetes-v1_32", "x64", "20250320.1.0"] => "369c7c869bba690771a1dcbbae52159defaa3fd3540f008ba6feea291e7a220a"
+      ["kubernetes-v1_32", "x64", "20250320.1.0"] => "369c7c869bba690771a1dcbbae52159defaa3fd3540f008ba6feea291e7a220a",
+      ["kubernetes-v1_33", "x64", "20250506.1.0"] => "35ca03c19385227117fa6579f58c73a362970359fa9486024ca393b134a698d4"
     }
 
     # YYY: In future all images should be checked for sha256 sum, so the nil


### PR DESCRIPTION
Kubernetes v1.33 image is built and its sha and config is added to Clover