### PR TITLE
Support sub sub domains for K8s service URLs

### DIFF
--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -34,11 +34,13 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   label def create_services_load_balancer
     hop_bootstrap_worker_vms if LoadBalancer[name: kubernetes_nodepool.cluster.services_load_balancer_name]
 
-    custom_hostname_dns_zone_id = DnsZone[name: Config.kubernetes_service_hostname]&.id
-    custom_hostname_prefix = if custom_hostname_dns_zone_id
+    dns_zone = DnsZone[name: Config.kubernetes_service_hostname]
+
+    custom_hostname_prefix = if dns_zone
       "#{kubernetes_nodepool.cluster.ubid.to_s[-10...]}-services"
     end
-    Prog::Vnet::LoadBalancerNexus.assemble(
+
+    lb = Prog::Vnet::LoadBalancerNexus.assemble(
       kubernetes_nodepool.cluster.private_subnet_id,
       name: kubernetes_nodepool.cluster.services_load_balancer_name,
       algorithm: "hash_based",
@@ -49,10 +51,12 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
       dst_port: 6443,
       health_check_endpoint: "/",
       health_check_protocol: "tcp",
-      custom_hostname_dns_zone_id:,
+      custom_hostname_dns_zone_id: dns_zone&.id,
       custom_hostname_prefix:,
       stack: LoadBalancer::Stack::IPV4
-    )
+    ).subject
+
+    lb.dns_zone&.insert_record(record_name: "*.#{lb.hostname}.", type: "CNAME", ttl: 3600, data: "#{lb.hostname}.")
 
     hop_bootstrap_worker_vms
   end
@@ -77,7 +81,12 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
     reap
     donate unless leaf?
     decr_destroy
-    LoadBalancer[name: kubernetes_nodepool.cluster.services_load_balancer_name]&.incr_destroy
+
+    lb = LoadBalancer[name: kubernetes_nodepool.cluster.services_load_balancer_name]
+    if (dns_zone = DnsZone[name: Config.kubernetes_service_hostname])
+      dns_zone.delete_record(record_name: "*.#{lb.hostname}.")
+    end
+    lb.incr_destroy
     kubernetes_nodepool.vms.each(&:incr_destroy)
     kubernetes_nodepool.remove_all_vms
     kubernetes_nodepool.destroy

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -115,6 +115,11 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       expect(lb.name).to eq kc.services_load_balancer_name
       expect(lb.custom_hostname_dns_zone_id).to eq dns_zone.id
       expect(lb.custom_hostname).to eq "#{kc.ubid.to_s[-10...]}-services.k8s.ubicloud.com"
+
+      record = DnsRecord[name: "*.#{kc.ubid.to_s[-10...]}-services.k8s.ubicloud.com."]
+      expect(record).not_to be_nil
+      expect(record.type).to eq "CNAME"
+      expect(record.data).to eq "#{lb.hostname}."
     end
   end
 
@@ -174,14 +179,21 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       expect { nx.destroy }.to exit({"msg" => "kubernetes nodepool is deleted"})
     end
 
-    it "destroys the nodepool and its vms with non existing services loadbalancer" do
-      vms = [create_vm, create_vm]
-      expect(kn).to receive(:vms).and_return(vms)
+    it "deletes the sub-subdomain DNS record if the DNS zone exists" do
+      allow(Config).to receive(:kubernetes_service_hostname).and_return("k8s.ubicloud.com")
+      dns_zone = DnsZone.create_with_id(project_id: Project.first.id, name: "k8s.ubicloud.com", last_purged_at: Time.now)
+      Prog::Vnet::LoadBalancerNexus.assemble(
+        subnet.id,
+        name: kc.services_load_balancer_name,
+        custom_hostname_dns_zone_id: dns_zone&.id,
+        custom_hostname_prefix: "#{kc.ubid.to_s[-10...]}-services",
+        src_port: 443, dst_port: 8443
+      )
 
-      expect(vms).to all(receive(:incr_destroy))
-      expect(kn).to receive(:remove_all_vms)
-      expect(kn).to receive(:destroy)
+      dns_zone.insert_record(record_name: "*.#{kc.ubid.to_s[-10...]}-services.k8s.ubicloud.com.", type: "CNAME", ttl: 123, data: "whatever.")
+
       expect { nx.destroy }.to exit({"msg" => "kubernetes nodepool is deleted"})
+      expect(DnsRecord[name: "*.#{kc.ubid.to_s[-10...]}-services.k8s.ubicloud.com.", tombstoned: true]).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
This change adds an additional wildcard DNS record routing anything
    under the K8s services URL to the actual K8s services URL.

This would allow users to deploy different applications on the provided
    domain and configure ingress inside the k8s cluster to route everything
    to the correct app.

One such example is Okteto. When Okteto is deployed:
    - It deploys 4 different apps for the Okteto itself
    (okteto.xxxxx-services, registry.xxxxx-services)
    - It also deploys every development environment with a subdomain too

As a future work, we can also integrate DNS challenge support to our CCM
    with these subdomains to make things even more interesting.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for sub-subdomains in Kubernetes service URLs by managing wildcard DNS records in `kubernetes_nodepool_nexus.rb`.
> 
>   - **Behavior**:
>     - Adds wildcard DNS record for sub-subdomains in `create_services_load_balancer` in `kubernetes_nodepool_nexus.rb`.
>     - Deletes DNS record in `destroy` in `kubernetes_nodepool_nexus.rb` if DNS zone exists.
>   - **Tests**:
>     - Updates `kubernetes_nodepool_nexus_spec.rb` to test creation and deletion of DNS records.
>     - Adds test for DNS record creation with `CNAME` type and correct data.
>     - Adds test for DNS record deletion when DNS zone exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0a4b3e02b668cb656e24ee15c43d7617b9316024. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->