### PR TITLE
Allow worker size selection in kubernetes creation UI

### DIFF
--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -5,7 +5,7 @@ class Clover
     authorize("KubernetesCluster:create", @project.id)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
-    params = check_required_web_params(["name", "location", "version", "cp_nodes", "worker_nodes"])
+    params = check_required_web_params(["name", "location", "version", "cp_nodes", "worker_size", "worker_nodes"])
 
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
@@ -19,7 +19,8 @@ class Clover
       Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
         name: name + "-np",
         node_count: params["worker_nodes"].to_i,
-        kubernetes_cluster_id: kc.id
+        kubernetes_cluster_id: kc.id,
+        target_node_size: params["worker_size"]
       )
       audit_log(kc, "create")
 
@@ -41,9 +42,11 @@ class Clover
     options.add_option(name: "location", values: Option.kubernetes_locations)
     options.add_option(name: "version", values: Option.kubernetes_versions)
     options.add_option(name: "cp_nodes", values: Option::KubernetesCPOptions.map(&:cp_node_count), parent: "location")
-    options.add_option(name: "worker_nodes", values: (1..10).map { {value: it, display_name: "#{it} Node#{(it == 1) ? "" : "s"}"} }, parent: "cp_nodes") do |location, cp_nodes, worker_nodes|
-      worker_nodes[:value] >= cp_nodes
+    options.add_option(name: "worker_size", values: Option::VmSizes.select { it.visible }.select { it.vcpus <= 16 }.map { it.display_name }, parent: "location") do |location, size|
+      vm_size = Option::VmSizes.find { it.display_name == size && it.arch == "x64" }
+      vm_size.family == "standard"
     end
+    options.add_option(name: "worker_nodes", values: (1..10).map { {value: it, display_name: "#{it} Node#{(it == 1) ? "" : "s"}"} }, parent: "worker_size")
 
     options.serialize
   end

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -151,8 +151,21 @@ module ContentGenerator
       ]
     end
 
-    def self.worker_nodes(location, cp_nodes, worker_nodes)
-      node_price = 2 * BillingRate.unit_price_from_resource_properties("KubernetesWorkerVCpu", "standard", location.name) +
+    def self.worker_size(location, size)
+      size = Option::VmSizes.find { it.display_name == size }
+      unit_price = BillingRate.unit_price_from_resource_properties("VmVCpu", "standard", location.name)
+
+      [
+        size.display_name,
+        "#{size.vcpus} vCPUs / #{size.memory_gib} GB RAM",
+        "$#{"%.2f" % (size.vcpus * unit_price * 60 * 672)}/mo",
+        "$#{"%.3f" % (size.vcpus * unit_price * 60)}/hour"
+      ]
+    end
+
+    def self.worker_nodes(location, worker_size, worker_nodes)
+      size = Option::VmSizes.find { it.display_name == worker_size }
+      node_price = size.vcpus * BillingRate.unit_price_from_resource_properties("KubernetesWorkerVCpu", "standard", location.name) +
         40 * BillingRate.unit_price_from_resource_properties("KubernetesWorkerStorage", "standard", location.name)
 
       "#{worker_nodes[:display_name]} - $#{"%.2f" % (worker_nodes[:value] * node_price * 60 * 672)}/mo ($#{"%.3f" % (worker_nodes[:value] * node_price * 60)}/hour)"

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -18,6 +18,7 @@
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:location)},
     {name: "version", type: "radio_small_cards", label: "Version", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:version)},
     {name: "cp_nodes", type: "radio_small_cards", label: "Control Plane", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:cp_nodes)},
+    {name: "worker_size", type: "radio_small_cards", label: "Worker size", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:worker_size)},
     {name: "worker_nodes", type: "select", label: "Worker Nodes", required: "required", placeholder: "Select number of worker nodes", content_generator: ContentGenerator::KubernetesCluster.method(:worker_nodes), opening_tag: "<div class='sm:col-span-3'>"},
   ]
 


### PR DESCRIPTION
A new option is added to the kubernetes creation form, allowing users to specify the Vm size they want for their nodepool.

The prices will also reflect the Vm size and will update accordingly.