### PR TITLE
Fix 0 maintenance_window_set param bug

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -361,7 +361,7 @@ class Clover
 
       r.post "set-maintenance-window" do
         authorize("Postgres:edit", pg.id)
-        maintenance_window_start_at = typecast_params.pos_int("maintenance_window_start_at")
+        maintenance_window_start_at = typecast_params.int("maintenance_window_start_at")
 
         DB.transaction do
           pg.update(maintenance_window_start_at:)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -405,6 +405,13 @@ RSpec.describe Clover, "postgres" do
 
         expect(last_response.status).to eq(400)
         expect(pg.reload.maintenance_window_start_at).to be_nil
+
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/set-maintenance-window", {
+          maintenance_window_start_at: -2
+        }.to_json
+
+        expect(last_response.status).to eq(400)
+        expect(pg.reload.maintenance_window_start_at).to be_nil
       end
 
       it "invalid payment" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -760,6 +760,15 @@ RSpec.describe Clover, "postgres" do
         click_button "Set"
         expect(pg.reload.maintenance_window_start_at).to be_nil
       end
+
+      it "sets maintenance window to 0 when 0 is passed" do
+        pg.update(maintenance_window_start_at: 9)
+        visit "#{project.path}#{pg.path}/settings"
+
+        select "00:00 - 02:00 (UTC)", from: "maintenance_window_start_at"
+        click_button "Set"
+        expect(pg.reload.maintenance_window_start_at).to eq(0)
+      end
     end
 
     describe "delete" do


### PR DESCRIPTION
typecast_params.pos_int(x) returns nil if the parameter is not a positive integer. This is problemmatic because 0 is a valid argument for 00:00 - 02:00 maintenance window. However, using pos_int, we simply nullify the value and return success. The problem is, using pos_int is even more problemmatic because for a value of 26, user gets a 400, failure because the db rejects it, however, for a non positive, they simply get 200, but nothing happens. This commit fixes this behavior by simply leaving the error to the database constraint.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix handling of `maintenance_window_start_at` parameter to allow zero and rely on database constraints for validation in `postgres.rb`.
> 
>   - **Behavior**:
>     - Change `typecast_params.pos_int` to `typecast_params.int` in `set-maintenance-window` route in `postgres.rb` to allow zero as a valid value.
>     - Database constraint now handles invalid values, returning 400 for negatives and values over 24.
>   - **Tests**:
>     - Update `postgres_spec.rb` to test zero and negative values for `maintenance_window_start_at`.
>     - Add test for setting maintenance window to 0 in `web/project/postgres_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e2a5c26a3dabeb173b8dbf882c451bf4b9f14f06. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->