### PR TITLE
Combine donate and reap

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -180,13 +180,6 @@ end
     )
   end
 
-  def donate
-    strand.children_dataset.each do |child|
-      nap 0 if child.run
-    end
-    nap 1
-  end
-
   # Process child strands
   #
   # Reapable children (child strands that have exited) are destroyed.
@@ -234,7 +227,14 @@ end
     unless fallthrough
       # Parent is not a leaf, nap for given time, or donate if no
       # nap time is given.
-      nap ? nap(nap) : donate
+      if nap
+        nap(nap)
+      else
+        active_children.each do |child|
+          nap 0 if child.run
+        end
+        nap 1
+      end
     end
   end
 

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -103,12 +103,12 @@ class Prog::Test < Prog::Base
 
   label def increment_semaphore
     incr_test_semaphore
-    donate
+    nap 1
   end
 
   label def decrement_semaphore
     decr_test_semaphore
-    donate
+    nap 1
   end
 
   label def set_expired_deadline

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -6,22 +6,14 @@ RSpec.describe Prog::Base do
   it "does not allow failure of one child strand inside donate to affect other strands" do
     parent = Strand.create(prog: "Test", label: "reap_exit_no_children")
     popper = Strand.create(parent_id: parent.id, prog: "Test", label: "popper")
-    leased = Strand.create(parent_id: parent.id, prog: "Test", label: "napper", lease: Time.now + 10)
     failer = Strand.create(parent_id: parent.id, prog: "Test", label: "failer")
-    array = [popper, leased, failer]
+    Strand.create(parent_id: parent.id, prog: "Test", label: "napper", lease: Time.now + 10)
 
-    # Avoid RSpec::Mocks::MockExpectationError by defining methods directly
-    def array.where(_)
-      a = []
-
-      def a.all
-        self
-      end
-
-      a
+    expect(parent).to receive(:children_dataset).twice.and_wrap_original do
+      # Force popper before failer
+      it.call.order(Sequel.case({"popper" => 1}, 2, :label))
     end
 
-    expect(parent).to receive(:children_dataset).exactly(4).and_return(array)
     expect { parent.run(10) }.to raise_error(RuntimeError)
     expect(popper.this.get(:exitval)).to eq("msg" => "popped")
     expect(failer.this.get(:exitval)).to be_nil


### PR DESCRIPTION
This builds on #3495 and #3493, and takes the additional step of combing donate into reap.

With #3495, Prog::Base#donate is only called by Prog::Base#reap (outside a couple of test calls that don't need to call it).

Moving donate into reap avoids a redundant child query. When we would call donate, we already know which children are active, because reap already selected all children, and separated them into reapable children and active children.

#3495 and #3493 are independent. Since you cannot base a PR on a merge of multiple other PRs, this includes #3493 as the first commit, and adds a second commit for combining donate into reap.

A future potential improvement is to nap for a longer time by default in reap (could do 120-3600 seconds instead of 1 second), and have exiting child progs schedule their parent prog if the parent prog has no longer has active children. I'm not sure whether that will result in any negative side effects, though.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Combines `donate` into `reap` in `prog/base.rb`, optimizing child strand handling and updating tests accordingly.
> 
>   - **Behavior**:
>     - Combines `donate` into `reap` in `prog/base.rb`, removing redundant child queries.
>     - `reap` now directly handles active children by running them and napping.
>   - **Tests**:
>     - Updates `prog/test.rb` to replace `donate` calls with `nap 1` in `increment_semaphore` and `decrement_semaphore`.
>     - Adds test in `spec/prog/base_spec.rb` to ensure failure in one child strand does not affect others.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6fe8762f9a0ae6189bcd3f81b9f2d0e1c73d1f7e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->