### PR TITLE
Simplify Postgres's Options Usage

### DIFF
--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -55,9 +55,9 @@ class Clover
         display_name: it.name
       }
     }
-    options.add_option(name: "private_subnet_id", values: subnets, parent: "location") do |location, private_subnet|
+    options.add_option(name: "private_subnet_id", values: subnets, parent: "location", check: ->(location, private_subnet) {
       private_subnet[:location_id] == location.id
-    end
+    })
     options.serialize
   end
 end

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -43,10 +43,10 @@ class Clover
     options.add_option(name: "location", values: Option.kubernetes_locations)
     options.add_option(name: "version", values: Option.kubernetes_versions)
     options.add_option(name: "cp_nodes", values: Option::KubernetesCPOptions.map(&:cp_node_count), parent: "location")
-    options.add_option(name: "worker_size", values: Option::VmSizes.select { it.visible && it.vcpus <= 16 }.map { it.display_name }, parent: "location") do |location, size|
+    options.add_option(name: "worker_size", values: Option::VmSizes.select { it.visible && it.vcpus <= 16 }.map { it.display_name }, parent: "location", check: ->(location, size) {
       vm_size = Option::VmSizes.find { it.display_name == size && it.arch == "x64" }
       vm_size.family == "standard"
-    end
+    })
     options.add_option(name: "worker_nodes", values: (1..10).map { {value: it, display_name: "#{it} Node#{(it == 1) ? "" : "s"}"} }, parent: "worker_size")
 
     options.serialize

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -85,18 +85,18 @@ class Clover
 
     options.add_option(name: "name")
     options.add_option(name: "flavor", values: flavor)
-    options.add_option(name: "location", values: Option.postgres_locations(project_id: @project.id), parent: "flavor") do |flavor, location|
+    options.add_option(name: "location", values: Option.postgres_locations(project_id: @project.id), parent: "flavor", check: ->(flavor, location) {
       !(location.provider == "aws" && flavor != PostgresResource::Flavor::STANDARD)
-    end
-    options.add_option(name: "family", values: all_sizes_for_project.map(&:vm_family).uniq, parent: "location") do |flavor, location, family|
+    })
+    options.add_option(name: "family", values: all_sizes_for_project.map(&:vm_family).uniq, parent: "location", check: ->(flavor, location, family) {
       if location.provider == "aws" && family != "standard"
         false
       else
         available_families = Option.families.map(&:name)
         available_families.include?(family) && BillingRate.from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location.name)
       end
-    end
-    options.add_option(name: "size", values: all_sizes_for_project.map(&:name).uniq, parent: "family") do |flavor, location, family, size|
+    })
+    options.add_option(name: "size", values: all_sizes_for_project.map(&:name).uniq, parent: "family", check: ->(flavor, location, family, size) {
       if location.provider == "aws" && (size.split("-").last.to_i > 16 || size.split("-").first == "burstable")
         false
       else
@@ -104,12 +104,12 @@ class Clover
         vm_size = Option::VmSizes.find { it.name == pg_size.vm_size && it.arch == "x64" && it.visible }
         vm_size.family == family
       end
-    end
+    })
 
-    options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "118", "237", "475", "950", "1781", "1900", "3562", "3800"], parent: "size") do |flavor, location, family, size, storage_size|
+    options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "118", "237", "475", "950", "1781", "1900", "3562", "3800"], parent: "size", check: ->(flavor, location, family, size, storage_size) {
       pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
       pg_size.storage_size_options.include?(storage_size.to_i)
-    end
+    })
 
     options.add_option(name: "version", values: Option::POSTGRES_VERSION_OPTIONS[flavor], parent: "flavor")
 
@@ -124,16 +124,16 @@ class Clover
     options.add_option(name: "flavor", values: flavor)
     options.add_option(name: "location", values: location, parent: "flavor")
 
-    options.add_option(name: "family", values: all_sizes_for_project.map(&:vm_family).uniq, parent: "location") do |flavor, location, family|
+    options.add_option(name: "family", values: all_sizes_for_project.map(&:vm_family).uniq, parent: "location", check: ->(flavor, location, family) {
       if location.provider == "aws" && family != "standard"
         false
       else
         available_families = Option.families.map(&:name)
         available_families.include?(family) && BillingRate.from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location.name)
       end
-    end
+    })
 
-    options.add_option(name: "size", values: all_sizes_for_project.map(&:name).uniq, parent: "family") do |flavor, location, family, size|
+    options.add_option(name: "size", values: all_sizes_for_project.map(&:name).uniq, parent: "family", check: ->(flavor, location, family, size) {
       if location.provider == "aws" && (size.split("-").last.to_i > 16 || size.split("-").first == "burstable")
         false
       else
@@ -141,12 +141,12 @@ class Clover
         vm_size = Option::VmSizes.find { it.name == pg_size.vm_size && it.arch == "x64" && it.visible }
         vm_size.family == family
       end
-    end
+    })
 
-    options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "118", "237", "475", "950", "1781", "1900", "3562", "3800"], parent: "size") do |flavor, location, family, size, storage_size|
+    options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "118", "237", "475", "950", "1781", "1900", "3562", "3800"], parent: "size", check: ->(flavor, location, family, size, storage_size) {
       pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
       pg_size.storage_size_options.include?(storage_size.to_i)
-    end
+    })
 
     options.add_option(name: "ha_type", values: [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC], parent: "storage_size")
 

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -79,13 +79,13 @@ class Clover
     end
   end
 
