### PR TITLE
Use released version of Sequel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", github: "jeremyevans/sequel", ref: "4934f70a921395df9241ae4e214e8e9a395b6758"
+gem "sequel", ">= 5.93"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,14 +16,6 @@ GIT
       rack
 
 GIT
-  remote: https://github.com/jeremyevans/sequel.git
-  revision: 4934f70a921395df9241ae4e214e8e9a395b6758
-  ref: 4934f70a921395df9241ae4e214e8e9a395b6758
-  specs:
-    sequel (5.92.0)
-      bigdecimal
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -376,6 +368,8 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
+    sequel (5.93.0)
+      bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
     sequel_pg (1.17.1)
@@ -509,7 +503,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel!
+  sequel (>= 5.93)
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords


### PR DESCRIPTION
Features Ubicloud was relying on have now been released.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `Gemfile` to use released version `>= 5.93` of `sequel` gem instead of a specific GitHub commit.
> 
>   - **Gemfile Update**:
>     - Change `sequel` gem source from a specific GitHub commit to the released version `>= 5.93`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6e6e22c71d63848f6c6ad3af44b4972f87a8b01f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->