### PR TITLE
Do not run multiple child strands inside donate

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -181,7 +181,9 @@ end
   end
 
   def donate
-    strand.children_dataset.each(&:run)
+    strand.children_dataset.each do |child|
+      nap 0 if child.run
+    end
     nap 1
   end
 

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -81,6 +81,10 @@ class Prog::Test < Prog::Base
     donate
   end
 
+  label def failer
+    fail "failure"
+  end
+
   label def napper
     nap(123)
   end


### PR DESCRIPTION
Running multiple child strands inside donate can lead to a situation where one or more child progs successfully complete, and a later child prog fails, and the failure of the later child prog rolls back the database changes made by the child progs that successfully complete.  If the child progs are not idempotent, this results in a situation that cannot be fixed without manual intervention.

Instead, as soon as a child is successfully run inside donate, nap for 0 seconds.  That will mean the remaining child strands are skipped during that donate method.  The Nap flow control exception will be caught inside Strand#unsynchronized_run.  The parent will update it's own schedule, and the transaction will commit. Strand#run will handle the Nap 0 exception and if the deadline hasn't passed, it will immediately rerun the strand. Assuming the strand still has child processes to run, that will likely get back to the donate call, where the next child strand will run, repeating this process until the deadline has passed, all child strands have run, or there is an error running a child strand.