### PR TITLE
Check all encrypted columns are redacted

### DIFF
--- a/model/victoria_metrics_resource.rb
+++ b/model/victoria_metrics_resource.rb
@@ -9,7 +9,7 @@ class VictoriaMetricsResource < Sequel::Model
   one_to_many :servers, class: :VictoriaMetricsServer, key: :victoria_metrics_resource_id
   many_to_one :private_subnet
 
-  plugin ResourceMethods, redacted_columns: [:admin_password, :root_cert_1, :root_cert_2],
+  plugin ResourceMethods, redacted_columns: [:root_cert_1, :root_cert_2],
     encrypted_columns: [:admin_password, :root_cert_key_1, :root_cert_key_2]
   plugin SemaphoreMethods, :destroy, :reconfigure
 


### PR DESCRIPTION
Also check that redacted columns are unique.

These specs didn't find any encrypted columns that weren't redacted,
but they did find that VictoriaMetricsResource.redacted_columns was
not unique, so fix that.