### PR TITLE
Rhizome: don't fail at purge if storage service isn't installed yet.

### DIFF
--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -325,10 +325,16 @@ class StorageVolume
     end
   end
 
+  def stop_service_if_loaded(name)
+    r "systemctl stop #{name.shellescape}"
+  rescue CommandFail => e
+    raise unless e.stderr.include?("not loaded")
+  end
+
   def purge_spdk_artifacts
     if @vhost_backend_version
       service_file_path = "/etc/systemd/system/#{vhost_user_block_service}"
-      r "systemctl stop #{q_vhost_user_block_service}"
+      stop_service_if_loaded(vhost_user_block_service)
       rm_if_exists(service_file_path)
       rm_if_exists(vhost_sock)
       return

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -525,4 +525,21 @@ RSpec.describe StorageVolume do
       expect { encrypted_sv.persistent_device_id("storage_path") }.to raise_error RuntimeError, "No persistent device ID found for storage path: storage_path"
     end
   end
+
+  describe "#stop_service_if_loaded" do
+    it "stops the service if it is loaded" do
+      expect(encrypted_vhost_sv).to receive(:r).with("systemctl stop test-2-storage.service")
+      encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service")
+    end
+
+    it "does nothing if the service is not loaded" do
+      allow(encrypted_vhost_sv).to receive(:r).and_raise(CommandFail.new("error", "", "Unit test-2-storage.service not loaded."))
+      expect { encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service") }.not_to raise_error
+    end
+
+    it "raises an error for unexpected command failures" do
+      allow(encrypted_vhost_sv).to receive(:r).and_raise(CommandFail.new("unexpected error", "some output", "Some error"))
+      expect { encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service") }.to raise_error(CommandFail, /unexpected error/)
+    end
+  end
 end


### PR DESCRIPTION
Previously if a VM was destroyed before its storage was installed, purge would fail with an error like:

```
Failed to stop vm123456-0-storage.service: Unit vm123456-0-storage.service not loaded.
```