### PR TITLE
Premium runner allocation improvements

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -11,7 +11,7 @@ class GithubRunner < Sequel::Model
   one_through_one :project, join_table: :github_installation, left_key: :id, left_primary_key: :installation_id, read_only: true
 
   plugin ResourceMethods, redacted_columns: :workflow_job
-  plugin SemaphoreMethods, :destroy, :skip_deregistration
+  plugin SemaphoreMethods, :destroy, :skip_deregistration, :not_upgrade_premium
   include HealthMonitorMethods
 
   dataset_module do

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -234,7 +234,7 @@ class Prog::Vm::Nexus < Prog::Base
           installation = runner&.installation
           prefs = installation&.allocator_preferences || {}
 
-          runner_family_filter = if vm.family == "premium"
+          runner_family_filter = if runner&.not_upgrade_premium_set? || vm.family == "premium"
             [vm.family]
           elsif installation&.free_runner_upgrade?
             prefs["family_filter"] || [vm.family, "premium"]

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -565,6 +565,27 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.start }.to hop("create_unix_user")
     end
 
+    it "do not downgrade the premium runner if it's explicitly requested" do
+      vm.location_id = Location::GITHUB_RUNNERS_ID
+      vm.family = "premium"
+      installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: prj.id, allocator_preferences: {"family_filter" => ["standard", "premium"]})
+      GithubRunner.create(label: "ubicloud-premium-30", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
+
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        host_exclusion_filter: [],
+        location_filter: [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID],
+        location_preference: [Location::GITHUB_RUNNERS_ID],
+        gpu_count: 0,
+        gpu_device: nil,
+        family_filter: ["premium"]
+      )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
     it "can force allocating a host" do
       allow(nx).to receive(:frame).and_return({
         "force_host_id" => :vm_host_id,


### PR DESCRIPTION
- **Do not downgrade premium runner that was explicitly requested**
  If the toggle on the UI is enabled, even a runner requested by the
  customer with a premium label might be downgraded to a standard runner
  because the toggle sets the installation's "family_filter" to
  `["standard", "premium"]`
  

- **Check premium utilization for the premium concurrency check as well**
  Currently, we check the overall utilization to be below 75% to allow
  exceeding the soft concurrency limit. However, this check is global and
  doesn’t differentiate between standard and premium runners.
  Consequently, if the standard utilization is low, but a single customer
  with premium runners requests a large number of vCPUs, they could
  consume all available premium capacity. As a result, other customers
  with premium access might be blocked from getting premium runners.
  
  If both standard and premium utilization are above 75%, we don’t allow
  exceeding the soft concurrency limit.
  
  If premium utilization is high, but standard utilization is low, we
  allow exceeding the soft concurrency limit without a premium upgrade.
  
  To accommodate requested premium customers, I reduced the limit to 50%
  for free upgrades.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves premium runner allocation by preventing downgrades and refining concurrency checks in `prog/vm/github_runner.rb` and `prog/vm/nexus.rb`.
> 
>   - **Behavior**:
>     - Prevents downgrading explicitly requested premium runners by adjusting `family_filter` in `prog/vm/nexus.rb`.
>     - Adjusts concurrency checks in `wait_concurrency_limit` in `prog/vm/github_runner.rb` to consider both standard and premium utilizations separately.
>     - Reduces limit for free premium upgrades to 50% utilization.
>   - **Code Changes**:
>     - Adds `:not_upgrade_premium` to `SemaphoreMethods` in `model/github_runner.rb`.
>     - Modifies `wait_concurrency_limit` in `prog/vm/github_runner.rb` to handle premium and standard utilization checks.
>     - Updates `before_run` and `start` methods in `prog/vm/nexus.rb` to respect premium runner requests.
>   - **Tests**:
>     - Adds tests in `spec/prog/vm/github_runner_spec.rb` for new concurrency logic and premium runner handling.
>     - Updates `spec/prog/vm/nexus_spec.rb` to test allocation logic respecting premium runner requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 211aa45f8b5051b0d0ab02a52242f4fca1a471c0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->