### PR TITLE
Revert the dispatcher changes

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -31,17 +31,9 @@ Strand.dataset.insert_conflict.insert(id: "08200dd2-20ce-833a-de82-10fd5a082bff"
 
 clover_freeze
 
-DB.synchronize do
-  until d.shutting_down
-    if d.start_cohort && !d.shutting_down
-      # Only sleep if not shutting down and there were no strands in previous scan
-      # Note that this results in an up to a 1 second delay to pick up new strands,
-      # but that is an accept tradeoff, because we do not want to busy loop the
-      # database (potentially, LISTEN/NOTIFY could be used to reduce this latency)
-      duration_slept = sleep 1
-      Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
-    end
-  end
+loop do
+  d.start_cohort
+  next if d.wait_cohort > 0
+  duration_slept = sleep 1
+  Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
 end
-
-Clog.emit("Shutting down.") { {unfinished_strand_count: d.num_current_strands} }

--- a/config.rb
+++ b/config.rb
@@ -77,9 +77,6 @@ module Config
   override :force_ssl, true, bool
   override :port, 3000, int
   override :pretty_json, false, bool
-  override :dispatcher_max_threads, 8, int
-  override :dispatcher_min_threads, 1, int
-  override :dispatcher_queue_size_ratio, 4, int
   override :puma_max_threads, 16, int
   override :puma_min_threads, 1, int
   override :puma_workers, 3, int

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -59,6 +59,21 @@ class Prog::Test < Prog::Base
     pop frame["test_level"]
   end
 
+  label def synchronized
+    th = Thread.list.find { it.name == "clover_test" }
+    w = th[:clover_test_in]
+    th.thread_variable_set(:clover_test_out, Thread.current)
+    w.close
+    pop "done"
+  end
+
+  label def wait_exit
+    th = Thread.list.find { it.name == "clover_test" }
+    r = th[:clover_test_in]
+    r.read
+    pop "done"
+  end
+
   label def hop_entry
     hop_hop_exit
   end

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -1,248 +1,93 @@
 # frozen_string_literal: true
 
-# Scheduling::Dispatcher is used for running strands. It finds strands
-# that should be run, and runs them using a thread pool. It keeps a
-# record of which strands are currently being processed, so that it
-# does not retrieve them.
 class Scheduling::Dispatcher
-  attr_reader :shutting_down
+  attr_reader :notifiers, :shutting_down
 
-  STRAND_RUNTIME = Strand::LEASE_EXPIRATION / 4
-  APOPTOSIS_MUTEX = Mutex.new
-
-  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.db_pool - 2)
+  def initialize
+    @apoptosis_timeout = Strand::LEASE_EXPIRATION - 29
+    @notifiers = []
     @shutting_down = false
