### PR TITLE
Remove "shortcut icon" link from layout

### DIFF
--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <title><%= ["Ubicloud", @page_title].compact.join(" - ") %></title>
     <%== assets(:css) %>


### PR DESCRIPTION
Leave "icon" link. "shortcut icon" appears to be a nonstandard link type used by old IE. It hasn't been helpful since IE 9, released over 14 years ago. It isn't a valid link rel attribute value in HTML5. I found that having both "shortcut icon" and "icon" links resulted in multiple requests for /favicon.ico.