### PR TITLE
Fix respirate partitioning on Heroku when using heroku run bin/respriate

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -2,10 +2,8 @@
 # frozen_string_literal: true
 
 partition_number = ARGV[0]
-partition_number ||= if (dyno = ENV["DYNO"])
-  dyno.split(".", 2)[1] # Heroku
-elsif (match = /respirate\.(\d+)\z/.match(ENV["PS"]))
-  match[1] # Foreman
+partition_number ||= if (match = /respirate\.(\d+)\z/.match(ENV["DYNO"] || ENV["PS"]))
+  match[1] # Heroku/Foreman
 end
 
 if partition_number

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -181,7 +181,7 @@ class Scheduling::Dispatcher
     @partition_recheck_time = Time.now + (@listen_timeout * rand * 2)
 
     DB.listen(:respirate, loop:, after_listen: proc { notify_partition }, timeout: @listen_timeout) do |_, _, payload|
-      unless (partition_num = Integer(payload, exception: false))
+      unless (partition_num = Integer(payload, exception: false)) && (partition_num <= 256)
         Clog.emit("invalid respirate repartition notification") { {payload:} }
         next
       end


### PR DESCRIPTION
To try to avoid strand delay spikes during deployments, I had the bright idea to run `heroku run -r prod bin/respirate`. Unfortunately, due to respirate DYNO environment variable parsing and a lack of sanity checking in the dispatcher, this resulted in increased delay during the deployment.  This should fix the issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `respirate` partitioning on Heroku by improving environment variable parsing and adding validation for partition numbers.
> 
>   - **Behavior**:
>     - Fix `partition_number` parsing in `bin/respirate` by consolidating Heroku and Foreman logic.
>     - Add validation in `repartition_thread` in `dispatcher.rb` to ensure `partition_num` is <= 256.
>   - **Tests**:
>     - Update `dispatcher_spec.rb` to test invalid `respirate` notifications for values like `foo` and `257`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 655e9bc81797bda2d4263e47a70af834c13d0ad6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->