### PR TITLE
Add config value for db pool size for monitor process

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -73,6 +73,7 @@ module Config
   override :base_url, "http://localhost:9292", string
   override :database_timeout, 10, int
   override :db_pool, 5, int
+  override :monitor_db_pool, 5, int
   override :deployment, "production", string
   override :force_ssl, true, bool
   override :port, 3000, int

--- a/db.rb
+++ b/db.rb
@@ -7,7 +7,11 @@ require_relative "lib/util"
 
 db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "db_ca_bundle.crt")
 Util.safe_write_to_file(db_ca_bundle_filename, Config.clover_database_root_certs)
-max_connections = Config.db_pool - 1
+max_connections = if ENV["DYNO"]&.include?("monitor")
+  Config.monitor_db_pool
+else
+  Config.db_pool - 1
+end
 max_connections = 1 if ENV["SHARED_CONNECTION"] == "1"
 pg_auto_parameterize_min_array_size = 1 if Config.test? && ENV["CLOVER_FREEZE"] == "1"
 DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:)


### PR DESCRIPTION
Since we want to update pool size for monitor process without updating pool size for other processes, adding a new config value and use it while initiating the monitor process.