### PR TITLE
Pass JIT config via file to runner script

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -170,7 +170,8 @@ class Project < Sequel::Model
     end
   end
 
-  feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations, :free_runner_upgrade_until, :gpu_vm, :postgres_lantern
+  feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics, :private_locations, :free_runner_upgrade_until, :gpu_vm, :postgres_lantern,
+    :runner_jit_file
 end
 
 # Table: project

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -13,6 +13,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
     vm_pool_service_project = Project.create(name: "Vm-Pool-Service-Project") { it.id = Config.vm_pool_project_id }
 
     github_test_project = Project.create(name: "Github-Runner-Test-Project")
+    github_test_project.set_ff_runner_jit_file(true)
     GithubInstallation.create(
       installation_id: Config.e2e_github_installation_id,
       name: "TestUser",

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -245,6 +245,31 @@ class Prog::Vm::GithubRunner < Prog::Base
       COMMAND
     end
 
+    if github_runner.installation.project.get_ff_runner_jit_file
+      # After testing in production for a while, we can move these files to the image generation process
+      command += <<~COMMAND
+        sudo tee /etc/systemd/system/runner-script.service > /dev/null > /dev/null <<'EOT'
+        [Unit]
+        Description=runner-script
+
+        [Service]
+        RemainAfterExit=yes
+        User=runner
+        Group=runner
+        WorkingDirectory=/home/runner
+        ExecStart=/home/runner/actions-runner/run-withenv.sh
+        EOT
+
+        sudo -u runner tee /home/runner/actions-runner/run-withenv.sh > /dev/null <<'EOT'
+        #!/bin/bash
+        mapfile -t env </etc/environment
+        JIT_CONFIG="$(cat ./actions-runner/.jit_token)"
+        exec env -- "${env[@]}" ./actions-runner/run.sh --jitconfig "$JIT_CONFIG"
+        EOT
+        sudo systemctl daemon-reload
+      COMMAND
+    end
+
     # Remove comments and empty lines before sending them to the machine
     vm.sshable.cmd(command.gsub(/^(\s*# .*)?\n/, ""))
 
@@ -258,12 +283,19 @@ class Prog::Vm::GithubRunner < Prog::Base
     data = {name: github_runner.ubid.to_s, labels: [github_runner.label], runner_group_id: 1, work_folder: "/home/runner/work"}
     response = github_client.post("/repos/#{github_runner.repository_name}/actions/runners/generate-jitconfig", data)
     github_runner.update(runner_id: response[:runner][:id], ready_at: Time.now)
-    # We initiate an API call and a SSH connection under the same label to avoid
-    # having to store the encoded_jit_config.
-    vm.sshable.cmd("sudo -- xargs -0 -- systemd-run --uid runner --gid runner " \
-                   "--working-directory '/home/runner' --unit runner-script --description runner-script --remain-after-exit -- " \
-                   "/home/runner/actions-runner/run-withenv.sh",
-      stdin: response[:encoded_jit_config].gsub("$", "$$"))
+    if github_runner.installation.project.get_ff_runner_jit_file
+      vm.sshable.cmd(<<~COMMAND, stdin: response[:encoded_jit_config])
+      sudo -u runner tee /home/runner/actions-runner/.jit_token > /dev/null
+      sudo systemctl start runner-script.service
+      COMMAND
+    else
+      # We initiate an API call and a SSH connection under the same label to avoid
+      # having to store the encoded_jit_config.
+      vm.sshable.cmd("sudo -- xargs -0 -- systemd-run --uid runner --gid runner " \
+                    "--working-directory '/home/runner' --unit runner-script --description runner-script --remain-after-exit -- " \
+                    "/home/runner/actions-runner/run-withenv.sh",
+        stdin: response[:encoded_jit_config].gsub("$", "$$"))
+    end
     github_runner.log_duration("runner_registered", github_runner.ready_at - github_runner.allocated_at)
 
     hop_wait

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -359,6 +359,39 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect { nx.setup_environment }.to hop("register_runner")
     end
 
+    it "persist the service file and the new execution script if the feature flag is enabled" do
+      project.set_ff_runner_jit_file(true)
+      expect(vm).to receive(:runtime_token).and_return("my_token")
+      installation.update(use_docker_mirror: false, cache_enabled: false)
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
+        set -ueo pipefail
+        echo "image version: $ImageVersion"
+        sudo usermod -a -G sudo,adm runneradmin
+        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info
+        echo "UBICLOUD_RUNTIME_TOKEN=my_token
+        UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment
+        sudo tee /etc/systemd/system/runner-script.service > /dev/null > /dev/null <<'EOT'
+        [Unit]
+        Description=runner-script
+        [Service]
+        RemainAfterExit=yes
+        User=runner
+        Group=runner
+        WorkingDirectory=/home/runner
+        ExecStart=/home/runner/actions-runner/run-withenv.sh
+        EOT
+        sudo -u runner tee /home/runner/actions-runner/run-withenv.sh > /dev/null <<'EOT'
+        #!/bin/bash
+        mapfile -t env </etc/environment
+        JIT_CONFIG="$(cat ./actions-runner/.jit_token)"
+        exec env -- "${env[@]}" ./actions-runner/run.sh --jitconfig "$JIT_CONFIG"
+        EOT
+        sudo systemctl daemon-reload
+      COMMAND
+
+      expect { nx.setup_environment }.to hop("register_runner")
+    end
+
     it "hops to register_runner with after enabling transparent cache" do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: true)
@@ -382,6 +415,18 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC$"})
       expect(vm.sshable).to receive(:cmd).with("sudo -- xargs -0 -- systemd-run --uid runner --gid runner --working-directory '/home/runner' --unit runner-script --description runner-script --remain-after-exit -- /home/runner/actions-runner/run-withenv.sh",
         stdin: "AABBCC$$")
+      expect { nx.register_runner }.to hop("wait")
+      expect(runner.runner_id).to eq(123)
+      expect(runner.ready_at).to eq(now)
+    end
+
+    it "pass JIT token via a file if the feature flag is enabled" do
+      project.set_ff_runner_jit_file(true)
+      expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC$"})
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND, stdin: "AABBCC$")
+        sudo -u runner tee /home/runner/actions-runner/.jit_token > /dev/null
+        sudo systemctl start runner-script.service
+      COMMAND
       expect { nx.register_runner }.to hop("wait")
       expect(runner.runner_id).to eq(123)
       expect(runner.ready_at).to eq(now)


### PR DESCRIPTION
Previously, we passed the JIT config to the runner execution script via
command-line arguments using xargs. However, GitHub recently increased
the size of JIT tokens by over 4KB, which made this approach unreliable
due to command-line length limits.

Now, we pass the JIT config via a file instead. This approach is more
stable for handling large strings. Additionally, we now persist the
runner’s service config rather than generating it ad hoc with
systemd-run.

This change is currently behind a feature flag. Once we confirm its
reliability, we can move the files created in the setup_environment step
into the image generation process.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch JIT config to file-based approach in `prog/vm/github_runner.rb`, controlled by a feature flag, with updated tests.
> 
>   - **Behavior**:
>     - Pass JIT config via file instead of command-line in `prog/vm/github_runner.rb` to handle large tokens.
>     - Controlled by `:runner_jit_file` feature flag in `model/project.rb`.
>     - Backward compatible; falls back to old method if feature flag is off.
>   - **Tests**:
>     - Update `spec/prog/vm/github_runner_spec.rb` to test new file-based JIT config behavior.
>     - Add tests for feature flag behavior in `prog/test/github_runner.rb`.
>   - **Misc**:
>     - Add `:runner_jit_file` to feature flags in `model/project.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b3599e2bf73237307fb9159297a147ba927b8867. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->