### PR TITLE
Fix modulus on nil rpt value crash in monitor

### DIFF
--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -44,7 +44,7 @@ class MonitorableResource
     @pulse_check_started_at = Time.now
     begin
       @pulse = @resource.check_pulse(session: @session, previous_pulse: @pulse)
-      Clog.emit("Got new pulse.") { {got_pulse: {ubid: @resource.ubid, pulse: @pulse}} } if @pulse[:reading_rpt] < 6 || @pulse[:reading_rpt] % 5 == 1 || @pulse[:reading] != "up"
+      Clog.emit("Got new pulse.") { {got_pulse: {ubid: @resource.ubid, pulse: @pulse}} } if (rpt = @pulse[:reading_rpt]) && (rpt < 6 || rpt % 5 == 1) || @pulse[:reading] != "up"
     rescue => ex
       Clog.emit("Pulse checking has failed.") { {pulse_check_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
     end


### PR DESCRIPTION
I ran across this while working with the questionably broad `rescue` in `MonitorableResource#check_pulse`.  Perhaps that rescue should be less inclusive of things like "no such method" exceptions and crash instead.

The test that provokes it is:

    describe "#check_pulse" do
      it "calls check_pulse on resource and sets pulse" do
        expect(postgres_server).to receive(:check_pulse).and_return({reading: "up"})
        expect { r_w_event_loop.check_pulse }.to change { r_w_event_loop.instance_variable_get(:@pulse) }.from({}).to({reading: "up"})
      end

The exception is:

    #<NoMethodError: undefined method '%' for nil>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `NoMethodError` in `MonitorableResource#check_pulse` by checking `@pulse[:reading_rpt]` for `nil` before operations.
> 
>   - **Bug Fix**:
>     - Fix `NoMethodError` in `MonitorableResource#check_pulse` by checking if `@pulse[:reading_rpt]` is not `nil` before using it.
>     - Prevents crash when `@pulse[:reading_rpt]` is `nil` by ensuring safe operations.
>   - **Code Suggestion**:
>     - Suggests refining the broad `rescue` in `MonitorableResource#check_pulse`, but no changes made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2a0dcd2ffd67b308d33556c8d22d42b26a3392c5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->