### PR TITLE
Attempt to reduce Heroku H12 (request timeout errors)

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -7,8 +7,8 @@ require "yaml"
 Octokit.configure do |c|
   c.connection_options = {
     request: {
-      open_timeout: 10,
-      timeout: 10
+      open_timeout: 5,
+      timeout: 5
     }
   }
 end

--- a/puma_config.rb
+++ b/puma_config.rb
@@ -3,7 +3,7 @@
 # :nocov:
 environment ENV["RACK_ENV"] || "development"
 port ENV["PORT"] || "3000"
-threads 5, 5
+threads 15, 15
 
 if @config.options[:workers] > 0
   silence_single_worker_warning


### PR DESCRIPTION
* Increase from 5 to 15 Puma threads 
* Decrease Octokit timeouts from 10 to 5
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase Puma threads and decrease Octokit timeouts to reduce Heroku H12 request timeout errors.
> 
>   - **Puma Configuration**:
>     - Increase Puma threads from 5 to 15 in `puma_config.rb` to handle more concurrent requests.
>   - **Octokit Configuration**:
>     - Decrease Octokit `open_timeout` and `timeout` from 10 to 5 seconds in `lib/github.rb` to reduce request timeouts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 158696f840da9ba8ea0b9b75356b6facc98f7228. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->