### PR TITLE
Use the premium VM pool if the premium runner is enabled

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -51,7 +51,7 @@
 - { name: ubicloud-standard-16-arm-ubuntu-2204, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-standard-30-arm-ubuntu-2204, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-standard-60-arm-ubuntu-2204, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-gpu,                         vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204, gpu: true  }
+- { name: ubicloud-gpu,                         vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204 }
 # Deprecated: Remove old labels once all customers have migrated to new labels.
 - { name: ubicloud-standard-2-ubuntu-2204-arm,  alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
 - { name: ubicloud-standard-4-ubuntu-2204-arm,  alias_for: ubicloud-standard-4-arm-ubuntu-2204 }

--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -5,33 +5,33 @@
 - { name: ubicloud-standard-16,                 alias_for: ubicloud-standard-16-ubuntu-2204 }
 - { name: ubicloud-standard-30,                 alias_for: ubicloud-standard-30-ubuntu-2204 }
 - { name: ubicloud-standard-60,                 alias_for: ubicloud-standard-60-ubuntu-2204 }
-- { name: ubicloud-standard-2-ubuntu-2404,      vm_size: standard-2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-4-ubuntu-2404,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-8-ubuntu-2404,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-16-ubuntu-2404,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-30-ubuntu-2404,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-60-ubuntu-2404,     vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-2-ubuntu-2204,      vm_size: standard-2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-4-ubuntu-2204,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-8-ubuntu-2204,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-16-ubuntu-2204,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-30-ubuntu-2204,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-60-ubuntu-2204,     vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-2-ubuntu-2404,      family: standard,     vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-4-ubuntu-2404,      family: standard,     vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-8-ubuntu-2404,      family: standard,     vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-16-ubuntu-2404,     family: standard,     vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-30-ubuntu-2404,     family: standard,     vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-60-ubuntu-2404,     family: standard,     vcpus: 60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-2-ubuntu-2204,      family: standard,     vcpus: 2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-4-ubuntu-2204,      family: standard,     vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-8-ubuntu-2204,      family: standard,     vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-16-ubuntu-2204,     family: standard,     vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-30-ubuntu-2204,     family: standard,     vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-60-ubuntu-2204,     family: standard,     vcpus: 60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-premium-2,                   alias_for: ubicloud-premium-2-ubuntu-2204 }
 - { name: ubicloud-premium-4,                   alias_for: ubicloud-premium-4-ubuntu-2204 }
 - { name: ubicloud-premium-8,                   alias_for: ubicloud-premium-8-ubuntu-2204 }
 - { name: ubicloud-premium-16,                  alias_for: ubicloud-premium-16-ubuntu-2204 }
 - { name: ubicloud-premium-30,                  alias_for: ubicloud-premium-30-ubuntu-2204 }
-- { name: ubicloud-premium-2-ubuntu-2404,       vm_size: premium-2,      arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
-- { name: ubicloud-premium-4-ubuntu-2404,       vm_size: premium-4,      arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-premium-8-ubuntu-2404,       vm_size: premium-8,      arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-premium-16-ubuntu-2404,      vm_size: premium-16,     arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-premium-30-ubuntu-2404,      vm_size: premium-30,     arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-premium-2-ubuntu-2204,       vm_size: premium-2,      arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
-- { name: ubicloud-premium-4-ubuntu-2204,       vm_size: premium-4,      arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-premium-8-ubuntu-2204,       vm_size: premium-8,      arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-premium-16-ubuntu-2204,      vm_size: premium-16,     arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-premium-30-ubuntu-2204,      vm_size: premium-30,     arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-2-ubuntu-2404,       family: premium,      vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-4-ubuntu-2404,       family: premium,      vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-8-ubuntu-2404,       family: premium,      vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-16-ubuntu-2404,      family: premium,      vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-30-ubuntu-2404,      family: premium,      vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-2-ubuntu-2204,       family: premium,      vcpus: 2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-4-ubuntu-2204,       family: premium,      vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-8-ubuntu-2204,       family: premium,      vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-16-ubuntu-2204,      family: premium,      vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-30-ubuntu-2204,      family: premium,      vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-arm,                         alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
 - { name: ubicloud-standard-2-arm,              alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
 - { name: ubicloud-standard-4-arm,              alias_for: ubicloud-standard-4-arm-ubuntu-2204 }
@@ -39,19 +39,19 @@
 - { name: ubicloud-standard-16-arm,             alias_for: ubicloud-standard-16-arm-ubuntu-2204 }
 - { name: ubicloud-standard-30-arm,             alias_for: ubicloud-standard-30-arm-ubuntu-2204 }
 - { name: ubicloud-standard-60-arm,             alias_for: ubicloud-standard-60-arm-ubuntu-2204 }
-- { name: ubicloud-standard-2-arm-ubuntu-2404,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-4-arm-ubuntu-2404,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-8-arm-ubuntu-2404,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-16-arm-ubuntu-2404, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-30-arm-ubuntu-2404, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-60-arm-ubuntu-2404, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2404 }
-- { name: ubicloud-standard-2-arm-ubuntu-2204,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-4-arm-ubuntu-2204,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-8-arm-ubuntu-2204,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-16-arm-ubuntu-2204, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-30-arm-ubuntu-2204, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-standard-60-arm-ubuntu-2204, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-gpu,                         vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204 }
+- { name: ubicloud-standard-2-arm-ubuntu-2404,  family: standard,     vcpus: 2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-4-arm-ubuntu-2404,  family: standard,     vcpus: 4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-8-arm-ubuntu-2404,  family: standard,     vcpus: 8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-16-arm-ubuntu-2404, family: standard,     vcpus: 16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-30-arm-ubuntu-2404, family: standard,     vcpus: 30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-60-arm-ubuntu-2404, family: standard,     vcpus: 60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-2-arm-ubuntu-2204,  family: standard,     vcpus: 2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-4-arm-ubuntu-2204,  family: standard,     vcpus: 4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-8-arm-ubuntu-2204,  family: standard,     vcpus: 8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-16-arm-ubuntu-2204, family: standard,     vcpus: 16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-30-arm-ubuntu-2204, family: standard,     vcpus: 30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-60-arm-ubuntu-2204, family: standard,     vcpus: 60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-gpu,                         family: standard-gpu, vcpus: 6,     arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204 }
 # Deprecated: Remove old labels once all customers have migrated to new labels.
 - { name: ubicloud-standard-2-ubuntu-2204-arm,  alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
 - { name: ubicloud-standard-4-ubuntu-2204-arm,  alias_for: ubicloud-standard-4-arm-ubuntu-2204 }

--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -5,33 +5,33 @@
 - { name: ubicloud-standard-16,                 alias_for: ubicloud-standard-16-ubuntu-2204 }
 - { name: ubicloud-standard-30,                 alias_for: ubicloud-standard-30-ubuntu-2204 }
 - { name: ubicloud-standard-60,                 alias_for: ubicloud-standard-60-ubuntu-2204 }
-- { name: ubicloud-standard-2-ubuntu-2404,      vm_size: standard-2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-4-ubuntu-2404,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-8-ubuntu-2404,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-16-ubuntu-2404,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-30-ubuntu-2404,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-60-ubuntu-2404,     vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-2-ubuntu-2204,      vm_size: standard-2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-4-ubuntu-2204,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-8-ubuntu-2204,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-16-ubuntu-2204,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-30-ubuntu-2204,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-60-ubuntu-2204,     vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-standard-2-ubuntu-2404,      vm_size: standard-2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-4-ubuntu-2404,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-8-ubuntu-2404,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-16-ubuntu-2404,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-30-ubuntu-2404,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-60-ubuntu-2404,     vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-2-ubuntu-2204,      vm_size: standard-2,     arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-4-ubuntu-2204,      vm_size: standard-4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-8-ubuntu-2204,      vm_size: standard-8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-16-ubuntu-2204,     vm_size: standard-16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-30-ubuntu-2204,     vm_size: standard-30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-60-ubuntu-2204,     vm_size: standard-60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-premium-2,                   alias_for: ubicloud-premium-2-ubuntu-2204 }
 - { name: ubicloud-premium-4,                   alias_for: ubicloud-premium-4-ubuntu-2204 }
 - { name: ubicloud-premium-8,                   alias_for: ubicloud-premium-8-ubuntu-2204 }
 - { name: ubicloud-premium-16,                  alias_for: ubicloud-premium-16-ubuntu-2204 }
 - { name: ubicloud-premium-30,                  alias_for: ubicloud-premium-30-ubuntu-2204 }
-- { name: ubicloud-premium-2-ubuntu-2404,       vm_size: premium-2,      arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-premium-4-ubuntu-2404,       vm_size: premium-4,      arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-premium-8-ubuntu-2404,       vm_size: premium-8,      arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-premium-16-ubuntu-2404,      vm_size: premium-16,     arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-premium-30-ubuntu-2404,      vm_size: premium-30,     arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-premium-2-ubuntu-2204,       vm_size: premium-2,      arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-premium-4-ubuntu-2204,       vm_size: premium-4,      arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-premium-8-ubuntu-2204,       vm_size: premium-8,      arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-premium-16-ubuntu-2204,      vm_size: premium-16,     arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-premium-30-ubuntu-2204,      vm_size: premium-30,     arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
+- { name: ubicloud-premium-2-ubuntu-2404,       vm_size: premium-2,      arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-4-ubuntu-2404,       vm_size: premium-4,      arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-8-ubuntu-2404,       vm_size: premium-8,      arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-16-ubuntu-2404,      vm_size: premium-16,     arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-30-ubuntu-2404,      vm_size: premium-30,     arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-premium-2-ubuntu-2204,       vm_size: premium-2,      arch: x64,   storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-4-ubuntu-2204,       vm_size: premium-4,      arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-8-ubuntu-2204,       vm_size: premium-8,      arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-16-ubuntu-2204,      vm_size: premium-16,     arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-premium-30-ubuntu-2204,      vm_size: premium-30,     arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-arm,                         alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
 - { name: ubicloud-standard-2-arm,              alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
 - { name: ubicloud-standard-4-arm,              alias_for: ubicloud-standard-4-arm-ubuntu-2204 }
@@ -39,19 +39,19 @@
 - { name: ubicloud-standard-16-arm,             alias_for: ubicloud-standard-16-arm-ubuntu-2204 }
 - { name: ubicloud-standard-30-arm,             alias_for: ubicloud-standard-30-arm-ubuntu-2204 }
 - { name: ubicloud-standard-60-arm,             alias_for: ubicloud-standard-60-arm-ubuntu-2204 }
-- { name: ubicloud-standard-2-arm-ubuntu-2404,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-4-arm-ubuntu-2404,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-8-arm-ubuntu-2404,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-16-arm-ubuntu-2404, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-30-arm-ubuntu-2404, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-60-arm-ubuntu-2404, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2404,     location: github-runners }
-- { name: ubicloud-standard-2-arm-ubuntu-2204,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-4-arm-ubuntu-2204,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-8-arm-ubuntu-2204,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-16-arm-ubuntu-2204, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-30-arm-ubuntu-2204, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-standard-60-arm-ubuntu-2204, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2204,     location: github-runners }
-- { name: ubicloud-gpu,                         vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204, location: github-runners, gpu: true  }
+- { name: ubicloud-standard-2-arm-ubuntu-2404,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-4-arm-ubuntu-2404,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-8-arm-ubuntu-2404,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-16-arm-ubuntu-2404, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-30-arm-ubuntu-2404, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-60-arm-ubuntu-2404, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2404 }
+- { name: ubicloud-standard-2-arm-ubuntu-2204,  vm_size: standard-2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-4-arm-ubuntu-2204,  vm_size: standard-4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-8-arm-ubuntu-2204,  vm_size: standard-8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-16-arm-ubuntu-2204, vm_size: standard-16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-30-arm-ubuntu-2204, vm_size: standard-30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-standard-60-arm-ubuntu-2204, vm_size: standard-60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2204 }
+- { name: ubicloud-gpu,                         vm_size: standard-gpu-6, arch: x64,   storage_size_gib: 180, boot_image: github-gpu-ubuntu-2204, gpu: true  }
 # Deprecated: Remove old labels once all customers have migrated to new labels.
 - { name: ubicloud-standard-2-ubuntu-2204-arm,  alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
 - { name: ubicloud-standard-4-ubuntu-2204-arm,  alias_for: ubicloud-standard-4-arm-ubuntu-2204 }

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -51,7 +51,8 @@ module Github
       labels = YAML.load_file("config/github_runner_labels.yml").to_h { [it["name"], it] }
       labels.transform_values do |v|
         new = (a = v["alias_for"]) ? labels[a] : v
-        new["vm_size_data"] = Validation.validate_vm_size(new["vm_size"], new["arch"])
+        new["vm_size"] = "#{new["family"]}-#{new["vcpus"]}"
+        Validation.validate_vm_size(new["vm_size"], new["arch"])
         new
       end.freeze
     end

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -19,7 +19,7 @@ class GithubRunner < Sequel::Model
       left_join(:strand, id: :id)
         .exclude(Sequel[:strand][:label] => ["start", "wait_concurrency_limit"])
         .select_map(Sequel[:github_runner][:label])
-        .sum { Github.runner_labels[it]["vm_size_data"].vcpus }
+        .sum { Github.runner_labels[it]["vcpus"] }
     end
   end
 

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -44,7 +44,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
       size: 1,
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
-      location_id: Location[name: label_data["location"]].id,
+      location_id: Location::GITHUB_RUNNERS_ID,
       storage_size_gib: label_data["storage_size_gib"],
       arch: label_data["arch"],
       storage_encrypted: true,

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -28,7 +28,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     pool = VmPool.where(
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
-      location_id: Location[name: label_data["location"]].id,
+      location_id: Location::GITHUB_RUNNERS_ID,
       storage_size_gib: label_data["storage_size_gib"],
       storage_encrypted: true,
       storage_skip_sync: true,
@@ -42,7 +42,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     ps = Prog::Vnet::SubnetNexus.assemble(
       Config.github_runner_service_project_id,
-      location_id: Location[name: label_data["location"]].id,
+      location_id: Location::GITHUB_RUNNERS_ID,
       allow_only_ssh: true
     ).subject
 
@@ -52,7 +52,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       sshable_unix_user: "runneradmin",
       name: github_runner.ubid.to_s,
       size: label_data["vm_size"],
-      location_id: Location[name: label_data["location"]].id,
+      location_id: Location::GITHUB_RUNNERS_ID,
       boot_image: label_data["boot_image"],
       storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true, skip_sync: true}],
       enable_ip4: true,

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -82,19 +82,23 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm.id).to eq(picked_vm.id)
     end
 
-    it "provisions a VM if the installation prefers premium runners" do
+    it "uses the premium vm pool if the installation prefers premium runners" do
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
       expect(installation).to receive(:premium_runner_enabled?).and_return(true)
-      vm = nx.pick_vm
-      expect(vm).not_to be_nil
-      expect(vm.pool_id).to be_nil
+      picked_vm = nx.pick_vm
+      expect(vm.id).to eq(picked_vm.id)
+      expect(picked_vm.family).to eq("premium")
     end
 
-    it "provisions a VM if a free premium upgrade is enabled" do
+    it "uses the premium vm pool if a free premium upgrade is enabled" do
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
       expect(installation).to receive(:premium_runner_enabled?).and_return(false)
       expect(installation).to receive(:free_runner_upgrade?).and_return(true)
-      vm = nx.pick_vm
-      expect(vm).not_to be_nil
-      expect(vm.pool_id).to be_nil
+      picked_vm = nx.pick_vm
+      expect(vm.id).to eq(picked_vm.id)
+      expect(picked_vm.family).to eq("premium")
     end
   end
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -7,48 +7,42 @@ require "octokit"
 RSpec.describe Prog::Vm::GithubRunner do
   subject(:nx) {
     described_class.new(Strand.new).tap {
-      it.instance_variable_set(:@github_runner, github_runner)
+      it.instance_variable_set(:@github_runner, runner)
     }
   }
 
-  let(:github_runner) {
-    GithubRunner.new_with_id(installation_id: "", repository_name: "test-repo", label: "ubicloud-standard-4", created_at: Time.now, allocated_at: Time.now + 10, ready_at: Time.now + 20)
-  }
-
-  let(:vm) {
-    Vm.new(family: "standard", cores: 1, vcpus: 2, name: "dummy-vm", location_id: Location[name: "github-runners"].id).tap {
-      it.id = "788525ed-d6f0-4937-a844-323d4fd91946"
-    }
-  }
-  let(:sshable) { instance_double(Sshable) }
+  let(:runner) do
+    customer_project = Project.create(name: "customer")
+    runner_project = Project.create(name: "runner-service")
+    installation_id = GithubInstallation.create(installation_id: 123, project_id: customer_project.id, name: "ubicloud", type: "Organization").id
+    vm_id = create_vm(location_id: Location::GITHUB_RUNNERS_ID, project_id: runner_project.id, boot_image: "github-ubuntu-2204").id
+    Sshable.create { it.id = vm_id }
+    GithubRunner.create(installation_id:, vm_id:, repository_name: "test-repo", label: "ubicloud-standard-4", created_at: now, allocated_at: now + 10, ready_at: now + 20, workflow_job: {"id" => 123})
+  end
+  let(:vm) { runner.vm }
+  let(:installation) { runner.installation }
+  let(:project) { installation.project }
   let(:client) { instance_double(Octokit::Client) }
-  let(:project) { Project.create(name: "default") }
+  let(:now) { Time.utc(2025, 5, 19, 19, 0) }
 
   before do
-    runner_project = Project.create(name: "runner-project")
-    allow(Config).to receive(:github_runner_service_project_id).and_return(runner_project.id)
+    allow(Config).to receive(:github_runner_service_project_id).and_return(vm.project_id)
     allow(Github).to receive(:installation_client).and_return(client)
-    allow(github_runner).to receive_messages(vm:, installation: instance_double(GithubInstallation, installation_id: 123, project:, allocator_preferences: {}, free_runner_upgrade?: false, premium_runner_enabled?: false))
-    allow(vm).to receive_messages(sshable: sshable, vm_host: instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", data_center: "FSN1-DC1"))
+    allow(Time).to receive(:now).and_return(now)
   end
 
   describe ".assemble" do
     it "creates github runner and vm with sshable" do
-      installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
+      runner = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud").subject
 
-      st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud")
-
-      runner = GithubRunner[st.id]
       expect(runner).not_to be_nil
       expect(runner.repository_name).to eq("test-repo")
       expect(runner.label).to eq("ubicloud")
     end
 
     it "creates github runner with custom size" do
-      installation = GithubInstallation.create_with_id(installation_id: 123, project_id: project.id, name: "test-user", type: "User")
-      st = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud-standard-8")
+      runner = described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud-standard-8").subject
 
-      runner = GithubRunner[st.id]
       expect(runner).not_to be_nil
       expect(runner.repository_name).to eq("test-repo")
       expect(runner.label).to eq("ubicloud-standard-8")
@@ -56,19 +50,15 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "fails if label is not valid" do
       expect {
-        described_class.assemble(instance_double(GithubInstallation), repository_name: "test-repo", label: "ubicloud-standard-1")
+        described_class.assemble(installation, repository_name: "test-repo", label: "ubicloud-standard-1")
       }.to raise_error RuntimeError, "Invalid GitHub runner label: ubicloud-standard-1"
     end
   end
 
   describe ".pick_vm" do
     it "provisions a VM if the pool is not existing" do
-      expect(VmPool).to receive(:where).and_return([])
-      expect(Prog::Vnet::SubnetNexus).to receive(:assemble).and_call_original
-      expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
-      expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
       vm = nx.pick_vm
-      expect(vm).not_to be_nil
+      expect(vm.pool_id).to be_nil
       expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
@@ -77,157 +67,118 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "provisions a new vm if pool is valid but there is no vm" do
-      git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location[name: "github-runners"].id, storage_size_gib: 150, arch: "x64")
-      expect(VmPool).to receive(:where).with(
-        vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location[name: "github-runners"].id,
-        storage_size_gib: 150, storage_encrypted: true,
-        storage_skip_sync: true, arch: "x64"
-      ).and_return([git_runner_pool])
-      expect(git_runner_pool).to receive(:pick_vm).and_return(nil)
-      expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
-      expect(FirewallRule).to receive(:create_with_id).and_call_original.at_least(:once)
+      VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
       vm = nx.pick_vm
-      expect(vm).not_to be_nil
+      expect(vm.pool_id).to be_nil
       expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.family).to eq("standard")
       expect(vm.vcpus).to eq(4)
     end
 
     it "uses the existing vm if pool can pick one" do
-      git_runner_pool = VmPool.create_with_id(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location[name: "github-runners"].id, storage_size_gib: 150, arch: "arm64")
-      expect(VmPool).to receive(:where).with(
-        vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location[name: "github-runners"].id,
-        storage_size_gib: 150, storage_encrypted: true,
-        storage_skip_sync: true, arch: "arm64"
-      ).and_return([git_runner_pool])
-      expect(git_runner_pool).to receive(:pick_vm).and_return(vm)
-      expect(github_runner).to receive(:label).and_return("ubicloud-standard-4-arm").at_least(:once)
-      vm = nx.pick_vm
-      expect(vm).not_to be_nil
-      expect(vm.name).to eq("dummy-vm")
+      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      vm = create_vm(pool_id: pool.id, display_state: "running")
+      picked_vm = nx.pick_vm
+      expect(vm.id).to eq(picked_vm.id)
     end
 
     it "provisions a VM if the installation prefers premium runners" do
-      expect(github_runner.installation).to receive(:premium_runner_enabled?).and_return(true)
-      expect(VmPool).to receive(:where).and_return([])
-      expect(Prog::Vnet::SubnetNexus).to receive(:assemble).and_call_original
-      expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
+      expect(installation).to receive(:premium_runner_enabled?).and_return(true)
       vm = nx.pick_vm
       expect(vm).not_to be_nil
+      expect(vm.pool_id).to be_nil
     end
 
     it "provisions a VM if a free premium upgrade is enabled" do
-      expect(github_runner.installation).to receive(:free_runner_upgrade?).and_return(true)
-      expect(VmPool).to receive(:where).and_return([])
-      expect(Prog::Vnet::SubnetNexus).to receive(:assemble).and_call_original
-      expect(Prog::Vm::Nexus).to receive(:assemble).and_call_original
+      expect(installation).to receive(:premium_runner_enabled?).and_return(false)
+      expect(installation).to receive(:free_runner_upgrade?).and_return(true)
       vm = nx.pick_vm
       expect(vm).not_to be_nil
+      expect(vm.pool_id).to be_nil
     end
   end
 
   describe ".update_billing_record" do
-    before do
-      allow(github_runner).to receive(:workflow_job).and_return({"id" => 123})
-      allow(github_runner).to receive(:update).with(billed_vm_size: "standard-2")
-    end
-
     it "not updates billing record if the runner is destroyed before it's ready" do
-      expect(github_runner).to receive(:ready_at).and_return(nil)
-
+      runner.update(ready_at: nil)
       expect(nx.update_billing_record).to be_nil
       expect(BillingRecord.count).to eq(0)
     end
 
     it "not updates billing record if the runner does not pick a job" do
-      expect(github_runner).to receive(:ready_at).and_return(Time.now)
-      expect(github_runner).to receive(:workflow_job).and_return(nil)
-
+      runner.update(ready_at: now, workflow_job: nil)
       expect(nx.update_billing_record).to be_nil
       expect(BillingRecord.count).to eq(0)
     end
 
     it "creates new billing record when no daily record" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
+      runner.update(ready_at: now - 5 * 60)
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       nx.update_billing_record
 
       br = BillingRecord[resource_id: project.id]
       expect(br.amount).to eq(5)
-      expect(br.duration(time, time)).to eq(1)
+      expect(br.duration(now, now)).to eq(1)
     end
 
     it "uses separate billing rate for arm64 runners" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:label).and_return("ubicloud-arm").at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
-      expect(github_runner).to receive(:update).with(billed_vm_size: "standard-2-arm")
+      runner.update(label: "ubicloud-arm", ready_at: now - 5 * 60)
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       nx.update_billing_record
 
       br = BillingRecord[resource_id: project.id]
       expect(br.amount).to eq(5)
-      expect(br.duration(time, time)).to eq(1)
+      expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-2-arm")
+      expect(runner.billed_vm_size).to eq("standard-2-arm")
     end
 
     it "uses separate billing rate for gpu runners" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      vm.family = "standard-gpu"
-      vm.vcpus = 6
-      expect(github_runner).to receive(:label).and_return("ubicloud-gpu").at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
-      expect(github_runner).to receive(:update).with(billed_vm_size: "standard-gpu-6")
+      vm.update(family: "standard-gpu", vcpus: 6)
+      runner.update(label: "ubicloud-gpu", ready_at: now - 5 * 60)
+
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       nx.update_billing_record
 
       br = BillingRecord[resource_id: project.id]
       expect(br.amount).to eq(5)
-      expect(br.duration(time, time)).to eq(1)
+      expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-gpu-6")
+      expect(runner.billed_vm_size).to eq("standard-gpu-6")
     end
 
     it "uses the premium billing rate for upgraded runners" do
-      time = Time.now
-      vm.family = "premium"
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:label).and_return("ubicloud-standard-2").at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
-      expect(github_runner).to receive(:update).with(billed_vm_size: "premium-2")
+      vm.update(family: "premium")
+      runner.update(label: "ubicloud-standard-2", ready_at: now - 5 * 60)
+
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       nx.update_billing_record
 
       br = BillingRecord[resource_id: project.id]
       expect(br.amount).to eq(5)
-      expect(br.duration(time, time)).to eq(1)
+      expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("premium-2")
+      expect(runner.billed_vm_size).to eq("premium-2")
     end
 
     it "uses the original billing rate for runners who were upgraded for free" do
-      time = Time.now
-      vm.family = "premium"
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:label).and_return("ubicloud-standard-2").at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
-      expect(github_runner).to receive(:update).with(billed_vm_size: "standard-2")
-      expect(github_runner.installation).to receive(:free_runner_upgrade?).and_return(true)
+      vm.update(family: "premium")
+      runner.update(label: "ubicloud-standard-2", ready_at: now - 5 * 60)
+
+      expect(runner.installation).to receive(:free_runner_upgrade?).and_return(true)
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       nx.update_billing_record
 
       br = BillingRecord[resource_id: project.id]
       expect(br.amount).to eq(5)
-      expect(br.duration(time, time)).to eq(1)
+      expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-2")
+      expect(runner.billed_vm_size).to eq("standard-2")
     end
 
     it "updates the amount of existing billing record" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
+      runner.update(ready_at: now - 5 * 60)
+
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       # Create a record
       nx.update_billing_record
@@ -239,14 +190,14 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "create a new record for a new day" do
       today = Time.now
       tomorrow = today + 24 * 60 * 60
-      expect(Time).to receive(:now).and_return(today).exactly(5)
-      expect(github_runner).to receive(:ready_at).and_return(today - 5 * 60).twice
+      expect(Time).to receive(:now).and_return(today).exactly(6)
+      expect(runner).to receive(:ready_at).and_return(today - 5 * 60).twice
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       # Create today record
       nx.update_billing_record
 
       expect(Time).to receive(:now).and_return(tomorrow).at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(tomorrow - 5 * 60).at_least(:once)
+      expect(runner).to receive(:ready_at).and_return(tomorrow - 5 * 60).at_least(:once)
       expect(BillingRecord).to receive(:create_with_id).and_call_original
       # Create tomorrow record
       expect { nx.update_billing_record }
@@ -256,9 +207,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "tries 3 times and creates single billing record" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
+      runner.update(ready_at: now - 5 * 60)
       expect(BillingRecord).to receive(:create_with_id).and_raise(Sequel::Postgres::ExclusionConstraintViolation).exactly(3)
       expect(BillingRecord).to receive(:create_with_id).and_call_original
 
@@ -268,9 +217,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "tries 4 times and fails" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(github_runner).to receive(:ready_at).and_return(time - 5 * 60).at_least(:once)
+      runner.update(ready_at: now - 5 * 60)
       expect(BillingRecord).to receive(:create_with_id).and_raise(Sequel::Postgres::ExclusionConstraintViolation).at_least(:once)
 
       expect {
@@ -302,28 +249,21 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#start" do
     it "hops to wait_concurrency_limit if there is no capacity" do
-      installation = instance_double(GithubInstallation)
-      project = instance_double(Project, quota_available?: false, github_installations: [installation], active?: true)
-
-      expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
+      expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+      expect(project).to receive(:active?).and_return(true)
 
       expect { nx.start }.to hop("wait_concurrency_limit")
     end
 
     it "hops to allocate_vm if there is capacity" do
-      installation = instance_double(GithubInstallation)
-      project = instance_double(Project, quota_available?: true, github_installations: [installation], active?: true)
-
-      expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
+      expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(true)
+      expect(project).to receive(:active?).and_return(true)
 
       expect { nx.start }.to hop("allocate_vm")
     end
 
     it "pops if the project is not active" do
-      installation = instance_double(GithubInstallation, project: instance_double(Project, active?: false))
-      expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
+      expect(project).to receive(:active?).and_return(false)
 
       expect { nx.start }.to exit({"msg" => "Could not provision a runner for inactive project"})
     end
@@ -331,92 +271,83 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#wait_concurrency_limit" do
     before do
-      [[Location::HETZNER_FSN1_ID, "x64"], [Location::GITHUB_RUNNERS_ID, "x64"], [Location::GITHUB_RUNNERS_ID, "arm64"]].each_with_index do |(location_id, arch), i|
+      [[Location::HETZNER_FSN1_ID, "x64"], [Location::GITHUB_RUNNERS_ID, "x64"], [Location::GITHUB_RUNNERS_ID, "arm64"]].each do |location_id, arch|
         create_vm_host(location_id:, arch:, total_cores: 16, used_cores: 16)
       end
     end
 
     it "waits until customer concurrency limit frees up" do
-      installation = instance_double(GithubInstallation)
-      project = instance_double(Project, quota_available?: false, github_installations: [installation])
-
-      expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
+      expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
 
       expect { nx.wait_concurrency_limit }.to nap
     end
 
     it "hops to allocate_vm when customer concurrency limit frees up" do
-      installation = instance_double(GithubInstallation)
-      project = instance_double(Project, quota_available?: true, github_installations: [installation])
-
-      expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
+      expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(true)
 
       expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
     end
 
     it "hops to allocate_vm when customer concurrency limit is full but the overall utilization is low" do
-      installation = instance_double(GithubInstallation)
-      project = instance_double(Project, quota_available?: false, github_installations: [installation])
+      expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
 
-      expect(github_runner).to receive(:installation).and_return(installation).at_least(:once)
-      expect(github_runner.installation).to receive(:project).and_return(project).at_least(:once)
-      VmHost[arch: "x64"].update(used_cores: 4)
+      VmHost[arch: "x64"].update(used_cores: 1)
       expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
     end
   end
 
   describe "#allocate_vm" do
     it "picks vm and hops" do
-      expect(nx).to receive(:pick_vm).and_return(vm)
-      expect(github_runner).to receive(:update).with(vm_id: vm.id, allocated_at: anything)
-      expect(vm).to receive(:update).with(name: github_runner.ubid)
-      expect(github_runner).to receive(:reload).and_return(github_runner)
+      picked_vm = create_vm(name: "picked-vm")
+      expect(nx).to receive(:pick_vm).and_return(picked_vm)
       expect(Clog).to receive(:emit).with("runner_allocated").and_call_original
       expect { nx.allocate_vm }.to hop("wait_vm")
+      expect(runner.vm_id).to eq(picked_vm.id)
+      expect(runner.allocated_at).to eq(now)
+      expect(picked_vm.name).to eq(runner.ubid)
     end
   end
 
   describe "#wait_vm" do
     it "naps 13 seconds if vm is not allocated yet" do
-      expect(vm).to receive(:allocated_at).and_return(nil)
+      vm.update(allocated_at: nil)
       expect { nx.wait_vm }.to nap(13)
     end
 
     it "naps a second if vm is allocated but not provisioned yet" do
-      expect(vm).to receive(:allocated_at).and_return(Time.now)
+      vm.update(allocated_at: now)
       expect { nx.wait_vm }.to nap(1)
     end
 
     it "hops if vm is ready" do
-      expect(vm).to receive_messages(allocated_at: Time.now, provisioned_at: Time.now)
+      vm.update(allocated_at: now, provisioned_at: now)
       expect { nx.wait_vm }.to hop("setup_environment")
     end
   end
 
   describe ".setup_info" do
     it "returns setup info with vm pool ubid" do
-      expect(vm).to receive(:pool_id).and_return("ccd51c1e-2c78-8f76-b182-467e6cdc51f0").at_least(:once)
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location_id: Location::HETZNER_FSN1_ID, data_center: "FSN1-DC8")).at_least(:once)
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
+      vm_host = create_vm_host(total_cores: 4, used_cores: 4, data_center: "FSN1-DC8")
+      pool = VmPool.create(size: 1, vm_size: "standard-2", location_id: Location::GITHUB_RUNNERS_ID, boot_image: "github-ubuntu-2204", storage_size_gib: 86)
+      vm.update(pool_id: pool.id, vm_host_id: vm_host.id)
 
-      expect(nx.setup_info[:detail]).to eq("Name: #{github_runner.ubid}\nLabel: ubicloud-standard-4\nVM Family: standard\nArch: \nImage: \nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\nVM Pool: vpskahr7hcf26p614czkcvh8z1\nLocation: hetzner-fsn1\nDatacenter: FSN1-DC8\nProject: pjwnadpt27b21p81d7334f11rx\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github")
+      expect(nx.setup_info[:detail]).to eq("Name: #{runner.ubid}\nLabel: ubicloud-standard-4\nVM Family: standard\nArch: x64\nImage: github-ubuntu-2204\nVM Host: #{vm_host.ubid}\nVM Pool: #{pool.ubid}\nLocation: hetzner-fsn1\nDatacenter: FSN1-DC8\nProject: #{project.ubid}\nConsole URL: http://localhost:9292/project/#{project.ubid}/github")
     end
   end
 
   describe "#setup_environment" do
+    before do
+      vm.update(vm_host_id: create_vm_host(data_center: "FSN1-DC8").id)
+    end
+
     it "hops to register_runner" do
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location_id: Location::HETZNER_FSN1_ID, data_center: "FSN1-DC8", id: "788525ed-d6f0-4937-a844-323d4fd91946")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
-      expect(github_runner.installation).to receive(:use_docker_mirror).and_return(true)
-      expect(github_runner.installation).to receive(:cache_enabled).and_return(false)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+      runner.installation.update(use_docker_mirror: true, cache_enabled: false)
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
         if [ -f /etc/docker/daemon.json ] && [ -s /etc/docker/daemon.json ]; then
@@ -440,16 +371,13 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "hops to register_runner without setting up registry mirror" do
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location_id: Location::HETZNER_FSN1_ID, data_center: "FSN1-DC8", id: "788525ed-d6f0-4937-a844-323d4fd91946")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
-      expect(github_runner.installation).to receive(:use_docker_mirror).and_return(false)
-      expect(github_runner.installation).to receive(:cache_enabled).and_return(false)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+      installation.update(use_docker_mirror: false, cache_enabled: false)
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
       COMMAND
@@ -458,17 +386,14 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "hops to register_runner with after enabling transparent cache" do
-      expect(vm).to receive(:vm_host).and_return(instance_double(VmHost, ubid: "vhfdmbbtdz3j3h8hccf8s9wz94", location_id: Location::HETZNER_FSN1_ID, data_center: "FSN1-DC8", id: "788525ed-d6f0-4937-a844-323d4fd91946")).at_least(:once)
       expect(vm).to receive(:runtime_token).and_return("my_token")
-      expect(github_runner.installation).to receive(:project).and_return(instance_double(Project, ubid: "pjwnadpt27b21p81d7334f11rx", path: "/project/pjwnadpt27b21p81d7334f11rx")).at_least(:once)
-      expect(github_runner.installation).to receive(:use_docker_mirror).and_return(false)
-      expect(github_runner.installation).to receive(:cache_enabled).and_return(true)
+      installation.update(use_docker_mirror: false, cache_enabled: true)
       expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))]).at_least(:once)