-
-    # How long to wait in seconds from the start of strand run
-    # for the strand to finish until killing the process.
-    @apoptosis_timeout = apoptosis_timeout
-
-    # Hash of currently executing strands.  This can be accessed by
-    # multiple threads concurrently, so access is protected via a mutex.
-    @current_strands = {}
-    # Mutex for current strands
-    @mutex = Mutex.new
-
-    # Set default limits on the thread pool size.  It needs to be at least 1, and we
-    # cannot use more threads than database connections (db_pool - 1), and we need
-    # a database connection for the scan thread.
-    pool_size = pool_size.clamp(1, Config.db_pool - 2)
-
-    # Set configured limits on pool size. This will raise if the maximum number
-    # of threads is lower than the minimum.
-    pool_size = pool_size.clamp(Config.dispatcher_min_threads, Config.dispatcher_max_threads)
-
-    # The Queue that all threads in the thread pool pull from.  This is a
-    # SizedQueue to allow for backoff in the case that the thread pool cannot
-    # process jobs fast enough. When the queue is full, the main thread to
-    # push strands into the queue blocks until the queue is no longer full.
-    # The queue size is 4 times the size of the thread pool, as that should
-    # ensure that for a busy thread pool, there are always strands to run.
-    # This should only cause issues if the thread pool can process more than
-    # 4 times its size in the time it takes the main thread to refill the queue.
-    @strand_queue = SizedQueue.new(pool_size * Config.dispatcher_queue_size_ratio)
-
-    # An array of thread pool data.  This starts pool_size * 2 threads.  Half
-    # of the threads are strand threads, responsible for running the strands.
-    # The other half are apoptosis threads, each responsible for monitoring
-    # the related strand thread.  The strand thread notifies the apoptosis
-    # thread via a queue when it starts, and also when it finishes.  If a
-    # strand thread does not notify the apoptosis thread of it finishing
-    # before the apoptosis timeout, then the process exits.
-    @thread_data = Array.new(pool_size) do
-      start_thread_pair(@strand_queue)
-    end
-
-    # A prepared statement to get the strands to run.  A prepared statement
-    # is used to reduce parsing/planning work in the database.
-    @strand_ps = Strand
-      .where(
-        Sequel.|({lease: nil}, Sequel[:lease] < Sequel::CURRENT_TIMESTAMP) &
-        (Sequel[:schedule] < Sequel::CURRENT_TIMESTAMP) &
-        {exitval: nil}
-      )
-      .order_by(:schedule)
-      .limit(pool_size)
-      .exclude(id: Sequel.function(:ANY, Sequel.cast(:$skip_strands, "uuid[]")))
-      .select(:id, :schedule)
-      .for_update
-      .skip_locked
-      .prepare(:select, :get_strand_cohort)
   end
 
-  # Wait for all threads to exit after shutdown is set.
-  # Designed for use in the tests.
-  def shutdown_and_cleanup_threads
-    # Make idempotent
-    return if @cleaned_up
-
-    shutdown
-
-    @cleaned_up = true
-
-    # Signal all threads to shutdown. This isn't done by
-    # default in shutdown as pushing to the queue can block.
-    @thread_data.each { @strand_queue.push(nil) }
-
-    # After all queues have been pushed to, it is safe to
-    # attempt joining them.
-    @thread_data.each do |data|
-      data[:apoptosis_thread].join
-      data[:strand_thread].join
-    end
-  end
-
-  # Signal that the dispatcher should shut down.  This only sets a flag.
-  # Strand threads will continue running their current thread, and
-  # apoptosis threads will continue running until after their related
-  # strand thread signals them to exit.
   def shutdown
     @shutting_down = true
   end
 
-  # Start a strand/apoptosis thread pair, where the strand thread will
-  # pull from the given strand queue.
-  #
-  # On strand run start:
-  #
-  # * The strand thread pushes the strand ubid to the start queue,
-  #   and the apoptosis thread pops it and starts a timed pop on the
-  #   finish queue.
-  #
-  # On strand run finish:
-  #
-  # * The strand thread pushes to the finish queue to signal to the
-  #   apoptosis thread that it is finished.  The strand goes back
-  #   to monitoring the strand queue, and the apoptosis thread goes
-  #   back to monitoring the start queue.
-  #
-  # On strand run timeout:
-  #
-  # * If the timed pop of the finish queue by the apoptosis thread
-  #   does not complete in time, the apoptosis thread kills the process.
-  def start_thread_pair(strand_queue)
-    start_queue = Queue.new
-    finish_queue = Queue.new
-    {
-      start_queue:,
-      finish_queue:,
-      apoptosis_thread: Thread.new { apoptosis_thread(start_queue, finish_queue) },
-      strand_thread: Thread.new { DB.synchronize { strand_thread(strand_queue, start_queue, finish_queue) } }
-    }
-  end
-
-  # If the process is shutting down, return an empty array.  Otherwise
-  # call the database prepared statement to find the strands to run,
-  # excluding the strands that are currently running in the thread pool.
   def scan
