### PR TITLE
Inference model card fixes and UI improvements

### DIFF
--- a/serializers/inference_router_model.rb
+++ b/serializers/inference_router_model.rb
@@ -9,7 +9,7 @@ class Serializers::InferenceRouterModel < Serializers::Base
     load_balancer = irm.inference_router.load_balancer
     {
       id: irm.ubid,
-      name: irm.model_name,
+      name: irm.tags["display_name"] || irm.model_name,
       model_name: irm.model_name,
       tags: irm.tags,
       url: "#{load_balancer.health_check_protocol}://#{load_balancer.hostname}",

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -76,6 +76,7 @@ curl #{ie[:url]}#{path} \\
           <pre class="text-sm bg-gray-800 text-white p-2 rounded-lg overflow-scroll"><%== curl_snippet %></pre>
         </div>
       </div>
+      <% if ie[:tags]["capability"] == "Text Generation" %>
       <%== render(
         "components/button",
         locals: {
@@ -86,6 +87,7 @@ curl #{ie[:url]}#{path} \\
           }
         }
       ) %>
+      <% end %>
     </div>
   </div>
   <% end %>

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -33,13 +33,13 @@ curl #{ie[:url]}#{path} \\
   CURL
     %>
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white p-4">
-    <h2 class="text-lg font-bold mb-4 text-gray-800"><%= ie[:name] %></h2>
+    <h2 class="text-lg font-bold mb-4 text-gray-800 line-clamp-1"><%= ie[:name] %></h2>
     <div class="grid sm:grid-cols-2 gap-4">
       <div>
         <h3 class="text-sm font-semibold text-gray-900">Model card</h3>
         <div class="flex items-center gap-1 text-gray-500">
           <%if hf_model = ie[:tags]["hf_model"]%>
-          <a target="_blank" rel="noreferrer" href="https://huggingface.co/<%= hf_model %>" class="text-orange-600">🤗 <%= hf_model %></a>
+          <a target="_blank" rel="noreferrer" href="https://huggingface.co/<%= hf_model %>" class="text-orange-600 line-clamp-2">🤗 <%= hf_model %></a>
           <%else%>
           <p class="text-gray-500">Not available</p>
           <%end%>


### PR DESCRIPTION
1. Display the "Try in Playground" button only for generative models, hide it for embedding models.
2. Visually align all "Try in Playground" buttons, ensuring consistent layout (using css line clamping).
3. Use the display_name tag for a more readable model name on the model card, when available.

Dev preview:
![Screenshot 2025-06-04 at 3 08 50 PM](https://github.com/user-attachments/assets/7c3830d0-f344-4889-80cb-17e7fa69fff4)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI improvements for generative models and model card display logic updates.
> 
>   - **UI Improvements**:
>     - Display "Try in Playground" button only for generative models in `index.erb`.
>     - Align "Try in Playground" buttons using CSS line clamping in `index.erb`.
>   - **Model Card Display**:
>     - Use `display_name` tag for model name in `serialize_internal()` in `inference_router_model.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 15f0aa2ed9699d1a04af05bbd1a7b6709fe0a463. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->