### PR TITLE
Make Kubernetes v1.33 the default

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -23,7 +23,7 @@ module Option
   end
 
   def self.kubernetes_versions
-    ["v1.32", "v1.33"].freeze
+    ["v1.33", "v1.32"].freeze
   end
 
   def self.families


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default Kubernetes version to v1.33 in `option.rb`.
> 
>   - **Behavior**:
>     - Change default Kubernetes version to v1.33 by reordering the list in `kubernetes_versions()` in `option.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for dab20e2a2cf14ce68e4352ecb4eda3549d925dcc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->