### PR TITLE
Bump ruby version from 3.4.3 to 3.4.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 3.4.3
+ruby 3.4.4
 postgres 15.8
 nodejs 23.6.0
 golang 1.24.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM docker.io/library/ruby:3.4.3-alpine3.21 AS bundler
+FROM docker.io/library/ruby:3.4.4-alpine3.21 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -20,7 +20,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM docker.io/library/ruby:3.4.3-alpine3.21
+FROM docker.io/library/ruby:3.4.4-alpine3.21
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Update ruby version in Dockerfile and .tool_versions when updating this
-ruby "3.4.3"
+ruby "3.4.4"
 
 gem "acme-client"
 gem "argon2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.4.3p32
+   ruby 3.4.4p34
 
 BUNDLED WITH
    2.6.8


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump Ruby version from 3.4.3 to 3.4.4 in `.tool-versions`, `Dockerfile`, and `Gemfile`.
> 
>   - **Ruby Version Update**:
>     - Bump Ruby version from 3.4.3 to 3.4.4 in `.tool-versions`, `Dockerfile`, and `Gemfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d5100b4b17a627cd0ad823c3114ef03d8ddb77d1. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->