### PR TITLE
Bump images

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -154,9 +154,9 @@ module Config
   optional :ubicloud_images_blob_storage_secret_key, string, clear: true
   optional :ubicloud_images_blob_storage_certs, string
 
-  override :ubuntu_noble_version, "20240702", string
-  override :ubuntu_jammy_version, "20240701", string
-  override :debian_12_version, "20241004-1890", string
+  override :ubuntu_noble_version, "20250502.1", string
+  override :ubuntu_jammy_version, "20250508", string
+  override :debian_12_version, "20250428-2096", string
   override :almalinux_9_version, "9.5-20241120", string
   override :github_ubuntu_2404_version, "20250406.1.1", string
   override :github_ubuntu_2204_version, "20250406.1.1", string


### PR DESCRIPTION
after puttering around to try to figure out how to encheapn this process (which is overdue), look at my cool makefile (a quick way to get resume and `make -j` parallelism)

```makefile
# Define URLs for all required images
URL_ubuntu-24.04-server-cloudimg-amd64.img := https://cloud-images.ubuntu.com/releases/noble/release-20250502.1/ubuntu-24.04-server-cloudimg-amd64.img
URL_ubuntu-24.04-server-cloudimg-arm64.img := https://cloud-images.ubuntu.com/releases/noble/release-20250502.1/ubuntu-24.04-server-cloudimg-arm64.img
URL_ubuntu-22.04-server-cloudimg-amd64.img := https://cloud-images.ubuntu.com/releases/jammy/release-20250508/ubuntu-22.04-server-cloudimg-amd64.img
URL_ubuntu-22.04-server-cloudimg-arm64.img := https://cloud-images.ubuntu.com/releases/jammy/release-20250508/ubuntu-22.04-server-cloudimg-arm64.img
URL_debian-12-genericcloud-amd64-20250428-2096.raw := https://cloud.debian.org/images/cloud/bookworm/20250428-2096/debian-12-genericcloud-amd64-20250428-2096.raw
URL_debian-12-genericcloud-arm64-20250428-2096.raw := https://cloud.debian.org/images/cloud/bookworm/20250428-2096/debian-12-genericcloud-arm64-20250428-2096.raw
URL_AlmaLinux-9-GenericCloud-9.5-20241120.x86_64.qcow2 := https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.5-20241120.x86_64.qcow2
URL_AlmaLinux-9-GenericCloud-9.5-20241120.aarch64.qcow2 := https://repo.almalinux.org/almalinux/9/cloud/aarch64/images/AlmaLinux-9-GenericCloud-9.5-20241120.aarch64.qcow2
URL_alpine-3.21.2-nocloud-uefi-x86_64.qcow2 := https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.2-x86_64-uefi-cloudinit-r0.qcow2
URL_alpine-3.21.2-nocloud-uefi-arm64.qcow2 := https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.2-aarch64-uefi-cloudinit-r0.qcow2

# Auto-detect targets from URL_* variables
IMAGES := $(patsubst URL_%,%,$(filter URL_%,$(.VARIABLES)))

# Group images by source (for better parallel distribution)
UBUNTU_IMAGES := $(filter ubuntu-%,$(IMAGES))
DEBIAN_IMAGES := $(filter debian-%,$(IMAGES))
ALMA_IMAGES := $(filter AlmaLinux-%,$(IMAGES))

# Interleave images from different sources
ORDERED_IMAGES := $(sort $(foreach i,$(shell seq 1 20),$(word $i,$(UBUNTU_IMAGES)) $(word $i,$(DEBIAN_IMAGES)) $(word $i,$(ALMA_IMAGES))))

.PHONY: all download checksums clean distclean

all: download checksums

download: $(ORDERED_IMAGES)

checksums: $(addsuffix .sha256,$(IMAGES))

$(IMAGES):
	@echo "Downloading $@ ..."
	@curl -sfL "$(URL_$@)" > "$@.tmp"
	@sync "$@.tmp"
	@mv "$@.tmp" "$@"
	@echo "Finished $@"

%.sha256: %
	@echo "Computing SHA256 for $< ..."
	@sha256sum "$<" | cut -d ' ' -f 1 > "$@.tmp"
	@sync "$@.tmp"
	@mv "$@.tmp" "$@"
	@echo "Generated $@"

clean:
	@rm -f $(addsuffix .tmp,$(IMAGES)) *.sha256 *.tmp

# Deep clean (removes downloaded images too)
distclean: clean
	@rm -f $(IMAGES)
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update image versions in `config.rb` and add a Makefile for automated image downloads and checksum verification.
> 
>   - **Image Version Updates in `config.rb`**:
>     - Update `ubuntu_noble_version` to `20250502.1`.
>     - Update `ubuntu_jammy_version` to `20250508`.
>     - Update `debian_12_version` to `20250428-2096`.
>   - **Makefile Enhancements**:
>     - Introduce Makefile to automate image downloads and checksum verification.
>     - Define URLs for Ubuntu, Debian, AlmaLinux, and Alpine images.
>     - Implement parallel download and checksum computation using `make -j`.
>     - Add `download`, `checksums`, `clean`, and `distclean` targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7300f1c7c9d7682fc59b64939916617e35476224. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->