### PR TITLE
Don't use frozen array for backtraces to work around RSpec bug #217

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -102,15 +102,13 @@ end
 
   class FlowControl < RuntimeError; end
 
-  EMPTY_ARRAY = [].freeze
-
   class Exit < FlowControl
     attr_reader :exitval
 
     def initialize(strand, exitval)
       @strand = strand
       @exitval = exitval
-      set_backtrace EMPTY_ARRAY
+      set_backtrace []
     end
 
     def to_s
@@ -125,7 +123,7 @@ end
       @old_prog = old_prog
       @old_label = old_label
       @strand_update_args = strand_update_args
-      set_backtrace EMPTY_ARRAY
+      set_backtrace []
     end
 
     def new_label
@@ -146,7 +144,7 @@ end
 
     def initialize(seconds)
       @seconds = seconds
-      set_backtrace EMPTY_ARRAY
+      set_backtrace []
     end
 
     def to_s


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces frozen empty array with non-frozen array for backtraces in `prog/base.rb` to address RSpec bug #217.
> 
>   - **Behavior**:
>     - Replaces frozen empty array with non-frozen array for backtraces in `Exit`, `Hop`, and `Nap` classes in `prog/base.rb`.
>     - Aims to work around RSpec bug #217 related to frozen arrays in backtraces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 05a458e8b1d2105fb09adbea00d4ba446af86d8e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->