### PR TITLE
BillingRecord model improvements

### DIFF
--- a/lib/free_quota.rb
+++ b/lib/free_quota.rb
@@ -25,7 +25,7 @@ class FreeQuota
     free_quota = free_quotas[name]
     used_amount = BillingRecord
       .where(project_id:, billing_rate_id: free_quota["billing_rate_ids"])
-      .where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }
+      .where_span(FreeQuota.begin_of_month, Time.now)
       .sum(:amount) || 0
     [0, free_quota["value"] - used_amount].max
   end
@@ -34,7 +34,7 @@ class FreeQuota
     free_quota = free_quotas[name]
     BillingRecord
       .where(billing_rate_id: free_quota["billing_rate_ids"])
-      .where { Sequel.pg_range(span).overlaps(Sequel.pg_range(FreeQuota.begin_of_month...Time.now)) }
+      .where_span(FreeQuota.begin_of_month, Time.now)
       .group(:project_id)
       .having { sum(:amount) >= free_quota["value"] }
       .select(:project_id)

--- a/lib/free_quota.rb
+++ b/lib/free_quota.rb
@@ -21,10 +21,10 @@ class FreeQuota
     @free_quotas
   end
 
-  def self.remaining_free_quota(name, project_id)
+  def self.remaining_free_quota(name, project)
     free_quota = free_quotas[name]
-    used_amount = BillingRecord
-      .where(project_id:, billing_rate_id: free_quota["billing_rate_ids"])
+    used_amount = project.billing_records_dataset
+      .where(billing_rate_id: free_quota["billing_rate_ids"])
       .where_span(FreeQuota.begin_of_month, Time.now)
       .sum(:amount) || 0
     [0, free_quota["value"] - used_amount].max

--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -184,8 +184,7 @@ class InvoiceGenerator
   end
 
   def active_billing_records
-    active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices])
-      .where { |br| Sequel.pg_range(br.span).overlaps(Sequel.pg_range(@begin_time...@end_time)) }
+    active_billing_records = BillingRecord.eager(project: [:billing_info, :invoices]).where_span(@begin_time, @end_time)
     active_billing_records = active_billing_records.where(project_id: @project_ids) unless @project_ids.empty?
     active_billing_records.all.map do |br|
       # We cap the billable duration at 672 hours. In this way, we can

--- a/model/billing_record.rb
+++ b/model/billing_record.rb
@@ -7,6 +7,10 @@ class BillingRecord < Sequel::Model
 
   dataset_module do
     where(:active, Sequel.function(:upper, :span) => nil)
+
+    def where_span(begin_time, end_time)
+      where(Sequel.pg_range(:span).overlaps(Sequel::Postgres::PGRange.new(begin_time, end_time)))
+    end
   end
 
   plugin ResourceMethods

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -7,7 +7,7 @@ class MinioServer < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :project
   many_to_one :vm
-  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
+  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, &:active
   many_to_one :pool, key: :minio_pool_id, class: :MinioPool
   one_through_one :cluster, join_table: :minio_pool, left_primary_key: :minio_pool_id, left_key: :id, class: :MinioCluster
 

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -5,7 +5,7 @@ require_relative "../../model"
 class PostgresResource < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :project
-  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
+  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, &:active
   many_to_one :parent, key: :parent_id, class: self
   one_to_many :servers, class: :PostgresServer, key: :resource_id
   one_to_one :representative_server, class: :PostgresServer, key: :resource_id, conditions: Sequel.~(representative_at: nil)

--- a/model/project.rb
+++ b/model/project.rb
@@ -10,6 +10,7 @@ class Project < Sequel::Model
   many_to_one :billing_info
   one_to_many :usage_alerts
   one_to_many :github_installations
+  one_to_many :billing_records
   many_to_many :github_runners, join_table: :github_installation, right_key: :id, right_primary_key: :installation_id
 
   many_to_many :accounts, join_table: :access_tag, right_key: :hyper_tag_id

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -12,7 +12,7 @@ class Vm < Sequel::Model
   one_to_one :sshable, key: :id
   one_to_one :assigned_vm_address, key: :dst_vm_id, class: :AssignedVmAddress
   one_to_many :vm_storage_volumes, key: :vm_id, order: Sequel.desc(:boot)
-  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id do |ds| ds.active end
+  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, &:active
   one_to_many :pci_devices, key: :vm_id, class: :PciDevice
   one_through_one :load_balancer, left_key: :vm_id, right_key: :load_balancer_id, join_table: :load_balancers_vms
   one_to_one :load_balancers_vms, key: :vm_id, class: :LoadBalancersVms

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -236,8 +236,8 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
       project = Project[id: UBID.to_uuid(usage["ubid"])]
 
       begin
