### PR TITLE
Add standard-32 and 64 to ubi-on-aws PG sizes

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -103,11 +103,12 @@ class Clover
       family_from_size, vcpu_count = size.split("-")
 
       next false if family_from_size != family
-      next false if location.provider == "aws" && vcpu_count.to_i > 16
+      next false if location.provider == "aws" && [30, 60].include?(vcpu_count.to_i)
+      next false if location.provider != "aws" && [32, 64].include?(vcpu_count.to_i)
       true
     end
 
-    aws_storage_size_options = {2 => ["118"], 4 => ["238"], 8 => ["475"], 16 => ["950"]}
+    aws_storage_size_options = {2 => ["118"], 4 => ["238"], 8 => ["475"], 16 => ["950"], 32 => ["1900"], 64 => ["3800"]}
     storage_size_options = Option::POSTGRES_STORAGE_SIZE_OPTIONS + aws_storage_size_options.values.flatten.uniq
     options.add_option(name: "storage_size", values: storage_size_options, parent: "size") do |flavor, location, family, size, storage_size|
       vcpu_count = size.split("-").last.to_i

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -68,6 +68,9 @@ module Option
     storage_size_options = [it * 10, it * 20]
     io_limits = IoLimits.new(it * 50, it * 50)
     VmSize.new("burstable-#{it}", "burstable", it, it * 50, it * 50, (it * 1.6).to_i, storage_size_options, io_limits, false, "arm64")
+  }).concat([32, 64].map {
+    storage_size_options = [it * 20, it * 40]
+    VmSize.new("standard-#{it}", "standard", it, it * 100, 0, it * 4, storage_size_options, NO_IO_LIMITS, false, "x64")
   }).freeze
 
   # Postgres Global Options
@@ -91,7 +94,9 @@ module Option
     ["standard", 8, 32],
     ["standard", 16, 64],
     ["standard", 30, 120],
+    ["standard", 32, 128],
     ["standard", 60, 240],
+    ["standard", 64, 256],
     ["burstable", 1, 2],
     ["burstable", 2, 4]
   ].map { |args| ["#{args[0]}-#{args[1]}", PostgresSizeOption.new("#{args[0]}-#{args[1]}", *args)] }.to_h.freeze

--- a/prog/aws/instance.rb
+++ b/prog/aws/instance.rb
@@ -30,7 +30,9 @@ usermod -L ubuntu
       2 => "m6id.large",
       4 => "m6id.xlarge",
       8 => "m6id.2xlarge",
