### PR TITLE
Remove error message in PG metrics UI after success

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -863,6 +863,7 @@ function queryAndUpdateChart(chartInstance, start_time, end_time) {
 
       chartInstance.chart.hideLoading();
       chartInstance.chart.setOption({
+        ...chartInstance.chart.getOption(),
         legend: {
           data: chartSeries.map(series => series.name),
           right: '2%',
@@ -872,8 +873,9 @@ function queryAndUpdateChart(chartInstance, start_time, end_time) {
           min: start_time.getTime(),
           max: end_time.getTime()
         },
-        series: chartSeries
-      });
+        series: chartSeries,
+        graphic: [],
+      }, true);
       chartInstance.chart.resize();
     })
     .catch(error => {


### PR DESCRIPTION
Remove the error message when metrics data can be fetched successfully again after a failed attempt.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove error message in `queryAndUpdateChart()` in `app.js` after successful data fetch by clearing `graphic` option.
> 
>   - **Behavior**:
>     - In `queryAndUpdateChart()` in `app.js`, clears error message by setting `graphic: []` when data is successfully fetched after a failure.
>   - **Misc**:
>     - Adds `...chartInstance.chart.getOption()` to preserve existing chart options when updating.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 58b5fd16ff891aeed77020e28c130dca6c02266a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->