### PR TITLE
Collect VmHost node_exporter metrics and store in VictoriaMetrics

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -14,7 +14,7 @@ health_monitor_queue = SizedQueue.new(health_monitor_queue_size)
 metrics_target_resources = {}
 metrics_export_mutex = Mutex.new
 metrics_export_thread_pool_size = (Config.max_metrics_export_threads - 2).clamp(1, nil)
-metrics_target_resource_types = [PostgresServer]
+metrics_target_resource_types = [PostgresServer, VmHost]
 metrics_export_queue_size = metrics_export_thread_pool_size + (metrics_target_resource_types.sum(&:count) * 1.5).round
 metrics_export_queue = SizedQueue.new(metrics_export_queue_size)
 

--- a/config.rb
+++ b/config.rb
@@ -221,4 +221,7 @@ module Config
   optional :invoices_blob_storage_endpoint, string
   optional :invoices_blob_storage_access_key, string, clear: true
   optional :invoices_blob_storage_secret_key, string, clear: true
+
+  # Monitoring
+  optional :monitoring_service_project_id, string
 end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -26,7 +26,8 @@ class VmHost < Sequel::Model
   plugin ResourceMethods
   include SemaphoreMethods
   include HealthMonitorMethods
-  semaphore :checkup, :reboot, :hardware_reset, :destroy, :graceful_reboot
+  include MetricsTargetMethods
+  semaphore :checkup, :reboot, :hardware_reset, :destroy, :graceful_reboot, :configure_metrics
 
   def host_prefix
     net6.netmask.prefix_len
@@ -355,6 +356,12 @@ class VmHost < Sequel::Model
     }
   end
 
+  def init_metrics_export_session
+    {
+      ssh_session: sshable.start_fresh_session
+    }
+  end
+
   def disk_device_ids
     # we use this next line to migrate data from the old formatting (storing device names) to the new (storing id) so we trigger the convert
     # whenever an element inside unix_device_list is not a SSD or NVMe id.
@@ -408,6 +415,19 @@ class VmHost < Sequel::Model
     else
       fail "BUG: inexhaustive render code"
     end
+  end
+
+  def metrics_config
+    {
+      endpoints: [
+        "http://localhost:9100/metrics"
+      ],
+      max_file_retention: 120,
+      interval: "15s",
+      additional_labels: {ubicloud_resource_id: ubid},
+      metrics_dir: "/home/rhizome/host/metrics",
+      project_id: Config.monitoring_service_project_id
+    }
   end
 end
 

--- a/prog/setup_grafana.rb
+++ b/prog/setup_grafana.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Prog::SetupGrafana < Prog::Base
+  subject_is :sshable
+
+  def self.assemble(sshable_id, grafana_domain:, certificate_owner_email:)
+    grafana_domain = grafana_domain.strip
+    certificate_owner_email = certificate_owner_email.strip
+    if grafana_domain.empty? || certificate_owner_email.empty?
+      fail "grafana_domain and certificate_owner_email should not be empty"
+    end
+    unless (sshable = Sshable[sshable_id])
+      fail "Sshable does not exist"
+    end
+    Strand.create(prog: "SetupGrafana", label: "start", stack: [{subject_id: sshable.id, domain: grafana_domain, cert_email: certificate_owner_email}])
+  end
+
+  def domain
+    frame["domain"]
+  end
+
+  def cert_email
+    frame["cert_email"]
+  end
+
+  label def start
+    bud Prog::BootstrapRhizome, {"target_folder" => "host", "subject_id" => sshable.id, "user" => sshable.unix_user}
+    hop_wait_for_rhizome
+  end
+
+  label def wait_for_rhizome
+    reap
+    hop_install_grafana if leaf?
+    donate
+  end
+
+  label def install_grafana
+    case sshable.d_check("install_grafana")
+    when "Succeeded"
+      sshable.d_clean("install_grafana")
+      pop "grafana was setup"
+    when "NotStarted"
+      sshable.d_run("install_grafana", "sudo", "host/bin/setup-grafana", domain, cert_email)
+      nap 10
+    when "InProgress"
+      nap 10
+    else
+      Clog.emit("Install grafana failed")
+      nap 65536
+    end
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -287,7 +287,7 @@ class Prog::Vm::HostNexus < Prog::Base
 
     vm_host.update(allocation_state: "accepting") if vm_host.allocation_state == "unprepared"
 