-  def generate_postgres_options(flavor: "standard")
+  def generate_postgres_options(flavor: "standard", location: nil)
     options = OptionTreeGenerator.new
     all_sizes_for_project = Option.customer_postgres_sizes_for_project(@project.id)
 
     options.add_option(name: "name")
     options.add_option(name: "flavor", values: flavor)
-    options.add_option(name: "location", values: Option.postgres_locations(project_id: @project.id), parent: "flavor", check: ->(flavor, location) {
+    options.add_option(name: "location", values: location || Option.postgres_locations(project_id: @project.id), parent: "flavor", check: ->(flavor, location) {
       !(location.provider == "aws" && flavor != PostgresResource::Flavor::STANDARD)
     })
     options.add_option(name: "family", values: all_sizes_for_project.map(&:vm_family).uniq, parent: "location", check: ->(flavor, location, family) {
@@ -114,42 +114,6 @@ class Clover
     options.add_option(name: "version", values: Option::POSTGRES_VERSION_OPTIONS[flavor], parent: "flavor")
 
     options.add_option(name: "ha_type", values: [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC], parent: "storage_size")
-    options.serialize
-  end
-
-  def generate_postgres_configure_options(flavor:, location:)
-    options = OptionTreeGenerator.new
-    all_sizes_for_project = Option.customer_postgres_sizes_for_project(@project.id)
-
-    options.add_option(name: "flavor", values: flavor)
-    options.add_option(name: "location", values: location, parent: "flavor")
-
-    options.add_option(name: "family", values: all_sizes_for_project.map(&:vm_family).uniq, parent: "location", check: ->(flavor, location, family) {
-      if location.provider == "aws" && family != "standard"
-        false
-      else
-        available_families = Option.families.map(&:name)
-        available_families.include?(family) && BillingRate.from_resource_properties("PostgresVCpu", "#{flavor}-#{family}", location.name)
-      end
-    })
-
-    options.add_option(name: "size", values: all_sizes_for_project.map(&:name).uniq, parent: "family", check: ->(flavor, location, family, size) {
-      if location.provider == "aws" && (size.split("-").last.to_i > 16 || size.split("-").first == "burstable")
-        false
-      else
-        pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
-        vm_size = Option::VmSizes.find { it.name == pg_size.vm_size && it.arch == "x64" && it.visible }
-        vm_size.family == family
-      end
-    })
-
-    options.add_option(name: "storage_size", values: ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "118", "237", "475", "950", "1781", "1900", "3562", "3800"], parent: "size", check: ->(flavor, location, family, size, storage_size) {
-      pg_size = all_sizes_for_project.find { it.name == size && it.flavor == flavor && it.location_id == location.id }
-      pg_size.storage_size_options.include?(storage_size.to_i)
-    })
-
-    options.add_option(name: "ha_type", values: [PostgresResource::HaType::NONE, PostgresResource::HaType::ASYNC, PostgresResource::HaType::SYNC], parent: "storage_size")
-
     options.serialize
   end
 end

--- a/lib/option_tree_generator.rb
+++ b/lib/option_tree_generator.rb
@@ -6,7 +6,7 @@ class OptionTreeGenerator
     @parents = {}
   end
 
-  def add_option(name:, values: nil, parent: nil, &check)
+  def add_option(name:, values: nil, parent: nil, check: nil)
     @options << {name:, values:, parent:, check:}
   end
 

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -31,7 +31,7 @@ class Clover
         else
           @pg = Serializers::Postgres.serialize(pg, {detailed: true, include_path: true})
           @family = Validation.validate_vm_size(pg.target_vm_size, "x64").family
-          @option_tree, @option_parents = generate_postgres_configure_options(flavor: @pg[:flavor], location: @location)
+          @option_tree, @option_parents = generate_postgres_options(flavor: @pg[:flavor], location: @location)
           view "postgres/show"
         end
       end


### PR DESCRIPTION
**Use lambda instead of block for option filtering**
Return statements in blocks return from not only the block but also from the
method that contains the block. This means returns cannot be used for exiting
early from option filtering blocks. Using lambdas instead allows us to use
return statements to exit early from the filtering logic without affecting
the surrounding method.

**Combine Postgres option generators**
In Postgres, we have 2 option generators: one for creation and one for updates.
They are quite similar to each other. This commit combines them into a single
generator that can handle both cases.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies option handling by using lambdas for filtering and combining Postgres option generators.
> 
>   - **Behavior**:
>     - Replaces block with lambda for option filtering in `generate_firewall_options` in `helpers/firewall.rb`, `generate_kubernetes_cluster_options` in `helpers/kubernetes_cluster.rb`, and `generate_vm_options` in `helpers/vm.rb`.
>     - Combines `generate_postgres_options` and `generate_postgres_configure_options` into a single function in `helpers/postgres.rb`.
>   - **Functions**:
>     - Updates `add_option` in `lib/option_tree_generator.rb` to accept a `check` lambda instead of a block.
>   - **Routes**:
>     - Updates `routes/project/location/postgres.rb` to use the combined `generate_postgres_options` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e971ca2bcc5420a25ae42e00ec5824776b82f8c4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->