### PR TITLE
Refactor error handling in the private subnet connect/disconnect routes

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -69,7 +69,6 @@ $("#new-ace-btn").on("click", function (event) {
 });
 
 $(".delete-btn").on("click", function (event) {
-  event.preventDefault();
   let url = $(this).data("url");
   let csrf = $(this).data("csrf");
   let confirmation = $(this).data("confirmation");
@@ -80,11 +79,20 @@ $(".delete-btn").on("click", function (event) {
   if (confirmation) {
     if (prompt(`Please type "${confirmation}" to confirm deletion`, "") != confirmation) {
       alert("Could not confirm resource name");
+      event.preventDefault();
       return;
     }
   } else if (!confirm(confirmationMessage || "Are you sure to delete?")) {
+    event.preventDefault();
     return;
   }
+
+  if (method === "POST") {
+    // Use normal form submission for POST requests
+    return true;
+  }
+
+  event.preventDefault();
 
   $.ajax({
     url: url,

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -44,9 +44,9 @@ class Clover
 
       r.post "disconnect", :ubid_uuid do |id|
         authorize("PrivateSubnet:disconnect", ps.id)
+        handle_validation_failure("networking/private_subnet/show")
         unless (subnet = authorized_private_subnet(id:, perm: "PrivateSubnet:disconnect"))
-          response.status = 400
-          next {error: {code: 400, type: "InvalidRequest", message: "Subnet to be disconnected not found"}}
+          raise CloverError.new(400, "InvalidRequest", "Subnet to be disconnected not found")
         end
 
         DB.transaction do
@@ -58,7 +58,7 @@ class Clover
           Serializers::PrivateSubnet.serialize(ps)
         else
           flash["notice"] = "#{subnet.name} will be disconnected in a few seconds"
-          204
+          r.redirect "#{@project.path}#{ps.path}"
         end
       end
 

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -237,9 +237,7 @@ RSpec.describe Clover, "private subnet" do
 
         expect(page).to have_content ps2.name
 
-        btn = find "#cps-delete-#{ps2.ubid} .delete-btn"
-        page.driver.post btn["data-url"], {_csrf: btn["data-csrf"]}
-
+        click_button "Disconnect"
         expect(private_subnet.reload.connected_subnets.count).to eq(0)
       end
 
@@ -278,11 +276,10 @@ RSpec.describe Clover, "private subnet" do
         ps2.strand.destroy
         ps2.destroy
 
-        btn = find "#cps-delete-#{ps2.ubid} .delete-btn"
-        page.driver.post btn["data-url"], {_csrf: btn["data-csrf"]}
-
+        click_button "Disconnect"
         expect(page.status_code).to eq(400)
-        expect(page.body).to eq({error: {code: 400, type: "InvalidRequest", message: "Subnet to be disconnected not found"}}.to_json)
+        expect(page).to have_flash_error("Subnet to be disconnected not found")
+        expect(page.title).to eq("Ubicloud - dummy-ps-1")
       end
     end
 

--- a/views/components/delete_button.erb
+++ b/views/components/delete_button.erb
@@ -1,6 +1,6 @@
 <%# locals: (url: request.path, csrf_url: url, text: "Delete", confirmation: nil, confirmation_message: nil, redirect: request.path, method: "DELETE") %>
 
-<%== part(
+<% button = part(
   "components/button",
   text: text,
   icon: "hero-trash",
@@ -15,3 +15,12 @@
     "data-method" => method
   }
 ) %>
+
+<% if method == "POST" %>
+  <form method="POST" action="<%= url %>">
+    <%== csrf_tag(url) %>
+    <%== button %>
+  </form>
+<% else %>
+  <%== button %>
+<% end %>

--- a/views/networking/private_subnet/show.erb
+++ b/views/networking/private_subnet/show.erb
@@ -122,7 +122,7 @@ viewable_fws, viewable_subnets =
                 confirmation_message: "Are you sure to disconnect?",
                 redirect: ps_path,
                 method: "POST",
-                text: ""
+                text: "Disconnect"
               ) %>
             </td>
           </tr>


### PR DESCRIPTION
This simplifies the error handling in the connect route, and changes the disconnect workflow to use a standard HTTP form submission instead of an ajax submission.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor error handling in private subnet connect/disconnect routes and switch disconnect to standard form submission.
> 
>   - **Behavior**:
>     - Refactor error handling in `connect` and `disconnect` routes in `private_subnet.rb` to raise `CloverError` instead of using conditional logic.
>     - Change `disconnect` workflow to use standard HTTP form submission instead of AJAX in `app.js` and `delete_button.erb`.
>   - **Tests**:
>     - Update `private_subnet_spec.rb` to reflect changes in disconnect workflow and error handling.
>   - **Views**:
>     - Modify `show.erb` to use standard form submission for disconnecting subnets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2d10ffa77788a85d1d7af2bea741581c8f522a29. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->