### PR TITLE
Fix old backup and wal files delete policy

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -149,11 +149,11 @@ PGHOST=/var/run/postgresql
           rules: [
             {
               id: "DeleteOldBackups",
-              prefix: "basebackups_005/",
               status: "Enabled",
               expiration: {
                 days: BACKUP_BUCKET_EXPIRATION_DAYS
-              }
+              },
+              filter: {}
             }
           ]
         }

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -210,7 +210,7 @@ PGHOST=/var/run/postgresql
 
     it "sets lifecycle policy" do
       s3_client.stub_responses(:put_bucket_lifecycle_configuration)
-      expect(s3_client).to receive(:put_bucket_lifecycle_configuration).with({bucket: postgres_timeline.ubid, lifecycle_configuration: {rules: [{id: "DeleteOldBackups", status: "Enabled", prefix: "basebackups_005/", expiration: {days: 8}}]}}).and_return(true)
+      expect(s3_client).to receive(:put_bucket_lifecycle_configuration).with({bucket: postgres_timeline.ubid, lifecycle_configuration: {rules: [{id: "DeleteOldBackups", status: "Enabled", expiration: {days: 8}, filter: {}}]}}).and_return(true)
       expect(postgres_timeline.set_lifecycle_policy).to be(true)
     end
   end


### PR DESCRIPTION
We were only cleaning up the basebackups and forget about the wal files. With this commit, we start cleaning up the wal files, too.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update lifecycle policy in `PostgresTimeline` to clean up wal files by modifying `set_lifecycle_policy` to use `filter` instead of `prefix`.
> 
>   - **Behavior**:
>     - Updates `set_lifecycle_policy` in `postgres_timeline.rb` to remove `prefix` and add `filter` for lifecycle rules, ensuring wal files are also cleaned up.
>   - **Tests**:
>     - Updates test in `postgres_timeline_spec.rb` to expect lifecycle configuration without `prefix` and with `filter`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6a91330cf72b207093a20ddf2cb64cc10ffe4edf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->