-      expect(sshable).to receive(:cmd).with(<<~COMMAND)
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{github_runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: \\nImage: \\nVM Host: vhfdmbbtdz3j3h8hccf8s9wz94\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: pjwnadpt27b21p81d7334f11rx\\nConsole URL: http://localhost:9292/project/pjwnadpt27b21p81d7334f11rx/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment
@@ -480,42 +405,43 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#register_runner" do
     it "registers runner hops" do
-      expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: github_runner.ubid.to_s, labels: [github_runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC"})
-      expect(sshable).to receive(:cmd).with("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh {}",
+      expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC"})
+      expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh {}",
         stdin: "AABBCC")
-      expect(github_runner).to receive(:update).with(runner_id: 123, ready_at: anything)
-
       expect { nx.register_runner }.to hop("wait")
+      expect(runner.runner_id).to eq(123)
+      expect(runner.ready_at).to eq(now)
     end
 
     it "deletes the runner if the generate request fails due to 'already exists with the same name' error and the runner script does not start yet." do
       expect(client).to receive(:post)
-        .with(/.*generate-jitconfig/, hash_including(name: github_runner.ubid.to_s, labels: [github_runner.label]))
+        .with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label]))
         .and_raise(Octokit::Conflict.new({body: "409 - Already exists - A runner with the name *** already exists."}))
       expect(client).to receive(:paginate)
