### PR TITLE
Additional improvements to monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -12,10 +12,8 @@ end
 # process, in which case, the partition is the entire id space.
 partition_number ||= "1"
 
-if partition_number
-  partition_number = Integer(partition_number)
-  raise "invalid partition_number: #{partition_number}" if partition_number < 1
-end
+partition_number = Integer(partition_number)
+raise "invalid partition_number: #{partition_number}" if partition_number < 1 || partition_number > 8
 
 require_relative "../loader"
 clover_freeze

--- a/bin/respirate
+++ b/bin/respirate
@@ -8,7 +8,7 @@ end
 
 if partition_number
   partition_number = Integer(partition_number)
-  raise "invalid partition_number: #{partition_number}" if partition_number < 1
+  raise "invalid partition_number: #{partition_number}" if partition_number < 1 || partition_number > 256
 end
 
 require_relative "../loader"

--- a/lib/monitor_repartitioner.rb
+++ b/lib/monitor_repartitioner.rb
@@ -72,13 +72,13 @@ class MonitorRepartitioner
     DB.listen(:monitor, loop:, after_listen: proc { notify }, timeout: @listen_timeout) do |_, _, payload|
       throw :stop if @shutdown
 
-      unless (partition_num = Integer(payload, exception: false)) && (partition_num <= 8)
+      unless (notify_partition_num = Integer(payload, exception: false)) && (notify_partition_num <= 8)
         Clog.emit("invalid monitor repartition notification") { {monitor_notify_payload: payload} }
         next
       end
 
-      repartition(partition_num) if partition_num > @num_partitions
-      @partition_times[partition_num] = Time.now
+      repartition(notify_partition_num) if notify_partition_num > @num_partitions
+      @partition_times[notify_partition_num] = Time.now
     end
   end
 

--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -66,10 +66,19 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_que
   # Check each resource for stuck pulses/metric exports, and log if any are found.
   def check_stuck_pulses
     timeout, msg, key = stuck_pulse_info
-    before = Time.now - timeout
+    t = Time.now
+    before = t - timeout
     resources.each_value do |r|
       if r.monitor_job_started_at&.<(before)
-        Clog.emit(msg) { {key => {ubid: r.resource.ubid}} }
+        Clog.emit(msg) do
+          {
+            key => {
+              ubid: r.resource.ubid,
+              job_started_at: r.monitor_job_started_at,
+              time_elapsed: t - r.monitor_job_started_at
+            }
+          }
+        end
       end
     end
   end

--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -104,7 +104,11 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_que
     # run queue. This can result in jobs that a very slightly out of order,
     # due to thread scheduling, but the differences are not likely to be material.
     while (r = finish_queue.pop(timeout: 0))
-      run_queue << r
+      if r.deleted
+        resources.delete(r.resource.id)
+      else
+        run_queue << r
+      end
     end
 
     unless run_queue.empty?

--- a/spec/lib/monitor_resource_type_spec.rb
+++ b/spec/lib/monitor_resource_type_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe MonitorResourceType do
       expect(@mrt.finish_queue.pop(timeout: 0)).to be_nil
     end
 
+    it "drops finished jobs if resource was deleted" do
+      mr.monitor_job_finished_at = Time.now
+      mr.instance_variable_set(:@deleted, true)
+      @mrt.resources[nil] = mr
+      @mrt.finish_queue.push(mr)
+      expect(@mrt.run_queue).to eq []
+      @mrt.enqueue(Time.now - 5)
+      expect(@mrt.run_queue).to eq []
+      expect(@mrt.resources).to eq({})
+      expect(@mrt.finish_queue.pop(timeout: 0)).to be_nil
+    end
+
     it "does not submit jobs if run queue is empty" do
       @mrt.submit_queue.close
       @mrt.enqueue(Time.now)


### PR DESCRIPTION
* Check max partition is valid when starting respirate/monitor.
* Stop monitor jobs sooner if resource is deleted (they weren't stopped until the following scan previously, which could be up to a minute later, potentially resulting in up to 12 pointless monitor jobs).
* Include more information for stuck pulses, including when the job started, and how long it has been running.
* Share the repartitioning code between monitor and respirate.

Thanks to @byucesoy for suggesting some of these improvements in #3657 .
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance monitoring and repartitioning logic with partition validation, immediate job stopping on resource deletion, improved stuck pulse logging, and shared repartitioning code.
> 
>   - **Behavior**:
>     - Validate `partition_number` in `monitor` and `respirate` scripts to ensure it is within valid range.
>     - Stop monitor jobs immediately if resource is deleted in `monitor_resource_type.rb`.
>     - Log additional information for stuck pulses in `monitor_resource_type.rb`.
>     - Share repartitioning logic between monitor and respirate in `monitor_repartitioner.rb` and `dispatcher.rb`.
>   - **Repartitioning**:
>     - Introduce `Repartitioner` class in `dispatcher.rb` to handle repartitioning logic.
>     - Use `strand_id_range` for partitioning in `monitor_repartitioner.rb` and `dispatcher.rb`.
>   - **Tests**:
>     - Update tests in `monitor_repartitioner_spec.rb`, `monitor_resource_type_spec.rb`, and `dispatcher_spec.rb` to cover new repartitioning logic and stuck pulse logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 952db232d84902a8a09f8954d822f7a466e1af68. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->