### PR TITLE
Increase to 50 puma threads

### DIFF
--- a/puma_config.rb
+++ b/puma_config.rb
@@ -3,7 +3,7 @@
 # :nocov:
 environment ENV["RACK_ENV"] || "development"
 port ENV["PORT"] || "3000"
-threads 15, 15
+threads 50, 50
 
 if @config.options[:workers] > 0
   silence_single_worker_warning


### PR DESCRIPTION
This is getting to the point that we may want to consider different thread pool sizes for production and development, though this commit does not make that change.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase Puma thread count from 15 to 50 in `puma_config.rb`.
> 
>   - **Configuration**:
>     - Increase Puma thread count from 15 to 50 in `puma_config.rb`.
>   - **Considerations**:
>     - Suggests evaluating different thread pool sizes for production vs. development environments, though not implemented in this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e4a043c7fa888a0d2100d7c1e0b9a7fd68b31f54. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->