### PR TITLE
Add grafana installation strand

### DIFF
--- a/prog/setup_grafana.rb
+++ b/prog/setup_grafana.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Prog::SetupGrafana < Prog::Base
+  subject_is :sshable
+
+  def self.assemble(sshable_id, grafana_domain:, certificate_owner_email:)
+    grafana_domain = grafana_domain.strip
+    certificate_owner_email = certificate_owner_email.strip
+    if grafana_domain.empty? || certificate_owner_email.empty?
+      fail "grafana_domain and certificate_owner_email should not be empty"
+    end
+    unless (sshable = Sshable[sshable_id])
+      fail "Sshable does not exist"
+    end
+    Strand.create(prog: "SetupGrafana", label: "start", stack: [{subject_id: sshable.id, domain: grafana_domain, cert_email: certificate_owner_email}])
+  end
+
+  def domain
+    frame["domain"]
+  end
+
+  def cert_email
+    frame["cert_email"]
+  end
+
+  label def start
+    bud Prog::BootstrapRhizome, {"target_folder" => "host", "subject_id" => sshable.id, "user" => sshable.unix_user}
+    hop_wait_for_rhizome
+  end
+
+  label def wait_for_rhizome
+    reap
+    hop_install_grafana if leaf?
+    donate
+  end
+
+  label def install_grafana
+    case sshable.d_check("install_grafana")
+    when "Succeeded"
+      sshable.d_clean("install_grafana")
+      pop "grafana was setup"
+    when "NotStarted"
+      sshable.d_run("install_grafana", "sudo", "host/bin/setup-grafana", domain, cert_email)
+      nap 10
+    when "InProgress"
+      nap 10
+    else
+      Clog.emit("Install grafana failed")
+      nap 65536
+    end
+  end
+end

--- a/rhizome/host/bin/setup-grafana
+++ b/rhizome/host/bin/setup-grafana
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "securerandom"
+
+domain = ARGV.shift.to_s.strip
+cert_email = ARGV.shift.to_s.strip
+if domain.empty? || cert_email.empty?
+  puts "Error: Both domain and cert_email must be provided."
+  exit 1
+end
+admin_password = SecureRandom.hex(16)
+grafana_ini = "/etc/grafana/grafana.ini"
+
+r "sudo apt update"
+r "sudo apt install -y apt-transport-https software-properties-common wget nginx snapd"
+r "sudo snap install certbot --classic"
+
+r "sudo mkdir -p /etc/apt/keyrings/"
+r "wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null"
+r "echo \"deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main\" | sudo tee -a /etc/apt/sources.list.d/grafana.list"
+
+r "sudo apt update"
+r "sudo apt install -y grafana"
+
+r "sudo cp #{grafana_ini} #{grafana_ini}.bak"
+
+r "sudo sed -i \
+  -e 's/;admin_user = admin/admin_user = admin/' \
+  -e 's/;admin_password = admin/admin_password = #{admin_password}/' \
+  #{grafana_ini}"
+
+r "sudo mkdir -p /var/www/html"
+
+r %(
+sudo tee /etc/nginx/sites-available/grafana.conf > /dev/null <<'EOF'
+server {
+    listen 80;
+    server_name {{DOMAIN}};
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+EOF
+)
+r "sudo sed -i 's|{{DOMAIN}}|'#{domain.shellescape}'|' /etc/nginx/sites-available/grafana.conf"
+
+r "sudo ln -s /etc/nginx/sites-available/grafana.conf /etc/nginx/sites-enabled/"
+r "sudo systemctl start nginx"
+
+r "sudo certbot --nginx -d #{domain.shellescape} --non-interactive --agree-tos --email #{cert_email.shellescape}"
+r "sudo apt install -y ufw"
+r "sudo ufw allow 22"
+r "sudo ufw allow 80"
+r "sudo ufw allow 443"
+r "sudo ufw enable"
+
+r "sudo systemctl enable grafana-server"
+r "sudo systemctl start grafana-server"

--- a/spec/prog/setup_grafana_spec.rb
+++ b/spec/prog/setup_grafana_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::SetupGrafana do
+  subject(:sn) {
+    described_class.new(Strand.new(prog: "SetupGrafana", stack: [{"subject_id" => sshable.id, "cert_email" => "email@gmail.com", "domain" => "grafana.domain.com"}]))
+  }
+
+  let(:sshable) { Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair) }
+
+  before do
+    allow(sn).to receive(:sshable).and_return(sshable)
+  end
+
+  describe "#domain" do
+    it "returns the domain based on the stack" do
+      expect(sn.domain).to eq("grafana.domain.com")
+    end
+  end
+
+  describe "#cert_email" do
+    it "returns the cert email based on the stack" do
+      expect(sn.cert_email).to eq("email@gmail.com")
+    end
+  end
+
+  describe "#assemble" do
+    it "fails if domain is not provided" do
+      expect { described_class.assemble(sshable.id, grafana_domain: "", certificate_owner_email: "cert@gmail.com") }.to raise_error(RuntimeError)
+    end
+
+    it "fails if cert_email is not provided" do
+      expect { described_class.assemble(sshable.id, grafana_domain: "domain.com", certificate_owner_email: "") }.to raise_error(RuntimeError)
+    end
+
+    it "fails if sshable is not provided or does not exist" do
+      expect { described_class.assemble("vm6htsmcfx5t1p60s609v49fbf", grafana_domain: "domain.com", certificate_owner_email: "cert@gmail.com") }.to raise_error(RuntimeError)
+    end
+
+    it "creates an strand with the right input" do
+      st = described_class.assemble(sshable.id, grafana_domain: "domain.com", certificate_owner_email: "cert@gmail.com")
+      st.reload
+      expect(st.label).to eq("start")
+    end
+  end
+
+  describe "#install_rhizome" do
+    it "buds a bootstrap rhizome prog and hops to wait_for_rhizome" do
+      expect(sn).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "host", "subject_id" => sshable.id, "user" => sshable.unix_user})
+      expect { sn.start }.to hop("wait_for_rhizome")
+    end
+  end
+
+  describe "#wait_for_rhizome" do
+    before { expect(sn).to receive(:reap) }
+
+    it "donates if install_rhizome is not done" do
+      expect(sn).to receive(:leaf?).and_return false
+      expect(sn).to receive(:donate).and_call_original
+
+      expect { sn.wait_for_rhizome }.to nap(1)
+    end
+
+    it "hops to install_grafana when rhizome is done" do
+      expect(sn).to receive(:leaf?).and_return true
+
+      expect { sn.wait_for_rhizome }.to hop("install_grafana")
+    end
+  end
+
+  describe "#install_grafana" do
+    it "starts to install the grafana if its the first time" do
+      expect(sn).to receive(:domain).and_return("grafana.domain.com")
+      expect(sn).to receive(:cert_email).and_return("email@gmail.com")
+      expect(sshable).to receive(:d_check).and_return("NotStarted")
+      expect(sshable).to receive(:d_run).with("install_grafana", "sudo", "host/bin/setup-grafana", "grafana.domain.com", "email@gmail.com")
+      expect { sn.install_grafana }.to nap(10)
+    end
+
+    it "cleans up and pops when the installation is done" do
+      expect(sshable).to receive(:d_check).and_return("Succeeded")
+      expect(sshable).to receive(:d_clean).with("install_grafana")
+      expect { sn.install_grafana }.to exit({"msg" => "grafana was setup"})
+    end
+
+    it "naps when strand is in the middle of execution" do
+      expect(sshable).to receive(:d_check).and_return("InProgress")
+      expect { sn.install_grafana }.to nap(10)
+    end
+
+    it "naps for a long time when the installation fails" do
+      expect(sshable).to receive(:d_check).and_return("Failed")
+      expect { sn.install_grafana }.to nap(65536)
+    end
+
+    it "naps forever if the daemonizer check returns something unknown" do
+      expect(sshable).to receive(:d_check).and_return("Unknown")
+      expect { sn.install_grafana }.to nap(65536)
+    end
+  end
+end


