### PR TITLE
Filter in the database for VmHost#sshable_address

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -191,7 +191,7 @@ class VmHost < Sequel::Model
   end
 
   def sshable_address
-    assigned_host_addresses.find { |a| a.ip.version == 4 }
+    assigned_host_addresses_dataset.first { {family(ip) => 4} }
   end
 
   def spdk_cpu_count

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -252,8 +252,8 @@ RSpec.describe VmHost do
   end
 
   it "sshable_address returns the sshable address" do
-    expect(vh).to receive(:assigned_host_addresses).and_return([assigned_host_address])
-    expect(vh.sshable_address).to eq(assigned_host_address)
+    vm_host = Prog::Vm::HostNexus.assemble("128.0.0.1").subject
+    expect(vm_host.sshable_address.ip.network.to_s).to eq("128.0.0.1")
   end
 
   it "hetznerifies a host" do


### PR DESCRIPTION
This appears to only be used in bin/stress_up, but in general we should not select all associated rows if we only need the first.