### PR TITLE
Absorb leaf into reap

### DIFF
--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -64,9 +64,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_download_lb_cert if leaf?
-    donate
+    reap(:download_lb_cert)
   end
 
   label def download_lb_cert

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -62,9 +62,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_setup if leaf?
-    donate
+    reap(:setup)
   end
 
   label def setup

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -185,8 +185,31 @@ end
     nap 1
   end
 
-  def reap
-    strand.children_dataset.where(Sequel.lit("lease < now() AND exitval IS NOT NULL")).all do |child|
+  # Process child strands
+  #
+  # Reapable children (child strands that have exited) are destroyed.
+  # If a repear argument is given, it is called with each child after
+  # the child is destroyed.
+  #
+  # If there are no reapable children:
+  #
+  # * If hop is given: hops to the target
+  # * If block is given: yields to block
+  #
+  # If there are still active children:
+  #
+  # * If fallthrough is given: returns nil
+  # * If nap is given: naps for given time
+  # * Otherswise, donates to run a child process
+  def reap(hop = nil, reaper: nil, nap: nil, fallthrough: false)
+    children = strand
+      .children_dataset
+      .select_append(Sequel.lit("lease < now() AND exitval IS NOT NULL").as(:reapable))
+      .all
+
+    reapable_children, active_children = children.partition { it.values.delete(:reapable) }
+
+    reapable_children.each do |child|
       # Clear any semaphores that get added to a exited Strand prog,
       # since incr is entitled to be run at *any time* (including
       # after exitval is set, though it doesn't do anything) and any
@@ -194,11 +217,23 @@ end
       # foreign_key
       child.semaphores_dataset.destroy
       child.destroy
+      reaper&.call(child)
     end
-  end
 
-  def leaf?
-    strand.children_dataset.empty?
+    # Parent is now a leaf, hop to given label, or yield if no label
+    if active_children.empty?
+      if hop
+        dynamic_hop(hop)
+      elsif block_given?
+        yield
+      end
+    end
+
+    unless fallthrough
+      # Parent is not a leaf, nap for given time, or donate if no
+      # nap time is given.
+      nap ? nap(nap) : donate
+    end
   end
 
   # A hop is a kind of jump, as in, like a jump instruction.

--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -14,9 +14,7 @@ class Prog::InstallDnsmasq < Prog::Base
   end
 
   label def wait_downloads
-    reap
-    hop_compile_and_install if leaf?
-    donate
+    reap(:compile_and_install)
   end
 
   label def compile_and_install

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -71,9 +71,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   end
 
   label def wait_worker_node
-    reap
-    hop_wait if leaf?
-    donate
+    reap(:wait)
   end
 
   label def wait
@@ -102,22 +100,20 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   end
 
   label def wait_upgrade
-    reap
-    hop_upgrade if leaf?
-    donate
+    reap(:upgrade)
   end
 
   label def destroy
-    reap
-    donate unless leaf?
-    decr_destroy
+    reap do
+      decr_destroy
 
-    lb = LoadBalancer[name: kubernetes_nodepool.cluster.services_load_balancer_name]
-    lb&.dns_zone&.delete_record(record_name: "*.#{lb.hostname}.")
-    lb&.incr_destroy
-    kubernetes_nodepool.vms.each(&:incr_destroy)
-    kubernetes_nodepool.remove_all_vms
-    kubernetes_nodepool.destroy
-    pop "kubernetes nodepool is deleted"
+      lb = LoadBalancer[name: kubernetes_nodepool.cluster.services_load_balancer_name]
+      lb&.dns_zone&.delete_record(record_name: "*.#{lb.hostname}.")
+      lb&.incr_destroy
+      kubernetes_nodepool.vms.each(&:incr_destroy)
+      kubernetes_nodepool.remove_all_vms
+      kubernetes_nodepool.destroy
+      pop "kubernetes nodepool is deleted"
+    end
   end
 end

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -108,9 +108,7 @@ TEMPLATE
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_assign_role if leaf?
-    donate
+    reap(:assign_role)
   end
 
   label def assign_role

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -73,9 +73,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_create_minio_user if leaf?
-    donate
+    reap(:create_minio_user)
   end
 
   label def create_minio_user
