### PR TITLE
Postgres failover improvements

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -133,6 +133,10 @@ class PostgresResource < Sequel::Model
     parent_id && restore_target.nil?
   end
 
+  def ongoing_failover?
+    servers.any? { it.taking_over? }
+  end
+
   module HaType
     NONE = "none"
     ASYNC = "async"

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -113,7 +113,7 @@ class PostgresServer < Sequel::Model
     }
   end
 
-  def trigger_failover
+  def trigger_failover(mode:)
     unless representative_at
       Clog.emit("Cannot trigger failover on a non-representative server") { {ubid: ubid} }
       return false
@@ -124,7 +124,7 @@ class PostgresServer < Sequel::Model
       return false
     end
 
-    standby.incr_take_over
+    standby.send(:"incr_#{mode}_take_over")
     true
   end
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -19,7 +19,7 @@ class PostgresServer < Sequel::Model
   include MetricsTargetMethods
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
-  semaphore :restart, :configure, :take_over, :configure_metrics, :destroy, :recycle, :promote
+  semaphore :restart, :configure, :fence, :planned_take_over, :configure_metrics, :destroy, :recycle, :promote
   semaphore :refresh_walg_credentials
 
   def configure_hash

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -297,6 +297,12 @@ class PostgresServer < Sequel::Model
       [vm.vm_storage_volumes.find { it.boot == false }.device_path.shellescape]
     end
   end
+
+  def taking_over?
+    unplanned_take_over_set? || planned_take_over_set? || FAILOVER_LABELS.include?(strand.label)
+  end
+
+  FAILOVER_LABELS = ["prepare_for_unplanned_take_over", "prepare_for_planned_take_over", "wait_fencing_of_old_primary", "taking_over"].freeze
 end
 
 # Table: postgres_server

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -19,8 +19,8 @@ class PostgresServer < Sequel::Model
   include MetricsTargetMethods
 
   semaphore :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup
-  semaphore :restart, :configure, :fence, :planned_take_over, :configure_metrics, :destroy, :recycle, :promote
-  semaphore :refresh_walg_credentials
+  semaphore :restart, :configure, :fence, :planned_take_over, :unplanned_take_over, :configure_metrics
+  semaphore :destroy, :recycle, :promote, :refresh_walg_credentials
 
   def configure_hash
     configs = {

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -36,6 +36,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   label def recycle_representative_server
     if (rs = postgres_resource.representative_server) && !postgres_resource.ongoing_failover?
       hop_prune_servers unless rs.needs_recycling?
+      hop_provision_servers unless postgres_resource.has_enough_ready_servers?
 
       nap 10 * 60 unless postgres_resource.in_maintenance_window?
 

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -34,7 +34,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   end
 
   label def recycle_representative_server
-    if (rs = postgres_resource.representative_server)
+    if (rs = postgres_resource.representative_server) && !postgres_resource.ongoing_failover?
       hop_prune_servers unless rs.needs_recycling?
 
       nap 10 * 60 unless postgres_resource.in_maintenance_window?

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -40,7 +40,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
       nap 10 * 60 unless postgres_resource.in_maintenance_window?
 
       register_deadline(nil, 10 * 60)
-      rs.trigger_failover
+      rs.trigger_failover(mode: "planned")
     end
 
     nap 60

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -560,8 +560,8 @@ SQL
       postgres_server.resource.incr_refresh_dns_record
       postgres_server.resource.servers.each(&:incr_configure)
       postgres_server.resource.servers.each(&:incr_configure_metrics)
+      postgres_server.resource.servers.each(&:incr_restart)
       postgres_server.resource.servers.reject(&:primary?).each { it.update(synchronization_status: "catching_up") }
-      postgres_server.incr_restart
       hop_configure
     when "Failed", "NotStarted"
       vm.sshable.cmd("common/bin/daemonizer 'sudo pg_ctlcluster #{postgres_server.resource.version} main promote' promote_postgres")

--- a/rhizome/postgres/bin/lockout
+++ b/rhizome/postgres/bin/lockout
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../../common/lib/util"
+
+if ARGV.count != 1
+  fail "Wrong number of arguments. Expected 1, Given #{ARGV.count}"
+end
+
+v = ARGV[0]
+
+# Create lockout pg_hba.conf that only allows UNIX socket connections
+# and connections from ubi_replication user
+lockout_pg_hba_entries = <<-PG_HBA
+# PostgreSQL Client Authentication Configuration File - LOCKOUT MODE
+# ================================================================
+#
+# This configuration restricts connections to UNIX sockets only
+# and ubi_replication user for replication.
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+# Database administrative login by Unix domain socket
+local   all             postgres                                peer map=system2postgres
+
+# Allow connections from localhost with ubi_monitoring OS user as
+# ubi_monitoring database user. This will be used by postgres_exporter
+# to scrape metrics and expose them to prometheus.
+local   all             ubi_monitoring                          peer
+
+# Allow replication connection using special replication user for
+# HA standbys (SSL connections from ubi_replication user only)
+hostssl replication     ubi_replication all                     cert map=standby2replication
+PG_HBA
+
+# Write the lockout pg_hba.conf
+safe_write_to_file("/etc/postgresql/#{v}/main/pg_hba.conf", lockout_pg_hba_entries)
+
+# Reload PostgreSQL configuration to apply the new pg_hba.conf
+puts "Reloading PostgreSQL configuration..."
+r "pg_ctlcluster #{v} main reload"
+
+# Terminate all existing connections except our own
+puts "Terminating all existing connections..."
+r "sudo -u postgres psql -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid();\""
+
+puts "PostgreSQL is now in lockout mode - only UNIX socket connections and ubi_replication are allowed."

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -124,4 +124,16 @@ RSpec.describe PostgresResource do
     ])
     postgres_resource.set_firewall_rules
   end
