### PR TITLE
Use FOR NO KEY UPDATE instead of FOR UPDATE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", ">= 5.93"
+gem "sequel", ">= 5.94"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,7 +366,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
-    sequel (5.93.0)
+    sequel (5.94.0)
       bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
@@ -502,7 +502,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel (>= 5.93)
+  sequel (>= 5.94)
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords

--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -54,7 +54,7 @@ class GithubRepository < Sequel::Model
 
   def setup_blob_storage
     DB.transaction do
-      lock!
+      lock!(:no_key_update)
       return if access_key && secret_key
 
       begin

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -79,7 +79,7 @@ class Strand < Sequel::Model
   TAKE_LEASE_PS = DB[:strand]
     .returning
     .where(
-      Sequel[id: DB[:strand].select(:id).where(id: :$id).for_update.skip_locked, exitval: nil] &
+      Sequel[id: DB[:strand].select(:id).where(id: :$id).for_no_key_update.skip_locked, exitval: nil] &
         (Sequel[:lease] < Sequel::CURRENT_TIMESTAMP)
     )
     .prepare_sql_type(:update)

--- a/model/vm_pool.rb
+++ b/model/vm_pool.rb
@@ -13,11 +13,11 @@ class VmPool < Sequel::Model
 
   def pick_vm
     # Find an available VM in the "running" state and not associated with a GitHub runner,
-    # and lock it with FOR UPDATE SKIP LOCKED.
+    # and lock it with FOR NO KEY UPDATE SKIP LOCKED.
     vms_dataset
       .where(Sequel[:vm][:display_state] => "running")
       .exclude(id: DB[:github_runner].exclude(vm_id: nil).select(:vm_id))
-      .for_update
+      .for_no_key_update
       .skip_locked
       .first
   end

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -241,7 +241,7 @@ end
         # Lock this parent strand. This is run inside a transaction,
         # and will make exited child strands attempting to update the
         # parent's schedule block until the transaction commits.
-        strand.lock!
+        strand.lock!(:no_key_update)
 
         # lock! does an implicit reload, so check the new schedule
         new_schedule = strand.schedule

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -208,7 +208,7 @@ class Scheduling::Dispatcher
       .limit(@queue_size)
       .exclude(id: Sequel.function(:ANY, Sequel.cast(:$skip_strands, "uuid[]")))
       .select(:id, :schedule, :lease)
-      .for_update
+      .for_no_key_update
       .skip_locked
 
     # If a partition is given, limit the strands to the partition.

--- a/spec/model/vm_pool_spec.rb
+++ b/spec/model/vm_pool_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe VmPool do
     it "returns the vm if there is one in running state" do
       locking_vms = class_double(Vm)
       expect(pool).to receive(:vms_dataset).and_return(locking_vms)
-      expect(locking_vms).to receive_message_chain(:where, :exclude, :for_update, :skip_locked, :first).and_return(vm) # rubocop:disable RSpec/MessageChain
+      expect(locking_vms).to receive_message_chain(:where, :exclude, :for_no_key_update, :skip_locked, :first).and_return(vm) # rubocop:disable RSpec/MessageChain
       expect(pool.pick_vm).to eq(vm)
     end
   end


### PR DESCRIPTION
FOR UPDATE takes stronger locks, and is only needed if you plan on deleting the row or modifying one of key columns.  If you use FOR UPDATE, you block other transactions insert rows that reference a row using a FOR UPDATE lock.  From looking at these cases, I don't think that is the case, so using FOR NO KEY UPDATE should allow the assurances we need without unnecessarily blocking other concurrent transactions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `FOR UPDATE` to `FOR NO KEY UPDATE` in several models to reduce lock strength and improve concurrency.
> 
>   - **Behavior**:
>     - Change `FOR UPDATE` to `FOR NO KEY UPDATE` in `setup_blob_storage` in `github_repository.rb`, `TAKE_LEASE_PS` in `strand.rb`, `pick_vm` in `vm_pool.rb`, and `setup_prepared_statements` in `dispatcher.rb`.
>     - This change reduces lock strength, allowing more concurrent transactions without blocking inserts that reference locked rows.
>   - **Tests**:
>     - Update test in `vm_pool_spec.rb` to expect `for_no_key_update` instead of `for_update`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e1132c1dbb6b8a87a34156589de153c6fe143d69. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->