### PR TITLE
Return 404 instead of 403 for unauthorized project access

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -614,6 +614,10 @@ class Clover < Roda
     end
 
     hash_branch("test-no-authorization-needed") do |r|
+      r.get "never" do
+        ""
+      end
+
       r.get "once" do
         no_authorization_needed
         ""
@@ -627,6 +631,10 @@ class Clover < Roda
         @project = current_account.projects.first
         dataset_authorize(current_account.projects_dataset, "Project:edit")
         no_authorization_needed
+      end
+
+      r.get "authorization-error" do
+        raise Authorization::Unauthorized
       end
 
       r.get "runtime-error" do

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -9,6 +9,11 @@ class Clover < Roda
     const_set(:"#{model.table_name.upcase}_NAME_OR_UBID", name_or_ubid_for(model))
   end
 
+  # Designed only for compatibility with existing mocking in the specs
+  def self.authorized_project(account, project_id)
+    account.projects_dataset[Sequel[:project][:id] => project_id, :visible => true]
+  end
+
   class RodaResponse
     API_DEFAULT_HEADERS = DEFAULT_HEADERS.merge("content-type" => "application/json").freeze
     WEB_DEFAULT_HEADERS = DEFAULT_HEADERS.merge(

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -53,16 +53,9 @@ class Clover
       view "project/create"
     end
 
-    r.on :ubid_uuid do |id|
-      @project = Project[id:, visible: true]
+    r.on :ubid_uuid do |project_id|
+      @project = Clover.authorized_project(current_account, project_id)
       check_found_object(@project)
-
-      # Would be better to select project from current_account.projects_dataset,
-      # but that requires returning 404 instead of 403 if a project the user
-      # does not have access to is requested.
-      if @project.accounts_dataset.where(Sequel[:accounts][:id] => current_account_id).empty?
-        fail Authorization::Unauthorized
-      end
 
       @project_data = Serializers::Project.serialize(@project, {include_path: true, web: true})
       @project_permissions = all_permissions(@project.id) if web?

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Clover, "postgres" do
 
       it "can update database properties" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(Project).to receive(:[]).and_return(project)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
         expect(pg.representative_server).to receive(:storage_size_gib).and_return(128)
 
         patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
@@ -161,7 +161,7 @@ RSpec.describe Clover, "postgres" do
 
       it "can scale down storage if the requested size is enough for existing data" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(Project).to receive(:[]).and_return(project)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
         expect(pg.representative_server).to receive(:storage_size_gib).and_return(128)
         expect(pg.representative_server.vm.sshable).to receive(:cmd).and_return("10000000\n")
 
@@ -174,7 +174,7 @@ RSpec.describe Clover, "postgres" do
 
       it "does not scale down storage if the requested size is too small for existing data" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(Project).to receive(:[]).and_return(project)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
         expect(pg.representative_server).to receive(:storage_size_gib).and_return(128)
         expect(pg.representative_server.vm.sshable).to receive(:cmd).and_return("999999999\n")
 
@@ -188,7 +188,7 @@ RSpec.describe Clover, "postgres" do
 
       it "returns error message if current usage is unknown" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(Project).to receive(:[]).and_return(project)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
         expect(pg.representative_server).to receive(:storage_size_gib).and_return(128)
         expect(pg.representative_server.vm.sshable).to receive(:cmd).and_raise(StandardError.new("error"))
 
@@ -202,7 +202,8 @@ RSpec.describe Clover, "postgres" do
 
       it "read-replica" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(Project).to receive(:[]).and_return(project, Project[Config.postgres_service_project_id]).at_least(:once)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
+        expect(Project).to receive(:[]).and_return(Project[Config.postgres_service_project_id]).thrice
 
         post "/project/#{project.ubid}/location/eu-central-h1/postgres/#{pg.name}/read-replica", {
           name: "my-read-replica"
@@ -213,7 +214,7 @@ RSpec.describe Clover, "postgres" do
 
       it "promote" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(Project).to receive(:[]).and_return(project)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
         pg.update(parent_id: pg.id)
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/promote"
 
@@ -222,7 +223,7 @@ RSpec.describe Clover, "postgres" do
 
       it "fails to promote if not read_replica" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(Project).to receive(:[]).and_return(project)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
 
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/promote"
 

--- a/spec/routes/api/project/private_location_spec.rb
+++ b/spec/routes/api/project/private_location_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Clover, "private-location" do
         p = create_account("test@test.com").create_project_with_default_policy("project-1")
         delete "/project/#{p.ubid}/private-location/#{private_location.ui_name}"
 
-        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
     end
 
@@ -167,7 +167,7 @@ RSpec.describe Clover, "private-location" do
         p = u.create_project_with_default_policy("project-1")
         get "/project/#{p.ubid}/private-location/#{private_location.ui_name}"
 
-        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
     end
 

--- a/spec/routes/api/project_spec.rb
+++ b/spec/routes/api/project_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Clover, "project" do
         p = create_account("test@test.com").create_project_with_default_policy("project-1")
         delete "/project/#{p.ubid}"
 
-        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
+        expect(last_response.status).to eq(204)
       end
     end
 
@@ -172,7 +172,7 @@ RSpec.describe Clover, "project" do
         p = u.create_project_with_default_policy("project-1")
         get "/project/#{p.ubid}"
 
-        expect(last_response).to have_api_error(403, "Sorry, you don't have permission to continue with this request.")
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
     end
   end

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -31,10 +31,15 @@ RSpec.describe Clover do
       visit "/test-no-authorization-needed/once"
       expect(page.status_code).to eq(200)
 
-      re = /called no_authorization_needed when authorization already not needed: /
-      expect { visit "/test-no-authorization-needed/twice" }.to raise_error(RuntimeError, re)
-      expect { visit "/test-no-authorization-needed/after-authorization" }.to raise_error(RuntimeError, re)
-      expect { visit "/test-no-authorization-needed/runtime-error" }.to raise_error(RuntimeError, /no authorization check for /)
+      visit "/test-no-authorization-needed/authorization-error"
+      expect(page.status_code).to eq(403)
+
+      multiple_re = /called no_authorization_needed when authorization already not needed: /
+      missing_re = /no authorization check for /
+      expect { visit "/test-no-authorization-needed/twice" }.to raise_error(RuntimeError, multiple_re)
+      expect { visit "/test-no-authorization-needed/after-authorization" }.to raise_error(RuntimeError, multiple_re)
+      expect { visit "/test-no-authorization-needed/never" }.to raise_error(RuntimeError, missing_re)
+      expect { visit "/test-no-authorization-needed/runtime-error" }.to raise_error(RuntimeError, missing_re)
     end
 
     it "raises error for non-GET request without audit logging" do

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Clover, "Kubernetes" do
       end
 
       it "can not create cluster if project has no valid payment method" do
-        expect(Project).to receive(:[]).and_return(project).at_least(:once)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).at_least(:once)
         expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 
         page.refresh

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "can not connect GitHub account if project has no valid payment method" do
-      expect(Project).to receive(:[]).and_return(project).at_least(:once)
+      expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).twice
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 
       visit "#{project.path}/github/create"
