### PR TITLE
Remove unnecessary escaping in Postgres' replication_connection_string

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -82,7 +82,7 @@ class PostgresResource < Sequel::Model
       sslkey: "/etc/ssl/certs/server.key",
       sslmode: "verify-full",
       application_name: application_name
-    }.map { |k, v| "#{k}=#{v}" }.join("\\&")
+    }.map { |k, v| "#{k}=#{v}" }.join("&")
 
     URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: identity, query: query_parameters).to_s
   end


### PR DESCRIPTION
This escaping was not needed since the beginning. It was added by mistake. The replication still works with it, but removing it since it is not needed.