@@ -97,11 +95,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   end
 
   label def wait_setup
-    reap
-    if leaf?
-      hop_wait
-    end
-    donate
+    reap(:wait)
   end
 
   label def wait
@@ -144,11 +138,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
 
   label def wait_reconfigure
     decr_reconfigure
-    reap
-    if leaf?
-      hop_wait
-    end
-    donate
+    reap(:wait)
   end
 
   label def minio_restart
@@ -165,8 +155,8 @@ class Prog::Minio::MinioServerNexus < Prog::Base
   label def unavailable
     register_deadline("wait", 10 * 60)
 
-    reap
-    nap 5 unless strand.children.select { it.prog == "Minio::MinioServerNexus" && it.label == "minio_restart" }.empty?
+    reap(fallthrough: true)
+    nap 5 unless strand.children_dataset.where(prog: "Minio::MinioServerNexus", label: "minio_restart").empty?
 
     if available?
       decr_checkup

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -118,9 +118,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     postgres_resource.server_cert, postgres_resource.server_cert_key = create_certificate
     postgres_resource.save_changes
 
-    reap
-    hop_wait_servers if leaf?
-    nap 5
+    reap(:wait_servers, nap: 5)
   end
 
   label def refresh_certificates
@@ -184,9 +182,9 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def wait
-    reap
+    reap(fallthrough: true)
 
-    if postgres_resource.needs_convergence? && strand.children.none? { it.prog == "Postgres::ConvergePostgresResource" }
+    if postgres_resource.needs_convergence? && strand.children_dataset.where(prog: "Postgres::ConvergePostgresResource").empty?
       bud Prog::Postgres::ConvergePostgresResource, frame, :start
     end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -99,9 +99,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_mount_data_disk if leaf?
-    donate
+    reap(:mount_data_disk)
   end
 
   label def mount_data_disk
@@ -463,8 +461,8 @@ SQL
 
     nap 0 if postgres_server.trigger_failover
 
-    reap
-    nap 5 unless strand.children.select { it.prog == "Postgres::PostgresServerNexus" && it.label == "restart" }.empty?
+    reap(fallthrough: true)
+    nap 5 unless strand.children_dataset.where(prog: "Postgres::PostgresServerNexus", label: "restart").empty?
 
     if available?
       decr_checkup

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -69,16 +69,11 @@ class Prog::Test < Prog::Base
 
   label def reaper
     # below loop is only for ensuring we are able to process reaped strands
-    reap.each do |st|
-      st.exitval
-    end
-    donate
+    reap(reaper: :exitval.to_proc)
   end
 
   label def reap_exit_no_children
-    reap
-    pop({msg: "reap_exit_no_children"}) if leaf?
-    donate
+    reap { pop({msg: "reap_exit_no_children"}) }
   end
 
   label def napper

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -66,9 +66,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def wait_verify_vms
-    reap
-    hop_verify_host_capacity if leaf?
-    donate
+    reap(:verify_host_capacity)
   end
 
   label def verify_host_capacity

--- a/prog/victoria_metrics/victoria_metrics_server_nexus.rb
+++ b/prog/victoria_metrics/victoria_metrics_server_nexus.rb
@@ -65,9 +65,7 @@ class Prog::VictoriaMetrics::VictoriaMetricsServerNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap
-    hop_create_victoria_metrics_user if leaf?
-    donate
+    reap(:create_victoria_metrics_user)
   end
 
   label def create_victoria_metrics_user

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -95,7 +95,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def wait_prep
-    reap.each do |st|
+    reaper = lambda do |st|
       case st.prog
       when "LearnOs"
         os_version = st.exitval.fetch("os_version")
@@ -125,10 +125,7 @@ class Prog::Vm::HostNexus < Prog::Base
       end
     end
 
