### PR TITLE
Use CloudHypervisor 46.0 for a percentage of GitHub Action VMs

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -182,6 +182,8 @@ module Config
   # Allocator
   override :allocator_target_host_utilization, 0.55, float
   override :allocator_max_random_score, 0.1, float
+  # Temporary while testing CloudHypervisor 46 rollout
+  override :github_actions_ch_46_percent, 0.01, float
 
   # e2e
   override :e2e_hetzner_server_id, string

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -52,6 +52,13 @@ class Prog::Vm::GithubRunner < Prog::Base
       allow_only_ssh: true
     ).subject
 
+    if rand * 100 < Config.github_actions_ch_46_percent
+      hugepages = false
+      ch_version = "46.0"
+    else
+      hugepages = true
+    end
+
     vm_st = Prog::Vm::Nexus.assemble_with_sshable(
       Config.github_runner_service_project_id,
       unix_user: "runneradmin",
@@ -64,7 +71,9 @@ class Prog::Vm::GithubRunner < Prog::Base
       enable_ip4: true,
       arch: label_data["arch"],
       swap_size_bytes: 4294963200, # ~4096MB, the same value with GitHub hosted runners
-      private_subnet_id: ps.id
+      private_subnet_id: ps.id,
+      hugepages:,
+      ch_version:
     )
 
     vm_st.subject

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -8,6 +8,7 @@ require "base64"
 
 class Prog::Vm::Nexus < Prog::Base
   DEFAULT_SIZE = "standard-2"
+  CH_VERSION_OS_VERSIONS = {"46.0" => "ubuntu-24.04"}.freeze
 
   subject_is :vm
 
@@ -249,6 +250,7 @@ class Prog::Vm::Nexus < Prog::Base
           [["accepting"], [vm.location_id], [], [], [vm.family]]
         end
       family_filter = ["standard"] if vm.family == "burstable"
+      os_filter = CH_VERSION_OS_VERSIONS[frame["ch_version"]] if frame["ch_version"]
 
       Scheduling::Allocator.allocate(
         vm, frame["storage_volumes"],
@@ -260,7 +262,8 @@ class Prog::Vm::Nexus < Prog::Base
         host_exclusion_filter: host_exclusion_filter,
         gpu_count: gpu_count,
         gpu_device: gpu_device,
-        family_filter: family_filter
+        family_filter: family_filter,
+        os_filter:
       )
     rescue RuntimeError => ex
       raise unless ex.message.include?("no space left on any eligible host")

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -42,6 +42,13 @@ class Prog::Vm::VmPool < Prog::Base
       allow_only_ssh: true
     ).subject
 
+    if rand * 100 < Config.github_actions_ch_46_percent
+      hugepages = false
+      ch_version = "46.0"
+    else
+      hugepages = true
+    end
+
     Prog::Vm::Nexus.assemble_with_sshable(
       Config.vm_pool_project_id,
       unix_user: "runneradmin",
@@ -54,7 +61,9 @@ class Prog::Vm::VmPool < Prog::Base
       pool_id: vm_pool.id,
       arch: vm_pool.arch,
       swap_size_bytes: 4294963200,
-      private_subnet_id: ps.id
+      private_subnet_id: ps.id,
+      hugepages:,
+      ch_version:
     )
 
     hop_wait

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -66,6 +66,26 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(vm.project_id).to eq(Config.github_runner_service_project_id)
     end
 
+    it "uses ch_version 46.0 without hugepages if randomly selected" do
+      allow(Config).to receive(:github_actions_ch_46_percent).and_return(100)
+      vm = nx.pick_vm
+      expect(vm.pool_id).to be_nil
+      expect(vm.sshable.unix_user).to eq("runneradmin")
+      expect(vm.unix_user).to eq("runneradmin")
+      expect(vm.family).to eq("standard")
+      expect(vm.vcpus).to eq(4)
+      expect(vm.project_id).to eq(Config.github_runner_service_project_id)
+      expect(vm.strand.stack[0]["hugepages"]).to be false
+      expect(vm.strand.stack[0]["ch_version"]).to eq "46.0"
+    end
+
+    it "does not specify ch_version or hugepages if not randomly selected" do
+      allow(Config).to receive(:github_actions_ch_46_percent).and_return(0)
+      vm = nx.pick_vm
+      expect(vm.strand.stack[0]["hugepages"]).to be true
+      expect(vm.strand.stack[0]["ch_version"]).to be_nil
+    end
+
     it "provisions a new vm if pool is valid but there is no vm" do
       VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
       vm = nx.pick_vm

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -443,8 +443,27 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
+    it "requires ubuntu-24.04 os_version if ch_version is 46.0" do
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        host_exclusion_filter: [],
+        location_filter: [Location::HETZNER_FSN1_ID],
+        location_preference: [],
+        gpu_count: 0,
+        gpu_device: nil,
+        os_filter: "ubuntu-24.04",
+        family_filter: ["standard"]
+      )
+      allow(nx).to receive(:frame).and_return({"storage_volumes" => :storage_volumes, "ch_version" => "46.0"})
       expect { nx.start }.to hop("create_unix_user")
     end
 
@@ -460,6 +479,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [Location::GITHUB_RUNNERS_ID],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -477,6 +497,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -497,6 +518,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [Location::GITHUB_RUNNERS_ID],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -520,6 +542,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [Location::LEASEWEB_WDC02_ID],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -540,6 +563,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [Location::GITHUB_RUNNERS_ID],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard", "premium"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -560,6 +584,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [Location::GITHUB_RUNNERS_ID],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard", "premium"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -581,6 +606,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: []
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -602,6 +628,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -631,6 +658,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [],
         gpu_count: 0,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
       expect { nx.start }.to hop("create_unix_user")
@@ -652,6 +680,7 @@ RSpec.describe Prog::Vm::Nexus do
         location_preference: [],
         gpu_count: 3,
         gpu_device: nil,
+        os_filter: nil,
         family_filter: ["standard"]
       )
       expect { nx.start }.to hop("create_unix_user")


### PR DESCRIPTION
This defaults to 0.01%, or 1 in 10,000 VMs.  The percentage can be modified using an environment variable.  This will not be merged until rhizome on all Ubuntu 24.04 hosts has been updated to support CloudHypervisor 46.0.