### PR TITLE
Delete the old backward compatibility for the runner script service

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -275,15 +275,6 @@ class Prog::Vm::GithubRunner < Prog::Base
     github_runner.log_duration("runner_registered", github_runner.ready_at - github_runner.allocated_at)
 
     hop_wait
-  rescue Sshable::SshError => e
-    if e.stderr.include?("Job for runner-script.service failed")
-      Clog.emit("Failed to start runner script") { {failed_to_start_runner: response.to_h} }
-      vm.sshable.cmd(<<~COMMAND)
-        sudo journalctl -xeu runner-script.service
-        cat /run/systemd/transient/runner-script.service || true
-      COMMAND
-    end
-    raise
   rescue Octokit::Conflict => e
     raise unless e.message.include?("Already exists")
 

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -255,30 +255,6 @@ class Prog::Vm::GithubRunner < Prog::Base
       COMMAND
     end
 
-    command += <<~COMMAND
-      if [ ! -f /etc/systemd/system/runner-script.service ]; then
-        sudo tee /etc/systemd/system/runner-script.service > /dev/null <<'EOT'
-      [Unit]
-      Description=runner-script
-
-      [Service]
-      RemainAfterExit=yes
-      User=runner
-      Group=runner
-      WorkingDirectory=/home/runner
-      ExecStart=/home/runner/actions-runner/run-withenv.sh
-      EOT
-
-        sudo -u runner tee /home/runner/actions-runner/run-withenv.sh > /dev/null <<'EOT'
-      #!/bin/bash
-      mapfile -t env </etc/environment
-      JIT_CONFIG="$(cat ./actions-runner/.jit_token)"
-      exec env -- "${env[@]}" ./actions-runner/run.sh --jitconfig "$JIT_CONFIG"
-      EOT
-        sudo systemctl daemon-reload
-      fi
-    COMMAND
-
     # Remove comments and empty lines before sending them to the machine
     vm.sshable.cmd(command.gsub(/^(\s*# .*)?\n/, ""))
 

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -432,25 +432,6 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
-        if [ ! -f /etc/systemd/system/runner-script.service ]; then
-          sudo tee /etc/systemd/system/runner-script.service > /dev/null <<'EOT'
-        [Unit]
-        Description=runner-script
-        [Service]
-        RemainAfterExit=yes
-        User=runner
-        Group=runner
-        WorkingDirectory=/home/runner
-        ExecStart=/home/runner/actions-runner/run-withenv.sh
-        EOT
-          sudo -u runner tee /home/runner/actions-runner/run-withenv.sh > /dev/null <<'EOT'
-        #!/bin/bash
-        mapfile -t env </etc/environment
-        JIT_CONFIG="$(cat ./actions-runner/.jit_token)"
-        exec env -- "${env[@]}" ./actions-runner/run.sh --jitconfig "$JIT_CONFIG"
-        EOT
-          sudo systemctl daemon-reload
-        fi
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")
@@ -468,25 +449,6 @@ RSpec.describe Prog::Vm::GithubRunner do
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment > /dev/null
-        if [ ! -f /etc/systemd/system/runner-script.service ]; then
-          sudo tee /etc/systemd/system/runner-script.service > /dev/null <<'EOT'
-        [Unit]
-        Description=runner-script
-        [Service]
-        RemainAfterExit=yes
-        User=runner
-        Group=runner
-        WorkingDirectory=/home/runner
-        ExecStart=/home/runner/actions-runner/run-withenv.sh
-        EOT
-          sudo -u runner tee /home/runner/actions-runner/run-withenv.sh > /dev/null <<'EOT'
-        #!/bin/bash
-        mapfile -t env </etc/environment
-        JIT_CONFIG="$(cat ./actions-runner/.jit_token)"
-        exec env -- "${env[@]}" ./actions-runner/run.sh --jitconfig "$JIT_CONFIG"
-        EOT
-          sudo systemctl daemon-reload
-        fi
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")


### PR DESCRIPTION
- **Delete the old backward compatibility for the runner script service init**
  We've moved it to image generation [^1], so there's no need to keep it
  after the deployment of the 20250724.1.0 image is complete.
  
  [^1]: https://github.com/ubicloud/runner-images/pull/37
  

- **Remove log for corrupted JIT tokens**
  We added a log for corrupted JIT tokens to investigate the issue. Since
  it has been resolved with e2627b5c969ef013f06bf0584fb3b9aa9a07f94e, it
  is no longer needed, so we are removing it.
  