### PR TITLE
Don't perform any work for subnet and nics in wait if aws?

### DIFF
--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -64,6 +64,11 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait
+    if nic.private_subnet.location.aws?
+      nic.semaphores.each(&:destroy)
+      nap 60 * 60 * 24 * 365
+    end
+
     when_repopulate_set? do
       nic.private_subnet.incr_refresh_keys
       decr_repopulate

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -176,6 +176,12 @@ RSpec.describe Prog::Vnet::SubnetNexus do
   end
 
   describe "#wait" do
+    it "naps if location is aws" do
+      expect(ps.location).to receive(:aws?).and_return(true)
+      expect(ps).to receive(:semaphores).and_return([])
+      expect { nx.wait }.to nap(60 * 60 * 24 * 365)
+    end
+
     it "hops to refresh_keys if when_refresh_keys_set?" do
       expect(nx).to receive(:when_refresh_keys_set?).and_yield
       expect(ps).to receive(:update).with(state: "refreshing_keys").and_return(true)


### PR DESCRIPTION
If the location is aws? we don't need to do anything in SubnetNexus and NicNexus except for provisioning and destroy. One exception is the distribution of firewall update to the VMs which we move into its own method and call.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify `wait` method in `NicNexus` and `SubnetNexus` to skip operations for AWS locations, except for firewall updates, and update tests accordingly.
> 
>   - **Behavior**:
>     - In `nic_nexus.rb` and `subnet_nexus.rb`, `wait` method skips operations if location is AWS, except for destroying semaphores and checking firewall updates.
>     - Introduces `check_firewall_update` method in `subnet_nexus.rb` to handle firewall updates separately.
>   - **Tests**:
>     - Updated `nic_nexus_spec.rb` and `subnet_nexus_spec.rb` to test new AWS-specific behavior in `wait` method.
>     - Added tests for `check_firewall_update` in `subnet_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2075333310505f0e69ba9fb1882c81883cabc0eb. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->