### PR TITLE
Shellescape unit names in daemonizer2 wrapper

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -113,15 +113,15 @@ class Sshable < Sequel::Model
   end
 
   def d_check(unit_name)
-    cmd("common/bin/daemonizer2 check #{unit_name}")
+    cmd("common/bin/daemonizer2 check #{unit_name.shellescape}")
   end
 
   def d_clean(unit_name)
-    cmd("common/bin/daemonizer2 clean #{unit_name}")
+    cmd("common/bin/daemonizer2 clean #{unit_name.shellescape}")
   end
 
   def d_run(unit_name, *run_command, stdin: nil, log: true)
-    cmd("common/bin/daemonizer2 run #{unit_name} #{Shellwords.join(run_command)}", stdin:, log:)
+    cmd("common/bin/daemonizer2 run #{unit_name.shellescape} #{Shellwords.join(run_command)}", stdin:, log:)
   end
 
   # A huge number of settings are needed to isolate net-ssh from the


### PR DESCRIPTION
Most unit names are written by hand and unlikely to use any interesting characters, but a few are computed.  There's no reason to task the caller with escaping the unit name, lest some of their unit name could bleed over into the remaining arguments.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Shell escape `unit_name` in `d_check`, `d_clean`, and `d_run` methods in `sshable.rb` to prevent command injection.
> 
>   - **Behavior**:
>     - Shell escape `unit_name` in `d_check`, `d_clean`, and `d_run` methods in `sshable.rb` to prevent command injection.
>   - **Functions**:
>     - `d_check(unit_name)`: Escapes `unit_name` before passing to `daemonizer2 check`.
>     - `d_clean(unit_name)`: Escapes `unit_name` before passing to `daemonizer2 clean`.
>     - `d_run(unit_name, *run_command)`: Escapes `unit_name` before passing to `daemonizer2 run`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8d4a3cfedc9cb901b7e5645384ed1c073681f82d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->