### PR DESCRIPTION
This strand will try to install grafana on the provided subject id. The strand won't create the vm or add the DNS records but takes care of all the remaining logics which must be run inside the vm like installing the nginx, certbot, getting the certificate and installing the grafana.

The API looks like this:

vm = Prog::Vm::Nexus.assemble_with_sshable(project_id,
  sshable_unix_user: "ubi", name: "grafana-0", enable_ip4: true).subject

At this step create an A record, resolving your domain to the vm ip.

Strand.create(prog: "SetupGrafana", label: "start", stack:
  [{subject_id: vm.id, domain: "grafana.domain.com",
  cert_email: "youremail@gmail.com"}])

You can then read the password of the grafana using this command: vm.sshable.cmd("sudo cat /etc/grafana/grafana.ini | grep admin_password")
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add strands for Grafana and Node Exporter setup, integrate metrics configuration in VM host lifecycle, and update tests.
> 
>   - **Behavior**:
>     - Adds `SetupGrafana` strand in `prog/setup_grafana.rb` to install Grafana on a VM, handling domain and certificate email.
>     - Adds `SetupNodeExporter` strand in `prog/setup_node_exporter.rb` to install Node Exporter version 1.9.1.
>     - Integrates metrics configuration in `prog/vm/host_nexus.rb` with a new `configure_metrics` label.
>   - **Scripts**:
>     - Adds `setup-grafana` script in `rhizome/host/bin/setup-grafana` for installing Grafana, configuring Nginx, and setting up SSL.
>     - Adds `setup-node-exporter` script in `rhizome/host/bin/setup-node-exporter` for installing Node Exporter and configuring it as a service.
>   - **Models**:
>     - Updates `VmHost` in `model/vm_host.rb` to include metrics configuration and session initialization for metrics export.
>   - **Tests**:
>     - Adds tests for `SetupGrafana` in `spec/prog/setup_grafana_spec.rb`.
>     - Adds tests for `SetupNodeExporter` in `spec/prog/setup_node_exporter_spec.rb`.
>     - Updates `VmHost` tests in `spec/model/vm_host_spec.rb` to cover metrics configuration.
>     - Updates `HostNexus` tests in `spec/prog/vm/host_nexus_spec.rb` to cover new metrics configuration behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 773bdd48952344cb75f472295c8d6fcf5b83669a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->