### PR TITLE
Use handle_validation_failure in places not originally covered by specs

### DIFF
--- a/routes/project.rb
+++ b/routes/project.rb
@@ -17,17 +17,11 @@ class Clover
 
       r.post do
         no_authorization_needed
-        if current_account.projects_dataset.count >= 10
-          err_msg = "Project limit exceeded. You can create up to 10 projects. Contact support@ubicloud.com if you need more."
-          if api?
-            fail CloverError.new(400, "InvalidRequest", err_msg)
-          else
-            flash["error"] = err_msg
-            r.redirect "/project"
-          end
-        end
-
         handle_validation_failure("project/create")
+
+        if current_account.projects_dataset.count >= 10
+          fail CloverError.new(400, "InvalidRequest", "Project limit exceeded. You can create up to 10 projects. Contact support@ubicloud.com if you need more.")
+        end
 
         DB.transaction do
           @project = current_account.create_project_with_default_policy(typecast_params.nonempty_str!("name"))

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -19,9 +19,9 @@ class Clover
       end
 
       r.get "create" do
+        handle_validation_failure("github/index")
         unless @project.has_valid_payment_method?
-          flash["error"] = "Project doesn't have valid billing information"
-          r.redirect "#{@project.path}/github"
+          raise CloverError.new(400, nil, "Project doesn't have valid billing information")
         end
         session[:github_installation_project_id] = @project.id
 

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -50,14 +50,10 @@ class Clover
 
       r.post %w[attach-subnet detach-subnet] do |action|
         authorize("Firewall:view", firewall.id)
+        handle_validation_failure("networking/firewall/show")
 
         unless (private_subnet = authorized_private_subnet(location_id: @location.id, perm: "PrivateSubnet:edit"))
-          if api?
-            fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{typecast_params.str("private_subnet_id")}\" and the location \"#{@location.display_name}\" is not found"})
-          else
-            flash["error"] = "Private subnet not found"
-            r.redirect "#{@project.path}#{firewall.path}"
-          end
+          fail Validation::ValidationFailed.new({private_subnet_id: "Private subnet with the given id \"#{typecast_params.str("private_subnet_id")}\" and the location \"#{@location.display_name}\" is not found"})
         end
 
         actioned = nil

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -201,6 +201,7 @@ class Clover
       r.on "metric-destination" do
         r.post true do
           authorize("Postgres:edit", pg.id)
+          handle_validation_failure("postgres/show") { @page = "charts" }
 
           password_param = (api? ? "password" : "metric-destination-password")
           url, username, password = typecast_params.nonempty_str!(["url", "username", password_param])

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -303,6 +303,7 @@ class Clover
       r.post "restore" do
         authorize("Postgres:create", @project.id)
         authorize("Postgres:view", pg.id)
+        handle_validation_failure("postgres/show") { @page = "backup_restore" }
 
         name, restore_target = typecast_params.nonempty_str!(["name", "restore_target"])
         st = nil

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -138,6 +138,7 @@ class Clover
 
           r.post do
             authorize("Postgres:edit", pg.id)
+            handle_validation_failure("postgres/show") { @page = "networking" }
 
             parsed_cidr = Validation.validate_cidr(typecast_params.nonempty_str!("cidr"))
 

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -381,8 +381,7 @@ class Clover
         next unless (user = @project.accounts_dataset[id:])
 
         unless @project.accounts_dataset.count > 1
-          response.status = 400
-          next {error: {message: "You can't remove the last user from '#{@project.name}' project. Delete project instead."}}
+          raise CloverError.new(400, nil, "You can't remove the last user from '#{@project.name}' project. Delete project instead.")
         end
 
         @project.disassociate_subject(user.id)

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -289,8 +289,8 @@ class Clover
               authorize(tag_perm_map[tag_type], @project.id)
 
               if @tag_type == "subject" && @tag.name == "Admin"
-                flash["error"] = "Cannot modify Admin subject tag"
-                r.redirect "#{@project_data[:path]}/user/access-control/tag/#{@tag_type}"
+                handle_validation_failure("project/tag-list")
+                raise CloverError.new(400, nil, "Cannot modify Admin subject tag")
               end
 
               r.post do

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -80,6 +80,7 @@ class Clover
 
       r.post "policy/managed" do
         authorize("Project:user", @project.id)
