### PR TITLE
Switch to released version of Roda

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "rack-unreloader", ">= 1.8"
 gem "rake"
 gem "refrigerator", ">= 1"
 gem "reline" # Remove it when pry adds it as a dependency
-gem "roda", github: "jeremyevans/roda", ref: "0e8c8067c4b84b402d72b10168c925c79fdc8016"
+gem "roda", ">= 3.93"
 gem "rodauth", ">= 2.39"
 gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"
 gem "rodish", ">= 2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,6 @@ GIT
       rodauth (~> 2.36)
 
 GIT
-  remote: https://github.com/jeremyevans/roda.git
-  revision: 0e8c8067c4b84b402d72b10168c925c79fdc8016
-  ref: 0e8c8067c4b84b402d72b10168c925c79fdc8016
-  specs:
-    roda (3.92.0)
-      rack
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -304,6 +296,8 @@ GEM
     reline (0.6.1)
       io-console (~> 0.5)
     rexml (3.4.1)
+    roda (3.93.0)
+      rack
     rodauth (2.39.0)
       roda (>= 2.6.0)
       sequel (>= 4)
@@ -490,7 +484,7 @@ DEPENDENCIES
   rake
   refrigerator (>= 1)
   reline
-  roda!
+  roda (>= 3.93)
   rodauth (>= 2.39)
   rodauth-omniauth!
   rodish (>= 2)


### PR DESCRIPTION
Changes we were depending on have been released.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch `roda` gem in `Gemfile` from specific commit to released version `>= 3.93`.
> 
>   - **Gemfile Update**:
>     - Change `roda` gem from specific commit `0e8c8067c4b84b402d72b10168c925c79fdc8016` to released version `>= 3.93`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6f96f821851dfe0c9c8c5bd04bba617f2d71f16b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->