### PR TITLE
Remove extra logging from archive command

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -73,7 +73,7 @@ class PostgresServer < Sequel::Model
     if timeline.blob_storage
       configs[:archive_mode] = "on"
       configs[:archive_timeout] = "60"
-      configs[:archive_command] = "'bash -c \"echo pushing %p >> /dat/postgres_archive.log; /usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env >> /dat/postgres_archive.log 2>&1\"'"
+      configs[:archive_command] = "'/usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env'"
 
       if primary?
         if resource.ha_type == PostgresResource::HaType::SYNC


### PR DESCRIPTION
We added this for ease of debugging, but it is not needed anymore.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove extra logging from `archive_command` in `configure_hash` method of `PostgresServer` class in `postgres_server.rb`.
> 
>   - **Behavior**:
>     - Remove extra logging from `archive_command` in `configure_hash` method of `PostgresServer` class in `postgres_server.rb`. The command no longer logs to `/dat/postgres_archive.log`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3f2d44accebb989c1138e8283f5397fa3b08a312. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->