### PR TITLE
Fix use of locked domains

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -360,7 +360,7 @@ class Clover < Roda
       if (locked_domain = locked_domain_for(email))
         error = if !omniauth_provider
           "Login via username and password"
-        elsif omniauth_provider != locked_domain.oidc_provider.ubid
+        elsif omniauth_provider.to_s != locked_domain.oidc_provider.ubid
           "Login via #{scope.omniauth_provider_name(omniauth_provider)}"
         end
 
@@ -523,7 +523,7 @@ class Clover < Roda
         redirect "/login"
       end
 
-      if (locked_domain = locked_domain_for(email)) && omniauth_provider != locked_domain.oidc_provider.ubid
+      if (locked_domain = locked_domain_for(email)) && omniauth_provider.to_s != locked_domain.oidc_provider.ubid
         flash["error"] = "Creating an account via authentication through #{scope.omniauth_provider_name(omniauth_provider)} is not supported for the #{domain_for_email(email)} domain. You must authenticate using #{locked_domain.oidc_provider.display_name}."
         redirect "/login"
       end


### PR DESCRIPTION
rodauth.omniauth_provider is a symbol, not a string. However, when using OmniAuth.config.add_mock (the recommended way to mock with omniauth), rodauth.omniauth_provider is a string, which is why the existing tests did not catch this.  Use to_s so it will work regardless of whether rodauth.omniauth_provider is a symbol or a string.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes type mismatch in `clover.rb` by converting `omniauth_provider` to string for consistent comparison with `locked_domain.oidc_provider.ubid`.
> 
>   - **Behavior**:
>     - Fixes type mismatch by converting `omniauth_provider` to string using `to_s` in `clover.rb`.
>     - Ensures consistent comparison with `locked_domain.oidc_provider.ubid`.
>   - **Files**:
>     - Changes in `clover.rb` at lines 360 and 523 to handle both symbol and string cases for `omniauth_provider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3cef18f4248cfa93a3c6e0435a93656b19d12a2f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->