### PR TITLE
When retrying a stale connection, also make a fresh ssh session

### DIFF
--- a/model/load_balancer_vm_port.rb
+++ b/model/load_balancer_vm_port.rb
@@ -49,6 +49,7 @@ class LoadBalancerVmPort < Sequel::Model
           e.message == "closed stream" &&
           session[:last_pulse]&.<(Time.now - 8)
         stale_retry = true
+        session.merge!(init_health_monitor_session)
         retry
       end
 


### PR DESCRIPTION
Otherwise, we'll simply get two exceptions in a row.

Fixes a bug in aa2e0c0749903b863bf5989b1c59f0cf6de7d8bb.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Initiate a fresh SSH session on retry for stale connections in `check_probe` to prevent consecutive exceptions, with updated tests for this behavior.
> 
>   - **Behavior**:
>     - In `check_probe` in `load_balancer_vm_port.rb`, initiate a fresh SSH session on retry for stale connections to prevent consecutive exceptions.
>   - **Tests**:
>     - Update `load_balancer_vm_port_spec.rb` to test new SSH session creation on retry in `check_probe`.
>     - Ensure session hash is updated with new SSH session on retry.
>     - Test scenarios for successful retry and consecutive IOErrors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 846e3b25a50e215ddd6657c44e023d31774b1384. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->