### PR TITLE
Use HTTP header instead of meta tag for OTP lockout refresh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "rake"
 gem "refrigerator", ">= 1"
 gem "reline" # Remove it when pry adds it as a dependency
 gem "roda", ">= 3.93"
-gem "rodauth", ">= 2.39"
+gem "rodauth", github: "jeremyevans/rodauth", ref: "a1780cd64e947d4531771e272ed97eb4f33058b9"
 gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"
 gem "rodish", ">= 2.0.1"
 gem "rotp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,15 @@ GIT
       rodauth (~> 2.36)
 
 GIT
+  remote: https://github.com/jeremyevans/rodauth.git
+  revision: a1780cd64e947d4531771e272ed97eb4f33058b9
+  ref: a1780cd64e947d4531771e272ed97eb4f33058b9
+  specs:
+    rodauth (2.39.0)
+      roda (>= 2.6.0)
+      sequel (>= 4)
+
+GIT
   remote: https://github.com/jeremyevans/sequel.git
   revision: 2b17b99b81a38da94c3ff73bc3f15e5adcda0e89
   ref: 2b17b99b81a38da94c3ff73bc3f15e5adcda0e89
@@ -311,9 +320,6 @@ GEM
     rexml (3.4.1)
     roda (3.93.0)
       rack
-    rodauth (2.39.0)
-      roda (>= 2.6.0)
-      sequel (>= 4)
     rodish (2.0.1)
       optparse
     rotp (6.3.0)
@@ -498,7 +504,7 @@ DEPENDENCIES
   refrigerator (>= 1)
   reline
   roda (>= 3.93)
-  rodauth (>= 2.39)
+  rodauth!
   rodauth-omniauth!
   rodish (>= 2.0.1)
   rotp

--- a/spec/routes/web/account_spec.rb
+++ b/spec/routes/web/account_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe Clover, "account" do
             click_button "Authenticate Using One-Time Password to Unlock"
             expect(page).to have_flash_notice("One-Time Password successful authentication, more successful authentication needed to unlock")
             expect(page.title).to eq("Ubicloud - One-Time Password Unlock Not Available")
+            expect(page.response_headers["refresh"]).to match(/\A1[012]\d\z/)
+            expect(page).to have_content(/Deadline for next authentication: \d+ seconds/)
+            expect(page).to have_content(/Page will automatically refresh when authentication is possible \(in \d+ seconds\)\./)
             DB[:account_otp_unlocks].update(next_auth_attempt_after: Sequel.date_sub(Sequel::CURRENT_TIMESTAMP, seconds: 200))
             visit page.current_path
           end

--- a/views/auth/otp_unlock.erb
+++ b/views/auth/otp_unlock.erb
@@ -6,7 +6,7 @@
 
   <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
   <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>
-  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= rodauth.otp_unlock_deadline.strftime(rodauth.strftime_format) %></p>
+  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds</p>
 
   <%== render("components/rodauth/otp_auth_code_field") %>
 

--- a/views/auth/otp_unlock_not_available.erb
+++ b/views/auth/otp_unlock_not_available.erb
@@ -3,8 +3,7 @@
 <div class="space-y-6">
   <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
   <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>
-  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= rodauth.otp_unlock_deadline.strftime(rodauth.strftime_format) %></p>
+  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds</p>
 
-  <p><%= rodauth.otp_unlock_next_auth_attempt_refresh_label %></p>
-  <%== rodauth.otp_unlock_refresh_tag %>
+  <p>Page will automatically refresh when authentication is possible (in <%= (rodauth.otp_unlock_next_auth_attempt_after - Time.now).to_i + 1 %> seconds).</p>
 </div>


### PR DESCRIPTION
Hopefully the HTTP header is more reliable than the meta tag. The meta tag was previously placed in the body and not the header, which isn't standard, so it's possible that's why some browsers didn't respect it.

Additionally, show the remaining time to complete authentication in seconds instead of a timestamp that may not match the user's timezone. Also show the number of seconds until the refresh.

This requires a new feature in Rodauth, so update to the latest Rodauth commit.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch OTP lockout refresh to HTTP header, display authentication deadlines in seconds, and update Rodauth version.
> 
>   - **Behavior**:
>     - Use HTTP header instead of meta tag for OTP lockout refresh in `otp_unlock_not_available.erb`.
>     - Display remaining authentication time in seconds instead of timestamp in `otp_unlock.erb` and `otp_unlock_not_available.erb`.
>   - **Testing**:
>     - Update `account_spec.rb` to test HTTP header refresh and seconds display for authentication deadlines.
>   - **Dependencies**:
>     - Update `Gemfile` to use latest Rodauth commit for new feature support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f88f4d92510a95616a658a84f48c253692c6f924. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->