### PR TITLE
Skip free premium runner upgrade in E2E

### DIFF
--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -12,13 +12,13 @@ class Prog::Test::GithubRunner < Prog::Test::Base
 
     vm_pool_service_project = Project.create(name: "Vm-Pool-Service-Project") { it.id = Config.vm_pool_project_id }
 
-    github_test_project = Project.create_with_id(name: "Github-Runner-Test-Project")
-    GithubInstallation.create_with_id(
+    github_test_project = Project.create(name: "Github-Runner-Test-Project")
+    GithubInstallation.create(
       installation_id: Config.e2e_github_installation_id,
       name: "TestUser",
       type: "User",
       project_id: github_test_project.id,
-      use_docker_mirror: true
+      created_at: Time.now - 8 * 24 * 60 * 60
     )
 
     Strand.create_with_id(


### PR DESCRIPTION
We recently introduced a 7-day free premium runner upgrade for new
installations.

Since E2E tests create a fresh installation each time, they were always
receiving the free upgrade. This caused them to look for premium runner
pools, which don’t exist in the E2E environment.

To fix this, I’ve updated the created_at value to be older than 7 days,
ensuring E2E tests default to standard runners.

Also removed the use_docker_mirror setting, as it’s no longer used.
