### PR TITLE
Handle Octokit::NotFound for runner recycle

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -299,6 +299,7 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def wait
+    register_deadline(nil, 5 * 24 * 60 * 60)
     case vm.sshable.cmd("systemctl show -p SubState --value runner-script").chomp
     when "exited"
       github_runner.incr_destroy

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -234,32 +234,6 @@ class Prog::Vm::GithubRunner < Prog::Base
       UBICLOUD_CACHE_URL=#{Config.base_url}/runtime/github/" | sudo tee -a /etc/environment
     COMMAND
 
-    if github_runner.installation.use_docker_mirror
-      mirror_address = "mirror.gcr.io"
-      command += <<~COMMAND
-        # Configure Docker daemon with registry mirror
-        if [ -f /etc/docker/daemon.json ] && [ -s /etc/docker/daemon.json ]; then
-          sudo jq '. + {"registry-mirrors": ["https://#{mirror_address}"]}' /etc/docker/daemon.json | sudo tee /etc/docker/daemon.json.tmp
-          sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
-        else
-          echo '{"registry-mirrors": ["https://#{mirror_address}"]}' | sudo tee /etc/docker/daemon.json
-        fi
-
-        # Configure BuildKit to use the mirror
-        sudo mkdir -p /etc/buildkit
-        echo '
-          [registry."docker.io"]
-            mirrors = ["#{mirror_address}"]
-
-          [registry."#{mirror_address}"]
-            http = false
-            insecure = false' | sudo tee -a /etc/buildkit/buildkitd.toml
-
-        sudo systemctl daemon-reload
-        sudo systemctl restart docker
-      COMMAND
-    end
-
     if github_runner.installation.cache_enabled
       command += <<~COMMAND
         echo "CUSTOM_ACTIONS_CACHE_URL=http://#{vm.private_ipv4}:51123/random_token/" | sudo tee -a /etc/environment

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -316,6 +316,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # GitHub API, but sometimes GitHub assigns a job at the last second.
     # Therefore, we wait a few extra seconds beyond the 5 minute mark.
     if github_runner.workflow_job.nil? && Time.now > github_runner.ready_at + 5 * 60 + 10
+      register_deadline(nil, 2 * 60 * 60)
       unless busy?
         Clog.emit("The runner does not pick a job") { github_runner }
         github_runner.incr_destroy


### PR DESCRIPTION
- **Remove the unused GCR mirror setup**
  We have already moved the GCR mirror setup to image generation at
  https://github.com/ubicloud/runner-images/pull/16
  
  There's no need to do it here again.
  

- **Handle Octokit::NotFound for deleted runners during recycle condition check**
  When deciding to recycle a runner, we query the GitHub API to ensure
  it’s not currently running a job, protects against delayed webhook
  events. If the runner has already been deleted, the API raises
  `Octokit::NotFound`. This case should be handled similarly to the
  destroy label logic, where we also verify if the runner is busy.
  
  This commit moves the busy-check logic into a separate method to handle
  both scenarios consistently.
  

- **Add deadline for recycling runners**
  In rare cases, a runner marked for recycling may get stuck due to GitHub
  API errors, and we lose visibility into its state. We've seen a few
  instances of long-running, stuck runners in production.
  
  This change adds a 2-hour deadline to the recycling process so we can
  detect and alert on such cases. While recycling typically completes
  within a minute, the runner might be busy and delay recycling, so the
  deadline is intentionally generous to avoid false positives, aligning
  with the existing 2-hour deadline used for the destroy label.
  

- **Register deadline for runner in wait state**
  GitHub allows self-hosted runners to stay active for up to 5 days. So we
  shouldn't have any runner in the "wait" state beyond that limit.
  
  https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/usage-limits-for-self-hosted-runners
  
  This change adds a safety check by registering a 5-day deadline for
  runners in the wait state. With this, all labels in the runner prog
  now have associated deadlines to help detect and recover from stuck
  states.
  