### PR TITLE
Add a warning to create more archived_record/audit_log partitions, before it would error

### DIFF
--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe "Database" do
     it "needs new partitions (action required)" do
       # if this test starts to fail, it's time to create new partitions for table audit_log. if this is ignored,
       # DB[:audit_log].insert will start to fail in 45 days or less.
+      # Add a warning 60 days out, so the issue can be fixed before the warning turns into an test failure.
+
+      begin
+        DB.transaction(savepoint: true) do
+          insert_row(Time.now + 60 * 60 * 24 * 60)
+        end
+      rescue Sequel::ConstraintViolation
+        warn "\n\nNEED TO CREATE MORE audit_log PARTITIONS!\n\n\n"
+      end
+
       expect(insert_row(Time.now + 60 * 60 * 24 * 45)).to eq [{ubid_type: "vm"}]
     end
 


### PR DESCRIPTION
This warns us 2 weeks before tests would start to fail, allowing us enough time to create the partitions before we get actual test failures.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning mechanism to alert 60 days before partition-related test failures in `audit_log` and `archived_record` tables.
> 
>   - **Behavior**:
>     - Adds a warning mechanism in `db_spec.rb` and `archived_record_spec.rb` to alert 60 days before partition-related test failures.
>     - Attempts to insert a record 60 days in the future; if it fails, logs a warning to create more partitions.
>   - **Tests**:
>     - Updates `needs new partitions (action required)` test in `db_spec.rb` and `archived_record_spec.rb` to include the new warning mechanism.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 368dda452d6327aa6a8063107ee5c4ac64c140d7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->