### PR TITLE
Start using public IPv4 for MinIO

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -22,9 +22,9 @@ class MinioServer < Sequel::Model
   end
 
   def generate_etc_hosts_entry
-    entries = ["::1 #{hostname}"]
+    entries = ["127.0.0.1 #{hostname}"]
     entries += cluster.servers.reject { it.id == id }.map do |server|
-      "#{server.public_ipv6_address} #{server.hostname}"
+      "#{server.public_ipv4_address} #{server.hostname}"
     end
     entries.join("\n")
   end
@@ -37,8 +37,8 @@ class MinioServer < Sequel::Model
     vm.private_ipv4.to_s
   end
 
-  def public_ipv6_address
-    vm.ephemeral_net6.nth(2).to_s
+  def public_ipv4_address
+    vm.ephemeral_net4.to_s
   end
 
   def minio_volumes
@@ -48,15 +48,15 @@ class MinioServer < Sequel::Model
   end
 
   def ip4_url
-    "https://#{vm.ephemeral_net4}:9000"
+    "https://#{public_ipv4_address}:9000"
   end
 
   def endpoint
-    cluster.dns_zone ? "#{hostname}:9000" : "#{vm.ephemeral_net4}:9000"
+    cluster.dns_zone ? "#{hostname}:9000" : "#{public_ipv4_address}:9000"
   end
 
   def init_health_monitor_session
-    socket_path = File.join(Dir.pwd, "var", "health_monitor_sockets", "ms_#{vm.ephemeral_net6.nth(2)}")
+    socket_path = File.join(Dir.pwd, "var", "health_monitor_sockets", "ms_#{public_ipv4_address}")
     FileUtils.rm_rf(socket_path)
     FileUtils.mkdir_p(socket_path)
 

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -60,7 +60,6 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     register_deadline("wait", 10 * 60)
 
     minio_server.cluster.dns_zone&.insert_record(record_name: cluster.hostname, type: "A", ttl: 10, data: vm.ephemeral_net4.to_s)
-    minio_server.cluster.dns_zone&.insert_record(record_name: cluster.hostname, type: "AAAA", ttl: 10, data: vm.ephemeral_net6.nth(2).to_s)
     cert, cert_key = create_certificate
     minio_server.update(cert: cert, cert_key: cert_key)
 
@@ -182,7 +181,6 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     register_deadline(nil, 10 * 60)
     decr_destroy
     minio_server.cluster.dns_zone&.delete_record(record_name: cluster.hostname, type: "A", data: vm.ephemeral_net4&.to_s)
-    minio_server.cluster.dns_zone&.delete_record(record_name: cluster.hostname, type: "AAAA", data: vm.ephemeral_net6&.nth(2)&.to_s)
     minio_server.vm.sshable.destroy
     minio_server.vm.nics.each { it.incr_destroy }
     minio_server.vm.incr_destroy
@@ -208,7 +206,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       root_cert_key = OpenSSL::PKey::EC.new(minio_server.cluster.root_cert_key_2)
     end
 
-    ip_san = (Config.development? || Config.is_e2e) ? ",IP:#{minio_server.vm.ephemeral_net4},IP:#{minio_server.vm.ephemeral_net6.nth(2)}" : nil
+    ip_san = (Config.development? || Config.is_e2e) ? ",IP:#{minio_server.vm.ephemeral_net4}" : nil
 
     Util.create_certificate(
       subject: "/C=US/O=Ubicloud/CN=#{minio_server.cluster.ubid} Server Certificate",

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -86,7 +86,7 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
-::1 minio-cluster-name0.minio.ubicloud.com
+127.0.0.1 minio-cluster-name0.minio.ubicloud.com
 ECHO
       JSON.generate({
         minio_config: minio_config,


### PR DESCRIPTION
It looks like performance tuning guideline of MinIO suggests disabling IPv6 for the instance all together. This is weird but I will still give the whole guideline a shot
(https://github.com/minio/minio/blob/master/docs/tuning/tuned.conf) which first requires me to switch the existing cluster to IPv4 from public IPv6.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch MinIO server configuration from public IPv6 to IPv4, updating methods and tests accordingly.
> 
>   - **Behavior**:
>     - Switches MinIO server configuration from public IPv6 to public IPv4 in `minio_server.rb` and `minio_server_nexus.rb`.
>     - Updates `/etc/hosts` entries to use `127.0.0.1` instead of `::1`.
>   - **Methods**:
>     - Replaces `public_ipv6_address` with `public_ipv4_address` in `minio_server.rb`.
>     - Updates `ip_san` in `create_certificate` to use IPv4.
>   - **Tests**:
>     - Updates tests in `minio_server_spec.rb` and `minio_server_nexus_spec.rb` to reflect IPv4 changes.
>     - Removes references to IPv6 in test setups and expectations.
>     - Ensures tests check for correct IPv4 behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 70e1d30b91ee6390a0621c0a77335535ee6a9d20. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->