### PR TITLE
Invalidate the rubocop cache if packages are updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/.cache/rubocop_cache
-        key: ${{ matrix.runs-on }}-rubocop-cache
+        key: ${{ matrix.runs-on }}-rubocop-cache-${{ hashFiles('Gemfile.lock', '.rubocop.yml') }}
 
     - name: Run rubocop
       run: bundle exec rake linter:rubocop


### PR DESCRIPTION
We need to invalidate the rubocop cache. Otherwise, we'll just keep
moving the old cache between runs, which doesn't provide any benefits.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update rubocop cache key in `ci.yml` to include `Gemfile.lock` and `.rubocop.yml` hashes for cache invalidation.
> 
>   - **Cache Invalidation**:
>     - Update cache key in `.github/workflows/ci.yml` to include hashes of `Gemfile.lock` and `.rubocop.yml`.
>     - Ensures rubocop cache is invalidated when these files change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 245b17997bfef3d0a4f563e0a4225ddedcf35e16. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->