### PR TITLE
Revert "Revert the use of the ipv4_address table to speed up VmHost#ip4_random_vm_network"

### DIFF
--- a/model/address.rb
+++ b/model/address.rb
@@ -30,17 +30,17 @@ class Address < Sequel::Model
   def populate_ipv4_addresses
     # Do nothing for ipv6 addresses, since VM addresses are chosen randomly from the /64.
     # Ignore the host's sshable IP address.
-    if cidr.is_a?(NetAddr::IPv4Net) && vm_host.sshable.host != cidr.network.to_s
-      addresses = Array.new(cidr.len) { [cidr.nth(it), cidr.to_s] }
+    return unless cidr.is_a?(NetAddr::IPv4Net) && vm_host.sshable.host != cidr.network.to_s
 
-      if vm_host.provider_name == "leaseweb"
-        # Do not use first or last addresses for leaseweb
-        addresses.shift
-        addresses.pop
-      end
+    addresses = Array.new(cidr.len) { [cidr.nth(it), cidr.to_s] }
 
-      DB[:ipv4_address].import([:ip, :cidr], addresses)
+    if vm_host.provider_name == "leaseweb"
+      # Do not use first or last addresses for leaseweb
+      addresses.shift
+      addresses.pop
     end
+
+    DB[:ipv4_address].import([:ip, :cidr], addresses)
   end
 end
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -21,6 +21,8 @@ class VmHost < Sequel::Model
   one_to_many :cpus, class: :VmHostCpu, key: :vm_host_id
   many_to_one :location, key: :location_id, class: :Location
 
+  many_to_many :assigned_vm_addresses, join_table: :address, left_key: :routed_to_host_id, right_key: :id, right_primary_key: :address_id, read_only: true
+
   plugin :association_dependencies, assigned_host_addresses: :destroy, assigned_subnets: :destroy, provider: :destroy, spdk_installations: :destroy, storage_devices: :destroy, pci_devices: :destroy, boot_images: :destroy, slices: :destroy, cpus: :destroy
 
   plugin ResourceMethods
@@ -127,15 +129,37 @@ class VmHost < Sequel::Model
   end
 
   def ip4_random_vm_network
+    ipv4_ds = DB[:ipv4_address].join(:address, [:cidr]).where(cidr: assigned_subnets_dataset.select(:cidr))
+
+    res = ipv4_ds
+      .exclude(assigned_vm_addresses_dataset.where(ip: Sequel[:ipv4_address][:ip]).select(1).exists)
+      .order { random.function }
+      .first
+
+    return [res.delete(:ip), Address.call(res)] if res
+
     # we get the available subnets and if the subnet is /32, we eliminate it
     available_subnets = assigned_subnets.select { |a| a.cidr.version == 4 && a.cidr.network.to_s != sshable.host }
+
+    if ipv4_ds.empty? && !available_subnets.empty?
+      # In case there is a bug and the ipv4_address table is not populated correctly,
+      # we fallback to the previous slow implementation.  After a certain amount of time,
+      # if we don't see any of these logs emitted in production, we can remove the fallback
+      # and rely on the ipv4_address table being populated.
+      Clog.emit("ipv4_address table not populated for ipv4 address range") { {vm_host_id: id} }
+    else
+      # ipv4_address table populated or there aren't any subnets, no point in
+      # doing further work.  This would not correctly handle cases where the ipv4
+      # address table is partially populated instead of fully populated.
+      return [nil, nil]
+    end
+
     # we eliminate the subnets that are full
     used_subnet = available_subnets.select { |as| as.assigned_vm_addresses.count != 2**(32 - as.cidr.netmask.prefix_len) }.sample
 
     # not available subnet
     return [nil, nil] unless used_subnet
 
