### PR TITLE
Allow 100GB of free cache storage if premium runners are enabled

### DIFF
--- a/model/github_installation.rb
+++ b/model/github_installation.rb
@@ -21,6 +21,10 @@ class GithubInstallation < Sequel::Model
   def premium_runner_enabled?
     !!allocator_preferences["family_filter"]&.include?("premium")
   end
+
+  def cache_storage_gib
+    [project.effective_quota_value("GithubRunnerCacheStorage"), premium_runner_enabled? ? 100 : 0].max
+  end
 end
 
 # Table: github_installation

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -107,7 +107,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     # Destroy oldest cache entries if the total usage exceeds the limit.
     dataset = github_repository.cache_entries_dataset.exclude(size: nil)
     total_usage = dataset.sum(:size).to_i
-    storage_limit = github_repository.installation.project.effective_quota_value("GithubRunnerCacheStorage") * 1024 * 1024 * 1024
+    storage_limit = github_repository.installation.cache_storage_gib * 1024 * 1024 * 1024
     if total_usage > storage_limit
       dataset.order(:created_at).limit(200).all do |oldest_entry|
         oldest_entry.destroy

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -81,7 +81,7 @@ class Clover
           r.get true do
             entries = @installation.cache_entries_dataset.exclude(committed_at: nil).eager(:repository).reverse(:created_at).all
             @entries_by_repo = Serializers::GithubCacheEntry.serialize(entries).group_by { it[:repository][:id] }
-            @quota_per_repo = "#{@project.effective_quota_value("GithubRunnerCacheStorage")} GB"
+            @quota_per_repo = "#{@installation.cache_storage_gib} GB"
 
             view "github/cache"
           end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `cache_storage_gib` method to `GithubInstallation` for cache storage limits, update cache handling and display logic, and add tests.
> 
>   - **Behavior**:
>     - Adds `cache_storage_gib` method in `GithubInstallation` to return 100GB if premium runners are enabled, otherwise returns effective quota.
>     - Updates cache cleanup logic in `cleanup_cache` in `github_repository_nexus.rb` to use `cache_storage_gib` for storage limit.
>     - Modifies cache quota display in `github.rb` to use `cache_storage_gib`.
>   - **Tests**:
>     - Adds tests for `cache_storage_gib` in `github_installation_spec.rb` to verify behavior with and without premium runners.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 945be291369d9dfcf38fa196e097c56ec9872a3d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->