### PR TITLE
Fix ipv4_address table population in Address#populate_ipv4_addresses

### DIFF
--- a/model/address.rb
+++ b/model/address.rb
@@ -29,9 +29,8 @@ class Address < Sequel::Model
 
   def populate_ipv4_addresses
     # Do nothing for ipv6 addresses, since VM addresses are chosen randomly from the /64.
-    # Ignore /32 IPv4 addresses, since those would be used by the host itself and not for
-    # VMs running on the host.
-    if cidr.is_a?(NetAddr::IPv4Net) && id != routed_to_host_id
+    # Ignore the host's sshable IP address.
+    if cidr.is_a?(NetAddr::IPv4Net) && vm_host.sshable.host != cidr.network.to_s
       addresses = Array.new(cidr.len) { [cidr.nth(it), cidr.to_s] }
 
       if vm_host.provider_name == "leaseweb"

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Address do
     expect(DB[:ipv4_address]).to be_empty
   end
 
+  it "does not populate host sshable address" do
+    Prog::Vm::HostNexus.assemble("1.1.1.1").subject
+    expect(described_class.count).to eq 1
+    expect(Sshable.count).to eq 1
+    expect(described_class.get(:cidr).network.to_s).to eq Sshable.get(:host)
+    expect(DB[:ipv4_address]).to be_empty
+  end
+
   it "populates ipv4_address table with addresses in cidr without first and last, when using leaseweb" do
     vm_host = Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "1").subject
     described_class.create(cidr: "0.0.0.0/30", vm_host:)


### PR DESCRIPTION
Change

id != routed_to_host_id

to

vm_host.sshable.host != cidr.network.to_s

We do not consistently use the VmHost id as the primary Address id (it is not done at all for Hetzner hosts), so the next simplest way to check is check the sshable address.

Existing installations that previously ran
Address#populate_ipv4_addresses can be fixed using:

DB[:ipv4_address].where(ip: Sshable.where(id: VmHost.select(:id)).select(Sequel.cast(:host, :inet))).delete