-    if leaf?
-      hop_setup_hugepages
-    end
-    donate
+    reap(:setup_hugepages, reaper:)
   end
 
   label def setup_hugepages
@@ -165,9 +162,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def wait_download_boot_images
-    reap
-    hop_prep_reboot if leaf?
-    donate
+    reap(:prep_reboot)
   end
 
   label def prep_reboot

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -194,9 +194,7 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   label def wait_aws_vm_started
-    reap
-    hop_wait_sshable if leaf?
-    nap 10
+    reap(:wait_sshable, nap: 10)
   end
 
   label def start
@@ -554,12 +552,10 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   label def wait_aws_vm_destroyed
-    reap
-    if leaf?
+    reap(nap: 10) do
       final_clean_up
       pop "vm deleted"
     end
-    nap 10
   end
 
   label def wait_lb_expiry

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -137,13 +137,10 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   end
 
   label def wait_update_vm_load_balancers
-    reap
-    if strand.children_dataset.where(prog: "Vnet::UpdateLoadBalancerNode").all? { it.exitval == "load balancer is updated" } || strand.children.empty?
+    reap(nap: 1) do
       decr_update_load_balancer
       hop_wait
     end
-
-    nap 1
   end
 
   label def destroy
@@ -168,14 +165,11 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   end
 
   label def wait_destroy
-    reap
-    if leaf?
+    reap(nap: 5) do
       load_balancer.destroy
 
       pop "load balancer deleted"
     end
-
-    nap 5
   end
 
   label def rewrite_dns_records

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -39,9 +39,7 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_aws_nic_created
-    reap
-    hop_wait if leaf?
-    nap 10
+    reap(:wait, nap: 10)
   end
 
   label def wait_allocation
@@ -134,12 +132,10 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_aws_nic_destroyed
-    reap
-    if leaf?
+    reap(nap: 10) do
       nic.destroy
       pop "nic deleted"
     end
-    nap 10
   end
   # Generate a MAC with the "local" (generated, non-manufacturer) bit
   # set and the multicast bit cleared in the first octet.

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -70,9 +70,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
   end
 
   label def wait_vpc_created
-    reap
-    hop_wait if leaf?
-    nap 2
+    reap(:wait, nap: 2)
   end
 
   label def wait
@@ -202,13 +200,11 @@ class Prog::Vnet::SubnetNexus < Prog::Base
   end
 
   label def wait_aws_vpc_destroyed
-    reap
-    if leaf?
+    reap(nap: 10) do
       private_subnet.private_subnet_aws_resource.destroy
       private_subnet.destroy
       pop "vpc destroyed"
     end
-    nap 10
   end
 
   def self.random_private_ipv6(location, project)

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 require_relative "../../../prog/ai/inference_endpoint_replica_nexus"
 
 RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
-  subject(:nx) { described_class.new(Strand.create(prog: "Prog::Ai::InferenceEndpointReplicaNexus", label: "start")) }
+  subject(:nx) { described_class.new(st) }
+
+  let(:st) { Strand.create(prog: "Prog::Ai::InferenceEndpointReplicaNexus", label: "start") }
 
   let(:project) { Project.create(name: "test") }
   let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: Location::HETZNER_HEL1_ID, net6: "fe80::/64", net4: "192.168.0.0/24") }
@@ -120,18 +122,12 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
   end
 
   describe "#wait_bootstrap_rhizome" do
-    before { expect(nx).to receive(:reap) }
-
     it "hops to setup if there are no sub-programs running" do
-      expect(nx).to receive(:leaf?).and_return true
-
       expect { nx.wait_bootstrap_rhizome }.to hop("download_lb_cert")
     end
 
     it "donates if there are sub-programs running" do
-      expect(nx).to receive(:leaf?).and_return false
-      expect(nx).to receive(:donate).and_call_original
-
+      Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_bootstrap_rhizome }.to nap(1)
     end
   end

--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -4,8 +4,9 @@ require "spec_helper"
 require_relative "../../../prog/ai/inference_router_replica_nexus"
 
 RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
