### PR TITLE
Clear cached instance state in Strand#take_lease_and_reload

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -19,7 +19,7 @@ class Strand < Sequel::Model
   plugin ResourceMethods
 
   def subject
-    return @subject if defined?(@subject)
+    return @subject if defined?(@subject) && @subject != :reload
     @subject = UBID.decode(ubid)
   end
 
@@ -90,7 +90,9 @@ class Strand < Sequel::Model
     lease_time = affected.fetch(:lease)
 
     # Also operate as reload query
-    @values = affected
+    _refresh_set_values(affected)
+    _clear_changed_columns(:refresh)
+    @subject = :reload
 
     begin
       yield

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Strand do
       expect(did_it).to be :did_it
     end
 
+    it "clears cached instance state" do
+      st.save_changes
+      st.set(label: "smoke_test_0")
+      st.associations[:parent] = st
+      st2 = st.subject
+      expect(st.subject).to equal st2
+      expect(st.changed_columns).not_to be_empty
+      st.take_lease_and_reload {
+        expect(st.label).to eq "start"
+        expect(st.changed_columns).to be_empty
+        expect(st.associations).to be_empty
+        expect(st.subject.id).to eq st.id
+        expect(st.subject).not_to equal st2
+      }
+    end
+
     it "does an integrity check that deleted records are gone" do
       st.label = "hop_exit"
       st.save_changes


### PR DESCRIPTION
This avoids the use of instance_variable_delete, as that doesn't play well with object shapes.  Internal code should always call the subject method, and not access `@subject` directly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `Strand#take_lease_and_reload`, set `@subject` to `:reload` to clear cached instance state, ensuring `subject` reloads after lease, with tests verifying this behavior.
> 
>   - **Behavior**:
>     - In `Strand#take_lease_and_reload`, set `@subject` to `:reload` to clear cached instance state, ensuring `subject` reloads after lease.
>     - Avoids `instance_variable_delete` for better object shape handling.
>   - **Tests**:
>     - Add test in `strand_spec.rb` to verify cached instance state is cleared and reloaded in `take_lease_and_reload`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7f66b61adc6408289a9728829af751ce0eea63e3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->