### PR TITLE
Improve VPC and NIC operations idempotency

### DIFF
--- a/prog/aws/vpc.rb
+++ b/prog/aws/vpc.rb
@@ -177,6 +177,7 @@ class Prog::Aws::Vpc < Prog::Base
   def ignore_invalid_id
     yield
   rescue ArgumentError,
+    Aws::EC2::Errors::GatewayNotAttached,
     Aws::EC2::Errors::InvalidSubnetIDNotFound,
     Aws::EC2::Errors::InvalidGroupNotFound,
     Aws::EC2::Errors::InvalidNetworkInterfaceIDNotFound,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve idempotency in VPC and NIC operations by refactoring methods and enhancing error handling in `nic.rb` and `vpc.rb`.
> 
>   - **Behavior**:
>     - Refactor `assign_ipv6_address` in `nic.rb` to use `get_network_interface` for checking existing IPv6 addresses.
>     - Add `get_network_interface` method in `nic.rb` for DRY principle.
>     - Add `Aws::EC2::Errors::GatewayNotAttached` to `ignore_invalid_id` in `vpc.rb`.
>   - **Tests**:
>     - Update `nic_spec.rb` to test new `assign_ipv6_address` behavior and `get_network_interface` usage.
>     - Add tests for skipping IPv6 assignment if already present in `nic_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a1bd508699472c0d8d5540affccca08ca1f258a5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->