### PR TITLE
Have last exiting child schedule parent strand

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -208,7 +208,7 @@ SQL
       update(exitval: ext.exitval, retval: nil)
       if parent_id.nil?
         # No parent Strand to reap here, so self-reap.
-        Semaphore.where(strand_id: id).destroy
+        semaphores_dataset.destroy
         destroy
         @deleted = true
       end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -105,9 +105,32 @@ SQL
           fail "BUG: strand with @deleted set still exists in the database"
         end
       else
-        unless RELEASE_LEASE_PS.call(id:, lease_time:) == 1
-          Clog.emit("lease violated data") { {lease_clear_debug_snapshot: this.all} }
-          fail "BUG: lease violated"
+        begin
+          unless RELEASE_LEASE_PS.call(id:, lease_time:) == 1
+            Clog.emit("lease violated data") { {lease_clear_debug_snapshot: this.all} }
+            fail "BUG: lease violated"
+          end
+        ensure
+          if @exited
+            active_siblings_ds = Strand.from { strand.as(:siblings) }
+              .where(parent_id: Sequel[:strand][:id])
+              .where(Sequel.lit("lease < now() AND exitval IS NOT NULL"))
+              .select(1)
+
+            # If exited child has no active siblings, schedule parent immediately,
+            # so all exited children can be reaped.
+            #
+            # To avoid race conditions, we do this after the lease for the child
+            # has been released. It's possible that multiple children could be
+            # calling this update concurrently, but that is fine. We must avoid
+            # the case where this is not called by the last exiting child, as
+            # that otherwise can result in up to 120s delay in parent strand
+            # execution.
+            Strand
+              .where(id: parent_id)
+              .exclude(active_siblings_ds.exists)
+              .update(schedule: Sequel::CURRENT_TIMESTAMP)
+          end
         end
       end
     end
@@ -206,7 +229,9 @@ SQL
       Clog.emit("exited") { {strand_exited: {duration: Time.now - last_changed_at, from: prog_label}} }
 
       update(exitval: ext.exitval, retval: nil)
-      if parent_id.nil?
+      if parent_id
+        @exited = true
+      else
         # No parent Strand to reap here, so self-reap.
         semaphores_dataset.destroy
         destroy

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -106,7 +106,7 @@ SQL
         end
       else
         unless RELEASE_LEASE_PS.call(id:, lease_time:) == 1
-          Clog.emit("lease violated data") { {lease_clear_debug_snapshot: this.for_update.all} }
+          Clog.emit("lease violated data") { {lease_clear_debug_snapshot: this.all} }
           fail "BUG: lease violated"
         end
       end

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
 
     it "donates if there are sub-programs running" do
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_bootstrap_rhizome }.to nap(1)
+      expect { nx.wait_bootstrap_rhizome }.to nap(120)
     end
   end
 

--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
 
     it "donates if there are sub-programs running" do
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_bootstrap_rhizome }.to nap(1)
+      expect { nx.wait_bootstrap_rhizome }.to nap(120)
     end
   end
 

--- a/spec/prog/install_dnsmasq_spec.rb
+++ b/spec/prog/install_dnsmasq_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Prog::InstallDnsmasq do
     it "donates if any sub-progs are still running" do
       st.update(label: "wait_downloads", stack: [{}])
       Strand.create(parent_id: st.id, prog: "InstallDnsmasq", label: "install_build_dependencies", stack: [{}], lease: Time.now + 10)
-      expect { idm.wait_downloads }.to nap(1)
+      expect { idm.wait_downloads }.to nap(120)
     end
 
     it "hops to compile_and_install when the downloads are done" do

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     it "donates if there are sub-programs running" do
       st.update(prog: "Kubernetes::KubernetesClusterNexus", label: "wait_control_plane_node", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_control_plane_node }.to nap(1)
+      expect { nx.wait_control_plane_node }.to nap(120)
     end
   end
 
@@ -315,7 +315,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     it "donates if there are sub-programs running" do
       st.update(prog: "Kubernetes::KubernetesClusterNexus", label: "destroy", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_upgrade }.to nap(1)
+      expect { nx.wait_upgrade }.to nap(120)
     end
   end
 
@@ -323,7 +323,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     it "donates if there are sub-programs running (Provision...)" do
       st.update(prog: "Kubernetes::KubernetesClusterNexus", label: "destroy", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.destroy }.to nap(1)
+      expect { nx.destroy }.to nap(120)
     end
 
     it "triggers deletion of associated resources and naps until all nodepools are gone" do

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     it "donates if there are sub-programs running" do
       st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_worker_node", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_worker_node }.to nap(1)
+      expect { nx.wait_worker_node }.to nap(120)
     end
   end
 
@@ -224,7 +224,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     it "donates if there are sub-programs running" do
       st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_upgrade", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::UpgradeKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_upgrade }.to nap(1)
+      expect { nx.wait_upgrade }.to nap(120)
     end
   end
 
@@ -232,7 +232,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     it "donates if there are sub-programs running (Provision...)" do
       st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_upgrade", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::UpgradeKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.destroy }.to nap(1)
