### PR TITLE
Fix a nondeterministic InferenceRouterReplicaNexus spec failure

### DIFF
--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
           project_completion_tps_limit: 10000
         }])
         expect(json_sent["routes"][0]["endpoints"].size).to eq(2)
-        expect(json_sent["routes"][0]["endpoints"][0].map { |h| h.transform_keys(&:to_sym) }).to eq([{
+        expect(json_sent["routes"][0]["endpoints"][0].sort_by { it["id"] }.map { |h| h.transform_keys(&:to_sym) }).to eq([{
           id: "test-target-a",
           host: "test-host-a",
           api_key: "test-key-a",


### PR DESCRIPTION
Sort the endpoints so the test passes with either order.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes nondeterministic test failure in `inference_router_replica_nexus_spec.rb` by sorting `endpoints` by `id`.
> 
>   - **Behavior**:
>     - Fixes nondeterministic test failure in `inference_router_replica_nexus_spec.rb` by sorting `endpoints` by `id`.
>     - Ensures test passes regardless of endpoint order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 254d02d2ed2a28084ff96e55400379711221b947. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->