### PR TITLE
Log of corrupted JIT tokens

### DIFF
--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -428,6 +428,26 @@ RSpec.describe Prog::Vm::GithubRunner do
         .and_raise(Octokit::Conflict.new({body: "409 - Another issue"}))
       expect { nx.register_runner }.to raise_error Octokit::Conflict
     end
+
+    it "logs if fails due to runner script failure" do
+      expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC$"})
+      expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -0 -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --description runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh",
+        stdin: "AABBCC$$").and_raise Sshable::SshError.new("command", "", "Job for runner-script.service failed.\n Check logs", 123, nil)
+      expect(Clog).to receive(:emit).with("Failed to start runner script").and_call_original
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
+        journalctl -xeu runner-script.service
+        cat /run/systemd/transient/runner-script.service || true
+      COMMAND
+      expect { nx.register_runner }.to raise_error Sshable::SshError
+    end
+
+    it "fails without a log if the ssh error doesn't match" do
+      expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC$"})
+      expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -0 -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --description runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh",
+        stdin: "AABBCC$$").and_raise Sshable::SshError.new("command", "", "unknown command", 123, nil)
+      expect(Clog).not_to receive(:emit).with("Failed to start runner script").and_call_original
+      expect { nx.register_runner }.to raise_error Sshable::SshError
+    end
   end
 
   describe "#wait" do


### PR DESCRIPTION
Lately, GitHub has been returning corrupted JIT tokens for some reason. It could be an encoding issue. If it fails, we'll log the error to figure out what's happening.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Logs errors when runner script fails to start due to SSH errors in `github_runner.rb`, with tests added in `github_runner_spec.rb`.
> 
>   - **Error Handling**:
>     - In `github_runner.rb`, logs error if runner script fails to start due to SSH error with "Job for runner-script.service failed".
>     - Executes `journalctl` and `cat` commands to gather logs for debugging.
>   - **Tests**:
>     - In `github_runner_spec.rb`, adds test to verify logging when runner script fails to start due to SSH error.
>     - Adds test to ensure no logging occurs if SSH error message does not match expected failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d6b2e8aeed87e9fb238f11ef2daa5a8346ccbefc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->