-        .and_yield({runners: [{name: github_runner.ubid.to_s, id: 123}]}, instance_double(Sawyer::Response, data: {runners: []}))
-        .and_return({runners: [{name: github_runner.ubid.to_s, id: 123}]})
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("dead")
-      expect(client).to receive(:delete).with("/repos/#{github_runner.repository_name}/actions/runners/123")
+        .and_yield({runners: [{name: runner.ubid.to_s, id: 123}]}, instance_double(Sawyer::Response, data: {runners: []}))
+        .and_return({runners: [{name: runner.ubid.to_s, id: 123}]})
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("dead")
+      expect(client).to receive(:delete).with("/repos/#{runner.repository_name}/actions/runners/123")
       expect(Clog).to receive(:emit).with("Deregistering runner because it already exists").and_call_original
       expect { nx.register_runner }.to nap(5)
     end
 
     it "hops to wait if the generate request fails due to 'already exists with the same name' error and the runner script is running" do
       expect(client).to receive(:post)
-        .with(/.*generate-jitconfig/, hash_including(name: github_runner.ubid.to_s, labels: [github_runner.label]))
+        .with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label]))
         .and_raise(Octokit::Conflict.new({body: "409 - Already exists - A runner with the name *** already exists."}))
       expect(client).to receive(:paginate)