@@ -70,7 +70,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "shows new billing info button instead of connect account if project has no valid payment method" do
-      expect(Project).to receive(:[]).and_return(project).at_least(:once)
+      expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).thrice
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
       # rubocop:disable RSpec/VerifiedDoubles
       expect(Stripe::Checkout::Session).to receive(:create).and_return(double(Stripe::Checkout::Session, url: ""))

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe Clover, "postgres" do
 
       it "can update PostgreSQL instance size configuration" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg)).at_least(:once)
-        expect(Project).to receive(:[]).and_return(project).at_least(:once)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).twice
         expect(pg.representative_server).to receive(:storage_size_gib).and_return(128).at_least(:once)
 
         visit "#{project.path}#{pg.path}"

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -106,13 +106,13 @@ RSpec.describe Clover, "project" do
         expect(page).to have_content project_wo_permissions.name
       end
 
-      it "raises forbidden when user isn't added to project" do
+      it "returns not found when user isn't added to project" do
         new_project = Project.create_with_id(name: "new-project")
         visit "#{new_project.path}/dashboard"
 
-        expect(page.title).to eq("Ubicloud - Forbidden")
-        expect(page.status_code).to eq(403)
-        expect(page).to have_content "Forbidden"
+        expect(page.title).to eq("Ubicloud - ResourceNotFound")
+        expect(page.status_code).to eq(404)
+        expect(page).to have_content "ResourceNotFound"
       end
 
       it "not show on sidebar when does not have permissions" do
@@ -693,7 +693,7 @@ RSpec.describe Clover, "project" do
       it "can not have more than 50 pending invitations" do
         visit "#{project.path}/user"
 
-        expect(Project).to receive(:[]).and_return(project).at_least(:once)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).twice
         expect(project).to receive(:invitations_dataset).and_return(instance_double(Sequel::Dataset, count: 50))
         expect(project).to receive(:invitations_dataset).and_call_original
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "can not create virtual machine if project has no valid payment method" do
-        expect(Project).to receive(:[]).and_return(project).at_least(:once)
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).thrice
         expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 
         visit "#{project.path}/vm/create"

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -111,7 +111,7 @@ module ThawedMock
   allow_mocking(BillingRate, :from_resource_properties)
   allow_mocking(Clog, :emit)
   allow_mocking(CloudflareClient, :new)
-  allow_mocking(Clover, :call)
+  allow_mocking(Clover, :call, :authorized_project)
   allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :hardware_reset_server, :set_server_name)
   allow_mocking(InvoiceGenerator, :new)
   allow_mocking(Minio::Client, :new)


### PR DESCRIPTION
403 leaks information about whether the requested project exists.
This approach for projects is now similar to how we treat other
nested objects, where we retrieve from an authorized dataset,
instead of retrieving the object and then (hopefully) performing
authorization on it.  It should also be faster as it eliminates
an unnecessary query.

Unfortunatley, the route specs mock Project.[] in quite a few
places.  To avoid a bunch of spec churn, add Clover.authorized_project,
and change the mocking to mock that instead.

As a consequence of this handling, deleting an unauthorized project
now returns 204 instead of 403.  I believe that is how deletion
of other unauthorized objects is handled, so the behavior is now
more consistent, but it is something to be aware of.

I had to add some explicit tests for a missing authorization call
and for Authorization::Unauthorized exception handling for coverage
tests to pass.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Unauthorized project access now returns 404 instead of 403, with project deletion returning 204 when unauthorized, improving consistency and performance.
> 
>   - **Behavior**:
>     - Unauthorized project access now returns 404 instead of 403 in `routes/project.rb`.
>     - Project deletion returns 204 instead of 403 when unauthorized.
>   - **Helpers**:
>     - Adds `Clover.authorized_project` method in `helpers/general.rb` for project authorization.
>   - **Tests**:
>     - Updates tests in `spec/routes/api/project_spec.rb` and `spec/routes/web/project_spec.rb` to expect 404 for unauthorized access and 204 for unauthorized deletion.
>     - Mocks `authorized_project` instead of `Project.[]` in several test files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 91571089769a151131b5e94de3816dc5e477b580. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->