### PR TITLE
Trigger worker mesh semamphore and improve ssh files permission

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -227,9 +227,9 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     public_keys = key_pairs.map { |kp| kp[:ssh_key].public_key }
     key_pairs.each do |kp|
       vm = kp[:vm]
-      vm.sshable.cmd("tee ~/.ssh/id_ed25519 > /dev/null", stdin: kp[:ssh_key].private_key)
+      vm.sshable.cmd("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: kp[:ssh_key].private_key)
       all_keys_str = ([vm.sshable.keys.first.public_key] + public_keys).join("\n")
-      vm.sshable.cmd("tee ~/.ssh/authorized_keys > /dev/null", stdin: all_keys_str)
+      vm.sshable.cmd("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: all_keys_str)
     end
 
     hop_wait

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -412,11 +412,11 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     end
 
     it "creates full mesh connectivity on cluster worker nodes" do
-      expect(first_vm.sshable).to receive(:cmd).with("tee ~/.ssh/id_ed25519 > /dev/null", stdin: first_ssh_key.private_key)
-      expect(first_vm.sshable).to receive(:cmd).with("tee ~/.ssh/authorized_keys > /dev/null", stdin: [first_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n"))
+      expect(first_vm.sshable).to receive(:cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
+      expect(first_vm.sshable).to receive(:cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: [first_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n"))
 
-      expect(second_vm.sshable).to receive(:cmd).with("tee ~/.ssh/id_ed25519 > /dev/null", stdin: second_ssh_key.private_key)
-      expect(second_vm.sshable).to receive(:cmd).with("tee ~/.ssh/authorized_keys > /dev/null", stdin: [second_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n"))
+      expect(second_vm.sshable).to receive(:cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: second_ssh_key.private_key)
+      expect(second_vm.sshable).to receive(:cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: [second_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n"))
 
       expect { nx.sync_worker_mesh }.to hop("wait")
     end


### PR DESCRIPTION
sync_worker_mesh semaphore is incremeneted at the beginning of the
cluster provisoning and will be run when cluster reaches the wait
state.

This semaphore needs to be incremented whenever a new node is added
to the cluster but for now it is sufficient.

Created ssh file permissions are also improved.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increment `sync_worker_mesh` semaphore at cluster provisioning start and improve SSH file permissions in `kubernetes_cluster_nexus.rb`.
> 
>   - **Behavior**:
>     - Increment `sync_worker_mesh` semaphore in `start` method in `kubernetes_cluster_nexus.rb` to trigger worker mesh sync at wait state.
>     - Improve SSH file permissions by adding `chmod 0600` for `id_ed25519` and `authorized_keys` in `sync_worker_mesh`.
>   - **Tests**:
>     - Update test in `kubernetes_cluster_nexus_spec.rb` to expect `incr_sync_worker_mesh` call in `start` method.
>     - Update test in `kubernetes_cluster_nexus_spec.rb` to check for `chmod 0600` in SSH commands for worker VMs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for bb878647163cf452a4ae32f4f4f28d65982f8717. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->