### PR TITLE
Prevent errors on GPU VM creation page when no customer-visible GPUs exist

### DIFF
--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -112,6 +112,7 @@ class Clover
         .from_self
         .select_group { [name.as(:location_name), device] }
         .select_append { max(:count).as(:max_count) }
+        .all.filter { !!BillingRate.from_resource_properties("Gpu", it[:device], it[:location_name]) }
 
       gpu_counts = [1, 2, 4, 8]
       gpu_options = available_gpus.map { it[:device] }.uniq.flat_map { |x| gpu_counts.map { |i| "#{i}:#{x}" } }

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -107,7 +107,7 @@ class Clover
       available_gpus = DB[:pci_device]
         .join(:vm_host, id: :vm_host_id)
         .join(:location, id: :location_id)
-        .where(device_class: ["0300", "0302"], vm_id: nil)
+        .where(device_class: ["0300", "0302"], vm_id: nil, visible: true)
         .group_and_count(:vm_host_id, :name, :device)
         .from_self
         .select_group { [name.as(:location_name), device] }


### PR DESCRIPTION
- **Filter GPU availability by customer-visible locations**
  Only include customer-visible locations when determining GPU VM
  availability.
  

- **Filter GPU availability by billing rate**
  Only include GPUs with a billing rate when determining GPU VM
  availability.
  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Filter GPU availability by customer-visible locations and billing rates in `generate_vm_options` to prevent errors on GPU VM creation page.
> 
>   - **Behavior**:
>     - In `generate_vm_options` in `helpers/vm.rb`, filter available GPUs by `visible: true` and ensure they have a billing rate.
>     - Prevents errors on GPU VM creation page when no customer-visible GPUs exist.
>   - **Misc**:
>     - Minor logic adjustments in `generate_vm_options` to handle GPU availability checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d185903328d0895e0372b8eca0f43b0c5cd98917. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->