### PR TITLE
Provide the database URL explicitly in E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Run tests
       env:
         BASE_URL: https://${{ secrets.CLOUDFLARED_ADDRESS }}
+        CLOVER_DATABASE_URL: postgres:///clover_test?user=clover
         RACK_ENV: production
         IS_E2E: "true"
         CI_HETZNER_SACRIFICIAL_SERVER_ID: ${{ secrets.CI_HETZNER_SACRIFICIAL_SERVER_ID }}


### PR DESCRIPTION
I unified our workflows to make similar steps into reusable actions in the previous commit.

We started to create the base environment with the `overwrite_envrb` rake task, which has values for `test` and `development` environments.

Since we run E2E tests in the `production` environment, we need to provide the database URL explicitly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `CLOVER_DATABASE_URL` to `e2e.yml` for explicit database URL configuration in E2E tests.
> 
>   - **Environment Configuration**:
>     - Add `CLOVER_DATABASE_URL` to `e2e.yml` to explicitly set the database URL for E2E tests in the production environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 289eb707ffa99b46ad9aacd14407982ca0c405e4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->