### PR TITLE
Fix stdin when using cli/ubi to run external commands

### DIFF
--- a/cli/ubi.go
+++ b/cli/ubi.go
@@ -163,6 +163,7 @@ func executeValidatedCommand(prog string, resp *http.Response) {
 	prog = getExecutablePath(prog)
 	debugLog("exec: %s %+v\n", prog, cmdArgs)
 	cmd := exec.Command(prog, cmdArgs...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
Previously it wouldn't use the current stdin when executing the program, preventing interactive use (psql/ssh without arguments).

This doesn't affect bin/ubi, as Ruby uses current stdin for executed programs by default (as any sane language would).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix stdin handling in `executeValidatedCommand()` in `ubi.go` to allow interactive use of external commands.
> 
>   - **Behavior**:
>     - Fixes stdin handling in `executeValidatedCommand()` in `ubi.go` by setting `cmd.Stdin = os.Stdin`.
>     - Allows interactive use of external commands (e.g., `psql`, `ssh`) executed by the CLI.
>   - **Misc**:
>     - No changes to `bin/ubi` as Ruby handles stdin correctly by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 98ae5d0e60105993f25c5e7dd1b8412e8b273f3a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->