-    @shutting_down ? [] : @strand_ps.call(skip_strands: Sequel.pg_array(@mutex.synchronize { @current_strands.keys }))
-  end
-
-  # The number of strands the thread pool is currently running.
-  def num_current_strands
-    @mutex.synchronize { @current_strands.size }
-  end
-
-  # The entry point for apoptosis threads.  This loops until the
-  # dispatcher shuts down, monitoring the start queue, and once
-  # signaled via the start queue, kills the process unless it is
-  # signaled via the finish queue within the apoptosis timeout.
-  def apoptosis_thread(start_queue, finish_queue)
-    timeout = @apoptosis_timeout
-    until @shutting_down
-      break unless apoptosis_run(timeout, start_queue, finish_queue)
-    end
-  rescue
-    apoptosis_failure
-  end
-
-  # Performs a single apoptosis run.  Waits until signaled by the
-  # start queue, then does a timed pop of the finish queue, killing
-  # the process if the pop times out.
-  def apoptosis_run(timeout, start_queue, finish_queue)
-    return unless (strand_ubid = start_queue.pop)
-    Thread.current.name = "apoptosis:#{strand_ubid}"
-    unless finish_queue.pop(timeout:)
-      apoptosis_failure
-    end
-    true
-  end
-
-  # Handle timeout of a strand thread by killing the process.
-  def apoptosis_failure
-    # Timed out, dump threads and exit.
-    # Don't thread print concurrently.
-    APOPTOSIS_MUTEX.synchronize do
-      ThreadPrinter.run
-      Kernel.exit!
-    end
-  end
-
-  # The entry point for strand threads.  The loops until the
-  # dispatcher shuts down, monitoring the strand queue, signalling
-  # the related apoptosis thread when starting, running the strand,
-  # and then signalling the related apoptosis thread when the
-  # strand run finishes.
-  def strand_thread(strand_queue, start_queue, finish_queue)
-    run_strand(strand_queue.pop, start_queue, finish_queue) until @shutting_down
-  ensure
-    # Signal related apoptosis thread to shutdown
-    start_queue.push(nil)
-  end
-
-  # Handle the running of a single strand.  Signals the apoptosis
-  # thread via the start queue when starting, and the finish queue
-  # when exiting.
-  def run_strand(strand, start_queue, finish_queue)
-    # Shutdown indicated, return immediately
-    return unless strand
-
-    strand_ubid = strand.ubid.freeze
-    Thread.current.name = strand_ubid
-    start_queue.push(strand_ubid)
-    strand.run(STRAND_RUNTIME)
-  rescue => ex
-    Clog.emit("exception terminates strand run") { Util.exception_to_hash(ex) }
-
-    cause = ex
-    loop do
-      break unless (cause = cause.cause)
-      Clog.emit("nested exception") { Util.exception_to_hash(cause) }
-    end
-    ex
-  ensure
-    # Always signal apoptosis thread that the strand has finished,
-    # even for non-StandardError exits
-    finish_queue.push(true)
-    @mutex.synchronize { @current_strands.delete(strand&.id) }
-
-    # If there are any sessions in the thread-local (really fiber-local) ssh
-    # cache after the strand run, close them eagerly to close the related
-    # file descriptors, then clear the cache to avoid a memory leak.
-    if (cache = Thread.current[:clover_ssh_cache]) && !cache.empty?
-      cache.each_value do
-        # closing the ssh connection shouldn't raise, but just in case it
-        # does, we want to ignore it so the strand thread doesn't exit.
-        it.close
-      rescue
+    return [] if shutting_down
+    idle_connections = Config.db_pool - @notifiers.count - 1
+    if idle_connections < 1
+      Clog.emit("Not enough database connections.") do
+        {pool: {db_pool: Config.db_pool, active_threads: @notifiers.count}}
       end