-  subject(:nx) { described_class.new(Strand.create(prog: "Prog::Ai::InferenceRouterReplicaNexus", label: "start")) }
+  subject(:nx) { described_class.new(st) }
 
+  let(:st) { Strand.create(prog: "Prog::Ai::InferenceRouterReplicaNexus", label: "start") }
   let(:project) { Project.create(name: "test") }
   let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: Location::HETZNER_HEL1_ID, net6: "fe80::/64", net4: "192.168.0.0/24") }
   let(:load_balancer) { Prog::Vnet::LoadBalancerNexus.assemble(private_subnet.id, name: "test", src_port: 443, dst_port: 8443).subject }
@@ -122,18 +123,12 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
   end
 
   describe "#wait_bootstrap_rhizome" do
-    before { expect(nx).to receive(:reap) }
-
     it "hops to setup if there are no sub-programs running" do
-      expect(nx).to receive(:leaf?).and_return true
-
       expect { nx.wait_bootstrap_rhizome }.to hop("setup")
     end
 
     it "donates if there are sub-programs running" do
-      expect(nx).to receive(:leaf?).and_return false
-      expect(nx).to receive(:donate).and_call_original
-
+      Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_bootstrap_rhizome }.to nap(1)
     end
   end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Prog::Base do
     parent = Strand.create_with_id(prog: "Test", label: "budder")
     expect {
       parent.unsynchronized_run
-      parent.reload
-    }.to change { parent.load.leaf? }.from(true).to(false)
+    }.to change { parent.children_dataset.empty? }.from(true).to(false)
 
     child_id = parent.children.first.id
     Semaphore.incr(child_id, :should_get_deleted)
@@ -19,7 +18,7 @@ RSpec.describe Prog::Base do
 
       # Parent notices exitval is set and reaps the child.
       parent.run
