### PR TITLE
Configure hugepages for Postgres

### DIFF
--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -98,6 +98,39 @@ standby2replication   #{identity}             ubi_replication
 PG_IDENT
 safe_write_to_file("/etc/postgresql/#{v}/main/pg_ident.conf", pg_ident_entries)
 
+# Configure system hugepages
+meminfo = File.read("/proc/meminfo")
+hugepage_size_kib = Integer(meminfo[/^Hugepagesize:\s*(\d+)\s*kB/, 1], 10)
+memory_total_kib = Integer(meminfo[/^MemTotal:\s*(\d+)\s*kB/, 1], 10)
+
+target_hugepages_size_kib = memory_total_kib / 4
+target_hugepages = target_hugepages_size_kib / hugepage_size_kib
+
+r "echo 'vm.nr_hugepages = #{target_hugepages}' | sudo tee /etc/sysctl.d/10-hugepages.conf"
+r "sync"
+r "echo 3 | sudo tee /proc/sys/vm/drop_caches"
+r "echo 1 | sudo tee /proc/sys/vm/compact_memory"
+r "sudo sysctl --system"
+
+meminfo = File.read("/proc/meminfo")
+allocated_hugepages = Integer(meminfo[/^HugePages_Total:\s*(\d+)/, 1], 10)
+
+if allocated_hugepages < target_hugepages
+  puts "Failed to allocate #{target_hugepages} hugepages. Only #{allocated_hugepages} were allocated."
+  exit 1
+else
+  puts "Successfully allocated #{allocated_hugepages} hugepages."
+end
+
+# Create drop-in directory for postgresql@.service to override
+# the default systemd service file with a custom ExecStartPre to configure hugepages.
+r "mkdir -p /etc/systemd/system/postgresql@.service.d"
+execstartpre_hugepages_conf = <<-HUGEPAGES_CONF
+[Service]
+ExecStartPre=/home/ubi/postgres/bin/configure-hugepages %i
+HUGEPAGES_CONF
+safe_write_to_file("/etc/systemd/system/postgresql@.service.d/hugepages.conf", execstartpre_hugepages_conf)
+
 # Reload the postmaster to apply changes
 r "pg_ctlcluster #{v} main reload || pg_ctlcluster #{v} main restart"
 

--- a/rhizome/postgres/bin/configure-hugepages
+++ b/rhizome/postgres/bin/configure-hugepages
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require_relative "../lib/hugepages_setup"
+require "logger"
+
+if ARGV.count != 1
+  fail "Wrong number of arguments. Expected 1, Given #{ARGV.count}"
+end
+
+instance = ARGV[0]
+
+logger = Logger.new($stdout)
+logger.level = Logger::INFO
+
+HugepagesSetup.new(instance, logger).setup

--- a/rhizome/postgres/lib/hugepages_setup.rb
+++ b/rhizome/postgres/lib/hugepages_setup.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "logger"
+
+class HugepagesSetup
+  def initialize(instance, logger)
+    @version, @cluster = instance.split("-", 2)
+    @logger = logger
+  end
+
+  def get_postgres_param(param)
+    Integer(r("sudo -u postgres /usr/lib/postgresql/#{@version.shellescape}/bin/postgres -D /dat/#{@version.shellescape}/data -c config_file=/etc/postgresql/#{@version.shellescape}/#{@cluster.shellescape}/postgresql.conf -C #{param.shellescape}"), 10)
+  end
+
+  def hugepage_info
+    meminfo = File.read("/proc/meminfo")
+    hugepages_count = Integer(meminfo[/^HugePages_Total:\s*(\d+)/, 1], 10)
+    hugepage_size_kib = Integer(meminfo[/^Hugepagesize:\s*(\d+)\s*kB/, 1], 10)
+    [hugepages_count, hugepage_size_kib]
+  end
+
+  def stop_postgres_cluster
+    r "sudo pg_ctlcluster stop #{@version} #{@cluster}", expect: [0, 2] # 2 is "not running"
+  end
+
+  def setup_postgres_hugepages
+    hugepages_count, hugepage_size_kib = hugepage_info
+
+    if hugepages_count == 0
+      @logger.warn("No hugepages configured, skipping setup.")
+      return
+    end
+
+    hugepages_kib = hugepages_count * hugepage_size_kib
+    update_postgres_hugepages_conf(hugepages_kib)
+
+    shmem_and_overhead_kib = 1024 * get_postgres_param("shared_memory_size")
+    overhead = shmem_and_overhead_kib - hugepages_kib
+
+    target_kib = hugepages_kib - overhead
+
+    # Floor division to nearest multiple of block_size: (a / b) * b
+    block_size_bytes = get_postgres_param("block_size")
+    block_size_kib = block_size_bytes / 1024
+    final_shared_buffers_kib = (target_kib / block_size_kib) * block_size_kib
+
+    update_postgres_hugepages_conf(final_shared_buffers_kib)
+  end
+
+  def update_postgres_hugepages_conf(shared_buffers_kib)
+    safe_write_to_file("/etc/postgresql/#{@version}/#{@cluster}/conf.d/002-hugepages.conf", <<CONF
+huge_pages = 'on'
+huge_page_size = 0
+shared_buffers = #{shared_buffers_kib}kB
+CONF
+    )
+  end
+
+  def postgres_running?
+    r "sudo pg_ctlcluster status #{@version} #{@cluster}", expect: [3]
+    false
+  rescue CommandFail
+    true
+  end
+
+  def setup
+    unless postgres_running?
+      stop_postgres_cluster
+      setup_postgres_hugepages
+    end
+  end
+end

