### PR TITLE
Avoid metrics export when resource is deleted

### DIFF
--- a/lib/metrics_target_resource.rb
+++ b/lib/metrics_target_resource.rb
@@ -31,6 +31,8 @@ class MetricsTargetResource
   end
 
   def export_metrics
+    return if @deleted
+
     @export_started_at = Time.now
     begin
       count = @resource.export_metrics(session: @session, tsdb_client: @tsdb_client)

--- a/spec/lib/metrics_target_resource_spec.rb
+++ b/spec/lib/metrics_target_resource_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe MetricsTargetResource do
       expect(Clog).to receive(:emit).and_call_original
       expect { resource.export_metrics }.not_to raise_error
     end
+
+    it "skips export if resource is deleted" do
+      resource.instance_variable_set(:@deleted, true)
+      expect(postgres_server).not_to receive(:export_metrics)
+      expect { resource.export_metrics }.not_to raise_error
+    end
   end
 
   describe "#close_resource_session" do


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `export_metrics` now skips execution if the resource is marked as deleted, with a corresponding test added.
> 
>   - **Behavior**:
>     - `export_metrics` in `metrics_target_resource.rb` now returns early if `@deleted` is true, preventing metric export for deleted resources.
>   - **Tests**:
>     - Added test in `metrics_target_resource_spec.rb` to ensure `export_metrics` is skipped when `@deleted` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9904af4334424fb138a10e39966c706ee6ce74b2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->