-    hop_wait
+    hop_configure_metrics
   end
 
   label def prep_graceful_reboot
@@ -307,6 +307,47 @@ class Prog::Vm::HostNexus < Prog::Base
     nap 30
   end
 
+  label def configure_metrics
+    metrics_dir = vm_host.metrics_config[:metrics_dir]
+    sshable.cmd("mkdir -p #{metrics_dir}")
+    sshable.cmd("tee #{metrics_dir}/config.json > /dev/null", stdin: vm_host.metrics_config.to_json)
+
+    metrics_service = <<SERVICE
+[Unit]
+Description=VmHost Metrics Collection
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=rhizome
+ExecStart=/home/rhizome/common/bin/metrics-collector #{metrics_dir}
+StandardOutput=journal
+StandardError=journal
+SERVICE
+    sshable.cmd("sudo tee /etc/systemd/system/vmhost-metrics.service > /dev/null", stdin: metrics_service)
+
+    metrics_interval = vm_host.metrics_config[:interval] || "15s"
+
+    metrics_timer = <<TIMER
+[Unit]
+Description=Run VmHost Metrics Collection Periodically
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=#{metrics_interval}
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target
+TIMER
+    sshable.cmd("sudo tee /etc/systemd/system/vmhost-metrics.timer > /dev/null", stdin: metrics_timer)
+
+    sshable.cmd("sudo systemctl daemon-reload")
+    sshable.cmd("sudo systemctl enable --now vmhost-metrics.timer")
+
+    hop_wait
+  end
+
   label def wait
     when_graceful_reboot_set? do
       hop_prep_graceful_reboot
@@ -323,6 +364,11 @@ class Prog::Vm::HostNexus < Prog::Base
     when_checkup_set? do
       hop_unavailable if !available?
       decr_checkup
+    end
+
+    when_configure_metrics_set? do
+      decr_configure_metrics
+      hop_configure_metrics
     end
 
     nap 6 * 60 * 60

