### PR TITLE
Move the runner service setup to image generation

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -172,7 +172,7 @@ class Project < Sequel::Model
 
   feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics
   feature_flag :private_locations, :enable_c6gd, :enable_m6gd, :enable_m8gd
-  feature_flag :free_runner_upgrade_until, :gpu_vm, :postgres_lantern, :runner_jit_file
+  feature_flag :free_runner_upgrade_until, :gpu_vm, :postgres_lantern
 end
 
 # Table: project

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -13,7 +13,6 @@ class Prog::Test::GithubRunner < Prog::Test::Base
     vm_pool_service_project = Project.create(name: "Vm-Pool-Service-Project") { it.id = Config.vm_pool_project_id }
 
     github_test_project = Project.create(name: "Github-Runner-Test-Project")
-    github_test_project.set_ff_runner_jit_file(true)
     GithubInstallation.create(
       installation_id: Config.e2e_github_installation_id,
       name: "TestUser",


### PR DESCRIPTION
We begin to directly control the unit file instead of relying on systemd-run’s transient unit generation at e2627b.

We tested it for a while in production, and it appears to be working well. It’s now enabled for all customers.

Therefore, we can move it to image generation to reduce runtime overhead.

https://github.com/ubicloud/runner-images/pull/37

Since the new image rollout takes some time, we retain the old code and create these files if they don’t exist for backward compatibility.

I’ll remove it after the image rollout is complete.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move runner service setup to image generation, removing `runner_jit_file` feature flag and updating tests for backward compatibility.
> 
>   - **Behavior**:
>     - Moves runner service setup to image generation in `github_runner.rb`, reducing runtime overhead.
>     - Retains old code for backward compatibility until new image rollout is complete.
>   - **Feature Flags**:
>     - Removes `runner_jit_file` feature flag from `project.rb` and associated logic in `github_runner.rb`.
>   - **Tests**:
>     - Updates `github_runner_spec.rb` to reflect changes in runner setup and feature flag removal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a36b2269c56f48f2f6ee658d8efa918170292c6f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->