### PR TITLE
Nap with time for bootstrap rhizome to avoid 120sec nap

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -96,7 +96,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   end
 
   label def wait_bootstrap_rhizome
-    reap(:mount_data_disk)
+    reap(:mount_data_disk, nap: 5)
   end
 
   label def mount_data_disk

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "donates if there are sub-programs running" do
       Strand.create(parent_id: st.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_bootstrap_rhizome }.to nap(120)
+      expect { nx.wait_bootstrap_rhizome }.to nap(5)
     end
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce nap time in `wait_bootstrap_rhizome` from 120 seconds to 5 seconds in `postgres_server_nexus.rb` and update corresponding test.
> 
>   - **Behavior**:
>     - In `postgres_server_nexus.rb`, `wait_bootstrap_rhizome` now uses `reap(:mount_data_disk, nap: 5)` instead of the default 120 seconds nap.
>     - In `postgres_server_nexus_spec.rb`, test for `wait_bootstrap_rhizome` updated to expect a 5-second nap when sub-programs are running.
>   - **Tests**:
>     - Adjusted test in `postgres_server_nexus_spec.rb` to reflect the reduced nap time from 120 seconds to 5 seconds for `wait_bootstrap_rhizome`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 95b0d0a906c2c2ad37cc7183855118ae52ffafd8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->