### PR TITLE
Log the exception in LoadBalancerVmPort monitor

### DIFF
--- a/model/load_balancer_vm_port.rb
+++ b/model/load_balancer_vm_port.rb
@@ -40,7 +40,8 @@ class LoadBalancerVmPort < Sequel::Model
 
     begin
       (session[:ssh_session].exec!(health_check_cmd(type)).strip == "200") ? "up" : "down"
-    rescue
+    rescue => e
+      Clog.emit("Exception in LoadBalancerVmPort #{ubid} monitor: #{e.class} - #{e.message} - #{e.backtrace.join(" | ")}")
       "down"
     end
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds exception logging to `check_probe` in `load_balancer_vm_port.rb` for SSH command errors.
> 
>   - **Behavior**:
>     - Adds exception logging in `check_probe` method in `load_balancer_vm_port.rb` to log errors during SSH command execution.
>     - Logs exception details including class, message, and backtrace.
>   - **Misc**:
>     - Uses `Clog.emit` for logging exceptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for aa40ac091aca772ffda4f6deb233a2409ca69772. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->