### PR TITLE
Add a workflow to trigger E2E tests with the "/run-e2e" command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Add e2e script to Procfile
       run: |
         test_cases="$(yq -r '[.[].name] | join(",")' config/e2e_test_cases.yml)"
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.test_cases }}" ]]; then
           test_cases="${{ inputs.test_cases }}"
         fi
         echo "Running e2e test cases: $test_cases"

--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -1,0 +1,65 @@
+name: Trigger E2E tests
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+    pr_comment:
+      if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/run-e2e')
+      runs-on: ubicloud
+      steps:
+        - name: Trigger E2E tests
+          uses: actions/github-script@v7
+          with:
+            script: |
+              // Check if the comment is from a contributor
+              const contributors = await github.rest.repos.listContributors({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              const contributorIds = contributors.data.map(c => c.id);
+              const isContributor = contributorIds.includes(context.payload.comment.user.id);
+
+              // Check if the given test cases string is secure or empty
+              const testCases = (context.payload.comment.body.trim().split(/\s+/)[1]) || '';
+              console.log(`testCases: ${testCases}`);
+              const isValid = testCases ? /^[a-zA-Z0-9_,-]+$/.test(testCases) : true;
+              console.log(`Is valid: ${isValid}`);
+
+              const allowedToRun = isContributor && isValid;
+
+              // Add a reaction to the comment
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: allowedToRun ? 'rocket' : '-1'
+              })
+
+              if (!allowedToRun) {
+                console.log('Not allowed to run E2E tests');
+                process.exit(1);
+              }
+
+              // Get pull request details
+              const pullRequest = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number
+              });
+
+              // Create a workflow dispatch event
+              const inputs = testCases ? { test_cases: testCases } : {}
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'e2e.yml',
+                ref: pullRequest.data.head.ref,
+                inputs: inputs
+              });


### PR DESCRIPTION
Currently, to trigger E2E tests, we need to open the workflow page on the GitHub UI, select a branch, and run the tests. There's a more developer-friendly way to do this. We can easily add support for the `/run-e2e` command using GitHub Actions workflows. When you run `/run-e2e` on a pull request, it triggers E2E tests for that PR. You can also pass specific test cases with `/run-e2e
vm,github_runner_ubuntu_2404`.

It only accepts comments from contributors, similar to the E2E test trigger.

Since "issue_comment" event doesn't have pull request head ref, we get it from API.

Additionally, we can add a check to this workflow to trigger E2E tests if there are any code changes in the `rhizome` path.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to trigger E2E tests via `/run-e2e` comment on PRs, with contributor validation and test case security checks.
> 
>   - **New Workflow**:
>     - Adds `trigger-e2e.yml` to trigger E2E tests via `/run-e2e` comment on PRs.
>     - Validates comment author is a contributor and test cases string is secure.
>     - Uses `actions/github-script@v7` to handle comment parsing and validation.
>   - **Behavior**:
>     - Triggers E2E tests for PRs when `/run-e2e` is commented.
>     - Supports specific test cases via `/run-e2e vm,github_runner_ubuntu_2404`.
>     - Adds a reaction to the comment based on validation success.
>   - **Modifications**:
>     - Updates `e2e.yml` to handle `workflow_dispatch` with specific test cases input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for bb327adea054686b6b016c763670ed6593e2d0d8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->