### PR TITLE
Mount data disk when setting up VictoriaMetrics

### DIFF
--- a/prog/victoria_metrics/victoria_metrics_server_nexus.rb
+++ b/prog/victoria_metrics/victoria_metrics_server_nexus.rb
@@ -85,7 +85,7 @@ class Prog::VictoriaMetrics::VictoriaMetricsServerNexus < Prog::Base
     case vm.sshable.d_check("install_victoria_metrics")
     when "Succeeded"
       vm.sshable.d_clean("install_victoria_metrics")
-      hop_configure
+      hop_mount_data_disk
     when "Failed", "NotStarted"
       vm.sshable.d_run("install_victoria_metrics", "/home/ubi/victoria_metrics/bin/install", Config.victoria_metrics_version)
     end

--- a/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
+++ b/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
     it "hops to configure if install is complete" do
       expect(vm.sshable).to receive(:d_check).with("install_victoria_metrics").and_return("Succeeded")
       expect(vm.sshable).to receive(:d_clean).with("install_victoria_metrics")
-      expect { nx.install }.to hop("configure")
+      expect { nx.install }.to hop("mount_data_disk")
     end
 
     it "naps if the status is unknown" do


### PR DESCRIPTION
## Description

Bugfix
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix bug in `victoria_metrics_server_nexus.rb` to mount data disk after VictoriaMetrics installation.
> 
>   - **Behavior**:
>     - In `victoria_metrics_server_nexus.rb`, change `hop_configure` to `hop_mount_data_disk` in `install` method to ensure data disk is mounted after installation.
>   - **Tests**:
>     - Update `victoria_metrics_server_nexus_spec.rb` to reflect the change from `hop("configure")` to `hop("mount_data_disk")` in `install` method test.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c40818b2e05aff8ea0345842a92473211342858f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->