-      cache.clear
+      return []
+    end
+
+    Strand.dataset.where(
+      Sequel.lit("(lease IS NULL OR lease < now()) AND schedule < now() AND exitval IS NULL")
+    ).order_by(:schedule).limit(idle_connections)
+  end
+
+  def start_strand(strand)
+    strand_ubid = strand.ubid.freeze
+    apoptosis_r, apoptosis_w = IO.pipe
+    notify_r, notify_w = IO.pipe
+
+    Thread.new do
+      Thread.current[:created_at] = Time.now
+      ready, _, _ = IO.select([apoptosis_r], nil, nil, @apoptosis_timeout)
+
+      if ready.nil?
+        # Timed out, dump threads and exit
+        ThreadPrinter.run
+        Kernel.exit!
+
+        # rubocop:disable Lint/UnreachableCode
+        # Reachable in test only.
+        next
+        # rubocop:enable Lint/UnreachableCode
+      end
+
+      ready.first.close
+    end.tap { it.name = "apoptosis:" + strand_ubid }
+
+    Thread.new do
+      Thread.current[:created_at] = Time.now
+      strand.run Strand::LEASE_EXPIRATION / 4
+    rescue => ex
+      Clog.emit("exception terminates thread") { Util.exception_to_hash(ex) }
+
+      loop do
+        ex = ex.cause
+        break unless ex
+        Clog.emit("nested exception") { Util.exception_to_hash(ex) }
+      end
+    ensure
+      # Adequate to unblock IO.select.
+      apoptosis_w.close
+      notify_w.close
+    end.tap { it.name = strand_ubid }
+
+    notify_r
+  end
+
+  def start_cohort
+    scan.each do |strand|
+      break if shutting_down
+      @notifiers << start_strand(strand)
     end
   end
 
-  # Find strands that need to be run, and push each onto the
-  # strand queue.  This can block if the strand queue is full,
-  # to allow for backoff in the case of a busy thread pool.
-  def start_cohort
-    strand_queue = @strand_queue
-    current_strands = @current_strands
-    strands = scan
-    strands.each do |strand|
-      break if @shutting_down
-      @mutex.synchronize { current_strands[strand.id] = true }
-      strand_queue.push(strand)
+  def wait_cohort
+    if shutting_down
+      Clog.emit("Shutting down.") { {unfinished_strand_count: @notifiers.length} }
+      Kernel.exit if @notifiers.empty?
     end
 
-    strands.size == 0
+    return 0 if @notifiers.empty?
+    ready, _, _ = IO.select(@notifiers)
+    ready.each(&:close)
+    @notifiers.delete_if { ready.include?(it) }
+    ready.count
   end
 end

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -5,156 +5,119 @@ require_relative "../model/spec_helper"
 RSpec.describe Scheduling::Dispatcher do
   subject(:di) { described_class.new }
 
-  after do
-    di.shutdown_and_cleanup_threads
-    Thread.current.name = nil
-  end
-
-  describe "#shutdown" do
-    it "sets shutting_down flag" do
-      expect { di.shutdown }.to change(di, :shutting_down).from(false).to(true)
-
-      # Test idempotent behavior
-      2.times { di.shutdown_and_cleanup_threads }
-    end
-  end
-
-  describe "#num_current_strands" do
-    it "returns the number of current strands being handled" do
-      expect(di.num_current_strands).to eq 0
-      di.instance_variable_get(:@current_strands)["a"] = true
-      expect(di.num_current_strands).to eq 1
-    end
-  end
-
   describe "#scan" do
-    it "returns empty array if there are no strands ready for running" do
-      expect(di.scan).to eq([])
+    it "exits if there's not enough database connections" do
+      expect(Config).to receive(:db_pool).and_return(0).at_least(:once)
+      expect(Clog).to receive(:emit).with("Not enough database connections.").and_call_original
+      di.scan
     end
 
-    it "returns array of strands ready for running" do
-      Strand.create(prog: "Test", label: "wait_exit")
-      st = Strand.first
-      expect(di.scan).to eq([])
-      st.update(schedule: Time.now + 10)
-      expect(di.scan).to eq([])
-      st.update(schedule: Time.now - 10)
-      expect(di.scan.map(&:id)).to eq([st.id])
-    end
-
-    it "returns empty array when shutting down" do
-      di.shutdown
+    it "does not return work when shutting down" do
+      expect { di.shutdown }.to change(di, :shutting_down).from(false).to(true)
       expect(di.scan).to eq([])
     end
   end
 
