### PR TITLE
Only accept single argument in Prog::Base#pop

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -60,13 +60,13 @@ end
     fail Nap.new(seconds)
   end
 
-  def pop(*args)
+  def pop(arg)
     outval = Sequel.pg_jsonb_wrap(
-      case args
-      in [String => s]
-        {"msg" => s}
-      in [Hash => h]
-        h
+      case arg
+      when String
+        {"msg" => arg}
+      when Hash
+        arg
       else
         fail "BUG: must pop with string or hash"
       end


### PR DESCRIPTION
Also, do not use unnecessary pattern matching.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `pop` method in `prog/base.rb` now accepts a single argument and uses a case statement instead of pattern matching.
> 
>   - **Behavior**:
>     - `pop` method in `prog/base.rb` now accepts a single argument instead of multiple arguments.
>     - Replaces pattern matching with a case statement to handle `String` and `Hash` inputs.
>     - Raises an error if the argument is neither `String` nor `Hash`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 27a5adb9383535745525beea71bad3b09630663a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->