### PR TITLE
More respirate improvements

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -69,7 +69,7 @@ DB.synchronize do
       # Note that this results in an up to a 1 second delay to pick up new strands,
       # but that is an accept tradeoff, because we do not want to busy loop the
       # database (potentially, LISTEN/NOTIFY could be used to reduce this latency)
-      duration_slept = sleep 1
+      duration_slept = sleep d.sleep_duration
       Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
     end
   end

--- a/config.rb
+++ b/config.rb
@@ -79,7 +79,7 @@ module Config
   override :pretty_json, false, bool
   override :dispatcher_max_threads, 8, int
   override :dispatcher_min_threads, 1, int
-  override :dispatcher_queue_size_ratio, 4, int
+  override :dispatcher_queue_size_ratio, 4, float
   override :puma_max_threads, 16, int
   override :puma_min_threads, 1, int
   override :puma_workers, 3, int

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -23,7 +23,7 @@ class Strand < Sequel::Model
     @subject = UBID.decode(ubid)
   end
 
-  RespirateMetrics = Struct.new(:scheduled, :scan_picked_up, :worker_started, :lease_checked, :lease_acquired, :queue_size, :available_workers, :old_strand) do
+  RespirateMetrics = Struct.new(:scheduled, :scan_picked_up, :worker_started, :lease_checked, :lease_acquired, :queue_size, :available_workers, :old_strand, :lease_expired) do
     def scan_delay
       scan_picked_up - scheduled
     end
@@ -48,7 +48,7 @@ class Strand < Sequel::Model
 
   def respirate_metrics
     lease_expired = lease > EXPIRED_LEASE_TIME
-    @respirate_metrics ||= RespirateMetrics.new(scheduled: lease_expired ? lease : schedule)
+    @respirate_metrics ||= RespirateMetrics.new(scheduled: lease_expired ? lease : schedule, lease_expired:)
   end
 
   def scan_picked_up!

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -41,8 +41,14 @@ class Strand < Sequel::Model
     end
   end
 
+  # If the lease time is after this, we must be dealing with an
+  # expired lease, since normal lease times are either in the future
+  # or 1000 years in the past.
+  EXPIRED_LEASE_TIME = Time.utc(2025)
+
   def respirate_metrics
-    @respirate_metrics ||= RespirateMetrics.new(scheduled: schedule)
+    lease_expired = lease > EXPIRED_LEASE_TIME
+    @respirate_metrics ||= RespirateMetrics.new(scheduled: lease_expired ? lease : schedule)
   end
 
   def scan_picked_up!

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -329,6 +329,7 @@ class Scheduling::Dispatcher
     end
     respirate_metrics[:lease_acquire_percentage] = array.count(&:lease_acquired) * METRICS_PERCENTAGE
     respirate_metrics[:old_strand_percentage] = array.count(&:old_strand) * METRICS_PERCENTAGE
+    respirate_metrics[:lease_expired_percentage] = array.count(&:lease_expired) * METRICS_PERCENTAGE
     respirate_metrics[:strand_count] = METRICS_EVERY
     @strands_per_second = METRICS_EVERY / elapsed_time
     respirate_metrics[:strands_per_second] = @strands_per_second

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -341,7 +341,7 @@ class Scheduling::Dispatcher
     # current delay numbers if the delay is increasing rapidly.
     array.reject!(&:old_strand)
     array.map!(&:total_delay)
-    @current_strand_delay = array[(array.count * 0.95r).floor] || 0
+    respirate_metrics[:current_strand_delay] = @current_strand_delay = array[(array.count * 0.95r).floor] || 0
 
     respirate_metrics
   end

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -340,6 +340,12 @@ class Scheduling::Dispatcher
     respirate_metrics
   end
 
+  # The amount of time to sleep if no strands or old strands were picked up
+  # during the last scan loop.
+  def sleep_duration
+    1
+  end
+
   # Start a strand/apoptosis thread pair, where the strand thread will
   # pull from the given strand queue.
   #

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -49,7 +49,7 @@ class Scheduling::Dispatcher
     # ensure that for a busy thread pool, there are always strands to run.
     # This should only cause issues if the thread pool can process more than
     # 4 times its size in the time it takes the main thread to refill the queue.
