### PR TITLE
Fix the `stripe_data` helper for the payment method

### DIFF
--- a/model/payment_method.rb
+++ b/model/payment_method.rb
@@ -10,7 +10,7 @@ class PaymentMethod < Sequel::Model
 
   def stripe_data
     if (Stripe.api_key = Config.stripe_secret_key)
-      @stripe_data ||= Stripe::PaymentMethod.retrieve(stripe_id)["card"].slice(*%w[last4 brand exp_month exp_year])
+      @stripe_data ||= Stripe::PaymentMethod.retrieve(stripe_id)["card"].to_h.transform_keys!(&:to_s).slice(*%w[last4 brand exp_month exp_year])
     end
   end
 


### PR DESCRIPTION
It returns a `Stripe::StripeObject`, which doesn’t have all the methods
from a hash.

It fails in production with the following exception:

    NoMethodError: undefined method 'slice' for #<Stripe::StripeObject:0x00007f9c27e9b4a0> (NoMethodError)

`to_h` returns a hash, but the keys are symbols, not strings. Since we
use string keys in the codebase, it's better to convert them before
slicing.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `stripe_data` in `PaymentMethod` to convert `Stripe::StripeObject` to hash with string keys before slicing.
> 
>   - **Bug Fix**:
>     - Fix `stripe_data` method in `PaymentMethod` class to handle `Stripe::StripeObject` correctly.
>     - Convert `Stripe::StripeObject` to hash with string keys using `to_h.transform_keys!(&:to_s)` before slicing.
>     - Prevents `NoMethodError` when calling `slice` on `Stripe::StripeObject`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 11652c543342e76495a286d2187f39829e1a18f5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->