### PR TITLE
Make cache entry clean up more explicit while destroying a repository

### DIFF
--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -37,11 +37,6 @@ class GithubRepository < Sequel::Model
     @admin_client ||= s3_client(Config.github_cache_blob_storage_access_key, Config.github_cache_blob_storage_secret_key)
   end
 
-  def after_destroy
-    super
-    destroy_blob_storage if access_key
-  end
-
   def destroy_blob_storage
     begin
       admin_client.delete_bucket(bucket: bucket_name)

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -158,6 +158,8 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
       nap 5 * 60
     end
 
+    github_repository.cache_entries_dataset.destroy
+    github_repository.destroy_blob_storage if github_repository.access_key
     github_repository.destroy
 
     pop "github repository destroyed"

--- a/spec/model/github/github_repository_spec.rb
+++ b/spec/model/github/github_repository_spec.rb
@@ -31,25 +31,6 @@ RSpec.describe GithubRepository do
     end
   end
 
-  describe ".after_destroy" do
-    it "deletes the blob storage and cache entries" do
-      github_repository.save_changes
-      GithubCacheEntry.create_with_id(repository_id: github_repository.id, key: "k1", version: "v1", scope: "main", upload_id: "upload-123", committed_at: Time.now, created_by: "3c9a861c-ab14-8218-a175-875ebb652f7b")
-      expect(blob_storage_client).to receive(:delete_object)
-      expect(github_repository).to receive(:destroy_blob_storage)
-
-      github_repository.destroy
-    end
-
-    it "do not delete the blob storage if does not have one" do
-      github_repository.save_changes
-      expect(github_repository).to receive(:access_key)
-      expect(github_repository).not_to receive(:destroy_blob_storage)
-
-      github_repository.destroy
-    end
-  end
-
   describe ".setup_blob_storage" do
     it "creates a bucket and token" do
       expect(Config).to receive_messages(github_cache_blob_storage_region: "weur", github_cache_blob_storage_account_id: "123")

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -234,6 +234,17 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect { nx.destroy }.to nap(5 * 60)
     end
 
+    it "destroys blob storage if has one" do
+      github_repository.update(access_key: "access_key")
+      GithubCacheEntry.create(repository_id: github_repository.id, key: "k1", version: "v1", scope: "main", upload_id: "upload-123", committed_at: Time.now, created_by: "3c9a861c-ab14-8218-a175-875ebb652f7b")
+      blob_storage_client = instance_double(Aws::S3::Client)
+      expect(Aws::S3::Client).to receive(:new).and_return(blob_storage_client)
+      expect(blob_storage_client).to receive(:delete_object)
+      expect(github_repository).to receive(:destroy_blob_storage)
+
+      expect { nx.destroy }.to exit({"msg" => "github repository destroyed"})
+    end
+
     it "deletes resource and pops" do
       expect(nx).to receive(:decr_destroy)
       expect(github_repository).to receive(:destroy)


### PR DESCRIPTION
We should only call `repository.destroy` from nexus prog, since it has a
strand. So no need to keep destroy logic in the model, we can move it to
the prog similar to PG timeline.

Also we remove cache entries explicitly. Previously, we are expecting
the association_dependencies in the model to handle this. But we just
need to be sure that the all caches are cleared before destroy the blob
storage bucket. Making this explicit in the prog makes it clearer.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor repository destruction to explicitly handle cache cleanup and blob storage deletion in `GithubRepositoryNexus` program.
> 
>   - **Behavior**:
>     - Moves cache entry cleanup and blob storage destruction from `GithubRepository` model to `GithubRepositoryNexus` program.
>     - Ensures cache entries are destroyed before blob storage in `destroy` method of `GithubRepositoryNexus`.
>   - **Model Changes**:
>     - Removes `after_destroy` callback from `GithubRepository`.
>     - `destroy_blob_storage` now explicitly aborts multipart uploads before deleting the bucket.
>   - **Program Changes**:
>     - Adds cache entry cleanup and blob storage destruction to `destroy` method in `GithubRepositoryNexus`.
>   - **Tests**:
>     - Updates `github_repository_spec.rb` to remove tests for `after_destroy`.
>     - Adds tests in `github_repository_nexus_spec.rb` for new destruction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for da2a1622c177729c7bfc34d6ac8cf403a45797e5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->