### PR TITLE
Add the debug gem to the development group in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development do
   gem "foreman"
   gem "pry-byebug"
   gem "rackup"
+  gem "debug"
 end
 
 group :rubocop do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,10 +129,14 @@ GEM
       capybara (~> 3.0)
       ferrum (~> 0.17.0)
     date (3.4.1)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
     ed25519 (1.4.0)
+    erb (5.0.1)
     erubi (1.13.1)
     excon (1.2.3)
     faraday (2.13.1)
@@ -166,6 +170,10 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     jmespath (1.6.2)
     json (2.12.2)
     json_schema (0.21.0)
@@ -259,12 +267,15 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.5.9)
+    pp (0.6.2)
+      prettyprint
     prawn (2.5.0)
       matrix (~> 0.4)
       pdf-core (~> 0.10.0)
       ttfunk (~> 1.8)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
+    prettyprint (0.2.0)
     prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
@@ -272,6 +283,9 @@ GEM
     pry-byebug (3.11.0)
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)
+    psych (5.2.6)
+      date
+      stringio
     public_suffix (6.0.2)
     puma (6.5.0)
       nio4r (~> 2.0)
@@ -295,6 +309,9 @@ GEM
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.3.0)
+    rdoc (6.14.1)
+      erb
+      psych (>= 4.0.0)
     refrigerator (1.8.0)
     regexp_parser (2.10.0)
     reline (0.6.1)
@@ -396,6 +413,7 @@ GEM
     standard-performance (1.8.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
+    stringio (3.1.7)
     stripe (12.6.0)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -464,6 +482,7 @@ DEPENDENCIES
   committee (>= 5.5.4)
   countries
   cuprite
+  debug
   ed25519
   erb-formatter!
   erubi (>= 1.5)


### PR DESCRIPTION
This allows you to place a binding.break call anywhere in the code, and have the process enter a debugging session when the call is reached.  The debug gem is one of the gems bundled with Ruby. I found this very helpful when debugging the OIDC login flow issues with dynamic OIDC providers.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `debug` gem to `Gemfile` development group to enable `binding.break` for debugging.
> 
>   - **Gemfile Changes**:
>     - Add `debug` gem to the `development` group in `Gemfile`.
>   - **Functionality**:
>     - Enables use of `binding.break` for debugging sessions in development.
>     - Aids in debugging OIDC login flow issues with dynamic OIDC providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7e20d1a846548d473bc4fa83040cf7823c2ba985. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->