### PR TITLE
Fix runner list to return the runners of the installation not project

### DIFF
--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -58,7 +58,7 @@ class Clover
 
         r.on "runner" do
           r.get true do
-            @runners = @project.github_runners_dataset.eager(:vm).eager_graph(:strand)
+            @runners = @installation.runners_dataset.eager(:vm).eager_graph(:strand)
               .exclude(Sequel[:strand][:prog] => "Vm::GithubRunner", Sequel[:strand][:label] => ["destroy", "wait_vm_destroy"])
               .reverse(Sequel[:github_runner][:created_at])
               .all


### PR DESCRIPTION
We recently changed our GitHub views to be based on installation instead of project. It seems this got overwritten while I was rebasing my latest PR.

So currently, if a project has multiple installations, all of them list all runners.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes runner list in `routes/project/github.rb` to fetch runners from installation instead of project.
> 
>   - **Behavior**:
>     - Fixes runner list to fetch runners from `@installation.runners_dataset` instead of `@project.github_runners_dataset` in `routes/project/github.rb`.
>     - Ensures correct runner listing when a project has multiple installations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 82628e5982195e43aaa901997b628735f8caeff7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->