### PR TITLE
Decrease E2E test timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,8 +20,7 @@ jobs:
     if: vars.RUN_E2E == 'true'
     runs-on: ubicloud
     environment: E2E-CI
-    # TODO: Revert it when the internal MinIO cluster is stabilized
-    timeout-minutes: 105
+    timeout-minutes: 60
     concurrency: e2e_environment
 
     env:
@@ -131,7 +130,7 @@ jobs:
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
       run: |
         set -o pipefail
-        timeout 100m foreman start | tee foreman.log | grep "e2e.1"
+        timeout 55m foreman start | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
       if: always()


### PR DESCRIPTION
We previously increased the timeout due to slow image downloads. Now
that our internal MinIO cluster has stabilized and boot images are
downloading reliably again, we can safely reduce the timeout.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduce E2E test timeout in `e2e.yml` due to improved MinIO cluster stability.
> 
>   - **Timeout Reduction**:
>     - Decrease `timeout-minutes` from 105 to 60 in `e2e.yml` for the `run-ci` job.
>     - Reduce `timeout` in the `Run tests` step from 100m to 55m in `e2e.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 377d7731903b2f6cfe7a774323950d322fc060f4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->