### PR TITLE
Skip VM pools if a free premium upgrade is enabled

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -34,7 +34,8 @@ class Prog::Vm::GithubRunner < Prog::Base
       arch: label_data["arch"]
     ).first
 
-    if !github_runner.installation.premium_runner_enabled? && (picked_vm = pool&.pick_vm)
+    installation = github_runner.installation
+    if !(installation.premium_runner_enabled? || installation.free_runner_upgrade?) && (picked_vm = pool&.pick_vm)
       return picked_vm
     end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -115,6 +115,15 @@ RSpec.describe Prog::Vm::GithubRunner do
       vm = nx.pick_vm
       expect(vm).not_to be_nil
     end
+
+    it "provisions a VM if a free premium upgrade is enabled" do
+      expect(github_runner.installation).to receive(:free_runner_upgrade?).and_return(true)
+      expect(VmPool).to receive(:where).and_return([])
+      expect(Prog::Vnet::SubnetNexus).to receive(:assemble).and_call_original
+      expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
+      vm = nx.pick_vm
+      expect(vm).not_to be_nil
+    end
   end
 
   describe ".update_billing_record" do


### PR DESCRIPTION
We skip VM pools if the customer prefers premium runners. We should also
skip them if a free premium upgrade is enabled for the customer.

Otherwise, it will select standard runners from the pool.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `pick_vm` to skip VM pools if a free premium upgrade is enabled, ensuring premium runners are preferred.
> 
>   - **Behavior**:
>     - Modify `pick_vm` in `github_runner.rb` to skip VM pools if `free_runner_upgrade?` is true, ensuring premium runners are preferred.
>   - **Tests**:
>     - Add test in `github_runner_spec.rb` to verify VM provisioning when `free_runner_upgrade?` is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ec1d530f351257dd1dd40ed298404a8b070fe72d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->