-        .and_yield({runners: [{name: github_runner.ubid.to_s, id: 123}]}, instance_double(Sawyer::Response, data: {runners: []}))
-        .and_return({runners: [{name: github_runner.ubid.to_s, id: 123}]})
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
-      expect(github_runner).to receive(:update).with(runner_id: 123, ready_at: anything)
+        .and_yield({runners: [{name: runner.ubid.to_s, id: 123}]}, instance_double(Sawyer::Response, data: {runners: []}))
+        .and_return({runners: [{name: runner.ubid.to_s, id: 123}]})
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
       expect { nx.register_runner }.to hop("wait")
+      expect(runner.runner_id).to eq(123)
+      expect(runner.ready_at).to eq(now)
     end
 
     it "fails if the generate request fails due to 'already exists with the same name' error but couldn't find the runner" do
       expect(client).to receive(:post)
-        .with(/.*generate-jitconfig/, hash_including(name: github_runner.ubid.to_s, labels: [github_runner.label]))
+        .with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label]))
         .and_raise(Octokit::Conflict.new({body: "409 - Already exists - A runner with the name *** already exists."}))
       expect(client).to receive(:paginate).and_return({runners: []})
       expect(client).not_to receive(:delete)
@@ -524,7 +450,7 @@ RSpec.describe Prog::Vm::GithubRunner do
 
     it "fails if the generate request fails due to 'Octokit::Conflict' but it's not already exists error" do
       expect(client).to receive(:post)
