### PR TITLE
OpenRouter: Delist mistral-small-3

### DIFF
--- a/config/openrouter.json
+++ b/config/openrouter.json
@@ -1,33 +1,3 @@
 {
-  "data": [
-    {
-      "id": "mistral-small-3",
-      "name": "mistralai/Mistral-Small-24B-Instruct-2501",
-      "base_url": "https://mistral-small-3.ai.ubicloud.com/v1",
-      "created": 1739816399,
-      "context_length": 32768,
-      "quantization": "bf16",
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000003",
-        "image": "0",
-        "request": "0"
-      },
-      "supported_sampling_parameters": [
-        "frequency_penalty",
-        "max_tokens",
-        "min_p",
-        "presence_penalty",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_k",
-        "top_p"
-      ]
-    }
-  ]
+  "data": []
 }


### PR DESCRIPTION
Delist the model from OpenRouter, as we're planning to deprecate `mistral-small-3`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Delists `mistral-small-3` model from `openrouter.json`, leaving the `data` array empty.
> 
>   - **Behavior**:
>     - Delists `mistral-small-3` model from `openrouter.json`.
>     - `data` array in `openrouter.json` is now empty, indicating no models are listed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1e96dee42929a8f192a3bfe76c4788035b89d2c6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->