### PR TITLE
Fix CA certificate download button

### DIFF
--- a/views/postgres/connection.erb
+++ b/views/postgres/connection.erb
@@ -47,7 +47,7 @@
 <% end %>
 
   <div class="mt-5 flex items-center gap-2">
-    CA Certificates: <%== part("components/download_button", link: "#{request.path}/ca-certificates")%>
+    CA Certificates: <%== part("components/download_button", link: "#{@project_data[:path]}#{@pg.path}/ca-certificates")%>
   </div>
 </div>
 


### PR DESCRIPTION
Connection information is now served from its own subpage, so `request.path` is not the correct way to generate the API endpoint.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CA certificate download link in `views/postgres/connection.erb` by using `@project_data[:path]` and `@pg.path` instead of `request.path`.
> 
>   - **Fix**:
>     - Corrects CA certificate download link in `views/postgres/connection.erb` by using `@project_data[:path]` and `@pg.path` instead of `request.path`.
>     - Ensures correct API endpoint generation for CA certificate download.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 39ca3f23b48eaa10dca76f3864c723f4dc6d7de9. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->