### PR TITLE
Use Sequel 5.95 instead of git checkout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", github: "jeremyevans/sequel", ref: "2b17b99b81a38da94c3ff73bc3f15e5adcda0e89"
+gem "sequel", ">= 5.95"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,14 +17,6 @@ GIT
       sequel (>= 4)
 
 GIT
-  remote: https://github.com/jeremyevans/sequel.git
-  revision: 2b17b99b81a38da94c3ff73bc3f15e5adcda0e89
-  ref: 2b17b99b81a38da94c3ff73bc3f15e5adcda0e89
-  specs:
-    sequel (5.94.0)
-      bigdecimal
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -381,6 +373,8 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
+    sequel (5.95.0)
+      bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
     sequel_pg (1.17.1)
@@ -516,7 +510,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel!
+  sequel (>= 5.95)
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords


### PR DESCRIPTION
The feature we were relying on (DB.pool.num_waiting) has been released, so we no longer need a git checkout.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `Gemfile` to use `sequel` version `>= 5.95` instead of a git commit reference.
> 
>   - **Dependencies**:
>     - Update `Gemfile` to use `sequel` version `>= 5.95` instead of a specific git commit reference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e654188f9fa7d17f1a31b5f2ac949144507676e5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->