### PR TITLE
Publish cache proxy logs to mezmo

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -400,6 +400,12 @@ class Prog::Vm::GithubRunner < Prog::Base
       }
       Clog.emit("Remaining DockerHub rate limits") { {dockerhub_rate_limits:} }
     end
+
+    proxy_log_command = <<~COMMAND
+      sudo cat /var/log/cacheproxy.log
+    COMMAND
+    cache_proxy_log = vm.sshable.cmd(proxy_log_command, log: false)
+    Clog.emit("Cache proxy log") { {cache_proxy_log:} } if cache_proxy_log
   rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError
     Clog.emit("Failed to collect final telemetry") { github_runner }
   end


### PR DESCRIPTION
To be able to debug cache proxy outputs via Mezmo logs, publishing the content of /var/log/cacheproxy.log, which keeps all the logs for proxy, to Mezmo.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to publish cache proxy logs to Mezmo in `collect_final_telemetry` and updates tests accordingly.
> 
>   - **Behavior**:
>     - `collect_final_telemetry` in `github_runner.rb` now reads `/var/log/cacheproxy.log` and emits its content to Mezmo.
>     - Handles SSH errors during telemetry collection by logging failure to Mezmo.
>   - **Tests**:
>     - Updated `github_runner_spec.rb` to test logging of cache proxy logs when `workflow_job` is successful, failed, or nil.
>     - Tests ensure cache proxy logs are emitted correctly and handle SSH errors gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 824d0d56b6988cdecee2c1ced09623967ab472fa. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->