### PR TITLE
Avoid sleeping inside transaction in runtime github route

### DIFF
--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -99,8 +99,24 @@ RSpec.describe Clover, "github" do
         expect(last_response).to have_runtime_error(400, "The cache size is over the 10GB limit")
       end
 
-      it "fails if the cache entry already exists" do
+      it "fails if the cache entry already exists before upload" do
         GithubCacheEntry.create_with_id(key: "k1", version: "v1", scope: "dev", repository_id: repository.id, created_by: runner.id, committed_at: Time.now)
+        post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100}
+
+        expect(last_response).to have_runtime_error(409, "A cache entry for dev scope already exists with k1 key and v1 version.")
+      end
+
+      it "fails if the cache entry already exists after upload" do
+        s3_client = instance_double(Aws::S3::Client, create_multipart_upload: nil, delete_object: nil)
+        repository_id = repository.id
+        created_by = runner.id
+        expect(s3_client).to receive(:create_multipart_upload) do |key:, bucket:|
+          GithubCacheEntry.create(key: "k1", version: "v1", scope: "dev", repository_id:, created_by:, committed_at: Time.now)
+          Struct.new(:upload_id).new("1")
+        end
+        expect(s3_client).not_to receive(:delete_object)
+        expect(Aws::S3::Client).to receive(:new).with(anything).and_return(s3_client)
+
         post "/runtime/github/caches", {key: "k1", version: "v1", cacheSize: 100}
 
         expect(last_response).to have_runtime_error(409, "A cache entry for dev scope already exists with k1 key and v1 version.")


### PR DESCRIPTION
This actually avoids the transaction completely.  Previously, the behavior was:

* BEGIN
* GithubCacheEntry.create
  * SELECT to check for existing object
  * INSERT
* Upload blob
* GithubCacheEntry#update (UPDATE)
* COMMIT

Now behavior is:

* SELECT to check for existing object
* Upload blob
* GithubCacheEntry.create
  * SELECT to check for existing object
  * INSERT

Previously, if the GithubCacheEntry#update failed, I believe the uploaded object was never deleted from the blob store, but that should only happen if the upload_id returned matched an existing record, which seems unlikely without a bug in the blob store.  This deletes the uploaded object the if the INSERT fails.

I don't think the sleeping inside transaction is related to the H12 errors, but when increasing the Puma threads beyond the database connection pool size, you definitely want to avoid sleeping inside transactions.

Best reviewed without whitespace differences.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor GitHub cache route to avoid sleeping inside transactions and ensure uploaded objects are deleted if entry creation fails.
> 
>   - **Behavior**:
>     - Refactor transaction handling in `routes/runtime/github.rb` to avoid sleeping inside transactions.
>     - Check for existing `GithubCacheEntry` before upload; create entry after successful upload.
>     - Delete uploaded object if `GithubCacheEntry.create` fails.
>   - **Tests**:
>     - Update `github_spec.rb` to test new behavior, including pre-upload existence check and post-upload failure handling.
>     - Add test for deleting uploaded object if entry creation fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d6019161b06471ae577f2a9ffa162e1fae3a9861. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->