### PR TITLE
Log how many runners can fit into available capacity

### DIFF
--- a/prog/log_vm_host_utilizations.rb
+++ b/prog/log_vm_host_utilizations.rb
@@ -11,19 +11,25 @@ class Prog::LogVmHostUtilizations < Prog::Base
         round(sum(:used_cores) * 100.0 / sum(:total_cores), 2).cast(:float).as(:core_utilization),
         sum(:used_hugepages_1g).as(:used_hugepages_1g),
         sum(:total_hugepages_1g).as(:total_hugepages_1g),
-        round(sum(:used_hugepages_1g) * 100.0 / sum(:total_hugepages_1g), 2).cast(:float).as(:hugepage_utilization)
+        round(sum(:used_hugepages_1g) * 100.0 / sum(:total_hugepages_1g), 2).cast(:float).as(:hugepage_utilization),
+        sum(floor((Sequel[:total_cores] - Sequel[:used_cores]) / Sequel.case({"x64" => 1, "arm64" => 2}, 0, :arch))).cast(:integer).as(:available_standard_2_count),
+        sum(floor((Sequel[:total_cores] - Sequel[:used_cores]) / Sequel.case({"x64" => 2, "arm64" => 4}, 0, :arch))).cast(:integer).as(:available_standard_4_count),
+        sum(floor((Sequel[:total_cores] - Sequel[:used_cores]) / Sequel.case({"x64" => 4, "arm64" => 8}, 0, :arch))).cast(:integer).as(:available_standard_8_count),
+        sum(floor((Sequel[:total_cores] - Sequel[:used_cores]) / Sequel.case({"x64" => 8, "arm64" => 16}, 0, :arch))).cast(:integer).as(:available_standard_16_count),
+        sum(floor((Sequel[:total_cores] - Sequel[:used_cores]) / Sequel.case({"x64" => 15, "arm64" => 30}, 0, :arch))).cast(:integer).as(:available_standard_30_count),
+        sum(floor((Sequel[:total_cores] - Sequel[:used_cores]) / Sequel.case({"x64" => 30, "arm64" => 60}, 0, :arch))).cast(:integer).as(:available_standard_60_count)
       ]
     }.group(:allocation_state, :location_id, :arch, :family).all
 
     rows.each { |row| Clog.emit("location utilization") { {location_utilization: row.values} } }
 
+    aggregation_keys = [:host_count, :used_cores, :total_cores, :used_hugepages_1g, :total_hugepages_1g,
+      :available_standard_2_count, :available_standard_4_count, :available_standard_8_count, :available_standard_16_count,
+      :available_standard_30_count, :available_standard_60_count].freeze
+
     rows.select { |row| row[:allocation_state] == "accepting" }.group_by { [it[:arch], it[:family]] }.each do |(arch, family), rows|
       values = rows.each_with_object(Hash.new(0)) do |row, totals|
-        totals[:host_count] += row[:host_count]
-        totals[:used_cores] += row[:used_cores]
-        totals[:total_cores] += row[:total_cores]
-        totals[:used_hugepages_1g] += row[:used_hugepages_1g]
-        totals[:total_hugepages_1g] += row[:total_hugepages_1g]
+        aggregation_keys.each { totals[it] += row[it] }
       end
       values[:arch] = arch
       values[:family] = family

--- a/prog/log_vm_host_utilizations.rb
+++ b/prog/log_vm_host_utilizations.rb
@@ -4,7 +4,7 @@ class Prog::LogVmHostUtilizations < Prog::Base
   label def wait
     rows = VmHost.where { (total_cores > 0) & (total_hugepages_1g > 0) }.select {
       [
-        :allocation_state, :location_id, :arch,
+        :allocation_state, :location_id, :arch, :family,
         count(:id).as(:host_count),
         sum(:used_cores).as(:used_cores),
         sum(:total_cores).as(:total_cores),
@@ -13,12 +13,12 @@ class Prog::LogVmHostUtilizations < Prog::Base
         sum(:total_hugepages_1g).as(:total_hugepages_1g),
         round(sum(:used_hugepages_1g) * 100.0 / sum(:total_hugepages_1g), 2).cast(:float).as(:hugepage_utilization)
       ]
-    }.group(:allocation_state, :location_id, :arch).all
+    }.group(:allocation_state, :location_id, :arch, :family).all
 
     rows.each { |row| Clog.emit("location utilization") { {location_utilization: row.values} } }
 
