### PR TITLE
Don't try to update dns when order doesn't exist at CertNexus

### DIFF
--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -158,7 +158,7 @@ class Prog::Vnet::CertNexus < Prog::Base
   end
 
   def dns_challenge
-    acme_order.authorizations.first.dns
+    acme_order&.authorizations&.first&.dns
   end
 
   def dns_record_name

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -246,6 +246,13 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect { nx.destroy }.to exit({"msg" => "certificate revoked and destroyed"})
     end
 
+    it "skips deleting the dns record if acme_order doesn't exist" do
+      expect(cert).to receive(:cert).and_return(nil)
+      expect(nx).to receive(:acme_order).and_return(nil)
+
+      expect { nx.destroy }.to exit({"msg" => "certificate revoked and destroyed"})
+    end
+
     it "skips revocation and dns record deletion for self-signed certificates" do
       expect(Config).to receive(:development?).and_return(true)
       expect(cert).to receive(:dns_zone_id).and_return(nil)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add safe navigation to handle `nil` `acme_order` in `dns_challenge` and update tests accordingly.
> 
>   - **Behavior**:
>     - Use safe navigation (`&.`) in `dns_challenge` method in `cert_nexus.rb` to handle `nil` `acme_order`.
>     - In `cert_nexus_spec.rb`, add test to ensure DNS record deletion is skipped if `acme_order` is `nil`.
>   - **Tests**:
>     - Add test case in `cert_nexus_spec.rb` to verify behavior when `acme_order` is `nil` during `destroy` method execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5d187f5d0f898cef7073d78403b54554ac2f3733. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->