### PR TITLE
Support Ubiblk v0.1‑7

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -132,7 +132,7 @@ module Config
   override :spdk_version, "v23.09-ubi-0.3"
 
   # Vhost Block Backend
-  override :vhost_block_backend_version, "v0.1-6"
+  override :vhost_block_backend_version, "v0.1-7"
 
   # Boot Images
   override :default_boot_image_name, "ubuntu-jammy", string

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -4,8 +4,8 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   subject_is :sshable, :vm_host
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
-    ["v0.1-6", "x64"],
-    ["v0.1-6", "arm64"]
+    ["v0.1-7", "x64"],
+    ["v0.1-7", "arm64"]
   ].freeze.each(&:freeze)
 
   def self.assemble(vm_host_id, version, allocation_weight: 0)

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -9,10 +9,10 @@ class VhostBlockBackend
   end
 
   def sha256
-    if @version == "v0.1-6" && Arch.x64?
-      "9e7e105e71e9316af40df5a79d6ef1cbbf48dea5d590cf82da60b6a7f99885dc"
-    elsif @version == "v0.1-6" && Arch.arm64?
-      "f9bce53f07f43e276077735461203ceed000c47554a7fab0fcc64db04bb17452"
+    if @version == "v0.1-7" && Arch.x64?
+      "114119bc78609db3795bcd426a386eb97a623ba78e9177de6b375b9616927ca6"
+    elsif @version == "v0.1-7" && Arch.arm64?
+      "aa92b91130de6e086332c4ad8dcb76e233624055532d5494db0a987883adee0f"
     else
       fail "Unsupported version: #{@version}, #{Arch.sym}"
     end


### PR DESCRIPTION
Ubiblk v0.1‑7 upgrades its dependencies to the most recent versions, which consequently fixes a startup race condition.

The observable symptom of the race condition was that CH sometimes failed to boot with Ubiblk disks. The sequence was:

1. CH sent `VHOST_USER_SET_VRING_ENABLE` to enable the vring, but didn’t require an acknowledgement that it had been processed by Ubiblk.
2. The first IO request was placed into the vring, and the kick EventFd was signalled to notify Ubiblk that there was IO to process.

The `vhost` crate used by Ubiblk ignores notifications before the vring is enabled, so sometimes step 2 occurred before the enable message was processed, causing Ubiblk to miss the IO request.

In vhost 0.14.0, the crate was updated to set the `REPLY_ACK` protocol feature. When Ubiblk advertises this feature to CH, CH will wait for the acknowledgement in step 1 before proceeding, eliminating the race condition.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates Ubiblk to v0.1-7 to fix a startup race condition by requiring acknowledgment for `VHOST_USER_SET_VRING_ENABLE`.
> 
>   - **Behavior**:
>     - Updates Ubiblk to v0.1-7 in `config.rb`, `setup_vhost_block_backend.rb`, and `vhost_block_backend.rb`.
>     - Fixes startup race condition by requiring acknowledgment for `VHOST_USER_SET_VRING_ENABLE`.
>   - **Versioning**:
>     - Updates `vhost_block_backend_version` to "v0.1-7" in `config.rb`.
>     - Updates supported versions to "v0.1-7" in `setup_vhost_block_backend.rb`.
>     - Updates SHA256 checksums for "v0.1-7" in `vhost_block_backend.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c3634e4740d7e568b16961aea0167937c9d48759. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->