### PR TITLE
Fix S3 Endpoint related errors crashing UI

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -54,7 +54,7 @@ PGHOST=/var/run/postgresql
       list_objects("basebackups_005/")
         .select { it.key.end_with?("backup_stop_sentinel.json") }
     rescue => ex
-      recoverable_errors = ["The Access Key Id you provided does not exist in our records.", "AccessDenied", "No route to host", "Connection refused"]
+      recoverable_errors = ["The AWS Access Key Id you provided does not exist in our records.", "The specified bucket does not exist", "AccessDenied", "No route to host", "Connection refused"]
       Clog.emit("Backup fetch exception") { Util.exception_to_hash(ex) }
       return [] if recoverable_errors.any? { ex.message.include?(it) }
       raise

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -110,7 +110,7 @@ PGHOST=/var/run/postgresql
   it "returns empty array if user is not created yet" do
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
     minio_client = instance_double(Minio::Client)
-    expect(minio_client).to receive(:list_objects).and_raise(RuntimeError.new("The Access Key Id you provided does not exist in our records."))
+    expect(minio_client).to receive(:list_objects).and_raise(RuntimeError.new("The AWS Access Key Id you provided does not exist in our records."))
     expect(Minio::Client).to receive(:new).and_return(minio_client)
     expect(postgres_timeline.backups).to eq([])
   end


### PR DESCRIPTION
We use s3 api calls to server read replica and backup/restore pages. When the endpoints fail, which happens when the server is freshly provisioned, these pages cause 500. This commit fixes that by simply swallowing some of the error messages.