### PR TITLE
Emit log for Sequel::SerializationFailure errors

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -211,7 +211,8 @@ class Clover < Roda
     when Sequel::SerializationFailure
       code = 500
       type = "InternalServerError"
-      message = e.message
+      message = "There was a temporary error attempting to make this change, please try again."
+      Clog.emit("route exception") { Util.exception_to_hash(e) }
     else
       raise e if Config.test? && e.message != "test error"
       Clog.emit("route exception") { Util.exception_to_hash(e) }


### PR DESCRIPTION
Additionally, don't leak internal details about the error, use a generic error message.  Previously, the exception wasn't displayeds to web users, but I think it was displayed in API responses.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Emit log for `Sequel::SerializationFailure` errors and replace detailed error messages with a generic message in `clover.rb`.
> 
>   - **Error Handling**:
>     - In `clover.rb`, for `Sequel::SerializationFailure` errors, emit a log using `Clog.emit` with `Util.exception_to_hash(e)`.
>     - Replace detailed error message with a generic message: "There was a temporary error attempting to make this change, please try again."
>   - **API Responses**:
>     - Prevents leaking internal error details in API responses by using a generic error message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a673e654f7908833d3c3f007e0b6f4c552629881. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->