### PR TITLE
Add respirate smoke test

### DIFF
--- a/.github/workflows/respirate-ci.yml
+++ b/.github/workflows/respirate-ci.yml
@@ -1,0 +1,77 @@
+name: respirate CI
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'bin/respirate'
+      - 'scheduling/dispatcher.rb'
+      - 'model/strand.rb'
+      - 'prog/test.rb'
+      - 'spec/respirate_smoke_test.rb'
+      - '.github/workflows/respirate-ci.yml'
+  pull_request:
+    paths:
+      - 'bin/respirate'
+      - 'scheduling/dispatcher.rb'
+      - 'model/strand.rb'
+      - 'prog/test.rb'
+      - 'spec/respirate_smoke_test.rb'
+      - '.github/workflows/respirate-ci.yml'
+
+jobs:
+  cli-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubicloud, ubicloud-arm]
+    name: respirate CI - ${{matrix.runs-on}}
+    runs-on: ${{matrix.runs-on}}
+
+    env:
+      DB_USER: clover
+      DB_PASSWORD: nonempty
+      DB_NAME: clover_test
+
+    services:
+      postgres:
+        image: postgres:15.8
+        env:
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+    - name: Perform superuser-only actions, then remove superuser
+      run: |
+        psql "postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}" \
+          -c "CREATE EXTENSION citext; CREATE EXTENSION btree_gist; CREATE ROLE clover_password PASSWORD '${{ env.DB_PASSWORD }}' LOGIN; ALTER ROLE ${{ env.DB_USER }} NOSUPERUSER"
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .tool-versions
+        bundler-cache: true
+
+    - name: Apply migrations
+      env:
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+      run: bundle exec rake _test_up
+
+    - name: Run respirate smoke test
+      env:
+        CLOVER_DATABASE_URL: postgres://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+        CLOVER_SESSION_SECRET: kbaf1V3biZ+R2QqFahgDLB5/lSomwxQusA4PwROUkFS1srn0xM/I47IdLW7HjbQoxWri6/aVgtkqTLFiP65h9g==
+        CLOVER_COLUMN_ENCRYPTION_KEY: TtlY0+hd4lvedPkNbu5qsj5H7giPKJSRX9KDBrvid7c=
+      run: bundle exec rake respirate_smoke_test

--- a/Rakefile
+++ b/Rakefile
@@ -272,6 +272,11 @@ task "check_separate_requires" do
   system({"RACK_ENV" => "test", "LOAD_FILES_SEPARATELY_CHECK" => "1"}, RbConfig.ruby, "-r", "./loader", "-e", "")
 end
 
+desc "Run respirate smoke tests"
+task :respirate_smoke_test do
+  system(RbConfig.ruby, "spec/respirate_smoke_test.rb")
+end
+
 desc "Run each spec file in a separate process"
 task :spec_separate do
   require "rbconfig"

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -8,6 +8,43 @@ class Prog::Test < Prog::Base
   label def start
   end
 
+  private def fib(n)
+    if n < 2
+      1
+    else
+      fib(n - 2) + fib(n - 1)
+    end
+  end
+
+  megabyte = (" " * 1024 * 1024)
+
+  3.times do |n|
+    n1 = n + 1
+    label(define_method(:"smoke_test_#{n1}") do
+      when_test_semaphore_set? do
+        decr_test_semaphore
+        dynamic_hop :"smoke_test_#{n}"
+      end
+
+      incr_test_semaphore
+
+      # CPU
+      fib(rand(15...25))
+
+      # IO
+      rand(20).times do
+        File.write(File::NULL, megabyte)
+      end
+
+      print n1
+      nap rand
+    end)
+  end
+
+  label def smoke_test_0
+    nap 1000
+  end
+
   label def pusher1
     pop "1" if retval
     push Prog::Test, {test_level: "2"}, :pusher2

--- a/spec/lib/github_spec.rb
+++ b/spec/lib/github_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe Github do
       {guid: "3", status: "Fail", delivered_at: time + 3}
     ])
     expect(app_client).to receive(:last_response).and_return(instance_double(Sawyer::Response, rels: {next: instance_double(Sawyer::Relation, href: "next_url")}))
-    expect(Clog).to receive(:emit).with("failed deliveries page limit reached")
-    expect(Clog).to receive(:emit).with("fetched deliveries")
+    expect(Clog).to receive(:emit).with("failed deliveries page limit reached").and_call_original
+    expect(Clog).to receive(:emit).with("fetched deliveries").and_call_original
     failed_deliveries = described_class.failed_deliveries(time, 1)
     expect(failed_deliveries).to eq([{guid: "3", status: "Fail", delivered_at: time + 3}])
   end