-        .with(/.*generate-jitconfig/, hash_including(name: github_runner.ubid.to_s, labels: [github_runner.label]))
+        .with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label]))
         .and_raise(Octokit::Conflict.new({body: "409 - Another issue"}))
       expect { nx.register_runner }.to raise_error Octokit::Conflict
     end
@@ -532,64 +458,63 @@ RSpec.describe Prog::Vm::GithubRunner do
 
   describe "#wait" do
     it "does not destroy runner if it does not pick a job in five minutes, and busy" do
-      expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
+      runner.update(ready_at: now - 6 * 60, workflow_job: nil)
       expect(client).to receive(:get).and_return({busy: true})
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
-      expect(github_runner).not_to receive(:incr_destroy)
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
+      expect(runner).not_to receive(:incr_destroy)
 
       expect { nx.wait }.to nap(60)
     end
 
     it "destroys runner if it does not pick a job in five minutes and not busy" do
-      expect(github_runner).to receive(:workflow_job).and_return(nil)
-      expect(Time).to receive(:now).and_return(github_runner.ready_at + 6 * 60)
+      runner.update(ready_at: now - 6 * 60, workflow_job: nil)
       expect(client).to receive(:get).and_return({busy: false})
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
-      expect(github_runner).to receive(:incr_destroy)
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
+      expect(runner).to receive(:incr_destroy)
       expect(Clog).to receive(:emit).with("The runner does not pick a job").and_call_original
 
       expect { nx.wait }.to nap(0)
     end
 
     it "does not destroy runner if it doesn not pick a job but two minutes not pass yet" do
