### PR TITLE
Add dot at the end of CNAME record

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -98,7 +98,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   label def refresh_dns_record
     decr_refresh_dns_record
 
-    type, data = postgres_resource.location.aws? ? ["CNAME", representative_server.vm.aws_instance.ipv4_dns_name] : ["A", representative_server.vm.ephemeral_net4.to_s]
+    type, data = postgres_resource.location.aws? ? ["CNAME", representative_server.vm.aws_instance.ipv4_dns_name + "."] : ["A", representative_server.vm.ephemeral_net4.to_s]
 
     Prog::Postgres::PostgresResourceNexus.dns_zone&.delete_record(record_name: postgres_resource.hostname)
     Prog::Postgres::PostgresResourceNexus.dns_zone&.insert_record(record_name: postgres_resource.hostname, type:, ttl: 10, data:)

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(postgres_resource).to receive(:hostname).and_return("pg-name.postgres.ubicloud.com.").twice
       dns_zone = instance_double(DnsZone)
       expect(dns_zone).to receive(:delete_record).with(record_name: "pg-name.postgres.ubicloud.com.")
-      expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "CNAME", ttl: 10, data: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
+      expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "CNAME", ttl: 10, data: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com.")
       expect(described_class).to receive(:dns_zone).and_return(dns_zone).twice
       expect(nx).to receive(:when_initial_provisioning_set?).and_yield
       expect { nx.refresh_dns_record }.to hop("initialize_certificates")


### PR DESCRIPTION
Without this, the DNS record gets fully qualified with the DNS Zone domain, which is, in this case, postgres.ubicloud.com, so the full record becomes ec2-xxx.amazonaws.com.postgres.ubicloud.com.postgres.ubicloud.com, which is not a valid DNS record.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a dot to CNAME records in `refresh_dns_record` to ensure correct DNS resolution for AWS instances.
> 
>   - **Behavior**:
>     - Adds a dot to the CNAME record in `refresh_dns_record` in `postgres_resource_nexus.rb` to prevent incorrect DNS qualification.
>     - Ensures CNAME records for AWS instances are correctly formatted as `ec2-xxx.amazonaws.com.`.
>   - **Tests**:
>     - Updates `refresh_dns_record` test in `postgres_resource_nexus_spec.rb` to expect a dot at the end of CNAME data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4dcdaa8b43f2d5d341c34ac3139c6b9c7033d3ea. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->