### PR TITLE
Immediately kill representative server for fencing

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -490,10 +490,15 @@ SQL
 
   label def prepare_for_take_over
     decr_take_over
+    representative_server = postgres_server.resource.representative_server
+    hop_taking_over if representative_server.nil?
 
-    hop_taking_over if postgres_server.resource.representative_server.nil?
+    begin
+      representative_server.vm.sshable.cmd("sudo pg_ctlcluster #{postgres_server.resource.version} main stop -m immediate")
+    rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError
+    end
 
-    postgres_server.resource.representative_server.incr_destroy
+    representative_server.incr_destroy
 
     nap 5
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -804,7 +804,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#prepare_for_take_over" do
     it "naps if primary still exists" do
       expect(nx).to receive(:decr_take_over)
-      representative_server = instance_double(PostgresServer, id: "something")
+      representative_server = instance_double(PostgresServer, id: "something", vm: instance_double(Vm, sshable: instance_double(Sshable)))
+      expect(representative_server.vm.sshable).to receive(:cmd).with("sudo pg_ctlcluster 16 main stop -m immediate").and_raise(Sshable::SshError.new("", "", "", "", ""))
       expect(representative_server).to receive(:incr_destroy)
       expect(postgres_server.resource).to receive(:representative_server).and_return(representative_server).at_least(:once)
       expect { nx.prepare_for_take_over }.to nap(5)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modifies `prepare_for_take_over` to immediately stop the representative server via SSH and updates tests accordingly.
> 
>   - **Behavior**:
>     - In `prepare_for_take_over` in `postgres_server_nexus.rb`, immediately stops the representative server using SSH with `pg_ctlcluster` and increments its destroy counter.
>     - Handles SSH connection errors during the stop command.
>   - **Tests**:
>     - Updates `prepare_for_take_over` test in `postgres_server_nexus_spec.rb` to expect SSH command execution and handle SSH errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9a60e9d668e269d7ef2d5e7eeb087fc7405a8275. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->