### PR TITLE
Add 15m timeout to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         runs-on: [ubicloud, ubicloud-arm]
     name: Ruby CI - ${{matrix.runs-on}}
     runs-on: ${{matrix.runs-on}}
+    timeout-minutes: 15
 
     env:
       DB_USER: clover


### PR DESCRIPTION
We have a few examples where CI tests get stuck and are canceled after 6
hours, which is the default timeout for GitHub Actions. Since our CI
runs in less than 10 minutes, it would be better to fail the job earlier
if it gets stuck instead of waiting for 6 hours. This also encourages us
to keep the CI fast and efficient.
