### PR TITLE
Add CloudHypervisor 46.0 as a supported version in Rhizome for Ubuntu 24 

### DIFF
--- a/prog/download_cloud_hypervisor.rb
+++ b/prog/download_cloud_hypervisor.rb
@@ -43,10 +43,10 @@ class Prog::DownloadCloudHypervisor < Prog::Base
     ["ch-remote", "x64", "35.1"] => "337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0",
     ["ch-bin", "arm64", "35.1"] => "071a0b4918565ce81671ecd36d65b87351c85ea9ca0fbf73d4a67ec810efe606",
     ["ch-remote", "arm64", "35.1"] => "355cdb1e2af7653a15912c66f7c76c922ca788fd33d77f6f75846ff41278e249",
-    ["ch-bin", "x64", "45.0"] => "362d42eb464e2980d7b41109a214f8b1518b4e1f8e7d8c227b67c19d4581c250",
-    ["ch-remote", "x64", "45.0"] => "11a050087d279f9b5860ddbf2545fda43edf93f9b266440d0981932ee379c6ec",
-    ["ch-bin", "arm64", "45.0"] => "3a8073379d098817d54f7c0ab25a7734b88b070a98e5d820ab39e244b35b5e5e",
-    ["ch-remote", "arm64", "45.0"] => "a4b736ce82f5e2fc4a92796a9a443f243ef69f4970dad1e1772bd841c76c3301"
+    ["ch-bin", "x64", "46.0"] => "00b5cf2976847d2f21d2b7266038c8fc40bd14f2a542115055e9e214867edc9e",
+    ["ch-remote", "x64", "46.0"] => "526c91cf6b2d30b24af6eb39511f4f562f7bbc50a4dfb17d486274057a162445",
+    ["ch-bin", "arm64", "46.0"] => "a5a19c7e7326a5ca5dcf83a7b895a03e81cdac8c7d0690d4e94133cc89d38561",
+    ["ch-remote", "arm64", "46.0"] => "6395a86db76f1f50d8b8c0ae1debbbb6a08e572b6f8c57cfbd9511e9beb4126a"
   }
 
   def sha_256(bin)

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -113,6 +113,13 @@ module CloudHypervisor
       arm64: new("35.1", "071a0b4918565ce81671ecd36d65b87351c85ea9ca0fbf73d4a67ec810efe606", "355cdb1e2af7653a15912c66f7c76c922ca788fd33d77f6f75846ff41278e249")
     )}
 
+    if ubuntu_version >= 24
+      SUPPORTED["46.0"] = Arch.render(
+        x64: new("46.0", "00b5cf2976847d2f21d2b7266038c8fc40bd14f2a542115055e9e214867edc9e", "526c91cf6b2d30b24af6eb39511f4f562f7bbc50a4dfb17d486274057a162445"),
+        arm64: new("46.0", "a5a19c7e7326a5ca5dcf83a7b895a03e81cdac8c7d0690d4e94133cc89d38561", "6395a86db76f1f50d8b8c0ae1debbbb6a08e572b6f8c57cfbd9511e9beb4126a")
+      )
+    end
+
     default = SUPPORTED["35.1"]
     SUPPORTED.freeze
 

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Prog::Vm::Nexus do
 
     [
       {"swap_size_bytes" => nil},
-      {"swap_size_bytes" => nil, "hugepages" => false, "ch_version" => "45.0", "firmware_version" => "202311"}
+      {"swap_size_bytes" => nil, "hugepages" => false, "ch_version" => "46.0", "firmware_version" => "202311"}
     ].each do |frame_update|
       it "generates and passes a params json if prep command is not started yet (with frame opts: #{frame_update.inspect})" do
         nx.strand.stack.first.update(frame_update)


### PR DESCRIPTION
This is the first step in upgrading CloudHypervisor from 35.1 to 46.0, supporting the installation of CloudHypervisor 46.0 (on Ubuntu 24.04 hosts), while keeping CloudHypervisor 35.1 as the default.

With this, you can install CloudHypervisor 46.0 on VM hosts via (for amd64 hosts):

```
vm_host.download_cloud_hypervisor(version_x64: "46.0")
```

While this does not change the default CloudHypervisor version, it marks CloudHypervisor 46.0 as a supported version on Ubuntu 24 hosts in Rhizome.  This will make it so that new hosts install both CloudHypervisor 35.1 and 46.0.

After this goes into production, we'll need to update rhizome on hosts and install CloudHypervisor 46.0 on them.  After that, we can start gradually testing CloudHypervisor 46.0 for VMs.

I've tested this on my development host, and have it running both a CloudHypervisor 35.1 VM and a CloudHypervisor 46.0 VM.

These changes are minimal, because most of the work to support newer CloudHypervisor versions was merged earlier when we were originally planning a rollout of CloudHypervisor 45.0.