### PR TITLE
Use PrivateSubnet#nics_dataset to simplify code

### DIFF
--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -90,7 +90,7 @@ class Clover
             .exclude(label: "destroy")
             .exclude(Sequel[:vm][:id] => Semaphore
               .where(
-                strand_id: DB[:nic].where(private_subnet_id: ps.id).select(:vm_id),
+                strand_id: ps.nics_dataset.select(:vm_id),
                 name: "destroy"
               )
               .select(:strand_id))


### PR DESCRIPTION
Recommended in https://github.com/ubicloud/ubicloud/pull/3390#discussion_r2154363150 , but I didn't get to it when merging the related PR.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies code in `private_subnet.rb` by using `ps.nics_dataset` instead of direct `nic` table query.
> 
>   - **Code Simplification**:
>     - Replaces direct query to `DB[:nic]` with `ps.nics_dataset` in `routes/project/location/private_subnet.rb` to select `vm_id` for exclusion in `vms_dataset`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d8cf8c801182632c09c432d4e6d984c9afa306c9. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->