### PR TITLE
Set the workflow_job data when fetching from the GitHub API

### DIFF
--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -27,6 +27,7 @@ class Clover < Roda
       return
     end
     if (job = jobs.find { it[:runner_name] == runner.ubid })
+      runner.this.update(workflow_job: Sequel.pg_jsonb(job.except("steps")))
       job[:head_branch]
     else
       Clog.emit("The workflow run does not have given runner") { {runner_scope_failure: log_context} }

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -26,14 +26,14 @@ module Github
       exp: current + (8 * 60),
       iss: Config.github_app_id
     }
-    jwt = JWT.encode(key, private_key, "RS256")
+    bearer_token = JWT.encode(key, private_key, "RS256")
 
-    Octokit::Client.new(bearer_token: jwt)
+    Octokit::Client.new(bearer_token:, per_page: 100)
   end
 
-  def self.installation_client(installation_id, auto_paginate: false)
+  def self.installation_client(installation_id, auto_paginate: false, per_page: 100)
     access_token = app_client.create_app_installation_access_token(installation_id)[:token]
-    Octokit::Client.new(access_token:, auto_paginate:)
+    Octokit::Client.new(access_token:, auto_paginate:, per_page:)
   end
 
   # :nocov:
@@ -52,7 +52,7 @@ module Github
 
   def self.failed_deliveries(since, max_page = 50)
     client = Github.app_client
-    all_deliveries = client.get("/app/hook/deliveries?per_page=100")
+    all_deliveries = client.get("/app/hook/deliveries")
     page = 1
     while (next_url = client.last_response.rels[:next]&.href) && (since < all_deliveries.last[:delivered_at])
       if page >= max_page

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -31,12 +31,9 @@ module Github
     Octokit::Client.new(bearer_token: jwt)
   end
 
-  def self.installation_client(installation_id)
+  def self.installation_client(installation_id, auto_paginate: false)
     access_token = app_client.create_app_installation_access_token(installation_id)[:token]
-
-    client = Octokit::Client.new(access_token: access_token)
-    client.auto_paginate = true
-    client
+    Octokit::Client.new(access_token:, auto_paginate:)
   end
 
   # :nocov:

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -19,7 +19,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
   end
 
   def client
-    @client ||= Github.installation_client(github_repository.installation.installation_id).tap { it.auto_paginate = true }
+    @client ||= Github.installation_client(github_repository.installation.installation_id, auto_paginate: true)
   end
 
   # We dynamically adjust the polling interval based on the remaining rate

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -174,6 +174,6 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   end
 
   def client
-    @client ||= Github.installation_client(Config.e2e_github_installation_id)
+    @client ||= Github.installation_client(Config.e2e_github_installation_id, auto_paginate: true)
   end
 end

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -115,7 +115,7 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   def github_client
-    @github_client ||= Github.installation_client(github_runner.installation.installation_id)
+    @github_client ||= Github.installation_client(github_runner.installation.installation_id, auto_paginate: true)
   end
 
   def label_data

--- a/spec/lib/github_spec.rb
+++ b/spec/lib/github_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Github do
     expect(described_class).to receive(:app_client).and_return(app_client)
     expect(app_client).to receive(:create_app_installation_access_token).with(installation_id).and_return({token: "abcdefg"})
     installation_client = instance_double(Octokit::Client)
-    expect(installation_client).to receive(:auto_paginate=).with(true)
+    expect(installation_client).to receive(:auto_paginate=).with(false)
     expect(Octokit::Client).to receive(:new).with(access_token: "abcdefg").and_return(installation_client)
 
     described_class.installation_client(installation_id)

--- a/spec/lib/github_spec.rb
+++ b/spec/lib/github_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Github do
     expect(private_key).to receive(:is_a?).with(OpenSSL::PKey::RSA).and_return(true)
     expect(private_key).to receive(:sign).and_return("signed")
     expect(OpenSSL::PKey::RSA).to receive(:new).and_return(private_key)
-    expect(Octokit::Client).to receive(:new).with(bearer_token: anything)
+    expect(Octokit::Client).to receive(:new).with(bearer_token: anything, per_page: 100)
 
     described_class.app_client
   end
@@ -24,8 +24,7 @@ RSpec.describe Github do
     expect(described_class).to receive(:app_client).and_return(app_client)
     expect(app_client).to receive(:create_app_installation_access_token).with(installation_id).and_return({token: "abcdefg"})
     installation_client = instance_double(Octokit::Client)
-    expect(installation_client).to receive(:auto_paginate=).with(false)
-    expect(Octokit::Client).to receive(:new).with(access_token: "abcdefg").and_return(installation_client)
+    expect(Octokit::Client).to receive(:new).with(access_token: "abcdefg", auto_paginate: false, per_page: 100).and_return(installation_client)
 
     described_class.installation_client(installation_id)
   end
