### PR TITLE
Change how errors on handled for web requests

### DIFF
--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -45,7 +45,17 @@ class Clover < Roda
     part("components/form/hidden", name: csrf_field, value: csrf_token(*))
   end
 
+  def handle_validation_failure(template)
+    return unless web?
+    @validation_failure_template = template
+  end
+
   def redirect_back_with_inputs
+    if (template = @validation_failure_template)
+      flash.sweep
+      request.on { view(template) }
+    end
+
     referrer = flash["referrer"] || env["HTTP_REFERER"]
     uri = begin
       Kernel.URI(referrer)

--- a/model/project.rb
+++ b/model/project.rb
@@ -145,7 +145,7 @@ class Project < Sequel::Model
   def validate
     super
     if new? || changed_columns.include?(:name)
-      validates_format(%r{\A[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\z}i, :name, message: "must only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
+      validates_format(%r{\A[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\z}i, :name, message: "must be less than 64 characters and only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
     end
   end
 

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -37,6 +37,7 @@ class Clover
         if api?
           Serializers::Project.serialize(@project)
         else
+          flash["notice"] = "Project created"
           r.redirect @project.path
         end
       end

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -27,6 +27,8 @@ class Clover
           end
         end
 
+        handle_validation_failure("project/create")
+
         DB.transaction do
           @project = current_account.create_project_with_default_policy(typecast_params.nonempty_str!("name"))
           audit_log(@project, "create")

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Project do
   subject(:project) { described_class.create_with_id(name: "test") }
 
   describe "#validate" do
-    invalid_name = "must only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number"
+    invalid_name = "must be less than 64 characters and only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number"
 
     it "validates that name for new object is not empty and has correct format" do
       project = described_class.new

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -233,6 +233,18 @@ RSpec.describe Clover, "project" do
         new_name = "New-Project-Name"
         visit project.path
 
+        fill_in "name", with: ""
+        click_button "Save"
+        expect(page).to have_flash_error("empty string provided for parameter name")
+
+        fill_in "name", with: "a" * 65
+        click_button "Save"
+        expect(page).to have_flash_error("name must be less than 64 characters and only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
+
+        # Check retains parameter value
+        click_button "Save"
+        expect(page).to have_flash_error("name must be less than 64 characters and only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
+
         fill_in "name", with: new_name
         click_button "Save"
 

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Clover, "project" do
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")
+        expect(page).to have_flash_notice("Project created")
         expect(page).to have_content name
 
         project = Project[name: name]

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -64,8 +64,18 @@ RSpec.describe Clover, "project" do
         expect(project.accounts_dataset.count).to eq 1
         expect(page.title).to eq("Ubicloud - Create Project")
 
-        fill_in "Name", with: name
+        click_button "Create"
+        expect(page).to have_flash_error("empty string provided for parameter name")
 
+        fill_in "Name", with: "a" * 65
+        click_button "Create"
+        expect(page).to have_flash_error("name must be less than 64 characters and only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
+
+        # Check retains parameter value
+        click_button "Create"
+        expect(page).to have_flash_error("name must be less than 64 characters and only include ASCII letters, numbers, and dashes, and must start and end with an ASCII letter or number")
+
+        fill_in "Name", with: name
         click_button "Create"
 
         expect(page.title).to eq("Ubicloud - #{name}")

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -1,5 +1,5 @@
 <%# locals: (name: nil, label: nil, type: "text", value: nil, attributes: {}, extra_class: nil, button_title: nil) %>
-<% value = flash.dig("old", name) || value
+<% value = flash.dig("old", name) || request.POST[name] || value
 error = rodauth.field_error(name) || flash.dig("errors", name) %>
 
 <div class="space-y-2 text-gray-900">

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -1,4 +1,11 @@
-<% @page_title = @project_data[:name] %>
+<% @page_title = @project_data[:name]
+@quotas = ["VmVCpu", "PostgresVCpu"].map {
+  {
+    resource_type: it,
+    current_resource_usage: @project.current_resource_usage(it),
+    quota: @project.effective_quota_value(it)
+  }
+} %>
 
 <%== part(
   "components/page_header",


### PR DESCRIPTION
This adds a handle_validation_failure web helper method. This method accepts a template, which will be rendered if there is a validation failure, instead of issuing an internal request based based on the referrer.  In the future, the method will accept a block, but that isn't necessary yet.

This uses handle_validation_failure in the create and update project route to show how it works. The plan is to expand the use of this method to all POST web routes, and then drop the code that issues internal requests. The internal request code has fewer issues than the code it replaced (which did a browser redirect, and broke with large forms), but it is still complex and brittle. In particular, storing referrer information the flash breaks if a user has multiple tabs open, and is getting form errors in one tab, and is using the other tab to make changes.

One of the features of the internal request code, that dates back to when redirects were used for errors, is the use of flash["old"] to store parameters from the previous request.  This isn't necessary if we aren't issuing an internal request, as we can look directly in request.POST for the submitted parameters. This changes the one component used for the project creation form, but other templates accessing flash["old"] can be updated the same way.

Not yet intended for commit, but submitting for earlier feedback on the approach.

This also contains a couple of other fixes:

* Better project name validation error
* Show flash notice on project creation