### PR TITLE
Split VM creation page into GPU/non-GPU if get_ff_gpu_vm feature flag is set

### DIFF
--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -132,9 +132,13 @@ class Clover
     end
 
     options.add_option(name: "gpu", values: ["0:"] + gpu_options, parent: "family") do |location, family, gpu|
-      gpu = gpu.split(":")
-      gpu_count = gpu[0].to_i
-      gpu_count == 0 || (family == "standard" && !!BillingRate.from_resource_properties("Gpu", gpu[1], location.name) && gpu_availability[location.name] && gpu_availability[location.name][gpu[1]] && gpu_availability[location.name][gpu[1]] >= gpu_count)
+      gpu_count, device = gpu.split(":", 2)
+      gpu_count = gpu_count.to_i
+      next true if gpu_count == 0
+
+      family == "standard" &&
+        !!BillingRate.from_resource_properties("Gpu", device, location.name) &&
+        gpu_availability.dig(location.name, device)&.>=(gpu_count)
     end
 
     options.add_option(name: "boot_image", values: Option::BootImages.map(&:name))

--- a/views/components/empty_state.erb
+++ b/views/components/empty_state.erb
@@ -1,11 +1,15 @@
-<%# locals: (title:, icon:, description:, button_link: nil, button_title: nil) %>
+<%# locals: (title:, icon:, description:, button_link: nil, button_title: nil, buttons: nil) %>
 
 <div class="text-center empty-state">
   <%== part("components/icon", name: icon, classes: "mx-auto h-12 w-12 text-gray-400") %>
   <h3 class="mt-2 text-sm font-semibold text-gray-900"><%= title %></h3>
   <p class="mt-1 text-sm text-gray-500"><%= description %></p>
   <div class="mt-6">
-    <% if button_link %>
+    <% if buttons %>
+      <% buttons.each do |text, link| %>
+        <%== part("components/button", link:, text:) %>
+      <% end %>
+    <% elsif button_link %>
       <%== part("components/button", link: button_link, text: button_title) %>
     <% elsif button_title %>
       <div class="flex justify-center">

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -1,4 +1,4 @@
-<% @page_title = "Create Virtual Machine" %>
+<% @page_title = "Create #{"GPU " if @show_gpu}Virtual Machine" %>
 
 <%== render("components/billing_warning") %>
 
@@ -24,7 +24,7 @@
     {name: "size", type: "radio_small_cards", label: "Server size", required: "required", content_generator: ContentGenerator::Vm.method(:size)},
     {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Vm.method(:storage_size)}
   ]
-  if @project.get_ff_gpu_vm
+  if @show_gpu != false
     form_elements <<
       {name: "gpu", type: "radio_small_cards", label: "GPU", required: "required", content_generator: ContentGenerator::Vm.method(:gpu)}
   end
@@ -33,6 +33,10 @@
     {name: "unix_user", type: "text", label: "Username", placeholder: "ubi", value: "ubi", required: "required", opening_tag: "<div class='sm:col-span-2'>"},
     {name: "public_key", type: "textarea", label: "SSH Public Key", required: "required", placeholder: "ssh-ed25519 AAAA...", description: "SSH keys are a more secure method of logging into a server."}
   ]
+
+  if @project.get_ff_gpu_vm
+    form_elements << {name: "show_gpu", type: "hidden", value: @show_gpu}
+  end
 
   action = "#{@project_data[:path]}/vm"
 %>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -24,15 +24,17 @@
     {name: "size", type: "radio_small_cards", label: "Server size", required: "required", content_generator: ContentGenerator::Vm.method(:size)},
     {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Vm.method(:storage_size)}
   ]
+
   if @show_gpu != false
     form_elements <<
       {name: "gpu", type: "radio_small_cards", label: "GPU", required: "required", content_generator: ContentGenerator::Vm.method(:gpu)}
   end
