### PR TITLE
Pick random AZ for AWS subnets

### DIFF
--- a/prog/aws/vpc.rb
+++ b/prog/aws/vpc.rb
@@ -66,7 +66,7 @@ class Prog::Aws::Vpc < Prog::Base
         vpc_id: vpc_response.vpc_id,
         cidr_block: private_subnet.net4.to_s,
         ipv_6_cidr_block: "#{ipv_6_cidr_block}/64",
-        availability_zone: location.name + "a", # YYY: This is a hack since we don't support multiple AZs yet
+        availability_zone: location.name + ["a", "b", "c"].sample,
         tag_specifications: Util.aws_tag_specifications("subnet", private_subnet.name)
       }).subnet.subnet_id
     else


### PR DESCRIPTION
This doesn't introduce proper AZ selection mechanism, but given our existing constraints and limited number of regions, this provides a simple way to not place all subnets in the same AZ.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Randomize availability zone selection for AWS subnets in `create_subnet` method of `vpc.rb`.
> 
>   - **Behavior**:
>     - In `create_subnet` method of `vpc.rb`, change availability zone selection from fixed `location.name + "a"` to random selection from `["a", "b", "c"].sample`.
>   - **Misc**:
>     - Comment update to reflect the change in AZ selection approach.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b463b90a5992fc9a12a902933f19c409ca8b96c2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->