--- a/rhizome/postgres/spec/hugepages_setup_spec.rb
+++ b/rhizome/postgres/spec/hugepages_setup_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "../lib/hugepages_setup"
+
+RSpec.describe HugepagesSetup do
+  let(:logger) { instance_double(Logger, warn: nil) }
+  let(:hugepages_setup) { described_class.new("17-main", logger) }
+
+  describe "#setup_postgres_hugepages" do
+    it "calculates hugepages via overhead subtraction and rounding" do
+      # Mock hugepage info: 512 x 2MB hugepages = 1024MB total hugepage space
+      expect(hugepages_setup).to receive(:hugepage_info).and_return([512, 2048])
+
+      # shared_memory_size increases due to simulated overhead:
+      # 1024MB -> 1061MB (37MB overhead)
+      expect(hugepages_setup).to receive(:get_postgres_param)
+        .with("shared_memory_size").and_return(1061)
+
+      # Block size for rounding shared_buffers
+      expect(hugepages_setup).to receive(:get_postgres_param)
+        .with("block_size").and_return(8192)  # 8KB blocks
+
+      # First call: set shared_buffers to total hugepage space
+      # (1024MB = 1,048,576 KiB)
+      expect(hugepages_setup).to receive(:update_postgres_hugepages_conf)
+        .with(1_048_576)
+
+      # Second call: back off by overhead and round down to block boundary
+      # overhead = (1061 - 1024) * 1024 = 37,888 KiB
+      # target = 1,048,576 - 37,888 = 1,010,688 KiB
+      expected_shared_buffers = 1_010_688
+      expect(hugepages_setup).to receive(:update_postgres_hugepages_conf)
+        .with(expected_shared_buffers)
+      expect(expected_shared_buffers & 0b111).to eq(0)  # Divisible by 8
+
+      expect { hugepages_setup.setup_postgres_hugepages }.not_to raise_error
+    end
+
+    it "skips setup if no hugepages are configured" do
+      expect(hugepages_setup).to receive(:hugepage_info).and_return([0, 2048])
+      expect(hugepages_setup).not_to receive(:get_postgres_param)
+      expect(hugepages_setup).not_to receive(:update_postgres_hugepages_conf)
+      expect(logger).to receive(:warn).with("No hugepages configured, skipping setup.")
+      expect { hugepages_setup.setup_postgres_hugepages }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a new label to postgres_server_nexus.rb to configure huge pages, via a rhizome lib+bin.

At the moment, it uses the default huge page size (2M), and calculates the number of huge pages using `postgres ... -C
shared_memory_size_in_huge_pages`. Since configuring hugepages needs to restart postgres, its placed in a separate label from `configure`, to allow other configuration changes to go through without restarting postgres.

In a subsequent change, we can consider adding the boot parameters to setup 1G hugepages for larger instances (possibly standard-30+), where they are most useful.

[1]: https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-HUGE-PAGES
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds hugepages configuration for Postgres with a new setup script and class, including tests for the setup logic.
> 
>   - **Behavior**:
>     - Adds hugepages configuration to `configure` script in `rhizome/postgres/bin/configure`.
>     - New script `configure-hugepages` to handle hugepages setup.
>     - Calculates hugepages based on system memory and Postgres parameters.
>     - Logs success or failure of hugepages allocation.
>   - **Classes**:
>     - New `HugepagesSetup` class in `hugepages_setup.rb` to manage hugepages configuration.
>     - Methods include `get_postgres_param`, `hugepage_info`, `setup_postgres_hugepages`, and `update_postgres_hugepages_conf`.
>   - **Tests**:
>     - Adds `hugepages_setup_spec.rb` to test `HugepagesSetup` class.
>     - Tests hugepages calculation and setup logic, including edge cases with no hugepages configured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 93dcb961a2e2eb049281f37cb0ecf43050da15a8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->