### PR TITLE
Fix AssignedVmAddress#vm association

### DIFF
--- a/model/assigned_vm_address.rb
+++ b/model/assigned_vm_address.rb
@@ -3,8 +3,8 @@
 require_relative "../model"
 
 class AssignedVmAddress < Sequel::Model
-  one_to_one :vm, key: :id, primary_key: :dst_vm_id
-  many_to_one :address, key: :address_id
+  many_to_one :vm, key: :dst_vm_id
+  many_to_one :address
   one_to_one :active_billing_record, class: :BillingRecord, key: :resource_id, &:active
 
   plugin ResourceMethods


### PR DESCRIPTION
The foreign key is in the current table, so this should be a many_to_one association.  While here, remove the unnecessary :key option for address association.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `AssignedVmAddress` associations by changing `vm` to `many_to_one` and simplifying `address` association.
> 
>   - **Associations**:
>     - Change `vm` association from `one_to_one` to `many_to_one` in `AssignedVmAddress` to correctly reflect foreign key relationship.
>     - Remove unnecessary `:key` option from `address` association in `AssignedVmAddress`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e2fc2c720dd7d2ba7fb518afabc3c0f588d58692. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->