### PR TITLE
Show different display state if waiting for the maintenance window

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -103,6 +103,10 @@ class PostgresResource < Sequel::Model
     servers.any? { it.needs_recycling? } || servers.count != target_server_count
   end
 
+  def in_maintenance_window?
+    maintenance_window_start_at.nil? || (Time.now.utc.hour - maintenance_window_start_at) % 24 < MAINTENANCE_DURATION_IN_HOURS
+  end
+
   def set_firewall_rules
     vm_firewall_rules = firewall_rules.map { {cidr: it.cidr.to_s, port_range: Sequel.pg_range(5432..5432)} }
     vm_firewall_rules.concat(firewall_rules.map { {cidr: it.cidr.to_s, port_range: Sequel.pg_range(6432..6432)} })

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -37,11 +37,9 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     if (rs = postgres_resource.representative_server)
       hop_prune_servers unless rs.needs_recycling?
 
-      current_hour = Time.now.utc.hour
-      maintenance_window_start_at = postgres_resource.maintenance_window_start_at
-      nap 10 * 60 if maintenance_window_start_at && (current_hour - maintenance_window_start_at) % 24 >= PostgresResource::MAINTENANCE_DURATION_IN_HOURS
-      register_deadline(nil, 10 * 60)
+      nap 10 * 60 unless postgres_resource.in_maintenance_window?
 
+      register_deadline(nil, 10 * 60)
       rs.trigger_failover
     end
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe PostgresResource do
     end
   end
 
+  it "returns in_maintenance_window? correctly" do
+    expect(postgres_resource).to receive(:maintenance_window_start_at).and_return(nil)
+    expect(postgres_resource.in_maintenance_window?).to be(true)
+
+    expect(postgres_resource).to receive(:maintenance_window_start_at).and_return(1).at_least(:once)
+    expect(Time).to receive(:now).and_return(Time.parse("2025-05-01 02:00:00Z"), Time.parse("2025-05-01 04:00:00Z"), Time.parse("2025-05-01 00:00:00Z"))
+    expect(postgres_resource.in_maintenance_window?).to be(true)
+    expect(postgres_resource.in_maintenance_window?).to be(false)
+    expect(postgres_resource.in_maintenance_window?).to be(false)
+  end
+
   it "returns target_standby_count correctly" do
     expect(postgres_resource).to receive(:ha_type).and_return(PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC)
     (0..2).each { expect(postgres_resource.target_standby_count).to eq(it) }

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -96,18 +96,15 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
     it "waits if it is not the maintenance window" do
       expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: true)).at_least(:once)
-      expect(postgres_resource).to receive(:maintenance_window_start_at).and_return(4)
-      expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 1, 1))
+      expect(postgres_resource).to receive(:in_maintenance_window?).and_return(false)
       expect(postgres_resource.representative_server).not_to receive(:trigger_failover)
       expect { nx.recycle_representative_server }.to nap(10 * 60)
     end
 
     it "triggers failover if maintenance window is not set or if it is the maintenance window" do
       expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: true)).at_least(:once)
-      expect(postgres_resource).to receive(:maintenance_window_start_at).and_return(nil, 4)
-      expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 1, 5)).at_least(:once)
-      expect(postgres_resource.representative_server).to receive(:trigger_failover).twice
-      expect { nx.recycle_representative_server }.to nap(60)
+      expect(postgres_resource).to receive(:in_maintenance_window?).and_return(true)
+      expect(postgres_resource.representative_server).to receive(:trigger_failover)
       expect { nx.recycle_representative_server }.to nap(60)
     end
   end


### PR DESCRIPTION
**Add in_maintenance_window? helper to PostgresResource**
Deciding whether a resource is in the maintenance window requires non-trivial
calculation. We will need it in multiple places, so we add a helper method to
the PostgresResource model.

**Show different display state if waiting for the maintenance window**
If the resource is ready for failover but waiting for the maintenance window,
it is better to show that in the UI. Otherwise users would have no idea on why
the resource is not failing over.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `in_maintenance_window?` to `PostgresResource` and updates display state and convergence logic to respect maintenance windows.
> 
>   - **Behavior**:
>     - Adds `in_maintenance_window?` to `PostgresResource` to check if current time is within maintenance window.
>     - Updates `display_state` in `PostgresResource` to show "waiting for maintenance window" if ready for failover but outside maintenance window.
>     - Modifies `recycle_representative_server` in `converge_postgres_resource.rb` to wait if outside maintenance window.
>   - **Tests**:
>     - Adds tests for `in_maintenance_window?` and updated `display_state` logic in `postgres_resource_spec.rb`.
>     - Updates tests in `converge_postgres_resource_spec.rb` to reflect changes in maintenance window handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e517a33bee9fadf1de74550603cc0895f767ef84. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->