### PR TITLE
Convert SemaphoreMethods to Sequel plugin

### DIFF
--- a/lib/semaphore_methods.rb
+++ b/lib/semaphore_methods.rb
@@ -1,30 +1,26 @@
 # frozen_string_literal: true
 
 module SemaphoreMethods
-  def self.included(base)
-    base.class_eval do
+  def self.configure(model, *semaphore_names)
+    model.class_exec do
       one_to_many :semaphores, key: :strand_id
-    end
-    base.extend(ClassMethods)
-  end
 
-  module ClassMethods
-    def semaphore_names
-      @semaphore_names || []
-    end
+      @semaphore_names = semaphore_names.freeze
 
-    def semaphore(*names)
-      (@semaphore_names ||= []).concat(names)
-      names.each do |sym|
+      semaphore_names.each do |sym|
         name = sym.name
         define_method :"incr_#{name}" do
           Semaphore.incr(id, sym)
         end
 
         define_method :"#{name}_set?" do
-          semaphores.any? { |s| s.name == name }
+          semaphores.any? { it.name == name }
         end
       end
     end
+  end
+
+  module ClassMethods
+    attr_reader :semaphore_names
   end
 end

--- a/model/ai/inference_endpoint.rb
+++ b/model/ai/inference_endpoint.rb
@@ -13,10 +13,8 @@ class InferenceEndpoint < Sequel::Model
   dataset_module Pagination
 
   plugin ResourceMethods
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :destroy, :maintenance
   include ObjectTag::Cleanup
-
-  semaphore :destroy, :maintenance
 
   def display_location
     location.display_name

--- a/model/ai/inference_endpoint_replica.rb
+++ b/model/ai/inference_endpoint_replica.rb
@@ -9,9 +9,7 @@ class InferenceEndpointReplica < Sequel::Model
   one_through_one :load_balancer_vm_port, left_key: :vm_id, left_primary_key: :vm_id, right_key: :id, right_primary_key: :load_balancer_vm_id, join_table: :load_balancers_vms
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy
+  plugin SemaphoreMethods, :destroy
 end
 
 # Table: inference_endpoint_replica

--- a/model/ai/inference_router.rb
+++ b/model/ai/inference_router.rb
@@ -11,9 +11,7 @@ class InferenceRouter < Sequel::Model
   many_to_one :location
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy, :maintenance
+  plugin SemaphoreMethods, :destroy, :maintenance
 end
 
 # Table: inference_router

--- a/model/ai/inference_router_replica.rb
+++ b/model/ai/inference_router_replica.rb
@@ -9,9 +9,7 @@ class InferenceRouterReplica < Sequel::Model
   one_through_one :load_balancer_vm_port, left_key: :vm_id, left_primary_key: :vm_id, right_key: :id, right_primary_key: :load_balancer_vm_id, join_table: :load_balancers_vms
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy
+  plugin SemaphoreMethods, :destroy
 end
 
 # Table: inference_router_replica

--- a/model/ai/inference_router_target.rb
+++ b/model/ai/inference_router_target.rb
@@ -8,9 +8,7 @@ class InferenceRouterTarget < Sequel::Model
   many_to_one :inference_router_model
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy
+  plugin SemaphoreMethods, :destroy
 
   plugin :column_encryption do |enc|
     enc.column :api_key

--- a/model/cert.rb
+++ b/model/cert.rb
@@ -10,8 +10,7 @@ class Cert < Sequel::Model
   plugin :association_dependencies, certs_load_balancers: :destroy
 
   plugin ResourceMethods, redacted_columns: :cert
-  include SemaphoreMethods
-  semaphore :destroy, :restarted
+  plugin SemaphoreMethods, :destroy, :restarted
 
   plugin :column_encryption do |enc|
     enc.column :account_key

--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -10,9 +10,7 @@ class DnsZone < Sequel::Model
   one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id, &:active
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :refresh_dns_servers
+  plugin SemaphoreMethods, :refresh_dns_servers
 
   def insert_record(record_name:, type:, ttl:, data:)
     record_name = add_dot_if_missing(record_name)

--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -13,9 +13,7 @@ class GithubRepository < Sequel::Model
   plugin :association_dependencies, cache_entries: :destroy
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy
+  plugin SemaphoreMethods, :destroy
 
   plugin :column_encryption do |enc|
     enc.column :secret_key

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -11,9 +11,8 @@ class GithubRunner < Sequel::Model
   one_through_one :project, join_table: :github_installation, left_key: :id, left_primary_key: :installation_id, read_only: true
 
   plugin ResourceMethods, redacted_columns: :workflow_job
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :destroy, :skip_deregistration
   include HealthMonitorMethods
