### PR TITLE
Prevent N+1 query issue in Model#has_resources

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -22,7 +22,7 @@ class Project < Sequel::Model
   one_to_many :inference_endpoints
   one_to_many :kubernetes_clusters
 
-  RESOURCE_ASSOCIATIONS = %i[vms minio_clusters private_subnets postgres_resources firewalls load_balancers kubernetes_clusters]
+  RESOURCE_ASSOCIATION_DATASET_METHODS = %w[vms minio_clusters private_subnets postgres_resources firewalls load_balancers kubernetes_clusters github_runners].map { :"#{it}_dataset" }
 
   one_to_many :invoices, order: Sequel.desc(:created_at)
   one_to_many :quotas, class: :ProjectQuota
@@ -67,7 +67,7 @@ class Project < Sequel::Model
   end
 
   def has_resources
-    RESOURCE_ASSOCIATIONS.any? { !send(:"#{it}_dataset").empty? } || github_installations.flat_map(&:runners).count > 0
+    RESOURCE_ASSOCIATION_DATASET_METHODS.any? { !send(it).empty? }
   end
 
   def soft_delete


### PR DESCRIPTION
No need to have special code for github runners accessed through github installations.  There is a github_runners association already, use that.  In addition to avoiding the N+1 query issue, this also only uses queries that return single row/column.

While here, rename RESOURCE_ASSOCIATIONS to
RESOURCE_ASSOCIATION_DATASET_METHODS, so the symbol is only calculated once, and not recalculated per call per association.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes N+1 query issue in `Project#has_resources` by using `github_runners` association and renames `RESOURCE_ASSOCIATIONS` for clarity.
> 
>   - **Behavior**:
>     - Fixes N+1 query issue in `has_resources` method in `project.rb` by using `github_runners` association instead of `github_installations`.
>     - Queries now return single row/column, improving performance.
>   - **Renames**:
>     - `RESOURCE_ASSOCIATIONS` to `RESOURCE_ASSOCIATION_DATASET_METHODS` for clarity and efficiency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 733d4cef46f64a2a395ab3a982d29a06d613e87d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->