### PR TITLE
Accept location as either ubid or uuid

### DIFF
--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -223,7 +223,7 @@ class Clover < Roda
     #
     # If location not previously retrieved, require it be visible or tied to the current project
     # when retrieving it.  This is called when creating resources in the web routes.
-    @location ||= if (id = typecast_params.uuid("location"))
+    @location ||= if (id = typecast_params.ubid_uuid("location") || typecast_params.uuid("location"))
       Location.visible_or_for_project(@project.id).first(id:)
     end
     handle_invalid_location unless @location&.visible_or_for_project?(@project.id)


### PR DESCRIPTION
This is the first step in the process.  When rolling out this change, you could have a GET request to display a page go to a new version of the code, but the POST request when submitted to go to the old version of the code.  This allows for that to work without breaking, using a multi-step commit process:

1) Application only accepts uuid format
2) This commit
3) New versions accept uuid or ubid, old versions accept uuid only,
   uuid is used for submission in all versions
4) After a few minutes, all versions accept uuid or ubid
5) Future commit that switches to submitting ubid
6) All versions accept uuid or ubid, new versions submit ubid,
   old versions submit uuid
7) After a few minutes, all versions accept uuid or ubid, and submit
   ubid
8) Future commit that drops support for uuid
9) All versions submit ubid, new versions only accept ubid, old versions
   accept both
10) After a few minutes, all versions only accept ubid and only submit
   ubid