### PR TITLE
Set cron.use_background_workers to on for pg_cron by default

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -55,7 +55,8 @@ class PostgresServer < Sequel::Model
       "lc_monetary" => "'C.UTF-8'",
       "lc_numeric" => "'C.UTF-8'",
       "lc_time" => "'C.UTF-8'",
-      "shared_preload_libraries" => "'pg_cron,pg_stat_statements'"
+      "shared_preload_libraries" => "'pg_cron,pg_stat_statements'",
+      "cron.use_background_workers" => "on"
     }
 
     if resource.flavor == PostgresResource::Flavor::PARADEDB


### PR DESCRIPTION
Pg_cron uses client connections by default which increases the connection count and it doesn't really work out of the box. We could either configure using unix sockets or let pg to use background workers. This commit configures it to use background workers that makes it work out of the box.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `cron.use_background_workers` to `on` by default for `pg_cron` in `PostgresServer` to improve functionality.
> 
>   - **Behavior**:
>     - Sets `cron.use_background_workers` to `on` by default in `configure_hash` method of `PostgresServer` class in `postgres_server.rb`.
>     - This change allows `pg_cron` to use background workers instead of client connections, improving default functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 12ea7ca91ba40529ade2676fb1fb8004d9a24d1f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->