### PR TITLE
Only allocate hugepages during initial provisioning

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -258,7 +258,7 @@ TIMER
       vm.sshable.cmd("sudo systemctl enable --now prometheus")
       vm.sshable.cmd("sudo systemctl enable --now postgres-metrics.timer")
 
-      hop_configure
+      hop_setup_hugepages
     end
 
     vm.sshable.cmd("sudo systemctl reload postgres_exporter || sudo systemctl restart postgres_exporter")
@@ -266,6 +266,18 @@ TIMER
     vm.sshable.cmd("sudo systemctl reload prometheus || sudo systemctl restart prometheus")
 
     hop_wait
+  end
+
+  label def setup_hugepages
+    case vm.sshable.d_check("setup_hugepages")
+    when "Succeeded"
+      vm.sshable.d_clean("setup_hugepages")
+      hop_configure
+    when "Failed", "NotStarted"
+      vm.sshable.d_run("setup_hugepages", "sudo", "postgres/bin/setup-hugepages")
+    end
+
+    nap 5
   end
 
   label def configure

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -98,30 +98,6 @@ standby2replication   #{identity}             ubi_replication
 PG_IDENT
 safe_write_to_file("/etc/postgresql/#{v}/main/pg_ident.conf", pg_ident_entries)
 
-# Configure system hugepages
-meminfo = File.read("/proc/meminfo")
-hugepage_size_kib = Integer(meminfo[/^Hugepagesize:\s*(\d+)\s*kB/, 1], 10)
-memory_total_kib = Integer(meminfo[/^MemTotal:\s*(\d+)\s*kB/, 1], 10)
-
-target_hugepages_size_kib = memory_total_kib / 4
-target_hugepages = target_hugepages_size_kib / hugepage_size_kib
-
-r "echo 'vm.nr_hugepages = #{target_hugepages}' | sudo tee /etc/sysctl.d/10-hugepages.conf"
-r "sync"
-r "echo 3 | sudo tee /proc/sys/vm/drop_caches"
-r "echo 1 | sudo tee /proc/sys/vm/compact_memory"
-r "sudo sysctl --system"
-
-meminfo = File.read("/proc/meminfo")
-allocated_hugepages = Integer(meminfo[/^HugePages_Total:\s*(\d+)/, 1], 10)
-
-if allocated_hugepages < target_hugepages
-  puts "Failed to allocate #{target_hugepages} hugepages. Only #{allocated_hugepages} were allocated."
-  exit 1
-else
-  puts "Successfully allocated #{allocated_hugepages} hugepages."
-end
-
 # Create drop-in directory for postgresql@.service to override
 # the default systemd service file with a custom ExecStartPre to configure hugepages.
 r "mkdir -p /etc/systemd/system/postgresql@.service.d"

--- a/rhizome/postgres/bin/setup-hugepages
+++ b/rhizome/postgres/bin/setup-hugepages
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+# Setup system hugepages
+meminfo = File.read("/proc/meminfo")
+hugepage_size_kib = Integer(meminfo[/^Hugepagesize:\s*(\d+)\s*kB/, 1], 10)
+memory_total_kib = Integer(meminfo[/^MemTotal:\s*(\d+)\s*kB/, 1], 10)
+
+target_hugepages_size_kib = memory_total_kib / 4
+target_hugepages = target_hugepages_size_kib / hugepage_size_kib
+
+r "echo 'vm.nr_hugepages = #{target_hugepages}' | sudo tee /etc/sysctl.d/10-hugepages.conf"
+
+r "sync"
+r "echo 3 | sudo tee /proc/sys/vm/drop_caches"
+r "echo 1 | sudo tee /proc/sys/vm/compact_memory"
+r "sudo sysctl --system"
+
+meminfo = File.read("/proc/meminfo")
+allocated_hugepages = Integer(meminfo[/^HugePages_Total:\s*(\d+)/, 1], 10)
+
+if allocated_hugepages < target_hugepages
+  puts "Failed to allocate #{target_hugepages} hugepages. Only #{allocated_hugepages} were allocated."
+  exit 1
+else
+  puts "Successfully allocated #{allocated_hugepages} hugepages."
+end


### PR DESCRIPTION
Avoid pinning memory to hugepages for existing PG instances.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move hugepage allocation to `setup_hugepages`, called only during initial provisioning, and extract logic into a new script.
> 
>   - **Behavior**:
>     - Move hugepage allocation logic from `configure` to `setup_hugepages` in `postgres_server_nexus.rb`.
>     - `setup_hugepages` is called only during initial provisioning.
>   - **Scripts**:
>     - Extract hugepage setup logic into new `setup-hugepages` script.
>   - **Tests**:
>     - Update tests in `postgres_server_nexus_spec.rb` to verify `setup_hugepages` behavior and ensure it is only called during initial provisioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1f17c0fca433e58104e413b095c30beb0c80c3d6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->