### PR TITLE
Fix logged respirate sleep_duration_sec

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -65,12 +65,13 @@ DB.synchronize do
     end
 
     if no_strands && no_old_strands && !d.shutting_down
+      sleep_duration_sec = d.sleep_duration
       # Only sleep if not shutting down and there were no strands in previous scan.
       # Note that this results in an up to a 1 second delay to pick up new strands,
       # but that is an accept tradeoff, because we do not want to busy loop the
       # database (potentially, LISTEN/NOTIFY could be used to reduce this latency)
-      duration_slept = sleep d.sleep_duration
-      Clog.emit("respirate finished sleep") { {sleep_duration_sec: duration_slept} }
+      sleep sleep_duration_sec
+      Clog.emit("respirate finished sleep") { {sleep_duration_sec:} }
     end
   end
 end


### PR DESCRIPTION
Kernel#sleep returns the duration slept rounded to an integer, which is less helpful when sleeps are going to be between 0.2 and 1. Return the number of seconds that sleep was requested for instead, which can be fractional. This should allow for proper calculation of how long respirate scan threads are actually sleeping.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `respirate`, log requested sleep duration instead of actual duration to allow fractional seconds, improving accuracy of sleep duration logging.
> 
>   - **Behavior**:
>     - In `respirate`, log requested sleep duration instead of actual duration, allowing fractional seconds.
>     - Affects `sleep` and `Clog.emit` calls when no strands are found and not shutting down.
>   - **Misc**:
>     - Improves accuracy of sleep duration logging for better monitoring of respirate scan threads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 396c9dc32c5434cecf5c95dad8a147de464d4130. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->