### PR TITLE
Serve a list of available IPv4 ranges

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -23,6 +23,7 @@ workers = [
   {ubid: "stcheckzvsagezalertszzzzza", prog: "CheckUsageAlerts"},
   {ubid: "stexp1repr0ject1nv1tat10na", prog: "ExpireProjectInvitations"},
   {ubid: "st10g0vmh0st0vt111zat10nzz", prog: "LogVmHostUtilizations"},
+  {ubid: "stp0pv1atez1pv4cachezzzzzz", prog: "PopulateIPv4Cache"},
   Config.heartbeat_url ? {ubid: "stheartbeatheartbheartheaz", prog: "Heartbeat"} : nil,
   Config.github_app_id ? {ubid: "stredelivergith0bfail0reaz", prog: "RedeliverGithubFailures", stack: [{last_check_at: Time.now}]} : nil
 ]

--- a/clover.rb
+++ b/clover.rb
@@ -668,6 +668,12 @@ class Clover < Roda
   # :nocov:
 
   route do |r|
+    r.is "ips-v4" do
+      response["content-type"] = "text/plain"
+      response["cache-control"] = "public, max-age=3600"
+      next File.read("var/ips-v4.txt")
+    end
+
     if api?
       unless /\ABearer:?\s+pat-/i.match?(env["HTTP_AUTHORIZATION"].to_s)
         if r.path_info == "/cli"

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -87,4 +87,12 @@ module Util
   def self.send_email(...)
     EmailRenderer.sendmail("/", ...)
   end
+
+  def self.populate_ipv4_txt
+    ips = Address.where { (family(cidr) =~ 4) & (routed_to_host_id !~ id) }
+      .map { NetAddr::IPv4Net.new(it.cidr.network, NetAddr::Mask32.new(16)).to_s }
+    ips.uniq!
+    ips.sort!
+    File.open("var/ips-v4.txt", "w") { it.write(ips.join("\n")) }
+  end
 end

--- a/prog/populate_ipv4_cache.rb
+++ b/prog/populate_ipv4_cache.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Prog::PopulateIpv4Cache < Prog::Base
+  label def wait
+    Util.populate_ipv4_txt
+
+    nap 60 * 60
+  end
+end

--- a/spec/prog/populate_ipv4_cache_spec.rb
+++ b/spec/prog/populate_ipv4_cache_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::PopulateIpv4Cache do
+  subject(:pc) {
+    described_class.new(Strand.new(prog: "PopulateIpv4Cache"))
+  }
+
+  describe "#wait" do
+    it "populates file and naps an hour" do
+      expect(Util).to receive(:populate_ipv4_txt).and_call_original
+      expect { pc.wait }.to nap(60 * 60)
+    end
+  end
+end

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -117,4 +117,18 @@ RSpec.describe Clover do
 
     expect(failures).to be_empty
   end
+
+  it "returns ipv4 list from cached file" do
+    vmh1, vmh2 = Array.new(2) { create_vm_host }
+    Address.create(cidr: "1.1.1.1/32", routed_to_host_id: vmh1.id) { it.id = vmh1.id }
+    Address.create(cidr: "3.3.3.3/27", routed_to_host_id: vmh2.id)
+    Address.create(cidr: "2.2.2.2/27", routed_to_host_id: vmh1.id)
+    Address.create(cidr: "3.3.3.3/28", routed_to_host_id: vmh2.id)
+    Util.populate_ipv4_txt
+
+    visit "/ips-v4"
+
+    expect(page.status_code).to eq(200)
+    expect(page.body).to eq("2.2.0.0/16\n3.3.0.0/16")
+  end
 end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -125,7 +125,7 @@ module ThawedMock
   allow_mocking(Serializers::Vm, :serialize_internal)
   allow_mocking(SshKey, :generate)
   allow_mocking(ThreadPrinter, :puts, :run)
-  allow_mocking(Util, :create_certificate, :create_root_certificate, :rootish_ssh, :send_email)
+  allow_mocking(Util, :create_certificate, :create_root_certificate, :rootish_ssh, :send_email, :populate_ipv4_txt)
   allow_mocking(UBID, :class_match?)
   allow_mocking(VictoriaMetrics::Client, :new)
 end


### PR DESCRIPTION
- **Serve a list of available IPv4 ranges**
  For security reasons, some of our customers need to restrict access to
  their resources by IP address. We currently share this list with them
  manually. Since it may change over time, we decided to automate the
  process and provide a simple API endpoint that returns the available
  IPv4 ranges.
  
  Instead of sharing exact IP addresses, we provide /16 CIDR ranges of
  IPv4 addresses to avoid exposing our addresses directly, which could
  make them vulnerable to attacks.
  
  Since customers may frequently call this endpoint, we don't want to run
  the query every time. Instead, we cache the result in a file and return
  the file's contents with cache headers. This way, the WAF can cache the
  result and return it to customers without hitting the API each time.
  

- **Repopulate IPv4 cache file every hour**
  