--- a/rhizome/host/bin/setup-grafana
+++ b/rhizome/host/bin/setup-grafana
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "securerandom"
+
+domain = ARGV.shift.to_s.strip
+cert_email = ARGV.shift.to_s.strip
+if domain.empty? || cert_email.empty?
+  puts "Error: Both domain and cert_email must be provided."
+  exit 1
+end
+admin_password = SecureRandom.hex(16)
+grafana_ini = "/etc/grafana/grafana.ini"
+
+r "sudo apt update"
+r "sudo apt install -y apt-transport-https software-properties-common wget nginx snapd"
+r "sudo snap install certbot --classic"
+
+r "sudo mkdir -p /etc/apt/keyrings/"
+r "wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null"
+r "echo \"deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main\" | sudo tee -a /etc/apt/sources.list.d/grafana.list"
+
+r "sudo apt update"
+r "sudo apt install -y grafana"
+
+r "sudo cp #{grafana_ini} #{grafana_ini}.bak"
+
+r "sudo sed -i \
+  -e 's/;admin_user = admin/admin_user = admin/' \
+  -e 's/;admin_password = admin/admin_password = #{admin_password}/' \
+  #{grafana_ini}"
+
+r "sudo mkdir -p /var/www/html"
+
+r %(
+sudo tee /etc/nginx/sites-available/grafana.conf > /dev/null <<'EOF'
+server {
+    listen 80;
+    server_name {{DOMAIN}};
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+EOF
+)
+r "sudo sed -i 's|{{DOMAIN}}|'#{domain.shellescape}'|' /etc/nginx/sites-available/grafana.conf"
+
+r "sudo ln -s /etc/nginx/sites-available/grafana.conf /etc/nginx/sites-enabled/"
+r "sudo systemctl start nginx"
+
+r "sudo certbot --nginx -d #{domain.shellescape} --non-interactive --agree-tos --email #{cert_email.shellescape}"
+r "sudo apt install -y ufw"
+r "sudo ufw allow 22"
+r "sudo ufw allow 80"
+r "sudo ufw allow 443"
+r "sudo ufw enable"
+
+r "sudo systemctl enable grafana-server"
+r "sudo systemctl start grafana-server"

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -370,6 +370,13 @@ RSpec.describe VmHost do
     vh.init_health_monitor_session
   end
 
+  it "initiates a new health monitor session for metrics exporter" do
+    sshable = instance_double(Sshable)
+    expect(vh).to receive(:sshable).and_return(sshable)
+    expect(sshable).to receive(:start_fresh_session)
+    vh.init_metrics_export_session
+  end
+
   it "returns disk device ids when StorageDevice has unix_device_list" do
     sd = StorageDevice.create_with_id(vm_host_id: vh.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id1", "wwn-random-id2"])
     allow(vh).to receive(:storage_devices).and_return([sd])
@@ -602,6 +609,24 @@ RSpec.describe VmHost do
     it "returns nil if there is no provider" do
       expect(vh).to receive(:provider).and_return(nil)
       expect(vh.provider_name).to be_nil
+    end
+  end
+
+  describe "#metrics_config" do
+    it "returns the right metrics config" do
+      sa = Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
+      vh = described_class.create(location_id: Location::HETZNER_FSN1_ID, family: "standard") { it.id = sa.id }
+      expect(Config).to receive(:monitoring_service_project_id).and_return("d272dc1f-52ba-4e52-9bcc-f90dce42a226")
+      expect(vh.metrics_config).to eq({
+        endpoints: [
+          "http://localhost:9100/metrics"
+        ],
+        max_file_retention: 120,
+        interval: "15s",
+        additional_labels: {ubicloud_resource_id: vh.ubid},
+        metrics_dir: "/home/rhizome/host/metrics",
+        project_id: "d272dc1f-52ba-4e52-9bcc-f90dce42a226"
+      })
     end
   end
 end

--- a/spec/prog/setup_grafana_spec.rb
+++ b/spec/prog/setup_grafana_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::SetupGrafana do
+  subject(:sn) {
+    described_class.new(Strand.new(prog: "SetupGrafana", stack: [{"subject_id" => sshable.id, "cert_email" => "email@gmail.com", "domain" => "grafana.domain.com"}]))
+  }
+
+  let(:sshable) { Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair) }
+
+  before do
+    allow(sn).to receive(:sshable).and_return(sshable)
+  end
+
+  describe "#domain" do
+    it "returns the domain based on the stack" do
+      expect(sn.domain).to eq("grafana.domain.com")
+    end
+  end
+
+  describe "#cert_email" do
+    it "returns the cert email based on the stack" do
+      expect(sn.cert_email).to eq("email@gmail.com")
+    end
+  end
+
+  describe "#assemble" do
+    it "fails if domain is not provided" do
+      expect { described_class.assemble(sshable.id, grafana_domain: "", certificate_owner_email: "cert@gmail.com") }.to raise_error(RuntimeError)
+    end
+
+    it "fails if cert_email is not provided" do
+      expect { described_class.assemble(sshable.id, grafana_domain: "domain.com", certificate_owner_email: "") }.to raise_error(RuntimeError)
+    end
+
+    it "fails if sshable is not provided or does not exist" do
+      expect { described_class.assemble("vm6htsmcfx5t1p60s609v49fbf", grafana_domain: "domain.com", certificate_owner_email: "cert@gmail.com") }.to raise_error(RuntimeError)
+    end
+
+    it "creates an strand with the right input" do
+      st = described_class.assemble(sshable.id, grafana_domain: "domain.com", certificate_owner_email: "cert@gmail.com")
+      st.reload
+      expect(st.label).to eq("start")
+    end
+  end
+
+  describe "#install_rhizome" do
+    it "buds a bootstrap rhizome prog and hops to wait_for_rhizome" do
+      expect(sn).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "host", "subject_id" => sshable.id, "user" => sshable.unix_user})
+      expect { sn.start }.to hop("wait_for_rhizome")
+    end
+  end
+
+  describe "#wait_for_rhizome" do
+    before { expect(sn).to receive(:reap) }
+
+    it "donates if install_rhizome is not done" do
+      expect(sn).to receive(:leaf?).and_return false
+      expect(sn).to receive(:donate).and_call_original
+
+      expect { sn.wait_for_rhizome }.to nap(1)
+    end
+
+    it "hops to install_grafana when rhizome is done" do
+      expect(sn).to receive(:leaf?).and_return true
+
+      expect { sn.wait_for_rhizome }.to hop("install_grafana")
+    end
+  end
+
+  describe "#install_grafana" do
+    it "starts to install the grafana if its the first time" do
+      expect(sn).to receive(:domain).and_return("grafana.domain.com")
+      expect(sn).to receive(:cert_email).and_return("email@gmail.com")
+      expect(sshable).to receive(:d_check).and_return("NotStarted")
+      expect(sshable).to receive(:d_run).with("install_grafana", "sudo", "host/bin/setup-grafana", "grafana.domain.com", "email@gmail.com")
+      expect { sn.install_grafana }.to nap(10)
+    end
+
+    it "cleans up and pops when the installation is done" do
+      expect(sshable).to receive(:d_check).and_return("Succeeded")
+      expect(sshable).to receive(:d_clean).with("install_grafana")
+      expect { sn.install_grafana }.to exit({"msg" => "grafana was setup"})
+    end
+
+    it "naps when strand is in the middle of execution" do
+      expect(sshable).to receive(:d_check).and_return("InProgress")
+      expect { sn.install_grafana }.to nap(10)
+    end
+
+    it "naps for a long time when the installation fails" do
+      expect(sshable).to receive(:d_check).and_return("Failed")
+      expect { sn.install_grafana }.to nap(65536)
+    end
+
+    it "naps forever if the daemonizer check returns something unknown" do
+      expect(sshable).to receive(:d_check).and_return("Unknown")
+      expect { sn.install_grafana }.to nap(65536)
+    end
+  end
+end


### PR DESCRIPTION
New logic is added to VmHost model to serve metrics config to start collecting node_exporter metrics on the VmHosts.

Also a new label is added to the VmHost prog to install the right scripts to collect the metrics from the node_exporter in the right directory for bin/monitor to collect
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add functionality to collect and store VmHost node_exporter metrics in VictoriaMetrics, including configuration and setup for Grafana.
> 
>   - **Behavior**:
>     - Add `VmHost` to `metrics_target_resource_types` in `bin/monitor` to collect node_exporter metrics.
>     - New method `metrics_config` in `VmHost` to define metrics collection configuration.
>     - New `configure_metrics` label in `host_nexus.rb` to set up metrics collection service and timer.
>   - **Configuration**:
>     - Add `monitoring_service_project_id` to `config.rb` for metrics configuration.
>   - **Setup**:
>     - New `Prog::SetupGrafana` class and `setup-grafana` script to install and configure Grafana.
>   - **Testing**:
>     - Add tests for `metrics_config` in `vm_host_spec.rb`.
>     - Add tests for `SetupGrafana` in `setup_grafana_spec.rb`.
>     - Add tests for `configure_metrics` in `host_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b2f79d61aad42067cc5ac2734eb157ab03790ebc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->