### PR TITLE
Fix writes after removing standbys

### DIFF
--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -55,6 +55,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
       .take(postgres_resource.target_standby_count) + [postgres_resource.representative_server]
     (postgres_resource.servers - servers_to_keep).each.each(&:incr_destroy)
 
+    servers_to_keep.each(&:incr_configure)
     postgres_resource.incr_update_billing_records
 
     pop "postgres resource is converged"

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -125,6 +125,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(postgres_resource.servers[2]).to receive(:incr_destroy)
       expect(postgres_resource.servers[4]).to receive(:incr_destroy)
 
+      expect(postgres_resource.servers[0]).to receive(:incr_configure)
+      expect(postgres_resource.servers[3]).to receive(:incr_configure)
       expect(postgres_resource).to receive(:incr_update_billing_records)
 
       expect { nx.prune_servers }.to exit


### PR DESCRIPTION
We need to trigger reconfiguring after purging some of the servers. Otherwise, if the customer has 2 standby nodes and they switch back to single server (only primary) deployment, primary server keeps waiting for write acknowledgement from standbys since we don't configure it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue of primary server waiting for removed standbys by reconfiguring remaining servers in `converge_postgres_resource.rb`.
> 
>   - **Behavior**:
>     - Fixes issue where primary server waits for acknowledgments from removed standbys by reconfiguring remaining servers.
>     - Adds `incr_configure` call to `servers_to_keep` in `prune_servers` method in `converge_postgres_resource.rb`.
>   - **Tests**:
>     - Updates `prune_servers` test in `converge_postgres_resource_spec.rb` to expect `incr_configure` on remaining servers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a0034fc52c3cd5a278ea12711ffc41799d8a34e2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->