### PR TITLE
Fix PG data disk device_path on AWS

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -283,6 +283,17 @@ class PostgresServer < Sequel::Model
       project_id: Config.postgres_service_project_id
     }
   end
+
+  def data_device_path
+    if vm.location.aws?
+      # On AWS, pick the largest block device to use as the data disk,
+      # since the device path detected by the VmStorageVolume is not always
+      # correct.
+      vm.sshable.cmd("lsblk -b -d -o NAME,SIZE | sort -n -k2 | tail -n1 |  awk '{print \"/dev/\"$1}'").strip
+    else
+      vm.vm_storage_volumes.find { it.boot == false }.device_path.shellescape
+    end
+  end
 end
 
 # Table: postgres_server

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -103,15 +103,13 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     case vm.sshable.cmd("common/bin/daemonizer --check format_disk")
     when "Succeeded"
       vm.sshable.cmd("sudo mkdir -p /dat")
-      device_path = vm.vm_storage_volumes.find { it.boot == false }.device_path.shellescape
 
-      vm.sshable.cmd("sudo common/bin/add_to_fstab #{device_path} /dat ext4 defaults 0 0")
-      vm.sshable.cmd("sudo mount #{device_path} /dat")
+      vm.sshable.cmd("sudo common/bin/add_to_fstab #{postgres_server.data_device_path} /dat ext4 defaults 0 0")
+      vm.sshable.cmd("sudo mount #{postgres_server.data_device_path} /dat")
 
       hop_configure_walg_credentials
     when "Failed", "NotStarted"
-      device_path = vm.vm_storage_volumes.find { it.boot == false }.device_path.shellescape
-      vm.sshable.cmd("common/bin/daemonizer 'sudo mkfs --type ext4 #{device_path}' format_disk")
+      vm.sshable.cmd("common/bin/daemonizer 'sudo mkfs --type ext4 #{postgres_server.data_device_path}' format_disk")
     end
 
     nap 5

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         sshable: sshable,
         ephemeral_net4: "1.1.1.1",
         private_subnets: [instance_double(PrivateSubnet)]
-      )
+      ),
+      data_device_path: "/dev/vdb"
     )
   }
 
@@ -221,7 +222,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#mount_data_disk" do
     it "formats data disk if format command is not sent yet or failed" do
-      expect(postgres_server.vm).to receive(:vm_storage_volumes).and_return([instance_double(VmStorageVolume, boot: true, device_path: "/dev/vda"), instance_double(VmStorageVolume, boot: false, device_path: "/dev/vdb")]).twice
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer 'sudo mkfs --type ext4 /dev/vdb' format_disk").twice
 
       # NotStarted
@@ -235,7 +235,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "mounts data disk if format disk is succeeded and hops to configure_walg_credentials" do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check format_disk").and_return("Succeeded")
-      expect(postgres_server.vm).to receive(:vm_storage_volumes).and_return([instance_double(VmStorageVolume, boot: true, device_path: "/dev/vda"), instance_double(VmStorageVolume, boot: false, device_path: "/dev/vdb")])
       expect(sshable).to receive(:cmd).with("sudo mkdir -p /dat")
       expect(sshable).to receive(:cmd).with("sudo common/bin/add_to_fstab /dev/vdb /dat ext4 defaults 0 0")
       expect(sshable).to receive(:cmd).with("sudo mount /dev/vdb /dat")


### PR DESCRIPTION
Since the device_path returned by the VmStorageVolume on AWS is an ephemeral identifier, we need to look at the disk sizes to determine the correct device to format when mounting data disk.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes AWS data disk identification by selecting the largest block device for mounting in `postgres_server.rb`.
> 
>   - **Behavior**:
>     - `data_device_path` method in `postgres_server.rb` now selects the largest block device on AWS instead of relying on `VmStorageVolume`.
>     - Updated `mount_data_disk` in `postgres_server_nexus.rb` to use `data_device_path` for mounting.
>   - **Tests**:
>     - Added tests in `postgres_server_spec.rb` for `data_device_path` method to verify correct device path selection on AWS and Hetzner.
>     - Updated `postgres_server_nexus_spec.rb` to ensure `mount_data_disk` uses the correct device path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4f3f4f877ab0ad44a06a09eb4dd37226c04a2138. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->