### PR TITLE
Revert the use of the ipv4_address table to speed up VmHost#ip4_random_vm_network

### DIFF
--- a/model/address.rb
+++ b/model/address.rb
@@ -29,18 +29,19 @@ class Address < Sequel::Model
 
   def populate_ipv4_addresses
     # Do nothing for ipv6 addresses, since VM addresses are chosen randomly from the /64.
-    # Ignore the host's main IPv4 address.
-    return unless cidr.is_a?(NetAddr::IPv4Net) && id != routed_to_host_id
+    # Ignore /32 IPv4 addresses, since those would be used by the host itself and not for
+    # VMs running on the host.
+    if cidr.is_a?(NetAddr::IPv4Net) && id != routed_to_host_id
+      addresses = Array.new(cidr.len) { [cidr.nth(it), cidr.to_s] }
 
-    addresses = Array.new(cidr.len) { [cidr.nth(it), cidr.to_s] }
+      if vm_host.provider_name == "leaseweb"
+        # Do not use first or last addresses for leaseweb
+        addresses.shift
+        addresses.pop
+      end
 
-    if vm_host.provider_name == "leaseweb"
-      # Do not use first or last addresses for leaseweb
-      addresses.shift
-      addresses.pop
+      DB[:ipv4_address].import([:ip, :cidr], addresses)
     end
-
-    DB[:ipv4_address].import([:ip, :cidr], addresses)
   end
 end
 


### PR DESCRIPTION
Revert "Use NOT EXISTS instead of NOT IN in VmHost#ip4_random_vm_network"

This reverts commit 5f47eedc33309b771de81844ac14ab7a8c3f6342.

Revert "Update/remove no longer accurate comments"

This reverts commit 6c17867cec48b051e5792b005e52d26db9dc3f7d.

Revert "Use early return in Address#populate_ipv4_addresses"

This reverts commit f1f720ecfb0f2d395f79fb6cb8775fb7df00ec95.

Revert "Use described_class.new_with_id in VmHost specs"

This reverts commit fa9e0b5a3c860e328185c2931672d8a78a2c3a41.

Revert "Use ipv4_address table to speed up VmHost#ip4_random_vm_network"

This reverts commit e8c2945c9d90292a8cab477f1763fb3e2407dcdb.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts changes to `VmHost#ip4_random_vm_network` and `Address#populate_ipv4_addresses`, removing `ipv4_address` table usage.
> 
>   - **Behavior**:
>     - Reverts `VmHost#ip4_random_vm_network` to previous logic, removing use of `ipv4_address` table.
>     - Reverts `Address#populate_ipv4_addresses` to previous logic, removing early return.
>   - **Associations**:
>     - Removes `assigned_vm_addresses` association from `VmHost`.
>   - **Tests**:
>     - Reverts tests in `vm_host_spec.rb` related to `ipv4_address` table population and usage.
>     - Removes tests for `ip4_random_vm_network` using `ipv4_address` table.
>   - **Misc**:
>     - Reverts comments in `address.rb` and `vm_host.rb` to previous state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1b79adf214db21466f41e0e65fa0014e09b252c2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->