### PR TITLE
Fix exit status for respirate and restarter

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -84,4 +84,6 @@ Clog.emit("Shutting down.") { {unfinished_strand_count: d.num_current_strands} }
 # additional second that no respirate process is processing new strands.
 Thread.new do
   d.shutdown_and_cleanup_threads
+  exit 0
 end.join(2)
+exit 1

--- a/bin/restarter
+++ b/bin/restarter
@@ -41,7 +41,7 @@ loop do
       success: status.success?
     }
   })
-  break if shutting_down
+  exit status.exitstatus if shutting_down
 
   sleep(rand(1..10))
 


### PR DESCRIPTION
Make respirate return 1 if it wasn't able to cleanup all threads before shutting down.

Make restarter exit the same as the respirate process it was monitoring.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix exit status handling in `respirate` and `restarter` to ensure proper shutdown behavior.
> 
>   - **Behavior**:
>     - `respirate` now exits with status `1` if it fails to clean up all threads before shutdown.
>     - `restarter` exits with the same status as the `respirate` process it monitors when shutting down.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8fb0fe355e38f8088ffc3262d2f7e3c56c455857. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->