### PR TITLE
Use hostname for VictoriaMetrics client in production

### DIFF
--- a/model/victoria_metrics_server.rb
+++ b/model/victoria_metrics_server.rb
@@ -29,6 +29,10 @@ class VictoriaMetricsServer < Sequel::Model
     "https://[#{public_ipv6_address}]:8427"
   end
 
+  def endpoint
+    (Config.development? || Config.is_e2e) ? ip6_url : "https://#{resource.hostname}:8427"
+  end
+
   def init_health_monitor_session
     socket_path = File.join(Dir.pwd, "var", "health_monitor_sockets", "vn_#{vm.ephemeral_net6.nth(2)}")
     FileUtils.rm_rf(socket_path)
@@ -63,7 +67,7 @@ class VictoriaMetricsServer < Sequel::Model
 
   def client(socket: nil)
     VictoriaMetrics::Client.new(
-      endpoint: ip6_url,
+      endpoint: endpoint,
       ssl_ca_file_data: resource.root_certs + cert,
       socket: socket,
       username: resource.admin_user,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `endpoint` method to use hostname for VictoriaMetrics client in production, updating client instantiation and tests accordingly.
> 
>   - **Behavior**:
>     - Add `endpoint` method in `victoria_metrics_server.rb` to use hostname in production and `ip6_url` in development or e2e.
>     - Update `client` method to use `endpoint` instead of `ip6_url`.
>   - **Tests**:
>     - Update tests in `victoria_metrics_server_spec.rb` to check `endpoint` method behavior in different environments.
>     - Modify `client` method tests to verify correct endpoint usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7f0038971f16d3fb5abb7c8eea7c823dba9c6f3f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->