### PR TITLE
Avoid recursion if VmHost#veth_pair_random_ip4_addr selects address in use

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -178,16 +178,29 @@ class VmHost < Sequel::Model
     [picked_subnet, used_subnet]
   end
 
-  def veth_pair_random_ip4_addr
-    addr = NetAddr::IPv4Net.parse("169.254.0.0/16")
-    # we get 1 address here and use the next address to assign
-    # route for vetho* and vethi* devices. So, we are splitting the local address
-    # space to two but only store 1 of them for the existence check.
-    # that's why the range is 2 * ((addr.len - 2) / 2)
-    selected_addr = NetAddr::IPv4Net.new(addr.nth(2 * SecureRandom.random_number((addr.len - 2) / 2)), NetAddr::Mask32.new(32))
+  # IPv4 range to use for setting local_vetho_ip for VM in hosts.
+  APIPA_RANGE = NetAddr::IPv4Net.parse("169.254.0.0/16").freeze
 
-    return veth_pair_random_ip4_addr if selected_addr.network.to_s.nil? || vms.any? { |vm| vm.local_vetho_ip == selected_addr.network.to_s }
-    selected_addr
+  # Calculate number of usable addresses in above range.  However, substract 1024.
+  # If the random assignment conflict with an already used address, we increment
+  # instead of looking for a different random assignment. Doing so can have problems
+  # when you are near the top of the range, so carve out 1024 spots at the top of
+  # the range. This should work correctly as long as a host does not run more than
+  # 1024 VMs.
+  #
+  # we get 1 address here and use the next address to assign
+  # route for vetho* and vethi* devices. So, we are splitting the local address
+  # space to two but only store 1 of them for the existence check.
+  # that's why the range is 2 * ((addr.len - 2) / 2)
+  APIPA_LEN = ((APIPA_RANGE.len - 2) / 2) - 1024
+
+  APIPA_MASK = NetAddr::Mask32.new(32).freeze
+
+  def veth_pair_random_ip4_addr
+    ips = vms_dataset.select_map(:local_vetho_ip)
+    ip = APIPA_RANGE.nth(2 * SecureRandom.random_number(APIPA_LEN))
+    ip = ip.next.next while ips.include?(ip.to_s)
+    NetAddr::IPv4Net.new(ip, APIPA_MASK)
   end
 
   def sshable_address


### PR DESCRIPTION
Instead of recursing and trying a new random address, keep trying the next valid address until an unused address is found.  Carve out the top of the range so we can be sure to always find a valid address before the end of the range.

While I believe this is an uncommon operation (even for a fully loaded host with 30 VMs, should only be a < 1/1000 chance of random address already being used), I'd like to avoid recursive approaches based on randomness.

In addition to removing recursion, this also reduces object allocation using constants.

This selects existing local_vetho_ip values using the association dataset instead of the association array.  This is only called by the allocator, and at the point it is called, the association is not cached, so using the dataset and only selecting the needed column is faster and uses less memory.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `veth_pair_random_ip4_addr` in `vm_host.rb` now iterates through IPs to find an unused one, avoiding recursion and optimizing memory usage.
> 
>   - **Behavior**:
>     - `veth_pair_random_ip4_addr` in `vm_host.rb` now iterates through IPs instead of using recursion to find an unused IP.
>     - Carves out 1024 addresses at the top of the range to ensure a valid IP is always found.
>   - **Performance**:
>     - Reduces object allocation by using constants for IP range and mask.
>   - **Testing**:
>     - Updates tests in `vm_host_spec.rb` to verify new IP selection logic without recursion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b760b72daffd47b32902961a96efa0cc9bea6952. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->