### PR TITLE
Emit a route exception for committee response errors

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -208,7 +208,7 @@ class Clover < Roda
         message = "Validation failed for following fields: body"
         details = {"body" => "Request body must include required parameters: #{keys.join(", ")}"}
       end
-    when Committee::InvalidResponse, Sequel::SerializationFailure
+    when Sequel::SerializationFailure
       code = 500
       type = "InternalServerError"
       message = e.message


### PR DESCRIPTION
I'm not sure why we would want to not emit this error, as this error should 100% of the time be the result of a bug in the application or in openapi.yml. If committee accepts the request, it should accept the application's response to the request. Hiding these errors only complicates debugging.

CC @geemus 