### PR TITLE
Speed up prog flow control

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -102,12 +102,15 @@ end
 
   class FlowControl < RuntimeError; end
 
+  EMPTY_ARRAY = [].freeze
+
   class Exit < FlowControl
     attr_reader :exitval
 
     def initialize(strand, exitval)
       @strand = strand
       @exitval = exitval
+      set_backtrace EMPTY_ARRAY
     end
 
     def to_s
@@ -122,6 +125,7 @@ end
       @old_prog = old_prog
       @old_label = old_label
       @strand_update_args = strand_update_args
+      set_backtrace EMPTY_ARRAY
     end
 
     def new_label
@@ -142,6 +146,7 @@ end
 
     def initialize(seconds)
       @seconds = seconds
+      set_backtrace EMPTY_ARRAY
     end
 
     def to_s


### PR DESCRIPTION
By far the most expensive part of exception raising is generating the backtrace.  The non-local exit is relatively inexpensive. When using exceptions for flow control, you should use an empty backtrace to avoid generating a backtrace you are just going to ignore.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize exception handling in `prog/base.rb` by setting empty backtraces for `Exit`, `Hop`, and `Nap` exceptions to improve performance.
> 
>   - **Behavior**:
>     - Sets empty backtrace for `Exit`, `Hop`, and `Nap` exceptions in `prog/base.rb` to optimize performance by avoiding unnecessary backtrace generation.
>   - **Constants**:
>     - Introduces `EMPTY_ARRAY` constant in `prog/base.rb` to represent an empty backtrace array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fc781dfa2647b3c87a73ab0cdca630181574657b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->