### PR TITLE
Do not downgrade premium runner that was explicitly requested

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -243,7 +243,7 @@ class Prog::Vm::Nexus < Prog::Base
             prefs["location_filter"] || runner_location_filter,
             prefs["location_preference"] || runner_location_preference,
             [],
-            prefs["family_filter"] || runner_family_filter
+            (vm.family == "premium" && [vm.family]) || prefs["family_filter"] || runner_family_filter
           ]
         else
           [["accepting"], [vm.location_id], [], [], [vm.family]]

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -565,6 +565,27 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.start }.to hop("create_unix_user")
     end
 
+    it "do not downgrade the premium runner if it's explicitly requested" do
+      vm.location_id = Location::GITHUB_RUNNERS_ID
+      vm.family = "premium"
+      installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: prj.id, allocator_preferences: {"family_filter" => ["standard", "premium"]})
+      GithubRunner.create(label: "ubicloud-premium-30", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
+
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        host_exclusion_filter: [],
+        location_filter: [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID],
+        location_preference: [Location::GITHUB_RUNNERS_ID],
+        gpu_count: 0,
+        gpu_device: nil,
+        family_filter: ["premium"]
+      )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
     it "can force allocating a host" do
       allow(nx).to receive(:frame).and_return({
         "force_host_id" => :vm_host_id,


### PR DESCRIPTION
If the toggle on the UI is enabled, even a runner requested by the
customer with a premium label might be downgraded to a standard runner
because the toggle sets the installation's "family_filter" to
`["standard", "premium"]`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent downgrading explicitly requested premium runners to standard in `nexus.rb`.
> 
>   - **Behavior**:
>     - Prevents downgrading premium runners to standard when explicitly requested by setting `family_filter` to `premium` in `before_run` in `nexus.rb`.
>   - **Tests**:
>     - Adds test in `nexus_spec.rb` to ensure premium runners are not downgraded when explicitly requested.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 93c5042ceb1b942dd12be2cf4d4331de03b7cf77. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->