-      16 => "m6id.4xlarge"
+      16 => "m6id.4xlarge",
+      32 => "m6id.8xlarge",
+      64 => "m6id.16xlarge"
     }
     instance_response = client.run_instances({
       image_id: vm.boot_image, # AMI ID

--- a/prog/aws/instance.rb
+++ b/prog/aws/instance.rb
@@ -90,16 +90,6 @@ usermod -L ubuntu
       vm.sshable&.update(host: public_ipv4)
       vm.update(cores: vm.vcpus / 2, allocated_at: Time.now, ephemeral_net6: instance_response.dig(:network_interfaces, 0, :ipv_6_addresses, 0, :ipv_6_address))
 
-      if (disk_size = vm.strand.stack.first["storage_volumes"].find { it["boot"] == false }&.dig("size_gib") || 0) > 0
-        VmStorageVolume.create_with_id(
-          vm_id: vm.id,
-          size_gib: disk_size,
-          boot: false,
-          use_bdev_ubi: false,
-          disk_index: 1
-        )
-      end
-
       pop "vm created"
     end
     nap 1

--- a/prog/aws/nic.rb
+++ b/prog/aws/nic.rb
@@ -28,13 +28,16 @@ class Prog::Aws::Nic < Prog::Base
   label def wait_network_interface_created
     network_interface_response = client.describe_network_interfaces({filters: [{name: "network-interface-id", values: [nic.name]}, {name: "tag:Ubicloud", values: ["true"]}]}).network_interfaces[0]
     if network_interface_response.status == "available"
-      eip_response = client.allocate_address
-      nic.nic_aws_resource.update(eip_allocation_id: eip_response.allocation_id)
-
-      hop_attach_eip_network_interface
+      hop_allocate_eip
     end
 
     nap 1
+  end
+
+  label def allocate_eip
+    eip_response = client.allocate_address
+    nic.nic_aws_resource.update(eip_allocation_id: eip_response.allocation_id)
+    hop_attach_eip_network_interface
   end
 
   label def attach_eip_network_interface

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -118,7 +118,21 @@ class Prog::Vm::Nexus < Prog::Base
         gpu_count = 1
         gpu_device = "27b0"
       end
-      label = (location.provider == "aws") ? "start_aws" : "start"
+
+      label = if location.provider == "aws"
+        storage_volumes.each_with_index do |volume, disk_index|
+          VmStorageVolume.create_with_id(
+            vm_id: vm.id,
+            size_gib: volume[:size_gib],
+            boot: volume[:boot],
+            use_bdev_ubi: false,
+            disk_index: disk_index
+          )
+        end
+        "start_aws"
+      else
+        "start"
+      end
 
       Strand.create(
         prog: "Vm::Nexus",

--- a/spec/prog/aws/instance_spec.rb
+++ b/spec/prog/aws/instance_spec.rb
@@ -97,24 +97,19 @@ usermod -L ubuntu
     it "updates the vm with the instance id" do
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(vm.strand).to receive(:stack).and_return([{"storage_volumes" => [{"boot" => false, "size_gib" => 10}]}], label: "start").at_least(:once)
       expect(client).to receive(:describe_instances).with({filters: [{name: "instance-id", values: [vm.name]}, {name: "tag:Ubicloud", values: ["true"]}]}).and_call_original
       expect(vm).to receive(:update).with(cores: 1, allocated_at: time, ephemeral_net6: "2a01:4f8:173:1ed3:aa7c::/79")
       expect { nx.wait_instance_created }.to exit({"msg" => "vm created"})
-      expect(VmStorageVolume.count).to eq(1)
-      expect(VmStorageVolume.first).to have_attributes(size_gib: 10, boot: false, use_bdev_ubi: false, disk_index: 1)
     end
 
-    it "doesn't create vm_storage_volumes if there are no storage volumes" do
+    it "updates the vm with the instance id and updates ip according to the sshable" do
       time = Time.now
       expect(Time).to receive(:now).and_return(time).at_least(:once)
       sshable = instance_double(Sshable)
       expect(vm).to receive(:sshable).and_return(sshable)
       expect(sshable).to receive(:update).with(host: "1.2.3.4")
-      expect(vm.strand).to receive(:stack).and_return([{"storage_volumes" => [{"boot" => true, "size_gib" => 10}]}], label: "start").at_least(:once)
       expect(vm).to receive(:update).with(cores: 1, allocated_at: time, ephemeral_net6: "2a01:4f8:173:1ed3:aa7c::/79")
       expect { nx.wait_instance_created }.to exit({"msg" => "vm created"})
-      expect(VmStorageVolume.count).to eq(0)
     end
 
     it "naps if the instance is not running" do

--- a/spec/prog/aws/nic_spec.rb
+++ b/spec/prog/aws/nic_spec.rb
@@ -51,9 +51,17 @@ RSpec.describe Prog::Aws::Nic do
       client.stub_responses(:describe_network_interfaces, network_interfaces: [{status: "available"}])
       client.stub_responses(:allocate_address, allocation_id: "eip-0123456789abcdefg")
       expect(client).to receive(:describe_network_interfaces).with({filters: [{name: "network-interface-id", values: [nic.name]}, {name: "tag:Ubicloud", values: ["true"]}]}).and_call_original
-      expect(nic.nic_aws_resource).to receive(:update).with(eip_allocation_id: "eip-0123456789abcdefg").and_call_original
 
-      expect { nx.wait_network_interface_created }.to hop("attach_eip_network_interface")
+      expect { nx.wait_network_interface_created }.to hop("allocate_eip")
+    end
+  end
+
+  describe "#allocate_eip" do
+    it "allocates an elastic ip" do
+      client.stub_responses(:allocate_address, allocation_id: "eip-0123456789abcdefg")
+      expect(client).to receive(:allocate_address).and_call_original
+      expect(nic.nic_aws_resource).to receive(:update).with(eip_allocation_id: "eip-0123456789abcdefg")
+      expect { nx.allocate_eip }.to hop("attach_eip_network_interface")
     end
   end
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -339,8 +339,8 @@ Options:
 Allowed Option Values:
     Flavor: standard paradedb lantern
     Replication Type: none async sync
-    Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
-          burstable-1 burstable-2
+    Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-32
+          standard-60 standard-64 burstable-1 burstable-2
     Storage Size: 16 32 64 128 256 512 1024 2048 4096
     Version: 17 16
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
@@ -15,7 +15,7 @@ Options:
 Allowed Option Values:
     Flavor: standard paradedb lantern
     Replication Type: none async sync
-    Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
-          burstable-1 burstable-2
+    Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-32
+          standard-60 standard-64 burstable-1 burstable-2
     Storage Size: 16 32 64 128 256 512 1024 2048 4096
     Version: 17 16


### PR DESCRIPTION
## Add standard-32 and 64 to ubi-on-aws PG sizes

## Allocate VmStorageVolume directly in assemble for AWS resources
Right at the time of creating the entities, we need to create the
vm_storage_volume entities as well. This is mainly because we calculate
the storage size through these entities in convergence prog to see if
there is a new server that matches resource's description of target
storage size. If not, we create a new VM infinitely. Therefore, this
must be created with the vm entity so that we create only 1 instance.

## Separate the EIP association from allocation
In case something goes wrong in association, we run the same state which
causes a new allocation of a new EIP. To avoid that, we separate their
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for `standard-32` and `standard-64` PostgreSQL sizes on AWS, updating instance mappings, options, and tests.
> 
>   - **Behavior**:
>     - Add support for `standard-32` and `standard-64` PostgreSQL sizes in `helpers/postgres.rb`.
>     - Update AWS instance size mappings in `prog/aws/instance.rb` to include `m6id.8xlarge` and `m6id.16xlarge`.
>     - Update CLI help files to include new sizes in `spec/routes/api/cli/golden-files/help -r.txt` and `pg eu-central-h1_test2-pg create invalid.txt`.
>   - **Options**:
>     - Update `POSTGRES_SIZE_OPTIONS` in `lib/option.rb` to include `standard-32` and `standard-64`.
>     - Update `aws_storage_size_options` in `helpers/postgres.rb` to include storage sizes for 32 and 64 vCPUs.
>   - **Tests**:
>     - Modify tests in `spec/prog/aws/instance_spec.rb` and `spec/prog/aws/nic_spec.rb` to reflect new instance sizes and behaviors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3ae18979ec78e96443e3c414dd76bff80027d878. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->