### PR TITLE
Fix K8s Worker Node Pricing

### DIFF
--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -170,7 +170,7 @@ module ContentGenerator
 
       [
         worker_size.display_name,
-        "#{worker_size.vcpus} vCPUs / #{worker_size.memory_gib} GB RAM",
+        "#{worker_size.vcpus} vCPUs / #{worker_size.memory_gib} GB RAM / #{worker_size.storage_size_options.first} GB NVMe Storage",
         "$#{"%.2f" % monthly_price(location, worker_size)}/mo",
         "$#{"%.3f" % hourly_price(location, worker_size)}/hour"
       ]

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -184,7 +184,7 @@ module ContentGenerator
 
     def self.node_price(location, worker_size)
       worker_size.vcpus * BillingRate.unit_price_from_resource_properties("KubernetesWorkerVCpu", "standard", location.name) +
-        40 * BillingRate.unit_price_from_resource_properties("KubernetesWorkerStorage", "standard", location.name)
+        worker_size.storage_size_options.first * BillingRate.unit_price_from_resource_properties("KubernetesWorkerStorage", "standard", location.name)
     end
 
     def self.hourly_price(location, worker_size)

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -160,6 +160,10 @@ RSpec.describe Clover, "Kubernetes" do
         choose option: 3
         find('select#worker_nodes option[value="4"]:not([disabled])').select_option
 
+        [1, 2, 4, 8].each do
+          expect(page).to have_content "#{it * 2} vCPUs / #{it * 8} GB RAM / #{it * 40} GB NVMe Storage"
+        end
+
         click_button "Create"
         expect(page.title).to eq("Ubicloud - k8stest")
         expect(page).to have_flash_notice("'k8stest' will be ready in a few minutes")


### PR DESCRIPTION
We were calculating the worker node prices slightly off, because the calculator was assuming that the nodes would get 40GB storage, while in reality the default storage is calculated in the VM nexus with `vm_size.storage_size_options.first`. This commit uses the same logic in the UI option content generator.

Also we display the local storage of the nodes.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Kubernetes worker node pricing by using actual storage size and updates UI to display it correctly.
> 
>   - **Behavior**:
>     - Fixes worker node pricing in `content_generator.rb` by using `worker_size.storage_size_options.first` instead of hardcoded 40GB.
>     - Updates UI to display correct storage size in `worker_size()`.
>   - **Tests**:
>     - Adds test in `kubernetes_cluster_spec.rb` to verify correct display of vCPUs, RAM, and storage size for worker nodes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for cb7184365a19b6593efd72d66bada795079350bb. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->