### PR TITLE
Paginate AWS S3 backup list

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -118,8 +118,18 @@ PGHOST=/var/run/postgresql
 
   def list_objects(prefix)
     aws? ?
-      blob_storage_client.list_objects_v2(bucket: ubid, prefix: prefix).contents
+    aws_list_objects(prefix)
     : blob_storage_client.list_objects(ubid, prefix)
+  end
+
+  def aws_list_objects(prefix)
+    response = blob_storage_client.list_objects_v2(bucket: ubid, prefix: prefix)
+    objects = response.contents
+    while response.is_truncated
+      response = blob_storage_client.list_objects_v2(bucket: ubid, prefix: prefix, continuation_token: response.next_continuation_token)
+      objects.concat(response.contents)
+    end
+    objects
   end
 
   def create_bucket


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add pagination support for AWS S3 object listing in `postgres_timeline.rb` with tests in `postgres_timeline_spec.rb`.
> 
>   - **Behavior**:
>     - Add pagination for AWS S3 object listing in `list_objects` by introducing `aws_list_objects` in `postgres_timeline.rb`.
>     - Handles truncated responses using `continuation_token` to fetch all objects.
>   - **Tests**:
>     - Add test for paginated AWS S3 responses in `postgres_timeline_spec.rb`.
>     - Simulate truncated responses and verify continuation token handling.
>   - **Misc**:
>     - No changes to non-AWS storage backends.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2eb27885e936ee19e1fadd66e9ff3fbcdbee6399. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->