### PR TITLE
Enable cloudwatch for log collection

### DIFF
--- a/migrate/20250723_add_aws_amis_with_cloudwatch.rb
+++ b/migrate/20250723_add_aws_amis_with_cloudwatch.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    run <<~SQL
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-033db45b22ea9d5f5' WHERE aws_location_name = 'us-west-2' AND pg_version = '16' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0eb8c2917209d976c' WHERE aws_location_name = 'us-east-1' AND pg_version = '16' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0d7b22644cc107f7c' WHERE aws_location_name = 'us-east-2' AND pg_version = '16' AND arch = 'x64';
+
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0146f517ef96a236b' WHERE aws_location_name = 'us-west-2' AND pg_version = '17' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0c983c025438aacd5' WHERE aws_location_name = 'us-east-1' AND pg_version = '17' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-07b914864bc47798c' WHERE aws_location_name = 'us-east-2' AND pg_version = '17' AND arch = 'x64';
+
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-08d241ef2c43bd58d' WHERE aws_location_name = 'us-west-2' AND pg_version = '16' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0209475e8298c63b3' WHERE aws_location_name = 'us-east-1' AND pg_version = '16' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-07324c2c6f7307040' WHERE aws_location_name = 'us-east-2' AND pg_version = '16' AND arch = 'arm64';
+
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0a8ac3994a2e84490' WHERE aws_location_name = 'us-west-2' AND pg_version = '17' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-076ab55b352bf0542' WHERE aws_location_name = 'us-east-1' AND pg_version = '17' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-05e078647d2147c95' WHERE aws_location_name = 'us-east-2' AND pg_version = '17' AND arch = 'arm64';
+    SQL
+
+    run <<~SQL
+      INSERT INTO pg_aws_ami(id, aws_location_name, aws_ami_id, pg_version, arch) VALUES
+        ('9d9b87e0-f5dc-8dda-834d-d59c157b71e3', 'ap-southeast-2', 'ami-0aec02d3a6ee785eb', '16', 'x64'),
+        ('3cc87ea6-f3f8-89da-a6a6-5c85415a213b', 'ap-southeast-2', 'ami-0485aad6f306cc719', '16', 'arm64'),
+        ('3d18774e-1f92-8dda-afc1-b3a6643fe48f', 'ap-southeast-2', 'ami-0ecfc07de00637f25', '17', 'x64'),
+        ('7da3ded3-112c-8dda-aef0-2808cf26e89d', 'ap-southeast-2', 'ami-0189c92fdb172fb82', '17', 'arm64');
+    SQL
+  end
+
+  down do
+    run <<~SQL
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0fa4a3d37a0340e0b' WHERE aws_location_name = 'us-west-2' AND pg_version = '16' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0be2c55a267846818' WHERE aws_location_name = 'us-east-1' AND pg_version = '16' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-05403488066ce85e5' WHERE aws_location_name = 'us-east-2' AND pg_version = '16' AND arch = 'x64';
+
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0dee3e51a7288abec' WHERE aws_location_name = 'us-west-2' AND pg_version = '17' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0a2be334cf2f6a94e' WHERE aws_location_name = 'us-east-1' AND pg_version = '17' AND arch = 'x64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0badeb4aed1febf46' WHERE aws_location_name = 'us-east-2' AND pg_version = '17' AND arch = 'x64';
+
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0d60ec66b6112a54b' WHERE aws_location_name = 'us-west-2' AND pg_version = '16' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0eb7b9f20283f461f' WHERE aws_location_name = 'us-east-1' AND pg_version = '16' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-03da875684e5bbda1' WHERE aws_location_name = 'us-east-2' AND pg_version = '16' AND arch = 'arm64';
+
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0cad1682a42fef6e5' WHERE aws_location_name = 'us-west-2' AND pg_version = '17' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-0cda981a9b43cd352' WHERE aws_location_name = 'us-east-1' AND pg_version = '17' AND arch = 'arm64';
+      UPDATE pg_aws_ami SET aws_ami_id = 'ami-03a0d9514e598f5c4' WHERE aws_location_name = 'us-east-2' AND pg_version = '17' AND arch = 'arm64';
+    SQL
+
+    run <<~SQL
+      DELETE FROM pg_aws_ami WHERE aws_location_name = 'ap-southeast-2';
+    SQL
+  end
+end

--- a/model/location_credential.rb
+++ b/model/location_credential.rb
@@ -2,6 +2,7 @@
 
 require_relative "../model"
 require "aws-sdk-ec2"
+require "aws-sdk-iam"
 
 class LocationCredential < Sequel::Model
   plugin ResourceMethods, encrypted_columns: [:access_key, :secret_key]
@@ -10,6 +11,10 @@ class LocationCredential < Sequel::Model
 
   def client
     Aws::EC2::Client.new(access_key_id: access_key, secret_access_key: secret_key, region: location.name)
+  end
+
+  def iam_client
+    Aws::IAM::Client.new(access_key_id: access_key, secret_access_key: secret_key, region: location.name)
   end
 end
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -93,6 +93,12 @@ class PostgresServer < Sequel::Model
       if standby? || doing_pitr?
         configs[:restore_command] = "'/usr/bin/wal-g wal-fetch %f %p --config /etc/postgresql/wal-g.env'"
       end
