### PR TITLE
Re-enable file input only for multimodal models

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -467,7 +467,7 @@ function setupPlayground() {
     if (controller) {
       controller.abort();
       $('#inference_submit').text("Submit");
-      $('#inference_files').prop('disabled', false);
+      update_file_input_state();
       controller = null;
       return;
     }
@@ -633,13 +633,13 @@ function setupPlayground() {
       $(`#inference_message_info_${assistant_message_id}`).text(errorMessage);
     } finally {
       $("#inference_submit").text("Submit");
-      $("#inference_files").prop("disabled", false);
+      update_file_input_state();
       controller = null;
     }
   };
 
   $('#inference_submit').on("click", generate);
-  $('#inference_config-show_advanced-0').on("change", function() {
+  $('#inference_config-show_advanced-0').on("change", function () {
     $('#inference_config_advanced_settings').toggleClass("hidden", !$(this).is(":checked"));
   });
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-enable file input only for multimodal models in `setupPlayground` by using `update_file_input_state()` to check model tags.
> 
>   - **Behavior**:
>     - Re-enable file input only for multimodal models in `setupPlayground` by using `update_file_input_state()`.
>     - `update_file_input_state()` checks model tags to enable/disable file input.
>   - **Functions**:
>     - Replace direct file input enabling/disabling with `update_file_input_state()` in `generate()` function in `app.js`.
>   - **Misc**:
>     - Minor formatting change in `setupPlayground` for event handler.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b3072c09d3793d8b7eb4a2ebb24581f97e97c8ae. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->