--- a/spec/lib/metrics_target_methods_spec.rb
+++ b/spec/lib/metrics_target_methods_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MetricsTargetMethods do
     context "when scrape results are empty" do
       before do
         allow(test_instance).to receive(:scrape_endpoints).and_return([])
-        allow(Clog).to receive(:emit)
+        allow(Clog).to receive(:emit).and_call_original
       end
 
       it "does not call import_prometheus or mark_pending_scrapes_as_done" do
@@ -50,7 +50,7 @@ RSpec.describe MetricsTargetMethods do
 
       before do
         allow(test_instance).to receive(:scrape_endpoints).and_return(scrape_results)
-        allow(Clog).to receive(:emit)
+        allow(Clog).to receive(:emit).and_call_original
         allow(test_instance).to receive(:mark_pending_scrapes_as_done)
       end
 

--- a/spec/lib/metrics_target_resource_spec.rb
+++ b/spec/lib/metrics_target_resource_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe MetricsTargetResource do
 
     it "swallows exceptions and logs them" do
       expect(postgres_server).to receive(:export_metrics).and_raise(StandardError.new("Export failed"))
-      expect(Clog).to receive(:emit)
+      expect(Clog).to receive(:emit).and_call_original
       expect { resource.export_metrics }.not_to raise_error
     end
   end
@@ -125,7 +125,7 @@ RSpec.describe MetricsTargetResource do
     it "triggers Kernel.exit if pulse check is stuck" do
       resource.instance_variable_get(:@mutex).lock
       resource.instance_variable_set(:@export_started_at, Time.now - 200)
-      expect(Clog).to receive(:emit).at_least(:once)
+      expect(Clog).to receive(:emit).at_least(:once).and_call_original
       resource.force_stop_if_stuck
       resource.instance_variable_get(:@mutex).unlock
     end

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe MonitorableResource do
       r_w_event_loop.instance_variable_set(:@session, session)
       expect(Thread).to receive(:new).and_yield
       expect(session[:ssh_session]).to receive(:loop).and_raise(StandardError)
-      expect(Clog).to receive(:emit)
+      expect(Clog).to receive(:emit).and_call_original
       expect(r_w_event_loop).to receive(:close_resource_session)
       r_w_event_loop.process_event_loop
     end
@@ -82,7 +82,7 @@ RSpec.describe MonitorableResource do
 
     it "swallows exception and logs it if check_pulse fails" do
       expect(vm_host).to receive(:check_pulse).and_raise(StandardError)
-      expect(Clog).to receive(:emit)
+      expect(Clog).to receive(:emit).and_call_original
       expect { r_without_event_loop.check_pulse }.not_to raise_error
     end
 
@@ -95,19 +95,19 @@ RSpec.describe MonitorableResource do
 
     it "logs the pulse if reading is not up" do
       expect(postgres_server).to receive(:check_pulse).and_return({reading: "down", reading_rpt: 5})
-      expect(Clog).to receive(:emit)
+      expect(Clog).to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
     end
 
     it "does not log the pulse if reading is up and reading_rpt is not every 5th reading" do
       expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 3})
-      expect(Clog).not_to receive(:emit)
+      expect(Clog).not_to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
     end
 
     it "logs the pulse if reading is up and reading_rpt is every 5th reading" do
       expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 6})
-      expect(Clog).to receive(:emit)
+      expect(Clog).to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
     end
   end
@@ -147,7 +147,7 @@ RSpec.describe MonitorableResource do
     it "triggers Kernel.exit if pulse check is stuck" do
       r_w_event_loop.instance_variable_get(:@mutex).lock
       r_w_event_loop.instance_variable_set(:@pulse_check_started_at, Time.now - 200)
-      expect(Clog).to receive(:emit).at_least(:once)
+      expect(Clog).to receive(:emit).at_least(:once).and_call_original
       r_w_event_loop.force_stop_if_stuck
       r_w_event_loop.instance_variable_get(:@mutex).unlock
     end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe PostgresServer do
     expect(PostgresLsnMonitor).to receive(:new).and_return(lsn_monitor)
     expect(lsn_monitor).to receive(:insert_conflict).and_return(lsn_monitor)
     expect(lsn_monitor).to receive(:save_changes).and_raise(Sequel::Error)
