### PR TITLE
Add image download time to failure E2E slack notification

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -137,6 +137,14 @@ jobs:
       if: always()
       run: grep -h -v -E "sleep_duration_sec|monitor.1" foreman.log
 
+    - name: Extract image download time
+      if: always()
+      id: extract_download
+      run: |
+        download_time="$(grep "VmHost.wait_download_boot_images" foreman.log | cut -d'|' -f2 | tail -1)"
+        echo "### Image downloaded in $download_time" >> $GITHUB_STEP_SUMMARY
+        echo "DOWNLOAD_TIME=$download_time" >> $GITHUB_OUTPUT
+
     - name: Upload logs
       if: always()
       uses: actions/upload-artifact@v4
@@ -162,5 +170,8 @@ jobs:
                   short: true
                   value: "<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.ref_name }}>"
                 - title: "Action"
-                  short: false
+                  short: true
                   value: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                - title: "Download Time"
+                  short: true
+                  value: "${{ steps.extract_download.outputs.DOWNLOAD_TIME }}"


### PR DESCRIPTION
When the internal MinIO is unstable, our E2E tests time out due to slow image downloads. We need to check the logs to confirm the root cause. By adding the image download time to the notification, we can speed up the investigation.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add image download time extraction and reporting to E2E test failure notifications in `.github/workflows/e2e.yml`.
> 
>   - **Behavior**:
>     - Adds step `Extract image download time` in `.github/workflows/e2e.yml` to capture image download duration from `foreman.log`.
>     - Appends download time to GitHub step summary and sets it as an output variable.
>     - Includes download time in Slack notification payload for E2E test failures.
>   - **Misc**:
>     - Modifies Slack notification to include `Download Time` field with extracted value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2fea73a8d5d6089cfef5ac0bffc4d928c3c519fe. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->