### PR TITLE
Add inline edit functionality for PostgreSQL firewall rules

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -110,6 +110,58 @@ $(".delete-btn").on("click", function (event) {
   });
 });
 
+$(".edit-inline-btn").on("click", function (event) {
+  let inline_editable_group = $(this).closest(".group\\/inline-editable");
+  inline_editable_group.find(".inline-editable").each(function () {
+    let value = $(this).find(".inline-editable-text").text();
+    $(this).find(".inline-editable-input").val(value);
+  });
+
+  inline_editable_group.addClass("active");
+});
+
+$(".cancel-inline-btn").on("click", function (event) {
+  $(this).closest(".group\\/inline-editable").removeClass("active");
+});
+
+$(".save-inline-btn").on("click", function (event) {
+  let inline_editable_group = $(this).closest(".group\\/inline-editable");
+  let data = {};
+  inline_editable_group.find(".inline-editable-input").each(function () {
+    data[$(this).attr("name")] = $(this).val();;
+  });
+
+  let url = $(this).data("url");
+  let csrf = $(this).data("csrf");
+  let confirmation_message = $(this).data("confirmation-message");
+
+  $.ajax({
+    url: url,
+    type: "PATCH",
+    data: { "_csrf": csrf, ...data },
+    dataType: "json",
+    headers: { "Accept": "application/json" },
+    success: function (result) {
+      inline_editable_group.find(".inline-editable").each(function () {
+        let value = $(this).find(".inline-editable-input").val();
+        $(this).find(".inline-editable-text").text(value);
+      });
+
+      inline_editable_group.removeClass("active");
+
+      alert(confirmation_message);
+    },
+    error: function (xhr, ajaxOptions, thrownError) {
+      let message = thrownError;
+      try {
+        response = JSON.parse(xhr.responseText);
+        message = response.error?.message
+      } catch { };
+      alert(`Error: ${message}`);
+    }
+  });
+});
+
 $(".restart-btn").on("click", function (event) {
   if (!confirm("Are you sure to restart?")) {
     event.preventDefault();

--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -30,6 +30,8 @@ class Clover < Roda
 
   BUTTON_COLOR = Hash.new { |h, k| raise "unsupported button type: #{k}" }.merge!(
     "primary" => "bg-orange-600 hover:bg-orange-700 focus-visible:outline-orange-600",
+    "safe" => "bg-green-600 hover:bg-green-700 focus-visible:outline-green-600",
+    "warning" => "bg-amber-600 hover:bg-amber-700 focus-visible:outline-amber-600",
     "danger" => "bg-rose-600 hover:bg-rose-700 focus-visible:outline-rose-600"
   ).freeze
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -900,6 +900,31 @@ paths:
       - $ref: '#/components/parameters/location'
       - $ref: '#/components/parameters/postgres_database_reference'
       - $ref: '#/components/parameters/postgres_firewall_rule_id'
+    patch:
+      operationId: patchLocationPostgresFirewallRule
+      summary: Update a specific Postgres firewall rule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cidr:
+                  description: CIDR of the firewall rule
+                  type: string
+                description:
+                  description: Description of the firewall rule
+                  type: string
+                  nullable: true
+              additionalProperties: false
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresFirewallRule'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Firewall Rule
     delete:
       operationId: deleteLocationPostgresFirewallRule
       summary: Delete a specific firewall rule

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -45,7 +45,7 @@ class Clover
         204
       end
 
-      r.patch do
+      r.patch true do
         authorize("Postgres:edit", pg.id)
 
         target_vm_size = Validation.validate_postgres_size(pg.location, typecast_params.str("size") || pg.target_vm_size, @project.id)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -255,6 +255,16 @@ RSpec.describe Clover, "postgres" do
         expect(last_response).to have_api_error(400, "Validation failed for following fields: cidr", {"cidr" => "Invalid CIDR"})
       end
 
+      it "firewall-rule edit" do
+        patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/firewall-rule/#{pg.firewall_rules.first.ubid}", {
+          cidr: "0.0.0.0/1",
+          description: "Updated rule"
+        }.to_json
+
+        expect(pg.firewall_rules.first.reload.description).to eq("Updated rule")
+        expect(last_response.status).to eq(200)
+      end
+
       it "metric-destination" do
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/metric-destination", {
           url: "https://example.com",

--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -174,6 +174,15 @@
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
     <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
   </svg>
+<% when "hero-pencil" %>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+  <path d="m 11 4 h -7 a 2 2 0 0 0 -2 2 v 14 a 2 2 0 0 0 2 2 h 14 a 2 2 0 0 0 2 -2 v -7"/>
+  <path d="M 18.5 2.5 A 2.121 2.121 0 0 1 21.5 5.5 L 12 15 L 8 16 L 9 12 L 18.5 2.5 Z"/>
+</svg>
+<% when "hero-check-circle" %>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+</svg>
 <%
 #:nocov:
 else

--- a/views/components/inline_edit_buttons.erb
+++ b/views/components/inline_edit_buttons.erb
@@ -1,0 +1,34 @@
+<%# locals: (url: request.path, csrf_url: url, confirmation_message: nil) %>
+
+<div class="group-[.active]/inline-editable:hidden block">
+<%== part(
+  "components/button",
+  text: "",
+  icon: "hero-pencil",
+  extra_class: "edit-inline-btn",
+  type: "warning"
+) %>
+</div>
+
+<div class="group-[.active]/inline-editable:block hidden">
+<%== part(
+  "components/button",
+  text: "",
+  icon: "hero-check-circle",
+  extra_class: "save-inline-btn",
+  type: "safe",
+  attributes: {
+    "data-url" => url,
+    "data-csrf" => csrf_token(csrf_url, "PATCH"),
+    "data-confirmation-message" => confirmation_message
+  }
+) %>
+
+<%== part(
+  "components/button",
+  text: "",
+  icon: "hero-x-circle",
+  extra_class: "cancel-inline-btn",
+  type: "danger"
+) %>
+</div>

--- a/views/networking/firewall/show.erb
+++ b/views/networking/firewall/show.erb
@@ -72,7 +72,6 @@
               <%== part(
                 "components/form/text",
                 name: "port_range",
-                type: "text",
                 attributes: {
                   placeholder: "0..65536",
                   form: "form-fw-create-rule-#{@firewall[:id]}"

--- a/views/networking/firewall/show.erb
+++ b/views/networking/firewall/show.erb
@@ -61,7 +61,6 @@
               <%== part(
                 "components/form/text",
                 name: "cidr",
-                type: "cidr",
                 attributes: {
                   placeholder: "0.0.0.0/0",
                   required: true,

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -360,16 +360,26 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           <% @pg[:firewall_rules].each do |fwr| %>
-            <tr>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:description] %></td>
+            <tr class="group/inline-editable">
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 inline-editable" scope="row">
+                <div class="inline-editable-text group-[.active]/inline-editable:hidden block"><%= fwr[:cidr] %></div>
+                <%== part("components/form/text", name: "cidr", attributes: {required: true}, extra_class: "inline-editable-input group-[.active]/inline-editable:block hidden") %>
+              </td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 inline-editable" scope="row">
+                <div class="inline-editable-text group-[.active]/inline-editable:hidden block"><%= fwr[:description] %></div>
+                <%== part("components/form/text", name: "description", extra_class: "inline-editable-input group-[.active]/inline-editable:block hidden") %>
+              </td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432, 6432</td>
               <% if edit_perm %>
                 <td
-                  id="fwr-delete-<%=fwr[:id]%>"
-                  class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+                  id="fwr-buttons-<%= fwr[:id] %>"
+                  class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 flex gap-2 items-center justify-end"
                 >
-                  <%== part("components/delete_button", url: "#{request.path}/firewall-rule/#{fwr[:id]}", text: "") %>
+                  <%== part("components/inline_edit_buttons", url: "#{request.path}/firewall-rule/#{fwr[:id]}", confirmation_message: "Firewall rule is updated successfully.") %>
+
+                  <div class="group-[.active]/inline-editable:hidden block">
+                    <%== part("components/delete_button", url: "#{request.path}/firewall-rule/#{fwr[:id]}", text: "") %>
+                  </div>
                 </td>
               <% end %>
             </tr>
@@ -388,7 +398,7 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
                   }
                 ) %>
               </td>
-              <td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
                 <%== part(
                   "components/form/text",
                   name: "description",

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -351,8 +351,8 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
         <thead class="bg-gray-50">
           <tr>
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Port Range</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Description</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Port Range</th>
             <% if edit_perm %>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
             <% end %>
@@ -362,8 +362,8 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
           <% @pg[:firewall_rules].each do |fwr| %>
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:cidr] %></td>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432, 6432</td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr[:description] %></td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">5432, 6432</td>
               <% if edit_perm %>
                 <td
                   id="fwr-delete-<%=fwr[:id]%>"
@@ -388,9 +388,6 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
                   }
                 ) %>
               </td>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-                5432, 6432
-              </td>
               <td>
                 <%== part(
                   "components/form/text",
@@ -400,6 +397,9 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
                     form: "form-pg-fwr-create"
                   }
                 ) %>
