### PR TITLE
Add -dedup.minScrapeInterval to VictoriaMetrics command line

### DIFF
--- a/rhizome/victoria_metrics/bin/configure
+++ b/rhizome/victoria_metrics/bin/configure
@@ -31,6 +31,7 @@ RestartSec=1
 ExecStart=/usr/local/bin/victoria-metrics-prod \
         -storageDataPath=/dat/victoria_metrics \
         -httpListenAddr=127.0.0.1:8428 \
+        -dedup.minScrapeInterval=15s \
         -retentionPeriod=#{config_json["retention_period"] or 1}
 ExecStop=/bin/kill -s SIGTERM $MAINPID
 LimitNOFILE=65536


### PR DESCRIPTION
This parameter is used to dedup samples recevied within a configured scrape interval (15s in our case), to avoid multiple copies of the same data in case of retransmission.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `-dedup.minScrapeInterval=15s` to VictoriaMetrics configuration to deduplicate samples within a 15-second interval.
> 
>   - **Behavior**:
>     - Adds `-dedup.minScrapeInterval=15s` to VictoriaMetrics startup command in `configure` to deduplicate samples within a 15-second interval.
>   - **Purpose**:
>     - Prevents multiple copies of the same data in case of retransmission.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 55db5474981b606a5aab23897a93d8c9d20dd36c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->