### PR TITLE
LBs that don't use HTTPS won't provision SSL Certs

### DIFF
--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -115,6 +115,7 @@ class LoadBalancer < Sequel::Model
   end
 
   def need_certificates?
+    return false unless health_check_protocol == "https"
     return true if certs_dataset.empty?
 
     certs_dataset.where { created_at > Time.now - 60 * 60 * 24 * 30 * 2 }.exclude(cert: nil).empty?

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe LoadBalancer do
   subject(:lb) {
     prj = Project.create_with_id(name: "test-prj")
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps")
-    Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080).subject
+    Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080, health_check_protocol: "https").subject
   }
 
   let(:vm1) {
@@ -183,6 +183,13 @@ RSpec.describe LoadBalancer do
       cert = Prog::Vnet::CertNexus.assemble(lb.hostname, dns_zone.id).subject
       lb.add_cert(cert)
       expect(lb.need_certificates?).to be(true)
+    end
+
+    it "returns false if health_check_protocol is not https" do
+      lb.update(health_check_protocol: "http")
+      expect(lb.need_certificates?).to be(false)
+      lb.update(health_check_protocol: "tcp")
+      expect(lb.need_certificates?).to be(false)
     end
   end
 


### PR DESCRIPTION
If the health check protocol is not set to be https, we are not provisioning SSL Certs.