### PR TITLE
Support monitor partitioning

### DIFF
--- a/.github/workflows/monitor-ci.yml
+++ b/.github/workflows/monitor-ci.yml
@@ -1,0 +1,53 @@
+name: monitor CI
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'bin/monitor'
+      - 'lib/monitor_runner.rb'
+      - 'lib/monitor_repartitioner.rb'
+      - 'lib/monitor_resource_type.rb'
+      - 'lib/monitorable_resource.rb'
+      - 'lib/monitor_resource_stub.rb'
+      - 'lib/metrics_target_resource.rb'
+      - 'spec/monitor_smoke_test.rb'
+      - '.github/workflows/monitor-ci.yml'
+      - '.github/actions/setup-clover/action.yml'
+  pull_request:
+    paths:
+      - 'bin/monitor'
+      - 'lib/monitor_runner.rb'
+      - 'lib/monitor_repartitioner.rb'
+      - 'lib/monitor_resource_type.rb'
+      - 'lib/monitorable_resource.rb'
+      - 'lib/monitor_resource_stub.rb'
+      - 'lib/metrics_target_resource.rb'
+      - 'spec/monitor_smoke_test.rb'
+      - '.github/workflows/monitor-ci.yml'
+      - '.github/actions/setup-clover/action.yml'
+
+jobs:
+  cli-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubicloud, ubicloud-arm]
+    name: monitor CI - ${{matrix.runs-on}}
+    runs-on: ${{matrix.runs-on}}
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Clover
+      uses: ./.github/actions/setup-clover
+
+    - name: Run monitor smoke test
+      run: bundle exec rake monitor_smoke_test
+

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", ">= 5.94"
+gem "sequel", github: "jeremyevans/sequel", ref: "2b17b99b81a38da94c3ff73bc3f15e5adcda0e89"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       rodauth (~> 2.36)
 
 GIT
+  remote: https://github.com/jeremyevans/sequel.git
+  revision: 2b17b99b81a38da94c3ff73bc3f15e5adcda0e89
+  ref: 2b17b99b81a38da94c3ff73bc3f15e5adcda0e89
+  specs:
+    sequel (5.94.0)
+      bigdecimal
+
+GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -367,8 +375,6 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
-    sequel (5.94.0)
-      bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
     sequel_pg (1.17.1)
@@ -504,7 +510,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel (>= 5.94)
+  sequel!
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords

--- a/Rakefile
+++ b/Rakefile
@@ -291,6 +291,11 @@ task "check_separate_requires" do
   system({"RACK_ENV" => "test", "LOAD_FILES_SEPARATELY_CHECK" => "1"}, RbConfig.ruby, "-r", "./loader", "-e", "")
 end
 
+desc "Run monitor smoke test"
+task :monitor_smoke_test do
+  system(RbConfig.ruby, "spec/monitor_smoke_test.rb")
+end
+
 desc "Run respirate smoke tests"
 task :respirate_smoke_test do
   # not partitioned, 1 process

--- a/bin/monitor
+++ b/bin/monitor
@@ -17,42 +17,8 @@ if partition_number
   raise "invalid partition_number: #{partition_number}" if partition_number < 1
 end
 
-# Used for NOTIFY, since NOTIFY payload must be a string
-partition_number_string = partition_number.to_s
-
-# Assume when starting that we are the final partition. For cases where we aren't,
-# this will quickly be updated after startup.
-num_partitions = partition_number
-
-# Flag set when we have repartitioned, to ensure we do a scan using the new partition
-# before enqueuing additional resources.
-repartitioned = true
-
-# Flag set when shutting down. All threads check this in their loops, and exit within
-# 1 second after it is set.
-shutdown = false
-
-# Time after which to run the scan query to check for new resources.
-scan_after = Time.now
-
-# Time after which to report the number of active threads and other metric information.
-report_after = Time.now + 5
-
-# Time after which to report the number of active threads.
-check_stuck_pulses_after = Time.now + 5
-
-# The number of seconds until we should run the next scan query. This runs a scan
-# every minute.
-scan_every = 60
-
-# The number of seconds between reporting monitor metrics.
-report_every = 5
-
-# The number of seconds after a monitor job completes before resubmitting it.
-enqueue_every = 5
-
-# The number of seconds between checking for for stuck pulses.
-check_stuck_pulses_every = 5
+require_relative "../loader"
+clover_freeze
 
 # Information (seconds, log message, log key) for stuck pulses for monitor jobs.
 monitor_pulse_info = [120, "Pulse check has stuck.", :pulse_check_stuck].freeze
@@ -60,248 +26,7 @@ monitor_pulse_info = [120, "Pulse check has stuck.", :pulse_check_stuck].freeze
 # Information (seconds, log message, log key) for stuck pulses for metric export jobs.
 metric_export_pulse_info = [100, "Pulse check has stuck.", :pulse_check_stuck].freeze
 
-# Used solely to allow for immediately main/scan/enqueue thread exiting early during
-# shutdown.
-wakeup_queue = Queue.new
-
-# All queues that should be closed during shutdown. The queues for each of the thread
-# pool will be added to this array later.
-queues = [wakeup_queue]
-
-do_shutdown = proc do
-  shutdown = true
-  queues.each(&:close)
-end
-
-Signal.trap("INT", &do_shutdown)
-Signal.trap("TERM", &do_shutdown)
-
-require_relative "../loader"
-
-# Class that abstracts both monitored resources and metric export resources, to avoid
-# duplication for the two types. Attributes:
-# wrapper_class :: Either MonitorableResource or MetricsTargetResource
-# resources :: Hash of resources, keyed by id
-# types :: The underlying model classes (or datasets) to handle
-# submit_queue :: A sized queue for submitting jobs for processing. Pushed to by the main thread,
-#                 popped by worker threads.
-# finish_queue :: A queue for jobs that just finished processing. Pushed to by the
-#                 worker threads, popped by the main thread.
-# run_queue :: An array keeping track of future jobs to run. The main thread appends jobs
-#              popped from the finish queue to this array, and slices the front of the
-#              and pushes those jobs to the submit queue.
-# threads :: Pool/array of worker threads, which process jobs on the submit queue.
-# stuck_pulse_info :: Array with timeout seconds, log message, and log key for handling stuck
-#                     pulses/metric exports.
-MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_queue, :finish_queue, :run_queue, :threads, :stuck_pulse_info) do
-  # Helper method for creating the instance
-  def self.create(klass, stuck_pulse_info, num_threads, *types)
-    pool_size = (num_threads - 2).clamp(1, nil)
-
-    # This does not get updated during runtime, which means that if many resources are
-    # added after startup, it may not be sized appropriately.  However, this seems
-    # unlikely to matter in practice.
-    queue_size = pool_size + (types.sum(&:count) * 1.5).round
-
-    submit_queue = SizedQueue.new(queue_size)
-    finish_queue = Queue.new
-
-    threads = Array.new(pool_size) do
-      Thread.new do
-        while (r = submit_queue.pop)
-          # We keep track of started at information to check for stuck pulses.
-          r.monitor_job_started_at = Time.now
-          r.open_resource_session
-
-          # Yield so that monitored resources and metric export resources can be
-          # handled differently.
-          yield r
-
-          # We unset the started at time so we will not check for stuck pulses
-          # while this is in the run queue.
-          r.monitor_job_started_at = nil
-
-          # We record the finish time before pushing to the queue to allow for
-          # more accurate scheduling.
-          r.monitor_job_finished_at = Time.now
-          finish_queue.push(r)
-        end
-      end
-    end
-
-    new(klass, {}, types, submit_queue, finish_queue, [], threads, stuck_pulse_info)
-  end
-
-  # Check each resource for stuck pulses/metric exports, and log if any are found.
-  def check_stuck_pulses
-    timeout, msg, key = stuck_pulse_info
-    before = Time.now - timeout
-    resources.each_value do |r|
-      if r.monitor_job_started_at&.<(before)
-        Clog.emit(msg) { {key => {ubid: r.ubid}} }
-      end
-    end
-  end
-
-  # Update the resources the instance will monitor/metric export. If the resource
-  # to be monitored was previously monitored, keep the previous version, as it will
-  # likely have an ssh session already setup. Returns the newly scanned resources,
-  # which will be the next ones to process.
-  def scan(id_range)
-    scanned_resources = {}
-    new_resources = []
-
-    types.each do |type|
-      type.where_each(id: id_range) do
-        unless (v = resources[it.id])
-          v = wrapper_class.new(it)
-          new_resources << v
-        end
-        scanned_resources[it.id] = v
-      end
-    end
-
-    self.resources = scanned_resources
-    new_resources
-  end
-
-  # Update the run_queue with jobs that have finished. Then enqueue each resource
-  # if . Enqueued resources will be processed by the worker
-  # thread pool.
-  def enqueue(before)
-    # Pop all available jobs out of the finish queue and add them to the
-    # run queue. This can result in jobs that a very slightly out of order,
-    # due to thread scheduling, but the differences are not likely to be material.
-    while (r = finish_queue.pop(timeout: 0))
-      run_queue << r
-    end
-
-    unless run_queue.empty?
-      i = run_queue.find_index { it.monitor_job_finished_at > before }
-      if i
-        run_queue.slice!(0, i + 1).each do
-          # If the job in the run queue is no longer a monitored resource,
-          # then don't add it to the submit queue. This ensures we don't
-          # continue to monitor a resource after it has been deleted or is
-          # no longer in the current partition.
-          submit_queue.push(it) if resources[it.resource.id]
-        end
-      end
-      run_queue[0]&.monitor_job_finished_at
-    end
-  end
-end
-
-# Need to define the MonitorResourceType constant before freezing
-clover_freeze
-
-partition_boundary = lambda do |partition_num, partition_size|
-  "%08x-0000-0000-0000-000000000000" % (partition_num * partition_size).to_i
-end
-
-# This calculates the partition of the id space that this process will monitor.
-strand_id_range = lambda do
-  partition_size = (16**8) / num_partitions.to_r
-  start_id = partition_boundary.call(partition_number - 1, partition_size)
-
-  if num_partitions == partition_number
-    start_id.."ffffffff-ffff-ffff-ffff-ffffffffffff"
-  else
-    start_id...partition_boundary.call(partition_number, partition_size)
-  end
-end
-
-# Notify the monitor channel that we exist, so that other monitor processes
-# can repartition appropriately if needed.
-notify_partition = proc do
-  DB.notify(:monitor, payload: partition_number_string)
-end
-
-# Listens on the monitor channel to determine what other monitor processes are
-# running, and updates the num_partitions information, so that the current process
-# scan thread will use the appropriate partition.
-repartition_thread = Thread.new do
-  # Check for shutdown every second
-  listen_timeout = 1
-
-  # Check for stale partitions and notify that the current process is still running
-  # every 18 seconds.
-  recheck_seconds = 18
-
-  # Remove a partition if we have not been notified about it in the last 40 seconds.
-  # Combined with the above two settings, this means that if the final monitor partition
-  # process exits, other monitor processes will repartition in 40-59 seconds.
-  stale_seconds = 40
-
-  # The next deadline after which to check for stale partitions and notify.
-  partition_recheck_time = Time.now + recheck_seconds - rand
-
-  # This starts out empty, but will be filled in by notifications from the current
-  # monitor process and other monitor processes.
-  partition_times = {}
-
-  # Updates the total number of partitions, and sets the repartition flag, so the
-  # next main loop iteration will run a scan query.
-  repartition = lambda do |np|
-    num_partitions = np
-    repartitioned = true
-    Clog.emit("monitor repartitioning") { {partition_number:, num_partitions:, range: strand_id_range.call} }
-  end
-
-  # Ensure we log partition information on startup
-  repartition.call(partition_number)
-
-  # Called every second. Used to exit the listen loop on shutdown, and to NOTIFY
-  # about the current process and remove stale processes when rechecking.
-  repartition_check = lambda do |partition_times|
-    throw :stop if shutdown
-
-    t = Time.now
-    if t > partition_recheck_time
-      partition_recheck_time = t + recheck_seconds
-      notify_partition.call
-      stale = t - stale_seconds
-      partition_times.reject! { |_, time| time < stale }
-      partition_times.keys.max
-    end
-  end
-
-  # If the maximum partition number after rechecking is lower than the currently
-  # expected partitioning, repartition the current process to expand the
-  # partition size.
-  loop = proc do
-    if (max_partition = repartition_check.call(partition_times))&.<(num_partitions)
-      repartition.call(max_partition)
-    end
-  end
-
-  # Continuouly LISTENs for notifications on the monitor channel until shutdown.
-  # If notified about a higher partition number than the currently expected
-  # partitioning, repartition the current process to decrease the partition size.
-  DB.listen(:monitor, loop:, after_listen: notify_partition, timeout: listen_timeout) do |_, _, payload|
-    throw :stop if shutdown
-
-    unless (partition_num = Integer(payload, exception: false)) && (partition_num <= 8)
-      Clog.emit("invalid monitor repartition notification") { {monitor_notify_payload: payload} }
-      next
-    end
-
-    repartition.call(partition_num) if partition_num > num_partitions
-    partition_times[partition_num] = Time.now
-  end
-end
-
-# Only NOTIFY for the first 3-5 seconds, so that by the time we actually start monitoring,
-# all monitor processes know the expected partitioning. The rand is to avoid thundering herd issues.
-sleep 1
-sleep rand
-3.times do
-  notify_partition.call
-  sleep 1
-end
-
-# Handle both monitored resources and metric export resources.
-monitor_resources = MonitorResourceType.create(MonitorableResource, monitor_pulse_info, Config.max_health_monitor_threads,
+monitor_models = [
   VmHost,
   PostgresServer,
   Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists),
@@ -310,108 +35,56 @@ monitor_resources = MonitorResourceType.create(MonitorableResource, monitor_puls
   VmHostSlice,
   LoadBalancerVmPort,
   KubernetesCluster,
-  VictoriaMetricsServer) do
+  VictoriaMetricsServer
+]
+
+metric_export_models = [
+  PostgresServer,
+  VmHost
+]
+
+# Handle both monitored resources and metric export resources.
+monitor_resources = MonitorResourceType.create(
+  MonitorableResource,
+  monitor_pulse_info,
+  Config.max_health_monitor_threads,
+  monitor_models
+) do
   it.process_event_loop
   it.check_pulse
 end
 