-  semaphore :destroy, :skip_deregistration
 
   dataset_module do
     def total_active_runner_vcpus

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -16,10 +16,8 @@ class KubernetesCluster < Sequel::Model
   dataset_module Pagination
 
   plugin ResourceMethods
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :destroy, :sync_kubernetes_services, :upgrade
   include HealthMonitorMethods
-
-  semaphore :destroy, :sync_kubernetes_services, :upgrade
 
   def validate
     super

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -8,9 +8,7 @@ class KubernetesNodepool < Sequel::Model
   many_to_many :vms, order: :created_at
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy, :start_bootstrapping, :upgrade
+  plugin SemaphoreMethods, :destroy, :start_bootstrapping, :upgrade
 end
 
 # Table: kubernetes_nodepool

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -19,10 +19,9 @@ class LoadBalancer < Sequel::Model
   plugin :association_dependencies, load_balancers_vms: :destroy, ports: :destroy, certs_load_balancers: :destroy
 
   plugin ResourceMethods
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :destroy, :update_load_balancer, :rewrite_dns_records, :refresh_cert
   include ObjectTag::Cleanup
   dataset_module Pagination
-  semaphore :destroy, :update_load_balancer, :rewrite_dns_records, :refresh_cert
 
   def display_location
     private_subnet.display_location

--- a/model/minio/minio_cluster.rb
+++ b/model/minio/minio_cluster.rb
@@ -11,9 +11,7 @@ class MinioCluster < Sequel::Model
   many_to_one :location, key: :location_id
 
   plugin ResourceMethods, redacted_columns: [:root_cert_1, :root_cert_2]
-  include SemaphoreMethods
-
-  semaphore :destroy, :reconfigure
+  plugin SemaphoreMethods, :destroy, :reconfigure
 
   plugin :column_encryption do |enc|
     enc.column :admin_password

--- a/model/minio/minio_pool.rb
+++ b/model/minio/minio_pool.rb
@@ -8,9 +8,7 @@ class MinioPool < Sequel::Model
   one_to_one :strand, key: :id
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy, :add_additional_pool
+  plugin SemaphoreMethods, :destroy, :add_additional_pool
 
   def volumes_url
     return "/minio/dat1" if cluster.single_instance_single_drive?

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -12,10 +12,8 @@ class MinioServer < Sequel::Model
   one_through_one :cluster, join_table: :minio_pool, left_primary_key: :minio_pool_id, left_key: :id, class: :MinioCluster
 
   plugin ResourceMethods, redacted_columns: :cert
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :checkup, :destroy, :restart, :reconfigure, :refresh_certificates, :initial_provisioning
   include HealthMonitorMethods
-
-  semaphore :checkup, :destroy, :restart, :reconfigure, :refresh_certificates, :initial_provisioning
 
   plugin :column_encryption do |enc|
     enc.column :cert_key

--- a/model/nic.rb
+++ b/model/nic.rb
@@ -12,9 +12,7 @@ class Nic < Sequel::Model
   plugin :association_dependencies, src_ipsec_tunnels: :destroy, dst_ipsec_tunnels: :destroy, nic_aws_resource: :destroy
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy, :start_rekey, :trigger_outbound_update,
+  plugin SemaphoreMethods, :destroy, :start_rekey, :trigger_outbound_update,
     :old_state_drop_trigger, :setup_nic, :repopulate, :lock, :vm_allocated
 
   plugin :column_encryption do |enc|

--- a/model/page.rb
+++ b/model/page.rb
@@ -22,9 +22,8 @@ class Page < Sequel::Model
     @pagerduty_client ||= Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2)
   end
 
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :resolve
   plugin ResourceMethods
-  semaphore :resolve
 
   def pagerduty_client
     self.class.pagerduty_client

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -20,10 +20,8 @@ class PostgresResource < Sequel::Model
   dataset_module Pagination
 
   plugin ResourceMethods, redacted_columns: [:root_cert_1, :root_cert_2, :server_cert]
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy, :promote
   include ObjectTag::Cleanup
-
-  semaphore :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy, :promote
 
   plugin :column_encryption do |enc|
     enc.column :superuser_password

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -14,13 +14,11 @@ class PostgresServer < Sequel::Model
   plugin :association_dependencies, lsn_monitor: :destroy
 
   plugin ResourceMethods
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup,
+    :restart, :configure, :fence, :planned_take_over, :unplanned_take_over, :configure_metrics,
+    :destroy, :recycle, :promote, :refresh_walg_credentials
   include HealthMonitorMethods
   include MetricsTargetMethods
