### PR TITLE
Allow creating private subnet with same name as previously destroyed private subnet

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -32,13 +32,13 @@ class Prog::Vnet::SubnetNexus < Prog::Base
         end
       else
         port_range = allow_only_ssh ? 22..22 : 0..65535
-        fw_name = "#{name}-default"
+        fw_name = "#{name[0, 55]}-default"
         # As is typical when checking before inserting, there is a race condition here with
         # a user concurrently manually creating a firewall with the same name.  However,
         # the worst case scenario is a bogus error message, and the user could try creating
         # the private subnet again.
         unless firewall_dataset.where(Sequel[:firewall][:name] => fw_name).empty?
-          fw_name += "-#{Array.new(7) { UBID.from_base32(rand(32)) }.join}"
+          fw_name = "#{name[0, 47]}-default-#{Array.new(7) { UBID.from_base32(rand(32)) }.join}"
         end
 
         firewall = Firewall.create(name: fw_name, location_id: location.id, project_id:)

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Clover, "private subnet" do
           visit "#{project.path}/private-subnet/create"
 
           expect(page.title).to eq("Ubicloud - Create Private Subnet")
-          name = "dummy-ps"
+          name = "a123456789" * 6
           fill_in "Name", with: name
           choose option: Location::HETZNER_FSN1_ID
 
@@ -151,6 +151,10 @@ RSpec.describe Clover, "private subnet" do
           expect(SemSnap.new(ps.id).set?("destroy")).to be true
           ps.destroy
         end
+
+        expect(Firewall.where(name: "a123456789a123456789a123456789a123456789a123456789a1234-default")).not_to be_empty
+        expect(Firewall.count).to eq 2
+        expect(Firewall.get { sum(Sequel.char_length(:name)) }).to eq 126
       end
     end
 


### PR DESCRIPTION
This failed because each time you create the private subnet, it tries
to create the -default firewall.  However, destroying the private
subnet does not destroy the related -default firewall.  So the second
creation with the same name would fail when attempting to create the
firewall.

Detect that case before it happens, and if the -default firewall
already exists, append a random string to the name.

This is prone to a race condition if the user concurrently creates
a -default firewall manually, but the worst case scenario in that case
is a bogus error message to the user, which I think is acceptable.
It is possible to use a savepoint and rescue the exception and retry,
but I don't think the benefit of avoiding the race condition is worth
the complexity cost.

Additionally, when creating the firewall, truncate the private subnet
name to ensure the generated firewall name is valid.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix issue allowing creation of private subnets with the same name as destroyed ones by appending random strings to firewall names if needed.
> 
>   - **Behavior**:
>     - In `subnet_nexus.rb`, detect existing `-default` firewalls before creating a new one with the same name. If exists, append a random string to the firewall name.
>     - Truncate private subnet name to ensure valid firewall name length.
>     - Acknowledge potential race condition with manual firewall creation, but accept it due to low impact.
>   - **Tests**:
>     - Add test in `private_subnet_spec.rb` to verify creating a private subnet with the same name after destruction works correctly.
>     - Ensure firewall name uniqueness and length constraints are respected in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 989370fdeed9839944116a9e8df02776df5861b5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->