### PR TITLE
Improve restarter and respirate exit handling

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -78,3 +78,10 @@ DB.synchronize do
 end
 
 Clog.emit("Shutting down.") { {unfinished_strand_count: d.num_current_strands} }
+
+# Wait up to 2 seconds for all strand threads to exit.
+# We cannot wait very long, as every second we wait is potentially an
+# additional second that no respirate process is processing new strands.
+Thread.new do
+  d.shutdown_and_cleanup_threads
+end.join(2)

--- a/bin/restarter
+++ b/bin/restarter
@@ -6,6 +6,7 @@ require "json"
 
 command = ARGV.dup.freeze
 start_time = Time.now
+shutting_down = false
 
 iso_start = start_time.utc.strftime("%Y-%m-%dT%H:%M:%S%:z").freeze
 puts JSON.generate(restarter: {
@@ -17,7 +18,12 @@ puts JSON.generate(restarter: {
 })
 
 loop do
-  system(*command)
+  pid = Process.spawn(*command)
+  Signal.trap("TERM") do
+    Process.kill(:TERM, pid)
+    shutting_down = true
+  end
+  Process.wait(pid)
   status = $?
 
   # Extra newline to prevent blending with subprocess just in
@@ -35,6 +41,7 @@ loop do
       success: status.success?
     }
   })
+  break if shutting_down
 
   sleep(rand(1..10))
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -449,7 +449,7 @@ class Scheduling::Dispatcher
   # and then signalling the related apoptosis thread when the
   # strand run finishes.
   def strand_thread(strand_queue, start_queue, finish_queue)
-    while !@shutting_down && (strand = strand_queue.pop)
+    while (strand = strand_queue.pop) && !@shutting_down
       strand.worker_started!
       metrics = strand.respirate_metrics
       metrics.queue_size = strand_queue.size


### PR DESCRIPTION
This has restarter wait until respirate exits before exiting.  It also fixes some edge case in respirate shutdown.

The last commit here allows up to 2 additional seconds for respirate to finish processing strands.  That should reduce the percentage of expired strands during each deploy, at the cost of more time when no respirate process is handling new strands.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves shutdown handling by ensuring `restarter` waits for `respirate` to exit and allowing `respirate` extra time to finish processing strands.
> 
>   - **Behavior**:
>     - `restarter` now waits for `respirate` to exit before exiting itself, handling `TERM` signal to terminate `respirate` process in `bin/restarter`.
>     - `respirate` allows up to 2 additional seconds for strand threads to exit in `bin/respirate`.
>   - **Shutdown Handling**:
>     - In `scheduling/dispatcher.rb`, `shutdown_and_cleanup_threads` now uses `SizedQueue#close` for `@strand_queue` and pushes `nil` to `@metrics_queue` to ensure proper shutdown.
>     - `strand_thread` in `scheduling/dispatcher.rb` now handles `ClosedQueueError` during shutdown.
>   - **Misc**:
>     - Minor changes to signal handling and process management in `bin/restarter` and `bin/respirate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1f93e9956ca1f4641c66ff9e2162c09c27d1f945. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->