### PR TITLE
Fix GitHub captialization in omniauth code

### DIFF
--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -85,11 +85,8 @@ class Clover < Roda
   end
 
   def omniauth_provider_name(provider)
-    if omniauth_providers.map { |provider,| provider.to_s }.include?(provider)
-      provider.capitalize
-    else
-      OidcProvider.name_for_ubid(provider) || provider
-    end
+    omniauth_providers.each { |sym, name| return name if sym.name == provider }
+    OidcProvider.name_for_ubid(provider) || provider
   end
 
   def omniauth_providers

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe Clover, "auth" do
         account_id = Account.first.id
         AccountIdentity.create(account_id:, provider: oidc_provider.ubid, uid: "789")
         AccountIdentity.create(account_id:, provider: "google", uid: "123")
-        mock_provider(:google, "uSer@example.com")
+        mock_provider(:github, "uSer@example.com")
         OmniAuth.config.add_mock(omniauth_key, provider: oidc_provider.ubid, uid: "789",
           info: {email: "user@example.com"})
         DB[:account_password_hashes].delete
@@ -688,7 +688,7 @@ RSpec.describe Clover, "auth" do
         click_button "Sign in"
         expect(page).to have_no_content("Password")
         expect(page).to have_content("Login with:")
-        expect(page).to have_content("Google")
+        expect(page).to have_content("GitHub")
         click_button "TestOIDC"
 
         expect(page.title).to eq("Ubicloud - Default Dashboard")
@@ -704,7 +704,7 @@ RSpec.describe Clover, "auth" do
         end
 
         expect(page.title).to eq("Ubicloud - Login Methods")
-        expect(page).to have_flash_notice("You have successfully connected your account with Github.")
+        expect(page).to have_flash_notice("You have successfully connected your account with GitHub.")
       end
 
       it "can disconnect from existing account" do
@@ -717,7 +717,7 @@ RSpec.describe Clover, "auth" do
         end
 
         expect(page.title).to eq("Ubicloud - Login Methods")
-        expect(page).to have_flash_notice("Your account has been disconnected from Github")
+        expect(page).to have_flash_notice("Your account has been disconnected from GitHub")
       end
 
       it "can delete password if another login method is available" do
@@ -756,7 +756,7 @@ RSpec.describe Clover, "auth" do
         end
 
         expect(page.title).to eq("Ubicloud - Login Methods")
-        expect(page).to have_flash_error("Your account already has been disconnected from Github")
+        expect(page).to have_flash_error("Your account already has been disconnected from GitHub")
       end
 
       it "can not connect an account with different email" do
@@ -768,7 +768,7 @@ RSpec.describe Clover, "auth" do
         end
 
         expect(page.title).to eq("Ubicloud - Login Methods")
-        expect(page).to have_flash_error("Your account's email address is different from the email address associated with the Github account.")
+        expect(page).to have_flash_error("Your account's email address is different from the email address associated with the GitHub account.")
       end
 
       it "can not connect a social account with multiple accounts" do
@@ -781,7 +781,7 @@ RSpec.describe Clover, "auth" do
         end
 
         expect(page.title).to eq("Ubicloud - Login Methods")
-        expect(page).to have_flash_error("Your account's email address is different from the email address associated with the Github account.")
+        expect(page).to have_flash_error("Your account's email address is different from the email address associated with the GitHub account.")
       end
     end
   end


### PR DESCRIPTION
The omniauth_provider_name method previously used provider.capitalize, as that's what the code it replaced used, but while that works fine for google, it doesn't work well for github. Use the name in omniauth_providers, which has the correct capitalization.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes GitHub capitalization in `omniauth_provider_name` and updates related tests in `auth_spec.rb`.
> 
>   - **Behavior**:
>     - Fixes capitalization of 'GitHub' in `omniauth_provider_name` in `helpers/web.rb` by using the correct name from `omniauth_providers`.
>     - Updates test cases in `auth_spec.rb` to expect 'GitHub' instead of 'Github'.
>   - **Tests**:
>     - Changes `mock_provider(:google, "uSer@example.com")` to `mock_provider(:github, "uSer@example.com")` in `auth_spec.rb`.
>     - Updates flash messages and content expectations in `auth_spec.rb` to use 'GitHub'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b0b173d76cac6854f1e37c4b5011a3ff01017046. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->