-metric_export_resources = MonitorResourceType.create(MetricsTargetResource, metric_export_pulse_info, Config.max_metrics_export_threads,
-  PostgresServer,
-  VmHost,
-  &:export_metrics)
+metric_export_resources = MonitorResourceType.create(
+  MetricsTargetResource,
+  metric_export_pulse_info,
+  Config.max_metrics_export_threads,
+  metric_export_models,
+  &:export_metrics
+)
 
-resource_types = [monitor_resources, metric_export_resources].freeze
+repartitioner = MonitorRepartitioner.new(partition_number)
 
-# Shutdown the worker thread queues on shutdown.
-queues.concat(resource_types.map(&:submit_queue))
-queues.freeze
+runner = MonitorRunner.new(monitor_resources:, metric_export_resources:, repartitioner:, ignore_threads: 2)
 
-# The 2 additional threads are the main thread and the repartition thread
-monitor_internal_threads = resource_types.sum { it.threads.size } + 2
+repartition_thread = Thread.new { repartitioner.listen }
 
-begin
-  until shutdown
-    t = Time.now
-
-    # If the time since last scan has exceeded the deadline, or we
-    # have repartitioned since the last iteration, scan again to get the
-    # current set of resources for both resource types.
-    if t > scan_after || repartitioned
-      scan_after = t + scan_every
-      repartitioned = false
-      id_range = strand_id_range.call
-      resource_types.each do |resource_type|
-        queue = resource_type.submit_queue
-
-        # Immediately enqueue new resources
-        resource_type.scan(id_range).each { queue.push(it) }
-      end
-
-      # Pushing to the queue may block, and there may a large amount of time
-      # since the last Time.now call.
-      t = Time.now
-    end
-
-    # If the time since the last report has exceeded the deadline, report again.
-    if t > report_after
-      report_after = t + report_every
-      Clog.emit("monitor metrics") do
-        {
-          active_threads_count: Thread.list.count - monitor_internal_threads,
-          threads_waiting_for_db_connection: DB.pool.num_waiting,
-          total_monitor_resources: monitor_resources.resources.size,
-          total_metric_export_resources: metric_export_resources.resources.size,
-          monitor_submit_queue_length: monitor_resources.submit_queue.length,
-          metric_export_submit_queue_length: metric_export_resources.submit_queue.length,
-          monitor_idle_worker_threads: monitor_resources.submit_queue.num_waiting,
-          metric_export_idle_worker_threads: metric_export_resources.submit_queue.num_waiting
-        }
-      end
-    end
-
-    # If the time since the last pulse check has exceeded the deadline,
-    # check again for stuck pulses.
-    if t > check_stuck_pulses_after
-      check_stuck_pulses_after = t + check_stuck_pulses_every
-      resource_types.each(&:check_stuck_pulses)
-    end
-
-    # We want to run all jobs that finished more than the given number
-    # of seconds ago.
-    before = t - enqueue_every
-
-    # Enqueue resources that finished more than the expected number
-    # of seconds ago. This returns the last finish time of the next
-    # job to run for each resource type.
-    last_finish_times = resource_types.map { it.enqueue(before) }
-
-    # The resource type may have no jobs to run currently, so remove
-    # any nil values.
-    last_finish_times.compact!
-
-    # Determine how long to sleep. In general, sleep until it is time
-    # to run the next job. If there are no jobs in either run queue,
-    # sleep for the maximum amount of time.
-    sleep_time = if (last_finish_time = last_finish_times.min)
-      ((last_finish_time + enqueue_every) - Time.now)
-    else
-      enqueue_every
-    end
-
-    # Sleep for the given number of seconds. This uses a timed pop on
-    # a queue so that it will exit immediately on shutdown
-    wakeup_queue.pop(timeout: sleep_time)
-  end
-rescue ClosedQueueError
-  # Shouldn't hit this block unless we are already shutting down,
-  # but better to be safe and handle case where we aren't already
-  # shutting down, otherwise joining the threads will block.
-  do_shutdown unless shutdown
-rescue => ex
-  Clog.emit("Pulse checking or resource scanning has failed.") { {pulse_checking_or_resource_scanning_failure: {exception: Util.exception_to_hash(ex)}} }
-  ThreadPrinter.run
-  Kernel.exit! 2
+# Only NOTIFY for the first 3-5 seconds, so that by the time we actually start monitoring,
+# all monitor processes know the expected partitioning. The rand is to avoid thundering herd issues.
+sleep(1 + rand)
+3.times do
+  repartitioner.notify
+  sleep 1
 end
+
+do_shutdown = proc do
+  repartitioner.shutdown!
+  runner.shutdown!
+end
+
+Signal.trap("INT", &do_shutdown)
+Signal.trap("TERM", &do_shutdown)
+
+runner.run
 
 # If not all threads exit within two seconds, exit 1 to indicate
 # unclean shutdown.
@@ -419,7 +92,7 @@ exit_status = 1
 
 Thread.new do
   repartition_thread.join
-  resource_types.each { it.threads.each(&:join) }
+  [monitor_resources, metric_export_resources].each(&:wait_cleanup!)
   # If all threads exit within two seconds, exit 0 to indicate clean shutdown.
   exit_status = 0
 end.join(2)

--- a/bin/monitor
+++ b/bin/monitor
@@ -32,16 +32,33 @@ repartitioned = true
 # 1 second after it is set.
 shutdown = false
 
-# Time after which to run the scan query to check for new resources. This is updated
-# every time we run the scan query.
+# Time after which to run the scan query to check for new resources.
 scan_after = Time.now
+
+# Time after which to report the number of active threads and other metric information.
+report_after = Time.now + 5
+
+# Time after which to report the number of active threads.
+check_stuck_pulses_after = Time.now + 5
 
 # The number of seconds until we should run the next scan query. This runs a scan
 # every minute.
 scan_every = 60
 
-# The number of seconds between enqueuing resources for pulse checking.
+# The number of seconds between reporting monitor metrics.
+report_every = 5
+
+# The number of seconds after a monitor job completes before resubmitting it.
 enqueue_every = 5
+
+# The number of seconds between checking for for stuck pulses.
+check_stuck_pulses_every = 5
+
+# Information (seconds, log message, log key) for stuck pulses for monitor jobs.
+monitor_pulse_info = [120, "Pulse check has stuck.", :pulse_check_stuck].freeze
+
+# Information (seconds, log message, log key) for stuck pulses for metric export jobs.
+metric_export_pulse_info = [100, "Pulse check has stuck.", :pulse_check_stuck].freeze
 
 # Used solely to allow for immediately main/scan/enqueue thread exiting early during
 # shutdown.
@@ -62,11 +79,23 @@ Signal.trap("TERM", &do_shutdown)
 require_relative "../loader"
 
 # Class that abstracts both monitored resources and metric export resources, to avoid
-# duplication for the two types. Each type monitors a certain number of types,
-# has a dedicated group of worker threads, and a queue for feeding the worker threads.
-MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :queue, :threads) do
-  # Helper method for creating the instance with the correct thread pool and queue
-  def self.create(klass, num_threads, *types)
+# duplication for the two types. Attributes:
+# wrapper_class :: Either MonitorableResource or MetricsTargetResource
+# resources :: Hash of resources, keyed by id
+# types :: The underlying model classes (or datasets) to handle
+# submit_queue :: A sized queue for submitting jobs for processing. Pushed to by the main thread,
+#                 popped by worker threads.
+# finish_queue :: A queue for jobs that just finished processing. Pushed to by the
+#                 worker threads, popped by the main thread.
+# run_queue :: An array keeping track of future jobs to run. The main thread appends jobs
+#              popped from the finish queue to this array, and slices the front of the
+#              and pushes those jobs to the submit queue.
+# threads :: Pool/array of worker threads, which process jobs on the submit queue.
+# stuck_pulse_info :: Array with timeout seconds, log message, and log key for handling stuck
+#                     pulses/metric exports.
+MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_queue, :finish_queue, :run_queue, :threads, :stuck_pulse_info) do
+  # Helper method for creating the instance
+  def self.create(klass, stuck_pulse_info, num_threads, *types)
     pool_size = (num_threads - 2).clamp(1, nil)
 
     # This does not get updated during runtime, which means that if many resources are
@@ -74,50 +103,91 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :queue, :th
     # unlikely to matter in practice.
     queue_size = pool_size + (types.sum(&:count) * 1.5).round
 
-    queue = SizedQueue.new(queue_size)
+    submit_queue = SizedQueue.new(queue_size)
+    finish_queue = Queue.new
 
     threads = Array.new(pool_size) do
       Thread.new do
-        while (r = queue.pop)
-          r.lock_no_wait do
-            r.open_resource_session
+        while (r = submit_queue.pop)
+          # We keep track of started at information to check for stuck pulses.
+          r.monitor_job_started_at = Time.now
+          r.open_resource_session
 
-            # Yield so that monitored resources and metric export resources can be
-            # handled differently.
-            yield r
-          end
+          # Yield so that monitored resources and metric export resources can be
+          # handled differently.
+          yield r
+
+          # We unset the started at time so we will not check for stuck pulses
+          # while this is in the run queue.
+          r.monitor_job_started_at = nil
+
+          # We record the finish time before pushing to the queue to allow for
+          # more accurate scheduling.
+          r.monitor_job_finished_at = Time.now
+          finish_queue.push(r)
         end
       end
     end
 
-    new(klass, {}, types, queue, threads)
+    new(klass, {}, types, submit_queue, finish_queue, [], threads, stuck_pulse_info)
+  end
+
+  # Check each resource for stuck pulses/metric exports, and log if any are found.
+  def check_stuck_pulses
+    timeout, msg, key = stuck_pulse_info
+    before = Time.now - timeout
+    resources.each_value do |r|
+      if r.monitor_job_started_at&.<(before)
+        Clog.emit(msg) { {key => {ubid: r.ubid}} }
+      end
+    end
   end
 
   # Update the resources the instance will monitor/metric export. If the resource
   # to be monitored was previously monitored, keep the previous version, as it will
