### PR TITLE
Use cert_store in VictoriaMetrics client

### DIFF
--- a/model/victoria_metrics_server.rb
+++ b/model/victoria_metrics_server.rb
@@ -68,7 +68,7 @@ class VictoriaMetricsServer < Sequel::Model
   def client(socket: nil)
     VictoriaMetrics::Client.new(
       endpoint: endpoint,
-      ssl_ca_file_data: resource.root_certs + cert,
+      ssl_ca_data: resource.root_certs + cert,
       socket: socket,
       username: resource.admin_user,
       password: resource.admin_password

--- a/spec/model/victoria_metrics/victoria_metrics_server_spec.rb
+++ b/spec/model/victoria_metrics/victoria_metrics_server_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe VictoriaMetricsServer do
       expect(vms).to receive(:private_ipv4_address).and_return("192.168.1.1")
       expect(VictoriaMetrics::Client).to receive(:new).with(
         endpoint: vms.endpoint,
-        ssl_ca_file_data: vms.resource.root_certs + vms.cert,
+        ssl_ca_data: vms.resource.root_certs + vms.cert,
         socket: File.join("unix://", socket_path, "health_monitor_socket"),
         username: vms.resource.admin_user,
         password: vms.resource.admin_password
@@ -154,7 +154,7 @@ RSpec.describe VictoriaMetricsServer do
     it "creates a client with the correct parameters in prod" do
       expect(VictoriaMetrics::Client).to receive(:new).with(
         endpoint: vms.endpoint,
-        ssl_ca_file_data: vms.resource.root_certs + vms.cert,
+        ssl_ca_data: vms.resource.root_certs + vms.cert,
         socket: nil,
         username: vms.resource.admin_user,
         password: vms.resource.admin_password
@@ -167,7 +167,7 @@ RSpec.describe VictoriaMetricsServer do
       socket = "unix:///path/to/socket"
       expect(VictoriaMetrics::Client).to receive(:new).with(
         endpoint: vms.endpoint,
-        ssl_ca_file_data: vms.resource.root_certs + vms.cert,
+        ssl_ca_data: vms.resource.root_certs + vms.cert,
         socket: socket,
         username: vms.resource.admin_user,
         password: vms.resource.admin_password


### PR DESCRIPTION
Previously we were relying on the ssl_ca_file api of Excon which seems that it couldn't parse a chain of certs. In order to fix that we will parse the certs and add them all to a cert_store and then pass that to the client which fixes the issue.