-    expect(Clog).to receive(:emit).with("Failed to update PostgresLsnMonitor")
+    expect(Clog).to receive(:emit).with("Failed to update PostgresLsnMonitor").and_call_original
     expect(postgres_server).to receive(:primary?).and_return(true)
     postgres_server.check_pulse(session: {db_connection: DB}, previous_pulse: {})
   end

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -103,12 +103,19 @@ WHERE id = \? AND lease = \?
     st.unsynchronized_run
   end
 
-  it "occasionally logs acquisition and release of lease" do
+  it "logs verbosely in test mode" do
     st.label = "napper"
     st.save_changes
-    expect(st).to receive(:rand).and_return(0)
     expect(Clog).to receive(:emit).with("obtained lease").and_call_original
     expect(Clog).to receive(:emit).with("lease cleared").and_call_original
+    st.take_lease_and_reload {}
+  end
+
+  it "does not log if configured not to" do
+    st.label = "napper"
+    st.save_changes
+    expect(st).to receive(:verbose_logging).and_return(false)
+    expect(Clog).not_to receive(:emit)
     st.take_lease_and_reload {}
   end
 end

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Prog::Heartbeat do
     it "naps if it can't send request in expected time" do
       expect(hb).to receive(:fetch_connected).and_return(described_class::EXPECTED)
       stub_request(:get, "http://localhost:3000").and_raise(Excon::Error::Timeout)
-      expect(Clog).to receive(:emit).with("heartbeat request timed out")
+      expect(Clog).to receive(:emit).with("heartbeat request timed out").and_call_original
       expect { hb.wait }.to nap(10)
     end
 

--- a/spec/prog/test_smoke_spec.rb
+++ b/spec/prog/test_smoke_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Prog::Test do
+  let(:strand) { Strand.create(prog: "Test", label: "smoke_test_1") }
+
+  let(:prog) { described_class.new(strand) }
+
+  it "smoke_test_1 naps, then hops to smoke_test_0" do
+    expect(prog).to receive(:rand).and_return(2).thrice
+    expect(prog).to receive(:print).with(1)
+    expect { prog.smoke_test_1 }.to nap(2)
+    expect { prog.smoke_test_1 }.to hop("smoke_test_0")
+    expect { prog.smoke_test_0 }.to nap(1000)
+  end
+end

--- a/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
+++ b/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
@@ -408,7 +408,8 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
       client = instance_double(VictoriaMetrics::Client)
       expect(client).to receive(:health).and_raise(StandardError.new("Connection failed"))
       expect(victoria_metrics_server).to receive(:client).and_return(client)
-      expect(Clog).to receive(:emit).with("victoria_metrics server is down")
+      expect(victoria_metrics_server).to receive(:ubid).and_return(nil)
+      expect(Clog).to receive(:emit).with("victoria_metrics server is down").and_call_original
       expect(nx.available?).to be false
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -1040,7 +1040,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "prevents destroy if the semaphore set" do
       expect(nx).to receive(:when_prevent_destroy_set?).and_yield
-      expect(Clog).to receive(:emit).with("Destroy prevented by the semaphore")
+      expect(Clog).to receive(:emit).with("Destroy prevented by the semaphore").and_call_original
       expect { nx.destroy }.to hop("prevent_destroy")
     end
 

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Prog::Vnet::CertNexus do
 
     it "hops to restart if dns_challenge validation fails" do
       expect(challenge).to receive(:status).and_return("failed")
-      expect(Clog).to receive(:emit).with("DNS validation failed")
+      expect(Clog).to receive(:emit).with("DNS validation failed").and_call_original
       expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect { nx.wait_dns_validation }.to hop("restart")
@@ -161,7 +161,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       challenge = instance_double(Acme::Client::Resources::Challenges::DNS01, status: "pending", record_name: "test-record-name", record_content: "content")
       expect(nx).to receive(:dns_challenge).and_return(challenge).at_least(:once)
       expect(acme_order).to receive(:status).and_return("failed")
-      expect(Clog).to receive(:emit).with("Certificate finalization failed")
+      expect(Clog).to receive(:emit).with("Certificate finalization failed").and_call_original
       expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect { nx.wait_cert_finalization }.to hop("restart")
@@ -260,7 +260,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(nx).to receive(:acme_client).and_return(client)
       expect(client).to receive(:revoke).and_raise(Acme::Client::Error::AlreadyRevoked.new("already revoked"))
 
-      expect(Clog).to receive(:emit).with("Certificate is already revoked")
+      expect(Clog).to receive(:emit).with("Certificate is already revoked").and_call_original
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
       expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name")).at_least(:once)
@@ -275,7 +275,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(nx).to receive(:acme_client).and_return(client)
       expect(client).to receive(:revoke).and_raise(Acme::Client::Error::NotFound.new("not found"))
 