-        today_record = BillingRecord
-          .where(project_id: project.id, resource_id: inference_endpoint.id, billing_rate_id: rate_id)
+        today_record = project.billing_records_dataset
+          .where(resource_id: inference_endpoint.id, billing_rate_id: rate_id)
           .where_span(begin_time, end_time)
           .first
 

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -238,7 +238,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
       begin
         today_record = BillingRecord
           .where(project_id: project.id, resource_id: inference_endpoint.id, billing_rate_id: rate_id)
-          .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
+          .where_span(begin_time, end_time)
           .first
 
         if today_record

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -323,8 +323,8 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
       project = Project[id: UBID.to_uuid(usage["ubid"])]
 
       begin
-        today_record = BillingRecord
-          .where(project_id: project.id, resource_id: inference_router.id, billing_rate_id: rate_id)
+        today_record = project.billing_records_dataset
+          .where(resource_id: inference_router.id, billing_rate_id: rate_id)
           .where_span(begin_time, end_time)
           .first
 

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -325,7 +325,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
       begin
         today_record = BillingRecord
           .where(project_id: project.id, resource_id: inference_router.id, billing_rate_id: rate_id)
-          .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
+          .where_span(begin_time, end_time)
           .first
 
         if today_record

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -95,8 +95,8 @@ class Prog::Vm::GithubRunner < Prog::Base
       duration = Time.now - github_runner.ready_at
       used_amount = (duration / 60).ceil
       github_runner.log_duration("runner_completed", duration)
-      today_record = BillingRecord
-        .where(project_id: project.id, resource_id: project.id, billing_rate_id: rate_id)
+      today_record = project.billing_records_dataset
+        .where(resource_id: project.id, billing_rate_id: rate_id)
         .where_span(begin_time, end_time)
         .first
 

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -97,7 +97,7 @@ class Prog::Vm::GithubRunner < Prog::Base
       github_runner.log_duration("runner_completed", duration)
       today_record = BillingRecord
         .where(project_id: project.id, resource_id: project.id, billing_rate_id: rate_id)
-        .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
+        .where_span(begin_time, end_time)
         .first
 
       if today_record

--- a/routes/project/inference_api_key.rb
+++ b/routes/project/inference_api_key.rb
@@ -7,7 +7,7 @@ class Clover
         @inference_api_keys = Serializers::InferenceApiKey.serialize(inference_api_key_ds.all)
 
         if web?
-          @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
+          @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project)
           @free_quota_unit = "inference tokens"
           @has_valid_payment_method = @project.has_valid_payment_method?
           view "inference/api_key/index"

--- a/routes/project/inference_endpoint.rb
+++ b/routes/project/inference_endpoint.rb
@@ -6,7 +6,7 @@ class Clover
       inference_endpoints = Serializers::InferenceEndpoint.serialize(inference_endpoint_ds.eager(:location).all)
       inference_router_models = Serializers::InferenceRouterModel.serialize(inference_router_model_ds.all)
       @inference_models = inference_endpoints + inference_router_models
-      @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
+      @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project)
       @free_quota_unit = "inference tokens"
       @has_valid_payment_method = @project.has_valid_payment_method?
       view "inference/endpoint/index"

--- a/routes/project/inference_playground.rb
+++ b/routes/project/inference_playground.rb
@@ -7,7 +7,7 @@ class Clover
       inference_router_models = Serializers::InferenceRouterModel.serialize(inference_router_model_ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation").all)
       @inference_models = inference_endpoints + inference_router_models
       @inference_api_keys = Serializers::InferenceApiKey.serialize(inference_api_key_ds.all)
-      @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project.id)
+      @remaining_free_quota = FreeQuota.remaining_free_quota("inference-tokens", @project)
       @free_quota_unit = "inference tokens"
       @has_valid_payment_method = @project.has_valid_payment_method?
       view "inference/endpoint/playground"


### PR DESCRIPTION
- **Add where_span helper to billing record**
  

- **Unify active condition for all billing record associations**
  

- **Add a billing_records association to the project**
  We access the billing_records of a project in multiple places, so it
  makes sense to add an association to the project model, just like we do
  for other associations.
  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `BillingRecord` model with `where_span` method, unify active conditions, and add `billing_records` association to `Project`.
> 
>   - **Behavior**:
>     - Adds `where_span` method to `BillingRecord` for querying records within a time range, used in `free_quota.rb`, `invoice_generator.rb`, and `inference_endpoint_replica_nexus.rb`.
>     - Replaces manual range overlap checks with `where_span` in 8 other places.
>     - Changes `remaining_free_quota` to accept `project` instead of `project_id` in `free_quota.rb` and 3 route files.
>   - **Associations**:
>     - Unifies active condition for `active_billing_records` associations using `&:active` in `minio_server.rb`, `postgres_resource.rb`, and `vm.rb`.
>     - Adds `billing_records` association to `Project` model in `project.rb`.
>   - **Misc**:
>     - Minor refactoring and code cleanup in affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c30302409a909f638debc381a89ec43e0637a84f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->