### PR TITLE
Replace revealable content logic with CSS

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -179,20 +179,8 @@ $(".copyable-content").on("click", ".copy-button", function (event) {
   }
 })
 
-$(".revealable-content").on("click", ".reveal-button", function (event) {
-  $(this).closest(".shadow-content").hide();
-  $(this).closest(".shadow-content").siblings(".revealed-content").show();
-
-  // For some reason, adding this style directly to the element does not trigger
-  // layout reflow for handling overflow when it is made visible. However, adding
-  // the overflow-wrap dynamically makes the browser recalculate the layout and
-  // apply the style correctly.
-  $(this).closest(".shadow-content").siblings(".revealed-content").css("overflow-wrap", "anywhere");
-})
-
-$(".revealable-content").on("click", ".hide-button", function (event) {
-  $(this).closest(".revealed-content").hide();
-  $(this).closest(".revealed-content").siblings(".shadow-content").show();
+$(".revealable-button").on("click", function () {
+  $(this).closest(".revealable-content").toggleClass("active");
 })
 
 $(".back-btn").on("click", function (event) {

--- a/views/components/revealable_content.erb
+++ b/views/components/revealable_content.erb
@@ -1,13 +1,13 @@
 <%# locals: (content:) %>
-<div class="revealable-content">
-  <div class="shadow-content flex items-center gap-2">
+<div class="revealable-content group">
+  <div class="shadow-content items-center gap-2 flex group-[.active]:hidden">
     ●●●●●●
-    <img src="/icons/hero-eye.svg" width="18px" class="reveal-button inline-block cursor-pointer ms1"/>
+    <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1"/>
   </div>
-  <div class="revealed-content hidden">
+  <div class="revealed-content hidden group-[.active]:block break-all">
     <div class="flex gap-2 items-center">
       <div class="revealed-content-text"><%= content %></div>
-      <img src="/icons/hero-eye-slash.svg" width="18px" class="hide-button inline-block cursor-pointer ms1"/>
+      <img src="/icons/hero-eye-slash.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1"/>
     </div>
   </div>
 </div>


### PR DESCRIPTION
It's better to maintain less JS.

Adding break-all to content results same with adding overflow-wrap via JS. @byucesoy, can you confirm that it's working for you?
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces JavaScript logic with CSS for toggling revealable content visibility and text wrapping.
> 
>   - **Behavior**:
>     - Replaces JavaScript logic for toggling visibility of `.revealable-content` with CSS classes in `app.js`.
>     - Uses CSS `break-all` for text wrapping in `revealable_content.erb`.
>   - **JavaScript**:
>     - Removes `.reveal-button` and `.hide-button` click handlers in `app.js`.
>     - Adds `.revealable-button` click handler to toggle `active` class on `.revealable-content`.
>   - **CSS**:
>     - Adds `group-[.active]:hidden` and `group-[.active]:block` to toggle visibility in `revealable_content.erb`.
>     - Uses `break-all` for text wrapping in `.revealed-content`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 373a8299458c1a8ca309cb2d41c2ad219ec1ab41. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->