-  describe "#apoptosis_run" do
-    it "does not trigger exit if strand runs on time" do
-      expect(ThreadPrinter).not_to receive(:run)
-      expect(Kernel).not_to receive(:exit!)
-      start_queue = Queue.new
-      finish_queue = Queue.new
-      start_queue.push(true)
-      finish_queue.push(true)
-      expect(di.apoptosis_run(0, start_queue, finish_queue)).to be true
-    end
-  end
-
-  describe "#apoptosis_thread" do
-    it "triggers thread dumps and exit if the Prog takes too long" do
-      exited = false
-      expect(ThreadPrinter).to receive(:run)
-      expect(Kernel).to receive(:exit!).and_invoke(-> { exited = true })
-      di = described_class.new(apoptosis_timeout: 0.05, pool_size: 1)
-      start_queue = di.instance_variable_get(:@thread_data).dig(0, :start_queue)
-      start_queue.push(true)
-      t = Time.now
-      until exited
-        raise "no apoptosis within 1 second" if Time.now - t > 1
-        sleep 0.1
-      end
-      expect(exited).to be true
+  describe "#wait_cohort" do
+    it "operates when no threads are running" do
+      expect(di.wait_cohort).to be_zero
     end
 
-    it "triggers thread dumps and exit if the there is an exception raised" do
-      exited = false
-      expect(ThreadPrinter).to receive(:run)
-      expect(Kernel).to receive(:exit!).and_invoke(-> { exited = true })
-      di = described_class.new(apoptosis_timeout: 0.05, pool_size: 1)
-      thread_data = di.instance_variable_get(:@thread_data)
-      start_queue = thread_data.dig(0, :start_queue)
-      finish_queue = thread_data.dig(0, :finish_queue)
-      finish_queue.singleton_class.undef_method(:pop)
-      start_queue.push(true)
-      t = Time.now
-      until exited
-        raise "no apoptosis within 1 second" if Time.now - t > 1
-        sleep 0.1
-      end
-      expect(exited).to be true
+    it "separates completed threads" do
+      complete_r, complete_w = IO.pipe
+      complete_w.close
+      incomplete_r, incomplete_w = IO.pipe
+
+      di.notifiers.concat([complete_r, incomplete_r])
+      expect(di.wait_cohort).to eq 1
+
+      expect(di.notifiers).to eq([incomplete_r])
+    ensure
+      [complete_r, complete_w, incomplete_r, incomplete_w].each(&:close)
+    end
+
+    it "exits if all strands have finished when shutting down" do
+      expect { di.shutdown }.to change(di, :shutting_down).from(false).to(true)
+      expect(Kernel).to receive(:exit)
+      di.wait_cohort
+    end
+
+    it "waits for running strands when shutting down" do
+      complete_r, complete_w = IO.pipe
+      complete_w.close
+      di.notifiers.concat([complete_r])
+      expect { di.shutdown }.to change(di, :shutting_down).from(false).to(true)
+      expect(di.wait_cohort).to eq 1
+    ensure
+      [complete_r, complete_w].each(&:close)
     end
   end
 
   describe "#start_cohort" do
-    it "returns true if there are no strands" do
-      expect(di.start_cohort).to be true
-      expect(di.instance_variable_get(:@strand_queue).pop(timeout: 0)).to be_nil
-      expect(di.instance_variable_get(:@current_strands)).to be_empty
+    after do
+      Thread.list.each { it.join if it != Thread.current }
     end
 
