### PR TITLE
Support for different DB pool size for monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+ENV["MONITOR_PROCESS"] = "1"
+
 require_relative "../loader"
 clover_freeze
 

--- a/config.rb
+++ b/config.rb
@@ -73,6 +73,7 @@ module Config
   override :base_url, "http://localhost:9292", string
   override :database_timeout, 10, int
   override :db_pool, 5, int
+  override :db_pool_monitor, Config.db_pool, int
   override :deployment, "production", string
   override :force_ssl, true, bool
   override :port, 3000, int

--- a/db.rb
+++ b/db.rb
@@ -4,18 +4,20 @@ require "netaddr"
 require "sequel/core"
 require_relative "config"
 require_relative "lib/util"
+require_relative "lib/clog"
 
 db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "db_ca_bundle.crt")
 Util.safe_write_to_file(db_ca_bundle_filename, Config.clover_database_root_certs)
-max_connections = Config.db_pool - 1
+max_connections = (Util.monitor_process? ? Config.db_pool_monitor : Config.db_pool) - 1
 max_connections = 1 if ENV["SHARED_CONNECTION"] == "1"
+Clog.emit("Setting max_connections for Clover database") { {max_connections:, config_db_pool: Config.db_pool, config_db_pool_monitor: Config.db_pool_monitor, is_monitor_process: Util.monitor_process?, shared_connection: ENV["SHARED_CONNECTION"] == "1"} }
 pg_auto_parameterize_min_array_size = 1 if Config.test? && ENV["CLOVER_FREEZE"] == "1"
 DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:)
 
 postgres_monitor_db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "postgres_monitor_db.crt")
 Util.safe_write_to_file(postgres_monitor_db_ca_bundle_filename, Config.postgres_monitor_database_root_certs)
 begin
-  POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool, pool_timeout: Config.database_timeout) if Config.postgres_monitor_database_url
+  POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool_monitor, pool_timeout: Config.database_timeout) if Config.postgres_monitor_database_url
 rescue Sequel::DatabaseConnectionError => ex
   Clog.emit("Failed to connect to Postgres Monitor database") { {database_connection_failed: {exception: Util.exception_to_hash(ex)}} }
 end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -92,4 +92,8 @@ module Util
     tags = [{key: "Ubicloud", value: "true"}, {key: "Name", value: name}].concat(additional_tags.map { |k, v| {key: k.to_s, value: v.to_s} })
     [{resource_type:, tags:}].compact
   end
+
+  def self.monitor_process?
+    ENV["MONITOR_PROCESS"] == "1"
+  end
 end


### PR DESCRIPTION
- **Add monitor_process? utility method**
  Add `monitor_process?` as  class method to `Util`. It allows to check
  whether the current process is the monitor process or not.
  

- **Config for db pool size of monitor process**
  Add `db_pool_monitor` to `Config`. If the corresponding environment
  variable is not defined it uses `db_pool` as default.
  
  Use the new config for defining max_connections for then monitor
  process, when connecting to Clover and the Postgres monitor DB.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for different DB pool sizes for monitor processes by introducing a new utility method and configuration option.
> 
>   - **Utility Method**:
>     - Add `monitor_process?` method to `Util` to check if the current process is a monitor process.
>   - **Configuration**:
>     - Add `db_pool_monitor` to `Config` to specify DB pool size for monitor process, defaulting to `db_pool` if not set.
>   - **Database Connection**:
>     - In `db.rb`, use `db_pool_monitor` for `max_connections` if `monitor_process?` is true, otherwise use `db_pool`.
>     - Log connection settings in `db.rb` using `Clog.emit`.
>   - **Misc**:
>     - Set `MONITOR_PROCESS` environment variable in `bin/monitor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1e0f77e4fe914483fd9664b8f4f07c5323123201. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->