### PR TITLE
Skip setting deadline for busy runners without workflow info

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -356,13 +356,11 @@ class Prog::Vm::GithubRunner < Prog::Base
     # so we destroy the runner. We check if the runner is busy or not with
     # GitHub API, but sometimes GitHub assigns a job at the last second.
     # Therefore, we wait a few extra seconds beyond the 5 minute mark.
-    if github_runner.workflow_job.nil? && Time.now > github_runner.ready_at + 5 * 60 + 10
+    if github_runner.workflow_job.nil? && Time.now > github_runner.ready_at + 5 * 60 + 10 && !busy?
       register_deadline(nil, 2 * 60 * 60)
-      unless busy?
-        Clog.emit("The runner does not pick a job") { github_runner }
-        github_runner.incr_destroy
-        nap 0
-      end
+      Clog.emit("The runner did not pick a job") { github_runner }
+      github_runner.incr_destroy
+      nap 0
     end
 
     nap 60


### PR DESCRIPTION
Once in a while, we don't receive the information on the workflows being in_progress from Github via the webhooks. In these cases, before deciding on canceling the runner, we check whether the runner is actually busy. In this specific case, we should not set a deadline for archival as we know that the runner is busy and could be running.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `wait` function in `github_runner.rb` to skip archival deadline if runner is busy, updating tests accordingly.
> 
>   - **Behavior**:
>     - In `github_runner.rb`, `wait` function now skips setting a deadline for archival if the runner is busy, even if `workflow_job` is `nil`.
>     - Logs "The runner did not pick a job" and increments destroy counter only if the runner is not busy.
>   - **Tests**:
>     - In `github_runner_spec.rb`, added test to ensure `register_deadline` is not called when runner is busy.
>     - Updated tests to check that `incr_destroy` is not called when runner is busy.
>     - Ensured tests verify correct logging behavior when runner does not pick a job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e710fe4314065be43a0754543a5777704ee4c580. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->