-    rows.select { |row| row[:allocation_state] == "accepting" }.group_by(&:arch).each do |arch, arch_rows|
-      values = arch_rows.each_with_object(Hash.new(0)) do |row, totals|
+    rows.select { |row| row[:allocation_state] == "accepting" }.group_by { [it[:arch], it[:family]] }.each do |(arch, family), rows|
+      values = rows.each_with_object(Hash.new(0)) do |row, totals|
         totals[:host_count] += row[:host_count]
         totals[:used_cores] += row[:used_cores]
         totals[:total_cores] += row[:total_cores]
@@ -26,9 +26,9 @@ class Prog::LogVmHostUtilizations < Prog::Base
         totals[:total_hugepages_1g] += row[:total_hugepages_1g]
       end
       values[:arch] = arch
+      values[:family] = family
       values[:core_utilization] = (values[:used_cores] * 100.0 / values[:total_cores]).round(2)
       values[:hugepage_utilization] = (values[:used_hugepages_1g] * 100.0 / values[:total_hugepages_1g]).round(2)
-
       Clog.emit("arch utilization") { {arch_utilization: values} }
     end
 

--- a/spec/prog/log_vm_host_utilizations_spec.rb
+++ b/spec/prog/log_vm_host_utilizations_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Prog::LogVmHostUtilizations do
         if dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:family] == "standard" && dat[:allocation_state] == "accepting"
           expect(dat[:core_utilization]).to eq(30.0)
           expect(dat[:hugepage_utilization]).to eq(25.0)
+          expect(dat[:available_standard_8_count]).to eq(1)
         elsif dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:family] == "standard" && dat[:allocation_state] == "draining"
           expect(dat[:core_utilization]).to eq(25.0)
           expect(dat[:hugepage_utilization]).to eq(33.33)
@@ -34,12 +35,15 @@ RSpec.describe Prog::LogVmHostUtilizations do
         if dat[:arch] == "x64" && dat[:family] == "standard"
           expect(dat[:core_utilization]).to eq(25)
           expect(dat[:hugepage_utilization]).to eq(22.22)
+          expect(dat[:available_standard_4_count]).to eq(7)
+          expect(dat[:available_standard_30_count]).to eq(0)
         elsif dat[:arch] == "x64" && dat[:family] == "premium"
           expect(dat[:core_utilization]).to eq(62.5)
           expect(dat[:hugepage_utilization]).to eq(31.25)
         elsif dat[:arch] == "arm64" && dat[:family] == "standard"
           expect(dat[:core_utilization]).to eq(12.5)
           expect(dat[:hugepage_utilization]).to eq(15.0)
+          expect(dat[:available_standard_30_count]).to eq(2)
         end
       end.exactly(3)
 

--- a/spec/prog/log_vm_host_utilizations_spec.rb
+++ b/spec/prog/log_vm_host_utilizations_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe Prog::LogVmHostUtilizations do
 
       expect(Clog).to receive(:emit).with("location utilization") do |&blk|
         dat = blk.call[:location_utilization]
-        if dat[:location] == "hetzner-fsn1" && dat[:arch] == "x64" && dat[:allocation_state] == "accepting"
+        if dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:allocation_state] == "accepting"
           expect(dat[:core_utilization]).to eq(30.0)
           expect(dat[:hugepage_utilization]).to eq(25.0)
-        elsif dat[:location] == "hetzner-fsn1" && dat[:arch] == "x64" && dat[:allocation_state] == "draining"
+        elsif dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:allocation_state] == "draining"
           expect(dat[:core_utilization]).to eq(25.0)
           expect(dat[:hugepage_utilization]).to eq(33.33)
         end

