### PR TITLE
Switch to multi phase login

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -383,6 +383,10 @@ class Clover < Roda
       scope.after_rodauth_create_account(account_id)
     end
 
+    use_multi_phase_login? true
+    need_password_notice_flash "Login recognized"
+    multi_phase_login_view { login_view }
+
     # :nocov:
     if Config.omniauth_github_id
       require "omniauth-github"

--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -145,7 +145,7 @@ class Clover < Roda
   def html_attrs(attributes)
     attributes.map do |key, value|
       case key
-      when :required, :checked
+      when :required, :checked, :readonly
         case value
         when true
           key.name

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -23,9 +23,8 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
-    fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
-
+    expect(page).to have_flash_error("The account you tried to login with is currently awaiting verification")
     expect(page.title).to eq("Ubicloud - Resend Verification")
   end
 
@@ -54,18 +53,16 @@ RSpec.describe Clover, "auth" do
     expect(Mail::TestMailer.deliveries.length).to eq 1
 
     fill_in "Email Address", with: TEST_USER_EMAIL
-    fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
+    expect(page).to have_flash_error("The account you tried to login with is currently awaiting verification")
     expect(page).to have_content("You need to wait at least 5 minutes before sending another verification email. If you did not receive the email, please check your spam folder.")
 
     DB[:account_verification_keys].update(email_last_sent: Time.now - 310)
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
-    fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
-
     expect(page).to have_flash_error("The account you tried to login with is currently awaiting verification")
 
     DB.transaction(rollback: :always) do
@@ -160,6 +157,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     check "Remember me"
     click_button "Sign in"
@@ -173,6 +171,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     check "Remember me"
     click_button "Sign in"
@@ -187,9 +186,9 @@ RSpec.describe Clover, "auth" do
     create_account
 
     visit "/login"
-    click_link "Forgot your password?"
-
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
+    click_link "Forgot your password?"
 
     click_button "Request Password Reset"
 
@@ -208,6 +207,7 @@ RSpec.describe Clover, "auth" do
     expect(page.title).to eq("Ubicloud - Login")
 
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: "#{TEST_USER_PASSWORD}_new"
 
     click_button "Sign in"
@@ -218,8 +218,11 @@ RSpec.describe Clover, "auth" do
     DB[:account_password_hashes].where(id: account.id).delete
 
     visit "/login"
-    click_link "Forgot your password?"
+    fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
+    expect(page).to have_no_content("Forget your password?")
 
+    visit "/reset-password-request"
     fill_in "Email Address", with: TEST_USER_EMAIL
     click_button "Request Password Reset"
 
@@ -234,6 +237,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -245,6 +249,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -256,6 +261,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
     expect(page.title).to eq("Ubicloud - #{account.projects.first.name} Dashboard")
@@ -264,6 +270,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -276,6 +283,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     check "Remember me"
     click_button "Sign in"
@@ -292,6 +300,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -303,6 +312,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -314,6 +324,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -325,6 +336,7 @@ RSpec.describe Clover, "auth" do
 
     visit "/login"
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
 
@@ -384,6 +396,7 @@ RSpec.describe Clover, "auth" do
         expect(page.title).to eq("Ubicloud - Login")
 
         fill_in "Email Address", with: new_email
+        click_button "Sign in"
         fill_in "Password", with: TEST_USER_PASSWORD
 
         click_button "Sign in"
@@ -408,6 +421,7 @@ RSpec.describe Clover, "auth" do
       expect(page.title).to eq("Ubicloud - Login")
 
       fill_in "Email Address", with: TEST_USER_EMAIL
+      click_button "Sign in"
       fill_in "Password", with: "#{TEST_USER_PASSWORD}_new"
 
       click_button "Sign in"
@@ -431,6 +445,7 @@ RSpec.describe Clover, "auth" do
         expect(page.title).to eq("Ubicloud - Login")
 
         fill_in "Email Address", with: TEST_USER_EMAIL
+        click_button "Sign in"
         fill_in "Password", with: "#{TEST_USER_PASSWORD}_new"
 
         click_button "Sign in"
@@ -499,7 +514,7 @@ RSpec.describe Clover, "auth" do
       OmniAuth.config.test_mode = true
     end
 
-    it "can login via OIDC flow" do
+    it "can login via OIDC flow using separate login page" do
       visit "/auth/#{OidcProvider.generate_ubid}"
       expect(page.status_code).to eq 404
 
@@ -639,6 +654,45 @@ RSpec.describe Clover, "auth" do
         expect(page).to have_flash_notice("Your account has been disconnected from TestOIDC")
       ensure
         OmniAuth.config.mock_auth[omniauth_key] = nil
