### PR TITLE
Add image sizes to E2E logs

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -74,7 +74,10 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   end
 
   label def wait_setup_host
-    nap 15 unless vm_host && vm_host.strand.label == "wait"
+    unless vm_host.strand.label == "wait"
+      Clog.emit(vm_host.sshable.cmd("ls -lah /var/storage/images").strip.tr("\n", "\t")) if vm_host.strand.label == "wait_download_boot_images"
+      nap 15
+    end
 
     if retval&.dig("msg") == "installed rhizome"
       verify_specs_installation(installed: true)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logging of image sizes during VM host setup in `wait_setup_host` and update tests accordingly.
> 
>   - **Behavior**:
>     - In `hetzner_server.rb`, `wait_setup_host` now logs image sizes when `vm_host.strand.label` is `wait_download_boot_images`.
>     - Adds a conditional logging statement using `Clog.emit` to log image sizes.
>   - **Tests**:
>     - In `hetzner_server_spec.rb`, adds test for logging image sizes when `vm_host.strand.label` is `wait_download_boot_images`.
>     - Updates existing tests to check for repeated label checks using `at_least(:once)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 06c315e256895dbb2353b015c37beda7bcfd0b73. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->