### PR TITLE
Make unit optional for PG configs with units

### DIFF
--- a/lib/validation/postgres_config_validator_schema.rb
+++ b/lib/validation/postgres_config_validator_schema.rb
@@ -56,7 +56,7 @@ module Validation
       "archive_timeout" => {
         description: "Sets the amount of time to wait before forcing a switch to the next WAL file.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "array_nulls" => {
@@ -67,7 +67,7 @@ module Validation
       "authentication_timeout" => {
         description: "Sets the maximum allowed time to complete client authentication.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "autovacuum" => {
@@ -113,13 +113,13 @@ module Validation
       "autovacuum_naptime" => {
         description: "Time to sleep between autovacuum runs.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "autovacuum_vacuum_cost_delay" => {
         description: "Vacuum cost delay in milliseconds, for autovacuum.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "2ms"
       },
       "autovacuum_vacuum_cost_limit" => {
@@ -158,7 +158,7 @@ module Validation
       "autovacuum_work_mem" => {
         description: "Sets the maximum memory to be used by each autovacuum worker process.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "-1"
       },
       "backend_flush_after" => {
@@ -181,13 +181,13 @@ module Validation
       "bgwriter_delay" => {
         description: "Background writer sleep time between rounds.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "200ms"
       },
       "bgwriter_flush_after" => {
         description: "Number of pages after which previously performed writes are flushed to disk.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "512kB"
       },
       "bgwriter_lru_maxpages" => {
@@ -234,19 +234,19 @@ module Validation
       "checkpoint_flush_after" => {
         description: "Number of pages after which previously performed writes are flushed to disk.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "256kB"
       },
       "checkpoint_timeout" => {
         description: "Sets the maximum time between automatic WAL checkpoints.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "5min"
       },
       "checkpoint_warning" => {
         description: "Sets the maximum time before warning if checkpoints triggered by WAL volume happen too frequently.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "30s"
       },
       "client_connection_check_interval" => {
@@ -289,7 +289,7 @@ module Validation
       "commit_timestamp_buffers" => {
         description: "Sets the size of the dedicated buffer pool used for the commit timestamp cache.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "4MB"
       },
       "compute_query_id" => {
@@ -411,7 +411,7 @@ module Validation
       "deadlock_timeout" => {
         description: "Sets the time to wait on a lock before checking for deadlock.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1s"
       },
       "debug_discard_caches" => {
@@ -514,7 +514,7 @@ module Validation
       "effective_cache_size" => {
         description: "Sets the planner's assumption about the total size of the data caches.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "(75% of total memory)"
       },
       "effective_io_concurrency" => {
@@ -707,7 +707,7 @@ module Validation
       "geqo_pool_size" => {
         description: "GEQO: number of individuals in the population.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "geqo_seed" => {
@@ -739,7 +739,7 @@ module Validation
       "gin_pending_list_limit" => {
         description: "Sets the maximum size of the pending list for GIN index.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "4MB"
       },
       "gss_accept_delegation" => {
@@ -750,7 +750,7 @@ module Validation
       "hash_mem_multiplier" => {
         description: 'Multiple of "work_mem" to use for hash tables.',
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2"
       },
       "hba_file" => {
@@ -771,7 +771,7 @@ module Validation
       "huge_page_size" => {
         description: "The size of huge page that should be requested.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "huge_pages" => {
@@ -823,7 +823,7 @@ module Validation
       "io_combine_limit" => {
         description: "Limit on the size of data reads and writes.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "128kB"
       },
       "jit" => {
@@ -941,7 +941,7 @@ module Validation
       "log_autovacuum_min_duration" => {
         description: "Sets the minimum execution time above which autovacuum actions will be logged.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "10min"
       },
       "log_checkpoints" => {
@@ -1075,19 +1075,19 @@ module Validation
       "log_rotation_age" => {
         description: "Sets the amount of time to wait before forcing log file rotation.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1d"
       },
       "log_rotation_size" => {
         description: "Sets the maximum size a log file can reach before being rotated.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "10MB"
       },
       "log_startup_progress_interval" => {
         description: "Time between progress updates for long-running startup operations.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "10s"
       },
       "log_statement" => {
@@ -1140,7 +1140,7 @@ module Validation
       "logical_decoding_work_mem" => {
         description: "Sets the maximum memory to be used for logical decoding.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "64MB"
       },
       "maintenance_io_concurrency" => {
@@ -1153,7 +1153,7 @@ module Validation
       "maintenance_work_mem" => {
         description: "Sets the maximum memory to be used for maintenance operations.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "512MB"
       },
       "max_connections" => {
@@ -1257,25 +1257,25 @@ module Validation
       "max_slot_wal_keep_size" => {
         description: "Sets the maximum WAL size that can be reserved by replication slots.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "-1"
       },
       "max_stack_depth" => {
         description: "Sets the maximum stack depth, in kilobytes.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2MB"
       },
       "max_standby_archive_delay" => {
         description: "Sets the maximum delay before canceling queries when a hot standby server is processing archived WAL data.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "30s"
       },
       "max_standby_streaming_delay" => {
         description: "Sets the maximum delay before canceling queries when a hot standby server is processing streamed WAL data.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "30s"
       },
       "max_sync_workers_per_subscription" => {
@@ -1295,7 +1295,7 @@ module Validation
       "max_wal_size" => {
         description: "Sets the WAL size that triggers a checkpoint.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "5GB"
       },
       "max_worker_processes" => {
@@ -1308,43 +1308,43 @@ module Validation
       "min_dynamic_shared_memory" => {
         description: "Amount of dynamic shared memory reserved at startup.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "min_parallel_index_scan_size" => {
         description: "Sets the minimum amount of index data for a parallel scan.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "512kB"
       },
       "min_parallel_table_scan_size" => {
         description: "Sets the minimum amount of table data for a parallel scan.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "8MB"
       },
       "min_wal_size" => {
         description: "Sets the minimum size to shrink the WAL to.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "80MB"
       },
       "multixact_member_buffers" => {
         description: "Sets the size of the dedicated buffer pool used for the MultiXact member cache.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "256kB"
       },
       "multixact_offset_buffers" => {
         description: "Sets the size of the dedicated buffer pool used for the MultiXact offset cache.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "128kB"
       },
       "notify_buffers" => {
         description: "Sets the size of the dedicated buffer pool used for the LISTEN/NOTIFY message cache.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "128kB"
       },
       "parallel_leader_participation" => {
@@ -1570,7 +1570,7 @@ module Validation
       "serializable_buffers" => {
         description: "Sets the size of the dedicated buffer pool used for the serializable transaction cache.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "256kB"
       },
       "session_preload_libraries" => {
@@ -1586,7 +1586,7 @@ module Validation
       "shared_buffers" => {
         description: "Sets the number of shared memory buffers used by the server.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "(25% of total memory)"
       },
       "shared_memory_type" => {
@@ -1675,10 +1675,9 @@ module Validation
       },
       "statement_timeout" => {
         description: "Sets the maximum allowed duration of any statement.",
-        type: :integer,
-        max: 2147483647,
-        min: 0,
-        default: 0
+        type: :string,
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
+        default: "0"
       },
       "stats_fetch_consistency" => {
         description: "Sets the consistency of accesses to statistics data.",
@@ -1689,7 +1688,7 @@ module Validation
       "subtransaction_buffers" => {
         description: "Sets the size of the dedicated buffer pool used for the subtransaction cache.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "4MB"
       },
       "summarize_wal" => {
@@ -1780,7 +1779,7 @@ module Validation
       "temp_buffers" => {
         description: "Sets the maximum number of temporary buffers used by each session.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "8MB"
       },
       "temp_file_limit" => {
@@ -1820,7 +1819,7 @@ module Validation
       "track_activity_query_size" => {
         description: "Sets the size reserved for pg_stat_activity.query, in bytes.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "1kB"
       },
       "track_commit_timestamp" => {
@@ -1852,7 +1851,7 @@ module Validation
       "transaction_buffers" => {
         description: "Sets the size of the dedicated buffer pool used for the transaction status cache.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "4MB"
       },
       "transaction_deferrable" => {
@@ -1907,7 +1906,7 @@ module Validation
       "vacuum_buffer_usage_limit" => {
         description: "Sets the buffer pool size for VACUUM, ANALYZE, and autovacuum.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2MB"
       },
       "vacuum_cost_delay" => {
@@ -1988,7 +1987,7 @@ module Validation
       "wal_buffers" => {
         description: "Sets the number of disk-page buffers in shared memory for WAL.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "16MB"
       },
       "wal_compression" => {
@@ -2004,7 +2003,7 @@ module Validation
       "wal_decode_buffer_size" => {
         description: "Buffer size for reading ahead in the WAL during recovery.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "512kB"
       },
       "wal_init_zero" => {
@@ -2015,7 +2014,7 @@ module Validation
       "wal_keep_size" => {
         description: "Sets the size of WAL files held for standby servers.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "wal_level" => {
@@ -2037,13 +2036,13 @@ module Validation
       "wal_receiver_status_interval" => {
         description: "Sets the maximum interval between WAL receiver status reports to the sending server.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "10s"
       },
       "wal_receiver_timeout" => {
         description: "Sets the maximum wait time to receive data from the sending server.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "wal_recycle" => {
@@ -2054,25 +2053,25 @@ module Validation
       "wal_retrieve_retry_interval" => {
         description: "Sets the time to wait before retrying to retrieve WAL after a failed attempt.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "5s"
       },
       "wal_sender_timeout" => {
         description: "Sets the maximum time to wait for WAL replication.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "wal_skip_threshold" => {
         description: "Minimum size of new file to fsync instead of writing WAL.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2MB"
       },
       "wal_summary_keep_time" => {
         description: "Time for which WAL summary files should be kept.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "10d"
       },
       "wal_sync_method" => {
@@ -2084,19 +2083,19 @@ module Validation
       "wal_writer_delay" => {
         description: "Time between WAL flushes performed in the WAL writer.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "200ms"
       },
       "wal_writer_flush_after" => {
         description: "Amount of WAL written out by WAL writer that triggers a flush.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "1MB"
       },
       "work_mem" => {
         description: "Sets the maximum memory to be used for query workspaces.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "(12.5% of total memory)"
       },
       "xmlbinary" => {
@@ -2168,7 +2167,7 @@ module Validation
       "archive_timeout" => {
         description: "Sets the amount of time to wait before forcing a switch to the next WAL file.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "array_nulls" => {
@@ -2179,7 +2178,7 @@ module Validation
       "authentication_timeout" => {
         description: "Sets the maximum allowed time to complete client authentication.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "autovacuum" => {
@@ -2225,13 +2224,13 @@ module Validation
       "autovacuum_naptime" => {
         description: "Time to sleep between autovacuum runs.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "autovacuum_vacuum_cost_delay" => {
         description: "Vacuum cost delay in milliseconds, for autovacuum.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "2ms"
       },
       "autovacuum_vacuum_cost_limit" => {
@@ -2270,7 +2269,7 @@ module Validation
       "autovacuum_work_mem" => {
         description: "Sets the maximum memory to be used by each autovacuum worker process.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "-1"
       },
       "backend_flush_after" => {
@@ -2293,13 +2292,13 @@ module Validation
       "bgwriter_delay" => {
         description: "Background writer sleep time between rounds.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "200ms"
       },
       "bgwriter_flush_after" => {
         description: "Number of pages after which previously performed writes are flushed to disk.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "512kB"
       },
       "bgwriter_lru_maxpages" => {
@@ -2346,19 +2345,19 @@ module Validation
       "checkpoint_flush_after" => {
         description: "Number of pages after which previously performed writes are flushed to disk.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "256kB"
       },
       "checkpoint_timeout" => {
         description: "Sets the maximum time between automatic WAL checkpoints.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "5min"
       },
       "checkpoint_warning" => {
         description: "Sets the maximum time before warning if checkpoints triggered by WAL volume happen too frequently.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "30s"
       },
       "client_connection_check_interval" => {
@@ -2522,7 +2521,7 @@ module Validation
       "deadlock_timeout" => {
         description: "Sets the time to wait on a lock before checking for deadlock.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1s"
       },
       "debug_discard_caches" => {
@@ -2624,7 +2623,7 @@ module Validation
       "effective_cache_size" => {
         description: "Sets the planner's assumption about the total size of the data caches.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "6GB"
       },
       "effective_io_concurrency" => {
@@ -2807,7 +2806,7 @@ module Validation
       "geqo_pool_size" => {
         description: "GEQO: number of individuals in the population.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "geqo_seed" => {
@@ -2839,7 +2838,7 @@ module Validation
       "gin_pending_list_limit" => {
         description: "Sets the maximum size of the pending list for GIN index.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "4MB"
       },
       "gss_accept_delegation" => {
@@ -2850,7 +2849,7 @@ module Validation
       "hash_mem_multiplier" => {
         description: "Multiple of work_mem to use for hash tables.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2"
       },
       "hba_file" => {
@@ -2871,7 +2870,7 @@ module Validation
       "huge_page_size" => {
         description: "The size of huge page that should be requested.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "huge_pages" => {
@@ -3035,7 +3034,7 @@ module Validation
       "log_autovacuum_min_duration" => {
         description: "Sets the minimum execution time above which autovacuum actions will be logged.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "10min"
       },
       "log_checkpoints" => {
@@ -3169,19 +3168,19 @@ module Validation
       "log_rotation_age" => {
         description: "Sets the amount of time to wait before forcing log file rotation.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1d"
       },
       "log_rotation_size" => {
         description: "Sets the maximum size a log file can reach before being rotated.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "10MB"
       },
       "log_startup_progress_interval" => {
         description: "Time between progress updates for long-running startup operations.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "10s"
       },
       "log_statement" => {
@@ -3234,7 +3233,7 @@ module Validation
       "logical_decoding_work_mem" => {
         description: "Sets the maximum memory to be used for logical decoding.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "64MB"
       },
       "maintenance_io_concurrency" => {
@@ -3247,7 +3246,7 @@ module Validation
       "maintenance_work_mem" => {
         description: "Sets the maximum memory to be used for maintenance operations.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "(8.25% of total memory)"
       },
       "max_connections" => {
@@ -3344,25 +3343,25 @@ module Validation
       "max_slot_wal_keep_size" => {
         description: "Sets the maximum WAL size that can be reserved by replication slots.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "-1"
       },
       "max_stack_depth" => {
         description: "Sets the maximum stack depth, in kilobytes.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2MB"
       },
       "max_standby_archive_delay" => {
         description: "Sets the maximum delay before canceling queries when a hot standby server is processing archived WAL data.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "30s"
       },
       "max_standby_streaming_delay" => {
         description: "Sets the maximum delay before canceling queries when a hot standby server is processing streamed WAL data.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "30s"
       },
       "max_sync_workers_per_subscription" => {
@@ -3382,7 +3381,7 @@ module Validation
       "max_wal_size" => {
         description: "Sets the WAL size that triggers a checkpoint.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "5GB"
       },
       "max_worker_processes" => {
@@ -3395,25 +3394,25 @@ module Validation
       "min_dynamic_shared_memory" => {
         description: "Amount of dynamic shared memory reserved at startup.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "min_parallel_index_scan_size" => {
         description: "Sets the minimum amount of index data for a parallel scan.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "512kB"
       },
       "min_parallel_table_scan_size" => {
         description: "Sets the minimum amount of table data for a parallel scan.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "8MB"
       },
       "min_wal_size" => {
         description: "Sets the minimum size to shrink the WAL to.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "80MB"
       },
       "old_snapshot_threshold" => {
@@ -3663,7 +3662,7 @@ module Validation
       "shared_buffers" => {
         description: "Sets the number of shared memory buffers used by the server.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2GB"
       },
       "shared_memory_type" => {
@@ -3752,10 +3751,9 @@ module Validation
       },
       "statement_timeout" => {
         description: "Sets the maximum allowed duration of any statement.",
-        type: :integer,
-        min: 0,
-        max: 2147483647,
-        default: 0
+        type: :string,
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
+        default: "0"
       },
       "stats_fetch_consistency" => {
         description: "Sets the consistency of accesses to statistics data.",
@@ -3837,7 +3835,7 @@ module Validation
       "temp_buffers" => {
         description: "Sets the maximum number of temporary buffers used by each session.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "8MB"
       },
       "temp_file_limit" => {
@@ -3877,7 +3875,7 @@ module Validation
       "track_activity_query_size" => {
         description: "Sets the size reserved for pg_stat_activity.query, in bytes.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "1kB"
       },
       "track_commit_timestamp" => {
@@ -3951,7 +3949,7 @@ module Validation
       "vacuum_buffer_usage_limit" => {
         description: "Sets the buffer pool size for VACUUM, ANALYZE, and autovacuum.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "256kB"
       },
       "vacuum_cost_delay" => {
@@ -4032,7 +4030,7 @@ module Validation
       "wal_buffers" => {
         description: "Sets the number of disk-page buffers in shared memory for WAL.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "16MB"
       },
       "wal_compression" => {
@@ -4048,7 +4046,7 @@ module Validation
       "wal_decode_buffer_size" => {
         description: "Buffer size for reading ahead in the WAL during recovery.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "512kB"
       },
       "wal_init_zero" => {
@@ -4059,7 +4057,7 @@ module Validation
       "wal_keep_size" => {
         description: "Sets the size of WAL files held for standby servers.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "0"
       },
       "wal_level" => {
@@ -4081,13 +4079,13 @@ module Validation
       "wal_receiver_status_interval" => {
         description: "Sets the maximum interval between WAL receiver status reports to the sending server.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "10s"
       },
       "wal_receiver_timeout" => {
         description: "Sets the maximum wait time to receive data from the sending server.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "wal_recycle" => {
@@ -4098,19 +4096,19 @@ module Validation
       "wal_retrieve_retry_interval" => {
         description: "Sets the time to wait before retrying to retrieve WAL after a failed attempt.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "5s"
       },
       "wal_sender_timeout" => {
         description: "Sets the maximum time to wait for WAL replication.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "1min"
       },
       "wal_skip_threshold" => {
         description: "Minimum size of new file to fsync instead of writing WAL.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "2MB"
       },
       "wal_sync_method" => {
@@ -4122,19 +4120,19 @@ module Validation
       "wal_writer_delay" => {
         description: "Time between WAL flushes performed in the WAL writer.",
         type: :string,
-        pattern: "^[0-9]+(us|ms|s|min|h|d)$",
+        pattern: "^[0-9]+(us|ms|s|min|h|d)?$",
         default: "200ms"
       },
       "wal_writer_flush_after" => {
         description: "Amount of WAL written out by WAL writer that triggers a flush.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "1MB"
       },
       "work_mem" => {
         description: "Sets the maximum memory to be used for query workspaces.",
         type: :string,
-        pattern: "^[0-9]+(kB|MB|GB|TB)$",
+        pattern: "^[0-9]+(kB|MB|GB|TB)?$",
         default: "1MB"
       },
       "xmlbinary" => {


### PR DESCRIPTION
Relax validation to allow only integer values for configs with units. Noticed these when persisting existing postgresql.auto.conf values to the database.