### PR TITLE
Use handle_validation_failure in account login method routes

### DIFF
--- a/routes/account.rb
+++ b/routes/account.rb
@@ -11,19 +11,14 @@ class Clover
       r.on "login-method" do
         r.get true do
           no_authorization_needed
-          @identities = current_account.identities_dataset.select_hash(:provider, :uid)
-          social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
-          @oidc_identities = @identities.reject { |provider,| social_login_providers.include?(provider) }
-          @oidc_identity_names = OidcProvider.where(id: @oidc_identities.keys.map! { UBID.to_uuid(it) }).select_hash(:id, :display_name)
-
           view "account/login_method"
         end
 
         r.get "oidc" do
           no_authorization_needed
+          handle_validation_failure("account/login_method")
           unless (id = typecast_params.ubid_uuid("provider")) && (oidc_provider = OidcProvider[id])
-            flash[:error] = "No valid OIDC provider with that ID"
-            r.redirect "/account/login-method"
+            raise CloverError.new(400, nil, "No valid OIDC provider with that ID")
           end
 
           r.redirect "/auth/#{oidc_provider.ubid}?redirect_url=/account/login-method"
@@ -32,11 +27,11 @@ class Clover
         r.post "disconnect" do
           no_authorization_needed
           no_audit_log
+          handle_validation_failure("account/login_method")
           provider, uid = typecast_params.nonempty_str(["provider", "uid"])
           identities = current_account.identities
           unless identities.length > (rodauth.has_password? ? 0 : 1)
-            flash[:error] = "You must have at least one login method"
-            r.redirect "/account/login-method"
+            raise CloverError.new(400, nil, "You must have at least one login method")
           end
           if provider == "password"
             DB[:account_password_hashes].where(id: current_account.id).delete
@@ -46,7 +41,7 @@ class Clover
             identity.destroy
             flash[:notice] = "Your account has been disconnected from #{omniauth_provider_name(provider)}"
           else
-            flash[:error] = "Your account already has been disconnected from #{omniauth_provider_name(provider)}"
+            raise CloverError.new(400, nil, "Your account already has been disconnected from #{omniauth_provider_name(provider)}")
           end
 
           r.redirect "/account/login-method"

--- a/views/account/login_method.erb
+++ b/views/account/login_method.erb
@@ -1,4 +1,8 @@
-<% @page_title = "Login Methods" %>
+<% @page_title = "Login Methods"
+@identities = current_account.identities_dataset.select_hash(:provider, :uid)
+social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
+@oidc_identities = @identities.reject { |provider,| social_login_providers.include?(provider) }
+@oidc_identity_names = OidcProvider.where(id: @oidc_identities.keys.map! { UBID.to_uuid(it) }).select_hash(:id, :display_name) %>
 
 <%== part("components/page_header", title: "My Account") %>
 


### PR DESCRIPTION
This avoids the redirect in error cases, displaying the page and using a 400 status code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `account.rb` to use `handle_validation_failure` for error handling in login method routes, ensuring 400 status codes, and move logic to `login_method.erb`.
> 
>   - **Behavior**:
>     - Replaces redirects with `CloverError` exceptions in `account.rb` for error cases in `login-method` routes, ensuring a 400 status code.
>     - Uses `handle_validation_failure` in `r.get "oidc"` and `r.post "disconnect"` routes.
>   - **Views**:
>     - Moves identity and provider logic from `account.rb` to `login_method.erb` for rendering login methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1e661ed34fae1375164430564bb3f73e53303bf6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->