### PR TITLE
Add a gen_timestamp_ubid_uuid database function

### DIFF
--- a/lib/sem_snap.rb
+++ b/lib/sem_snap.rb
@@ -39,7 +39,7 @@ class SemSnap
 
   def incr(name)
     if (semaphore = Semaphore.incr(@strand_id, name))
-      add_semaphore_instance_to_snapshot(semaphore)
+      add_semaphore_instance_to_snapshot(Semaphore.with_pk(semaphore))
     end
   end
 

--- a/migrate/20250529_gen_timestamp_ubid_uuid.rb
+++ b/migrate/20250529_gen_timestamp_ubid_uuid.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    # This function generates a timestamp-based UUID,
+    # that is in valid UBID format.  It is passed the UBID type as an integer.
+    # You can get the type integer using `UBID.to_base32_n(prefix)`
+    # (e.g. `UBID.to_base32_n("vm") # => 884`).
+    #
+    # This could be used in the future as the DEFAULT value for uuid primary
+    # keys for tables that use timestamp ubids.
+    run <<~SQL
+      CREATE FUNCTION gen_timestamp_ubid_uuid(ubid_type int) RETURNS uuid AS $$
+      DECLARE
+        r0 bigint;
+        r1 int;
+        r2 int;
+        r3 bigint;
+
+        p1 text;
+        p2 text;
+      BEGIN
+        -- 48 bit timestamp milliseconds
+        r0 = floor(extract(epoch from clock_timestamp()) * 1000)::bigint;
+        -- 4 bit version + 2 bit random + 10 bit type
+        r1 = ((32 + floor(4 * random()::numeric)::integer) << 10) | ubid_type;
+        --  2 bit variant + 2 bit random
+        r2 = 8 + floor(4 * random()::numeric)::integer;
+        -- 60 bit random
+        r3 = floor(1152921504606846976 * random()::numeric)::bigint;
+
+        p1 = lpad(to_hex(r0), 12, '0');
+        p2 = lpad(to_hex(r3), 15, '0');
+
+        RETURN (substr(p1, 1, 8) || '-' || substr(p1, 9, 4) || '-' || lpad(to_hex(r1), 4, '0') || '-' || to_hex(r2) || substr(p2, 1, 3) || '-' || substr(p2, 4, 12))::uuid;
+      END
+      $$ LANGUAGE plpgsql;
+    SQL
+  end
+
+  down do
+    run "DROP FUNCTION gen_timestamp_ubid_uuid(int)"
+  end
+end

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -5,12 +5,23 @@ require_relative "../model"
 class Semaphore < Sequel::Model
   include ResourceMethods
 
-  def self.incr(strand_id, name)
-    DB.transaction do
-      if Strand.where(id: strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) == 1
-        create(strand_id:, name:)
-      end
+  def self.incr(id, name)
+    case name
+    when Symbol
+      name = name.to_s
+    when String
+      # nothing
+    else
+      raise "invalid name given to Semaphore.incr: #{name.inspect}"
     end
+
+    with(:updated_strand,
+      Strand
+        .where(id:)
+        .returning(:id)
+        .with_sql(:update_sql, schedule: Sequel::CURRENT_TIMESTAMP))
+      .insert([:id, :strand_id, :name],
+        DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end
 end
 

--- a/spec/model/semaphore_spec.rb
+++ b/spec/model/semaphore_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe Semaphore do
   end
 
   it ".incr raises if invalid name is given" do
-    expect { described_class.incr(st.id, nil) }.to raise_error(Sequel::ValidationFailed)
+    expect { described_class.incr(st.id, nil) }.to raise_error(RuntimeError)
   end
 end

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -151,6 +151,28 @@ RSpec.describe UBID do
     }
   end
 
+  it "database generates timestamp UUID in valid UBID format for timestamp types" do
+    described_class::CURRENT_TIMESTAMP_TYPES.each { |type|
+      # generate 10 ids with this type, and verify that their timestamp
+      # part is not close
+      klass = described_class
+      ubids = Array.new(10) do
+        described_class.from_uuidish(DB.get { gen_timestamp_ubid_uuid(klass.to_base32_n(type)) })
+      end
+      expect(ubids.map { it.to_s[0..1] }).to eq([type] * 10)
+      ints = ubids.map(&:to_i)
+      max_ubid = ints.max
+      min_ubid = ints.min
+
+      # Timestamp is the left 48 bits of the 128-bit ubid.
+      time_difference = (max_ubid >> 80) - (min_ubid >> 80)
+
+      # Timestamp parts are random, so with a very high probability
+      # the difference between them will be > 8ms.
+      expect(time_difference).to be < 128
+    }
+  end
+
   it "generates random timestamp for most types" do
     (all_types - described_class::CURRENT_TIMESTAMP_TYPES).each { |type|
       # generate 10 ids with this type, and verify that their timestamp


### PR DESCRIPTION
Use this function in Semaphore.incr to reduce the number of queries from 4 to 1.

The function is basically the same as the existing gen_random_ubid_uuid, except the first 48 bits are the epoch timestamp in milliseconds instead of being random.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `gen_timestamp_ubid_uuid` function to generate timestamp-based UUIDs, optimizing `Semaphore.incr` to reduce queries.
> 
>   - **Database Functionality**:
>     - Adds `gen_timestamp_ubid_uuid` function in `20250529_gen_timestamp_ubid_uuid.rb` to generate timestamp-based UUIDs in UBID format.
>     - Function uses 48-bit timestamp and random bits for UUID generation.
>   - **Model Changes**:
>     - Updates `Semaphore.incr` in `semaphore.rb` to use `gen_timestamp_ubid_uuid`, reducing queries from 4 to 1.
>     - Handles invalid `name` in `Semaphore.incr` by raising `RuntimeError`.
>   - **Testing**:
>     - Updates `semaphore_spec.rb` to test `Semaphore.incr` with invalid names.
>     - Adds test in `ubid_spec.rb` to verify timestamp UUID generation in UBID format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 78566a0cc0a3f6e17a1fff87293d8c843d720514. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->