### PR TITLE
Use cert_store in MinioClient

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -9,13 +9,16 @@ REGION = "us-east-1"
 ADMIN_URI_PATH = "/minio/admin/v3"
 
 class Minio::Client
-  def initialize(endpoint:, access_key:, secret_key:, ssl_ca_file_data:, socket: nil)
-    ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", Digest::SHA256.hexdigest(ssl_ca_file_data) + ".crt")
-    Util.safe_write_to_file(ca_bundle_filename, ssl_ca_file_data) unless File.exist?(ca_bundle_filename)
-
+  def initialize(endpoint:, access_key:, secret_key:, ssl_ca_data:, socket: nil)
+    cert_store = OpenSSL::X509::Store.new
+    certs_pem = ssl_ca_data.scan(/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m)
+    certs_pem.each do |cert_pem|
+      cert = OpenSSL::X509::Certificate.new(cert_pem)
+      cert_store.add_cert(cert)
+    end
     @creds = {access_key: access_key, secret_key: secret_key}
     @endpoint = endpoint
-    @client = Excon.new(endpoint, socket: socket, ssl_ca_file: ca_bundle_filename)
+    @client = Excon.new(endpoint, socket: socket, ssl_cert_store: cert_store)
     @signer = Minio::HeaderSigner.new
     @crypto = Minio::Crypto.new
   end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -97,7 +97,7 @@ class MinioServer < Sequel::Model
       endpoint: server_url,
       access_key: cluster.admin_user,
       secret_key: cluster.admin_password,
-      ssl_ca_file_data: cluster.root_certs + cert,
+      ssl_ca_data: cluster.root_certs + cert,
       socket: socket
     )
   end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -90,7 +90,7 @@ PGHOST=/var/run/postgresql
       endpoint: blob_storage_endpoint,
       access_key: access_key,
       secret_key: secret_key,
-      ssl_ca_file_data: blob_storage.root_certs
+      ssl_ca_data: blob_storage.root_certs
     )
   end
 

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -126,7 +126,7 @@ class Prog::DownloadBootImage < Prog::Base
       endpoint: Config.ubicloud_images_blob_storage_endpoint,
       access_key: Config.ubicloud_images_blob_storage_access_key,
       secret_key: Config.ubicloud_images_blob_storage_secret_key,
-      ssl_ca_file_data: Config.ubicloud_images_blob_storage_certs
+      ssl_ca_data: Config.ubicloud_images_blob_storage_certs
     )
   end
 

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -93,7 +93,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       endpoint: postgres_timeline.blob_storage_endpoint,
       access_key: postgres_timeline.blob_storage.admin_user,
       secret_key: postgres_timeline.blob_storage.admin_password,
-      ssl_ca_file_data: postgres_timeline.blob_storage.root_certs
+      ssl_ca_data: postgres_timeline.blob_storage.root_certs
     )
 
     admin_client.admin_remove_user(postgres_timeline.access_key)
@@ -105,7 +105,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       endpoint: postgres_timeline.blob_storage_endpoint,
       access_key: postgres_timeline.blob_storage.admin_user,
       secret_key: postgres_timeline.blob_storage.admin_password,
-      ssl_ca_file_data: postgres_timeline.blob_storage.root_certs
+      ssl_ca_data: postgres_timeline.blob_storage.root_certs
     )
 
     # Setup user keys and policy for the timeline

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -2,19 +2,13 @@
 
 RSpec.describe Minio::Client do
   let(:endpoint) { "https://localhost:9000" }
-  let(:minio_client) { described_class.new(endpoint: endpoint, access_key: "minioadmin", secret_key: "minioadminpw", ssl_ca_file_data: "data") }
+  let(:cert) { "-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUasLyHvpgRtp3/8N9pRPE7f89Gi4wDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKTXkgVGVzdCBDQTAeFw0yNTA2MDIwOTE2MjFaFw0zNTA1\nMzEwOTE2MjFaMBUxEzARBgNVBAMMCk15IFRlc3QgQ0EwggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQC0WFDSoccSl95/VL4U73JYAYgg1ar96Mo9VJn5H+Y0\nvyfKUI7DWrqZtiqYlCr01nN52FFHwEBgCIYr+aa5MmMHZfe0nbeDK4AbsZKJHr0Z\nBfJfqI9pRxVd9MyRcU2XTAeDWRK3k3sRj6webU2MFxUvF7xB2Wx2+rNhLZhB+d8t\nZSRpwFiX9rgMKYkycY1kV4ZurUT72ct/Q+dNCTTUOel/brMDQhdn02PYAUKgh2UB\nELeooXt1JPedjSH41ShV2yEBA1NyTctaVp3tWfiq+b4p0ZiV/ekoBtkDe5WtaNo1\nxgvRGH/rcOfTraZKokgqCVCG1Ka4DrkvSsaTlOe9XrQlAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQUnKN3Du3ihaNNK3Q9+lztEI4pajAfBgNVHSMEGDAWgBQUnKN3Du3ihaNN\nK3Q9+lztEI4pajAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAG\ndJijmtiYx2dCw50V3QhjyVyTvhFf1B9XUKGP2i0IPApULXqDGll47iIGo6i1yD7V\n7hjpV0BCtFlNH5nH2bZ0zyUi3XCLTqlnHM8+tI6ZUMWRq2lJAgILVHH/D/VUTUl6\nS+h6rGbtzNBCz2jmP3LiL2lmfcPivJpim5RPtAbApyt7fvHWD8aGQWZHpLYn+2v5\n1laUkm55cvWlsnC27PeNT00/3Eu96dqMiLHFJgKkUGFJMr+49X+BTaLcCUXCja+s\n4nXqhVt+iVVk1RtVS/b1C17DvxnV5g1NAFiZQOx5Gfsr5v8SafKCgR/4xm/kGfEz\nIkfEWqyeWXMj/JRB2yCy\n-----END CERTIFICATE-----" }
+  let(:minio_client) { described_class.new(endpoint: endpoint, access_key: "minioadmin", secret_key: "minioadminpw", ssl_ca_data: cert) }
 
