### PR TITLE
Check active session before the root route

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -704,16 +704,15 @@ class Clover < Roda
 
       check_csrf!
       rodauth.load_memory
+      rodauth.check_active_session
 
       r.root do
-        if rodauth.logged_in?
+        if current_account
           redirect_default_project_dashboard
         else
           r.redirect rodauth.login_route
         end
       end
-
-      rodauth.check_active_session
     end
 
     r.rodauth


### PR DESCRIPTION
Fixes issue if the session has an account id, but the account has been closed, as closing the account deletes all active sessions.

To be extra sure to avoid the error, also check current_account instead of rodauth.logged_in? in the root route.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `rodauth.check_active_session` before root route logic in `clover.rb` to ensure session is active and replace `rodauth.logged_in?` with `current_account` check.
> 
>   - **Behavior**:
>     - Move `rodauth.check_active_session` before root route logic in `clover.rb` to ensure session is active before checking `current_account`.
>     - Fixes issue where closed accounts (which delete sessions) could cause errors if session has an account id.
>   - **Logic**:
>     - Replace `rodauth.logged_in?` with `current_account` check in root route to ensure account is valid and active.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 021c41eeea780653eb7b5b89d3ee778e2cb48553. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->