+
+      if timeline.aws?
+        configs[:log_line_prefix] = "'%m [%p:%l] (%x,%v): host=%r,db=%d,user=%u,app=%a,client=%h '"
+        configs[:log_connections] = "on"
+        configs[:log_disconnections] = "on"
+      end
     end
 
     {

--- a/model/project.rb
+++ b/model/project.rb
@@ -172,7 +172,7 @@ class Project < Sequel::Model
 
   feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics
   feature_flag :private_locations, :enable_c6gd, :enable_m6gd, :enable_m8gd
-  feature_flag :free_runner_upgrade_until, :gpu_vm, :postgres_lantern
+  feature_flag :free_runner_upgrade_until, :gpu_vm, :postgres_lantern, :aws_cloudwatch_logs
 end
 
 # Table: project

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -271,6 +271,7 @@ TIMER
       vm.sshable.cmd("sudo systemctl enable --now prometheus")
       vm.sshable.cmd("sudo systemctl enable --now postgres-metrics.timer")
 
+      hop_setup_cloudwatch if postgres_server.timeline.aws? && postgres_server.resource.project.get_ff_aws_cloudwatch_logs
       hop_setup_hugepages
     end
 
@@ -279,6 +280,39 @@ TIMER
     vm.sshable.cmd("sudo systemctl reload prometheus || sudo systemctl restart prometheus")
 
     hop_wait
+  end
+
+  label def setup_cloudwatch
+    filepath = "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d"
+    filename = "001-ubicloud-config.json"
+    config = <<CONFIG
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/dat/#{postgres_server.resource.version}/data/pg_log/postgresql.log",
+            "log_group_name": "/#{postgres_server.ubid}/postgresql",
+            "log_stream_name": "#{postgres_server.ubid}/postgresql",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/auth.log",
+            "log_group_name": "/#{postgres_server.ubid}/auth",
+            "log_stream_name": "#{postgres_server.ubid}/auth",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+          }
+        ]
+      }
+    }
+  }
+}
+CONFIG
+    vm.sshable.cmd("sudo mkdir -p #{filepath}")
+    vm.sshable.cmd("sudo tee #{filepath}/#{filename} > /dev/null", stdin: config)
+    vm.sshable.cmd("sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:#{filepath}/#{filename} -s")
+    hop_setup_hugepages
   end
 
   label def setup_hugepages

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PostgresServer do
 
   describe "#configure" do
     before do
-      allow(postgres_server).to receive_messages(timeline: instance_double(PostgresTimeline, blob_storage: "dummy-blob-storage"), read_replica?: false)
+      allow(postgres_server).to receive_messages(timeline: instance_double(PostgresTimeline, blob_storage: "dummy-blob-storage", aws?: false), read_replica?: false)
       allow(resource).to receive(:flavor).and_return(PostgresResource::Flavor::STANDARD)
     end
 
@@ -108,6 +108,12 @@ RSpec.describe PostgresServer do
       postgres_server.timeline_access = "push"
       expect(resource).to receive(:flavor).and_return(PostgresResource::Flavor::LANTERN).at_least(:once)
       expect(postgres_server.configure_hash[:configs]).to include("shared_preload_libraries" => "'pg_cron,pg_stat_statements,lantern_extras'")
+    end
+
+    it "puts extra logging options for AWS" do
+      expect(postgres_server.timeline).to receive(:aws?).and_return(true)
+      postgres_server.timeline_access = "push"
+      expect(postgres_server.configure_hash[:configs]).to include(:log_line_prefix, :log_connections, :log_disconnections)
     end
   end
 


### PR DESCRIPTION
## Add Cloudwatch binary to the AWS AMIs and update the entities

## Setup individual instance IAMs to be used by cloudwatch agent

## Setup the Cloudwatch config for each postgres server
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable CloudWatch for log collection by updating AWS AMIs, setting up IAM roles, and configuring CloudWatch on Postgres servers.
> 
>   - **AWS AMIs**:
>     - Updates `pg_aws_ami` table with new AMI IDs for various regions and architectures in `20250723_add_aws_amis_with_cloudwatch.rb`.
>     - Adds new AMI entries for `ap-southeast-2`.
>   - **IAM Roles**:
>     - Adds `iam_client` method to `LocationCredential`.
>     - Implements IAM role and policy creation in `Prog::Aws::Instance`.
>     - Handles role attachment and instance profile creation.
>   - **Postgres Server Configuration**:
>     - Updates `configure_hash` in `PostgresServer` to include AWS-specific logging configs.
>     - Adds CloudWatch setup in `Prog::Postgres::PostgresServerNexus`.
>   - **Feature Flags**:
>     - Adds `aws_cloudwatch_logs` feature flag in `Project`.
>   - **Testing**:
>     - Adds tests for IAM role creation and CloudWatch setup in `instance_spec.rb` and `postgres_server_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d19ea8dcccec601460c73594987bb379c6d88d2e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->