### PR TITLE
Show softirq usage in PostgreSQL metrics dashboard

### DIFF
--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -13,7 +13,7 @@ module Metrics
       series: [
         TimeSeries.new(
           labels: {},
-          query: "avg(rate(node_cpu_seconds_total{mode=~\"(iowait|user|system|steal)\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])) by (mode) * 100"
+          query: "avg(rate(node_cpu_seconds_total{mode=~\"(iowait|user|system|steal|softirq)\", ubicloud_resource_id=\"$ubicloud_resource_id\", ubicloud_resource_role=\"primary\"}[1m])) by (mode) * 100"
         )
       ]
     ),


### PR DESCRIPTION
Prometheus has many modes for CPU usage metrics and we only share information about few of them. We recently hit a case where softirq usage was significant (> 10%), but it was not shown in the dashboard, because it was not one of the metrics we were showing in the dashboard.

This commit adds softirq usage to the dashboard, so that we can see it in the future. It seems it is interesting enough to be shown in the dashboard.