### PR TITLE
Allow md5 in pg_hba.conf

### DIFF
--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -76,8 +76,10 @@ host    replication     all             ::1/128                 scram-sha-256
 # HA standbys
 hostssl replication     ubi_replication all                     cert map=standby2replication
 
-# Allow connections from public internet with SCRAM authentication
-host    all             all             all                     scram-sha-256
+# Allow connections from public internet with md5 authentication
+# Note that if the password is encrypted as scram-sha-256, PostgreSQL
+# still uses scram-sha-256 for authentication.
+host    all             all             all                     md5
 PG_HBA
 safe_write_to_file("/etc/postgresql/#{v}/main/pg_hba.conf", pg_hba_entries)
 


### PR DESCRIPTION
We still use scram-sha-256 as default password encryption method. Even if the authentication method is set to md5, PostgreSQL uses scram-sha-256 if the password is encrypted with scram-sha-256, but not the other way around. By allowing md5 in pg_hba.conf, users coming from legacy systems can still use md5 authentication without having to change their passwords, while ensuring that new users are created and authenticated with scram-sha-256.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allows `md5` authentication in `pg_hba.conf` while maintaining `scram-sha-256` as the default encryption, supporting legacy systems without password changes.
> 
>   - **Behavior**:
>     - Allows `md5` authentication in `pg_hba.conf` in `rhizome/postgres/bin/configure`.
>     - Maintains `scram-sha-256` as the default password encryption method.
>     - Supports legacy systems using `md5` without requiring password changes.
>   - **Configuration**:
>     - Updates `pg_hba.conf` to allow `md5` authentication for all connections.
>     - Ensures `scram-sha-256` is used if the password is encrypted with it, even if `md5` is specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 375b174c62bda42e2a2bff599ce44c76e5ac652a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->