### PR TITLE
Allow ResourceMethods plugin to accept redacted_columns keyword argument

### DIFF
--- a/lib/resource_methods.rb
+++ b/lib/resource_methods.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 module ResourceMethods
-  def self.configure(model, etc_type: false)
+  def self.configure(model, etc_type: false, redacted_columns: nil)
     model.instance_exec do
       extend UbidTypeEtcMethods if etc_type
       @ubid_format = /\A#{ubid_type}[a-z0-9]{24}\z/
+      @redacted_columns = Array(redacted_columns).freeze
     end
   end
 
@@ -141,7 +142,7 @@ module ResourceMethods
     end
 
     def redacted_columns
-      column_encryption_metadata.keys || []
+      (column_encryption_metadata.keys || []) + @redacted_columns
     end
   end
 end

--- a/model/cert.rb
+++ b/model/cert.rb
@@ -9,7 +9,7 @@ class Cert < Sequel::Model
 
   plugin :association_dependencies, certs_load_balancers: :destroy
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: :cert
   include SemaphoreMethods
   semaphore :destroy, :restarted
 
@@ -23,10 +23,6 @@ class Cert < Sequel::Model
     where(:needing_recert, Sequel::CURRENT_TIMESTAMP - Sequel.cast("60 days", :interval) < :created_at)
     where(:active, Sequel::CURRENT_TIMESTAMP - Sequel.cast("90 days", :interval) < :created_at)
     reverse(:by_most_recent, :created_at)
-  end
-
-  def self.redacted_columns
-    super + [:cert]
   end
 end
 

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -9,7 +9,7 @@ class GithubRunner < Sequel::Model
   many_to_one :repository, key: :repository_id, class: :GithubRepository
   one_to_one :vm, key: :id, primary_key: :vm_id
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: :workflow_job
   include SemaphoreMethods
   include HealthMonitorMethods
   semaphore :destroy, :skip_deregistration
@@ -74,10 +74,6 @@ class GithubRunner < Sequel::Model
       "down"
     end
     aggregate_readings(previous_pulse: previous_pulse, reading: reading, data: {available_memory: available_memory})
-  end
-
-  def self.redacted_columns
-    super + [:workflow_job]
   end
 end
 

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -10,7 +10,7 @@ class MinioCluster < Sequel::Model
   many_to_one :private_subnet
   many_to_one :location, key: :location_id
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: [:root_cert_1, :root_cert_2]
   include SemaphoreMethods
 
   semaphore :destroy, :reconfigure
@@ -59,10 +59,6 @@ class MinioCluster < Sequel::Model
 
   def root_certs
     root_cert_1.to_s + root_cert_2.to_s
-  end
-
-  def self.redacted_columns
-    super + [:root_cert_1, :root_cert_2]
   end
 end
 

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -11,7 +11,7 @@ class MinioServer < Sequel::Model
   many_to_one :pool, key: :minio_pool_id, class: :MinioPool
   one_through_one :cluster, join_table: :minio_pool, left_primary_key: :minio_pool_id, left_key: :id, class: :MinioCluster
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: :cert
   include SemaphoreMethods
   include HealthMonitorMethods
 
@@ -100,10 +100,6 @@ class MinioServer < Sequel::Model
       ssl_ca_data: cluster.root_certs + cert,
       socket: socket
     )
-  end
-
-  def self.redacted_columns
-    super + [:cert]
   end
 end
 

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -19,7 +19,7 @@ class PostgresResource < Sequel::Model
   plugin :association_dependencies, firewall_rules: :destroy, metric_destinations: :destroy
   dataset_module Pagination
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: [:root_cert_1, :root_cert_2, :server_cert]
   include SemaphoreMethods
   include ObjectTag::Cleanup
 
@@ -155,10 +155,6 @@ class PostgresResource < Sequel::Model
   DEFAULT_VERSION = "17"
 
   MAINTENANCE_DURATION_IN_HOURS = 2
-
-  def self.redacted_columns
-    super + [:root_cert_1, :root_cert_2, :server_cert]
-  end
 end
 
 # Table: postgres_resource

--- a/model/victoria_metrics_resource.rb
+++ b/model/victoria_metrics_resource.rb
@@ -9,7 +9,7 @@ class VictoriaMetricsResource < Sequel::Model
   one_to_many :servers, class: :VictoriaMetricsServer, key: :victoria_metrics_resource_id
   many_to_one :private_subnet
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: [:admin_password, :root_cert_1, :root_cert_2]
   include SemaphoreMethods
 
   semaphore :destroy, :reconfigure
@@ -35,10 +35,6 @@ class VictoriaMetricsResource < Sequel::Model
       {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(8427..8427)},
       {cidr: "::/0", port_range: Sequel.pg_range(8427..8427)}
     ])
-  end
-
-  def self.redacted_columns
-    super + [:admin_password, :root_cert_1, :root_cert_2]
   end
 end
 

--- a/model/victoria_metrics_server.rb
+++ b/model/victoria_metrics_server.rb
@@ -7,7 +7,7 @@ class VictoriaMetricsServer < Sequel::Model
   many_to_one :vm
   many_to_one :resource, class: :VictoriaMetricsResource, key: :victoria_metrics_resource_id
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: :cert
   include SemaphoreMethods
   include HealthMonitorMethods
 
@@ -73,10 +73,6 @@ class VictoriaMetricsServer < Sequel::Model
       username: resource.admin_user,
       password: resource.admin_password
     )
-  end
-
-  def self.redacted_columns
-    super + [:cert]
   end
 end
 

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -31,7 +31,7 @@ class Vm < Sequel::Model
 
   dataset_module Pagination
 
-  plugin ResourceMethods
+  plugin ResourceMethods, redacted_columns: :public_key
   include SemaphoreMethods
   include HealthMonitorMethods
   semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
@@ -202,10 +202,6 @@ class Vm < Sequel::Model
     fail "SPDK version #{version} not found on host" unless spdk_installation
     vm_storage_volumes_dataset.update(spdk_installation_id: spdk_installation.id)
     incr_update_spdk_dependency
-  end
-
-  def self.redacted_columns
-    super + [:public_key]
   end
 
   def params_json(swap_size_bytes: nil, ch_version: nil, firmware_version: nil, hugepages: nil)


### PR DESCRIPTION
This avoids the need to define a singleton redacted_columns method on a number of models.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `redacted_columns` keyword argument to `ResourceMethods` plugin, updating several models to use it and removing singleton methods.
> 
>   - **Behavior**:
>     - `ResourceMethods.configure` now accepts `redacted_columns` keyword argument to specify columns to redact.
>     - `redacted_columns` method in `ResourceMethods` combines `column_encryption_metadata.keys` with `@redacted_columns`.
>   - **Models**:
>     - Updated `Cert`, `GithubRunner`, `MinioCluster`, `MinioServer`, `PostgresResource`, `VictoriaMetricsResource`, `VictoriaMetricsServer`, and `Vm` to use `redacted_columns` argument in `ResourceMethods` plugin.
>   - **Misc**:
>     - Removed singleton `redacted_columns` methods from affected models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b622c70dbd42e7ac267467f718cf331b49ffc435. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->