### PR TITLE
Disable the use of HTTP 1.1 keep alives in Puma

### DIFF
--- a/puma_config.rb
+++ b/puma_config.rb
@@ -4,6 +4,7 @@
 environment ENV["RACK_ENV"] || "development"
 port ENV["PORT"] || "3000"
 threads 15, 15
+enable_keep_alives false
 
 if @config.options[:workers] > 0
   silence_single_worker_warning


### PR DESCRIPTION
Fixes issues in Puma when used with Heroku Router 2.0. See https://www.heroku.com/blog/pumas-routers-keepalives-ohmy/