### PR TITLE
Optimize Project#current_resource_usage

### DIFF
--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -11,11 +11,7 @@ class GithubInstallation < Sequel::Model
   include ResourceMethods
 
   def total_active_runner_vcpus
-    runners_dataset
-      .left_join(:strand, id: :id)
-      .exclude(Sequel[:strand][:label] => ["start", "wait_concurrency_limit"])
-      .select_map(Sequel[:github_runner][:label])
-      .sum { Github.runner_labels[it]["vm_size_data"].vcpus }
+    runners_dataset.total_active_runner_vcpus
   end
 
   def free_runner_upgrade?

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -14,6 +14,15 @@ class GithubRunner < Sequel::Model
   include HealthMonitorMethods
   semaphore :destroy, :skip_deregistration
 
+  dataset_module do
+    def total_active_runner_vcpus
+      left_join(:strand, id: :id)
+        .exclude(Sequel[:strand][:label] => ["start", "wait_concurrency_limit"])
+        .select_map(Sequel[:github_runner][:label])
+        .sum { Github.runner_labels[it]["vm_size_data"].vcpus }
+    end
+  end
+
   def label_data
     @label_data ||= Github.runner_labels[label]
   end

--- a/model/project.rb
+++ b/model/project.rb
@@ -113,9 +113,9 @@ class Project < Sequel::Model
 
   def current_resource_usage(resource_type)
     case resource_type
-    when "VmVCpu" then vms.sum(&:vcpus)
-    when "GithubRunnerVCpu" then github_installations.sum(&:total_active_runner_vcpus)
-    when "PostgresVCpu" then postgres_resources.flat_map { it.servers.map { |s| s.vm.vcpus } }.sum
+    when "VmVCpu" then vms_dataset.sum(:vcpus) || 0
+    when "GithubRunnerVCpu" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).total_active_runner_vcpus
+    when "PostgresVCpu" then postgres_resources_dataset.association_join(servers: :vm).sum(:vcpus) || 0
     else
       raise "Unknown resource type: #{resource_type}"
     end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -147,13 +147,32 @@ RSpec.describe Project do
   end
 
   it "calculates current resource usage" do
-    expect(project).to receive(:vms).and_return([instance_double(Vm, vcpus: 2), instance_double(Vm, vcpus: 4)])
+    expect(project.current_resource_usage("VmVCpu")).to eq 0
+    vm1 = Prog::Vm::Nexus.assemble("a a", project.id).subject
+    expect(project.current_resource_usage("VmVCpu")).to eq 2
+    Prog::Vm::Nexus.assemble("a a", project.id, size: "standard-4")
     expect(project.current_resource_usage("VmVCpu")).to eq 6
 
-    expect(project).to receive(:github_installations).and_return([instance_double(GithubInstallation, total_active_runner_vcpus: 10), instance_double(GithubInstallation, total_active_runner_vcpus: 20)])
-    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 30
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 0
+    gi = GithubInstallation.create(installation_id: 1, name: "a", project_id: project.id, type: "a")
+    gr = gi.add_runner(label: "ubicloud", repository_name: "a/a")
+    gr.update(vm_id: vm1.id)
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 0
+    grst = Strand.new(id: gr.id, label: "start", prog: "Prog::Vm::GithubRunner")
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 0
+    grst.update(label: "wait_vm")
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 2
+    gr2 = gi.add_runner(label: "ubicloud-standard-60", repository_name: "a/a")
+    grst2 = Strand.new(id: gr2.id, label: "wait_concurrency_limit", prog: "Prog::Vm::GithubRunner")
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 2
+    grst2.update(label: "wait_vm")
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 62
 
-    expect(project).to receive(:postgres_resources).and_return([instance_double(PostgresResource, servers: [instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 2)), instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 4))])])
+    expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
+    expect(project.current_resource_usage("PostgresVCpu")).to eq 0
+    Prog::Postgres::PostgresResourceNexus.assemble(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "a", target_vm_size: "standard-2", target_storage_size_gib: 64)
+    expect(project.current_resource_usage("PostgresVCpu")).to eq 2
+    Prog::Postgres::PostgresResourceNexus.assemble(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "b", target_vm_size: "standard-4", target_storage_size_gib: 128)
     expect(project.current_resource_usage("PostgresVCpu")).to eq 6
 
     expect { project.current_resource_usage("UnknownResource") }.to raise_error(RuntimeError)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -143,9 +143,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can update database properties" do
-        expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
-        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
-        expect(pg.representative_server).to receive(:storage_size_gib).and_return(128)
+        pg.representative_server.vm.add_vm_storage_volume(boot: false, size_gib: 128, disk_index: 0)
 
         patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
           size: "standard-8",
@@ -160,9 +158,9 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can scale down storage if the requested size is enough for existing data" do
-        expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
+        pg.representative_server.vm.add_vm_storage_volume(boot: false, size_gib: 128, disk_index: 0)
+        expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(PostgresResource.dataset.class, first: pg, association_join: instance_double(Sequel::Dataset, sum: 1))).twice
         expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
-        expect(pg.representative_server).to receive(:storage_size_gib).and_return(128)
         expect(pg.representative_server.vm.sshable).to receive(:cmd).and_return("10000000\n")
 
         patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -307,9 +307,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can update PostgreSQL instance size configuration" do
-        expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg)).at_least(:once)
-        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).twice
-        expect(pg.representative_server).to receive(:storage_size_gib).and_return(128).at_least(:once)
+        pg.representative_server.vm.add_vm_storage_volume(boot: false, size_gib: 128, disk_index: 0)
 
         visit "#{project.path}#{pg.path}"
         expect(page).to have_content "Configure PostgreSQL database"


### PR DESCRIPTION
This does most of the work in the database, and avoids multiple N+1 query issues.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `Project#current_resource_usage` by calculating resource usage in the database, reducing N+1 queries.
> 
>   - **Optimization**:
>     - `Project#current_resource_usage` now calculates resource usage directly in the database, reducing N+1 query issues.
>     - Introduces `total_active_runner_vcpus` in `GithubRunner` to calculate vCPUs directly in the database.
>   - **Refactoring**:
>     - Moves vCPU calculation logic from `GithubInstallation#total_active_runner_vcpus` to `GithubRunner` dataset module.
>   - **Tests**:
>     - Updates `project_spec.rb` to test new database-driven resource usage calculations.
>     - Modifies `postgres_spec.rb` in both `api` and `web` routes to align with the new resource usage logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2b110ef2336e578d44b472d4ba11b62a7021f02a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->