### PR TITLE
Increase standard utilization soft limit threshold to 80%

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -172,9 +172,9 @@ class Prog::Vm::GithubRunner < Prog::Base
         .to_hash(:family, :utilization)
 
       not_allow = if github_runner.label_data["arch"] == "x64" && github_runner.label_data["family"] == "standard" && github_runner.installation.premium_runner_enabled?
-        family_utilization["premium"] > 75 && family_utilization["standard"] > 75
+        family_utilization["premium"] > 75 && family_utilization["standard"] > 80
       else
-        family_utilization.fetch(github_runner.label_data["family"], 0) > 75
+        family_utilization.fetch(github_runner.label_data["family"], 0) > 80
       end
 
       if not_allow


### PR DESCRIPTION
We allow runner customers to provision more runners than their
concurrency limit up to a certain utilization threshold.

This threshold was previously set at 75%. As our fleet has grown, the
idle portion has also increased. To make better use of our available
resources, we've raised the threshold to 80% for standard runners.

We continue to reserve 20% idle capacity to support other services and
customers.

The threshold for premium runners remains unchanged, as the fleet size
is still relatively small.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase standard runner utilization threshold to 80% in `github_runner.rb`, optimizing resource usage.
> 
>   - **Behavior**:
>     - Increase utilization threshold for standard runners from 75% to 80% in `quota_available?` and `wait_concurrency_limit` methods in `github_runner.rb`.
>     - Premium runner threshold remains at 75%.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for dfb5a5fa0f2f5086e0defc7ea6eb206aae72c1ce. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->