### PR TITLE
Fix running only vm and postgres e2e tests

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -36,7 +36,7 @@ def main(options)
     tests_to_wait << unencrypted_vms_st
   end
 
-  if (gh_test_cases = all_test_cases.values_at(*options[:test_cases].select { it.include?("github_runner") }))
+  if (gh_test_cases = all_test_cases.values_at(*options[:test_cases].select { it.include?("github_runner") })).any?
     tests_to_wait << Prog::Test::GithubRunner.assemble(gh_test_cases)
   end
 


### PR DESCRIPTION
Since empty array was returning truthy, github runner tests were tried to run even if the user doesn't pass them while running e2e tests, fixing that.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes logical error in `bin/e2e` to prevent unintended execution of GitHub runner tests by checking if `gh_test_cases` is non-empty.
> 
>   - **Behavior**:
>     - Fixes logical error in `bin/e2e` where empty array was treated as truthy, causing unintended GitHub runner tests execution.
>     - Now checks if `gh_test_cases` has any elements before adding to `tests_to_wait`.
>   - **Code**:
>     - Modifies condition in `bin/e2e` to use `.any?` for `gh_test_cases` to ensure it contains elements before proceeding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 833a1fcc0da7f187a70c55922033afc7205419bd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->