-
-  semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
-  semaphore :restart, :configure, :fence, :planned_take_over, :unplanned_take_over, :configure_metrics
-  semaphore :destroy, :recycle, :promote, :refresh_walg_credentials
 
   def configure_hash
     configs = {

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -10,9 +10,7 @@ class PostgresTimeline < Sequel::Model
   many_to_one :location
 
   plugin ResourceMethods
-  include SemaphoreMethods
-
-  semaphore :destroy
+  plugin SemaphoreMethods, :destroy
 
   plugin :column_encryption do |enc|
     enc.column :secret_key

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -60,8 +60,7 @@ class PrivateSubnet < Sequel::Model
     (state == "waiting") ? "available" : state
   end
 
-  include SemaphoreMethods
-  semaphore :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
+  plugin SemaphoreMethods, :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules
 
   def self.random_subnet
     subnet_dict = PRIVATE_SUBNET_RANGES.each_with_object({}) do |subnet, hash|

--- a/model/victoria_metrics_resource.rb
+++ b/model/victoria_metrics_resource.rb
@@ -10,9 +10,7 @@ class VictoriaMetricsResource < Sequel::Model
   many_to_one :private_subnet
 
   plugin ResourceMethods, redacted_columns: [:admin_password, :root_cert_1, :root_cert_2]
-  include SemaphoreMethods
-
-  semaphore :destroy, :reconfigure
+  plugin SemaphoreMethods, :destroy, :reconfigure
 
   plugin :column_encryption do |enc|
     enc.column :admin_password

--- a/model/victoria_metrics_server.rb
+++ b/model/victoria_metrics_server.rb
@@ -8,10 +8,8 @@ class VictoriaMetricsServer < Sequel::Model
   many_to_one :resource, class: :VictoriaMetricsResource, key: :victoria_metrics_resource_id
 
   plugin ResourceMethods, redacted_columns: :cert
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :checkup, :destroy, :initial_provisioning, :restart, :reconfigure
   include HealthMonitorMethods
-
-  semaphore :checkup, :destroy, :initial_provisioning, :restart, :reconfigure
 
   plugin :column_encryption do |enc|
     enc.column :cert_key

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -33,10 +33,9 @@ class Vm < Sequel::Model
   dataset_module Pagination
 
   plugin ResourceMethods, redacted_columns: :public_key
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules,
+    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :stop
   include HealthMonitorMethods
-  semaphore :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules, :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started
-  semaphore :restart, :stop
 
   include ObjectTag::Cleanup
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -26,10 +26,9 @@ class VmHost < Sequel::Model
   plugin :association_dependencies, assigned_host_addresses: :destroy, assigned_subnets: :destroy, provider: :destroy, spdk_installations: :destroy, storage_devices: :destroy, pci_devices: :destroy, boot_images: :destroy, slices: :destroy, cpus: :destroy, vhost_block_backends: :destroy
 
   plugin ResourceMethods
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :checkup, :reboot, :hardware_reset, :destroy, :graceful_reboot, :configure_metrics
   include HealthMonitorMethods
   include MetricsTargetMethods
-  semaphore :checkup, :reboot, :hardware_reset, :destroy, :graceful_reboot, :configure_metrics
 
   def host_prefix
     net6.netmask.prefix_len

--- a/model/vm_host_slice.rb
+++ b/model/vm_host_slice.rb
@@ -9,9 +9,8 @@ class VmHostSlice < Sequel::Model
   one_to_many :cpus, class: :VmHostCpu, key: :vm_host_slice_id
 
   plugin ResourceMethods
-  include SemaphoreMethods
+  plugin SemaphoreMethods, :destroy, :start_after_host_reboot, :checkup
   include HealthMonitorMethods
-  semaphore :destroy, :start_after_host_reboot, :checkup
 
   plugin :association_dependencies, cpus: :nullify
 

--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -7,9 +7,7 @@ class VmPool < Sequel::Model
   one_to_many :vms, key: :pool_id
 
   plugin ResourceMethods
-
-  include SemaphoreMethods
-  semaphore :destroy
+  plugin SemaphoreMethods, :destroy
 
   def pick_vm
     # Find an available VM in the "running" state and not associated with a GitHub runner,


### PR DESCRIPTION
Have it take the semaphores as arguments.  This allows using a simple attr_reader for the semaphore names.  It also makes sure the semaphore name array is frozen.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Convert `SemaphoreMethods` to a Sequel plugin, updating models to use the new plugin format for semaphore management.
> 
>   - **Behavior**:
>     - Convert `SemaphoreMethods` to a Sequel plugin, taking semaphore names as arguments and freezing them.
>     - Replace `include SemaphoreMethods` and `semaphore` calls with `plugin SemaphoreMethods` in models like `InferenceEndpoint`, `InferenceRouter`, and `Cert`.
>   - **Code Changes**:
>     - `lib/semaphore_methods.rb`: Add `configure` method to set up semaphores and define methods dynamically.
>     - `model/ai/inference_endpoint.rb`, `model/ai/inference_router.rb`, `model/cert.rb`: Use `plugin SemaphoreMethods` with semaphore names as arguments.
>     - Update 30+ other model files similarly to use the new plugin format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 12b94ba1b0ddf987e5317aafb35c18a185bdebf5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->