### PR TITLE
Postgres metrics bugfixes

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -700,10 +700,10 @@ function bytesFormatter(unit, precision) {
   const suffix = unitParts.length > 1 ? "/" + unitParts[1] : "";
 
   return function (value, index) {
-    if (value >= 1024 ** 4) return (value / (1024 ** 4)).toFixed(precision) + ' TiB' + suffix;
-    if (value >= 1024 ** 3) return (value / (1024 ** 3)).toFixed(precision) + ' GiB' + suffix;
-    if (value >= 1024 ** 2) return (value / (1024 ** 2)).toFixed(precision) + ' MiB' + suffix;
-    if (value >= 1024) return (value / 1024).toFixed(precision) + ' KiB' + suffix;
+    if (value >= 1024 ** 4) return flexiblePrecision(value / (1024 ** 4), precision) + ' TiB' + suffix;
+    if (value >= 1024 ** 3) return flexiblePrecision(value / (1024 ** 3), precision) + ' GiB' + suffix;
+    if (value >= 1024 ** 2) return flexiblePrecision(value / (1024 ** 2), precision) + ' MiB' + suffix;
+    if (value >= 1024) return flexiblePrecision(value / 1024, precision) + ' KiB' + suffix;
     return value + ' bytes' + suffix;
   }
 }
@@ -714,9 +714,9 @@ function opsFormatter(unit, precision) {
   const unitName = unitParts[0];
 
   return function (value, index) {
-    if (value >= 1000 ** 3) return (value / (1000 ** 3)).toFixed(precision) + ' G ' + unitName + suffix;
-    if (value >= 1000 ** 2) return (value / (1000 ** 2)).toFixed(precision) + ' M ' + unitName + suffix;
-    if (value >= 1000) return (value / 1000).toFixed(precision) + ' K ' + unitName + suffix;
+    if (value >= 1000 ** 3) return flexiblePrecision(value / (1000 ** 3), precision)+ ' G ' + unitName + suffix;
+    if (value >= 1000 ** 2) return flexiblePrecision(value / (1000 ** 2), precision)+ ' M ' + unitName + suffix;
+    if (value >= 1000) return flexiblePrecision(value / 1000, precision) + ' K ' + unitName + suffix;
     return value + ' ' + unitName + suffix;
   }
 }
@@ -757,4 +757,12 @@ function debounce(callback, delay = 1000) {
       callback(...args);
     }, delay);
   };
+}
+
+// Increase precision for values less than 10 if using 0 precision, to not
+// repeat the same single-digit axis value multiple times.
+function flexiblePrecision(value, precision) {
+  const increasedPrecision = Math.max(1, precision);
+
+  return (value < 10) ? value.toFixed(increasedPrecision) : value.toFixed(precision);
 }

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -488,6 +488,7 @@ SQL
   label def taking_over
     if postgres_server.read_replica?
       postgres_server.update(representative_at: Time.now)
+      postgres_server.resource.servers.each(&:incr_configure_metrics)
       postgres_server.resource.incr_refresh_dns_record
       hop_configure
     end
@@ -497,6 +498,7 @@ SQL
       postgres_server.update(timeline_access: "push", representative_at: Time.now, synchronization_status: "ready")
       postgres_server.resource.incr_refresh_dns_record
       postgres_server.resource.servers.each(&:incr_configure)
+      postgres_server.resource.servers.each(&:incr_configure_metrics)
       postgres_server.resource.servers.reject(&:primary?).each { it.update(synchronization_status: "catching_up") }
       postgres_server.incr_restart
       hop_configure

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -758,13 +758,15 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(postgres_server.resource).to receive(:incr_refresh_dns_record)
       expect(postgres_server).to receive(:primary?).and_return(true)
       expect(postgres_server).to receive(:incr_configure)
+      expect(postgres_server).to receive(:incr_configure_metrics)
       expect(postgres_server).to receive(:incr_restart)
 
       standby = instance_double(PostgresServer, primary?: false)
       expect(standby).to receive(:update).with(synchronization_status: "catching_up")
       expect(standby).to receive(:incr_configure)
+      expect(standby).to receive(:incr_configure_metrics)
 
-      expect(postgres_server.resource).to receive(:servers).and_return([postgres_server, standby]).twice
+      expect(postgres_server.resource).to receive(:servers).at_least(:once).and_return([postgres_server, standby])
 
       expect { nx.taking_over }.to hop("configure")
     end
@@ -781,6 +783,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         expect(Time).to receive(:now).and_return(time)
         expect(postgres_server).to receive(:update).with(representative_at: time)
         expect(postgres_server.resource).to receive(:incr_refresh_dns_record)
+        expect(postgres_server.resource).to receive(:servers).at_least(:once).and_return([postgres_server])
+        expect(postgres_server).to receive(:incr_configure_metrics)
         expect { nx.taking_over }.to hop("configure")
       end
     end


### PR DESCRIPTION
Make sure that the "ubicloud_resource_role" value in prometheus config is properly updated after a failover or promotion.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix bug to update `ubicloud_resource_role` in Prometheus config after failover/promotion and add `flexiblePrecision` for better precision handling in `app.js`.
> 
>   - **Behavior**:
>     - Ensure `ubicloud_resource_role` in Prometheus config is updated after failover/promotion in `taking_over` method of `postgres_server_nexus.rb`.
>     - Introduce `flexiblePrecision` in `app.js` to increase precision for values < 10.
>   - **Tests**:
>     - Update `taking_over` tests in `postgres_server_nexus_spec.rb` to verify `incr_configure_metrics` calls.
>   - **Misc**:
>     - Modify `bytesFormatter` and `opsFormatter` in `app.js` to use `flexiblePrecision`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3a950e195eb45120cfa6d84692a082b0c0bd2a0d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->