@@ -45,7 +44,7 @@ RSpec.describe Github do
     time = Time.now
     app_client = instance_double(Octokit::Client)
     expect(described_class).to receive(:app_client).and_return(app_client)
-    expect(app_client).to receive(:get).with("/app/hook/deliveries?per_page=100").and_return([
+    expect(app_client).to receive(:get).with("/app/hook/deliveries").and_return([
       {guid: "1", status: "Fail", delivered_at: time + 5},
       {guid: "2", status: "Fail", delivered_at: time + 4},
       {guid: "3", status: "OK", delivered_at: time + 3}
@@ -72,7 +71,7 @@ RSpec.describe Github do
     time = Time.now
     app_client = instance_double(Octokit::Client)
     expect(described_class).to receive(:app_client).and_return(app_client)
-    expect(app_client).to receive(:get).with("/app/hook/deliveries?per_page=100").and_return([
+    expect(app_client).to receive(:get).with("/app/hook/deliveries").and_return([
       {guid: "3", status: "Fail", delivered_at: time + 3}
     ])
     expect(app_client).to receive(:last_response).and_return(instance_double(Sawyer::Response, rels: {next: instance_double(Sawyer::Relation, href: "next_url")}))

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prog::Test::GithubRunner do
     expect(Config).to receive(:github_runner_service_project_id).and_return("fabd95f8-d002-8ed2-9f4c-00625eb7f574")
     expect(Config).to receive(:vm_pool_project_id).and_return("c3fd495f-9888-82d2-8100-7fae94e87e27")
     expect(Config).to receive(:e2e_github_installation_id).and_return(123456).at_least(:once)
-    allow(Github).to receive(:installation_client).with(Config.e2e_github_installation_id).and_return(client)
+    allow(Github).to receive(:installation_client).with(Config.e2e_github_installation_id, auto_paginate: true).and_return(client)
   end
 
   describe "#start" do

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -286,6 +286,7 @@ RSpec.describe Clover, "github" do
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["k1", "v1", "dev"])
+        expect(runner.reload.workflow_job["head_branch"]).to eq("dev")
       end
 
       it "returns a cache from default branch when no branch info" do


### PR DESCRIPTION
- **Enable GitHub client auto pagination explicitly**
  When the "auto_paginate" flag is enabled, the Ockokit client will
  paginate until there are no resources left.
  
  This can be risky depending on the API. For example, if you’re
  retrieving the list of jobs for a workflow, it’s fine since a single run
  has a limited number of jobs. However, if you’re getting the list of
  runs for repositories, it’s risky because there could be hundreds of
  pages.
  
  Auto-pagination is acceptable for API calls in respirate since they are
  asynchronous, but it's not ideal to paginate extensively in web
  requests.
  
  Therefore, I have disabled it by default and only enable it for clients
  in respirate.
  

- **Set the GitHub API's per_page value at the client level**
  The GitHub API returns 30 resources per page by default and allows a
  maximum of 100 resources per page.
  
  When the client has auto_paginate enabled, it automatically sets the
  per_page value to 100.
  
  It seems configurable at the client level. Instead of setting it for
  each request separately, we can set it at the client level.
  

- **Set the workflow_job data when fetching from the GitHub API**
  Normally, we fill the `workflow_job` data of the `GithubRunner` object
  when the `workflow_job.in_progress` webhook event is delivered. [^1]
  
  We use the `head_branch` value from this data at runtime endpoints to
  validate the scope cache.
  
  When this data is missing, we try to retrieve it from the GitHub API.
  Since this operation can be costly, it's a good idea to persist the
  result if the same job needs the same data before the webhook is
  delivered. [^2]
  
  Since the GitHub API doesn't have proper filtering, we fetch all jobs of
  the workflow run and try to find the corresponding runner using the
  `runner_name` property.
  
  As another improvement, we can update the `workflow_job` column of the
  all jobs we've already fetched. We can use code similar to this, but I
  need to think more about it. It's not good practice to update resources
  other than the prog's subject, so we should also prevent to overwrite
  existing data.
  
  ```ruby
  jobs.each do |job|
    GithubRunner.where(id: UBID.to_uuid(job[:runner_name]), workflow_job: nil).update(workflow_job: Sequel.pg_jsonb(job.except("steps")))
  end
  ```
  
  [^1]: https://github.com/ubicloud/ubicloud/blob/d4c19c2bec5887f96e40079da3eb2f8b4074fea5/routes/webhook/github.rb#L90
  [^2]: https://github.com/ubicloud/ubicloud/blob/d4c19c2bec5887f96e40079da3eb2f8b4074fea5/routes/runtime/github.rb#L28
  