-  # likely have an ssh session already setup.
+  # likely have an ssh session already setup. Returns the newly scanned resources,
+  # which will be the next ones to process.
   def scan(id_range)
-    new_resources = {}
+    scanned_resources = {}
+    new_resources = []
+
     types.each do |type|
       type.where_each(id: id_range) do
-        new_resources[it.id] = resources[it.id] || wrapper_class.new(it)
+        unless (v = resources[it.id])
+          v = wrapper_class.new(it)
+          new_resources << v
+        end
+        scanned_resources[it.id] = v
       end
     end
-    self.resources = new_resources
+
+    self.resources = scanned_resources
+    new_resources
   end
 
-  # Enqueue each resource. Enqueued resources will be processed by the worker
+  # Update the run_queue with jobs that have finished. Then enqueue each resource
+  # if . Enqueued resources will be processed by the worker
   # thread pool.
-  def enqueue
-    resources.each_value do
-      # This method name is misleading, it only logs, it doesn't force stop
-      it.force_stop_if_stuck
+  def enqueue(before)
+    # Pop all available jobs out of the finish queue and add them to the
+    # run queue. This can result in jobs that a very slightly out of order,
+    # due to thread scheduling, but the differences are not likely to be material.
+    while (r = finish_queue.pop(timeout: 0))
+      run_queue << r
+    end
 
-      # Even if the resource is locked, we still enqueue it, which seems
-      # questionable. Maybe it will be unlocked by the time a worker thread
-      # picks it up, but we should probably consider not enqueuing a locked
-      # resource.
-      queue.push(it)
+    unless run_queue.empty?
+      i = run_queue.find_index { it.monitor_job_finished_at > before }
+      if i
+        run_queue.slice!(0, i + 1).each do
+          # If the job in the run queue is no longer a monitored resource,
+          # then don't add it to the submit queue. This ensures we don't
+          # continue to monitor a resource after it has been deleted or is
+          # no longer in the current partition.
+          submit_queue.push(it) if resources[it.resource.id]
+        end
+      end
+      run_queue[0]&.monitor_job_finished_at
     end
   end
 end
@@ -231,28 +301,29 @@ sleep rand
 end
 
 # Handle both monitored resources and metric export resources.
-resource_types = [
-  MonitorResourceType.create(MonitorableResource, Config.max_health_monitor_threads,
-    VmHost,
-    PostgresServer,
-    Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists),
-    MinioServer,
-    GithubRunner,
-    VmHostSlice,
-    LoadBalancerVmPort,
-    KubernetesCluster,
-    VictoriaMetricsServer) do
-    it.process_event_loop
-    it.check_pulse
-  end,
-  MonitorResourceType.create(MetricsTargetResource, Config.max_metrics_export_threads,
-    PostgresServer,
-    VmHost,
-    &:export_metrics)
-]
+monitor_resources = MonitorResourceType.create(MonitorableResource, monitor_pulse_info, Config.max_health_monitor_threads,
+  VmHost,
+  PostgresServer,
+  Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists),
+  MinioServer,
+  GithubRunner,
+  VmHostSlice,
+  LoadBalancerVmPort,
+  KubernetesCluster,
+  VictoriaMetricsServer) do
+  it.process_event_loop
+  it.check_pulse
+end
+
+metric_export_resources = MonitorResourceType.create(MetricsTargetResource, metric_export_pulse_info, Config.max_metrics_export_threads,
+  PostgresServer,
+  VmHost,
+  &:export_metrics)
+
+resource_types = [monitor_resources, metric_export_resources].freeze
 
 # Shutdown the worker thread queues on shutdown.
-queues.concat(resource_types.map(&:queue))
+queues.concat(resource_types.map(&:submit_queue))
 queues.freeze
 
 # The 2 additional threads are the main thread and the repartition thread
@@ -260,9 +331,8 @@ monitor_internal_threads = resource_types.sum { it.threads.size } + 2
 
 begin
   until shutdown
-    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - monitor_internal_threads, threads_waiting_for_db_connection: DB.pool.num_waiting} }
-
     t = Time.now
+
     # If the time since last scan has exceeded the deadline, or we
     # have repartitioned since the last iteration, scan again to get the
     # current set of resources for both resource types.
@@ -270,15 +340,67 @@ begin
       scan_after = t + scan_every
       repartitioned = false
       id_range = strand_id_range.call
-      resource_types.each { it.scan(id_range) }
+      resource_types.each do |resource_type|
+        queue = resource_type.submit_queue
+
+        # Immediately enqueue new resources
+        resource_type.scan(id_range).each { queue.push(it) }
+      end
+
+      # Pushing to the queue may block, and there may a large amount of time
+      # since the last Time.now call.
+      t = Time.now
     end
 
-    # Enqueue every resource for both resource types
-    resource_types.each(&:enqueue)
+    # If the time since the last report has exceeded the deadline, report again.
+    if t > report_after
+      report_after = t + report_every
+      Clog.emit("monitor metrics") do
+        {
+          active_threads_count: Thread.list.count - monitor_internal_threads,
+          threads_waiting_for_db_connection: DB.pool.num_waiting,
+          total_monitor_resources: monitor_resources.resources.size,
+          total_metric_export_resources: metric_export_resources.resources.size,
+          monitor_submit_queue_length: monitor_resources.submit_queue.length,
+          metric_export_submit_queue_length: metric_export_resources.submit_queue.length,
+          monitor_idle_worker_threads: monitor_resources.submit_queue.num_waiting,
+          metric_export_idle_worker_threads: metric_export_resources.submit_queue.num_waiting
+        }
+      end
+    end
+
+    # If the time since the last pulse check has exceeded the deadline,
+    # check again for stuck pulses.
+    if t > check_stuck_pulses_after
+      check_stuck_pulses_after = t + check_stuck_pulses_every
+      resource_types.each(&:check_stuck_pulses)
+    end
+
+    # We want to run all jobs that finished more than the given number
+    # of seconds ago.
+    before = t - enqueue_every
+
+    # Enqueue resources that finished more than the expected number
+    # of seconds ago. This returns the last finish time of the next
+    # job to run for each resource type.
+    last_finish_times = resource_types.map { it.enqueue(before) }
+
+    # The resource type may have no jobs to run currently, so remove
+    # any nil values.
+    last_finish_times.compact!
+
+    # Determine how long to sleep. In general, sleep until it is time
+    # to run the next job. If there are no jobs in either run queue,
+    # sleep for the maximum amount of time.
+    sleep_time = if (last_finish_time = last_finish_times.min)
+      ((last_finish_time + enqueue_every) - Time.now)
+    else
+      enqueue_every
+    end
 
     # Sleep for the given number of seconds. This uses a timed pop on
     # a queue so that it will exit immediately on shutdown
-    wakeup_queue.pop(timeout: enqueue_every)
+    wakeup_queue.pop(timeout: sleep_time)
   end
 rescue ClosedQueueError
   # Shouldn't hit this block unless we are already shutting down,

--- a/bin/monitor
+++ b/bin/monitor
@@ -26,22 +26,37 @@ monitor_pulse_info = [120, "Pulse check has stuck.", :pulse_check_stuck].freeze
 # Information (seconds, log message, log key) for stuck pulses for metric export jobs.
 metric_export_pulse_info = [100, "Pulse check has stuck.", :pulse_check_stuck].freeze
 
-monitor_models = [
-  VmHost,
-  PostgresServer,
-  Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists),
-  MinioServer,
-  GithubRunner,
-  VmHostSlice,
-  LoadBalancerVmPort,
-  KubernetesCluster,
-  VictoriaMetricsServer
-]
+if Config.test?
+  # Run during monitor smoke tests
+  $stdout.sync = $stderr.sync = true
+  # Ensure clog output during smoke test
+  Clog::Config = Struct.new(:test?).new(false)
+  MonitorResourceStub.add(UBID.generate_vanity("et", "mr", "vp"))
+  MonitorResourceStub.add(UBID.generate_vanity("et", "mr", "down"), pulse: "down")
+  MonitorResourceStub.add(UBID.generate_vanity("et", "mr", "evloop"), need_event_loop: true)
+  MonitorResourceStub.add(UBID.generate_vanity("et", "mr", "mc2"), metrics_count: 2)
+  monitor_models = [MonitorResourceStub]
+  metric_export_models = [MonitorResourceStub]
+  runner_args = {scan_every: 1, report_every: 1, enqueue_every: 1, check_stuck_pulses_every: 1}
+else
+  runner_args = {ignore_threads: 2}
+  monitor_models = [
+    VmHost,
+    PostgresServer,
+    Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists),
+    MinioServer,
+    GithubRunner,
+    VmHostSlice,
+    LoadBalancerVmPort,
+    KubernetesCluster,
+    VictoriaMetricsServer
+  ]
 
-metric_export_models = [
-  PostgresServer,
-  VmHost
-]
+  metric_export_models = [
+    PostgresServer,
+    VmHost
+  ]
+end
 
 # Handle both monitored resources and metric export resources.
 monitor_resources = MonitorResourceType.create(
@@ -64,7 +79,7 @@ metric_export_resources = MonitorResourceType.create(
 
 repartitioner = MonitorRepartitioner.new(partition_number)
 
-runner = MonitorRunner.new(monitor_resources:, metric_export_resources:, repartitioner:, ignore_threads: 2)
+runner = MonitorRunner.new(monitor_resources:, metric_export_resources:, repartitioner:, **runner_args)
 
 repartition_thread = Thread.new { repartitioner.listen }
 

--- a/bin/monitor
+++ b/bin/monitor
@@ -260,7 +260,7 @@ monitor_internal_threads = resource_types.sum { it.threads.size } + 2
 
 begin
   until shutdown
-    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - monitor_internal_threads} }
+    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - monitor_internal_threads, threads_waiting_for_db_connection: DB.pool.num_waiting} }
 
     t = Time.now
     # If the time since last scan has exceeded the deadline, or we

--- a/bin/monitor
+++ b/bin/monitor
@@ -3,99 +3,303 @@
 
 ENV["MONITOR_PROCESS"] = "1"
 
+partition_number = ARGV[0]
+partition_number ||= if (match = /monitor\.(\d+)\z/.match(ENV["DYNO"] || ENV["PS"]))
+  match[1] # Heroku/Foreman
+end
+
+# For simplicity, monitor always runs partitioned. Even if only running a single
+# process, in which case, the partition is the entire id space.
+partition_number ||= "1"
+
+if partition_number
+  partition_number = Integer(partition_number)
+  raise "invalid partition_number: #{partition_number}" if partition_number < 1
+end
+
+# Used for NOTIFY, since NOTIFY payload must be a string
+partition_number_string = partition_number.to_s
+
+# Assume when starting that we are the final partition. For cases where we aren't,
+# this will quickly be updated after startup.
+num_partitions = partition_number
+
+# Flag set when we have repartitioned, to ensure we do a scan using the new partition
+# before enqueuing additional resources.
+repartitioned = true
+
+# Flag set when shutting down. All threads check this in their loops, and exit within
+# 1 second after it is set.
+shutdown = false
+
+# Time after which to run the scan query to check for new resources. This is updated
+# every time we run the scan query.
+scan_after = Time.now
+
+# The number of seconds until we should run the next scan query. This runs a scan
+# every minute.
+scan_every = 60
+
+# The number of seconds between enqueuing resources for pulse checking.
+enqueue_every = 5
+
+# Used solely to allow for immediately main/scan/enqueue thread exiting early during
+# shutdown.
+wakeup_queue = Queue.new
+
+# All queues that should be closed during shutdown. The queues for each of the thread
+# pool will be added to this array later.
+queues = [wakeup_queue]
+
+do_shutdown = proc do
+  shutdown = true
+  queues.each(&:close)
+end
+
+Signal.trap("INT", &do_shutdown)
+Signal.trap("TERM", &do_shutdown)
+
 require_relative "../loader"
