### PR TITLE
Add backend API to fetch metrics for Postgres resource

### DIFF
--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Metrics
+  TimeSeries = Data.define(:labels, :query)
+  MetricDefinition = Data.define(:name, :description, :unit, :series)
+
+  POSTGRES_METRICS = {
+    cpu_usage:
+    MetricDefinition.new(
+      name: "CPU Usage",
+      description: "Percentage of CPU used by the system",
+      unit: "percent",
+      series: [
+        TimeSeries.new(
+          labels: {},
+          query: "(1 - sum(avg(rate(node_cpu_seconds_total{mode=\"idle\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])))) * 100"
+        )
+      ]
+    ),
+    load_average:
+    MetricDefinition.new(
+      name: "Load Average",
+      description: "System load average over different time periods",
+      unit: nil,
+      series: [
+        TimeSeries.new(
+          labels: {name: "1 minute"},
+          query: "sum(node_load1{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"})"
+        ),
+        TimeSeries.new(
+          labels: {name: "5 minutes"},
+          query: "sum(node_load5{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"})"
+        ),
+        TimeSeries.new(
+          labels: {name: "15 minutes"},
+          query: "sum(node_load15{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"})"
+        )
+      ]
+    ),
+    memory_usage:
+    MetricDefinition.new(
+      name: "Memory Usage",
+      description: "Memory usage statistics",
+      unit: "percent",
+      series: [
+        TimeSeries.new(
+          labels: {name: "Used Memory"},
+          query: "(1 - (node_memory_MemAvailable_bytes{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"} / node_memory_MemTotal_bytes{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"})) * 100"
+        ),
+        TimeSeries.new(
+          labels: {name: "Cache & Buffers"},
+          query: "(node_memory_Cached_bytes{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"} + node_memory_Buffers_bytes{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}) / node_memory_MemTotal_bytes{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"} * 100"
+        )
+      ]
+    ),
+    disk_usage:
+    MetricDefinition.new(
+      name: "Disk Usage",
+      description: "Disk space utilization",
+      unit: "percent",
+      series: [
+        TimeSeries.new(
+          labels: {name: "Used Space"},
+          query: "100 - (sum(node_filesystem_avail_bytes{mountpoint=\"/dat\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"} / node_filesystem_size_bytes{mountpoint=\"/dat\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}) * 100)"
+        )
+      ]
+    ),
+    network_traffic:
+    MetricDefinition.new(
+      name: "Network Traffic",
+      description: "Network traffic in bytes per second",
+      unit: "bytes/s",
+      series: [
+        TimeSeries.new(
+          labels: {name: "Received"},
+          query: "rate(node_network_receive_bytes_total{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])"
+        ),
+        TimeSeries.new(
+          labels: {name: "Transmitted"},
+          query: "rate(node_network_transmit_bytes_total{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])"
+        )
+      ]
+    ),
+    connection_count:
+    MetricDefinition.new(
+      name: "Connection count",
+      description: "Database activity metrics",
+      unit: nil,
+      series: [
+        TimeSeries.new(
+          labels: {name: "Active"},
+          query: "sum(pg_stat_activity_count{state=\"active\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"})"
+        ),
+        TimeSeries.new(
+          labels: {name: "Total"},
+          query: "sum(pg_stat_activity_count{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"})"
+        )
+      ]
+    ),
+    cache_hit_ratio:
+    MetricDefinition.new(
+      name: "Cache hit ratio",
+      description: "Cache hit ratio",
+      unit: "percent",
+      series: [
+        TimeSeries.new(
+          labels: {},
+          query: "sum(rate(pg_stat_database_blks_hit{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])) / (sum(rate(pg_stat_database_blks_hit{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])) + sum(rate(pg_stat_database_blks_read{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))) * 100"
+        )
+      ]
+    ),
+    operation_throughput:
+    MetricDefinition.new(
+      name: "Operation throughput",
+      description: "Fetch, insert, update, delete operations per second",
+      unit: "operations/s",
+      series: [
+        TimeSeries.new(
+          labels: {name: "Fetch"},
+          query: "sum(rate(pg_stat_database_tup_fetched{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        ),
+        TimeSeries.new(
+          labels: {name: "Insert"},
+          query: "sum(rate(pg_stat_database_tup_inserted{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        ),
+        TimeSeries.new(
+          labels: {name: "Update"},
+          query: "sum(rate(pg_stat_database_tup_updated{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        ),
+        TimeSeries.new(
+          labels: {name: "Delete"},
+          query: "sum(rate(pg_stat_database_tup_deleted{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        )
+      ]
+    ),
+    deadlocks:
+    MetricDefinition.new(
+      name: "Deadlocks",
+      description: "Deadlocks per second",
+      unit: "deadlocks/s",
+      series: [
+        TimeSeries.new(
+          labels: {},
+          query: "sum(rate(pg_stat_database_deadlocks{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        )
+      ]
+    ),
+    database_size:
+    MetricDefinition.new(
+      name: "Database size",
+      description: "Top 5 databases by size",
+      unit: "bytes",
+      series: [
+        TimeSeries.new(
+          labels: {},
+          query: "topk(5, sum(pg_database_size_bytes{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\", datname!~\"template0|template1\"}) by (datname))"
+        )
+      ]
+    )
+  }
+end

--- a/lib/metrics_target_methods.rb
+++ b/lib/metrics_target_methods.rb
@@ -21,7 +21,10 @@ module MetricsTargetMethods
       additional_labels: {foo: "bar"},
 
       # Directory to store the collected metrics
-      metrics_dir: "/home/ubi/metrics"
+      metrics_dir: "/home/ubi/metrics",
+
+      # Service Project ID to use for the metrics storage
+      project_id: Config.victoria_metrics_service_project_id
     }
   end
 

--- a/lib/metrics_target_resource.rb
+++ b/lib/metrics_target_resource.rb
@@ -13,7 +13,7 @@ class MetricsTargetResource
     @export_started_at = Time.now
     @deleted = false
 
-    vmr = VictoriaMetricsResource.first(project_id: Config.victoria_metrics_service_project_id)
+    vmr = VictoriaMetricsResource.first(project_id: resource.metrics_config[:project_id])
     vms = vmr&.servers&.first
     @tsdb_client = vms&.client
   end

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -303,4 +303,12 @@ module Validation
     fail ValidationFailed.new({storage_size: "VictoriaMetrics storage must be between #{min_storage_size}GiB and #{max_storage_size}GiB"}) unless storage_size.between?(min_storage_size, max_storage_size)
     storage_size
   end
+
+  def self.validate_rfc3339_datetime_str(datetime_str, param = "time")
+    # Try parsing as RFC 3339 datetime string
+    DateTime.rfc3339(datetime_str).to_time.utc
+  rescue ArgumentError
+    msg = "\"#{datetime_str}\" is not a valid date for \"#{param}\"."
+    fail ValidationFailed.new({param => msg})
+  end
 end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -264,7 +264,8 @@ class PostgresServer < Sequel::Model
       max_file_retention: 120,
       interval: "15s",
       additional_labels: {},
-      metrics_dir: "/home/ubi/postgres/metrics"
+      metrics_dir: "/home/ubi/postgres/metrics",
+      project_id: Config.postgres_service_project_id
     }
   end
 end

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -958,6 +958,45 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Metric Destination
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/metrics':
+    parameters:
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_reference'
+      - $ref: '#/components/parameters/project_id'
+    get:
+      operationId: getPostgresDatabaseMetrics
+      summary: Get metrics for a specific Postgres Database in a location
+      parameters:
+        - name: start
+          in: query
+          description: Start time for metrics query (rfc3339 format)
+          required: false
+          schema:
+            type: string
+            example: '2025-05-12T11:57:24+00:00'
+            default: now-30m
+        - name: end
+          in: query
+          description: End time for metrics query (rfc3339 format)
+          required: false
+          schema:
+            type: string
+            example: '2025-05-12T11:27:24+00:00'
+            default: now
+        - name: key
+          in: query
+          description: Key of the specific metric to retrieve
+          required: false
+          schema:
+            type: string
+            example: cpu_usage
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabaseMetrics'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/promote':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -1869,6 +1908,68 @@ components:
         - vm_size
         - maintenance_window_start_at
         - read_replica
+    PostgresDatabaseMetrics:
+      type: object
+      properties:
+        metrics:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              key:
+                description: Key of the metric
+                type: string
+                example: cpu_usage
+              name:
+                description: Name of the metric
+                type: string
+                example: CPU Usage
+              description:
+                description: Description of the metric
+                type: string
+                example: CPU usage of the Postgres database
+              unit:
+                description: Unit of measurement for the metric
+                type: string
+                example: percent
+                nullable: true
+              series:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    labels:
+                      description: Labels identifying the time series
+                      type: object
+                      example:
+                        server: pv9z3a26qkyy4qcxrhzg5f1bs8
+                      additionalProperties:
+                        type: string
+                    values:
+                      description: Array of timestamp-value pairs
+                      type: array
+                      items:
+                        type: array
+                        minItems: 2
+                        maxItems: 2
+                        items:
+                          oneOf:
+                            - type: number
+                              description: Unix timestamp
+                            - type: string
+                              description: Sample value
+                  required:
+                    - labels
+                    - values
+            required:
+              - name
+              - unit
+              - series
+      additionalProperties: false
+      required:
+        - metrics
     PostgresFirewallRule:
       type: object
       properties:
@@ -2232,6 +2333,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/PostgresFirewallRule'
+    PostgresDatabaseMetrics:
+      description: Metrics data for a Postgres Database
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PostgresDatabaseMetrics'
     PostgresFirewallRules:
       description: A list of Postgres Firewall Rules
       content:

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -308,6 +308,93 @@ class Clover
         response.headers["Content-Type"] = "application/x-pem-file"
         certs
       end
+
+      r.get "metrics" do
+        authorize("Postgres:view", pg.id)
+
+        start_time = request.params["start"] || (DateTime.now.new_offset(0) - 30.0 / 1440).rfc3339
+        start_time = Validation.validate_rfc3339_datetime_str(start_time, "start")
+
+        end_time = request.params["end"] || DateTime.now.new_offset(0).rfc3339
+        end_time = Validation.validate_rfc3339_datetime_str(end_time, "end")
+
+        start_ts = start_time.to_i
+        end_ts = end_time.to_i
+
+        if end_ts < start_ts
+          raise CloverError.new(400, "InvalidRequest", "End timestamp must be greater than start timestamp")
+        end
+
+        if end_ts - start_ts > 31 * 24 * 60 * 60 + 5 * 60
+          raise CloverError.new(400, "InvalidRequest", "Maximum time range is 31 days")
+        end
+
+        if start_ts < Time.now.utc.to_i - 31 * 24 * 60 * 60
+          raise CloverError.new(400, "InvalidRequest", "Cannot query metrics older than 31 days")
+        end
+
+        metric_key = request.params["key"]&.to_sym
+        single_query = !request.params["key"].nil?
+
+        if single_query && !Metrics::POSTGRES_METRICS.key?(metric_key)
+          raise CloverError.new(400, "InvalidRequest", "Invalid metric name")
+        end
+
+        metric_keys = metric_key ? [metric_key] : Metrics::POSTGRES_METRICS.keys
+
+        vmr = VictoriaMetricsResource.first(project_id: Config.victoria_metrics_service_project_id)
+        vms = vmr&.servers&.first
+        tsdb_client = vms&.client
+
+        if tsdb_client.nil?
+          raise CloverError.new(404, "NotFound", "Metrics are not configured for this instance")
+        end
+
+        results = metric_keys.map do |key|
+          metric_definition = Metrics::POSTGRES_METRICS[key]
+
+          series_results = metric_definition.series.filter_map do |s|
+            query = s.query.gsub("$ubicloud_resource_id", pg.ubid)
+            begin
+              series_query_result = tsdb_client.query_range(
+                query: query,
+                start_ts: start_ts,
+                end_ts: end_ts
+              )
+
+              # This can be a two cases:
+              # 1. Missing data (e.g. no data for the given time range)
+              # 2. No data for the given query (maybe bad query)
+              if series_query_result.empty?
+                next
+              end
+
+              # Combine labels with configured series labesls.
+              series_query_result.each { it["labels"].merge!(s.labels) }
+
+              series_query_result
+            rescue VictoriaMetrics::ClientError => e
+              Clog.emit("Could not query VictoriaMetrics") { {error: e.message, query: query} }
+
+              if single_query
+                raise CloverError.new(500, "InternalError", "Internal error while querying metrics", {query: query})
+              end
+            end
+          end
+
+          {
+            key: key.to_s,
+            name: metric_definition.name,
+            unit: metric_definition.unit,
+            description: metric_definition.description,
+            series: series_results.flatten
+          }
+        end
+
+        {
+          metrics: results
+        }
+      end
     end
   end
 end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -342,7 +342,7 @@ class Clover
 
         metric_keys = metric_key ? [metric_key] : Metrics::POSTGRES_METRICS.keys
 
-        vmr = VictoriaMetricsResource.first(project_id: Config.victoria_metrics_service_project_id)
+        vmr = VictoriaMetricsResource.first(project_id: pg.representative_server.metrics_config[:project_id])
         vms = vmr&.servers&.first
         tsdb_client = vms&.client
 

--- a/spec/lib/metrics_target_resource_spec.rb
+++ b/spec/lib/metrics_target_resource_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe MetricsTargetResource do
 
   describe "#initialize" do
     it "initializes with a resource and nil tsdb client when VictoriaMetrics is not found" do
+      expect(Config).to receive(:postgres_service_project_id).and_return("4d8f9896-26a3-4784-8f52-2ed5d5e55c0e")
       expect(resource.instance_variable_get(:@resource)).to eq(postgres_server)
     end
 
     it "initializes with a resource and a tsdb client when VictoriaMetrics is found" do
-      prj = Project.create_with_id(name: "vm-project") { it.id = "4d8f9896-26a3-4784-8f52-2ed5d5e55c0e" }
-      expect(Config).to receive(:victoria_metrics_service_project_id).and_return(prj.id)
+      expect(Config).to receive(:postgres_service_project_id).at_least(:once).and_return("4d8f9896-26a3-4784-8f52-2ed5d5e55c0e")
+      prj = Project.create_with_id(name: "pg-project") { it.id = Config.postgres_service_project_id }
       vmr = instance_double(VictoriaMetricsResource, project_id: prj.id)
       expect(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
       expect(vmr).to receive(:servers).and_return([instance_double(VictoriaMetricsServer, client: "tsdb_client")])
@@ -62,7 +63,7 @@ RSpec.describe MetricsTargetResource do
   describe "#export_metrics" do
     before do
       prj = Project.create_with_id(name: "vm-project") { it.id = "4d8f9896-26a3-4784-8f52-2ed5d5e55c0d" }
-      expect(Config).to receive(:victoria_metrics_service_project_id).and_return(prj.id)
+      expect(Config).to receive(:postgres_service_project_id).and_return(prj.id)
       vmr = instance_double(VictoriaMetricsResource, project_id: prj.id)
       expect(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
       expect(vmr).to receive(:servers).and_return([instance_double(VictoriaMetricsServer, client: "tsdb_client")])

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -555,4 +555,22 @@ RSpec.describe Validation do
       expect(described_class.validate_victoria_metrics_storage_size("100")).to eq(100)
     end
   end
+
+  describe "#validate_rfc3339_datetime_str" do
+    it "validates RFC 3339 datetime strings" do
+      ["2025-05-12T11:57:24+00:00", "2025-05-12T11:57:24+05:30", "2025-05-12T11:57:24-02:00"].each do |datetime_str|
+        expect { described_class.validate_rfc3339_datetime_str(datetime_str) }.not_to raise_error
+      end
+    end
+
+    it "invalidates non-RFC 3339 datetime strings" do
+      ["1747053663", "abc", "2025-05-12T11:57:24"].each do |datetime_str|
+        expect { described_class.validate_rfc3339_datetime_str(datetime_str) }.to raise_error described_class::ValidationFailed
+      end
+    end
+
+    it "converts string input to Time" do
+      expect(described_class.validate_rfc3339_datetime_str("2025-05-12T11:57:24+00:00")).to be_a(Time)
+    end
+  end
 end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe Clover, "postgres" do
       let(:tsdb_client) { instance_double(VictoriaMetrics::Client) }
 
       before do
-        allow(Config).to receive(:victoria_metrics_service_project_id).and_return(prj.id)
+        allow(Config).to receive(:postgres_service_project_id).and_return(prj.id)
         allow(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
         allow(vmr).to receive(:servers).and_return([vm_server])
         allow(Project).to receive(:from_ubid).and_return(project)


### PR DESCRIPTION
## Description

This commit introduces an API to fetch metrics for a given PG resource. The list supported metrics is maintained in lib/metrics.rb. The system supports upto a month of historical data, with the query evaluation interval adjusted to return upto 480 datapoints per time series.

## Tests
- [x] Unit tests
- [x] Local run
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds an API endpoint to fetch metrics for Postgres resources, supporting various metrics and historical data, with comprehensive validation and error handling.
> 
>   - **API**:
>     - Adds `GET /project/{project_id}/location/{location}/postgres/{postgres_database_reference}/metrics` endpoint in `openapi.yml` to fetch metrics for a Postgres database.
>     - Supports optional query parameters `start`, `end`, and `key` for time range and specific metric selection.
>   - **Metrics**:
>     - Introduces `lib/metrics.rb` to define supported Postgres metrics like `cpu_usage`, `memory_usage`, `disk_io`, etc.
>     - Implements `query_range` in `lib/victoria_metrics/client.rb` to fetch time series data from VictoriaMetrics.
>   - **Validation**:
>     - Adds `validate_rfc3339_datetime_str` in `lib/validation.rb` to validate datetime strings.
>   - **Configuration**:
>     - Updates `metrics_config` in `lib/metrics_target_methods.rb` and `model/postgres/postgres_server.rb` to include `project_id` for metrics storage.
>   - **Error Handling**:
>     - Handles errors for invalid metric names, time ranges, and missing configurations in `routes/project/location/postgres.rb`.
>   - **Tests**:
>     - Adds tests in `spec/routes/api/project/location/postgres_spec.rb` for the new metrics endpoint.
>     - Includes unit tests for `query_range` in `spec/lib/victoria_metrics/client_spec.rb` and validation in `spec/lib/validation_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 75e43d501835cf18d986dbcf74a978d6cb527cfd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->