### PR TITLE
Bring back frozen arrays for flow control exception backtraces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -102,13 +102,15 @@ end
 
   class FlowControl < RuntimeError; end
 
+  EMPTY_ARRAY = [].freeze
+
   class Exit < FlowControl
     attr_reader :exitval
 
     def initialize(strand, exitval)
       @strand = strand
       @exitval = exitval
-      set_backtrace []
+      set_backtrace EMPTY_ARRAY
     end
 
     def to_s
@@ -123,7 +125,7 @@ end
       @old_prog = old_prog
       @old_label = old_label
       @strand_update_args = strand_update_args
-      set_backtrace []
+      set_backtrace EMPTY_ARRAY
     end
 
     def new_label
@@ -144,7 +146,7 @@ end
 
     def initialize(seconds)
       @seconds = seconds
-      set_backtrace []
+      set_backtrace EMPTY_ARRAY
     end
 
     def to_s


### PR DESCRIPTION
The related rspec bug was fixed in rspec-core 3.13.5.