### PR TITLE
Remove MockStringWithExitstatus class

### DIFF
--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -2,15 +2,6 @@
 
 require_relative "../../model/spec_helper"
 
-class MockStringWithExitstatus < String
-  attr_accessor :exitstatus
-
-  def initialize(str, exitstatus = 0)
-    super(str)
-    self.exitstatus = exitstatus
-  end
-end
-
 RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   subject(:prog) { described_class.new(Strand.new) }
 
@@ -190,20 +181,16 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
     end
 
     it "deletes the node object from kubernetes" do
-      result = instance_double(MockStringWithExitstatus)
       client = instance_double(Kubernetes::Client)
       expect(kubernetes_cluster).to receive(:client).and_return(client)
-      expect(client).to receive(:delete_node).with(prog.old_vm.name).and_return(result)
-      expect(result).to receive(:exitstatus).and_return(0)
+      expect(client).to receive(:delete_node).with(prog.old_vm.name).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("success", 0))
       expect { prog.delete_node_object }.to hop("destroy_node")
     end
 
     it "raises if the error of delete node command is not successful" do
-      result = instance_double(MockStringWithExitstatus)
       client = instance_double(Kubernetes::Client)
       expect(kubernetes_cluster).to receive(:client).and_return(client)
-      expect(client).to receive(:delete_node).with(prog.old_vm.name).and_return(result)
-      expect(result).to receive(:exitstatus).and_return(1)
+      expect(client).to receive(:delete_node).with(prog.old_vm.name).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("failed", 1))
       expect { prog.delete_node_object }.to raise_error(RuntimeError)
     end
   end


### PR DESCRIPTION
We already use the "Net::SSH::Connection::Session::StringWithExitstatus"
class returned by `session.exec!` in some tests, so there's no need for
an additional "MockStringWithExitstatus" class. It also raises the
following warning in CI.

```
/home/runner/work/ubicloud/ubicloud/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb:6: warning: method redefined; discarding old exitstatus
/home/runner/work/ubicloud/ubicloud/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb:6: warning: method redefined; discarding old exitstatus=
/home/runner/work/ubicloud/ubicloud/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb:8: warning: method redefined; discarding old initialize
/home/runner/work/ubicloud/ubicloud/spec/model/vm_host_spec.rb:9: warning: previous definition of initialize was here
```

We might add the "StringWithExitstatus" alias for it, but I couldn't get
it to run with freeze.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `MockStringWithExitstatus` class and replace its usage with `Net::SSH::Connection::Session::StringWithExitstatus` in tests to resolve CI warnings.
> 
>   - **Removal**:
>     - Remove `MockStringWithExitstatus` class from `vm_host_spec.rb` and `upgrade_kubernetes_node_spec.rb`.
>   - **Replacement**:
>     - Replace `MockStringWithExitstatus` with `Net::SSH::Connection::Session::StringWithExitstatus` in `vm_host_spec.rb` for SSH command mocks.
>     - Replace `MockStringWithExitstatus` with `Net::SSH::Connection::Session::StringWithExitstatus` in `upgrade_kubernetes_node_spec.rb` for Kubernetes client mocks.
>   - **Warnings**:
>     - Resolves CI warnings about method redefinitions in `upgrade_kubernetes_node_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 326e1412aa830937c9ed9feafa89b84c477d85bf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->