+
+# Class that abstracts both monitored resources and metric export resources, to avoid
+# duplication for the two types. Each type monitors a certain number of types,
+# has a dedicated group of worker threads, and a queue for feeding the worker threads.
+MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :queue, :threads) do
+  # Helper method for creating the instance with the correct thread pool and queue
+  def self.create(klass, num_threads, *types)
+    pool_size = (num_threads - 2).clamp(1, nil)
+
+    # This does not get updated during runtime, which means that if many resources are
+    # added after startup, it may not be sized appropriately.  However, this seems
+    # unlikely to matter in practice.
+    queue_size = pool_size + (types.sum(&:count) * 1.5).round
+
+    queue = SizedQueue.new(queue_size)
+
+    threads = Array.new(pool_size) do
+      Thread.new do
+        while (r = queue.pop)
+          r.lock_no_wait do
+            r.open_resource_session
+
+            # Yield so that monitored resources and metric export resources can be
+            # handled differently.
+            yield r
+          end
+        end
+      end
+    end
+
+    new(klass, {}, types, queue, threads)
+  end
+
+  # Update the resources the instance will monitor/metric export. If the resource
+  # to be monitored was previously monitored, keep the previous version, as it will
+  # likely have an ssh session already setup.
+  def scan(id_range)
+    new_resources = {}
+    types.each do |type|
+      type.where_each(id: id_range) do
+        new_resources[it.id] = resources[it.id] || wrapper_class.new(it)
+      end
+    end
+    self.resources = new_resources
+  end
+
+  # Enqueue each resource. Enqueued resources will be processed by the worker
+  # thread pool.
+  def enqueue
+    resources.each_value do
+      # This method name is misleading, it only logs, it doesn't force stop
+      it.force_stop_if_stuck
+
+      # Even if the resource is locked, we still enqueue it, which seems
+      # questionable. Maybe it will be unlocked by the time a worker thread
+      # picks it up, but we should probably consider not enqueuing a locked
+      # resource.
+      queue.push(it)
+    end
+  end
+end
+
+# Need to define the MonitorResourceType constant before freezing
 clover_freeze
 
-health_monitor_resources = {}
-health_monitor_mutex = Mutex.new
-health_monitor_thread_pool_size = (Config.max_health_monitor_threads - 2).clamp(1, nil)
-monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice, LoadBalancerVmPort, KubernetesCluster, VictoriaMetricsServer]
-health_monitor_queue_size = health_monitor_thread_pool_size + (monitorable_resource_types.sum(&:count) * 1.5).round
-health_monitor_queue = SizedQueue.new(health_monitor_queue_size)
-
-metrics_target_resources = {}
-metrics_export_mutex = Mutex.new
-metrics_export_thread_pool_size = (Config.max_metrics_export_threads - 2).clamp(1, nil)
-metrics_target_resource_types = [PostgresServer, VmHost]
-metrics_export_queue_size = metrics_export_thread_pool_size + (metrics_target_resource_types.sum(&:count) * 1.5).round
-metrics_export_queue = SizedQueue.new(metrics_export_queue_size)
-
-resource_scanner = Thread.new do
-  loop do
-    monitorable_resources = monitorable_resource_types.flat_map(&:all)
-    health_monitor_mutex.synchronize do
-      monitorable_resources.each do |r|
-        health_monitor_resources[r.id] ||= MonitorableResource.new(r)
-      end
-    end
-    metrics_resources = metrics_target_resource_types.flat_map(&:all)
-    metrics_export_mutex.synchronize do
-      metrics_resources.each do |r|
-        metrics_target_resources[r.id] ||= MetricsTargetResource.new(r)
-      end
-    end
-
-    sleep 60
-  end
-rescue => ex
-  Clog.emit("Resource scanning has failed.") { {resource_scanning_failure: {exception: Util.exception_to_hash(ex)}} }
-  ThreadPrinter.run
-  Kernel.exit!
+partition_boundary = lambda do |partition_num, partition_size|
+  "%08x-0000-0000-0000-000000000000" % (partition_num * partition_size).to_i
 end
 
-health_monitor_thread_pool = Array.new(health_monitor_thread_pool_size) do
-  Thread.new do
-    while (r = health_monitor_queue.pop)
-      r.lock_no_wait do
-        r.open_resource_session
-        r.process_event_loop
-        r.check_pulse
-      end
-    end
+# This calculates the partition of the id space that this process will monitor.
+strand_id_range = lambda do
+  partition_size = (16**8) / num_partitions.to_r
+  start_id = partition_boundary.call(partition_number - 1, partition_size)
+
+  if num_partitions == partition_number
+    start_id.."ffffffff-ffff-ffff-ffff-ffffffffffff"
+  else
+    start_id...partition_boundary.call(partition_number, partition_size)
   end
 end
 
-metrics_export_thread_pool = Array.new(metrics_export_thread_pool_size) do
-  Thread.new do
-    while (r = metrics_export_queue.pop)
-      r.lock_no_wait do
-        r.open_resource_session
-        r.export_metrics
-      end
+# Notify the monitor channel that we exist, so that other monitor processes
+# can repartition appropriately if needed.
+notify_partition = proc do
+  DB.notify(:monitor, payload: partition_number_string)
+end
+
+# Listens on the monitor channel to determine what other monitor processes are
+# running, and updates the num_partitions information, so that the current process
+# scan thread will use the appropriate partition.
+repartition_thread = Thread.new do
+  # Check for shutdown every second
+  listen_timeout = 1
+
+  # Check for stale partitions and notify that the current process is still running
+  # every 18 seconds.
+  recheck_seconds = 18
+
+  # Remove a partition if we have not been notified about it in the last 40 seconds.
+  # Combined with the above two settings, this means that if the final monitor partition
+  # process exits, other monitor processes will repartition in 40-59 seconds.
+  stale_seconds = 40
+
+  # The next deadline after which to check for stale partitions and notify.
+  partition_recheck_time = Time.now + recheck_seconds - rand
+
+  # This starts out empty, but will be filled in by notifications from the current
+  # monitor process and other monitor processes.
+  partition_times = {}
+
+  # Updates the total number of partitions, and sets the repartition flag, so the
+  # next main loop iteration will run a scan query.
+  repartition = lambda do |np|
+    num_partitions = np
+    repartitioned = true
+    Clog.emit("monitor repartitioning") { {partition_number:, num_partitions:, range: strand_id_range.call} }
+  end
+
+  # Ensure we log partition information on startup
+  repartition.call(partition_number)
+
+  # Called every second. Used to exit the listen loop on shutdown, and to NOTIFY
+  # about the current process and remove stale processes when rechecking.
+  repartition_check = lambda do |partition_times|
+    throw :stop if shutdown
+
+    t = Time.now
+    if t > partition_recheck_time
+      partition_recheck_time = t + recheck_seconds
+      notify_partition.call
+      stale = t - stale_seconds
+      partition_times.reject! { |_, time| time < stale }
+      partition_times.keys.max
     end
   end
+
+  # If the maximum partition number after rechecking is lower than the currently
+  # expected partitioning, repartition the current process to expand the
+  # partition size.
+  loop = proc do
+    if (max_partition = repartition_check.call(partition_times))&.<(num_partitions)
+      repartition.call(max_partition)
+    end
+  end
+
+  # Continuouly LISTENs for notifications on the monitor channel until shutdown.
+  # If notified about a higher partition number than the currently expected
+  # partitioning, repartition the current process to decrease the partition size.
+  DB.listen(:monitor, loop:, after_listen: notify_partition, timeout: listen_timeout) do |_, _, payload|
+    throw :stop if shutdown
+
+    unless (partition_num = Integer(payload, exception: false)) && (partition_num <= 8)
+      Clog.emit("invalid monitor repartition notification") { {monitor_notify_payload: payload} }
+      next
+    end
+
+    repartition.call(partition_num) if partition_num > num_partitions
+    partition_times[partition_num] = Time.now
+  end
 end
+
+# Only NOTIFY for the first 3-5 seconds, so that by the time we actually start monitoring,
+# all monitor processes know the expected partitioning. The rand is to avoid thundering herd issues.
+sleep 1
+sleep rand
+3.times do
+  notify_partition.call
+  sleep 1
+end
+
+# Handle both monitored resources and metric export resources.
+resource_types = [
+  MonitorResourceType.create(MonitorableResource, Config.max_health_monitor_threads,
+    VmHost,
+    PostgresServer,
+    Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists),
+    MinioServer,
+    GithubRunner,
+    VmHostSlice,
+    LoadBalancerVmPort,
+    KubernetesCluster,
+    VictoriaMetricsServer) do
+    it.process_event_loop
+    it.check_pulse
+  end,
+  MonitorResourceType.create(MetricsTargetResource, Config.max_metrics_export_threads,
+    PostgresServer,
+    VmHost,
+    &:export_metrics)
+]
+
+# Shutdown the worker thread queues on shutdown.
+queues.concat(resource_types.map(&:queue))
+queues.freeze
+
+# The 2 additional threads are the main thread and the repartition thread
+monitor_internal_threads = resource_types.sum { it.threads.size } + 2
 
 begin
-  loop do
-    # Since the switch to use a thread pool for monitored resources,
-    # this emits the number of pulse threads + export threads, not the number of monitor threads + pulse threads
-    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - health_monitor_thread_pool_size - metrics_export_thread_pool_size - 2} }
+  until shutdown
+    Clog.emit("Active threads count.") { {active_threads_count: Thread.list.count - monitor_internal_threads} }
 
-    health_monitor_rs = health_monitor_mutex.synchronize { health_monitor_resources.values }
-    health_monitor_rs.each do |r|
-      r.force_stop_if_stuck
-      health_monitor_queue.push(r)
+    t = Time.now
+    # If the time since last scan has exceeded the deadline, or we
+    # have repartitioned since the last iteration, scan again to get the
+    # current set of resources for both resource types.
+    if t > scan_after || repartitioned
+      scan_after = t + scan_every
+      repartitioned = false
+      id_range = strand_id_range.call
+      resource_types.each { it.scan(id_range) }
     end
-    health_monitor_mutex.synchronize { health_monitor_resources.delete_if { |_, r| r.deleted } }
 
-    metrics_export_rs = metrics_export_mutex.synchronize { metrics_target_resources.values }
-    metrics_export_rs.each do |r|
-      r.force_stop_if_stuck
-      metrics_export_queue.push(r)
-    end
-    metrics_export_mutex.synchronize { metrics_target_resources.delete_if { |_, r| r.deleted } }
+    # Enqueue every resource for both resource types
+    resource_types.each(&:enqueue)
 
-    sleep 5
+    # Sleep for the given number of seconds. This uses a timed pop on
+    # a queue so that it will exit immediately on shutdown
+    wakeup_queue.pop(timeout: enqueue_every)
   end
+rescue ClosedQueueError
+  # Shouldn't hit this block unless we are already shutting down,
+  # but better to be safe and handle case where we aren't already
+  # shutting down, otherwise joining the threads will block.
+  do_shutdown unless shutdown
 rescue => ex
-  Clog.emit("Pulse checking has failed.") { {pulse_checking_failure: {exception: Util.exception_to_hash(ex)}} }
+  Clog.emit("Pulse checking or resource scanning has failed.") { {pulse_checking_or_resource_scanning_failure: {exception: Util.exception_to_hash(ex)}} }
   ThreadPrinter.run
-  Kernel.exit!
+  Kernel.exit! 2
 end
 
-resource_scanner.join
-health_monitor_thread_pool.each { health_monitor_queue.push(nil) }
-health_monitor_thread_pool.each(&:join)
-metrics_export_thread_pool.each { metrics_export_queue.push(nil) }
-metrics_export_thread_pool.each(&:join)
+# If not all threads exit within two seconds, exit 1 to indicate
+# unclean shutdown.
+exit_status = 1
+
+Thread.new do
+  repartition_thread.join
+  resource_types.each { it.threads.each(&:join) }
+  # If all threads exit within two seconds, exit 0 to indicate clean shutdown.
+  exit_status = 0
+end.join(2)
+
+exit exit_status

