### PR TITLE
Fix postgres metrics reconfiguration on metric destination update

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -19,7 +19,7 @@ class PostgresServer < Sequel::Model
   include MetricsTargetMethods
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
-  semaphore :restart, :configure, :take_over, :configure_prometheus, :configure_metrics, :destroy, :recycle, :promote
+  semaphore :restart, :configure, :take_over, :configure_metrics, :destroy, :recycle, :promote
 
   def configure_hash
     configs = {

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -186,7 +186,7 @@ class Clover
 
           DB.transaction do
             md = PostgresMetricDestination.create(postgres_resource_id: pg.id, url:, username:, password:)
-            pg.servers.each(&:incr_configure_prometheus)
+            pg.servers.each(&:incr_configure_metrics)
             audit_log(md, "create", pg)
           end
 
@@ -204,7 +204,7 @@ class Clover
           if (md = pg.metric_destinations_dataset[id:])
             DB.transaction do
               md.destroy
-              pg.servers.each(&:incr_configure_prometheus)
+              pg.servers.each(&:incr_configure_metrics)
               audit_log(md, "destroy")
             end
           end


### PR DESCRIPTION
Remove unused semaphore and fix updates to metric-destination.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused semaphore and update metric destination configuration in `postgres_server.rb` and `postgres.rb`.
> 
>   - **Semaphore Removal**:
>     - Remove `configure_prometheus` semaphore from `PostgresServer` in `postgres_server.rb`.
>   - **Metric Destination Update**:
>     - Change `incr_configure_prometheus` to `incr_configure_metrics` in `routes/project/location/postgres.rb` for metric destination creation and deletion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e037d744932f862dbb78deddba33db88d9570315. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->