### PR TITLE
Make `VmHostSlice.enabled` mean "not scheduled for destroy".

### DIFF
--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -38,7 +38,6 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
     case host.sshable.cmd("common/bin/daemonizer --check prep_#{vm_host_slice.name}")
     when "Succeeded"
       host.sshable.cmd("common/bin/daemonizer --clean prep_#{vm_host_slice.name}")
-      vm_host_slice.update(enabled: true)
       hop_wait
     when "NotStarted", "Failed"
       host.sshable.cmd("common/bin/daemonizer 'sudo host/bin/setup-slice prep #{vm_host_slice.inhost_name} \"#{vm_host_slice.allowed_cpus_cgroup}\"' prep_#{vm_host_slice.name}")

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -466,11 +466,12 @@ module Scheduling::Allocator
           # update the VM
           vm.update(vm_host_slice_id: st.subject.id)
 
-          # update the allocation on the VM
-          # we are updating a newly created slice, so not checking for 'enabled' flag
+          # Update the allocation on the VM. We also set enabled to true
+          # to mark it as allocatable and not scheduled for destruction.
           VmHostSlice.dataset.where(id: vm.vm_host_slice_id).update(
             used_cpu_percent: Sequel[:used_cpu_percent] + vm.cpu_percent_limit,
-            used_memory_gib: Sequel[:used_memory_gib] + vm.memory_gib
+            used_memory_gib: Sequel[:used_memory_gib] + vm.memory_gib,
+            enabled: true
           )
 
           # Update the host utilization

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
     it "hops to wait" do
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --check prep_standard").and_return("Succeeded")
       expect(sshable).to receive(:cmd).with("common/bin/daemonizer --clean prep_standard")
-      expect(vm_host_slice).to receive(:update).with(enabled: true)
 
       expect { nx.prep }.to hop("wait")
     end


### PR DESCRIPTION
Previously, `VmHostSlice.enabled` was overloaded to mean both:
- The slice was prepared
- The slice was not scheduled for destruction

In old times, we waited for slice to be prepared before preparing the VM inside it. We removed the “prepared” check in 428d367, so tracking preparedness in a vm_host_slice column is no longer needed. The “prepared” state can still be inferred from the Strand’s label if necessary.

A slice is allocatable immediately upon creation (we already allocate the first VM at creation time). When `slice.is_shared=false`, 2nd allocation couldn't happen. When `slice.is_shared=true`, we waited until the slice is prepared to allow the 2nd allocation. This isn't necessary.

The other use of `enabled` is to prevent new VM allocations once a slice is scheduled for destruction. A slice is marked for destroy when its last VM begins teardown.

-------------

Dropping the “prepared” purpose of `enabled` clarifies its intent and fixes an edge case where unprepared slices could be left behind after their final VM was deleted. Previously, `Nexus::destroy_slice` relied on an `enabled: true → false` transition that never fired for unprepared slices, leaving them orphaned. This could happen for example in cases when a VM was destroyed before its slice was prepared.

Theoretically, there were few other ways to solve this issue. But this change makes the system less complex in addition to solving the issue.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies `VmHostSlice.enabled` to only indicate non-destruction status, fixing orphaned slice issue and updating related logic and tests.
> 
>   - **Behavior**:
>     - `VmHostSlice.enabled` now only indicates if a slice is not scheduled for destruction.
>     - Removes `enabled: true` update in `before_run` in `vm_host_slice_nexus.rb`.
>     - Sets `enabled: true` during VM allocation in `allocator.rb` to mark slices as allocatable.
>   - **Edge Case Fix**:
>     - Fixes orphaned slices issue by ensuring `enabled` transition occurs for all slices in `Nexus::destroy_slice`.
>   - **Tests**:
>     - Removes expectation for `enabled: true` update in `prep` test in `vm_host_slice_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5c909cf4e5254494e2b572828a18715ee3399fdf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->