### PR TITLE
Update to tilt 2.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "sequel", ">= 5.94"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"
-gem "tilt", ">= 2.6"
+gem "tilt", ">= 2.6.1"
 gem "warning"
 gem "webauthn"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,7 +397,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
     stripe (12.6.0)
-    tilt (2.6.0)
+    tilt (2.6.1)
     timeout (0.4.3)
     tpm-key_attestation (0.12.1)
       bindata (~> 2.4)
@@ -509,7 +509,7 @@ DEPENDENCIES
   simplecov
   standard (>= 1.24.3)
   stripe
-  tilt (>= 2.6)
+  tilt (>= 2.6.1)
   turbo_tests
   warning
   webauthn


### PR DESCRIPTION
Fixes errors like

```
undefined method '__tilt_2720' for module 'Tilt::CompiledTemplates'
```

during parallel coverage testing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `tilt` gem to version `2.6.1` in `Gemfile` to fix an error during parallel coverage testing.
> 
>   - **Gem Update**:
>     - Update `tilt` gem version from `>= 2.6` to `>= 2.6.1` in `Gemfile`.
>   - **Error Fix**:
>     - Fixes `undefined method '__tilt_2720' for module 'Tilt::CompiledTemplates'` error during parallel coverage testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3ec3b2b3901b36931aad4e92631840edb7bc5168. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->