### PR TITLE
Use NUL delimiter for xargs in github actions

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -283,7 +283,7 @@ class Prog::Vm::GithubRunner < Prog::Base
 
     # We initiate an API call and a SSH connection under the same label to avoid
     # having to store the encoded_jit_config.
-    vm.sshable.cmd("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner " \
+    vm.sshable.cmd("sudo -- xargs -0I{} -- systemd-run --uid runner --gid runner " \
                    "--working-directory '/home/runner' --unit runner-script --remain-after-exit -- " \
                    "/home/runner/actions-runner/run-withenv.sh {}",
       stdin: response[:encoded_jit_config])

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#register_runner" do
     it "registers runner hops" do
       expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC"})
-      expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -I{} -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh {}",
+      expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -0I{} -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh {}",
         stdin: "AABBCC")
       expect { nx.register_runner }.to hop("wait")
       expect(runner.runner_id).to eq(123)


### PR DESCRIPTION
Some `encoded_jit_config` values can interact badly with `xargs`'s quoting rules, which are not of that of the shell, but of xargs's own, similar design (see the first few paragraphs of the manual page)

In 29cbec28c, I packed the token in `xargs` to avoid it being emitted in our log telemetry, as we don't save stdin, because we customarily use it for secrets.

Because we're only packing a single value for a single invocation of the subcommand, we can use the NUL byte delimitation mode of `xargs` to evade its own interpretation of spaces and quotes, so long as `encoded_jit_config` is not binary. That no NUL byte appears in stdin is fine: the end-of-file condition when emitting the token is enough.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `xargs` command in `github_runner.rb` to use NUL byte delimiter for robust handling of `encoded_jit_config`.
> 
>   - **Behavior**:
>     - Change `xargs` command in `github_runner.rb` to use `-0` option for NUL byte delimiter, ensuring robust handling of `encoded_jit_config`.
>   - **Tests**:
>     - Update test in `github_runner_spec.rb` to expect `xargs -0I{}` command format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7db8eadc8a58a669a421dc50246adea06c604c6f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->