### PR TITLE
Rhizome: support Ubiblk backed storage.

### DIFF
--- a/rhizome/host/lib/storage_path.rb
+++ b/rhizome/host/lib/storage_path.rb
@@ -35,4 +35,16 @@ class StoragePath
   def vhost_sock
     @vhost_sock ||= File.join(storage_dir, "vhost.sock")
   end
+
+  def kek_pipe
+    @kek_pipe ||= File.join(storage_dir, "kek.pipe")
+  end
+
+  def vhost_backend_config
+    @vhost_backend_config ||= File.join(storage_dir, "vhost-backend.conf")
+  end
+
+  def vhost_backend_metadata
+    @vhost_backend_metadata ||= File.join(storage_dir, "metadata")
+  end
 end


### PR DESCRIPTION
If a storage volume's vhost_block_backend_version param is set, then a Ubiblk installation is used instead of SPDK.

Let `storage-root=/var/storage/${vm_name}/$disk-index/`. Then:
- Ubiblk config is stored at `${storage-root}/vhost-backend.conf`.
- Ubiblk metadata is stored at `$storage-root/metadata`.
- A systemd-unit `${vm_name}-${disk-idx}-storage` is created to act as VM's storage device. It starts the Ubiblk's vhost-backend binary, stored at `/opt/vhost-block-backend/${version}/`.
- Key Encryption Key (KEK) is communicated to the storage service using a pipe created at `${storage-root$}/kek.pipe`.
- Storage service creates a vhost-user-blk socket at `${storage-root}/vhost.socket` which Cloud-Hypervisor connects to.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for Ubiblk-backed storage in Rhizome, with configuration, metadata, and service management via systemd, and updates tests accordingly.
> 
>   - **Behavior**:
>     - Adds support for Ubiblk-backed storage in `StorageVolume` when `vhost_block_backend_version` is set.
>     - Creates Ubiblk config at `vhost-backend.conf` and metadata at `metadata` in `storage_dir`.
>     - Uses systemd service to manage Ubiblk backend, starting `vhost-backend` binary.
>     - Communicates Key Encryption Key (KEK) via `kek.pipe`.
>     - Creates vhost-user-blk socket for Cloud-Hypervisor connection.
>   - **Classes and Functions**:
>     - `StorageVolume`: Adds methods `prep_vhost_backend`, `vhost_backend_create_config`, `vhost_backend_create_metadata`, `vhost_backend_create_service_file`, and `vhost_backend_start`.
>     - `VmSetup`: Updates `install_systemd_unit` to handle Ubiblk services.
>   - **Tests**:
>     - Expands `storage_volume_spec.rb` to test Ubiblk functionality, including config, metadata, and service file creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c54b241a62320330a5caae68332b5d25d5439704. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->