### PR TITLE
Increase respirate power in E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,7 +115,7 @@ jobs:
         STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       run: |
         set -o pipefail
-        timeout 55m foreman start | tee foreman.log | grep "e2e.1"
+        timeout 55m foreman start -m all=1,respirate=2 | tee foreman.log | grep "e2e.1"
 
     - name: Print logs
       if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   run-ci:
     if: vars.RUN_E2E == 'true'
-    runs-on: ubicloud
+    runs-on: ubicloud-standard-4
     environment: E2E-CI
     timeout-minutes: 60
     concurrency: e2e_environment
@@ -79,6 +79,7 @@ jobs:
         CLOVER_DATABASE_URL: postgres:///clover_test?user=clover
         RACK_ENV: production
         IS_E2E: "true"
+        DISPATCHER_MAX_THREADS: 16
         E2E_HETZNER_SERVER_ID: ${{ secrets.E2E_HETZNER_SERVER_ID }}
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
         HETZNER_SSH_PUBLIC_KEY: ${{ secrets.HETZNER_SSH_PUBLIC_KEY }}


### PR DESCRIPTION
- **Run two respirate processes in E2E**
  In production, we run multiple respirate processes in parallel. To
  better reflect this setup and catch potential concurrency issues, we now
  run two respirate processes in our E2E tests.
  
  This should help surface bugs that only appear when multiple instances
  are active simultaneously.
  

- **Increase thread count of respirate in E2E**
  Occasionally, respirate shows high delays in E2E tests around 20s P75
  and 60s P95 total delay. To address this, we increased its thread count
  to improve responsiveness and reduce queueing delays during tests.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance E2E tests by running two respirate processes and increasing thread count to simulate production concurrency and reduce delays.
> 
>   - **E2E Workflow Changes**:
>     - Run two `respirate` processes in `e2e.yml` to simulate production concurrency.
>     - Increase `DISPATCHER_MAX_THREADS` to 16 to reduce delays in E2E tests.
>   - **Misc**:
>     - Change `runs-on` to `ubicloud-standard-4` in `e2e.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3ac042367d4b72e70b8038b3d49b4d20ccc60d37. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->