### PR TITLE
Update timeout-minutes from 15 to 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: [ubicloud, ubicloud-arm]
     name: Ruby CI - ${{matrix.runs-on}}
     runs-on: ${{matrix.runs-on}}
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     env:
       DB_USER: clover


### PR DESCRIPTION
The arm CI can take close to 7 minutes for one run, and it runs twice, once in coverage mode and once in frozen mode.  Killing it at 15 minutes is probably a false positive. Increase to 25 minutes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase `timeout-minutes` from 15 to 25 in `.github/workflows/ci.yml` to prevent premature timeouts for ARM CI jobs.
> 
>   - **CI Configuration**:
>     - Update `timeout-minutes` from 15 to 25 in `.github/workflows/ci.yml` to accommodate longer ARM CI job durations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for aad0cbb2bb05ccc91abef8204414c1fad72ea207. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->