### PR TITLE
Do not create cert related strands when LB doesn't need certs

### DIFF
--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -4,11 +4,11 @@ require_relative "spec_helper"
 
 RSpec.describe LoadBalancer do
   subject(:lb) {
-    prj = Project.create_with_id(name: "test-prj")
-    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps")
     Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080, health_check_protocol: "https").subject
   }
 
+  let(:project) { Project.create(name: "test-prj") }
+  let(:ps) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-ps") }
   let(:vm1) {
     prj = lb.private_subnet.project
     Prog::Vm::Nexus.assemble("pub key", prj.id, name: "test-vm1", private_subnet_id: lb.private_subnet.id).subject
@@ -108,6 +108,40 @@ RSpec.describe LoadBalancer do
     end
   end
 
+  describe "detach_vm" do
+    let(:ce) {
+      dz = DnsZone.create(name: "test-dns-zone", project_id: lb.project_id)
+      Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
+    }
+
+    before do
+      lb.add_cert(ce)
+      lb.add_vm(vm1)
+    end
+
+    it "increments update_load_balancer and tries to remove_cert_server" do
+      expect(lb).to receive(:incr_update_load_balancer)
+      expect(Strand).to receive(:create) do |args|
+        expect(args[:prog]).to eq("Vnet::CertServer")
+        expect(args[:label]).to eq("remove_cert_server")
+      end
+      lb.detach_vm(vm1)
+      expect(lb.vm_ports.first[:state]).to eq("detaching")
+    end
+
+    it "increments update_load_balancer and does not create a strand for removing cert server" do
+      expect(lb).to receive(:incr_update_load_balancer)
+      expect(lb).to receive(:cert_enabled_lb?).and_return(false)
+      expect(Strand).not_to receive(:create) do |args|
+        expect(args[:prog]).to eq("Vnet::CertServer")
+        expect(args[:label]).to eq("remove_cert_server")
+      end
+
+      lb.detach_vm(vm1)
+      expect(lb.vm_ports.first[:state]).to eq("detaching")
+    end
+  end
+
   describe "remove_vm" do
     let(:ce) {
       dz = DnsZone.create_with_id(name: "test-dns-zone", project_id: lb.project_id)
@@ -152,6 +186,13 @@ RSpec.describe LoadBalancer do
       lb.reload
       expect(lb.vm_ports.count).to eq(0)
       expect(lb.load_balancers_vms.count).to eq(0)
+    end
+  end
+
+  describe "cert_enabled_lb?" do
+    it "returns false when healthcheck protocol is not https" do
+      lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080, health_check_protocol: "http").subject
+      expect(lb.cert_enabled_lb?).to equal(false)
     end
   end
 

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
 
   let(:st) {
     cert = Prog::Vnet::CertNexus.assemble("test-host-name", dns_zone.id).subject
-    lb = described_class.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080).subject
+    lb = described_class.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080, health_check_protocol: "https").subject
     lb.add_cert(cert)
     lb.strand
   }


### PR DESCRIPTION
Prior to this commit, we would create strands for putting or removing certs for VMs belonging to a LoadBalancer which didn't need to provision certificates.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure certificate strands are created only when load balancer requires certificates by checking `cert_enabled_lb?`.
> 
>   - **Behavior**:
>     - Modify `add_vm`, `detach_vm`, and `evacuate_vm` in `load_balancer.rb` to conditionally create strands for certificate operations only if `cert_enabled_lb?` is true.
>     - Introduce `cert_enabled_lb?` method in `load_balancer.rb` to check if the load balancer requires certificates based on `health_check_protocol`.
>   - **Tests**:
>     - Add tests in `load_balancer_spec.rb` for `detach_vm` to verify strand creation is conditional on `cert_enabled_lb?`.
>     - Add test for `cert_enabled_lb?` in `load_balancer_spec.rb` to ensure it returns false when `health_check_protocol` is not `https`.
>     - Update `load_balancer_nexus_spec.rb` to reflect changes in load balancer assembly with `health_check_protocol`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2a30ed73e16f81aaab56b18fa1b475fdee1fa0d8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->