### PR TITLE
Go back to 15 threads

### DIFF
--- a/puma_config.rb
+++ b/puma_config.rb
@@ -3,7 +3,7 @@
 # :nocov:
 environment ENV["RACK_ENV"] || "development"
 port ENV["PORT"] || "3000"
-threads 50, 50
+threads 15, 15
 
 if @config.options[:workers] > 0
   silence_single_worker_warning


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts thread count from 50 to 15 in `puma_config.rb` to adjust server concurrency settings.
> 
>   - **Concurrency**:
>     - Reverts thread count from 50 to 15 in `puma_config.rb` to adjust server concurrency settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for bea0c74f233bae0de9099f89c013dbd6663a88ce. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->