### PR TITLE
Add sudo to journalctl command for runner-script service

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -271,7 +271,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     if e.stderr.include?("Job for runner-script.service failed")
       Clog.emit("Failed to start runner script") { {failed_to_start_runner: response.to_h} }
       vm.sshable.cmd(<<~COMMAND)
-        journalctl -xeu runner-script.service
+        sudo journalctl -xeu runner-script.service
         cat /run/systemd/transient/runner-script.service || true
       COMMAND
     end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -435,7 +435,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         stdin: "AABBCC$$").and_raise Sshable::SshError.new("command", "", "Job for runner-script.service failed.\n Check logs", 123, nil)
       expect(Clog).to receive(:emit).with("Failed to start runner script").and_call_original
       expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
-        journalctl -xeu runner-script.service
+        sudo journalctl -xeu runner-script.service
         cat /run/systemd/transient/runner-script.service || true
       COMMAND
       expect { nx.register_runner }.to raise_error Sshable::SshError


### PR DESCRIPTION
It returns an empty output when run as a non-root user with the following message:

    Hint: You are currently not seeing messages from other users and the system.
    Users in groups 'adm', 'systemd-journal' can see all messages.
    Pass -q to turn off this notice