+
+  describe "#ongoing_failover?" do
+    it "returns false if there is no ongoing failover" do
+      expect(postgres_resource).to receive(:servers).and_return([instance_double(PostgresServer, taking_over?: false), instance_double(PostgresServer, taking_over?: false)])
+      expect(postgres_resource.ongoing_failover?).to be false
+    end
+
+    it "returns true if there is an ongoing failover" do
+      expect(postgres_resource).to receive(:servers).and_return([instance_double(PostgresServer, taking_over?: true), instance_double(PostgresServer, taking_over?: false)])
+      expect(postgres_resource.ongoing_failover?).to be true
+    end
+  end
 end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -115,22 +115,22 @@ RSpec.describe PostgresServer do
     it "logs error when server is not primary" do
       expect(postgres_server).to receive(:representative_at).and_return(nil)
       expect(Clog).to receive(:emit).with("Cannot trigger failover on a non-representative server")
-      expect(postgres_server.trigger_failover).to be false
+      expect(postgres_server.trigger_failover(mode: "planned")).to be false
     end
 
     it "logs error when no suitable standby found" do
       expect(postgres_server).to receive(:representative_at).and_return(Time.now)
       expect(postgres_server).to receive(:failover_target).and_return(nil)
       expect(Clog).to receive(:emit).with("No suitable standby found for failover")
-      expect(postgres_server.trigger_failover).to be false
+      expect(postgres_server.trigger_failover(mode: "planned")).to be false
     end
 
     it "returns true only when failover is successfully triggered" do
       standby = instance_double(described_class)
       expect(postgres_server).to receive(:representative_at).and_return(Time.now)
       expect(postgres_server).to receive(:failover_target).and_return(standby)