--- a/lib/monitor_repartitioner.rb
+++ b/lib/monitor_repartitioner.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+class MonitorRepartitioner
+  attr_reader :strand_id_range
+
+  attr_accessor :repartitioned
+
+  def initialize(partition_number, listen_timeout: 1, recheck_seconds: 18, stale_seconds: 40)
+    @partition_number = partition_number
+
+    # Assume when starting that we are the final partition. For cases where we aren't,
+    # this will quickly be updated after startup.
+    @num_partitions = partition_number
+
+    # Used for NOTIFY, since NOTIFY payload must be a string
+    @partition_number_string = partition_number.to_s
+
+    # Flag set when we have repartitioned, to ensure we do a scan using the new partition
+    # before enqueuing additional resources.
+    @repartitioned = true
+
+    # This starts out empty, but will be filled in by notifications from the current
+    # monitor process and other monitor processes.
+    @partition_times = {}
+
+    # Check for shutdown every second
+    @listen_timeout = listen_timeout
+
+    # Check for stale partitions and notify that the current process is still running
+    # every 18 seconds.
+    @recheck_seconds = recheck_seconds
+
+    # Remove a partition if we have not been notified about it in the last 40 seconds.
+    # Combined with the above two settings, this means that if the final monitor partition
+    # process exits, other monitor processes will repartition in 40-59 seconds.
+    @stale_seconds = stale_seconds
+
+    # The next deadline after which to check for stale partitions and notify.
+    @partition_recheck_time = Time.now + recheck_seconds - rand
+
+    @shutdown = false
+
+    repartition(partition_number)
+  end
+
+  def shutdown!
+    @shutdown = true
+  end
+
+  # Notify the monitor channel that we exist, so that other monitor processes
+  # can repartition appropriately if needed.
+  def notify
+    DB.notify(:monitor, payload: @partition_number_string)
+  end
+
+  # Listens on the monitor channel to determine what other monitor processes are
+  # running, and updates the num_partitions information, so that the current process
+  # scan thread will use the appropriate partition.
+  def listen
+    # If the maximum partition number after rechecking is lower than the currently
+    # expected partitioning, repartition the current process to expand the
+    # partition size.
+    loop = proc do
+      if (max_partition = repartition_check)&.<(@num_partitions)
+        repartition(max_partition)
+      end
+    end
+
+    # Continuouly LISTENs for notifications on the monitor channel until shutdown.
+    # If notified about a higher partition number than the currently expected
+    # partitioning, repartition the current process to decrease the partition size.
+    DB.listen(:monitor, loop:, after_listen: proc { notify }, timeout: @listen_timeout) do |_, _, payload|
+      throw :stop if @shutdown
+
+      unless (partition_num = Integer(payload, exception: false)) && (partition_num <= 8)
+        Clog.emit("invalid monitor repartition notification") { {monitor_notify_payload: payload} }
+        next
+      end
+
+      repartition(partition_num) if partition_num > @num_partitions
+      @partition_times[partition_num] = Time.now
+    end
+  end
+
+  private
+
+  def partition_boundary(partition_num, partition_size)
+    "%08x-0000-0000-0000-000000000000" % (partition_num * partition_size).to_i
+  end
+
+  # This calculates the partition of the id space that this process will monitor.
+  def calculate_strand_id_range
+    partition_size = (16**8) / @num_partitions.to_r
+    start_id = partition_boundary(@partition_number - 1, partition_size)
+
+    @strand_id_range = if @num_partitions == @partition_number
+      start_id.."ffffffff-ffff-ffff-ffff-ffffffffffff"
+    else
+      start_id...partition_boundary(@partition_number, partition_size)
+    end
+  end
+
+  # Updates the total number of partitions, and sets the repartition flag, so the
+  # next main loop iteration will run a scan query.
+  def repartition(np)
+    @num_partitions = np
+    calculate_strand_id_range
+    @repartitioned = true
+    Clog.emit("monitor repartitioning") {
+      {monitor_repartition: {
+        partition_number: @partition_number,
+        num_partitions: np,
+        range: @strand_id_range
+      }}
+    }
+  end
+
+  # Called every second. Used to exit the listen loop on shutdown, and to NOTIFY
+  # about the current process and remove stale processes when rechecking.
+  def repartition_check
+    throw :stop if @shutdown
+
+    t = Time.now
+    if t > @partition_recheck_time
+      @partition_recheck_time = t + @recheck_seconds
+      notify
+      stale = t - @stale_seconds
+      @partition_times.reject! { |_, time| time < stale }
+      @partition_times.keys.max
+    end
+  end
+end

--- a/lib/monitor_resource_stub.rb
+++ b/lib/monitor_resource_stub.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Only used by the monitor smoke test
+# :nocov:
+class MonitorResourceStub
+  OBJECTS = []
+
+  class Session
+    def loop(sleep_for)
+      Kernel.loop do
+        sleep(sleep_for)
+        break unless yield
+      end
+    end
+
+    def shutdown!
+      nil
+    end
+
+    def close
+      nil
+    end
+  end
+
+  def self.add(...)
+    OBJECTS << new(...)
+  end
+
+  def self.where_each(_range, &)
+    OBJECTS.each(&)
+  end
+
+  def self.count
+    OBJECTS.size
+  end
+
+  attr_reader :id, :ubid
+
+  def initialize(ubid, need_event_loop: false, pulse: "up", metrics_count: 1)
+    @id = ubid.to_uuid
+    @ubid = ubid.to_s
+    @need_event_loop = need_event_loop
+    @pulse_count = 0
+    @pulse = pulse
+    @metrics_counts = metrics_count
+  end
+
+  def needs_event_loop_for_pulse_check?
+    @need_event_loop
+  end
+
+  def check_pulse(session:, previous_pulse:)
+    @pulse_count += 1
+    sleep(0.1 + rand)
+    {reading: @pulse, reading_rpt: @pulse_count}
+  end
+
+  def export_metrics(session:, tsdb_client:)
+    sleep(0.1 + rand)
+    @metrics_counts
+  end
+
+  def reload
+    self
+  end
+
+  def init_health_monitor_session
+    {ssh_session: Session.new}
+  end
+  alias_method :init_metrics_export_session, :init_health_monitor_session
+
+  def metrics_config
+    {}
+  end
+end
+# :nocov:

--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Class that abstracts both monitored resources and metric export resources, to avoid
+# duplication for the two types. Attributes:
+# wrapper_class :: Either MonitorableResource or MetricsTargetResource
+# resources :: Hash of resources, keyed by id
+# types :: The underlying model classes (or datasets) to handle
+# submit_queue :: A sized queue for submitting jobs for processing. Pushed to by the main thread,
+#                 popped by worker threads.
+# finish_queue :: A queue for jobs that just finished processing. Pushed to by the
+#                 worker threads, popped by the main thread.
+# run_queue :: An array keeping track of future jobs to run. The main thread appends jobs
+#              popped from the finish queue to this array, and slices the front of the
+#              and pushes those jobs to the submit queue.
+# threads :: Pool/array of worker threads, which process jobs on the submit queue.
+# stuck_pulse_info :: Array with timeout seconds, log message, and log key for handling stuck
+#                     pulses/metric exports.
+MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_queue, :finish_queue, :run_queue, :threads, :stuck_pulse_info) do
+  # Helper method for creating the instance
+  def self.create(klass, stuck_pulse_info, num_threads, types)
+    pool_size = (num_threads - 2).clamp(1, nil)
+
+    # This does not get updated during runtime, which means that if many resources are
+    # added after startup, it may not be sized appropriately.  However, this seems
+    # unlikely to matter in practice.
+    queue_size = pool_size + (types.sum(&:count) * 1.5).round
+
+    submit_queue = SizedQueue.new(queue_size)
+    finish_queue = Queue.new
+
+    threads = Array.new(pool_size) do
+      Thread.new do
+        while (r = submit_queue.pop)
+          # We keep track of started at information to check for stuck pulses.
+          r.monitor_job_started_at = Time.now
+          r.open_resource_session
+
+          # Yield so that monitored resources and metric export resources can be
+          # handled differently.
+          yield r
+
+          # We unset the started at time so we will not check for stuck pulses
+          # while this is in the run queue.
+          r.monitor_job_started_at = nil
+
+          # We record the finish time before pushing to the queue to allow for
+          # more accurate scheduling.
+          r.monitor_job_finished_at = Time.now
+          finish_queue.push(r)
+        end
+      end
+    end
+
+    new(klass, {}, types, submit_queue, finish_queue, [], threads, stuck_pulse_info)
+  end
+
+  def shutdown!
+    submit_queue.close
+  end
+
+  def wait_cleanup!(seconds = nil)
+    shutdown!
+    threads.each { it.join(seconds) }
+  end
+
+  # Check each resource for stuck pulses/metric exports, and log if any are found.
+  def check_stuck_pulses
+    timeout, msg, key = stuck_pulse_info
+    before = Time.now - timeout
+    resources.each_value do |r|
+      if r.monitor_job_started_at&.<(before)
+        Clog.emit(msg) { {key => {ubid: r.ubid}} }
+      end
+    end
+  end
+
+  # Update the resources the instance will monitor/metric export. If the resource
+  # to be monitored was previously monitored, keep the previous version, as it will
+  # likely have an ssh session already setup. Returns the newly scanned resources,
+  # which will be the next ones to process.
+  def scan(id_range)
+    scanned_resources = {}
+    new_resources = []
+
+    types.each do |type|
+      type.where_each(id: id_range) do
+        unless (v = resources[it.id])
+          v = wrapper_class.new(it)
+          new_resources << v
+        end
+        scanned_resources[it.id] = v
+      end
+    end
+
+    self.resources = scanned_resources
+    new_resources
+  end
+
+  # Update the run_queue with jobs that have finished. Then enqueue each resource
+  # if . Enqueued resources will be processed by the worker
+  # thread pool.
+  def enqueue(before)
+    # Pop all available jobs out of the finish queue and add them to the
+    # run queue. This can result in jobs that a very slightly out of order,
+    # due to thread scheduling, but the differences are not likely to be material.
+    while (r = finish_queue.pop(timeout: 0))
+      run_queue << r
+    end
+
+    unless run_queue.empty?
+      # Find first job in run queue that shouldn't be submitted.
+      #
+      # Slice the jobs before that in the run queue, which should be submitted,
+      # from the front of the run queue.
+      #
+      # If the first job in the run queue shouldn't be submitted, this ends
+      # up not slicing anything off the run queue.
+      #
+      # If all jobs should be submitted, then this slices all jobs off the
+      # run queue.
+      i = run_queue.find_index { it.monitor_job_finished_at > before } || run_queue.size
+      run_queue.slice!(0, i).each do
+        # If the job in the run queue is no longer a monitored resource,
+        # then don't add it to the submit queue. This ensures we don't
+        # continue to monitor a resource after it has been deleted or is
+        # no longer in the current partition.
+        submit_queue.push(it) if resources[it.resource.id]
+      end
+      run_queue[0]&.monitor_job_finished_at
+    end
+  end
+end

--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -69,7 +69,7 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_que
     before = Time.now - timeout
     resources.each_value do |r|
       if r.monitor_job_started_at&.<(before)
-        Clog.emit(msg) { {key => {ubid: r.ubid}} }
+        Clog.emit(msg) { {key => {ubid: r.resource.ubid}} }
       end
     end
   end

