### PR TITLE
Simply declare caught up if primary is destroyed when rr is being created

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -149,11 +149,12 @@ class PostgresServer < Sequel::Model
 
   def lsn_caught_up
     parent_server = if read_replica?
-      resource.parent.representative_server
+      resource.parent&.representative_server
     else
       resource.representative_server
     end
-    lsn_diff(parent_server.current_lsn, current_lsn) < 80 * 1024 * 1024
+
+    lsn_diff(parent_server&.current_lsn || current_lsn, current_lsn) < 80 * 1024 * 1024
   end
 
   def current_lsn

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -257,6 +257,20 @@ RSpec.describe PostgresServer do
       expect(postgres_server.lsn_caught_up).to be_truthy
     end
 
+    it "returns true if read replica and the parent representative server is nil" do
+      expect(postgres_server).to receive(:read_replica?).and_return(true)
+      expect(parent_resource).to receive(:representative_server).and_return(nil)
+      expect(postgres_server).to receive(:run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F").twice
+      expect(postgres_server.lsn_caught_up).to be_truthy
+    end
+
+    it "returns true if read replica and the parent is nil" do
+      expect(postgres_server).to receive(:read_replica?).and_return(true)
+      expect(postgres_server.resource).to receive(:parent).and_return(nil)
+      expect(postgres_server).to receive(:run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F").twice
+      expect(postgres_server.lsn_caught_up).to be_truthy
+    end
+
     it "returns false if the diff is less than 80MB" do
       expect(postgres_server).to receive(:read_replica?).and_return(true)
       expect(postgres_server).to receive(:run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("1/00000000")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `lsn_caught_up` in `postgres_server.rb` to handle `nil` parent server or representative server, with corresponding tests in `postgres_server_spec.rb`.
> 
>   - **Behavior**:
>     - Update `lsn_caught_up` in `postgres_server.rb` to handle `nil` parent server or representative server.
>     - Returns `true` if `parent_server` is `nil` or its `current_lsn` is `nil`.
>   - **Tests**:
>     - Add tests in `postgres_server_spec.rb` for `lsn_caught_up` to cover cases where parent server or representative server is `nil`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 492144f5421cf411bf2cc66648d3a24da486afc3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->