### PR TITLE
Remove VmHost#hetznerify

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -243,13 +243,6 @@ class VmHost < Sequel::Model
     Strand.create(prog: "DownloadCloudHypervisor", label: "start", stack: [{subject_id: id, version: version, sha256_ch_bin: sha256_ch_bin, sha256_ch_remote: sha256_ch_remote}])
   end
 
-  def hetznerify(server_id)
-    DB.transaction do
-      HostProvider.create(provider_name: HostProvider::HETZNER_PROVIDER_NAME, server_identifier: server_id) { it.id = id }
-      create_addresses
-    end
-  end
-
   def set_data_center
     update(data_center: Hosting::Apis.pull_data_center(self))
   end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -196,13 +196,6 @@ RSpec.describe VmHost do
     expect(vm_host.sshable_address.ip.network.to_s).to eq("128.0.0.1")
   end
 
-  it "hetznerifies a host" do
-    expect(vh).to receive(:create_addresses).at_least(:once)
-    expect(HostProvider).to receive(:create).with(server_identifier: "12", provider_name: HostProvider::HETZNER_PROVIDER_NAME).and_return(true)
-
-    vh.hetznerify("12")
-  end
-
   it "reimage server fails for non development" do
     expect(Config).to receive(:development?).and_return(false)
     expect {


### PR DESCRIPTION
This was originally added in 1c75bfdb8e728127b97fde2ee49dec76258b1a65 (June 2023), and when originally added, it used HetznerHost, and it worked correctly.

In b48756e163115bd36d5bb587c5314e7a48d4c772, it was changed from using HetznerHost to using HostProvider, and at this point it broke, because host_provider.{server_identifier,provider_name} are primary key columns, and cannot be set via mass assignment by default.

It's possible to fix this issue, but considering it has been broken for over 6 months, and is not used anywhere, it seems better to remove it. The only reason this wasn't discovered sooner is that the VmHost model specs are mostly mocked (yet another bug hidden by mocking).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused and broken `hetznerify` method from `VmHost` class and its test.
> 
>   - **Removal**:
>     - Remove `hetznerify` method from `VmHost` class in `vm_host.rb`.
>     - Remove `hetznerifies a host` test from `vm_host_spec.rb`.
>   - **Reason**:
>     - `hetznerify` was broken due to changes in `HostProvider` interaction and has been unused for over 6 months.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3cc0e27761d357271c90d5d9f7e03bedfc344254. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->