### PR TITLE
Fix load balancer destroy issue in Kubernetes nodepools

### DIFF
--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -86,10 +86,8 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
     decr_destroy
 
     lb = LoadBalancer[name: kubernetes_nodepool.cluster.services_load_balancer_name]
-    if (dns_zone = DnsZone[name: Config.kubernetes_service_hostname])
-      dns_zone.delete_record(record_name: "*.#{lb.hostname}.")
-    end
-    lb.incr_destroy
+    lb&.dns_zone&.delete_record(record_name: "*.#{lb.hostname}.")
+    lb&.incr_destroy
     kubernetes_nodepool.vms.each(&:incr_destroy)
     kubernetes_nodepool.remove_all_vms
     kubernetes_nodepool.destroy

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -65,7 +65,7 @@ module ThawedMock
   allow_mocking(HostProvider, :create)
   allow_mocking(IpsecTunnel, :[], :create)
   allow_mocking(KubernetesCluster, :[], :kubeconfig)
-  allow_mocking(LoadBalancer, :generate_uuid)
+  allow_mocking(LoadBalancer, :[], :generate_uuid)
   allow_mocking(MinioCluster, :[])
   allow_mocking(Nic, :[], :create, :generate_ubid)
   allow_mocking(Page, :from_tag_parts)


### PR DESCRIPTION
The services load balancer for nodepools had an issue in drop state, because we didn't handle the case where the load balancer is not created, which happens if a cluster is destroyed before the first CP node is created.