### PR TITLE
Inference Router: Support for embedding models

### DIFF
--- a/config/inference_router_config.json
+++ b/config/inference_router_config.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "inference",
-      "path": "^/v1/(chat/)?completions$",
+      "path": "^/v1/(chat/completions|completions|embeddings)$",
       "app": "inference"
     },
     {

--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
         }])
         expect(json_sent["locations"].map { |h| h.transform_keys(&:to_sym) }).to eq([
           {name: "up", path: "^/up$", app: "up"},
-          {name: "inference", path: "^/v1/(chat/)?completions$", app: "inference"},
+          {name: "inference", path: "^/v1/(chat/completions|completions|embeddings)$", app: "inference"},
           {name: "usage", path: "^/usage$", app: "usage"}
         ])
         expect(json_sent["routes"].map { |h| h.transform_keys(&:to_sym).except(:endpoints) }).to eq([{
@@ -384,7 +384,7 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
       expect(inference_router).to receive(:ubid).and_return("irubid")
       expect(sshable).to receive(:cmd).with(
         "md5sum /ir/workdir/config.json | awk '{ print $1 }'"
-      ).and_return("4569f48e2c010e208e6b11af2a40d9d5") # md5sum of the test config.
+      ).and_return("dd8a549def177e5a6cbedeb511b55208") # md5sum of the test config.
       expect(sshable).not_to receive(:cmd).with(
         "sudo mkdir -p /ir/workdir && sudo tee /ir/workdir/config.json > /dev/null",
         hash_including(stdin: a_string_matching(/"projects":/))


### PR DESCRIPTION
Update the inference router configuration to handle embedding requests.

Previously, the router supported the following paths:
* /v1/chat/completions
* /v1/completions

It now also supports:
* /v1/embeddings

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `/v1/embeddings` path in inference router configuration and updates test config md5sum.
> 
>   - **Behavior**:
>     - Adds support for `/v1/embeddings` path in inference router configuration in `inference_router_replica_nexus_spec.rb`.
>     - Updates md5sum of test config to `dd8a549def177e5a6cbedeb511b55208` in `inference_router_replica_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e3060a0e7ada06ce8dfa20345bf3c478f1f4b22c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->