### PR TITLE
Change Prog#donate to only nap

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -181,7 +181,6 @@ end
   end
 
   def donate
-    strand.children_dataset.each(&:run)
     nap 1
   end
 

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Prog::InstallDnsmasq do
     before { expect(idm).to receive(:reap) }
 
     it "donates if any sub-progs are still running" do
-      expect(idm).to receive(:donate).and_call_original
-      expect(idm).to receive(:strand).and_return(instance_double(Strand, children_dataset: []))
       expect(idm).to receive(:leaf?).and_return false
       expect { idm.wait_downloads }.to nap(1)
     end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -176,9 +176,6 @@ table ip6 pod_access {
 
     it "donates if there are sub-programs running" do
       expect(prog).to receive(:leaf?).and_return false
-      expect(prog).to receive(:donate).and_call_original
-      expect(prog).to receive(:strand).and_return(instance_double(Strand, children_dataset: []))
-
       expect { prog.wait_bootstrap_rhizome }.to nap(1)
     end
   end

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
       prog.strand.label = "somestep"
       expect(prog).to receive(:reap)
       expect(prog).to receive(:leaf?).and_return(false)
-      expect(prog.strand).to receive(:children_dataset).and_return([])
       expect { prog.before_run }.to nap(1)
     end
   end
@@ -85,9 +84,6 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   describe "#wait_new_node" do
     it "donates if there are sub-programs running" do
       expect(prog).to receive(:reap).and_return([])
-      expect(prog).to receive(:donate).and_call_original
-      expect(prog.strand).to receive(:children_dataset).and_return([])
-
       expect { prog.wait_new_node }.to nap(1)
     end
 


### PR DESCRIPTION
Running child progs in donate causes issues.  Let's say you have two child progs A and B:

* Prog A runs successfully
* Prog B does not run successfully

The failure of prog B rolls back the changes in prog A. If prog A is not idempotent, this is a permanent failure that requires external intervention.

The current approach is designed to run progs in serial, they are also executed concurrently in parallel by other respirate threads or processes.  For example, while prog A is running in the above example inside donate, prog B could be executing concurrently. By the time prog A finishes, it checks prog B, which has already finished.

The nap 1 approach may result in higher than desired load on the database.  A more efficient approach would be to nap longer in donate, and have exiting children update the schedule for their parent if all of the parent's children are ready to be reaped.