### PR TITLE
Fixes for AWS setup

### DIFF
--- a/prog/aws/instance.rb
+++ b/prog/aws/instance.rb
@@ -5,7 +5,7 @@ class Prog::Aws::Instance < Prog::Base
   subject_is :vm
 
   label def start
-    public_keys = vm.sshable.keys.map(&:public_key).join("\n")
+    public_keys = (vm.sshable.keys.map(&:public_key) + (vm.project.get_ff_vm_public_ssh_keys || [])).join("\n")
     # Define user data script to set a custom username
     user_data = <<~USER_DATA
 #!/bin/bash

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -109,7 +109,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   def destroy_aws_s3
-    iam = Aws::IAM::Client.new(access_key_id: postgres_timeline.location.location_credential.access_key, secret_access_key: postgres_timeline.location.location_credential.secret_key)
+    iam = Aws::IAM::Client.new(access_key_id: postgres_timeline.location.location_credential.access_key, secret_access_key: postgres_timeline.location.location_credential.secret_key, region: postgres_timeline.location.name)
     iam.list_attached_user_policies(user_name: postgres_timeline.ubid).attached_policies.each do |it|
       iam.detach_user_policy(user_name: postgres_timeline.ubid, policy_arn: it.policy_arn)
       iam.delete_policy(policy_arn: it.policy_arn)
@@ -131,7 +131,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   def setup_aws_s3
-    iam = Aws::IAM::Client.new(access_key_id: postgres_timeline.location.location_credential.access_key, secret_access_key: postgres_timeline.location.location_credential.secret_key)
+    iam = Aws::IAM::Client.new(access_key_id: postgres_timeline.location.location_credential.access_key, secret_access_key: postgres_timeline.location.location_credential.secret_key, region: postgres_timeline.location.name)
 
     iam.create_user(user_name: postgres_timeline.ubid)
     policy = iam.create_policy(policy_name: postgres_timeline.ubid, policy_document: postgres_timeline.blob_storage_policy.to_json)

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     describe "when blob storage is aws s3" do
       it "creates user and policies and hops" do
         expect(postgres_timeline).to receive(:aws?).and_return(true)
-        expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, location_credential: instance_double(LocationCredential, access_key: "access-key", secret_key: "secret-key"))).at_least(:once)
+        expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, name: "us-west-2", location_credential: instance_double(LocationCredential, access_key: "access-key", secret_key: "secret-key"))).at_least(:once)
         client = Aws::IAM::Client.new(stub_responses: true)
         expect(Aws::IAM::Client).to receive(:new).and_return(client)
         client.stub_responses(:create_user)
@@ -217,7 +217,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     describe "when blob storage is aws s3" do
       before do
         expect(postgres_timeline).to receive(:aws?).and_return(true)
-        expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, location_credential: instance_double(LocationCredential, access_key: "access-key", secret_key: "secret-key"))).at_least(:once)
+        expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, name: "us-west-2", location_credential: instance_double(LocationCredential, access_key: "access-key", secret_key: "secret-key"))).at_least(:once)
       end
 
       it "destroys blob storage and postgres timeline" do


### PR DESCRIPTION
**Pass region while creating Aws::IAM::Client**
`Aws::IAM::Client` requires a region to be specified when creating an instance.
This change ensures that the client is initialized with the correct region.

**Add project public keys on AWS resources**
We are adding the public keys in the project to the VMs authorized_keys file
for the other providers but not for AWS. This commit adds the public keys
to the AWS resources as well.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix AWS IAM client initialization with region and add project public keys to AWS VMs.
> 
>   - **AWS IAM Client Initialization**:
>     - Add `region` parameter to `Aws::IAM::Client` initialization in `destroy_aws_s3` and `setup_aws_s3` in `prog/postgres/postgres_timeline_nexus.rb`.
>     - Update tests in `postgres_timeline_nexus_spec.rb` to include `region` in mock expectations.
>   - **Public Keys on AWS VMs**:
>     - Modify `start` method in `prog/aws/instance.rb` to include project public keys in `authorized_keys` for AWS VMs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4b998e72d6e0334b8ac9460a395ba562ab6ce435. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->