### PR TITLE
Save and upload postgres statement logs at E2E.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,14 @@ jobs:
           POSTGRES_DB: ${{ env.DB_NAME }}
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: >-
+          --name ci-postgres
+          -c log_statement=all
+          -c log_min_duration_statement=0
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
     - name: Perform superuser-only actions, then remove superuser
@@ -150,6 +157,16 @@ jobs:
       with:
         name: e2e-${{ github.run_id }}-logs
         path: foreman.log
+
+    - name: Dump Postgres log
+      if: always()
+      run: docker logs ci-postgres > postgres.log
+
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: postgres-${{ github.run_id }}.log
+        path: postgres.log
 
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}


### PR DESCRIPTION
We had issues in E2E where later strand runs seemed to have lost earlier database updates. Knowing which statements were run by postgres is pretty useful when debugging them.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable and upload PostgreSQL statement logs in E2E CI workflow for better debugging.
> 
>   - **PostgreSQL Logging**:
>     - Enable statement logging in PostgreSQL by adding `-c log_statement=all` and `-c log_min_duration_statement=0` in `e2e.yml`.
>     - Assign container name `ci-postgres` for easier log retrieval.
>   - **Log Upload**:
>     - Add step to dump PostgreSQL logs using `docker logs ci-postgres > postgres.log`.
>     - Upload `postgres.log` as an artifact with name `postgres-${{ github.run_id }}.log` using `actions/upload-artifact@v4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5b6750c2c0ab27fb2acc1dce3c1a7dd3ae550f22. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->