### PR TITLE
Don't increment nic destroy unnecessarily twice

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -514,7 +514,6 @@ class Prog::Vm::Nexus < Prog::Base
     vm.update(display_state: "deleting")
     if vm.location.provider == "aws"
       bud Prog::Aws::Instance, {"subject_id" => vm.id}, :destroy
-      vm.nics.map(&:incr_destroy)
       hop_wait_aws_vm_destroyed
     end
 

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -133,6 +133,7 @@ class Prog::Vnet::NicNexus < Prog::Base
 
   label def wait_aws_nic_destroyed
     reap(nap: 10) do
+      nic.private_subnet.incr_refresh_keys
       nic.destroy
       pop "nic deleted"
     end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -1125,11 +1125,8 @@ RSpec.describe Prog::Vm::Nexus do
     it "hops to wait_aws_vm_destroyed if vm is in aws" do
       vm = instance_double(Vm, location: instance_double(Location, provider: "aws"), id: "vm_id")
       expect(vm).to receive(:update).with(display_state: "deleting")
-      nics = [instance_double(Nic, strand: instance_double(Strand, label: "wait"))]
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:nics).and_return(nics)
       expect(nx).to receive(:bud).with(Prog::Aws::Instance, {"subject_id" => "vm_id"}, :destroy)
-      expect(nics.first).to receive(:incr_destroy)
       expect { nx.destroy }.to hop("wait_aws_vm_destroyed")
     end
   end

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -269,8 +269,10 @@ RSpec.describe Prog::Vnet::NicNexus do
     it "reaps and destroys nic if leaf" do
       st.update(prog: "Vnet::NicNexus", label: "wait_aws_nic_destroyed", stack: [{}])
       nic = instance_double(Nic, id: "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e")
-      expect(nx).to receive(:nic).and_return(nic)
+      expect(nx).to receive(:nic).and_return(nic).at_least(:once)
       expect(nic).to receive(:destroy)
+      expect(nic).to receive(:private_subnet).and_return(ps)
+      expect(ps).to receive(:incr_refresh_keys)
       expect { nx.wait_aws_nic_destroyed }.to exit({"msg" => "nic deleted"})
     end
 


### PR DESCRIPTION
We are already incr_destroy for nics when we destroy the vm at the "final_cleanup" there is no need to increment it again in "destroy"
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant NIC destruction increment in `nexus.rb` and add refresh keys increment in `nic_nexus.rb`.
> 
>   - **Behavior**:
>     - Remove `vm.nics.map(&:incr_destroy)` from `destroy` in `nexus.rb` as NIC destruction is already handled in `final_clean_up`.
>     - Add `nic.private_subnet.incr_refresh_keys` in `wait_aws_nic_destroyed` in `nic_nexus.rb`.
>   - **Tests**:
>     - Update `nexus_spec.rb` to remove expectation of `incr_destroy` call on NICs in `destroy`.
>     - Update `nic_nexus_spec.rb` to expect `incr_refresh_keys` call in `wait_aws_nic_destroyed`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ca45c9f4da78ef34bc1b2b4c8a6fc0a62215c8ee. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->