### PR TITLE
Minor respirate tweaks

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -14,6 +14,7 @@ end
 require_relative "../loader"
 
 d = Scheduling::Dispatcher.new(partition_number:)
+Signal.trap("INT") { d.shutdown }
 Signal.trap("TERM") { d.shutdown }
 
 if Config.heartbeat_url
@@ -78,11 +79,14 @@ end
 
 Clog.emit("Shutting down.") { {unfinished_strand_count: d.num_current_strands} }
 
+exit_status = 1
+
 # Wait up to 2 seconds for all strand threads to exit.
 # We cannot wait very long, as every second we wait is potentially an
 # additional second that no respirate process is processing new strands.
 Thread.new do
   d.shutdown_and_cleanup_threads
-  exit 0
+  exit_status = 0
 end.join(2)
-exit 1
+
+exit exit_status

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -476,7 +476,7 @@ class Scheduling::Dispatcher
     # Don't thread print concurrently.
     APOPTOSIS_MUTEX.synchronize do
       ThreadPrinter.run
-      Kernel.exit!
+      Kernel.exit! 2
     end
   end
 

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Scheduling::Dispatcher do
     it "triggers thread dumps and exit if the Prog takes too long" do
       exited = false
       expect(ThreadPrinter).to receive(:run)
-      expect(Kernel).to receive(:exit!).and_invoke(-> { exited = true })
+      expect(Kernel).to receive(:exit!).with(2).and_invoke(->(_) { exited = true })
       di = @di = described_class.new(apoptosis_timeout: 0.05, pool_size: 1)
       start_queue = di.instance_variable_get(:@thread_data).dig(0, :start_queue)
       start_queue.push(true)
@@ -223,7 +223,7 @@ RSpec.describe Scheduling::Dispatcher do
     it "triggers thread dumps and exit if the there is an exception raised" do
       exited = false
       expect(ThreadPrinter).to receive(:run)
-      expect(Kernel).to receive(:exit!).and_invoke(-> { exited = true })
+      expect(Kernel).to receive(:exit!).with(2).and_invoke(->(_) { exited = true })
       di = @di = described_class.new(apoptosis_timeout: 0.05, pool_size: 1)
       thread_data = di.instance_variable_get(:@thread_data)
       start_queue = thread_data.dig(0, :start_queue)


### PR DESCRIPTION
This fixes some minor issues that I noticed and fixed when adding partitioning to monitor.

* Trap both INT as well as TERM. This allows you to use Ctrl+C to cleanly shutdown a respirate process started manually.

* On apoptosis, exit 2 instead of 0, since I don't think apoptosis indicates success.

* Avoid a potential race condition, where Kernel#exit is called concurrently by multiple threads.  I don't think this matters on CRuby, but it's better to only exit in a single place, and have the thread update a variable to indicate clean shutdown.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves `respirate` process shutdown handling by trapping `INT` signal, ensuring consistent exit codes, and avoiding race conditions.
> 
>   - **Behavior**:
>     - `bin/respirate`: Traps `INT` signal for clean shutdown, similar to `TERM`.
>     - `scheduling/dispatcher.rb`: Changes exit code to `2` on apoptosis in `apoptosis_failure`.
>     - `bin/respirate`: Uses `exit_status` variable to avoid race conditions in thread exit.
>   - **Tests**:
>     - `dispatcher_spec.rb`: Updates tests to expect `Kernel.exit!` with code `2` for apoptosis scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 818400a4415b33d7320e1137f37df7c9c68eea5b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->