### PR TITLE
Add dump_sequel_caches rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /sql_query_parameterization_analysis.txt
 /spec/routes/api/cli/spec-output-files
 /cli-golden-files.diff
+/cache-text-*
 
 # Used by rake by
 /bin/by

--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,7 @@ task :prod_up do
   migrate.call("production", nil)
 end
 
-desc "Refresh schema and index caches"
+desc "Refresh Sequel caches"
 task :refresh_sequel_caches do
   %w[schema index static_cache pg_auto_constraint_validations].each do |type|
     filename = "cache/#{type}.cache"
@@ -140,6 +140,18 @@ task :refresh_sequel_caches do
      Sequel::Model.dump_static_cache_cache
      Sequel::Model.dump_pg_auto_constraint_validations_cache
   END
+end
+
+desc "Dump Sequel caches to text, useful for diffing"
+task :dump_sequel_caches do
+  load_db.call("test")
+  require "pp"
+  text_dir = "cache-text-#{Time.now.to_i}"
+  Dir.mkdir(text_dir)
+  puts "Writing diffable version of cache files to #{text_dir}"
+  %w[schema index static_cache pg_auto_constraint_validations].each do |type|
+    File.write(File.join(text_dir, "#{type}.txt"), Marshal.load(File.binread("cache/#{type}.cache")).pretty_inspect)
+  end
 end
 
 # Database setup


### PR DESCRIPTION
This converts the marshalled cache file to a text based file. The reason to have this is it allows you to debug changes in cache files.  If you are rebasing a commit and there is a conflict in a cache file, you can run this before the commit, run this after the commit, and then `diff -ru` the two directories, to see what actually changed in the cache.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `dump_sequel_caches` task to `Rakefile` to convert marshalled cache files to text format for easier debugging and diffing.
> 
>   - **New Task**:
>     - Adds `dump_sequel_caches` task to `Rakefile` to convert marshalled cache files to text format.
>     - Handles `schema`, `index`, `static_cache`, and `pg_auto_constraint_validations` cache types.
>     - Outputs text files to a timestamped directory for easy diffing.
>   - **Misc**:
>     - Updates description of `refresh_sequel_caches` task in `Rakefile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9daf1b4a980845d0a2316fac4e8aefb5f8ff16f8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->