### PR TITLE
Increase audit log coverage for HIPAA

### DIFF
--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -63,7 +63,7 @@ class Clover < Roda
     update_billing
     update_invitation
   ACTIONS
-  LOGGED_ACTIONS = Set.new(%w[create create_replica destroy]).freeze
+  LOGGED_ACTIONS = Set.new(%w[create create_replica destroy promote reset_superuser_password restart restore update]).freeze
 
   def audit_log(object, action, objects = [])
     raise "unsupported audit_log action: #{action}" unless SUPPORTED_ACTIONS.include?(action)


### PR DESCRIPTION
We need to start logging every action that impacts data integrity. Therefore, I am increasing the coverage of audit_log.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expanded `LOGGED_ACTIONS` in `helpers/general.rb` to log additional actions for improved data integrity tracking.
> 
>   - **Audit Log Coverage**:
>     - Expanded `LOGGED_ACTIONS` in `helpers/general.rb` to include `promote`, `reset_superuser_password`, `restart`, `restore`, and `update` actions.
>     - Ensures these actions are logged for better data integrity tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 45d6693ae471f141d2dd607d67e1291c32408ce6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->