### PR TITLE
Suppress params.json from being echoed to the client

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -310,7 +310,7 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   def write_params_json
-    host.sshable.cmd("sudo -u #{q_vm} tee #{params_path.shellescape}",
+    host.sshable.cmd("sudo -u #{q_vm} tee #{params_path.shellescape} > /dev/null",
       stdin: vm.params_json(**frame.slice("swap_size_bytes", "hugepages", "ch_version", "firmware_version").transform_keys!(&:to_sym)))
   end
 


### PR DESCRIPTION
We just put it in, we don't need to expend bandwidth and cycles reading it back out.  This is not the first or only oversight I've seen with `tee` in this way.