### PR TITLE
Add more panels to PG metrics dashboard

### DIFF
--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -172,6 +172,22 @@ module Metrics
           query: "topk(5, sum(pg_database_size_bytes{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\", datname!~\"template0|template1\"}) by (datname))"
         )
       ]
+    ),
+    transactions:
+    MetricDefinition.new(
+      name: "Transactions",
+      description: "Committed vs rolled back transactions",
+      unit: "count/s",
+      series: [
+        TimeSeries.new(
+          labels: {name: "Commits"},
+          query: "sum(rate(pg_stat_database_xact_commit{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        ),
+        TimeSeries.new(
+          labels: {name: "Rollbacks"},
+          query: "sum(rate(pg_stat_database_xact_rollback{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        )
+      ]
     )
   }
 end

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -65,6 +65,22 @@ module Metrics
         )
       ]
     ),
+    disk_io:
+    MetricDefinition.new(
+      name: "Disk I/O",
+      description: "I/O operations per second",
+      unit: "IOPS",
+      series: [
+        TimeSeries.new(
+          labels: {name: "Reads"},
+          query: "sum(rate(node_disk_reads_completed_total{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        ),
+        TimeSeries.new(
+          labels: {name: "Writes"},
+          query: "sum(rate(node_disk_writes_completed_total{ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m]))"
+        )
+      ]
+    ),
     network_traffic:
     MetricDefinition.new(
       name: "Network Traffic",


### PR DESCRIPTION
* Add disk IOPS stat to PG metrics
Had removed this earlier because of suspected bad data being reported (read IOPS were consistently 0). Turns out that was because all reads were cached, dropping the page cache showed read IOPS activity.

![image](https://github.com/user-attachments/assets/bc5cbdca-1127-4c1b-8578-8b11001e7a6f)

* Add transaction stats to PG metrics

Adds another panel in the DB stats section, mostly for symmetry reasons.

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/86de7998-351d-4125-bba9-9fb76e1039a9" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds disk IOPS and transaction stats panels to PostgreSQL metrics dashboard in `lib/metrics.rb`.
> 
>   - **Metrics Added**:
>     - `disk_io`: Adds disk IOPS metrics with read and write operations per second.
>     - `transactions`: Adds transaction metrics with committed and rolled back transactions per second.
>   - **File Modified**:
>     - `lib/metrics.rb`: Adds `disk_io` and `transactions` `MetricDefinition` entries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b0894aafd56372a1707b6039a214a9351084e8c7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->