+              </td>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                5432, 6432
               </td>
               <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                 <form action="<%= "#{request.path}/firewall-rule" %>" role="form" method="POST" id="form-pg-fwr-create">

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -390,7 +390,6 @@ delete_perm = has_permission?("Postgres:delete", @pg[:id]) %>
                 <%== part(
                   "components/form/text",
                   name: "cidr",
-                  type: "cidr",
                   attributes: {
                     placeholder: "0.0.0.0/0",
                     required: true,

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -279,7 +279,6 @@
                   "components/form/text",
                   name: "alert_name",
                   label: "Alert Name",
-                  type: "text",
                   attributes: {
                     required: true,
                     placeholder: "Alert Name"


### PR DESCRIPTION
**Fix matcher for postgres resource patch endpoint**
Previously, we didn't add `true` keyword, which caused the matcher to match
every patch request, without checking if there are more segments in the path
that needs to be matched. `true` keyword ensures that the matcher matches only
the exact path and not any sub-paths. It didn't cause any problem so far, as we
only had one patch endpoint.

**Reorder firewall description and port range**
In the UI, we used to put static port information before user controlled
description. I moved the description to be before the port range, so all
the user controlled information is grouped together.

**Add edit inline button component**
This commits adds a new button component for inline editing functionality.
When clicked, it converts the text into an editable input field, allowing
users to modify the content directly on the page. Currently it only supportss
text input fields, but can be extended to support other types of inputs such
as select dropdowns or radio buttons in the future.

**Add cancel inline edit button component**
This commit adds a button that allows users to cancel the inline edit operation
they started.

**Add save inline edit button component**
This commit adds a new component for the save the changes made in the inline
edit mode.

**Add ability to inline edit PostgreSQL firewall rules**

![chrome-capture-2025-5-28](https://github.com/user-attachments/assets/f579ed71-6f6b-424d-b722-c3ba9410a439)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds inline editing functionality for PostgreSQL firewall rules, updates API endpoint matching, and refines UI components and layout.
> 
>   - **Behavior**:
>     - Adds inline editing for PostgreSQL firewall rules in `postgres.rb` and `show.erb`.
>     - Updates `openapi.yml` to include `patchLocationPostgresFirewallRule` for editing firewall rules.
>     - Refines path matcher in `postgres.rb` to use `r.patch true` for exact path matching.
>   - **UI Components**:
>     - Adds `edit_inline_button.erb`, `cancel_inline_button.erb`, and `save_inline_button.erb` for inline editing controls.
>     - Updates `icon.erb` to include `hero-pencil` and `hero-check-circle` icons.
>   - **UI Layout**:
>     - Reorders description and port range in `show.erb` for better user information grouping.
>   - **JavaScript**:
>     - Implements inline edit, cancel, and save functionality in `app.js` for `.edit-inline-btn`, `.cancel-inline-btn`, and `.save-inline-btn`.
>   - **Testing**:
>     - Adds tests for inline editing in `postgres_spec.rb` and `web/project/postgres_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 09cfbd7273770e1c813396d7ea528eb92085eae6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->