-    it "returns false if the dispatcher is shutting down after the scan" do
-      Strand.create(prog: "Test", label: "wait_exit", schedule: Time.now - 10)
-      expect(di).to receive(:scan).and_wrap_original do |original_method|
-        res = original_method.call
-        di.shutdown
-        res
-      end
-      expect(di.start_cohort).to be false
-      expect(di.instance_variable_get(:@strand_queue).pop(timeout: 0)).to be_nil
-      expect(di.instance_variable_get(:@current_strands)).to be_empty
+    it "can create threads" do
+      # Isolate some thread local variables used for communication
+      # within.
+      Thread.new do
+        th = Thread.current
+        r, w = IO.pipe
+
+        # Set a temporally-unique name that allows the Test strand to
+        # find this thread and read its variables.
+        th.name = "clover_test"
+
+        # Pass part of a pipe: the test will synchronize by blocking
+        # on it having been closed.
+        th[:clover_test_in] = w
+
+        # Ensure the test can be found by "#scan" and runs in a
+        # thread.
+        Strand.create_with_id(prog: "Test", label: "synchronized")
+        di.start_cohort
+        expect(di.notifiers.count).to be 1
+
+        # Blocks until :clover_test_out has been set.
+        r.read
+        r.close
+
+        # Wait until thread has changed "alive?" status to "false".
+        th.thread_variable_get(:clover_test_out).join
+
+        # Expect a dead thread to get reaped by wait_cohort.
+        di.wait_cohort
+        expect(di.notifiers).to be_empty
+      ensure
+        # Multiple transactions are required for this test across
+        # threads, so we need to clean up differently than using
+        # ROLLBACK on the main thread's transaction.
+        Strand.truncate(cascade: true)
+      end.join
     end
 
-    it "returns true if the dispatcher is shutting down and there are no strands" do
-      di.shutdown
-      expect(di.start_cohort).to be true
-      expect(di.instance_variable_get(:@strand_queue).pop(timeout: 0)).to be_nil
-      expect(di.instance_variable_get(:@current_strands)).to be_empty
+    it "can trigger thread dumps and exit if the Prog takes too long" do
+      expect(ThreadPrinter).to receive(:run)
+      expect(Kernel).to receive(:exit!)
+
+      Thread.new do
+        th = Thread.current
+        r, w = IO.pipe
+        th.name = "clover_test"
+        th[:clover_test_in] = r
+
+        di.instance_variable_set(:@apoptosis_timeout, 0)
+        Strand.create_with_id(prog: "Test", label: "wait_exit")
+        di.start_cohort
+        w.close
+        di.notifiers.each(&:read)
+      ensure
+        Strand.truncate(cascade: true)
+      end.join
     end
 
-    it "returns false and pushes to strand queue if there are strands" do
-      st = Strand.create(prog: "Test", label: "wait_exit", schedule: Time.now - 10)
-      old_queue = di.instance_variable_get(:@strand_queue)
-      new_queue = di.instance_variable_set(:@strand_queue, Queue.new)
-      expect(di.start_cohort).to be false
-      expect(new_queue.pop(true).id).to eq st.id
-      expect(di.instance_variable_get(:@current_strands)).to eq(st.id => true)
-
-      # Check that we don't retrieve strands currently executing
-      di.instance_variable_set(:@strand_queue, old_queue)
-      expect(di.start_cohort).to be true
-      expect(di.instance_variable_get(:@current_strands)).to eq(st.id => true)
-    end
-  end
-
-  describe "#run_strand" do
-    it "runs strand" do
-      Strand.create(prog: "Test", label: "napper", schedule: Time.now - 10)
-      st = di.scan.first
-      start_queue = Queue.new
-      finish_queue = Queue.new
-      current_strands = di.instance_variable_get(:@current_strands)
-      current_strands[st.id] = true
-      session = instance_double(Net::SSH::Connection::Session)
-      expect(session).to receive(:close).and_raise(RuntimeError)
-      Thread.current[:clover_ssh_cache] = {nil => session}
-      expect(di.run_strand(st, start_queue, finish_queue)).to be_a(Prog::Base::Nap)
-      expect(start_queue.pop(true)).to eq st.ubid
-      expect(finish_queue.pop(true)).to be true
-      expect(current_strands).to be_empty
-      expect(Thread.current[:clover_ssh_cache]).to be_empty
-    end
-
-    it "print exceptions if they are raised" do
+    it "can print exceptions if they are raised" do
       ex = begin
         begin
           raise StandardError.new("nested test error")
