### PR TITLE
Fix location nilref for postgres timelines

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -90,7 +90,7 @@ PGHOST=/var/run/postgresql
   end
 
   def aws?
-    location.aws?
+    location&.aws?
   end
 
   S3BlobStorage = Struct.new(:url)

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -143,6 +143,14 @@ PGHOST=/var/run/postgresql
     expect(postgres_timeline.blob_storage_client).to eq("dummy-client")
   end
 
+  it "returns blob storage client when aws properly" do
+    expect(postgres_timeline).to receive(:location).and_return(nil)
+    expect(postgres_timeline).to receive(:blob_storage_endpoint).and_return("https://blob-endpoint")
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, root_certs: "certs")).once
+    expect(Minio::Client).to receive(:new).and_return("dummy-client").once
+    expect(postgres_timeline.blob_storage_client).to eq("dummy-client")
+  end
+
   it "returns blob storage policy" do
     policy = {Version: "2012-10-17", Statement: [{Effect: "Allow", Action: ["s3:*"], Resource: ["arn:aws:s3:::dummy-ubid*"]}]}
     expect(postgres_timeline).to receive(:ubid).and_return("dummy-ubid")


### PR DESCRIPTION
Since we started resolving to blob storage through location to accommodate s3 enabled regions, we started to have nil ref for timelines without location_id. Therefore, we are fixing it in this commit.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix nil reference in `aws?` method of `PostgresTimeline` and add corresponding test.
> 
>   - **Bug Fix**:
>     - Fix nil reference in `aws?` method in `postgres_timeline.rb` by using safe navigation (`location&.aws?`).
>   - **Tests**:
>     - Add test in `postgres_timeline_spec.rb` to verify `blob_storage_client` returns correctly when `location` is nil.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7474b4dff9c24599fe54187bdbf3a88e76e56a00. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->