### PR TITLE
Partition management for archived_records

### DIFF
--- a/migrate/20250512_archived_record_maintenance.rb
+++ b/migrate/20250512_archived_record_maintenance.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    Array.new(4) { |i| Date.new(2024, 12, 1).next_month(i) }.each do |month|
+      drop_table("archived_record_#{month.strftime("%Y_%m")}")
+    end
+
+    Array.new(4) { |i| Date.new(2026, 2, 1).next_month(i) }.each do |month|
+      create_table("archived_record_#{month.strftime("%Y_%m")}", partition_of: :archived_record) do
+        from month
+        to month.next_month
+      end
+    end
+  end
+end


### PR DESCRIPTION
Drop partitions:
archived_record_2024_12
archived_record_2025_01
archived_record_2025_02
archived_record_2025_03

Create partitions:
archived_record_2026_02
archived_record_2026_03
archived_record_2026_04
archived_record_2026_05
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds migration to drop old `archived_record` partitions and create new ones for future dates.
> 
>   - **Migration**:
>     - Adds `20250512_archived_record_maintenance.rb` to manage `archived_record` partitions.
>     - Drops partitions: `archived_record_2024_12` to `archived_record_2025_03`.
>     - Creates partitions: `archived_record_2026_02` to `archived_record_2026_05`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a3ebc39dd57f1dd79495bad36f3eabd54bf3834b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->