### PR TITLE
Optimize Strand#take_lease_and_reload

### DIFF
--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -48,14 +48,14 @@ RSpec.describe Strand do
     it "does an integrity check that the lease was modified as expected" do
       st.label = "napper"
       st.save_changes
-      original = DB.method(:[])
+      original = DB.method(:prepared_statement)
       original = original.super_method unless original.owner == Sequel::Database
-      expect(DB).to receive(:[]) do |*args, **kwargs|
-        case args[0]
-        when /UPDATE strand SET lease = .* WHERE id = \? AND lease = \?/
-          instance_double(Sequel::Dataset, update: 0)
+      expect(DB).to receive(:prepared_statement) do |ps_name|
+        case ps_name
+        when :strand_release_lease
+          instance_double(Sequel::Dataset, call: 0)
         else
-          original.call(*args, **kwargs)
+          original.call(ps_name)
         end
       end.at_least(:once)
 

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -52,10 +52,7 @@ RSpec.describe Strand do
       original = original.super_method unless original.owner == Sequel::Database
       expect(DB).to receive(:[]) do |*args, **kwargs|
         case args[0]
-        when /UPDATE strand
-SET lease = .*
-WHERE id = \? AND lease = \?
-/
+        when /UPDATE strand SET lease = .* WHERE id = \? AND lease = \?/
           instance_double(Sequel::Dataset, update: 0)
         else
           original.call(*args, **kwargs)

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -48,19 +48,10 @@ RSpec.describe Strand do
     it "does an integrity check that the lease was modified as expected" do
       st.label = "napper"
       st.save_changes
-      original = DB.method(:prepared_statement)
-      original = original.super_method unless original.owner == Sequel::Database
-      expect(DB).to receive(:prepared_statement) do |ps_name|
-        case ps_name
-        when :strand_release_lease
-          instance_double(Sequel::Dataset, call: 0)
-        else
-          original.call(ps_name)
-        end
-      end.at_least(:once)
-
+      expect(st).to receive(:unsynchronized_run) do
+        st.this.update(lease: Sequel[:lease] + Sequel.cast("1 second", :interval))
+      end
       expect(Clog).to receive(:emit).with("lease violated data").and_call_original
-      allow(Clog).to receive(:emit).and_call_original
       expect { st.run }.to raise_error RuntimeError, "BUG: lease violated"
     end
   end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -45,7 +45,7 @@ module ThawedMock
   allow_mocking(Time, :now)
 
   # Database
-  allow_mocking(DB, :[])
+  allow_mocking(DB, :[], :prepared_statement)
 
   # Models
   allow_mocking(Account, :[])

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -45,7 +45,7 @@ module ThawedMock
   allow_mocking(Time, :now)
 
   # Database
-  allow_mocking(DB, :[], :prepared_statement)
+  allow_mocking(DB, :[])
 
   # Models
   allow_mocking(Account, :[])


### PR DESCRIPTION
This has three separate changes:

* Remove lease_clear_debug_snapshot for every strand checkin
* Use a prepared statement for the strand release lease UPDATE
* Use Strand constants for prepared statements

See individual commit messages for details.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `Strand#take_lease_and_reload` by removing redundant operations and using prepared statements for database updates.
> 
>   - **Optimization**:
>     - Remove `lease_clear_debug_snapshot` for every strand check-in in `strand.rb`.
>     - Use prepared statements `TAKE_LEASE_PS` and `RELEASE_LEASE_PS` for lease operations in `strand.rb`.
>   - **Testing**:
>     - Update tests in `strand_spec.rb` to reflect changes in lease handling and ensure integrity checks are performed correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4a0d3e24d25ee280011e6d55e3d2deb7c32058b2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->