### PR TITLE
Increase utilization limit to 75%

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -160,7 +160,7 @@ class Prog::Vm::GithubRunner < Prog::Base
         sum(:used_cores) * 100.0 / sum(:total_cores)
       }.first.to_f
 
-      unless utilization < 70
+      unless utilization < 75
         Clog.emit("Waiting for customer concurrency limit, utilization is high") { [github_runner, {utilization: utilization}] }
         nap rand(5..15)
       end


### PR DESCRIPTION
We allow our customers to exceed the concurrency limit by up to 70%. We set this limit a year ago and have almost doubled our capacity since then. We can increase this threshold to 75 to make better use of this idle capacity
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase utilization threshold from 70% to 75% in `github_runner.rb` to allow more concurrency before waiting.
> 
>   - **Behavior**:
>     - Increase utilization threshold from 70% to 75% in `quota_available?` method in `github_runner.rb`.
>     - Affects when the system waits due to high utilization, allowing more concurrency before waiting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a6f8ddbfc0e1b43a5d8a24c76b5248a6eb8c715e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->