### PR TITLE
[openapi] use shared request body for load balancer creation requests

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -288,40 +288,7 @@ paths:
       operationId: createLoadBalancer
       summary: Create a new Load Balancer in a project
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                algorithm:
-                  description: Algorithm of the Load Balancer
-                  type: string
-                stack:
-                  description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
-                  type: string
-                dst_port:
-                  description: Destination port for the Load Balancer
-                  type: integer
-                health_check_endpoint:
-                  description: Health check endpoint URL
-                  type: string
-                health_check_protocol:
-                  description: Health check endpoint protocol
-                  type: string
-                private_subnet_id:
-                  description: ID of Private Subnet
-                  type: string
-                src_port:
-                  description: Source port for the Load Balancer
-                  type: integer
-              additionalProperties: false
-              required:
-                - algorithm
-                - dst_port
-                - health_check_protocol
-                - private_subnet_id
-                - src_port
+        $ref: '#/components/requestBodies/LoadBalancer'
       responses:
         '200':
           $ref: '#/components/responses/LoadBalancer'
@@ -626,40 +593,7 @@ paths:
       operationId: createLocationLoadBalancer
       summary: Create a new Load Balancer in a specific location of a project
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                algorithm:
-                  description: Algorithm of the Load Balancer
-                  type: string
-                stack:
-                  description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
-                  type: string
-                dst_port:
-                  description: Destination port for the Load Balancer
-                  type: integer
-                health_check_endpoint:
-                  description: Health check endpoint URL
-                  type: string
-                health_check_protocol:
-                  description: Health check endpoint protocol
-                  type: string
-                private_subnet_id:
-                  description: ID of Private Subnet
-                  type: string
-                src_port:
-                  description: Source port for the Load Balancer
-                  type: integer
-              additionalProperties: false
-              required:
-                - algorithm
-                - dst_port
-                - health_check_protocol
-                - private_subnet_id
-                - src_port
+        $ref: '#/components/requestBodies/LoadBalancer'
       responses:
         '200':
           $ref: '#/components/responses/LoadBalancer'
@@ -2146,6 +2080,42 @@ components:
         - state
         - storage_size_gib
         - unix_user
+  requestBodies:
+    LoadBalancer:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              algorithm:
+                description: Algorithm of the Load Balancer
+                type: string
+              stack:
+                description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
+                type: string
+              dst_port:
+                description: Destination port for the Load Balancer
+                type: integer
+              health_check_endpoint:
+                description: Health check endpoint URL
+                type: string
+              health_check_protocol:
+                description: Health check endpoint protocol
+                type: string
+              private_subnet_id:
+                description: ID of Private Subnet
+                type: string
+              src_port:
+                description: Source port for the Load Balancer
+                type: integer
+            additionalProperties: false
+            required:
+              - algorithm
+              - dst_port
+              - health_check_protocol
+              - private_subnet_id
+              - src_port
   responses:
     Delete:
       description: An empty response after successful resource delete


### PR DESCRIPTION
I noted a couple of other discrepancies/inconsistencies related to this that I wanted to call out (they are a bit less easy to fix and I have limited availability, so I thought I would share/highlight to start and then figure out if I should tackle them).

1. Although the API allows creation of load balancers at either the project layer or project+location layer, it only allows them to be edited at the project+location layer. Unless there is a technical reason for this, it might be better to allow editing at both layers. Delete for load balancers is also only available at the project+location layer, fwiw.
2. The create methods have the same request bodies, but update differs (otherwise I would have moved it to the shared requestBody as well). Patch adds a `vms` field that is not available at creation time. From talking briefly to @fdr it sounds like this was likely just oversight. So it would be great to add `vms` to the create method for consistency (and then shift the patch method to also use the same shared requestBody to simplify and avoid drift).