+      end
+
+      it "can login via OIDC flow with already connected account using normal login page" do
+        omniauth_key = oidc_provider.ubid.to_sym
+        AccountIdentity.create(account_id: Account.first.id, provider: oidc_provider.ubid, uid: "789")
+        OmniAuth.config.add_mock(omniauth_key, provider: oidc_provider.ubid, uid: "789",
+          info: {email: "user@example.com"})
+        click_button "Log out"
+
+        fill_in "Email Address", with: TEST_USER_EMAIL
+        click_button "Sign in"
+        expect(page).to have_content("Password")
+        expect(page).to have_content("Or login with:")
+        click_button "TestOIDC"
+
+        expect(page.title).to eq("Ubicloud - Default Dashboard")
+        expect(page).to have_flash_notice("You have been logged in")
+      end
+
+      it "can login via OIDC flow with already connected account using normal login page when account does not have password" do
+        omniauth_key = oidc_provider.ubid.to_sym
+        account_id = Account.first.id
+        AccountIdentity.create(account_id:, provider: oidc_provider.ubid, uid: "789")
+        AccountIdentity.create(account_id:, provider: "google", uid: "123")
+        mock_provider(:google, "uSer@example.com")
+        OmniAuth.config.add_mock(omniauth_key, provider: oidc_provider.ubid, uid: "789",
+          info: {email: "user@example.com"})
+        DB[:account_password_hashes].delete
+        click_button "Log out"
+
+        fill_in "Email Address", with: TEST_USER_EMAIL
+        click_button "Sign in"
+        expect(page).to have_no_content("Password")
+        expect(page).to have_content("Login with:")
+        expect(page).to have_content("Google")
+        click_button "TestOIDC"
+
+        expect(page.title).to eq("Ubicloud - Default Dashboard")
+        expect(page).to have_flash_notice("You have been logged in")
       end
 
       it "can connect to existing account" do

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Clover do
     expect(page.status_code).to eq(200)
     expect(page).to have_current_path("/login", ignore_query: true)
     fill_in "Email Address", with: TEST_USER_EMAIL
+    click_button "Sign in"
     fill_in "Password", with: TEST_USER_PASSWORD
     click_button "Sign in"
     expect(page.title).to end_with("Dashboard")

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -83,6 +83,7 @@ RSpec.configure do |config|
     def login(email = TEST_USER_EMAIL, password = TEST_USER_PASSWORD)
       visit "/login"
       fill_in "Email Address", with: email
+      click_button "Sign in"
       fill_in "Password", with: password
       click_button "Sign in"
 

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -2,33 +2,77 @@
 
 <% @page_message = "Sign in to your account" %>
 
-<form class="rodauth space-y-6" role="form" method="POST">
-  <%== rodauth.login_additional_form_tags %>
-  <%== rodauth.csrf_tag %>
+<div class="space-y-6">
+  <form class="space-y-6 rodauth" role="form" method="POST" id="login-form">
+    <%== rodauth.login_additional_form_tags %>
+    <%== rodauth.csrf_tag %>
 
-  <%== render("components/rodauth/login_field") %>
-  <%== render("components/rodauth/password_field") %>
+    <%== render("components/rodauth/login_field") %>
+    <% if rodauth.valid_login_entered? %>
+      <% if rodauth.has_password? %>
+        <%== render("components/rodauth/password_field") %>
+      <% end %>
+    <% end %>
+  </form>
 
-  <div class="flex items-center justify-between">
-    <div class="flex items-center">
-      <input
-        id="remember-me"
-        name="remember-me"
-        type="checkbox"
-        class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
-      >
-      <label for="remember-me" class="ml-2 block text-sm text-gray-900">Remember me</label>
+  <% if rodauth.valid_login_entered? %>
+    <% identities = AccountIdentity.where(account_id: rodauth.account_id).all %>
+    <% unless identities.empty? %>
+      <div class="relative flex justify-center text-sm font-medium leading-6">
+        <span class="bg-white px-6 text-gray-900"><%= rodauth.has_password? ? "Or login" : "Login" %>
+          with:</span>
+      </div>
+    <% end %>
+
+    <% identities.each do |identity| %>
+      <% if identity.provider.start_with?("0p") %>
+        <% provider = OidcProvider.with_pk!(UBID.to_uuid(identity.provider)) %>
+        <% provider_name = provider.display_name %>
+        <% content_security_policy.add_form_action(provider.url) %>
+      <% end %>
+      <form action="<%= rodauth.omniauth_request_path(identity.provider) %>" role="form" method="POST" class="grow">
+        <div class="hidden"><%== rodauth.csrf_tag(rodauth.omniauth_request_path(identity.provider)) %></div>
+        <button
+          class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+          type="submit"
+        >
+          <%== part("components/icon", name: identity.provider.to_s) unless provider_name %>
+          <span class="text-sm font-semibold leading-6"><%= provider_name || identity.provider.capitalize %></span>
+        </button>
+      </form>
+    <% end %>
+  <% end %>
+
+  <% if !rodauth.valid_login_entered? || rodauth.has_password? %>
+    <div class="flex items-center justify-between">
+      <div class="flex items-center">
+        <input
+          id="remember-me"
+          name="remember-me"
+          type="checkbox"
+          class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
+          form="login-form"
+        >
+        <label for="remember-me" class="ml-2 block text-sm text-gray-900">Remember me</label>
+      </div>
+
+      <div class="text-sm">
+        <a
+          href="/reset-password-request?login=<%= Rack::Utils.escape(rodauth.param("login")) %>"
+          class="font-medium text-orange-600 hover:text-orange-700"
+        >Forgot your password?</a>
+      </div>
     </div>