-    # we pick a random /31 subnet from the available subnet
     rand = SecureRandom.random_number(2**(32 - used_subnet.cidr.netmask.prefix_len)).to_i
     picked_subnet = used_subnet.cidr.nth(rand)
     # we check if the picked subnet is used by one of the vms

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -5,7 +5,7 @@ require_relative "../../model/address"
 
 RSpec.describe VmHost do
   subject(:vh) {
-    described_class.new(
+    described_class.new_with_id(
       net6: NetAddr.parse_net("2a01:4f9:2b:35a::/64"),
       ip6: NetAddr.parse_ip("2a01:4f9:2b:35a::2")
     )
@@ -59,6 +59,7 @@ RSpec.describe VmHost do
   end
 
   it "tries to get another random network if the proposal matches the reserved nework" do
+    vh.id = nil
     expect(SecureRandom).to receive(:random_number).and_return(0)
     expect(SecureRandom).to receive(:random_number).and_call_original
     expect(vh.ip6_random_vm_network.to_s).not_to eq(vh.ip6_reserved_network)
@@ -165,6 +166,7 @@ RSpec.describe VmHost do
   end
 
   it "assigned_subnets returns the assigned subnets" do
+    expect(Clog).to receive(:emit).and_call_original
     expect(vh).to receive(:assigned_subnets).and_return([address])
     expect(vh).to receive(:vm_addresses).and_return([])
     expect(SecureRandom).to receive(:random_number).with(4).and_return(0)
@@ -191,6 +193,28 @@ RSpec.describe VmHost do
     ip4, r_address = vh.ip4_random_vm_network
     expect(ip4.to_s).to eq("0.0.0.1")
     expect(r_address).to eq(address)
+  end
+
+  context "when ipv4_address table is populated" do
+    it "ip4_random_vm_network returns an unused ip address if there is one" do
+      vm_host = Prog::Vm::HostNexus.assemble("127.0.0.1").subject
+      address_id = Address.create(vm_host:, cidr: "128.0.0.0/30").id
+      ips = %w[128.0.0.0 128.0.0.1 128.0.0.2 128.0.0.3]
+
+      4.times do
+        ip4, r_address = vm_host.ip4_random_vm_network
+        expect(r_address).to be_a Address
+        expect(r_address.id).to eq address_id
+        expect(ips).to include ip4.to_s
+
+        project_id = Project.create(name: "test").id
+        vm = Prog::Vm::Nexus.assemble("a a", project_id, force_host_id: vm_host.id)
+        AssignedVmAddress.create(address_id:, dst_vm_id: vm.id, ip: ips.shift)
+      end
+
+      expect(Clog).not_to receive(:emit)
+      expect(vm_host.ip4_random_vm_network).to eq [nil, nil]
+    end
   end
 
   context "when provider name is leaseweb" do
@@ -353,6 +377,7 @@ RSpec.describe VmHost do
   end
 
   it "finds local ip to assign to veth* devices" do
+    expect(vh).to receive(:vms).and_return([]).at_least(:once)
     expect(SecureRandom).to receive(:random_number).with(32767).and_return(5)
     expect(vh.veth_pair_random_ip4_addr.network.to_s).to eq("169.254.0.10")
   end
@@ -371,13 +396,13 @@ RSpec.describe VmHost do
   end
 
   it "returns disk device ids when StorageDevice has unix_device_list" do
-    sd = StorageDevice.create_with_id(vm_host_id: vh.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id1", "wwn-random-id2"])
+    sd = StorageDevice.create_with_id(name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id1", "wwn-random-id2"])
     allow(vh).to receive(:storage_devices).and_return([sd])
     expect(vh.disk_device_ids).to eq(["wwn-random-id1", "wwn-random-id2"])
   end
 
   it "returns disk device names" do
-    sd = StorageDevice.create_with_id(vm_host_id: vh.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id1", "wwn-random-id2"])
+    sd = StorageDevice.create_with_id(name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id1", "wwn-random-id2"])
     session = {
       ssh_session: instance_double(Net::SSH::Connection::Session)
     }
@@ -390,7 +415,7 @@ RSpec.describe VmHost do
   end
 
   it "converts disk devices when StorageDevice has unix_device_list with the old formatting for SSD disks" do
-    sd = StorageDevice.create_with_id(vm_host_id: vh.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["sda"])
+    sd = StorageDevice.create_with_id(name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["sda"])
     sshable = instance_double(Sshable)
     expect(sd).to receive(:vm_host).and_return(vh)
     expect(sshable).to receive(:cmd).with("ls -l /dev/disk/by-id/ | grep 'sda$' | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-random-id1")
@@ -400,7 +425,7 @@ RSpec.describe VmHost do
   end
 
   it "converts disk devices when StorageDevice has unix_device_list with the old formatting for NVMe disks" do
-    sd = StorageDevice.create_with_id(vm_host_id: vh.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["nvme0n1"])
+    sd = StorageDevice.create_with_id(name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["nvme0n1"])
     sshable = instance_double(Sshable)
     expect(sd).to receive(:vm_host).and_return(vh)
     expect(sshable).to receive(:cmd).with("ls -l /dev/disk/by-id/ | grep 'nvme0n1$' | grep 'nvme-eui' | sed -E 's/.*(nvme-eui[^ ]*).*/\\1/'").and_return("nvme-eui.random-id")


### PR DESCRIPTION
This reverts commit e95a6bcc9982261b69ee20cfe0145f63f294fa05.

This includes a conflict fix for the previous commit.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts previous commit to restore `ipv4_address` table usage in `VmHost#ip4_random_vm_network`, optimizing IP allocation logic and updating tests.
> 
>   - **Behavior**:
>     - Reverts previous commit to restore use of `ipv4_address` table in `VmHost#ip4_random_vm_network`.
>     - Adjusts logic in `populate_ipv4_addresses` in `address.rb` to handle IPv4 addresses correctly.
>     - Updates `ip4_random_vm_network` in `vm_host.rb` to use `ipv4_address` table for faster IP allocation.
>   - **Tests**:
>     - Updates tests in `vm_host_spec.rb` to reflect changes in IP allocation logic.
>     - Adds test cases for scenarios when `ipv4_address` table is populated and when it is not.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fdfee6e09894d912e0c8b18374fab18f58f98d58. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->