### PR TITLE
Use only client-secret-basic authentication for OIDC

### DIFF
--- a/vendor/omniauth_oidc.rb
+++ b/vendor/omniauth_oidc.rb
@@ -109,9 +109,7 @@ module OmniAuth
           body: query_string_for({
             "grant_type" => "authorization_code",
             "code" => params["code"],
-            "redirect_uri" => redirect_uri,
-            "client_id" => opts[:identifier],
-            "client_secret" => opts[:secret]
+            "redirect_uri" => redirect_uri
           }.compact),
           expects: [200, 201]
         )


### PR DESCRIPTION
Okta complains if you provide both client-secret-basic and client-secret-post authentication, even if the two credentials are the same.