### PR TITLE
Show CPU usage breakdown in PG metrics

### DIFF
--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -13,7 +13,7 @@ module Metrics
       series: [
         TimeSeries.new(
           labels: {},
-          query: "(1 - sum(avg(rate(node_cpu_seconds_total{mode=\"idle\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])))) * 100"
+          query: "avg(rate(node_cpu_seconds_total{mode=~\"(iowait|user|system|steal)\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])) by (mode) * 100"
         )
       ]
     ),


### PR DESCRIPTION
This creates a a more actionable graph, especially for burstable DB instances.

![image](https://github.com/user-attachments/assets/54a17ece-517f-4684-b3a0-a5cc55ad8124)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update CPU usage query in `lib/metrics.rb` to breakdown usage by mode for better insights.
> 
>   - **Behavior**:
>     - Updates CPU usage query in `lib/metrics.rb` to breakdown usage by `iowait`, `user`, `system`, and `steal` modes.
>     - Provides more actionable insights for burstable DB instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7fad9cec341fff2f5bf0bc3b2883d4dd88a5d1b6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->