### PR TITLE
Enable yjit before freezing core

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -240,5 +240,6 @@ def clover_freeze
     Validation::ValidationFailed
   ].each(&:freeze)
 
+  RubyVM::YJIT.enable
   Refrigerator.freeze_core
 end


### PR DESCRIPTION
You cannot do it after freezing core, as enabling yjit modifies Integer.

By doing it near the end of clover_freeze, it affects:

* production environment (monitor, respirate, web)
* frozen_specs (to match production environment)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable `RubyVM::YJIT` before freezing core in `clover_freeze` to affect production environment and frozen specs.
> 
>   - **Behavior**:
>     - Enables `RubyVM::YJIT` before `Refrigerator.freeze_core` in `clover_freeze` function.
>     - Affects production environment and frozen specs by modifying `Integer` before freezing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 63ffb7deaa087b674effd02d3aed95b6f74337c0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->