-
-    <div class="text-sm">
-      <a href="/reset-password-request" class="font-medium text-orange-600 hover:text-orange-700">Forgot your password?</a>
-    </div>
-  </div>
+  <% end %>
 
   <div class="flex flex-col text-center">
-    <%== part("components/form/submit_button", text: "Sign in") %>
-    <a href="/create-account" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Create a new account</a>
+    <% if !rodauth.valid_login_entered? || rodauth.has_password? %>
+      <%== part("components/form/submit_button", text: "Sign in", attributes: {form: "login-form"}) %>
+    <% end %>
+    <% unless rodauth.valid_login_entered? %>
+      <a href="/create-account" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Create a new account</a>
+    <% end %>
   </div>
-</form>
+</div>
 
-<%== render("auth/social_buttons") %>
+<%== render("auth/social_buttons") unless rodauth.valid_login_entered? %>

--- a/views/components/rodauth/login_field.erb
+++ b/views/components/rodauth/login_field.erb
@@ -5,8 +5,14 @@
   name: rodauth.login_param,
   type: rodauth.login_input_type,
   label: label,
+  value: rodauth.param("login"),
+  extra_class: ("bg-gray-100" if rodauth.valid_login_entered?),
   attributes: {
     required: true,
+    # Using readonly is technically better, but may result in password
+    # managers such as 1Password not being able to fill in the password,
+    # so it is better to leave it off.
+    # readonly: rodauth.valid_login_entered?,
     autocomplete: rodauth.login_field_autocomplete_value
   }
 ) %>


### PR DESCRIPTION
Multi phase login is the practice where you first ask for the login (email) and not the password, and after you know the related account, you show the options available for login to that account.

Multi phase login allows social login and OIDC login to be part of the normal login flow. Once we know the related account, we can show the authentication options for the account, and not include options that are not available. If the account does not have a password and is only connected to one social login provider, then the password field does not display, and the only button is the button login to the social login provider.

For accounts that only allow password authentication, multi phase login results in an extra step during login. However, I think it's better to support non-password authentication as part of the normal login flow.

A minor improvement I made during this process is if the user enters their login, but cannot remember their password, if they click the "Forgot your password?" link, their email address is already filled in.

Ideally, the login field would be have the readonly attribute during the second login phase.  However, I found that this negatively affects password managers such as 1password.  So I didn't mark the field as readonly.  I left the handling of the readonly attribute as boolean, in case we want to use readonly attributes elsewhere.

This required relatively few spec changes outside of the auth tests, since almost all tests that test for logged in accounts use the login helper method.

Here's what the UI looks like.  For the case where both password and another form of login are supported, I wonder whether it would be better to have the other forms of login under the "Sign in" button instead of above it.

Initial Login page:

![localhost_3000_login(iPhone XR)](https://github.com/user-attachments/assets/6046ae5f-27d4-466d-ae41-e1965276ab37)

Only Password Authentication Supported:

![localhost_3000_login(iPhone XR) (1)](https://github.com/user-attachments/assets/eda86aa0-44df-492f-9e60-94556cb9afcc)

Only OIDC Supported:

![localhost_3000_login(iPhone XR) (2)](https://github.com/user-attachments/assets/f743f728-b20d-4c33-85df-3d1ceef65e8f)

Password and OIDC Supported: 

![localhost_3000_login(iPhone XR) (3)](https://github.com/user-attachments/assets/8e421a0f-5d3f-421e-a04b-d31b46ab15ef)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implements multi-phase login to separate email and password input, supporting social and OIDC logins, with UI and test updates.
> 
>   - **Behavior**:
>     - Implements multi-phase login in `clover.rb`, asking for email first, then showing available login options.
>     - Updates `login.erb` to conditionally render password and social login options based on email input.
>     - If only one login method is available, it is automatically selected.
>     - Pre-fills email in "Forgot your password?" link.
>   - **UI**:
>     - `login.erb` updated to show login options after email is entered.
>     - Login field not set to readonly to support password managers.
>   - **Tests**:
>     - Updates in `auth_spec.rb` and `clover_web_spec.rb` to reflect multi-phase login.
>     - Adds tests for OIDC login flow in `auth_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d2973dc8ffecd0c67a44c3581f2abe2dd77c8e7b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->