### PR TITLE
Ensure OIDC nonce does not repeat

### DIFF
--- a/vendor/omniauth_oidc.rb
+++ b/vendor/omniauth_oidc.rb
@@ -66,7 +66,8 @@ module OmniAuth
       end
 
       def request_phase
-        nonce = session['omniauth.nonce'] = Base64.urlsafe_encode64(SecureRandom.bytes(32))
+        t = Time.now
+        nonce = session['omniauth.nonce'] = Base64.urlsafe_encode64("#{t.to_i}#{t.nsec}#{SecureRandom.bytes(13)}")
         state = session['omniauth.state'] = Base64.urlsafe_encode64(SecureRandom.bytes(32))
 
         opts = client_options


### PR DESCRIPTION
Currently, the nonce is randomly generated with 32 bytes, so statistically it should not run result in a duplicate nonce until 256**16 nonces have been generated. While that's probably fine, it's better to use an approach where nonces are not more likely to be duplicates over time.

This changes nonce generation to use a time-based component. The nonce is now nanosecond specific, and still has 13 bytes of randomness, which should be sufficiently random while still providing the quality that the chance of a duplicate nonce does not increase over time.