### PR TITLE
Fix the leaseweb first/last ip address assignment issue

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -141,7 +141,7 @@ class VmHost < Sequel::Model
     return ip4_random_vm_network if vm_addresses.map { it.ip.to_s }.include?("#{picked_subnet}/32")
 
     # For Leaseweb, avoid using the very first and the last ips
-    if provider == "leaseweb"
+    if provider_name == "leaseweb"
       subnet_size = 2**(32 - used_subnet.cidr.netmask.prefix_len)
       last_ip = used_subnet.cidr.nth(subnet_size - 1).to_s
       first_ip = used_subnet.cidr.network.to_s

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -202,9 +202,9 @@ RSpec.describe VmHost do
     expect(r_address).to eq(address)
   end
 
-  context "when provider is leaseweb" do
+  context "when provider name is leaseweb" do
     before do
-      allow(vh).to receive(:provider).and_return("leaseweb")
+      allow(vh).to receive(:provider_name).and_return("leaseweb")
     end
 
     it "finds another address if it's already assigned" do


### PR DESCRIPTION
Another bug that passed specs due to mocking with the incorrect type.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Leaseweb IP assignment issue by changing `provider` to `provider_name` in `vm_host.rb` to avoid assigning first/last IPs.
> 
>   - **Behavior**:
>     - Fixes IP address assignment issue for Leaseweb providers in `ip4_random_vm_network` in `vm_host.rb` by changing `provider` to `provider_name`.
>     - Ensures first and last IPs are not assigned to VMs for Leaseweb.
>   - **Tests**:
>     - Updates test context in `vm_host_spec.rb` from "when provider is leaseweb" to "when provider name is leaseweb".
>     - Modifies mock to use `provider_name` instead of `provider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for eca23648149c641b1ba4c4b6daa0ad44c121c658. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->