### PR TITLE
Enable slice-based allocation by default on Ubuntu 24.04.

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -17,9 +17,6 @@ def main(options)
   tests_to_wait = []
   if options[:test_cases].include?("vm") && (test_case = all_test_cases["vm"])
     # Testing slices is not parallel with other tests as it requires a specific host state
-    # YYY: Make this default when all hosts in prod support slices.
-    Semaphore.incr(hetzner_server_st.id, "allow_slices")
-    wait_until(hetzner_server_st, "wait")
 
     # This tests encrypted VMs with slices, which will create both standard and
     # burstable VMs. The test will also test host reboot.
@@ -30,6 +27,7 @@ def main(options)
     # on when the host is rebooted and can cause flaky issues for github runner tests.
     wait_until(encrypted_vms_st)
 
+    # YYY: Remove this when all hosts use slices
     Semaphore.incr(hetzner_server_st.id, "disallow_slices")
     wait_until(hetzner_server_st, "wait")
 

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HetznerServer < Prog::Test::Base
-  semaphore :verify_cleanup_and_destroy, :allow_slices, :disallow_slices
+  semaphore :verify_cleanup_and_destroy, :disallow_slices
 
   def self.assemble(vm_host_id: nil, default_boot_images: [])
     frame = if vm_host_id
@@ -110,22 +110,11 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       hop_verify_cleanup
     end
 
-    when_allow_slices_set? do
-      hop_allow_slices
-    end
-
     when_disallow_slices_set? do
       hop_disallow_slices
     end
 
     nap 15
-  end
-
-  label def allow_slices
-    vm_host.allow_slices
-    Semaphore.where(strand_id: strand.id, name: "allow_slices").destroy
-
-    hop_wait
   end
 
   label def disallow_slices

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -90,11 +90,16 @@ class Prog::Vm::HostNexus < Prog::Base
     hop_wait_prep
   end
 
+  def os_supports_slices?(os_version)
+    os_version == "ubuntu-24.04"
+  end
+
   label def wait_prep
     reap.each do |st|
       case st.prog
       when "LearnOs"
-        vm_host.update(os_version: st.exitval.fetch("os_version"))
+        os_version = st.exitval.fetch("os_version")
+        vm_host.update(os_version: os_version, accepts_slices: os_supports_slices?(os_version))
       when "LearnMemory"
         mem_gib = st.exitval.fetch("mem_gib")
         vm_host.update(total_mem_gib: mem_gib)

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -147,11 +147,6 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.wait }.to hop("verify_cleanup")
     end
 
-    it "hops to allow_slices when signaled" do
-      expect(hs_test).to receive(:when_allow_slices_set?).and_yield
-      expect { hs_test.wait }.to hop("allow_slices")
-    end
-
     it "hops to disallow_slices when signaled" do
       expect(hs_test).to receive(:when_disallow_slices_set?).and_yield
       expect { hs_test.wait }.to hop("disallow_slices")
@@ -159,13 +154,6 @@ RSpec.describe Prog::Test::HetznerServer do
 
     it "naps" do
       expect { hs_test.wait }.to nap(15)
-    end
-  end
-
-  describe "#allow_slices" do
-    it "allows slices" do
-      expect(vm_host).to receive(:allow_slices)
-      expect { hs_test.allow_slices }.to hop("wait")
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -197,11 +197,18 @@ RSpec.describe Prog::Vm::HostNexus do
     end
   end
 
+  describe "#os_supports_slices?" do
+    it "returns true if the OS supports slices" do
+      expect(nx.os_supports_slices?("ubuntu-22.04")).to be false
+      expect(nx.os_supports_slices?("ubuntu-24.04")).to be true
+    end
+  end
+
   describe "#wait_prep" do
     it "updates the vm_host record from the finished programs" do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
-      expect(vm_host).to receive(:update).with(os_version: "ubuntu-22.04")
+      expect(vm_host).to receive(:update).with(os_version: "ubuntu-22.04", accepts_slices: false)
       expect(vm_host).to receive(:update).with(arch: "arm64", total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),


### PR DESCRIPTION
Now that we have tested slice-based allocation for a while, it is reasonable to make it default for future host setups.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable slice-based allocation by default for Ubuntu 24.04, removing conditional logic for allowing slices.
> 
>   - **Behavior**:
>     - Enables slice-based allocation by default for Ubuntu 24.04 in `host_nexus.rb`.
>     - Removes `allow_slices` semaphore and related logic in `hetzner_server.rb` and `ci`.
>   - **Functions**:
>     - Updates `os_supports_slices?` in `host_nexus.rb` to return true for Ubuntu 24.04.
>   - **Tests**:
>     - Removes tests related to `allow_slices` in `hetzner_server_spec.rb`.
>     - Adds test for `os_supports_slices?` in `host_nexus_spec.rb` to verify behavior for Ubuntu 24.04.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a8e92799626bc994a3954634fc96f8314ce41ef2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->