### PR TITLE
Fix race with cert server leaving vm stuck in prep

### DIFF
--- a/rhizome/host/lib/cert_server_setup.rb
+++ b/rhizome/host/lib/cert_server_setup.rb
@@ -131,7 +131,10 @@ CERT_SERVICE
   end
 
   def put_certificate(cert_payload, cert_key_payload)
-    FileUtils.mkdir_p(cert_folder)
+    begin
+      FileUtils.mkdir(cert_folder)
+    rescue Errno::EEXIST
+    end
     safe_write_to_file(cert_path, cert_payload)
     safe_write_to_file(key_path, cert_key_payload)
   end

--- a/rhizome/host/spec/cert_server_setup_spec.rb
+++ b/rhizome/host/spec/cert_server_setup_spec.rb
@@ -127,7 +127,7 @@ MemoryLimit=10M
 
   describe "#put_certificate" do
     it "puts the certificate to the server" do
-      expect(FileUtils).to receive(:mkdir_p).with("/vm/test-vm/cert")
+      expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert")
       expect(cert_server_setup).to receive(:safe_write_to_file).with("/vm/test-vm/cert/cert.pem", "cert")
       expect(cert_server_setup).to receive(:safe_write_to_file).with("/vm/test-vm/cert/key.pem", "key")
 


### PR DESCRIPTION
When creating a VM attached to a load balancer, cert server puts a certificate into the folder `/vm/inhost_name/cert` by executing `sudo host/bin/setup-cert-server put-certificate inhost_name`

During that call, before writing the certs, it first creates the cert folder using `mkdir_p` (as the root user). If  /vm/inhost_name didn't exist yet at that point, the folder /vm/inhost_name was created like this:

```
ll inhost_name
total 12
drwxr-xr-x 3 root root 4096 May  9 12:52 ./
drwxr-xr-x 7 root root 4096 May  9 12:52 ../
drwxr-xr-x 2 root root 4096 May  9 12:52 cert/
```

This is what subsequently happens to VM provisioning in that case:

* create_unix_user: succeeds but gives this warning
```
adduser: Warning: The home directory `/vm/inhost_name'
does not belong to the user you are currently creating.
```

* prep: Fails with `tee: /vm/inhost_name/prep.json: Permission denied`

As a fix, we use `mkdir` instead of `mkdir_p` and just ignore the error indicating that the folder already exists. That way, it won't create the /vm/inhost_name folder. Putting the certificate should succeed after `create_unix_user` has created /vm/inhost_name.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes race condition in `put_certificate` by using `mkdir` to prevent incorrect directory creation, updating tests accordingly.
> 
>   - **Behavior**:
>     - Fixes race condition in `put_certificate` in `cert_server_setup.rb` by using `mkdir` instead of `mkdir_p` to prevent incorrect directory creation.
>     - Ensures `/vm/inhost_name` is not created prematurely, avoiding permission issues during VM provisioning.
>   - **Tests**:
>     - Updates test in `cert_server_setup_spec.rb` to expect `mkdir` instead of `mkdir_p` for certificate directory creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 65c0425a1afd98fe537c0494b616503f0787a4ec. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->