### PR TITLE
Log the first 5 "up" messages in monitor

### DIFF
--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -46,7 +46,7 @@ class MonitorableResource
     @pulse_check_started_at = Time.now
     begin
       @pulse = @resource.check_pulse(session: @session, previous_pulse: @pulse)
-      Clog.emit("Got new pulse.") { {got_pulse: {ubid: @resource.ubid, pulse: @pulse}} } if @pulse[:reading_rpt] % 5 == 1 || @pulse[:reading] != "up"
+      Clog.emit("Got new pulse.") { {got_pulse: {ubid: @resource.ubid, pulse: @pulse}} } if @pulse[:reading_rpt] < 6 || @pulse[:reading_rpt] % 5 == 1 || @pulse[:reading] != "up"
     rescue => ex
       Clog.emit("Pulse checking has failed.") { {pulse_check_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
     end

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -93,20 +93,26 @@ RSpec.describe MonitorableResource do
       r_w_event_loop.check_pulse
     end
 
-    it "logs the pulse if reading is not up" do
-      expect(postgres_server).to receive(:check_pulse).and_return({reading: "down", reading_rpt: 5})
-      expect(Clog).to receive(:emit).and_call_original
+    it "does not log the pulse if reading is up and reading_rpt is not every 5th and reading_rpt is large enough" do
+      expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 13})
+      expect(Clog).not_to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
     end
 
-    it "does not log the pulse if reading is up and reading_rpt is not every 5th reading" do
-      expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 3})
-      expect(Clog).not_to receive(:emit).and_call_original
+    it "logs the pulse if reading is not up" do
+      expect(postgres_server).to receive(:check_pulse).and_return({reading: "down", reading_rpt: 13})
+      expect(Clog).to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
     end
 
     it "logs the pulse if reading is up and reading_rpt is every 5th reading" do
       expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 6})
+      expect(Clog).to receive(:emit).and_call_original
+      r_w_event_loop.check_pulse
+    end
+
+    it "logs the pulse if reading is up and reading_rpt is recent enough" do
+      expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 3})
       expect(Clog).to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
     end


### PR DESCRIPTION
We log every 5th "up" message of monitor to our logging infrastructure in order to save some cost. However, especially in the flaky scenarios this makes it harder to understand the fail ratios. Therefore, this change makes the logger log the first 5 "up" messages as well.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Log the first 5 "up" messages in `MonitorableResource` to improve monitoring clarity.
> 
>   - **Behavior**:
>     - In `check_pulse` method of `MonitorableResource`, log the first 5 "up" messages by checking if `reading_rpt` is less than 6.
>     - Continue logging every 5th "up" message and any non-"up" message.
>   - **Tests**:
>     - Update `monitorable_resource_spec.rb` to test logging of the first 5 "up" messages.
>     - Add test case to ensure no logging for "up" messages when `reading_rpt` is not recent and not every 5th.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a40cf7d5b8500ceb3b6794d20d64485b141e322b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->