--- a/spec/prog/log_vm_host_utilizations_spec.rb
+++ b/spec/prog/log_vm_host_utilizations_spec.rb
@@ -8,36 +8,40 @@ RSpec.describe Prog::LogVmHostUtilizations do
   describe "#wait" do
     it "logs vm host utilizations every minute" do
       [
-        ["hetzner-fsn1", "x64", "accepting", 3, 10, 20, 80],
-        ["hetzner-fsn1", "x64", "draining", 5, 20, 50, 150],
-        ["hetzner-fsn1", "arm64", "accepting", 10, 80, 30, 200],
-        ["hetzner-hel1", "x64", "accepting", 2, 10, 20, 100],
-        ["hetzner-hel1", "x64", "accepting", 0, nil, 0, 0]
-      ].each do |location, arch, allocation_state, used_cores, total_cores, used_hugepages_1g, total_hugepages_1g|
-        create_vm_host(location_id: Location[name: location].id, arch:, allocation_state:, used_cores:, total_cores:, used_hugepages_1g:, total_hugepages_1g:)
+        ["hetzner-fsn1", "x64", "standard", "accepting", 3, 10, 20, 80],
+        ["hetzner-fsn1", "x64", "standard", "draining", 5, 20, 50, 150],
+        ["hetzner-fsn1", "arm64", "standard", "accepting", 10, 80, 30, 200],
+        ["hetzner-hel1", "x64", "standard", "accepting", 2, 10, 20, 100],
+        ["hetzner-hel1", "x64", "standard", "accepting", 0, nil, 0, 0],
+        ["hetzner-fsn1", "x64", "premium", "accepting", 10, 16, 80, 256]
+      ].each do |location, arch, family, allocation_state, used_cores, total_cores, used_hugepages_1g, total_hugepages_1g|
+        create_vm_host(location_id: Location[name: location].id, arch:, family:, allocation_state:, used_cores:, total_cores:, used_hugepages_1g:, total_hugepages_1g:)
       end
 
       expect(Clog).to receive(:emit).with("location utilization") do |&blk|
         dat = blk.call[:location_utilization]
-        if dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:allocation_state] == "accepting"
+        if dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:family] == "standard" && dat[:allocation_state] == "accepting"
           expect(dat[:core_utilization]).to eq(30.0)
           expect(dat[:hugepage_utilization]).to eq(25.0)
-        elsif dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:allocation_state] == "draining"
+        elsif dat[:location_id] == Location::HETZNER_FSN1_ID && dat[:arch] == "x64" && dat[:family] == "standard" && dat[:allocation_state] == "draining"
           expect(dat[:core_utilization]).to eq(25.0)
           expect(dat[:hugepage_utilization]).to eq(33.33)
         end
-      end.at_least(:once)
+      end.exactly(5)
 
       expect(Clog).to receive(:emit).with("arch utilization") do |&blk|
         dat = blk.call[:arch_utilization]
-        if dat[:arch] == "x64"
-          expect(dat[:core_utilization]).to eq(25.0)
+        if dat[:arch] == "x64" && dat[:family] == "standard"
+          expect(dat[:core_utilization]).to eq(25)
           expect(dat[:hugepage_utilization]).to eq(22.22)
-        elsif dat[:arch] == "arm64"
+        elsif dat[:arch] == "x64" && dat[:family] == "premium"
+          expect(dat[:core_utilization]).to eq(62.5)
+          expect(dat[:hugepage_utilization]).to eq(31.25)
+        elsif dat[:arch] == "arm64" && dat[:family] == "standard"
           expect(dat[:core_utilization]).to eq(12.5)
           expect(dat[:hugepage_utilization]).to eq(15.0)
         end
-      end.at_least(:once)
+      end.exactly(3)
 
       expect { lvmhu.wait }.to nap(60)
     end


### PR DESCRIPTION
- **Fix unreachable expectations in the utilization log test**
  We replaced `:location` with `:location_id` in the VM host table.
  
  We didn't catch this bug earlier because the if condition didn't match,
  so it just skipped the expectation.
  

- **Group utilization metrics with family along with arch**
  Since standard and premium VMs are allocated on their corresponding
  hosts, it's better to log their utilization separately. We might have
  available capacity for standard VMs but not for premium VMs.
  

- **Log how many runners can fit into available capacity**
  We currently log overall utilization, which gives a good high-level
  view, but it’s not very useful for larger runner sizes. For example, we
  might have enough free cores for a standard-30 runner, but if those
  cores are fragmented across multiple hosts, we can’t actually allocate
  one.
  
  This change adds tracking for how many runners of each type can
  realistically fit into the available capacity on the hosts.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance VM host utilization logging by adding runner count metrics and fixing test expectations.
> 
>   - **Logging Enhancements**:
>     - Add `family` to grouping in `Prog::LogVmHostUtilizations` to separate standard and premium VM utilization.
>     - Log available runner counts (`available_standard_2_count`, `available_standard_4_count`, etc.) based on core availability in `prog/log_vm_host_utilizations.rb`.
>   - **Test Fixes**:
>     - Replace `:location` with `:location_id` in `spec/prog/log_vm_host_utilizations_spec.rb` to fix unreachable expectations.
>     - Update test cases to include `family` and validate new runner count metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7777931d9f9bb5e6e500a55ded2a4d1ff90c14c0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->