### PR TITLE
Change the text for the premium runner toggle

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -102,6 +102,8 @@ class RegenScreenshots
 
     click_button "Verify Account"
 
+    project = Project.first
+
     resize(900, width: 1600)
     visit "/"
     screenshot "quick-start/managed-services-1-screenshot.png"
@@ -113,7 +115,10 @@ class RegenScreenshots
     click_link "GitHub Runners"
     screenshot "github-actions-integration/quickstart-2-screenshot.png"
 
-    project = Project.first
+    GithubInstallation.create(installation_id: 123, name: "ubicloud-demo", type: "Organization", project_id: project.id, allocator_preferences: {"family_filter" => ["premium", "standard"]})
+    page.refresh
+    click_link "Settings", class: "text-gray-500"
+    screenshot "github-actions-integration/use-premium-runners-1-screenshot.png"
 
     resize(650)
     click_link "Tokens"

--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -78,8 +78,8 @@ class RegenScreenshots
     puts "Saved screenshot: #{filename}"
   end
 
-  def resize(height)
-    Capybara.current_session.driver.browser.resize(width: 1200, height:)
+  def resize(height, width: 1200)
+    Capybara.current_session.driver.browser.resize(width:, height:)
   end
 
   def call
@@ -102,6 +102,7 @@ class RegenScreenshots
 
     click_button "Verify Account"
 
+    resize(900, width: 1600)
     visit "/"
     screenshot "quick-start/managed-services-1-screenshot.png"
 
@@ -162,6 +163,7 @@ class RegenScreenshots
     fill_in "Cluster Name", with: "kubernetes-demo"
     find('input[name="cp_nodes"][value="3"]:not([disabled])').trigger("click")
     find('select#worker_nodes option[value="5"]:not([disabled])').select_option
+    resize(900)
     screenshot "managed-kubernetes/create-screenshot.png"
 
     kc_ubid = "kcj4veqfy46a4pcxpmj3dzwzf5"

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -27,10 +27,10 @@
       </div>
       <ul role="list" class="mt-4 grid grid-cols-1 gap-4 text-sm/6 text-gray-600 sm:grid-cols-2">
         <% [
-          "Fast gaming CPUs",
           "Twice as fast",
           "One fifth the cost",
-          "10x better price/performance"
+          "10x better price-performance",
+          "100GB free cache storage",
         ].each do |text| %>
           <li class="flex gap-x-3">
             <%== part("components/icon", name: "hero-check", classes: "h-6 w-5 flex-none text-orange-600") %>
@@ -39,20 +39,19 @@
         <% end %>
       </ul>
     </div>
-    <div class="-mt-2 p-2 lg:mt-0 lg:w-full lg:max-w-md lg:shrink-0">
+    <div class="-mt-2 p-2 lg:mt-0 lg:w-full lg:max-w-sm lg:shrink-0">
       <div
         class="rounded-lg bg-gray-50 py-10 text-center ring-1 ring-inset ring-gray-900/5 lg:flex lg:flex-col lg:justify-center lg:py-16"
       >
-        <div class="mx-auto max-w-xs px-8 space-y-6">
-          <p class="text-base font-semibold text-gray-600">Boost your builds.
-            <br>
-            1/5th the cost of GitHub runners</p>
+        <div class="mx-auto max-w-sm px-8 space-y-8">
           <p class="flex items-baseline justify-center gap-x-2">
-            <span class="text-5xl font-semibold tracking-tight text-gray-900">$0.0016</span>
-            <span class="text-sm/6 font-semibold tracking-wide text-gray-600">/minute</span>
+            <span class="text-4xl font-semibold tracking-tight text-gray-900">Boost your builds</span>
           </p>
           <%== part("components/form/toggle_form", name: "premium_runner_enabled", action: "#{@project_data[:path]}/github/#{@installation.ubid}", active: @installation.premium_runner_enabled?) %>
-          <p class="mt-6 text-xs/5 text-gray-600"></p>
+          <div class="mt-6 text-sm/5 text-gray-600 italic">
+            <p class="font-semibold">1/5th the cost of GitHub runners</p>
+            <p>For example, 2 gaming vCPUs, 8GB of RAM, 80GB of NVMe storage comes at $0.0016/min.</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- **Add the ability to change the width in the screenshot script**
  We can already change the window height, but for some screenshots, like
  the dashboard, the width isn't enough, and it makes all the dashboard
  cards look a bit squeezed. It would be better to use a wider window for
  those.
  

- **Change the text for the premium runner toggle**
  

- **Add screenshot for premium runner toggle**
  
| Before | After |
|--------|-------|
| ![CleanShot 2025-05-23 at 16 26 03@2x](https://github.com/user-attachments/assets/ffd80829-d5b1-4c50-a745-38a4e12e9145) | ![CleanShot 2025-05-23 at 16 25 55@2x](https://github.com/user-attachments/assets/09c8f870-82ba-4f53-8440-6d43bef7319d) |

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update premium runner toggle text and enhance screenshot script for width adjustments.
> 
>   - **Behavior**:
>     - Updated text for premium runner toggle in `views/github/setting.erb`.
>     - Added screenshot for premium runner toggle in `bin/regen-screenshots`.
>   - **Screenshot Script**:
>     - Added width parameter to `resize()` in `bin/regen-screenshots`.
>     - Adjusted window size to 1600x900 for specific screenshots in `bin/regen-screenshots`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for daf82def68b19ff8231cc93c8be8985becaaad60. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->