### PR TITLE
Playground: Display reasoning output for DeepSeek R1

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -617,7 +617,7 @@ function setupPlayground() {
             $(`#inference_message_info_${assistant_message_id}`).text(`Usage: ${prompt_tokens} input tokens and ${completion_tokens} output tokens.`);
           }
           const new_content = parsedLine?.choices?.[0]?.delta?.content;
-          const new_reasoning_content = parsedLine?.choices?.[0]?.delta?.reasoning_content;
+          const new_reasoning_content = parsedLine?.choices?.[0]?.delta?.reasoning_content ?? parsedLine?.choices?.[0]?.delta?.reasoning;
           if (!new_content && !new_reasoning_content) {
             return;
           }


### PR DESCRIPTION
Reasoning output may currently vary slightly in format. In the future, we plan to standardize the API response for reasoning output.

Until then, the playground will render both the `reasoning_content` and `reasoning` fields as reasoning content.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify `setupPlayground()` in `app.js` to support both `reasoning_content` and `reasoning` fields for reasoning output.
> 
>   - **Behavior**:
>     - In `setupPlayground()` in `app.js`, modify reasoning content handling to support both `reasoning_content` and `reasoning` fields.
>     - Ensures compatibility with varying API responses for reasoning output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 19a41f182bb1126f6ee6c83db25bb51163614505. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->