-  form_elements += [
+
+  form_elements.push(
     {name: "boot_image", type: "radio_small_cards", label: "Boot Image", required: "required", content_generator: ContentGenerator::Vm.method(:boot_image)},
     {name: "unix_user", type: "text", label: "Username", placeholder: "ubi", value: "ubi", required: "required", opening_tag: "<div class='sm:col-span-2'>"},
     {name: "public_key", type: "textarea", label: "SSH Public Key", required: "required", placeholder: "ssh-ed25519 AAAA...", description: "SSH keys are a more secure method of logging into a server."}
-  ]
+  )
 
   if @project.get_ff_gpu_vm
     form_elements << {name: "show_gpu", type: "hidden", value: @show_gpu}

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -4,9 +4,15 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [%w[Projects /project], [@project_data[:name], @project_data[:path]], ["Virtual Machines", "#"]],
-  right_items: (!@vms.empty? && has_project_permission("Vm:create")) ? [
-    part("components/button", text: "Create Virtual Machine", link: "vm/create")
-  ] : []
+  right_items: (!@vms.empty? && has_project_permission("Vm:create")) ?
+    (if @project.get_ff_gpu_vm
+      [
+        part("components/button", text: "Create Virtual Machine", link: "vm/create?show_gpu=f", extra_class: "mr-2"),
+        part("components/button", text: "Create GPU Virtual Machine", link: "vm/create?show_gpu=t"),
+      ]
+     else
+      [part("components/button", text: "Create Virtual Machine", link: "vm/create")]
+     end) : []
 ) %>
 
 <div class="grid gap-6">
@@ -32,8 +38,15 @@
       description: "You don't have permission to create virtual machines."
     }.merge(has_project_permission("Vm:create") ? {
       description: "Get started by creating a new virtual machine.",
-      button_link: "#{@project_data[:path]}/vm/create",
-      button_title: "Create Virtual Machine"
+      buttons: (
+        if @project.get_ff_gpu_vm
+          {
+            "Create Virtual Machine" => "#{@project_data[:path]}/vm/create?show_gpu=f",
+            "Create GPU Virtual Machine" => "#{@project_data[:path]}/vm/create?show_gpu=t",
+          }
+        else
+          {"Create Virtual Machine" => "#{@project_data[:path]}/vm/create"}
+        end)
     } : {})
   ) %>
 </div>


### PR DESCRIPTION
This can potentially make it easier to select a GPU instance.

With the feature flag set, instead of one button link to the create page, there are two:
![localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_vm](https://github.com/user-attachments/assets/cf5066a7-21be-44d5-abad-3412d0fb880d)
![localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_vm (1)](https://github.com/user-attachments/assets/74524ab4-92ed-4661-bb35-74fd8ee5224f)

The "Create Virtual Machine" link does not show any GPU options:

![localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_vm_create_gpu=f](https://github.com/user-attachments/assets/51cc699f-89ab-4d04-b471-e31084aa0061)

The "Create GPU Virtual Machine" only shows valid options for a GPU configuration:

![localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_vm_create_gpu=true](https://github.com/user-attachments/assets/0916c29a-89db-4959-b1ad-457e577eda3c)

If users have a direct link to the old page, it works the same as before, showing both GPU and non GPU options:

![localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_vm_create](https://github.com/user-attachments/assets/e9c40536-96cc-4804-9588-912477086070)

Ignore the fact that the screenshots show the GPU VM in Finland.  My test host is in Finland, and I had to add billing rates to get things to work in development.

Requested by @umurc
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Split VM creation page into GPU and non-GPU options based on feature flag, with UI updates and tests.
> 
>   - **Behavior**:
>     - Split VM creation page into GPU and non-GPU options if `get_ff_gpu_vm` feature flag is set.
>     - `generate_vm_options` in `helpers/vm.rb` now considers `@show_gpu` to filter GPU options.
>     - Redirects to error if no GPU VMs are available when `show_gpu` is true.
>   - **UI Changes**:
>     - `views/vm/index.erb` and `views/vm/create.erb` updated to show separate buttons for "Create Virtual Machine" and "Create GPU Virtual Machine" based on feature flag.
>     - `views/components/empty_state.erb` supports multiple buttons.
>   - **Tests**:
>     - Added tests in `spec/routes/web/vm_spec.rb` to verify GPU and non-GPU VM creation paths and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 702ec88424bea2378bcb8139b2a1be2037abccea. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->