### PR TITLE
Limit max dispatcher threads to 8

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -77,6 +77,8 @@ module Config
   override :force_ssl, true, bool
   override :port, 3000, int
   override :pretty_json, false, bool
+  override :dispatcher_max_threads, 8, int
+  override :dispatcher_min_threads, 1, int
   override :puma_max_threads, 16, int
   override :puma_min_threads, 1, int
   override :puma_workers, 3, int

--- a/config.rb
+++ b/config.rb
@@ -79,6 +79,7 @@ module Config
   override :pretty_json, false, bool
   override :dispatcher_max_threads, 8, int
   override :dispatcher_min_threads, 1, int
+  override :dispatcher_queue_size_ratio, 4, int
   override :puma_max_threads, 16, int
   override :puma_min_threads, 1, int
   override :puma_workers, 3, int

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -40,7 +40,7 @@ class Scheduling::Dispatcher
     # ensure that for a busy thread pool, there are always strands to run.
     # This should only cause issues if the thread pool can process more than
     # 4 times its size in the time it takes the main thread to refill the queue.
-    @strand_queue = SizedQueue.new(pool_size * 4)
+    @strand_queue = SizedQueue.new(pool_size * Config.dispatcher_queue_size_ratio)
 
     # An array of thread pool data.  This starts pool_size * 2 threads.  Half
     # of the threads are strand threads, responsible for running the strands.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Limits dispatcher threads to a maximum of 8 and adds new configuration options for thread management in `config.rb` and `dispatcher.rb`.
> 
>   - **Configuration**:
>     - Add `dispatcher_max_threads`, `dispatcher_min_threads`, and `dispatcher_queue_size_ratio` to `config.rb`.
>   - **Dispatcher Initialization**:
>     - In `dispatcher.rb`, `initialize` method now clamps `pool_size` between `dispatcher_min_threads` and `dispatcher_max_threads`.
>     - Adjust `@strand_queue` size using `dispatcher_queue_size_ratio` in `dispatcher.rb`.
>   - **Behavior**:
>     - Limits dispatcher threads to a maximum of 8, ensuring efficient resource usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fd05ea9c327f78ed0b8998e88ef21972a0c799cf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->