@@ -165,7 +128,7 @@ RSpec.describe Scheduling::Dispatcher do
         ex
       end
 
-      st = Strand.create(prog: "Test", label: "wait_exit", schedule: Time.now - 10)
+      st = instance_double(Strand, ubid: "st065wajns766jkqa7af15vm6g")
       expect(st).to receive(:run).and_raise(ex)
 
       # Go to the trouble of emitting those exceptions to provoke
@@ -174,14 +137,16 @@ RSpec.describe Scheduling::Dispatcher do
       expect($stdout).to receive(:write).with(a_string_matching(/outer test error/))
       expect($stdout).to receive(:write).with(a_string_matching(/nested test error/))
 
-      start_queue = Queue.new
-      finish_queue = Queue.new
-      current_strands = di.instance_variable_get(:@current_strands)
-      current_strands[st.id] = true
-      expect(di.run_strand(st, start_queue, finish_queue)).to eq ex
-      expect(start_queue.pop(true)).to eq st.ubid
-      expect(finish_queue.pop(true)).to be true
-      expect(current_strands).to be_empty
+      notif = di.start_strand(st)
+      notif.read
+      di.wait_cohort
+    end
+
+    it "does not start new strands when shutting down" do
+      expect { di.shutdown }.to change(di, :shutting_down).from(false).to(true)
+      expect(di).to receive(:scan).and_return([Strand.new(prog: "Test", label: "test")])
+      expect(di).not_to receive(:start_strand)
+      di.start_cohort
     end
   end
 end


### PR DESCRIPTION
This PR is only designed for use by the on-call, in case there are problems discovered over the next few days, and backing out the changes is desired as part of the troubleshooting.

Revert "Allow dispatcher queue size ratio to be configured"

This reverts commit 09771367746d39773f13234948047f3ddea14337.

Revert "Allow configurable min/max limits for dispatcher threads"

This reverts commit c2672df9308f3adfda8816069f170724f89cb868.

Revert "Close ssh sessions and clear ssh session cache after strand run"

This reverts commit bf0c22cd1cd33d3d876006caa57b64e7bff7377c.

Revert "Use a maximum of 15 worker threads for respirate"

This reverts commit 43246aaa082959798d763d92706ab05aed122586.

Revert "Select schedule in dispatcher scan query in addition to id"

This reverts commit 1eca3c01b69fa6ecc0fbfafcceaeb2c580e41ad6.

Reapply "Revert dispatcher rewrite"

This reverts commit 46e403c0d872083744a89e65846c36ac4b30cf43.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts recent dispatcher changes, including thread management and configuration, to previous stable state for troubleshooting purposes.
> 
>   - **Reverts**:
>     - Reverts dispatcher queue size ratio configuration changes.
>     - Reverts configurable min/max limits for dispatcher threads.
>     - Reverts changes to close SSH sessions and clear cache after strand run.
>     - Reverts the use of a maximum of 15 worker threads for respirate.
>     - Reverts selection of schedule in dispatcher scan query.
>     - Reapplies previous dispatcher rewrite revert.
>   - **Files Affected**:
>     - `scheduling/dispatcher.rb`: Reverts to previous thread management and scanning logic.
>     - `config.rb`: Removes dispatcher thread and queue size configuration options.
>     - `bin/respirate`: Reverts loop logic to previous implementation.
>   - **Tests**:
>     - Updates `dispatcher_spec.rb` to reflect reverted logic and ensure tests align with previous dispatcher behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4826b9fafe42b5ffe14aa62d2b3cd306bbf20e3b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->