### PR TITLE
Make `SpdkSetup.prep` idempotent in Ubuntu 24.04.

### DIFF
--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -17,7 +17,7 @@ class SpdkSetup
     begin
       r "adduser #{SpdkPath.user.shellescape} --disabled-password --gecos '' --home #{SpdkPath.home.shellescape}"
     rescue CommandFail => ex
-      raise unless /adduser: The user `.*' already exists\./.match?(ex.message)
+      raise unless /The user `.*' already exists\./.match?(ex.message)
     end
 
     # Directory to put vhost sockets.

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -16,9 +16,17 @@ RSpec.describe SpdkSetup do
       expect { described_class.prep }.not_to raise_error
     end
 
-    it "continues if user already exists" do
+    it "continues if user already exists (ubuntu 22.04)" do
       expect(described_class).to receive(:r).with(/apt-get -y .*/)
-      expect(described_class).to receive(:r).with(/adduser .*/).and_raise CommandFail.new("adduser: The user `spdk' already exists.", "", "")
+      expect(described_class).to receive(:r).with(/adduser .*/).and_raise CommandFail.new("Warning: The home dir /home/spdk you specified already exists.\nadduser: The user `spdk' already exists.", "", "")
+      expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
+      expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
+      expect { described_class.prep }.not_to raise_error
+    end
+
+    it "continues if user already exists (ubuntu 24.04)" do
+      expect(described_class).to receive(:r).with(/apt-get -y .*/)
+      expect(described_class).to receive(:r).with(/adduser .*/).and_raise CommandFail.new("info: The home dir /home/spdk you specified already exists.\n\nfatal: The user `spdk' already exists.", "", "")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
       expect { described_class.prep }.not_to raise_error


### PR DESCRIPTION
This function was intended to be idempotent. In Ubuntu 22.04, when the `spdk` user already existed, we got the following error:

```
Warning: The home dir /home/spdk you specified already exists.
adduser: The user `spdk' already exists.
```

In Ubuntu 24.04, this has changed to:

```
info: The home dir /home/spdk you specified already exists.

fatal: The user `spdk' already exists.
```

This PR changes the regex to catch both cases.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `SpdkSetup.prep` to handle user existence errors in Ubuntu 22.04 and 24.04 by modifying regex and adding tests.
> 
>   - **Behavior**:
>     - Update `SpdkSetup.prep` in `spdk_setup.rb` to handle user existence error messages for both Ubuntu 22.04 and 24.04.
>     - Modify regex to match both "adduser: The user `spdk' already exists." and "fatal: The user `spdk' already exists.".
>   - **Tests**:
>     - Add test for Ubuntu 24.04 user existence case in `spdk_setup_spec.rb`.
>     - Ensure existing test for Ubuntu 22.04 user existence case remains valid.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0ae1b78f861443aa8fa75313e9ff1e08abe89b3c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->