### PR TITLE
Update regen-screenshots to show all fields when PG is ready

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -147,6 +147,8 @@ class RegenScreenshots
       end
     end
     PostgresResource.define_method(:display_state) { "running" }
+    PostgresResource.define_method(:connection_string) { "sample-connection-string" }
+    PostgresResource.define_method(:ca_certificates) { "certs" }
     Authorization.define_singleton_method(:authorize) { |*| }
 
     resize(800)


### PR DESCRIPTION
Add `connection_string` and `ca_certificates` to show the correct UI elements for a ready PG instance.

Before vs after

![image](https://github.com/user-attachments/assets/a451e8eb-4a65-40f0-9a41-38801f4f7c87)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `connection_string` and `ca_certificates` methods to `PostgresResource` in `regen-screenshots` to display additional UI elements for a ready PostgreSQL instance.
> 
>   - **Behavior**:
>     - Adds `connection_string` and `ca_certificates` methods to `PostgresResource` in `regen-screenshots` to display additional UI elements for a ready PostgreSQL instance.
>   - **Misc**:
>     - No changes to existing functionality outside of screenshot generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 89981adec34cf936fbe37d41ca936dc820306207. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->