-      expect(github_runner).to receive(:workflow_job).and_return(nil)
-      expect(Time).to receive(:now).and_return(github_runner.ready_at + 1 * 60)
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
-      expect(github_runner).not_to receive(:incr_destroy)
+      runner.update(ready_at: now - 60, workflow_job: nil)
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
+      expect(runner).not_to receive(:incr_destroy)
 
       expect { nx.wait }.to nap(60)
     end
 
     it "destroys the runner if the runner-script is succeeded" do
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("exited")
-      expect(github_runner).to receive(:incr_destroy)
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("exited")
+      expect(runner).to receive(:incr_destroy)
 
       expect { nx.wait }.to nap(15)
     end
 
     it "provisions a spare runner and destroys the current one if the runner-script is failed" do
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("failed")
-      expect(github_runner).to receive(:provision_spare_runner)
-      expect(github_runner).to receive(:incr_destroy)
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("failed")
+      expect(runner).to receive(:provision_spare_runner)
+      expect(runner).to receive(:incr_destroy)
       expect { nx.wait }.to nap(0)
     end
 
     it "naps if the runner-script is running" do
-      expect(github_runner).to receive(:workflow_job).and_return({"id" => 123})
-      expect(sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
+      expect(vm.sshable).to receive(:cmd).with("systemctl show -p SubState --value runner-script").and_return("running")
 
       expect { nx.wait }.to nap(60)
     end
   end
 
   describe ".collect_final_telemetry" do
+    before do
+      vm.update(vm_host_id: create_vm_host(data_center: "FSN1-DC8").id)
+    end
+
     it "Logs journalctl and docker limits if workflow_job is not successful" do
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "failure"})
-      vmh_sshable = instance_double(Sshable)
-      expect(vm.vm_host).to receive(:sshable).and_return(vmh_sshable)
-      expect(vmh_sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
-      expect(sshable).to receive(:cmd).with(<<~COMMAND, log: false)
+      runner.update(workflow_job: {"conclusion" => "failure"})
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ln /vm/#{vm.inhost_name}/serial.log /var/log/ubicloud/serials/#{runner.ubid}_serial.log")
+      expect(vm.sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND, log: false)
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
@@ -598,12 +523,10 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "Logs journalctl and docker limits if workflow_job is nil" do
-      expect(github_runner).to receive(:workflow_job).and_return(nil)
-      vmh_sshable = instance_double(Sshable)
-      expect(vm.vm_host).to receive(:sshable).and_return(vmh_sshable)
-      expect(vmh_sshable).to receive(:cmd).with("sudo ln /vm/9qf22jbv/serial.log /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-      expect(sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
-      expect(sshable).to receive(:cmd).with(<<~COMMAND, log: false)
+      runner.update(workflow_job: nil)
+      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ln /vm/#{vm.inhost_name}/serial.log /var/log/ubicloud/serials/#{runner.ubid}_serial.log")
+      expect(vm.sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND, log: false)
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
@@ -612,8 +535,8 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "Logs only docker limits if workflow_job is successful" do
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"})
-      expect(sshable).to receive(:cmd).with(<<~COMMAND, log: false).and_return("ratelimit-limit: 100;w=21600\nratelimit-remaining: 98;w=21600\ndocker-ratelimit-source: 192.168.1.1\n")
+      runner.update(workflow_job: {"conclusion" => "success"})
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND, log: false).and_return("ratelimit-limit: 100;w=21600\nratelimit-remaining: 98;w=21600\ndocker-ratelimit-source: 192.168.1.1\n")
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
@@ -625,16 +548,16 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "doesn't fail if it failed due to Sshable::SshError" do
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"})
-      expect(sshable).to receive(:cmd).and_raise Sshable::SshError.new("bogus", "", "", nil, nil)
+      runner.update(workflow_job: {"conclusion" => "success"})
+      expect(vm.sshable).to receive(:cmd).and_raise Sshable::SshError.new("bogus", "", "", nil, nil)
       expect(Clog).to receive(:emit).with("Failed to collect final telemetry").and_call_original
 
       nx.collect_final_telemetry
     end
 
     it "doesn't fail if it failed due to Net::SSH::ConnectionTimeout" do
-      expect(github_runner).to receive(:workflow_job).and_return({"conclusion" => "success"})
-      expect(sshable).to receive(:cmd).and_raise Net::SSH::ConnectionTimeout
+      runner.update(workflow_job: {"conclusion" => "success"})
+      expect(vm.sshable).to receive(:cmd).and_raise Net::SSH::ConnectionTimeout
       expect(Clog).to receive(:emit).with("Failed to collect final telemetry").and_call_original
 
       nx.collect_final_telemetry
@@ -656,6 +579,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "destroys resources and hops if runner deregistered" do
+      vm.update(vm_host_id: create_vm_host.id)
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)
@@ -671,8 +595,9 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "skip deregistration and destroy vm immediately" do
+      vm.update(vm_host_id: create_vm_host.id)
       expect(nx).to receive(:decr_destroy)
