### PR TITLE
Fix incorrect mocking of Stripe::PaymentMethod.retrieve

### DIFF
--- a/spec/model/payment_method_spec.rb
+++ b/spec/model/payment_method_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentMethod do
 
   it "return Stripe Data if Stripe enabled" do
     allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
-    expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return({"id" => "pm_1234567890", "card" => {"brand" => "Visa", "last4" => "1234", "exp_month" => 12, "exp_year" => 2023}})
+    expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return(Stripe::StripeObject.construct_from("id" => "pm_1234567890", "card" => Stripe::StripeObject.construct_from("brand" => "Visa", "last4" => "1234", "exp_month" => 12, "exp_year" => 2023)))
     expect(payment_method.stripe_data).to eq({"brand" => "Visa", "last4" => "1234", "exp_month" => 12, "exp_year" => 2023})
   end
 


### PR DESCRIPTION
The method returns Stripe::StripeObject objects, not hashes.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `Stripe::PaymentMethod.retrieve` mock to return `Stripe::StripeObject` instead of hashes in test files.
> 
>   - **Behavior**:
>     - Fixes `Stripe::PaymentMethod.retrieve` mock to return `Stripe::StripeObject` instead of hashes in `payment_method_spec.rb` and `billing_spec.rb`.
>     - Introduces `stripe_object` helper function in `billing_spec.rb` to construct `Stripe::StripeObject` from hashes.
>   - **Tests**:
>     - Updates multiple test cases in `billing_spec.rb` to use `stripe_object` for mocking `Stripe::PaymentMethod.retrieve`.
>     - Ensures consistent return type for Stripe API mocks across tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3628875693e33e0d1202f69a4254cf4464d0d9dc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->