### PR TITLE
Make Service URL of k8s clusters copy-able

### DIFF
--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -27,7 +27,7 @@
   ]
   
   if @kc.display_state == "running"
-    data.push(["Service URL", LoadBalancer[name: @kc.services_load_balancer_name].hostname]) # TODO: Assign LB to a column properly
+    data.push(["Service URL", LoadBalancer[name: @kc.services_load_balancer_name].hostname, { copyable: true }]) # TODO: Assign LB to a column properly
     data.push(["Kubeconfig", part("components/download_button", link: "#{request.path}/kubeconfig"), { escape: false }])
   else
     data.push(["Kubeconfig", "Waiting for cluster to be ready..."])


### PR DESCRIPTION
I find myself doing a lof of copy-paste for the service URL, so why not make it easier to copy.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `{ copyable: true }` to Service URL in `show.erb` for easier copying when Kubernetes cluster is running.
> 
>   - **Behavior**:
>     - Adds `{ copyable: true }` to the Service URL in `show.erb` for Kubernetes clusters, making it easier to copy when the cluster is running.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 757bfd344721fbc52a06fa3d6d11e9f3a379f392. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->