-      expect(github_runner).to receive(:skip_deregistration_set?).and_return(true)
+      expect(runner).to receive(:skip_deregistration_set?).and_return(true)
       expect(nx).to receive(:collect_final_telemetry)
       expect(vm).to receive(:incr_destroy)
 
@@ -680,9 +605,9 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "does not collect telemetry if the vm not allocated" do
+      vm.update(vm_host_id: nil)
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
-      expect(vm).to receive(:vm_host).and_return(nil)
       expect(nx).not_to receive(:collect_final_telemetry)
       expect(vm).to receive(:incr_destroy)
 
@@ -690,11 +615,11 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "does not destroy vm if it's already destroyed" do
+      runner.update(vm_id: nil)
+      expect(nx).to receive(:vm).and_return(nil).at_least(:once)
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)
-      expect(github_runner).to receive(:vm).and_return(nil)
-      expect(vm).not_to receive(:incr_destroy)
 
       expect { nx.destroy }.to hop("wait_vm_destroy")
     end
@@ -706,14 +631,14 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "extends deadline if vm prevents destroy" do
-      expect(vm).to receive(:prevent_destroy_set?).and_return(true)
+      expect(runner.vm).to receive(:prevent_destroy_set?).and_return(true)
       expect(nx).to receive(:register_deadline).with(nil, 15 * 60, allow_extension: true)
       expect { nx.wait_vm_destroy }.to nap(10)
     end
 
     it "pops if vm destroyed" do
       expect(nx).to receive(:vm).and_return(nil).twice
