### PR TITLE
Emit metrics every 200 strands instead of 1000 strands

### DIFF
--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Scheduling::Dispatcher do
       n = described_class::METRICS_EVERY
       n.times { q.push 1 }
       q.push nil
-      expect(di).to receive(:metrics_hash).with([1] * n).and_return({})
+      expect(di).to receive(:metrics_hash).with([1] * n, instance_of(Float)).and_return({})
       expect(Clog).to receive(:emit).and_call_original
       di.metrics_thread(q)
     end
@@ -249,14 +249,15 @@ RSpec.describe Scheduling::Dispatcher do
       arrays << Array.new(8) { rm.new(t, t + 5, t + 12, t + 21, false, 30, 5) }
       arrays << Array.new(1) { rm.new(t, t + 6, t + 16, t + 29, true, 40, 3) }
       arrays << Array.new(1) { rm.new(t, t + 7, t + 20, t + 37, false, 50, 1) }
-      expect(di.metrics_hash(arrays.flatten)).to eq({
+      expect(di.metrics_hash(arrays.flatten, 0.5)).to eq({
         available_workers: {average: 1, max: 9, median: 0, p75: 1, p85: 7, p95: 9, p99: 9},
         lease_acquire_percentage: 95.5,
         lease_delay: {average: 1.96, max: 17.0, median: 1.0, p75: 3.0, p85: 4.0, p95: 9.0, p99: 13.0},
         queue_delay: {average: 1.845, max: 13.0, median: 1.0, p75: 2.0, p85: 5.0, p95: 7.0, p99: 10.0},
         queue_size: {average: 4, max: 50, median: 0, p75: 10, p85: 20, p95: 30, p99: 40},
         scan_delay: {average: 1.515, max: 7.0, median: 1.0, p75: 2.0, p85: 3.0, p95: 5.0, p99: 6.0},
-        strand_count: 200
+        strand_count: 200,
+        strands_per_second: 400
       })
     end
   end

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Scheduling::Dispatcher do
       Thread.new { DB.notify(:respirate, payload: "3") }.join
 
       q.pop
-      expect(args).to eq [{num_partitions: 2}, {num_partitions: 3}]
+      expect(args).to eq([{num_partitions: 2}, {num_partitions: 3}]).or([{num_partitions: 3}])
       args.clear
       expect(di).to receive(:setup_prepared_statements).with(num_partitions: 1).and_wrap_original do |m, **kw|
         args << kw


### PR DESCRIPTION
With 1000 strands, and Mezmo using 30 second batches in live view,
there are often 30 second periods where no records come in, which
complicates the graphing.  Switching to 200 strands should flatten
the graphs and make them less spiky, at the cost of increased
metrics traffic and slightly less useful p99 numbers (since p99 of
200 is only the 2nd from the top instead of the 10th from the top).

Instead of hardcoding the offsets based on the batch size, calculate
them and store them in constants, so you can change the batch size
by only changing one number.

Also add strands_per_second to respirate metrics. You can guesstimate
based on existing metrics, but this allows for looking at minimums and
maximums, which can be helpful to determine if some respirate processes
are significantly slower than others.

This also fixes a nondeterministic dispatcher spec failure.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change metrics emission frequency to 200 strands and add `strands_per_second` metric in `dispatcher.rb`, with corresponding test updates.
> 
>   - **Behavior**:
>     - Change metrics emission frequency from 1000 to 200 strands in `dispatcher.rb` to reduce graph spikiness.
>     - Add `strands_per_second` metric to `metrics_hash()` in `dispatcher.rb` for better performance analysis.
>   - **Constants**:
>     - Introduce `METRICS_EVERY`, `METRICS_MEDIAN`, `METRICS_P75`, `METRICS_P85`, `METRICS_P95`, `METRICS_P99`, and `METRICS_LAP_MULTIPLIER` in `dispatcher.rb` to calculate metrics offsets dynamically.
>   - **Tests**:
>     - Update `dispatcher_spec.rb` to reflect new metrics frequency and add tests for `strands_per_second` metric.
>     - Fix nondeterministic test failure in `dispatcher_spec.rb` by adjusting expectations for partition notifications.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a67eb7b4ce874ce498658e28167cc5722d02b2b7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->