### PR TITLE
Fix stale walg credentials bug for read replicas after promo

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -20,6 +20,7 @@ class PostgresServer < Sequel::Model
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
   semaphore :restart, :configure, :take_over, :configure_metrics, :destroy, :recycle, :promote
+  semaphore :refresh_walg_credentials
 
   def configure_hash
     configs = {

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -424,6 +424,11 @@ SQL
       hop_taking_over
     end
 
+    when_refresh_walg_credentials_set? do
+      decr_refresh_walg_credentials
+      refresh_walg_credentials
+    end
+
     if postgres_server.read_replica? && postgres_server.resource.parent
       nap 60 if postgres_server.lsn_caught_up
 

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -138,6 +138,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     iam.attach_user_policy(user_name: postgres_timeline.ubid, policy_arn: policy.policy.arn)
     response = iam.create_access_key(user_name: postgres_timeline.ubid)
     postgres_timeline.update(access_key: response.access_key.access_key_id, secret_key: response.access_key.secret_access_key)
+    postgres_timeline.leader.incr_refresh_walg_credentials
   end
 
   def admin_client

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -675,6 +675,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.wait }.to hop("configure")
     end
 
+    it "decrements and calls refresh_walg_credentials if refresh_walg_credentials is set" do
+      expect(nx).to receive(:when_refresh_walg_credentials_set?).and_yield
+      expect(nx).to receive(:decr_refresh_walg_credentials)
+      expect(nx).to receive(:refresh_walg_credentials)
+      expect { nx.wait }.to nap(6 * 60 * 60)
+    end
+
     it "pushes restart if restart is set" do
       expect(nx).to receive(:when_restart_set?).and_yield
       expect(nx).to receive(:push).with(described_class, {}, "restart").and_call_original

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
         client.stub_responses(:attach_user_policy)
         client.stub_responses(:create_access_key, access_key: {access_key_id: "access-key", secret_access_key: "secret-key", user_name: "username", status: "Active"})
         expect(postgres_timeline).to receive(:update).with(access_key: "access-key", secret_key: "secret-key").and_return(postgres_timeline)
+        expect(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait"))).at_least(:once)
+        expect(postgres_timeline.leader).to receive(:incr_refresh_walg_credentials)
         expect { nx.start }.to hop("setup_bucket")
       end
     end


### PR DESCRIPTION
Since the access key and secret key are only set after the timeline is
created and the first state of the timeline nexus is processed. when we
switch to a new timeline, we do not have the proper credentials, yet.
Still, we do update the walg config after timeline switch and it makes
sense. However, for AWS instances, we need to be able to trigger it
again once we create the access/secret key pair. This commit handles
that.
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes stale WALG credentials bug by adding logic to refresh credentials after read replica promotion and AWS S3 setup.
> 
>   - **Behavior**:
>     - Adds `refresh_walg_credentials` semaphore to `PostgresServer` in `postgres_server.rb`.
>     - In `postgres_server_nexus.rb`, refreshes WALG credentials when `refresh_walg_credentials` semaphore is set.
>     - In `postgres_timeline_nexus.rb`, increments `refresh_walg_credentials` on the leader when AWS S3 setup is complete.
>   - **Tests**:
>     - Adds test in `postgres_server_nexus_spec.rb` to verify WALG credentials refresh when semaphore is set.
>     - Adds test in `postgres_timeline_nexus_spec.rb` to verify leader increments `refresh_walg_credentials` after AWS S3 setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 61e7fc2209d4e7926d6d308728afa9f9d9b2283f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->