+        handle_validation_failure("project/user")
         user_policies = typecast_params.Hash("user_policies") || {}
         invitation_policies = typecast_params.Hash("invitation_policies") || {}
         user_policies.transform_keys! { UBID.to_uuid(it) }
@@ -137,9 +138,7 @@ class Clover
           removals.transform_keys!(&:name)
 
           if @project.subject_tags_dataset.first(name: "Admin").member_ids.empty?
-            flash["error"] = "The project must have at least one admin."
-            DB.rollback_on_exit
-            r.redirect "#{@project.path}/user"
+            raise CloverError.new(400, nil, "The project must have at least one admin.")
           end
 
           invitatation_map = @project

--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -789,10 +789,8 @@ RSpec.describe Clover, "access control" do
       admin.update(name: "Admin")
       btn = find ".delete-btn"
       page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+      expect(page.status_code).to eq 400
       expect(SubjectTag[project_id: project.id, name: "Admin"]).not_to be_nil
-
-      visit "#{project.path}/user/access-control/tag/subject"
-      expect(page).to have_flash_error "Cannot modify Admin subject tag"
     end
 
     it "cannot rename Admin subject tag" do

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -253,7 +253,8 @@ RSpec.describe Clover, "firewall" do
         click_button "Attach"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_flash_error("Private subnet not found")
+        expect(page).to have_flash_error("Validation failed for following fields: private_subnet_id")
+        expect(page).to have_content("Private subnet with the given id \"#{ps.ubid}\" and the location \"eu-central-h1\" is not found")
         expect(firewall.private_subnets_dataset.count).to eq(0)
       end
 
@@ -282,12 +283,13 @@ RSpec.describe Clover, "firewall" do
         visit "#{project.path}#{firewall.path}"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(firewall.private_subnets_dataset.count).to eq(1)
         ps.destroy
+        expect(firewall.private_subnets_dataset.count).to eq(0)
         click_button "Detach"
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_flash_error("Private subnet not found")
+        expect(page).to have_flash_error("Validation failed for following fields: private_subnet_id")
+        expect(page).to have_content("Private subnet with the given id \"#{ps.ubid}\" and the location \"eu-central-h1\" is not found")
         expect(firewall.private_subnets_dataset.count).to eq(0)
       end
     end

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe Clover, "github" do
     end
 
     it "can not connect GitHub account if project has no valid payment method" do
-      expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).twice
+      expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
 
       visit "#{project.path}/github/create"
 
-      expect(page.status_code).to eq(200)
+      expect(page.status_code).to eq(400)
       expect(page.title).to eq("Ubicloud - GitHub Runners Integration")
       expect(page).to have_flash_error("Project doesn't have valid billing information")
     end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -725,13 +725,16 @@ RSpec.describe Clover, "postgres" do
 
     describe "metric-destination" do
       it "can create metric destination" do
-        pg
         visit "#{project.path}#{pg.path}/charts"
+        find(".metric-destination-create-button").click
+        fill_in "username", with: "username"
+        expect(page).to have_flash_error "empty string provided for parameter url"
 
         fill_in "url", with: "https://example.com"
-        fill_in "username", with: "username"
         find(".metric-destination-password").set("password")
         find(".metric-destination-create-button").click
+        expect(page.title).to eq "Ubicloud - pg-with-permission"
+        expect(page).to have_flash_notice "Metric destination is created"
         expect(page).to have_content "https://example.com"
         expect(pg.reload.metric_destinations.count).to eq(1)
       end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -646,23 +646,24 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can create firewall rule" do
-        pg
         visit "#{project.path}#{pg.path}/networking"
+        find(".firewall-rule-create-button").click
+        expect(page).to have_flash_error "empty string provided for parameter cidr"
 
         find('input[name="cidr"][form="form-pg-fwr-create"]').set("1.1.1.2")
         find(".firewall-rule-create-button").click
-        expect(page).to have_content "Firewall rule is created"
+        expect(page).to have_flash_notice "Firewall rule is created"
         expect(page).to have_content "1.1.1.2/32"
         expect(page).to have_content "5432"
 
         find('input[name="cidr"][form="form-pg-fwr-create"]').set("12.12.12.0/26")
         find(".firewall-rule-create-button").click