-      expect(Clog).to receive(:emit).with("Certificate is not found")
+      expect(Clog).to receive(:emit).with("Certificate is not found").and_call_original
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
       expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name")).at_least(:once)
@@ -290,7 +290,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(nx).to receive(:acme_client).and_return(client)
       expect(client).to receive(:revoke).and_raise(Acme::Client::Error::Unauthorized.new("The certificate has expired and cannot be revoked"))
 
-      expect(Clog).to receive(:emit).with("Certificate is expired and cannot be revoked")
+      expect(Clog).to receive(:emit).with("Certificate is expired and cannot be revoked").and_call_original
       expect(nx).to receive(:dns_zone).and_return(dns_zone)
       expect(dns_zone).to receive(:delete_record).with(record_name: "test-record-name.cert-hostname")
       expect(nx).to receive(:dns_challenge).and_return(instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name")).at_least(:once)

--- a/spec/respirate_smoke_test.rb
+++ b/spec/respirate_smoke_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+ENV["RACK_ENV"] = "test"
+
+require_relative "../loader"
+
+num_strands = 1000
+seconds_allowed = 30
+
+keep_strand_ids = Strand.select_map(&:id)
+at_exit do
+  delete_strand_ds = Strand
+    .exclude(id: keep_strand_ids)
+    .select(:id)
+
+  Semaphore
+    .where(strand_id: delete_strand_ds)
+    .delete(force: true)
+
+  delete_strand_ds.delete(force: true)
+end
+
+strands = Array.new(num_strands) { Strand.create(prog: "Test", label: "smoke_test_3") }
+ds = Strand.where(id: strands.map(&:id))
+
+r, w = IO.pipe
+output = +""
+Thread.new do
+  output << r.read(4096).to_s
+end
+respirate_pid = Process.spawn("bin/respirate", :in => :close, [:out, :err] => w)
+w.close
+
+finished_ds = ds.where(label: "smoke_test_0")
+deadline = Time.now + seconds_allowed
+until finished_ds.count == num_strands || Time.now > deadline
+  print "."
+  sleep 1
+end
+puts
+
+Process.kill(:TERM, respirate_pid)
+sleep 1
+
+# puts "output:"
+# puts output
+
+finished_count = finished_ds.count
+unless finished_count == num_strands
+  raise "Only #{finished_count}/#{num_strands} strands finished processing within #{seconds_allowed} seconds"
+end
+
+unless output.length == num_strands * 3
+  raise "unexpected output length: #{output.length}"
+end
+
+(1..3).each do |n|
+  unless output.count(n.to_s) == num_strands
+    raise "Not all strands output expected information"
+  end
+end

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Clover, "billing" do
       expect(Stripe::Checkout::Session).to receive(:retrieve).with("session_123").and_return({"setup_intent" => "st_123456790"})
       expect(Stripe::SetupIntent).to receive(:retrieve).with("st_123456790").and_return({"customer" => "cs_1234567890", "payment_method" => "pm_1234567890"})
       expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return({"card" => {"brand" => "visa"}}).once
-      expect(Clog).to receive(:emit)
+      expect(Clog).to receive(:emit).and_call_original
 
       visit project.path
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "updates job details of runner when receive in_progress action" do
-      expect(Clog).to receive(:emit).with("runner_started")
+      expect(Clog).to receive(:emit).with("runner_started").and_call_original
       runner
       send_webhook("workflow_job", workflow_job_payload(action: "in_progress", workflow_job: workflow_job_object(runner_id: runner.runner_id)))
 


### PR DESCRIPTION
Also, always use verbose logging in tests for Strand#take_lease_and_reload , and always call yield to   Clog.emit block in the tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `respirate` smoke test and CI workflow, ensure verbose logging in tests, and modify `Clog.emit` behavior in tests.
> 
>   - **Behavior**:
>     - Add `respirate` smoke test in `spec/respirate_smoke_test.rb` to verify processing of 1000 strands within 30 seconds.
>     - Always use verbose logging in tests for `Strand#take_lease_and_reload` in `model/strand.rb`.
>     - Ensure `Clog.emit` calls original method in tests across multiple specs.
>   - **CI/CD**:
>     - Add `respirate-ci.yml` GitHub Actions workflow to run `respirate` smoke tests on `main` branch and specific paths.
>   - **Rake Tasks**:
>     - Add `respirate_smoke_test` task to `Rakefile` to execute the smoke test script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 088bfbf77b9e7f97b34c53a70a48e579bbc48caf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->