### PR TITLE
Fix rspec `.or` chain

### DIFF
--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Scheduling::Dispatcher do
       Thread.new { DB.notify(:respirate, payload: "3") }.join
 
       q.pop
-      expect(args).to eq([{num_partitions: 2}, {num_partitions: 3}]).or([{num_partitions: 3}])
+      expect(args).to eq([{num_partitions: 2}, {num_partitions: 3}]).or eq([{num_partitions: 3}])
       args.clear
       expect(di).to receive(:setup_prepared_statements).with(num_partitions: 1).and_wrap_original do |m, **kw|
         args << kw


### PR DESCRIPTION
In rspec, when you want to use `.or()`, you need to use it with two complete matchers, not chain it after a matcher.

It fails for the second case

     1) Scheduling::Dispatcher#repartition_thread repartitions for new processes and stale processes
     Failure/Error: expect(args).to eq([{num_partitions: 2}, {num_partitions: 3}]).or([{num_partitions: 3}])

     NoMethodError:
       undefined method 'matches?' for an instance of Array
     # ./spec/scheduling/dispatcher_spec.rb:60:in 'block (3 levels) in <top (required)>'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `.or` chain in `dispatcher_spec.rb` by using complete matchers to resolve `NoMethodError`.
> 
>   - **RSpec Test Fix**:
>     - Fixes `.or` chain in `dispatcher_spec.rb` by using complete matchers in `expect(args).to eq(...).or eq(...)`.
>     - Resolves `NoMethodError` for `matches?` on Array in `#repartition_thread` test.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6451edf72e471b39e4810f089feaf76c41782fca. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->