+      expect { nx.destroy }.to nap(120)
     end
 
     it "destroys the nodepool and its vms" do

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -176,7 +176,7 @@ table ip6 pod_access {
     it "donates if there are sub-programs running" do
       st.update(prog: "Kubernetes::ProvisionKubernetesNode", label: "wait_bootstrap_rhizome", stack: [{}])
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { prog.wait_bootstrap_rhizome }.to nap(1)
+      expect { prog.wait_bootstrap_rhizome }.to nap(120)
     end
   end
 

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
       st.update(prog: "Kubernetes::UpgradeKubernetesNode", label: "somestep", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
       kubernetes_cluster.strand.label = "destroy"
-      expect { prog.before_run }.to nap(1)
+      expect { prog.before_run }.to nap(120)
     end
   end
 
@@ -84,7 +84,7 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
     it "donates if there are sub-programs running" do
       st.update(prog: "Kubernetes::UpgradeKubernetesNode", label: "wait_new_node", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { prog.wait_new_node }.to nap(1)
+      expect { prog.wait_new_node }.to nap(120)
     end
 
     it "hops to assign_role if there are no sub-programs running" do

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   describe "#wait_bootstrap_rhizome" do
     it "donates if bootstrap rhizome continues" do
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_bootstrap_rhizome }.to nap(1)
+      expect { nx.wait_bootstrap_rhizome }.to nap(120)
     end
 
     it "hops to setup if bootstrap rhizome is done" do
@@ -199,7 +199,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   describe "#wait_setup" do
     it "donates if setup continues" do
       Strand.create(parent_id: st.id, prog: "SetupMinio", label: "mount_data_disks", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_setup }.to nap(1)
+      expect { nx.wait_setup }.to nap(120)
     end
 
     it "hops to wait if setup is done" do
@@ -319,7 +319,7 @@ RSpec.describe Prog::Minio::MinioServerNexus do
   describe "#wait_reconfigure" do
     it "donates if reconfigure continues" do
       Strand.create(parent_id: st.id, prog: "SetupMinio", label: "configure_minio", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_reconfigure }.to nap(1)
+      expect { nx.wait_reconfigure }.to nap(120)
     end
 
     it "hops to wait if reconfigure is done" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "donates if there are sub-programs running" do
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_bootstrap_rhizome }.to nap(1)
+      expect { nx.wait_bootstrap_rhizome }.to nap(120)
     end
   end
 

--- a/spec/prog/setup_grafana_spec.rb
+++ b/spec/prog/setup_grafana_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Prog::SetupGrafana do
   describe "#wait_for_rhizome" do
     it "donates if install_rhizome is not done" do
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { sn.wait_for_rhizome }.to nap(1)
+      expect { sn.wait_for_rhizome }.to nap(120)
     end
 
     it "hops to install_grafana when rhizome is done" do

--- a/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
+++ b/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
     it "donates if bootstrap is not complete" do
       st.update(prog: "VictoriaMetrics::VictoriaMetricsServerNexus", label: "wait_bootstrap_rhizome", stack: [{}])
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_bootstrap_rhizome }.to nap(1)
+      expect { nx.wait_bootstrap_rhizome }.to nap(120)
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
     it "donates to children if they are not exited yet" do
       Strand.create(parent_id: st.id, prog: "LearnCpu", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_prep }.to nap(1)
+      expect { nx.wait_prep }.to nap(120)
     end
   end
 
@@ -297,7 +297,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
     it "donates its time if child strands are still running" do
       Strand.create(parent_id: st.id, prog: "DownloadBootImage", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_download_boot_images }.to nap(1)
+      expect { nx.wait_download_boot_images }.to nap(120)
     end
   end
 


### PR DESCRIPTION
Previously, when reaping child processes, if there were no remaining
reapable children, the parent strand would only nap 1, which puts
unnecessary load on respirate unless at least one child strand
exits in the next second.

Change this approach by having the exiting child strands, after they
release the lease, schedule their parent immediately if the parent
has no non-exited child strands.

When doing this, you need to be careful to make sure there are not
race conditions that would delay the scheduling of the parent.
There are two potential situations you need to handle:

1. Multiple children exiting at the same time
2. Parent currently running while child is exiting

By waiting until after the child strand leases are released, you
still have a race condition with 1, but the race condition is that 
multiple child strands exiting concurrently could both reschedule
the parent strand.  However, that isn't a problem. You want to avoid
the case where neither child strand schedules the parent, which
rescheduling after releasing the lease should do.

To handle 2, inside reap use Model#lock! to lock the parent strand.
This will make exiting child strands block if they UPDATE the parent
strand with a new schedule, until the parent strand's transaction
commits.  However, it's possible that a child strand already UPDATED
the parent. To handle this situation, before calling lock!, store
the cached schedule value in a local variable.  lock! implicitly does
a reload, so compare the schedule value after reload.  If the schedule
has changed, likely a child scheduled the parent for immediate
execution, so nap 0 in that case.

Just in case there are unforeseen race conditions that are not handled,
only nap for 120 seconds if there are active children.  Worst case
scenario, this results in a 2 minute delay for running the parent.
However, this can potentially result in 120x less load from parent
strands polling children.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize parent strand scheduling by having the last exiting child schedule the parent immediately, reducing unnecessary load and potential delays.
> 
>   - **Behavior**:
>     - Exiting child strands now schedule their parent immediately if no active siblings exist, reducing potential 120s delay (`strand.rb`).
>     - Parent strand locks during reap to prevent race conditions (`base.rb`).
>     - Default nap time increased to 120s if active children exist (`base.rb`).
>   - **Tests**:
>     - Updated nap expectations from 1s to 120s in various test files (`inference_endpoint_replica_nexus_spec.rb`, `inference_router_replica_nexus_spec.rb`, `install_dnsmasq_spec.rb`, `kubernetes_cluster_nexus_spec.rb`, `kubernetes_nodepool_nexus_spec.rb`, `provision_kubernetes_node_spec.rb`, `upgrade_kubernetes_node_spec.rb`, `minio_server_nexus_spec.rb`, `postgres_server_nexus_spec.rb`, `setup_grafana_spec.rb`, `vm_group_spec.rb`, `victoria_metrics_server_nexus_spec.rb`, `host_nexus_spec.rb`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 79843f8dccbb8c3be720517bc9146e355f8413c0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->