### PR TITLE
Increase ssh keep_alive interval to 60 seconds

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -133,7 +133,7 @@ class Sshable < Sequel::Model
   COMMON_SSH_ARGS = {non_interactive: true, timeout: 10,
                      user_known_hosts_file: [], global_known_hosts_file: [],
                      verify_host_key: :accept_new, keys: [], key_data: [], use_agent: false,
-                     keepalive: true, keepalive_interval: 3, keepalive_maxcount: 5}.freeze
+                     keepalive: true, keepalive_interval: 60, keepalive_maxcount: 5}.freeze
 
   def connect
     Thread.current[:clover_ssh_cache] ||= {}


### PR DESCRIPTION
As our load increased, we scaled up accordingly, and the current keep_alive interval, which is set to 3 seconds, is too aggressive. By increasing the interval, we allow the VmHosts to catch up with the keepalive packets.

Right now, we are getting many SSH exceptions in LoadBalancerVmPort monitor like this:
class IOError, message: closed stream
for loadbalancer healthchecks.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase SSH `keepalive_interval` to 60 seconds in `model/sshable.rb` to reduce exceptions and align with OpenSSH defaults.
> 
>   - **Behavior**:
>     - Increase `keepalive_interval` from 3 to 60 seconds in `COMMON_SSH_ARGS` in `model/sshable.rb` to reduce SSH exceptions.
>     - Aligns with OpenSSH's default keepalive interval.
>   - **Rationale**:
>     - Current 3-second interval is too aggressive under increased load, causing SSH exceptions.
>     - Allows VmHosts to better handle keepalive packets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 26db3483adb491aa9a1337d86f2061d3584204bc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->