### PR TITLE
Cleanup the daemon after setting up VhostBlockBackend.

### DIFF
--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -40,6 +40,7 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
     q_name = "setup-vhost-block-backend-#{q_version}".shellescape
     case sshable.cmd("common/bin/daemonizer --check #{q_name}")
     when "Succeeded"
+      sshable.cmd("common/bin/daemonizer --clean #{q_name}")
       VhostBlockBackend.first(
         vm_host_id: vm_host.id, version: frame["version"]
       ).update(allocation_weight: frame["allocation_weight"])

--- a/spec/prog/storage/setup_vhost_block_backend_spec.rb
+++ b/spec/prog/storage/setup_vhost_block_backend_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Prog::Storage::SetupVhostBlockBackend do
     it "updates and pops if succeeded" do
       VhostBlockBackend.create(version: version.to_s, allocation_weight: 0, vm_host_id: vm_host.id)
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check setup-vhost-block-backend-#{version}").and_return("Succeeded")
+      expect(sshable).to receive(:cmd).with("common/bin/daemonizer --clean setup-vhost-block-backend-#{version}")
       expect { setup_vhost_block_backend.install_vhost_backend }.to exit({"msg" => "VhostBlockBackend was setup"})
       expect(VhostBlockBackend.first.allocation_weight).to eq(50)
     end


### PR DESCRIPTION
Otherwise, destroy -> reinstall of it won't work properly, which comes up frequently during development.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds daemon cleanup in `install_vhost_backend` to ensure proper reinstall functionality, with updated tests.
> 
>   - **Behavior**:
>     - Adds `sshable.cmd("common/bin/daemonizer --clean #{q_name}")` in `install_vhost_backend` method in `setup_vhost_block_backend.rb` to clean up the daemon after successful setup.
>   - **Tests**:
>     - Updates test in `setup_vhost_block_backend_spec.rb` to expect daemon cleanup command after a successful check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9c750f48cdaed5705a518d680bac9e98c23e04d6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->