-      expect(github_runner).to receive(:destroy)
+      expect(runner).to receive(:destroy)
 
       expect { nx.wait_vm_destroy }.to exit({"msg" => "github runner deleted"})
     end

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -11,9 +11,8 @@
     rows:
       @runners.map do |runner|
         destroy_url = "#{@project_data[:path]}/github/#{@installation.ubid}/runner/#{runner.ubid}"
-        vm_size = runner.label_data["vm_size_data"]
         os = runner.label_data["boot_image"].match(/(ubuntu-\d{2})\d{2}/)[1]
-        family = runner.vm&.family || vm_size.family
+        family = runner.vm&.family || runner.label_data["family"]
         [
           [
             [[
@@ -24,9 +23,9 @@
               [runner.ubid, {link: runner.runner_url}],
               [<<~CONTENT, {escape: false}],
                 <div class="flex gap-1">
-                  <div class="rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800">#{vm_size.vcpus} vCPU</div>
+                  <div class="rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800">#{runner.label_data["vcpus"]} vCPU</div>
                   <div class="rounded-md px-2 text-xs font-medium leading-5 #{(family == "premium") ? "bg-orange-100 text-orange-600" : "bg-slate-100 text-slate-800"}">#{family}</div>
-                  <div class="rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800">#{vm_size.arch}</div>
+                  <div class="rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800">#{runner.label_data["arch"]}</div>
                   <div class="rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800">#{os}</div>
                 </div>
               CONTENT


### PR DESCRIPTION
- **Remove the location field from the runner label configs**
  In the initial design, we planned to create a separate label for each
  location, but we decided against it. Our codebase expects the runner to
  have the location set as "github-runners" in multiple places. Therefore,
  the location field is redundant and makes the config file cluttered.
  

- **Remove the gpu field from the runner label config**
  We use the vm size family to determine GPU requirements. Since the vm
  size is "standard-gpu-6" for our GPU runners, the label.gpu is not used
  anywhere in the codebase.
  

- **Separate family and vCPUs in runner label configs**
  We need family and vCPUs separated in multiple places, so it's better to
  keep them separate instead of using a single property.
  

- **Clean up the Prog::Vm::GithubRunner tests**
  We're trying to keep our tests as close to the database as possible.
  Some of the runner nexus specs relied heavily on mocking instead of
  using real database queries, so I refactored them. This removed a lot of
  lines and made testing easier in some cases.
  

- **Use the premium VM pool if the premium runner is enabled**
  Before, we skipped the VM pool when the premium runner was enabled. Now,
  we can use the premium pools for them.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance GitHub runner configuration by using premium VM pools, simplifying label configs, and refactoring tests.
> 
>   - **Behavior**:
>     - Use premium VM pool if premium runner is enabled in `github_runner.rb` and `github_runner_spec.rb`.
>     - Remove `location` and `gpu` fields from runner label configs in `config/github_runner_labels.yml`.
>     - Separate `family` and `vCPUs` in runner label configs in `config/github_runner_labels.yml`.
>   - **Code Refactoring**:
>     - Refactor `Prog::Vm::GithubRunner` tests in `github_runner_spec.rb` to reduce mocking and use real database queries.
>     - Update `runner_labels` in `lib/github.rb` to compute `vm_size` from `family` and `vCPUs`.
>   - **Misc**:
>     - Update `total_active_runner_vcpus` in `model/github_runner.rb` to use `vCPUs` directly.
>     - Adjust `setup_info` in `prog/vm/github_runner.rb` to reflect new label structure.
>     - Update `views/github/runner.erb` to display `vCPUs` and `family` from new label structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b2381674e03572cb0578dc4b2f3b4d5c348cd871. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->