### PR TITLE
Remove sampling strands for metrics

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -62,18 +62,6 @@ class Strand < Sequel::Model
     respirate_metrics.old_strand = true
   end
 
-  if Config.test?
-    private def verbose_logging
-      true
-    end
-    # :nocov:
-  else
-    private def verbose_logging
-      rand(1000) == 0
-    end
-  end
-  # :nocov:
-
   def take_lease_and_reload
     unless (ps = DB.prepared_statement(:strand_take_lease_and_reload))
       # :nocov:
@@ -100,9 +88,7 @@ class Strand < Sequel::Model
     lease_checked!(affected)
     return false unless affected
     lease_time = affected.fetch(:lease)
-    verbose_logging = self.verbose_logging
 
-    Clog.emit("obtained lease") { {lease_acquired: {time: lease_time, delay: Time.now - schedule}} } if verbose_logging
     # Also operate as reload query
     @values = affected
 
@@ -121,7 +107,6 @@ UPDATE strand
 SET lease = now() - '1000 years'::interval
 WHERE id = ? AND lease = ?
 SQL
-          Clog.emit("lease cleared") { {lease_cleared: {num_updated: num_updated}} } if verbose_logging
           unless num_updated == 1
             Clog.emit("lease violated data") do
               {lease_clear_debug_snapshot: lease_clear_debug_snapshot}

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -92,20 +92,4 @@ WHERE id = \? AND lease = \?
     expect(Clog).to receive(:emit).with("finished strand").and_call_original
     st.unsynchronized_run
   end
-
-  it "logs verbosely in test mode" do
-    st.label = "napper"
-    st.save_changes
-    expect(Clog).to receive(:emit).with("obtained lease").and_call_original
-    expect(Clog).to receive(:emit).with("lease cleared").and_call_original
-    st.take_lease_and_reload {}
-  end
-
-  it "does not log if configured not to" do
-    st.label = "napper"
-    st.save_changes
-    expect(st).to receive(:verbose_logging).and_return(false)
-    expect(Clog).not_to receive(:emit)
-    st.take_lease_and_reload {}
-  end
 end


### PR DESCRIPTION
The new respirate provides much more accurate metrics, so it's not worth keeping these sampled metrics.