-  it "can use ssl_ca_file_data" do
-    ssl_ca_file_name = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7"
-    expect(File).to receive(:exist?).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")).and_return(false)
-    expect(FileUtils).to receive(:mkdir_p).with(File.dirname(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt")))
-    lock_file = instance_double(File, flock: true)
-    expect(File).to receive(:open).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt.tmp.lock"), File::RDWR | File::CREAT).and_yield(lock_file)
-    expect(lock_file).to receive(:flock).with(File::LOCK_EX)
-    expect(File).to receive(:write)
-    expect(File).to receive(:rename).with(File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt.tmp").to_s, File.join(Dir.pwd, "var", "ca_bundles", ssl_ca_file_name + ".crt"))
-
-    minio_client
+  it "can use ssl_ca_data" do
+    excon_client = minio_client.instance_variable_get(:@client)
+    expect(excon_client).to be_a(Excon::Connection)
+    expect(excon_client.data[:ssl_cert_store]).to be_a(OpenSSL::X509::Store)
   end
 
   describe "admin_info" do

--- a/spec/model/minio/minio_server_spec.rb
+++ b/spec/model/minio/minio_server_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe MinioServer do
   it "checks pulse" do
     session = {
       ssh_session: instance_double(Net::SSH::Connection::Session),
-      minio_client: Minio::Client.new(endpoint: "https://1.2.3.4:9000", access_key: "dummy-key", secret_key: "dummy-secret", ssl_ca_file_data: "data")
+      minio_client: Minio::Client.new(endpoint: "https://1.2.3.4:9000", access_key: "dummy-key", secret_key: "dummy-secret", ssl_ca_data: "data")
     }
 
     expect(ms.vm).to receive(:ephemeral_net4).and_return("1.2.3.4").at_least(:once)

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -123,7 +123,7 @@ PGHOST=/var/run/postgresql
   it "returns list of backups" do
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
 
-    minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key", ssl_ca_file_data: "data")
+    minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key", ssl_ca_data: "data")
     expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/").and_return([instance_double(Minio::Client::Blob, key: "backup_stop_sentinel.json"), instance_double(Minio::Client::Blob, key: "unrelated_file.txt")])
     expect(Minio::Client).to receive(:new).and_return(minio_client)
 

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
 
     it "creates bucket and hops" do
       expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs", admin_user: "admin", admin_password: "secret")).at_least(:once)
-      expect(Minio::Client).to receive(:new).with(endpoint: "https://blob-endpoint", access_key: "admin", secret_key: "secret", ssl_ca_file_data: "certs").and_return(admin_blob_storage_client)
+      expect(Minio::Client).to receive(:new).with(endpoint: "https://blob-endpoint", access_key: "admin", secret_key: "secret", ssl_ca_data: "certs").and_return(admin_blob_storage_client)
       expect(postgres_timeline).to receive(:blob_storage_client).and_return(blob_storage_client).twice
       expect(admin_blob_storage_client).to receive(:admin_add_user).with(postgres_timeline.access_key, postgres_timeline.secret_key).and_return(200)
       expect(admin_blob_storage_client).to receive(:admin_policy_add).with(postgres_timeline.ubid, postgres_timeline.blob_storage_policy).and_return(200)
@@ -184,7 +184,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs", admin_user: "admin", admin_password: "secret")).at_least(:once)
       expect(postgres_timeline).to receive(:destroy)
 
-      expect(Minio::Client).to receive(:new).with(endpoint: postgres_timeline.blob_storage_endpoint, access_key: "admin", secret_key: "secret", ssl_ca_file_data: "certs").and_return(admin_blob_storage_client)
+      expect(Minio::Client).to receive(:new).with(endpoint: postgres_timeline.blob_storage_endpoint, access_key: "admin", secret_key: "secret", ssl_ca_data: "certs").and_return(admin_blob_storage_client)
       expect(admin_blob_storage_client).to receive(:admin_remove_user).with(postgres_timeline.access_key).and_return(200)
       expect(admin_blob_storage_client).to receive(:admin_policy_remove).with(postgres_timeline.ubid).and_return(200)
       expect { nx.destroy }.to exit({"msg" => "postgres timeline is deleted"})


### PR DESCRIPTION
Previously we were relying on the ssl_ca_file api of Excon which seems that it couldn't parse a chain of certs. In order to fix that we will parse the certs and add them all to a cert_store and then pass that to the client which fixes the issue.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch `Minio::Client` to use a certificate store for handling multiple certificates, updating initialization and tests accordingly.
> 
>   - **Behavior**:
>     - `Minio::Client` now uses `ssl_cert_store` instead of `ssl_ca_file` in `client.rb`.
>     - Parses `ssl_ca_data` to add multiple certificates to `OpenSSL::X509::Store`.
>   - **Parameters**:
>     - Renames `ssl_ca_file_data` to `ssl_ca_data` in `client.rb`, `minio_server.rb`, `postgres_timeline.rb`, `download_boot_image.rb`, and `postgres_timeline_nexus.rb`.
>   - **Tests**:
>     - Updates `client_spec.rb` to test `ssl_cert_store` usage.
>     - Updates `minio_server_spec.rb`, `postgres_timeline_spec.rb`, and `postgres_timeline_nexus_spec.rb` to reflect parameter rename and new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for cb8107d5d54bd8d286458869edf980b47922e63b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->