### PR TITLE
Decrease the initial nap for wait_sshable from 8 to 7 seconds

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -345,9 +345,9 @@ class Prog::Vm::Nexus < Prog::Base
     unless vm.update_firewall_rules_set?
       vm.incr_update_firewall_rules
       # This is the first time we get into this state and we know that
-      # wait_sshable will take definitely more than 8 seconds. So, we nap here
+      # wait_sshable will take definitely more than 7 seconds. So, we nap here
       # to reduce the amount of load on the control plane unnecessarily.
-      nap 8
+      nap 7
     end
     addr = vm.ephemeral_net4
     hop_create_billing_record unless addr

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -713,10 +713,10 @@ RSpec.describe Prog::Vm::Nexus do
   end
 
   describe "#wait_sshable" do
-    it "naps 8 second if it's the first time we execute wait_sshable" do
+    it "naps 7 second if it's the first time we execute wait_sshable" do
       expect(vm).to receive(:update_firewall_rules_set?).and_return(false)
       expect(vm).to receive(:incr_update_firewall_rules)
-      expect { nx.wait_sshable }.to nap(8)
+      expect { nx.wait_sshable }.to nap(7)
     end
 
     it "naps if not sshable" do


### PR DESCRIPTION
Over time, we updated the Cloud Hypervisor version, migrated some hosts to the new storage layer (ubiblk), and improved the performance of respirate.

We have a significant number of wait_sshable runs that are less than 9 seconds in production. Therefore, we can safely reduce the initial nap to 7 seconds.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduce initial nap time in `wait_sshable` from 8 to 7 seconds in `nexus.rb` based on performance data.
> 
>   - **Behavior**:
>     - Decrease initial nap time in `wait_sshable` from 8 to 7 seconds in `nexus.rb`.
>     - Update test in `nexus_spec.rb` to expect a 7-second nap instead of 8.
>   - **Rationale**:
>     - Performance improvements and data indicate `wait_sshable` often completes in under 9 seconds, allowing for a reduced nap time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 87e582a84c1362b7a2a3f526b4a81667f84265f6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->