### PR TITLE
Give explicit description to runner script service

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -263,7 +263,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     # We initiate an API call and a SSH connection under the same label to avoid
     # having to store the encoded_jit_config.
     vm.sshable.cmd("sudo -- xargs -0 -- systemd-run --uid runner --gid runner " \
-                   "--working-directory '/home/runner' --unit runner-script --remain-after-exit -- " \
+                   "--working-directory '/home/runner' --unit runner-script --description runner-script --remain-after-exit -- " \
                    "/home/runner/actions-runner/run-withenv.sh",
       stdin: response[:encoded_jit_config].gsub("$", "$$"))
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe Prog::Vm::GithubRunner do
   describe "#register_runner" do
     it "registers runner hops" do
       expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC$"})
-      expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -0 -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh",
+      expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -0 -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --description runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh",
         stdin: "AABBCC$$")
       expect { nx.register_runner }.to hop("wait")
       expect(runner.runner_id).to eq(123)


### PR DESCRIPTION
Previously, if no description was provided, the service used the full
command as the description. Since the command includes the JIT token,
and GitHub recently increased the token length. This resulted in overly
long descriptions.

More importantly, including the token in the description is not ideal
from a security and clarity standpoint. To address this, we now assign a
default, explicit description instead.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds explicit description to runner script service to prevent JIT token exposure in `github_runner.rb`.
> 
>   - **Behavior**:
>     - Adds explicit description `runner-script` to `systemd-run` command in `setup_info` in `github_runner.rb` to avoid using full command as description.
>     - Prevents JIT token from being included in service description for security and clarity.
>   - **Tests**:
>     - Updates test in `github_runner_spec.rb` to expect `--description runner-script` in `register_runner` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for dcc0397c959e5c75bed45b19e8d93adfea5d7bf6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->