-        expect(page).to have_content "Firewall rule is created"
+        expect(page).to have_flash_notice "Firewall rule is created"
 
         find('input[name="cidr"][form="form-pg-fwr-create"]').set("fd00::/64")
         find('input[name="description"][form="form-pg-fwr-create"]').set("test description - new firewall rule")
         find(".firewall-rule-create-button").click
-        expect(page).to have_content "Firewall rule is created"
+        expect(page).to have_flash_notice "Firewall rule is created"
         expect(page.status_code).to eq(200)
         expect(page).to have_content "fd00::/64"
         expect(page).to have_content "test description - new firewall rule"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -468,14 +468,16 @@ RSpec.describe Clover, "postgres" do
 
         visit "#{project.path}#{pg.path}/backup-restore"
         expect(page).to have_content "Fork PostgreSQL database"
-
         fill_in "#{pg.name}-fork", with: "restored-server"
-        fill_in "Target Time (UTC)", with: restore_target.strftime("%Y-%m-%d %H:%M"), visible: false
-
         click_button "Fork"
+        expect(page.title).to eq("Ubicloud - pg-with-permission")
+        expect(page).to have_flash_error("empty string provided for parameter restore_target")
 
+        fill_in "Target Time (UTC)", with: restore_target.strftime("%Y-%m-%d %H:%M"), visible: false
+        click_button "Fork"
         expect(page.status_code).to eq(200)
         expect(page.title).to eq("Ubicloud - restored-server")
+        expect(page).to have_flash_notice("'restored-server' will be ready in a few minutes")
       end
 
       it "shows proper message when there is no backups to restore" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -734,9 +734,9 @@ RSpec.describe Clover, "project" do
         # We send delete request manually instead of just clicking to button because delete action triggered by JavaScript.
         # UI tests run without a JavaScript enginer.
         btn = find "#user-#{user.ubid} .delete-btn"
-        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}
+        page.driver.delete btn["data-url"], {_csrf: btn["data-csrf"]}, {"HTTP_ACCEPT" => "application/json"}
         expect(page.status_code).to eq(400)
-        expect(page.body).to eq({error: {message: "You can't remove the last user from '#{project.name}' project. Delete project instead."}}.to_json)
+        expect(JSON.parse(page.body)).to eq({"error" => {"message" => "You can't remove the last user from '#{project.name}' project. Delete project instead.", "code" => 400, "type" => nil, "details" => nil}})
 
         visit "#{project.path}/user"
         expect(page).to have_content user.email

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -716,7 +716,7 @@ RSpec.describe Clover, "project" do
       it "can not have more than 50 pending invitations" do
         visit "#{project.path}/user"
 
-        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project).twice
+        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
         expect(project).to receive(:invitations_dataset).and_return(instance_double(Sequel::Dataset, count: 50))
         expect(project).to receive(:invitations_dataset).and_call_original
 

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Clover, "project" do
         click_button "Create"
 
         expect(page).to have_flash_error("Project limit exceeded. You can create up to 10 projects. Contact support@ubicloud.com if you need more.")
-        expect(page.title).to eq("Ubicloud - Projects")
+        expect(page.title).to eq("Ubicloud - Create Project")
         expect(user.projects_dataset.count).to eq 10
       end
     end

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -1,4 +1,10 @@
-<% @page_title = "#{@project_data[:name]} - Users" %>
+<% @page_title = "#{@project_data[:name]} - Users"
+@users = @project.accounts_dataset.order_by(:email).all
+@subject_tag_map = SubjectTag.subject_id_map_for_project_and_accounts(@project.id, @users.map(&:id))
+@allowed_view_tag_names = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:view").map(:name)
+@allowed_add_tag_names_map = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").select_hash(:name, Sequel.as(true, :v))
+@allowed_remove_tag_names_map = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:remove").select_hash(:name, Sequel.as(true, :v))
+@invitations = @project.invitations_dataset.order_by(:email).all %>
 <%== render("project/user-tabbar") %>
 
 <%== part(


### PR DESCRIPTION
I did an audit of the routes, looking for routes that could result in the error handler being called, and changed them to use handle_validation_failure. In a few of these cases, I consolidated the web and api error handling, making the routes simpler.