-    }.to change { parent.load.leaf? }.from(false).to(true).and change {
+    }.to change { parent.children_dataset.empty? }.from(false).to(true).and change {
       Semaphore.where(strand_id: child_id).empty?
     }.from(false).to(true).and change {
       parent.children.empty?

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -4,8 +4,10 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::InstallDnsmasq do
   subject(:idm) {
-    described_class.new(Strand.new(prog: "InstallDnsmasq"))
+    described_class.new(st)
   }
+
+  let(:st) { Strand.new(prog: "InstallDnsmasq") }
 
   describe "#start" do
     it "starts sub-programs to install dependencies and download dnsmasq concurrently" do
@@ -17,17 +19,14 @@ RSpec.describe Prog::InstallDnsmasq do
   end
 
   describe "#wait_downloads" do
-    before { expect(idm).to receive(:reap) }
-
     it "donates if any sub-progs are still running" do
-      expect(idm).to receive(:donate).and_call_original
-      expect(idm).to receive(:strand).and_return(instance_double(Strand, children_dataset: []))
-      expect(idm).to receive(:leaf?).and_return false
+      st.update(label: "wait_downloads", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "InstallDnsmasq", label: "install_build_dependencies", stack: [{}], lease: Time.now + 10)
       expect { idm.wait_downloads }.to nap(1)
     end
 
     it "hops to compile_and_install when the downloads are done" do
-      expect(idm).to receive(:leaf?).and_return true
+      st.update(label: "wait_downloads", stack: [{}])
       expect { idm.wait_downloads }.to hop("compile_and_install")
     end
   end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -3,7 +3,9 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
-  subject(:prog) { described_class.new(Strand.new) }
+  subject(:prog) { described_class.new(st) }
+
+  let(:st) { Strand.new }
 
   let(:project) {
     Project.create(name: "default")
@@ -166,19 +168,14 @@ table ip6 pod_access {
   end
 
   describe "#wait_bootstrap_rhizome" do
-    before { expect(prog).to receive(:reap) }
-
     it "hops to assign_role if there are no sub-programs running" do
-      expect(prog).to receive(:leaf?).and_return true
-
+      st.update(prog: "Kubernetes::ProvisionKubernetesNode", label: "wait_bootstrap_rhizome", stack: [{}])
       expect { prog.wait_bootstrap_rhizome }.to hop("assign_role")
     end
 
     it "donates if there are sub-programs running" do
-      expect(prog).to receive(:leaf?).and_return false
-      expect(prog).to receive(:donate).and_call_original
-      expect(prog).to receive(:strand).and_return(instance_double(Strand, children_dataset: []))
-
+      st.update(prog: "Kubernetes::ProvisionKubernetesNode", label: "wait_bootstrap_rhizome", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
       expect { prog.wait_bootstrap_rhizome }.to nap(1)
     end
   end

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -3,7 +3,9 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Minio::MinioServerNexus do
-  subject(:nx) { described_class.new(described_class.assemble(minio_pool.id, 0)) }
+  subject(:nx) { described_class.new(st) }
+
+  let(:st) { described_class.assemble(minio_pool.id, 0) }
 
   let(:minio_pool) {
     ps = Prog::Vnet::SubnetNexus.assemble(
@@ -154,16 +156,12 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   end
 
   describe "#wait_bootstrap_rhizome" do
-    before { expect(nx).to receive(:reap) }
-
     it "donates if bootstrap rhizome continues" do
-      expect(nx).to receive(:leaf?).and_return(false)
-      expect(nx).to receive(:donate).and_call_original
+      Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_bootstrap_rhizome }.to nap(1)
     end
 
     it "hops to setup if bootstrap rhizome is done" do
-      expect(nx).to receive(:leaf?).and_return(true)
       expect { nx.wait_bootstrap_rhizome }.to hop("create_minio_user")
     end
   end
@@ -199,16 +197,12 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   end
 
   describe "#wait_setup" do
-    before { expect(nx).to receive(:reap) }
-
     it "donates if setup continues" do
-      expect(nx).to receive(:leaf?).and_return(false)
-      expect(nx).to receive(:donate).and_call_original
+      Strand.create(parent_id: st.id, prog: "SetupMinio", label: "mount_data_disks", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_setup }.to nap(1)
     end
 
     it "hops to wait if setup is done" do
-      expect(nx).to receive(:leaf?).and_return(true)
       expect { nx.wait_setup }.to hop("wait")
     end
   end
@@ -323,16 +317,12 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   end
 
   describe "#wait_reconfigure" do
-    before { expect(nx).to receive(:reap) }
-
     it "donates if reconfigure continues" do
-      expect(nx).to receive(:leaf?).and_return(false)
-      expect(nx).to receive(:donate).and_call_original
+      Strand.create(parent_id: st.id, prog: "SetupMinio", label: "configure_minio", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_reconfigure }.to nap(1)
     end
 
     it "hops to wait if reconfigure is done" do
-      expect(nx).to receive(:leaf?).and_return(true)
       expect { nx.wait_reconfigure }.to hop("wait")
     end
   end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -3,7 +3,9 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Postgres::PostgresResourceNexus do
-  subject(:nx) { described_class.new(Strand.new(id: "8148ebdf-66b8-8ed0-9c2f-8cfe93f5aa77")) }
+  subject(:nx) { described_class.new(st) }
+
+  let(:st) { Strand.new(id: "8148ebdf-66b8-8ed0-9c2f-8cfe93f5aa77") }
 
   let(:postgres_resource) {
     instance_double(
@@ -211,9 +213,10 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "naps if there are children" do
+      st.update(prog: "Postgres::PostgresResourceNexus", label: "initialize_certificates", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "Postgres::PostgresResourceNexus", label: "trigger_pg_current_xact_id_on_parent", stack: [{}], lease: Time.now + 10)
       expect(Util).to receive(:create_root_certificate).twice
       expect(nx).to receive(:create_certificate)
-      expect(nx).to receive(:leaf?).and_return(false)
       expect { nx.initialize_certificates }.to nap(5)
     end
   end

--- a/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
+++ b/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
@@ -5,9 +5,10 @@ require_relative "../../model/spec_helper"
 RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
   subject(:nx) {
     allow(Config).to receive(:victoria_metrics_service_project_id).and_return(project.id)
-    described_class.new(Strand.new(id: "e29d876b-9437-4ba3-9949-99075ad8767d", prog: "VictoriaMetrics::VictoriaMetricsServerNexus", label: "start"))
+    described_class.new(st)
   }
 
+  let(:st) { Strand.new(id: "e29d876b-9437-4ba3-9949-99075ad8767d", prog: "VictoriaMetrics::VictoriaMetricsServerNexus", label: "start") }
   let(:project) { Project.create_with_id(name: "default") }
 
   let(:vm) {
@@ -91,13 +92,13 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
 
   describe "#wait_bootstrap_rhizome" do
     it "hops to create_victoria_metrics_user if bootstrap is complete" do
-      expect(nx).to receive(:leaf?).and_return(true)
+      st.update(prog: "VictoriaMetrics::VictoriaMetricsServerNexus", label: "wait_bootstrap_rhizome", stack: [{}])
       expect { nx.wait_bootstrap_rhizome }.to hop("create_victoria_metrics_user")
     end
 
     it "donates if bootstrap is not complete" do
-      expect(nx).to receive(:leaf?).and_return(false)
-      expect(nx).to receive(:donate).and_call_original
+      st.update(prog: "VictoriaMetrics::VictoriaMetricsServerNexus", label: "wait_bootstrap_rhizome", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_bootstrap_rhizome }.to nap(1)
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -237,14 +237,13 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe "#wait_aws_vm_started" do
     it "reaps and naps if not leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(false)
+      st.update(prog: "Vm::Nexus", label: "wait_aws_vm_started", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "Aws::Instance", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_aws_vm_started }.to nap(10)
     end
 
     it "hops to wait_sshable if leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(true)
+      st.update(prog: "Vm::Nexus", label: "wait_aws_vm_started", stack: [{}])
       expect { nx.wait_aws_vm_started }.to hop("wait_sshable")
     end
   end
@@ -1137,15 +1136,14 @@ RSpec.describe Prog::Vm::Nexus do
 
   describe "#wait_aws_vm_destroyed" do
     it "reaps and pops if leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(true)
+      st.update(prog: "Vm::Nexus", label: "wait_aws_vm_destroyed", stack: [{}])
       expect(nx).to receive(:final_clean_up)
       expect { nx.wait_aws_vm_destroyed }.to exit({"msg" => "vm deleted"})
     end
 
     it "naps if not leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(false)
+      st.update(prog: "Vm::Nexus", label: "wait_aws_vm_destroyed", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "Aws::Instance", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_aws_vm_destroyed }.to nap(10)
     end
   end

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
     end
 
     it "naps for 1 second if not all children are done" do
-      expect(nx).to receive(:reap)
+      Strand.create(parent_id: st.id, prog: "UpdateLoadBalancerNode", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_update_vm_load_balancers }.to nap(1)
     end
 
@@ -287,15 +287,11 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
 
   describe "#wait_destroy" do
     it "naps for 5 seconds if not all children are done" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(false)
-
+      Strand.create(parent_id: st.id, prog: "UpdateLoadBalancerNode", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_destroy }.to nap(5)
     end
 
     it "deletes the load balancer and pops" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(true)
       expect(nx.load_balancer).to receive(:destroy)
       expect { nx.wait_destroy }.to exit({"msg" => "load balancer deleted"})
       expect(LoadBalancersVms.count).to eq 0
@@ -306,8 +302,6 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       lb = st.subject
       lb.add_cert(cert)
       expect(lb.certs.count).to eq 2
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(true)
       expect { nx.wait_destroy }.to exit({"msg" => "load balancer deleted"})
       expect(CertsLoadBalancers.count).to eq 0
       expect(cert.destroy_set?).to be true

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -102,14 +102,13 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#wait_aws_nic_created" do
     it "reaps and hops to wait if leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(true)
+      st.update(prog: "Vnet::NicNexus", label: "wait_aws_nic_created", stack: [{}])
       expect { nx.wait_aws_nic_created }.to hop("wait")
     end
 
     it "naps if not leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(false)
+      st.update(prog: "Vnet::NicNexus", label: "wait_aws_nic_created", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "Aws::Nic", label: "create_network_interface", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_aws_nic_created }.to nap(10)
     end
   end
@@ -268,8 +267,7 @@ RSpec.describe Prog::Vnet::NicNexus do
 
   describe "#wait_aws_nic_destroyed" do
     it "reaps and destroys nic if leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(true)
+      st.update(prog: "Vnet::NicNexus", label: "wait_aws_nic_destroyed", stack: [{}])
       nic = instance_double(Nic, id: "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e")
       expect(nx).to receive(:nic).and_return(nic)
       expect(nic).to receive(:destroy)
@@ -277,8 +275,8 @@ RSpec.describe Prog::Vnet::NicNexus do
     end
 
     it "naps if not leaf" do
-      expect(nx).to receive(:reap)
-      expect(nx).to receive(:leaf?).and_return(false)
+      st.update(prog: "Vnet::NicNexus", label: "wait_aws_nic_destroyed", stack: [{}])
+      Strand.create(parent_id: st.id, prog: "Aws::Nic", label: "destroy", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_aws_nic_destroyed }.to nap(10)
     end
   end


### PR DESCRIPTION
Reviewing leaf usage in progs, it always occurs right after reap. Combining leaf and reap methods avoids a redundant query for the strand's children.

It's typical for nap or donate to be called after the leaf check after reap.  Also build this into reap, by calling donate by default, or nap if a nap keyword argument is given.

There are a few cases where reap was called without leaf/donate. Add a fallthrough keyword argument to support this, so if there are no children, it does not call either nap or donate

Vm::HostNexus#wait_prep and Kubernetes::UpgradeKubernetesNode#wait_new_node both need the return value of the reapable child(ren). Add a reaper keyword argument for this, which is called once for each child.

The most common pattern for using reap/leaf/donate was:

```ruby
reap
hop_download_lb_cert if leaf?
donate
```

This turns into:

```ruby
reap(:download_lb_cert)
```

The second most common pattern was:

```ruby
reap
donate unless leaf?
pop "upgrade cancelled" # or other code
```

This turns into:

```ruby
reap { pop "upgrade cancelled" }
```

In a few places, I changed operations on strand.children to strand.children_dataset.  Now that we are no longer using cached children by default, it's better to do these checks in the database intead of in Ruby.  These places deserve careful review:

* Prog::Minio::MinioServerNexus#unavailable
* Prog::Postgres::PostgresResourceNexus#wait
* Prog::Postgres::PostgresServerNexus#unavailable

For Prog::Vnet::LoadBalancerNexus#wait_update_vm_load_balancers, I removed a check on the children completely. It was checking for an exitval using children_dataset directly after reap, which should only be true if there was still an active lease for the child.  This also deserves careful review.

This broke many mocked tests.  This fixes the mocked tests to use database-backed objects, ensuring that we are testing observable behavior and not implementation details.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `reap` method to integrate `leaf` and `donate` functionality, streamline child strand handling, and update tests accordingly.
> 
>   - **Behavior**:
>     - Refactor `reap` method in `base.rb` to absorb `leaf` and `donate` functionality, reducing redundant queries.
>     - Introduce `hop`, `reaper`, `nap`, and `fallthrough` keyword arguments to handle different scenarios in `reap`.
>     - Update `reap` usage across various classes, such as `Vm::HostNexus`, `Kubernetes::UpgradeKubernetesNode`, and `LoadBalancerNexus`.
>   - **Tests**:
>     - Update test cases in `*_spec.rb` files to align with the refactored `reap` method.
>     - Modify mock objects and expectations to reflect changes in child strand handling.
>   - **Misc**:
>     - Remove `leaf` and `donate` methods where no longer needed.
>     - Ensure database-backed objects are used in tests to verify observable behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for cf619dedf8aaa04207ffe68789f3c4aa0f6c100e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->