--- a/lib/monitor_runner.rb
+++ b/lib/monitor_runner.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+class MonitorRunner
+  def initialize(monitor_resources:, metric_export_resources:, repartitioner:, ignore_threads: 0,
+    scan_every: 60, report_every: 5, enqueue_every: 5, check_stuck_pulses_every: 5)
+    @monitor_resources = monitor_resources
+    @metric_export_resources = metric_export_resources
+    @resource_types = [monitor_resources, metric_export_resources].freeze
+    @repartitioner = repartitioner
+    @internal_threads = @resource_types.sum { it.threads.size } + ignore_threads
+    @wakeup_queue = Queue.new
+    @shutdown = false
+
+    # The number of seconds until we should run the next scan query. This runs a scan
+    # every minute.
+    @scan_every = scan_every
+
+    # The number of seconds between reporting monitor metrics.
+    @report_every = report_every
+
+    # The number of seconds after a monitor job completes before resubmitting it.
+    @enqueue_every = enqueue_every
+
+    # The number of seconds between checking for for stuck pulses.
+    @check_stuck_pulses_every = check_stuck_pulses_every
+  end
+
+  def shutdown!
+    @shutdown = true
+    @wakeup_queue.close
+    @resource_types.each(&:shutdown!)
+  end
+
+  def wait_cleanup!(seconds = nil)
+    shutdown!
+    @resource_types.each { it.wait_cleanup!(seconds) }
+  end
+
+  def scan
+    id_range = @repartitioner.strand_id_range
+
+    @resource_types.each do |resource_type|
+      queue = resource_type.submit_queue
+
+      # Immediately enqueue new resources
+      resource_type.scan(id_range).each { queue.push(it) }
+    end
+  end
+
+  def emit_metrics
+    Clog.emit("monitor metrics") do
+      {
+        monitor_metrics: {
+          active_threads_count: Thread.list.count - @internal_threads,
+          threads_waiting_for_db_connection: DB.pool.num_waiting,
+          total_monitor_resources: @monitor_resources.resources.size,
+          total_metric_export_resources: @metric_export_resources.resources.size,
+          monitor_submit_queue_length: @monitor_resources.submit_queue.length,
+          metric_export_submit_queue_length: @metric_export_resources.submit_queue.length,
+          monitor_idle_worker_threads: @monitor_resources.submit_queue.num_waiting,
+          metric_export_idle_worker_threads: @metric_export_resources.submit_queue.num_waiting
+        }
+      }
+    end
+  end
+
+  def check_stuck_pulses
+    @resource_types.each(&:check_stuck_pulses)
+  end
+
+  def enqueue
+    # We want to run all jobs that finished more than the given number
+    # of seconds ago.
+    before = Time.now - @enqueue_every
+
+    # Enqueue resources that finished more than the expected number
+    # of seconds ago. This returns the last finish time of the next
+    # job to run for each resource type.
+    last_finish_times = @resource_types.map { it.enqueue(before) }
+
+    # The resource type may have no jobs to run currently, so remove
+    # any nil values.
+    last_finish_times.compact!
+
+    # Determine how long to sleep. In general, sleep until it is time
+    # to run the next job. If there are no jobs in either run queue,
+    # sleep for the maximum amount of time.
+    if (last_finish_time = last_finish_times.min)
+      (last_finish_time + @enqueue_every) - Time.now
+    else
+      @enqueue_every
+    end
+  end
+
+  def run
+    # Time after which to run the scan query to check for new resources.
+    scan_after = Time.now
+
+    # Time after which to report the number of active threads and other metric information.
+    report_after = Time.now + @report_every
+
+    # Time after which to report the number of active threads.
+    check_stuck_pulses_after = Time.now + @check_stuck_pulses_every
+
+    until @shutdown
+      t = Time.now
+
+      # If the time since last scan has exceeded the deadline, or we
+      # have repartitioned since the last iteration, scan again to get the
+      # current set of resources for both resource types.
+      if t > scan_after || @repartitioner.repartitioned
+        scan_after = t + @scan_every
+        @repartitioner.repartitioned = false
+
+        scan
+
+        # Pushing to the queue may block, and there may a large amount of time
+        # since the last Time.now call.
+        t = Time.now
+      end
+
+      # If the time since the last report has exceeded the deadline, report again.
+      if t > report_after
+        report_after = t + @report_every
+        emit_metrics
+      end
+
+      # If the time since the last pulse check has exceeded the deadline,
+      # check again for stuck pulses.
+      if t > check_stuck_pulses_after
+        check_stuck_pulses_after = t + @check_stuck_pulses_every
+        check_stuck_pulses
+      end
+
+      sleep_time = enqueue
+
+      # Sleep for the given number of seconds. This uses a timed pop on
+      # a queue so that it will exit immediately on shutdown
+      @wakeup_queue.pop(timeout: sleep_time)
+    end
+  rescue ClosedQueueError
+    # Shouldn't hit this block unless we are already shutting down,
+    # but better to be safe and handle case where we aren't already
+    # shutting down, otherwise joining the threads will block.
+    shutdown! unless @shutdown
+    nil
+  rescue => ex
+    Clog.emit("Pulse checking or resource scanning has failed.") { {pulse_checking_or_resource_scanning_failure: {exception: Util.exception_to_hash(ex)}} }
+    ThreadPrinter.run
+    Kernel.exit! 2
+  end
+end