-      expect(standby).to receive(:incr_take_over)
-      expect(postgres_server.trigger_failover).to be true
+      expect(standby).to receive(:incr_planned_take_over)
+      expect(postgres_server.trigger_failover(mode: "planned")).to be true
     end
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -405,4 +405,16 @@ RSpec.describe PostgresServer do
     expect(postgres_server.vm).to receive(:vm_storage_volumes).and_return([instance_double(VmStorageVolume, boot: false, device_path: "/dev/vdb")])
     expect(postgres_server.storage_device_paths).to eq(["/dev/vdb"])
   end
+
+  describe "#taking_over?" do
+    it "returns true if the strand label is 'taking_over'" do
+      expect(postgres_server).to receive(:strand).and_return(instance_double(Strand, label: "taking_over"))
+      expect(postgres_server.taking_over?).to be true
+    end
+
+    it "returns false if the strand label is not 'wait'" do
+      expect(postgres_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
+      expect(postgres_server.taking_over?).to be false
+    end
+  end
 end

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -91,11 +91,13 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
     it "hops to prune_servers if the representative server does not need recycling" do
       expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: false)).at_least(:once)
+      expect(postgres_resource).to receive(:ongoing_failover?).and_return(false)
       expect { nx.recycle_representative_server }.to hop("prune_servers")
     end
 
     it "waits if it is not the maintenance window" do
       expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: true)).at_least(:once)
+      expect(postgres_resource).to receive(:ongoing_failover?).and_return(false)
       expect(postgres_resource).to receive(:in_maintenance_window?).and_return(false)
       expect(postgres_resource.representative_server).not_to receive(:trigger_failover)
       expect { nx.recycle_representative_server }.to nap(10 * 60)
@@ -103,6 +105,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
     it "triggers failover if maintenance window is not set or if it is the maintenance window" do
       expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, needs_recycling?: true)).at_least(:once)
+      expect(postgres_resource).to receive(:ongoing_failover?).and_return(false)
       expect(postgres_resource).to receive(:in_maintenance_window?).and_return(true)
       expect(postgres_resource.representative_server).to receive(:trigger_failover)
       expect { nx.recycle_representative_server }.to nap(60)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -926,6 +926,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby).to receive(:update).with(synchronization_status: "catching_up")
       expect(standby).to receive(:incr_configure)
       expect(standby).to receive(:incr_configure_metrics)
+      expect(standby).to receive(:incr_restart)
 
       expect(postgres_server.resource).to receive(:servers).at_least(:once).and_return([postgres_server, standby])
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances Postgres failover handling by adding new methods for planned and unplanned failovers, updating server configurations, and improving test coverage.
> 
>   - **Behavior**:
>     - Adds `ongoing_failover?` to `PostgresResource` to check if any server is taking over.
>     - Modifies `trigger_failover` in `PostgresServer` to handle `planned` and `unplanned` modes, logging errors if conditions are not met.
>     - Introduces `fence`, `planned_take_over`, and `unplanned_take_over` semaphores in `PostgresServer`.
>     - Implements `taking_over?` in `PostgresServer` to determine if a server is in the process of taking over.
>     - Adds `lockout` script to restrict connections during failover.
>   - **Configuration**:
>     - Updates `configure_hash` in `PostgresServer` to set archival configs for all servers with blob storage.
>     - Adjusts `configure_hash` to include `archive_command` for all servers, not just primary.
>   - **Failover Process**:
>     - Adds `fence`, `prepare_for_unplanned_take_over`, and `prepare_for_planned_take_over` labels in `PostgresServerNexus`.
>     - Implements `wait_fencing_of_old_primary` to manage fencing and LSN catch-up.
>     - Updates `taking_over` to handle synchronization and DNS refresh.
>   - **Testing**:
>     - Adds tests for `ongoing_failover?` in `postgres_resource_spec.rb`.
>     - Updates `trigger_failover` tests in `postgres_server_spec.rb` to cover new modes.
>     - Adds tests for new failover methods in `postgres_server_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 717bda105201d342d2c7f9768a0f0b49bb9ba96c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->