### PR TITLE
Fix cleanup_roles when the policy is not created yet

### DIFF
--- a/prog/aws/instance.rb
+++ b/prog/aws/instance.rb
@@ -208,12 +208,14 @@ usermod -L ubuntu
       iam_client.delete_instance_profile({instance_profile_name: "#{vm.name}-instance-profile"})
     end
 
-    ignore_invalid_entity do
-      iam_client.detach_role_policy({role_name: vm.name, policy_arn: cloudwatch_policy.arn})
-    end
+    if cloudwatch_policy
+      ignore_invalid_entity do
+        iam_client.detach_role_policy({role_name: vm.name, policy_arn: cloudwatch_policy.arn})
+      end
 
-    ignore_invalid_entity do
-      iam_client.delete_policy({policy_arn: cloudwatch_policy.arn})
+      ignore_invalid_entity do
+        iam_client.delete_policy({policy_arn: cloudwatch_policy.arn})
+      end
     end
 
     ignore_invalid_entity do

--- a/spec/prog/aws/instance_spec.rb
+++ b/spec/prog/aws/instance_spec.rb
@@ -316,5 +316,13 @@ usermod -L ubuntu
 
       expect { nx.cleanup_roles }.to exit({"msg" => "vm destroyed"})
     end
+
+    it "skips policy cleanup if the cloudwatch policy doesn't exist" do
+      iam_client.stub_responses(:list_policies, policies: [])
+      iam_client.stub_responses(:remove_role_from_instance_profile, {})
+      iam_client.stub_responses(:delete_instance_profile, {})
+      iam_client.stub_responses(:delete_role, {})
+      expect { nx.cleanup_roles }.to exit({"msg" => "vm destroyed"})
+    end
   end
 end


### PR DESCRIPTION
If the cleanup is started before the policy is there, we get nil ref for cloudwatch_policy.arn. This commit simply skips those calls.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes nil reference error in `cleanup_roles` by checking for `cloudwatch_policy` existence before detaching or deleting it, with a test added to verify behavior.
> 
>   - **Behavior**:
>     - Fixes nil reference error in `cleanup_roles` in `instance.rb` by checking if `cloudwatch_policy` exists before detaching or deleting it.
>   - **Tests**:
>     - Adds test in `instance_spec.rb` to verify `cleanup_roles` skips policy cleanup if `cloudwatch_policy` doesn't exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 65f00411a4a1f19f69d5e73bd8d6d4060be0fe8f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->