### PR TITLE
Improve monitoring of E2E test output

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Create .env.rb file
       shell: bash
-      run: bundle exec rake overwrite_envrb
+      run: "bundle exec rake overwrite_envrb && echo '$stdout.sync = true' >> .env.rb"
 
     - name: Setup clover database
       shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,7 +116,7 @@ jobs:
         STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       run: |
         set -o pipefail
-        timeout 55m foreman start -m all=1,respirate=2 | tee foreman.log | grep "e2e.1"
+        timeout 55m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
 
     - name: Print logs
       if: always()


### PR DESCRIPTION
This has 3 separate changes:

* Use `$stdout.sync = true` when running E2E tests.  This actually turns it on for all tests using `setup-clover`.  This makes it so that web/monitor/respirate processes do not buffer output given to foreman. Without this, log analysis of the foreman log is much more difficult, since the order in which entries appear in the log is not the order in which they occurred.

* Use `--line-buffered` option to `grep`. This makes real-time monitoring of the E2E tests works as expected.  Without this, `grep` will buffer the output, and GitHub will only show E2E test process in large chunks instead of line by line.

* Use `-F` option to `grep`. This makes it so unexpected output does not show up in the logs (see https://github.com/ubicloud/ubicloud/actions/runs/16228320530/job/45825364291#step:14:274 for an example, where an `e2eb1` string caused a unexpected line to show up).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable real-time E2E test log monitoring by setting `$stdout.sync = true` and using `grep --line-buffered -F`.
> 
>   - **Behavior**:
>     - Enable `$stdout.sync = true` in `setup-clover/action.yml` to prevent output buffering in E2E tests.
>     - Use `--line-buffered` and `-F` options with `grep` in `e2e.yml` to ensure real-time log monitoring and prevent unexpected log entries.
>   - **Misc**:
>     - Modify `setup-clover/action.yml` to append `$stdout.sync = true` to `.env.rb`.
>     - Update `e2e.yml` to include `grep --line-buffered -F` for filtering logs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 38122ccbc590b4fe6e1281963eb082fd7c60b0d0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->