-    @queue_size = pool_size * Config.dispatcher_queue_size_ratio
+    @queue_size = (pool_size * Config.dispatcher_queue_size_ratio).round.clamp(1, nil)
 
     # The Queue that all threads in the thread pool pull from.  This is a
     # SizedQueue to allow for backoff in the case that the thread pool cannot

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -203,7 +203,7 @@ class Scheduling::Dispatcher
       .order_by(:schedule)
       .limit(@queue_size)
       .exclude(id: Sequel.function(:ANY, Sequel.cast(:$skip_strands, "uuid[]")))
-      .select(:id, :schedule)
+      .select(:id, :schedule, :lease)
       .for_update
       .skip_locked
 

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -326,6 +326,12 @@ RSpec.describe Scheduling::Dispatcher do
     end
   end
 
+  describe "#sleep_duration" do
+    it "is 1" do
+      expect(di.sleep_duration).to eq 1
+    end
+  end
+
   describe "#strand_thread" do
     it "runs strands pushed onto queue" do
       Strand.create(prog: "Test", label: "napper", schedule: Time.now - 10)

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -308,10 +308,11 @@ RSpec.describe Scheduling::Dispatcher do
       arrays << Array.new(20) { rm.new(t, t + 3, t + 8, t + 12, true, 20, 7) }
       arrays << Array.new(8) { rm.new(t, t + 5, t + 12, t + 21, false, 30, 5) }
       arrays << Array.new(1) { rm.new(t, t + 6, t + 16, t + 29, true, 40, 3, true) }
-      arrays << Array.new(1) { rm.new(t, t + 7, t + 20, t + 37, false, 50, 1, true) }
+      arrays << Array.new(1) { rm.new(t, t + 7, t + 20, t + 37, false, 50, 1, true, true) }
       expect(di.metrics_hash(arrays.flatten, 0.5)).to eq({
         available_workers: {average: 1, max: 9, median: 0, p75: 1, p85: 7, p95: 9, p99: 9},
         lease_acquire_percentage: 95.5,
+        lease_expired_percentage: 0.5,
         lease_delay: {average: 1.96, max: 17.0, median: 1.0, p75: 3.0, p85: 4.0, p95: 9.0, p99: 13.0},
         old_strand_percentage: 1.0,
         queue_delay: {average: 1.845, max: 13.0, median: 1.0, p75: 2.0, p85: 5.0, p95: 7.0, p99: 10.0},

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -311,6 +311,7 @@ RSpec.describe Scheduling::Dispatcher do
       arrays << Array.new(1) { rm.new(t, t + 7, t + 20, t + 37, false, 50, 1, true, true) }
       expect(di.metrics_hash(arrays.flatten, 0.5)).to eq({
         available_workers: {average: 1, max: 9, median: 0, p75: 1, p85: 7, p95: 9, p99: 9},
+        current_strand_delay: 12.0,
         lease_acquire_percentage: 95.5,
         lease_expired_percentage: 0.5,
         lease_delay: {average: 1.96, max: 17.0, median: 1.0, p75: 3.0, p85: 4.0, p95: 9.0, p99: 13.0},


### PR DESCRIPTION
Improvements:

* For strands with expired leases, calculate delay based on lease time instead of schedule time, to prevent the delay numbers showing 120 second spikes when processing a strand with an expired lease.

* Make respirate sleep time dependent on dispatcher state.  This shouldn't do much in production currently, but it is necessary step to prevent starvation when decreasing the queue size ratio, which is something I'd like to try to see if it results in lower overall delay.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve `respirate` by handling expired leases and dynamically adjusting sleep duration based on dispatcher state.
> 
>   - **Behavior**:
>     - Calculate delay based on lease time for expired leases in `Strand#respirate_metrics`.
>     - Adjust `respirate` sleep duration based on dispatcher state in `Dispatcher#sleep_duration`.
>   - **Config**:
>     - Change `dispatcher_queue_size_ratio` type from `int` to `float` in `config.rb`.
>   - **Metrics**:
>     - Add `lease_expired_percentage` to metrics in `Dispatcher#metrics_hash`.
>   - **Tests**:
>     - Add tests for expired lease handling in `dispatcher_spec.rb`.
>     - Add tests for dynamic sleep duration in `dispatcher_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 155770cebd12c2881ec9c1739fa8468ad32692c6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->