### PR TITLE
Make cloudify_server Hetzner-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,20 @@ The control plane is responsible for cloudifying bare metal Linux machines.
 The easiest way to build your own cloud is to lease instances from one of those
 providers. For example: https://www.hetzner.com/sb
 
-Once you lease instance(s), run the following script for each instance to cloudify
-the instance. By default, the script cloudifies bare metal instances leased from 
-Hetzner. After you cloudify your instances, you can provision and manage cloud 
+Once you lease instance(s), update the `.env` file with the following environment
+variables:
+- `HETZNER_USER`
+- `HETZNER_PASSWORD`
+- `HETZNER_SSH_PUBLIC_KEY`
+- `HETZNER_SSH_PRIVATE_KEY`
+
+Then, run the following script for each instance to cloudify it.
+Currently, the script cloudifies bare metal instances leased from Hetzner.
+After you cloudify your instances, you can provision and manage cloud
 resources on these machines.
 
 ```
-# Enter hostname/IP and provider, and install SSH key as instructed by script
+# Enter hostname/IP and provider
 docker exec -it ubicloud-app ./demo/cloudify_server
 ```
 

--- a/demo/cloudify_server
+++ b/demo/cloudify_server
@@ -7,6 +7,7 @@ require_relative "../loader"
 require "timeout"
 
 LOCATIONS = Location.where(visible: true).map { |l| [l, "#{l.provider} #{l.name} (#{l.display_name})"] }.to_h
+REQUIRED_ENV_VARS = %w[HETZNER_USER HETZNER_PASSWORD HETZNER_SSH_PUBLIC_KEY HETZNER_SSH_PRIVATE_KEY].freeze
 
 def get_input(msg, default = nil)
   prompt = "#{msg}#{default.nil? ? "" : " [default: #{default}]"}: "
@@ -46,32 +47,39 @@ def select_option(msg, options, default = nil)
   selected
 end
 
+unless REQUIRED_ENV_VARS.all? { Config.public_send(it.downcase) }
+  puts "Please set the following variables in the .env file and re-run docker-compose up:"
+  puts REQUIRED_ENV_VARS.join("\n")
+  exit 1
+end
+
 hostname = get_input("Enter host IP address")
 host_id = get_input("Enter host identifier", "")
 location = select_option("Select provider and location", LOCATIONS, 1)
 
 puts "\n\nCloudifying '#{hostname}' server for '#{LOCATIONS[location]}' \n\n"
 
-strand = Prog::Vm::HostNexus.assemble(
-  hostname,
-  provider_name: location.provider,
-  server_identifier: host_id,
-  location: location.name,
-  default_boot_images: ["ubuntu-jammy"]
-)
-
-puts "Waiting public SSH keys\n\n"
-until (ssh_key = strand.reload.subject.sshable.keys.map(&:public_key).first)
-  sleep 2
+if location.provider != HostProvider::HETZNER_PROVIDER_NAME
+  puts "Currently only Hetzner is supported for this demo. Please use a Hetzner server for cloudification."
+  exit 1
 end
-puts "Add following public SSH key to '/root/.ssh/authorized_keys' on your machine\n\n"
-puts ssh_key
 
-print "\n\nPress enter after you add the above SSH key to your machine\n\n"
-gets.chomp
+strand = if (vmh = VmHost.all.find { it.sshable.host == hostname && it.location == location && it.provider.server_identifier == host_id })
+  puts "Found existing cloudified server for '#{hostname}' with ID: #{vmh.id}"
+  vmh.strand
+else
+  # Create a new strand for the cloudified server
+  Prog::Vm::HostNexus.assemble(
+    hostname,
+    provider_name: location.provider,
+    server_identifier: host_id,
+    location_id: location.id,
+    default_boot_images: ["ubuntu-jammy"]
+  )
+end
 
 begin
-  Timeout.timeout(10 * 60) do
+  Timeout.timeout(30 * 60) do
     puts "Waiting for server to be cloudified"
     previous_state = nil
     while (state = strand.reload.label) != "wait"
@@ -84,7 +92,7 @@ begin
   end
 rescue Timeout::Error
   puts "\n\n"
-  puts "Could not cloudify server in 10 minutes. Probably something went wrong."
+  puts "Could not cloudify server in 30 minutes. Probably something went wrong."
   puts "Last state: #{strand.label}. Server ID for debug: #{strand.id}"
   puts "Please check your hostname/IP address and be sure that you added the correct public SSH key to your server."
   puts "You can ask for help on GitHub discussion page: https://github.com/ubicloud/ubicloud/discussions"

--- a/demo/cloudify_server
+++ b/demo/cloudify_server
@@ -79,7 +79,7 @@ else
     provider_name: location.provider,
     server_identifier: host_id,
     location_id: location.id,
-    default_boot_images: ["ubuntu-jammy"]
+    default_boot_images: ["ubuntu-noble"]
   )
 end
 

--- a/demo/cloudify_server
+++ b/demo/cloudify_server
@@ -64,7 +64,12 @@ if location.provider != HostProvider::HETZNER_PROVIDER_NAME
   exit 1
 end
 
-strand = if (vmh = VmHost.all.find { it.sshable.host == hostname && it.location == location && it.provider.server_identifier == host_id })
+vm_host_ds = VmHost
+  .where(id: Sshable.where(host: hostname).select(:id))
+  .where(id: HostProvider.where(server_identifier: host_id).select(:id))
+  .where(location_id: location.id)
+
+strand = if (vmh = vm_host_ds.first)
   puts "Found existing cloudified server for '#{hostname}' with ID: #{vmh.id}"
   vmh.strand
 else


### PR DESCRIPTION
As we developed clover, we made more assumptions about the hosting providers and coupled the code with them, specifically Hetzner. As reported by users, things break in the cloudify_server demo script and we don't do a great job at actively maintaining it.

This commit applies some modifications to the cloudify_server script:
- Make the script Hetzner-only
- Ask for Hetzner details to be entered in .env file beforehand
- Allow re-issue of the script on the same host, for retry attempts
- Bump the VmHost init timeout from 10m to 30m
- Update VM image downloaded to the Host to Ubuntu Noble
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make `cloudify_server` script Hetzner-specific, requiring Hetzner credentials in `.env` and allowing retries on the same host.
> 
>   - **Behavior**:
>     - `cloudify_server` script is now Hetzner-only, exiting if a non-Hetzner provider is selected.
>     - Requires `HETZNER_USER`, `HETZNER_PASSWORD`, `HETZNER_SSH_PUBLIC_KEY`, `HETZNER_SSH_PRIVATE_KEY` in `.env` file.
>     - Allows re-running the script on the same host by checking existing cloudified servers.
>     - Increases `VmHost` initialization timeout from 10m to 30m.
>   - **Documentation**:
>     - Updates `README.md` to reflect Hetzner-only support and `.env` file requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 44336c24d1163209a970663870a9ebc46444820c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->