### PR TITLE
(not for merge) Log postgres statements at E2E.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,6 +128,7 @@ jobs:
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
         HETZNER_SSH_PUBLIC_KEY: ${{ secrets.HETZNER_SSH_PUBLIC_KEY }}
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
+        DATABASE_LOGGER_LEVEL: info
       run: |
         set -o pipefail
         timeout 55m foreman start | tee foreman.log | grep "e2e.1"


### PR DESCRIPTION
We had issues in E2E where later strand runs seemed to have lost earlier database updates. Knowing which statements were run by postgres is pretty useful when debugging them.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `DATABASE_LOGGER_LEVEL: info` to E2E CI workflow for detailed database logging.
> 
>   - **Environment Variables**:
>     - Add `DATABASE_LOGGER_LEVEL: info` to `.github/workflows/e2e.yml` to enable detailed logging of database statements during E2E tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0d0bccb6836fa473201b61001f4b3d2f79d1efb5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->