### PR TITLE
Decrease the initial nap for wait_vm from 13s to 11s

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -202,8 +202,8 @@ class Prog::Vm::GithubRunner < Prog::Base
 
   label def wait_vm
     # If the vm is not allocated yet, we know that the vm provisioning will take
-    # definitely more than 13 seconds.
-    nap 13 unless vm.allocated_at
+    # definitely more than 11 seconds.
+    nap 11 unless vm.allocated_at
     nap 1 unless vm.provisioned_at
     register_deadline("wait", 10 * 60)
     hop_setup_environment

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -391,9 +391,9 @@ RSpec.describe Prog::Vm::GithubRunner do
   end
 
   describe "#wait_vm" do
-    it "naps 13 seconds if vm is not allocated yet" do
+    it "naps 11 seconds if vm is not allocated yet" do
       vm.update(allocated_at: nil)
-      expect { nx.wait_vm }.to nap(13)
+      expect { nx.wait_vm }.to nap(11)
     end
 
     it "naps a second if vm is allocated but not provisioned yet" do


### PR DESCRIPTION
Our VM provisioning times have improved over time, and we have bunch of VMs that are provisioned in less than 12 seconds. Therefore, we can reduce the initial nap for wait_vm from 13 seconds to 11 seconds.