### PR TITLE
Set runtime token secret for E2E

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -183,10 +183,12 @@ when "test"
   ENV["CLOVER_SESSION_SECRET"] ||= "#{SecureRandom.base64(64)}"
   ENV["CLOVER_DATABASE_URL"] ||= "postgres:///clover_test\#{ENV["TEST_ENV_NUMBER"]}?user=clover"
   ENV["CLOVER_COLUMN_ENCRYPTION_KEY"] ||= "#{SecureRandom.base64(32)}"
+  ENV["CLOVER_RUNTIME_TOKEN_SECRET"] ||= "#{SecureRandom.base64(64)}"
 else
   ENV["CLOVER_SESSION_SECRET"] ||= "#{SecureRandom.base64(64)}"
   ENV["CLOVER_DATABASE_URL"] ||= "postgres:///clover_development?user=clover"
   ENV["CLOVER_COLUMN_ENCRYPTION_KEY"] ||= "#{SecureRandom.base64(32)}"
+  ENV["CLOVER_RUNTIME_TOKEN_SECRET"] ||= "#{SecureRandom.base64(64)}"
 end
 ENVRB
 end


### PR DESCRIPTION
This was removed during the unification changes. However, E2E tests
require it, especially for testing Ubicloud Cache.

I’ve added it back via a rake task instead of setting it directly in the
workflow. The reason is that this value is also needed in the
development environment if you want to test Ubicloud Cache locally.

This change is part of our effort to make the development environment
setup as simple and consistent as possible.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reintroduces `CLOVER_RUNTIME_TOKEN_SECRET` in `Rakefile` for test and development environments to support E2E tests and local development for Ubicloud Cache.
> 
>   - **Environment Variables**:
>     - Reintroduces `CLOVER_RUNTIME_TOKEN_SECRET` in `Rakefile` for both test and development environments.
>     - Uses `SecureRandom.base64(64)` to generate the secret.
>   - **Rake Tasks**:
>     - Adds the secret setup in the `overwrite_envrb` task to ensure it's available in both environments.
>   - **Purpose**:
>     - Supports E2E tests and local development for Ubicloud Cache.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a9b3f24f4f2fd93e34f72810203618390a150f33. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->