--- a/spec/lib/monitor_repartitioner_spec.rb
+++ b/spec/lib/monitor_repartitioner_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe MonitorRepartitioner do
+  describe ".new" do
+    it "repartitions when initializing" do
+      expect(Clog).to receive(:emit).with("monitor repartitioning").and_call_original
+      mp = described_class.new(1)
+      expect(mp.repartitioned).to be true
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+    end
+
+    it "assumes given partition is last partition" do
+      expect(Clog).to receive(:emit).with("monitor repartitioning").and_call_original
+      expect(described_class.new(2).strand_id_range).to eq("80000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+    end
+  end
+
+  describe "#notify" do
+    it "uses NOTIFY to notify listeners on monitor channel" do
+      q = Queue.new
+      th = Thread.new do
+        payload = nil
+        DB.listen(:monitor, after_listen: proc { q.push nil }, timeout: 1) do |_, _, pl|
+          payload = pl
+        end
+        payload
+      end
+      q.pop(timeout: 1)
+      Thread.new { described_class.new(1).notify }.join(1)
+      expect(th.value).to eq "1"
+    end
+  end
+
+  describe "#listen" do
+    after do
+      @mp.shutdown!
+      @th.join(1)
+      expect(@th.alive?).to be false
+    end
+
+    it "repartitions when it receives a notification about a new partition" do
+      @mp = mp = described_class.new(1, listen_timeout: 0.01, recheck_seconds: 2)
+      q = Queue.new
+      mp.define_singleton_method(:notify) do
+        super()
+        q.push nil
+      end
+      mp.define_singleton_method(:repartition) do |n|
+        super(n)
+        q.push nil if n == 2
+      end
+      @th = Thread.new { mp.listen }
+
+      q.pop(timeout: 1)
+      expect(mp).to receive(:repartition).with(2).and_call_original
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+      Thread.new { described_class.new(2).notify }.join(1)
+
+      q.pop(timeout: 1)
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000"..."80000000-0000-0000-0000-000000000000")
+    end
+
+    it "repartitions when an existing partition goes stale" do
+      @mp = mp = described_class.new(1, listen_timeout: 0.01, recheck_seconds: 0.01)
+      q = Queue.new
+      notified = false
+      mp.define_singleton_method(:notify) do
+        super()
+        q.push nil unless notified
+        notified = true
+      end
+      mp.define_singleton_method(:repartition) do |n|
+        super(n)
+        q.push nil if n > 1
+      end
+      @th = Thread.new { mp.listen }
+
+      q.pop(timeout: 1)
+      expect(mp).to receive(:repartition).with(3).and_call_original
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+      Thread.new { described_class.new(3).notify }.join(1)
+      Thread.new { described_class.new(2).notify }.join(1)
+
+      q.pop(timeout: 1)
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000"..."55555555-0000-0000-0000-000000000000")
+
+      expect(mp).to receive(:repartition).with(2).and_call_original
+      mp.instance_variable_get(:@partition_times)[3] = Time.now - 60
+      q.pop(timeout: 1)
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000"..."80000000-0000-0000-0000-000000000000")
+    end
+
+    it "emits and otherwise ignores invalid partition numbers" do
+      @mp = mp = described_class.new(1, listen_timeout: 0.01)
+      q = Queue.new
+      mp.define_singleton_method(:notify) do
+        super()
+        q.push nil
+      end
+      @th = Thread.new { mp.listen }
+
+      q.pop(timeout: 1)
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+      received_invalid = false
+      expect(Clog).to receive(:emit).at_least(:once).and_wrap_original do |m, msg, &blk|
+        m.call(msg, &blk)
+        if msg == "invalid monitor repartition notification"
+          received_invalid = true
+          q.push nil
+        end
+      end
+      Thread.new { described_class.new(1000).notify }.join(1)
+
+      q.pop(timeout: 1)
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+      expect(received_invalid).to be true
+    end
+
+    it "stops listen loop if notification is received after shutting down" do
+      @mp = mp = described_class.new(1, listen_timeout: 1)
+      q = Queue.new
+      mp.define_singleton_method(:notify) do
+        super()
+        q.push nil
+      end
+      mp.define_singleton_method(:listen) do
+        super()
+        q.push nil
+      end
+      @th = Thread.new { mp.listen }
+
+      q.pop(timeout: 1)
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+      mp.shutdown!
+
+      expect(mp).not_to receive(:repartition)
+      Thread.new { described_class.new(2).notify }.join(1)
+      q.pop(timeout: 1)
+      expect(mp.strand_id_range).to eq("00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff")
+    end
+  end
+end

--- a/spec/lib/monitor_resource_type_spec.rb
+++ b/spec/lib/monitor_resource_type_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe MonitorResourceType do
+  after do
+    @mrt&.wait_cleanup!(1)
+  end
+
+  describe ".create" do
+    it "creates an instance with appropriate settings" do
+      c = Class.new
+      @mrt = mrt = described_class.create(c, :foo, 4, [[:foo], [:bar]])
+      expect(mrt.wrapper_class.equal?(c)).to be true
+      expect(mrt.resources).to eq({})
+      expect(mrt.types).to eq [[:foo], [:bar]]
+      expect(mrt.submit_queue).to be_a SizedQueue
+      expect(mrt.submit_queue.max).to eq 5
+      expect(mrt.finish_queue).to be_a Queue
+      expect(mrt.run_queue).to eq []
+      expect(mrt.threads.size).to eq 2
+      expect(mrt.threads.all?(Thread)).to be true
+      expect(mrt.stuck_pulse_info).to eq :foo
+    end
+
+    it "clamps pool size, and bases queue size on pool size and object count" do
+      @mrt = mrt = described_class.create(Object, :foo, 2, [[]])
+      expect(mrt.submit_queue.max).to eq 1
+      expect(mrt.threads.size).to eq 1
+    end
+  end
+
+  describe "thread pool" do
+    it "processes jobs on submit queue" do
+      started_at = nil
+      @mrt = mrt = described_class.create(Object, :foo, 2, [[]]) do
+        started_at = it.monitor_job_started_at
+      end
+
+      mr = MonitorableResource.new(nil)
+      expect(mr).to receive(:open_resource_session)
+      mrt.submit_queue.push(mr)
+
+      expect(mrt.finish_queue.pop(timeout: 1)).to eq mr
+      expect(started_at).to be_within(1).of(Time.now)
+      expect(mr.monitor_job_started_at).to be_nil
+      expect(mr.monitor_job_finished_at).to be_within(1).of(Time.now)
+    end
+  end
+
+  describe "#check_stuck_pulses" do
+    before do
+      @mrt = described_class.create(Object, [5, "stuck", :stuck], 2, [[]])
+    end
+
+    it "emits for active jobs running longer than the stuck pulse timeout" do
+      mr = MonitorableResource.new(VmHost.new_with_id)
+      mr.monitor_job_started_at = Time.now - 10
+      @mrt.resources[1] = mr
+      expect(Clog).to receive(:emit).with("stuck").and_call_original
+      @mrt.check_stuck_pulses
+    end
+
+    it "does not emit for active jobs not running longer than the stuck pulse timeout" do
+      mr = MonitorableResource.new(nil)
+      mr.monitor_job_started_at = Time.now
+      @mrt.resources[1] = mr
+      expect(Clog).not_to receive(:emit)
+      @mrt.check_stuck_pulses
+    end
+
+    it "does not emit for non-active jobs" do
+      @mrt.resources[1] = MonitorableResource.new(nil)
+      expect(Clog).not_to receive(:emit)
+      @mrt.check_stuck_pulses
+    end
+  end
+
+  describe "#scan" do
+    entire_range = "00000000-0000-0000-0000-000000000000".."ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+    before do
+      @mrt = described_class.create(MonitorableResource, [5, "stuck", :stuck], 2, [VmHost])
+    end
+
+    it "adds resources picked up by scan to resources" do
+      vm_host = create_vm_host
+      expect(@mrt.resources).to eq({})
+      @mrt.scan(entire_range)
+      expect(@mrt.resources.keys).to eq [vm_host.id]
+      expect(@mrt.resources.values.map(&:resource)).to eq [vm_host]
+    end
+
+    it "removes entries from resources if they were not picked up" do
+      @mrt.resources[1] = nil
+      @mrt.scan(entire_range)
+      expect(@mrt.resources).to eq({})
+    end
+
+    it "returns new resources that were not previously in resources" do
+      vm_host = create_vm_host
+      @mrt.resources[1] = nil
+      expect(@mrt.scan(entire_range).map(&:resource)).to eq [vm_host]
+      expect(@mrt.scan(entire_range)).to eq []
+    end
+
+    it "respects given id_range when scanning for objects" do
+      vm_host = create_vm_host
+      @mrt.scan("00000000-0000-0000-0000-000000000000"...vm_host.id)
+      expect(@mrt.resources.keys).to eq []
+      @mrt.scan(vm_host.id.."ffffffff-ffff-ffff-ffff-ffffffffffff")
+      expect(@mrt.resources.keys).to eq [vm_host.id]
+      @mrt.scan("00000000-0000-0000-0000-000000000000"..vm_host.id)
+      expect(@mrt.resources.keys).to eq [vm_host.id]
+    end
+  end
+
+  describe "#enqueue" do
+    let(:mr) { MonitorableResource.new(VmHost.new) }
+
+    before do
+      @mrt = described_class.create(nil, nil, 2, [])
+    end
+
+    it "moves jobs from finish queue to run queue" do
+      mr.monitor_job_finished_at = Time.now
+      @mrt.finish_queue.push(mr)
+      expect(@mrt.run_queue).to eq []
+      @mrt.enqueue(Time.now - 5)
+      expect(@mrt.run_queue).to eq [mr]
+      expect(@mrt.finish_queue.pop(timeout: 0)).to be_nil
+    end
+
+    it "does not submit jobs if run queue is empty" do
+      @mrt.submit_queue.close
+      @mrt.enqueue(Time.now)
+      expect(@mrt.run_queue).to eq []
+    end
+
+    it "does not submit jobs if all jobs in run_queue are not yet ready to be run again" do
+      @mrt.submit_queue.close
+      mr.monitor_job_finished_at = Time.now
+      @mrt.run_queue.push(mr)
+      @mrt.enqueue(Time.now - 5)
+      expect(@mrt.run_queue).to eq [mr]
+    end
+
+    it "only submits jobs in run queue that are ready to be run again" do
+      submit_queue = @mrt.submit_queue
+      @mrt.submit_queue = Queue.new
+      mr.monitor_job_finished_at = Time.now
+      @mrt.run_queue.push(mr)
+      @mrt.resources[nil] = mr
+      @mrt.enqueue(Time.now + 5)
+      expect(@mrt.run_queue).to eq []
+      expect(@mrt.submit_queue.pop(timeout: 0)).to eq mr
+    ensure
+      @mrt.submit_queue = submit_queue
+    end
+
+    it "does not submit jobs in run queue if resource is no longer monitored" do
+      @mrt.submit_queue.close
+      mr.monitor_job_finished_at = Time.now
+      @mrt.run_queue.push(mr)
+      @mrt.enqueue(Time.now + 5)
+      expect(@mrt.run_queue).to eq []
+    end
+
+    it "returns nil if no jobs are in the run queue" do
+      expect(@mrt.enqueue(Time.now)).to be_nil
+    end
+
+    it "returns nil if all jobs in the run queue were submitted or dropped" do
+      mr.monitor_job_finished_at = Time.now
+      @mrt.run_queue.push(mr)
+      expect(@mrt.enqueue(Time.now + 5)).to be_nil
+    end
+
+    it "returns the last finish time of the first remaining entry in the run queue" do
+      t = mr.monitor_job_finished_at = Time.now
+      @mrt.run_queue.push(mr)
+      expect(@mrt.enqueue(Time.now - 5)).to eq t
+    end
+  end
+end

--- a/spec/lib/monitor_runner_spec.rb
+++ b/spec/lib/monitor_runner_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe MonitorRunner do
+  stuck_info = [10, "stuck", :stuck].freeze
+
+  let(:monitor_runner) do
+    described_class.new(monitor_resources:, metric_export_resources:, repartitioner:, **monitor_runner_args)
+  end
+  let(:monitor_resources) { MonitorResourceType.create(MonitorableResource, stuck_info, 2, [VmHost]) {} }
+  let(:metric_export_resources) { MonitorResourceType.create(MetricsTargetResource, stuck_info, 2, [VmHost]) {} }
+  let(:repartitioner) { MonitorRepartitioner.new(2) }
+  let(:monitor_runner_args) do
+    {
+      scan_every: 0.01,
+      report_every: 0.01,
+      enqueue_every: 0.01,
+      check_stuck_pulses_every: 0.01
+    }
+  end
+
+  def vm_host_with_id(id)
+    args = {location_id: Location::HETZNER_FSN1_ID, allocation_state: "accepting", arch: "x64", family: "standard", total_cores: 48, used_cores: 2}
+    Sshable.create { it.id = id }
+    VmHost.create(**args) { it.id = id }
+  end
+
+  after do
+    monitor_runner.wait_cleanup!(1)
+  end
+
+  describe "#scan" do
+    it "scans both resource types and pushes only new resources in partition to respective queues" do
+      vm1 = vm_host_with_id("90000000-0000-0000-0000-000000000000")
+      vm2 = vm_host_with_id("a0000000-0000-0000-0000-000000000000")
+
+      # Check that it doesn't pick up resources outside partition
+      vm_host_with_id("10000000-0000-0000-0000-000000000000")
+
+      msq = monitor_resources.submit_queue
+      mesq = metric_export_resources.submit_queue
+      q1 = monitor_resources.submit_queue = Queue.new
+      q2 = metric_export_resources.submit_queue = Queue.new
+
+      # Check that id doesn't pick up existing resources
+      monitor_resources.resources[vm2.id] = true
+      metric_export_resources.resources[vm2.id] = true
+
+      monitor_runner.scan
+
+      v = q1.pop(timeout: 1)
+      expect(v).to be_a MonitorableResource
+      expect(v.resource).to eq vm1
+
+      v = q2.pop(timeout: 1)
+      expect(v).to be_a MetricsTargetResource
+      expect(v.resource).to eq vm1
+
+      expect(q1.pop(timeout: 0)).to be_nil
+      expect(q2.pop(timeout: 0)).to be_nil
+    ensure
+      monitor_resources.submit_queue = msq
+      metric_export_resources.submit_queue = mesq
+    end
+  end
+
+  describe "#emit_metrics" do
+    it "emits metrics" do
+      q = Queue.new
+      expect(Clog).to receive(:emit).at_least(:once).and_wrap_original do |m, a, &b|
+        if a == "monitor metrics"
+          m.call(a, &b)
+          q.push(b.call)
+        end
+      end
+
+      monitor_runner.emit_metrics
+      hash = q.pop(timeout: 1)
+      expect(hash.keys).to eq [:monitor_metrics]
+      hash = hash[:monitor_metrics]
+      expect(hash.delete(:active_threads_count)).to be_a Integer
+      expect(hash.delete(:monitor_idle_worker_threads)).to be <= 1
+      expect(hash.delete(:metric_export_idle_worker_threads)).to be <= 1
+      expect(hash).to eq({
+        threads_waiting_for_db_connection: 0,
+        total_monitor_resources: 0,
+        total_metric_export_resources: 0,
+        monitor_submit_queue_length: 0,
+        metric_export_submit_queue_length: 0
+      })
+
+      monitor_resources.resources["a0000000-0000-0000-0000-000000000000"] = true
+      metric_export_resources.resources["90000000-0000-0000-0000-000000000000"] = true
+      metric_export_resources.resources["a0000000-0000-0000-0000-000000000000"] = true
+
+      mr = MonitorableResource.new(nil)
+      q2 = Queue.new
+      expect(mr).to receive(:open_resource_session).twice do
+        q2.pop(timeout: 1)
+      end
+      2.times { monitor_resources.submit_queue.push(mr) }
+
+      monitor_runner.emit_metrics
+      hash = q.pop(timeout: 1)
+      expect(hash.keys).to eq [:monitor_metrics]
+      hash = hash[:monitor_metrics]
+      expect(hash.delete(:active_threads_count)).to be_a Integer
+      expect(hash).to eq({
+        threads_waiting_for_db_connection: 0,
+        total_monitor_resources: 1,
+        total_metric_export_resources: 2,
+        monitor_submit_queue_length: 1,
+        metric_export_submit_queue_length: 0,
+        monitor_idle_worker_threads: 0,
+        metric_export_idle_worker_threads: 1
+      })
+      2.times { q2.push nil }
+    end
+  end
+
+  describe "#check_stuck_pulses" do
+    it "emits for stuck pulses" do
+      i = 0
+      expect(Clog).to receive(:emit).at_least(:once) do |a|
+        i += 1 if a == "stuck"
+      end
+      monitor_runner.check_stuck_pulses
+      expect(i).to eq 0
+
+      mr = MonitorableResource.new(VmHost.new_with_id)
+      mr.monitor_job_started_at = Time.now - 5
+      monitor_resources.resources[1] = mr
+      metric_export_resources.resources[1] = mr
+      monitor_runner.check_stuck_pulses
+      expect(i).to eq 0
+
+      mr.monitor_job_started_at = Time.now - 15
+      monitor_runner.check_stuck_pulses
+      expect(i).to eq 2
+    end
+  end
+
+  describe "#enqueue" do
+    before do
+      monitor_runner_args[:enqueue_every] = 10
+    end
+
+    it "enqueues jobs for both resource types" do
+      mr = MonitorableResource.new(VmHost.new_with_id)
+      mr.monitor_job_finished_at = Time.now - 15
+      monitor_resources.run_queue << mr
+
+      mr = MetricsTargetResource.new(VmHost.new_with_id)
+      mr.monitor_job_finished_at = Time.now - 15
+      metric_export_resources.run_queue << mr
+
+      expect(monitor_resources.run_queue.size).to eq 1
+      expect(metric_export_resources.run_queue.size).to eq 1
+      monitor_runner.enqueue
+      expect(monitor_resources.run_queue.size).to eq 0
+      expect(metric_export_resources.run_queue.size).to eq 0
+    end
+
+    it "returns enqueue_every if there are no jobs in either run queue" do
+      expect(monitor_runner.enqueue).to eq 10
+    end
+
+    it "returns time to sleep based on next entry in run queue" do
+      mr = MonitorableResource.new(VmHost.new_with_id)
+      mr.monitor_job_finished_at = Time.now - 4
+      monitor_resources.run_queue << mr
+      expect(monitor_resources.run_queue.size).to eq 1
+      expect(monitor_runner.enqueue).to be_within(1).of(6)
+
+      mr = MetricsTargetResource.new(VmHost.new_with_id)
+      mr.monitor_job_finished_at = Time.now - 8
+      metric_export_resources.run_queue << mr
+      expect(monitor_runner.enqueue).to be_within(1).of(2)
+      expect(metric_export_resources.run_queue.size).to eq 1
+
+      mr.monitor_job_finished_at = Time.now - 12
+      expect(monitor_runner.enqueue).to be_within(1).of(6)
+      expect(metric_export_resources.run_queue.size).to eq 0
+    end
+  end
+
+  describe "#run" do
+    before do
+      i = 0
+      monitor_runner_args[:enqueue_every] = 0
+      monitor_runner.define_singleton_method(:enqueue) do
+        shutdown! if i == 100
+        i += 1
+        super()
+      end
+    end
+
+    it "runs scan/report/check_stuck_pulse/enqueue loop with no resources" do
+      expect(monitor_runner.run).to be_nil
+    end
+
+    it "runs scan/report/check_stuck_pulse/enqueue loop with resources" do
+      vm1 = vm_host_with_id("90000000-0000-0000-0000-000000000000")
+      msq = monitor_resources.submit_queue
+      mesq = metric_export_resources.submit_queue
+      q1 = monitor_resources.submit_queue = Queue.new
+      q2 = metric_export_resources.submit_queue = Queue.new
+
+      monitor_runner.instance_variable_set(:@report_every, 0)
+      monitor_runner.instance_variable_set(:@check_stuck_pulses_every, 0)
+      monitor_runner.run
+      expect(q1.pop(timeout: 0).resource).to eq vm1
+      expect(q2.pop(timeout: 0).resource).to eq vm1
+    ensure
+      monitor_resources.submit_queue = msq
+      metric_export_resources.submit_queue = mesq
+    end
+
+    it "handles ClosedQueueError before shutdown" do
+      vm_host_with_id("90000000-0000-0000-0000-000000000000")
+      monitor_resources.submit_queue.close
+      expect(monitor_runner.run).to be_nil
+    end
+
+    it "handles shutting down after scanning" do
+      monitor_runner.define_singleton_method(:scan) do
+        super()
+        shutdown!
+      end
+      expect(monitor_runner.run).to be_nil
+    end
+
+    it "handles shutting down before scanning when there are resources" do
+      vm_host_with_id("90000000-0000-0000-0000-000000000000")
+      monitor_runner.define_singleton_method(:scan) do
+        shutdown!
+        super()
+      end
+      expect(monitor_runner.run).to be_nil
+    end
+
+    it "thread prints and exits for other failures" do
+      exited = false
+      expect(ThreadPrinter).to receive(:run)
+      expect(Kernel).to receive(:exit!).and_invoke(->(_) { exited = true })
+      expect(Clog).to receive(:emit).with("Pulse checking or resource scanning has failed.").and_call_original
+      monitor_runner.define_singleton_method(:scan) { raise }
+      monitor_runner.run
+      expect(exited).to be true
+    end
+  end
+end

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -129,39 +129,4 @@ RSpec.describe MonitorableResource do
       r_w_event_loop.close_resource_session
     end
   end
-
-  describe "#force_stop_if_stuck" do
-    it "does nothing if pulse check is not stuck" do
-      expect(Kernel).not_to receive(:exit!)
-
-      # not locked
-      r_w_event_loop.force_stop_if_stuck
-
-      # not timed out
-      r_w_event_loop.instance_variable_get(:@mutex).lock
-      r_w_event_loop.instance_variable_set(:@pulse_check_started_at, Time.now)
-      r_w_event_loop.force_stop_if_stuck
-      r_w_event_loop.instance_variable_get(:@mutex).unlock
-    end
-
-    it "triggers Kernel.exit if pulse check is stuck" do
-      r_w_event_loop.instance_variable_get(:@mutex).lock
-      r_w_event_loop.instance_variable_set(:@pulse_check_started_at, Time.now - 200)
-      expect(Clog).to receive(:emit).at_least(:once).and_call_original
-      r_w_event_loop.force_stop_if_stuck
-      r_w_event_loop.instance_variable_get(:@mutex).unlock
-    end
-  end
-
-  describe "#lock_no_wait" do
-    it "does not yield if mutex is locked" do
-      r_w_event_loop.instance_variable_get(:@mutex).lock
-      expect { |b| r_w_event_loop.lock_no_wait(&b) }.not_to yield_control
-      r_w_event_loop.instance_variable_get(:@mutex).unlock
-    end
-
-    it "yields if mutex is not locked" do
-      expect { |b| r_w_event_loop.lock_no_wait(&b) }.to yield_control
-    end
-  end
 end

--- a/spec/monitor_smoke_test.rb
+++ b/spec/monitor_smoke_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+ENV["RACK_ENV"] = "test"
+
+require "json"
+require_relative "../ubid"
+
+r, w = IO.pipe
+output = +""
+Thread.new do
+  until (s = r.read(4096).to_s).empty?
+    output << s
+  end
+rescue
+  p $!
+end
+
+fd_map = {:in => :close, [:out, :err] => w}
+monitor_pids = [
+  Process.spawn({"DYNO" => "monitor.2"}, "bin/monitor", **fd_map),
+  Process.spawn({"PS" => "monitor.3"}, "bin/monitor", **fd_map),
+  Process.spawn("bin/monitor", "4", **fd_map),
+  Process.spawn("bin/monitor", **fd_map)
+]
+
+w.close
+
+print("monitor smoke test: ")
+10.times do
+  print "."
+  sleep 1
+end
+puts "finished, shutting down processes"
+
+Process.kill(:TERM, *monitor_pids)
+clean = nil
+Thread.new do
+  monitor_pids.each do
+    Process.waitpid(it)
+    clean = false unless $?.success?
+  end
+  clean = true if clean.nil?
+end.join(3)
+
+unless clean
+  warn "Not all monitor processes shutdown cleanly within 3 seconds"
+  exit 1
+end
+
+required_ranges = [
+  ["00000000-0000-0000-0000-000000000000", "40000000-0000-0000-0000-000000000000"], # 1/4
+  ["40000000-0000-0000-0000-000000000000", "80000000-0000-0000-0000-000000000000"], # 2/4
+  ["80000000-0000-0000-0000-000000000000", "c0000000-0000-0000-0000-000000000000"], # 3/4
+  ["c0000000-0000-0000-0000-000000000000", "ffffffff-ffff-ffff-ffff-ffffffffffff"]  # 4/4
+]
+possible_ranges = required_ranges + [
+  ["00000000-0000-0000-0000-000000000000", "ffffffff-ffff-ffff-ffff-ffffffffffff"], # 1/1
+  ["00000000-0000-0000-0000-000000000000", "55555555-0000-0000-0000-000000000000"], # 1/3
+  ["00000000-0000-0000-0000-000000000000", "80000000-0000-0000-0000-000000000000"], # 1/2
+  ["55555555-0000-0000-0000-000000000000", "aaaaaaaa-0000-0000-0000-000000000000"], # 2/3
+  ["80000000-0000-0000-0000-000000000000", "ffffffff-ffff-ffff-ffff-ffffffffffff"], # 2/2
+  ["aaaaaaaa-0000-0000-0000-000000000000", "ffffffff-ffff-ffff-ffff-ffffffffffff"]  # 3/3
+]
+ranges = output.scan(/"range":"([-0-9a-f]+)\.\.\.?([-0-9a-f]+)"/)
+ranges.each do
+  next if possible_ranges.include?(it)
+  warn "unexpected monitor repartition range: #{it}"
+  exit 1
+end
+unless ranges.length.between?(4, 10)
+  warn "unexpected number of monitor repartitions (should be 4-10): #{ranges.length}"
+  warn output
+  exit 1
+end
+unless (missing_ranges = required_ranges - ranges).empty?
+  warn "not all required monitor repartition ranges present: #{missing_ranges}"
+  exit 1
+end
+
+up, down, evloop, mc2 = resources = %w[vp down evloop mc2].map { UBID.generate_vanity("et", "mr", it).to_s }
+
+lines = {}
+output.split("\n").each do |line|
+  next if line.include?("monitor_repartition")
+  resource = resources.find { line.include?(it) } || :other
+  data = JSON.parse(line)
+  data.delete("time")
+  (lines[resource] ||= []) << data
+end
+lines.each_value(&:uniq!).each_value { it.sort_by!(&:inspect) }
+
+[up, evloop].each do |r|
+  expected_lines = [
+    {"got_pulse" => {"ubid" => r, "pulse" => {"reading" => "up", "reading_rpt" => 1}}, "message" => "Got new pulse."},
+    {"metrics_export_success" => {"ubid" => r, "count" => 1}, "message" => "Metrics export has finished."}
+  ]
+  unless lines[r] == expected_lines
+    warn "unexpected lines for #{r}: #{lines[r]}"
+    exit 1
+  end
+end
+
+expected_lines = [
+  {"got_pulse" => {"ubid" => mc2, "pulse" => {"reading" => "up", "reading_rpt" => 1}}, "message" => "Got new pulse."},
+  {"metrics_export_success" => {"ubid" => mc2, "count" => 2}, "message" => "Metrics export has finished."}
+]
+unless lines[mc2] == expected_lines
+  warn "unexpected lines for #{mc2}: #{lines[mc2]}"
+  exit 1
+end
+
+expected_lines = Array.new(lines[down].size - 1) do
+  {"got_pulse" => {"ubid" => down, "pulse" => {"reading" => "down", "reading_rpt" => it + 1}}, "message" => "Got new pulse."}
+end
+expected_lines << {"metrics_export_success" => {"ubid" => down, "count" => 1}, "message" => "Metrics export has finished."}
+unless lines[down] == expected_lines
+  warn "unexpected lines for #{down}: #{lines[down]}"
+  exit 1
+end
+
+unless lines[:other].flat_map(&:keys).uniq.sort == ["message", "monitor_metrics"]
+  warn "unexpected other lines: #{lines[:other]}"
+  exit 1
+end
+
+puts "all checks passed!"


### PR DESCRIPTION
This adds respirate-style partitioning to monitor, and refactors monitor.

With this, partitioning works the same way for monitor as it does for respirate. There is a repartition thread that listens on a channel for information about active partitions, and notifies about the current process so that other monitor processes are aware of its existance.

As monitor is less time sensitive than respirate, only scanning for new resources once a minute instead of once a second, the repartition thread doesn't notify as often. Repartitioning for new monitor processes still happens immediately, before the next enqueue (within 5 seconds). Removing stale monitor processes happens within 1 minute.

In adding to adding partitioning, this refactors monitor significantly:

* This abstracts the monitor and metric export handling into a single Struct class.  Almost all of the logic was shared, and this removes the duplication.

* This avoids the separation of the scan thread from the main/enqueuing thread. Instead, the main/enqueing thread just scans if it has been more than a minute since the last scan, or if it was repartitioned since the last enqueue.  This removes the need for a mutex to protect the hash of resources.

* Previously, all resources that were initially monitored continued to be monitored until they were deleted. That doesn't work when repartitioning.  If the scan query does not pick up the resource, either because the resource was deleted or is no longer in the current partition, then it is no longer monitored.  It will keep the same resource previously used if it still exists, ensuring that the same SSH session is still used.

* Monitor now traps TERM (and INT), and generally exits cleanly within about 1 second on shutdown unless worker threads are busy. It gives worker threads up to 2 seconds to exit, and if they don't exit within 2 second, the process exits with status 1, signifying failure.  If the process dies due to pulse checking or resource scanning failure, it exits with status 2.

This keeps the behavior of enqueuing locked resources, but I think that behavior is questionable and should probably be removed.  It's better to skip a locked resource in the current loop, and enqueue it in a later loop after it is no longer locked.

In general, the enqueuing approach is questionable. We enqueue every monitored resource every 5 seconds, regardless of the current status.  If it takes 4 seconds to run the job, then it is enqueued again 1 second after finishing. We should probably have each resource keep track of when monitoring finished, and only enqueue 5 seconds after the resource last completed its action. This may result in increased overall time between monitoring in some cases, but it can result in decreased overall time between monitoring in the case where the resource was locked, assuming that we look at existing resources every second, and only enqueue those that are not locked and finished over 5 seconds ago.

The monitor process is now extensively documented. Hopefully, it should be easier to understand.

We currently lack a test suite for monitor, which makes a change like this risky. We should consider adding a test suite. We would need the equivalent of Prog::Test for monitor. Then we could have the equivalent of the respirate_smoke_test for monitor.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds partitioning to monitor process, refactors codebase, and introduces CI and smoke tests for monitor functionality.
> 
>   - **Behavior**:
>     - Adds partitioning to monitor similar to respirate, using `MonitorRepartitioner` for partition management.
>     - Monitor process scans for new resources every minute and handles repartitioning within 5 seconds.
>     - Traps TERM and INT signals for clean shutdown, allowing 2 seconds for worker threads to exit.
>   - **Refactoring**:
>     - Abstracts monitor and metric export handling into `MonitorResourceType` to reduce duplication.
>     - Removes separate scan thread; main thread handles scanning and enqueuing.
>     - Updates resource monitoring logic to stop monitoring resources not in the current partition.
>   - **Testing and CI**:
>     - Adds `monitor-ci.yml` for GitHub Actions to run monitor smoke tests.
>     - Introduces `spec/monitor_smoke_test.rb` for testing monitor partitioning and functionality.
>   - **Misc**:
>     - Updates `Gemfile` to use a specific Sequel version from GitHub.
>     - Adds `monitor_smoke_test` task to `Rakefile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 86952e52df29af5cab927ae96597da52f0b9f5b0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->