### PR TITLE
Rename MonitorRepartitioner to Repartitioner and other fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -281,35 +281,35 @@ end
 desc "Check generated SQL for parameterization"
 task "check_query_parameterization" do
   require "rbconfig"
-  system({"CHECK_LOGGED_SQL" => "1"}, RbConfig.ruby, "-S", "rake", "frozen_sspec")
-  system(RbConfig.ruby, "bin/check_for_parameters", out: "sql_query_parameterization_analysis.txt")
+  sh({"CHECK_LOGGED_SQL" => "1"}, RbConfig.ruby, "-S", "rake", "frozen_sspec")
+  sh(RbConfig.ruby, "bin/check_for_parameters", out: "sql_query_parameterization_analysis.txt")
 end
 
 desc "Check that model files work when required separately"
 task "check_separate_requires" do
   require "rbconfig"
-  system({"RACK_ENV" => "test", "LOAD_FILES_SEPARATELY_CHECK" => "1"}, RbConfig.ruby, "-r", "./loader", "-e", "")
+  sh({"RACK_ENV" => "test", "LOAD_FILES_SEPARATELY_CHECK" => "1"}, RbConfig.ruby, "-r", "./loader", "-e", "")
 end
 
 desc "Run monitor smoke test"
 task :monitor_smoke_test do
-  system(RbConfig.ruby, "spec/monitor_smoke_test.rb")
+  sh(RbConfig.ruby, "spec/monitor_smoke_test.rb")
 end
 
 desc "Run respirate smoke tests"
 task :respirate_smoke_test do
   # not partitioned, 1 process
-  system(RbConfig.ruby, "spec/respirate_smoke_test.rb")
+  sh(RbConfig.ruby, "spec/respirate_smoke_test.rb")
 
   # not partitioned, 8 processes
-  system(RbConfig.ruby, "spec/respirate_smoke_test.rb", "1", "8")
+  sh(RbConfig.ruby, "spec/respirate_smoke_test.rb", "1", "8")
 
   # 8-way partition, 8 processes
-  system(RbConfig.ruby, "spec/respirate_smoke_test.rb", "8")
+  sh(RbConfig.ruby, "spec/respirate_smoke_test.rb", "8")
 
   # 8-way partition, but only 7 processes. This simulates a crash/apoptosis
   # in a respirate process, checking that other processes pick up the slack.
-  system(RbConfig.ruby, "spec/respirate_smoke_test.rb", "8", "7")
+  sh(RbConfig.ruby, "spec/respirate_smoke_test.rb", "8", "7")
 end
 
 desc "Run each spec file in a separate process"
@@ -318,6 +318,7 @@ task :spec_separate do
 
   failures = []
   Dir["spec/**/*_spec.rb"].each do |file|
+    # system instead of sh as we are reporting all failures at the end
     failures << file unless system(RbConfig.ruby, "-w", "-S", "rspec", file)
   end
 

--- a/bin/monitor
+++ b/bin/monitor
@@ -12,8 +12,10 @@ end
 # process, in which case, the partition is the entire id space.
 partition_number ||= "1"
 
+max_partition = 8
+
 partition_number = Integer(partition_number)
-raise "invalid partition_number: #{partition_number}" if partition_number < 1 || partition_number > 8
+raise "invalid partition_number: #{partition_number}" if partition_number < 1 || partition_number > max_partition
 
 require_relative "../loader"
 clover_freeze
@@ -75,7 +77,7 @@ metric_export_resources = MonitorResourceType.create(
   &:export_metrics
 )
 
-repartitioner = MonitorRepartitioner.new(partition_number)
+repartitioner = Repartitioner.new(partition_number:, channel: :monitor, listen_timeout: 1, recheck_seconds: 18, stale_seconds: 40, max_partition:)
 
 runner = MonitorRunner.new(monitor_resources:, metric_export_resources:, repartitioner:, **runner_args)
 

--- a/lib/repartitioner.rb
+++ b/lib/repartitioner.rb
@@ -142,7 +142,7 @@ class Repartitioner
       @partition_recheck_time = t + @recheck_seconds
       notify
       stale = t - @stale_seconds
-      @partition_times.reject! { |_, time| time < stale }
+      @partition_times.reject! { |number, time| time < stale && number != @partition_number }
       @partition_times.keys.max
     end
   end

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -10,10 +10,10 @@ class Scheduling::Dispatcher
   STRAND_RUNTIME = Strand::LEASE_EXPIRATION / 4
   APOPTOSIS_MUTEX = Mutex.new
 
-  class Repartitioner < MonitorRepartitioner
-    def initialize(*, dispatcher:, **)
+  class Repartitioner < ::Repartitioner
+    def initialize(dispatcher:, **)
       @dispatcher = dispatcher
-      super(*, **)
+      super(**)
     end
 
     # Update the dispatcher prepared statement when repartitioning.
@@ -112,7 +112,7 @@ class Scheduling::Dispatcher
     if partition_number
       # Handles repartitioning when new partitions show up or old partitions
       # go stale.
-      @repartitioner = Repartitioner.new(partition_number, channel: :respirate,
+      @repartitioner = Repartitioner.new(partition_number:, channel: :respirate,
         max_partition: 256, dispatcher: self, listen_timeout:,
         recheck_seconds: listen_timeout * 2, stale_seconds: listen_timeout * 4)
 

--- a/spec/lib/monitor_runner_spec.rb
+++ b/spec/lib/monitor_runner_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MonitorRunner do
   end
   let(:monitor_resources) { MonitorResourceType.create(MonitorableResource, stuck_info, 2, [VmHost]) {} }
   let(:metric_export_resources) { MonitorResourceType.create(MetricsTargetResource, stuck_info, 2, [VmHost]) {} }
-  let(:repartitioner) { MonitorRepartitioner.new(2) }
+  let(:repartitioner) { Repartitioner.new(partition_number: 2, channel: :monitor, listen_timeout: 1, recheck_seconds: 18, stale_seconds: 40, max_partition: 8) }
   let(:monitor_runner_args) do
     {
       scan_every: 0.01,

--- a/spec/monitor_smoke_test.rb
+++ b/spec/monitor_smoke_test.rb
@@ -89,33 +89,20 @@ output.split("\n").each do |line|
 end
 lines.each_value(&:uniq!).each_value { it.sort_by!(&:inspect) }
 
-[up, evloop].each do |r|
-  expected_lines = [
-    {"got_pulse" => {"ubid" => r, "pulse" => {"reading" => "up", "reading_rpt" => 1}}, "message" => "Got new pulse."},
-    {"metrics_export_success" => {"ubid" => r, "count" => 1}, "message" => "Metrics export has finished."}
-  ]
+{
+  up => ["up", 1],
+  evloop => ["up", 1],
+  mc2 => ["up", 2],
+  down => ["down", 1]
+}.each do |r, (reading, count)|
+  expected_lines = Array.new(lines[r].size - 1) do
+    {"got_pulse" => {"ubid" => r, "pulse" => {"reading" => reading, "reading_rpt" => it + 1}}, "message" => "Got new pulse."}
+  end
+  expected_lines << {"metrics_export_success" => {"ubid" => r, "count" => count}, "message" => "Metrics export has finished."}
   unless lines[r] == expected_lines
     warn "unexpected lines for #{r}: #{lines[r]}"
     exit 1
   end
-end
-
-expected_lines = [
-  {"got_pulse" => {"ubid" => mc2, "pulse" => {"reading" => "up", "reading_rpt" => 1}}, "message" => "Got new pulse."},
-  {"metrics_export_success" => {"ubid" => mc2, "count" => 2}, "message" => "Metrics export has finished."}
-]
-unless lines[mc2] == expected_lines
-  warn "unexpected lines for #{mc2}: #{lines[mc2]}"
-  exit 1
-end
-
-expected_lines = Array.new(lines[down].size - 1) do
-  {"got_pulse" => {"ubid" => down, "pulse" => {"reading" => "down", "reading_rpt" => it + 1}}, "message" => "Got new pulse."}
-end
-expected_lines << {"metrics_export_success" => {"ubid" => down, "count" => 1}, "message" => "Metrics export has finished."}
-unless lines[down] == expected_lines
-  warn "unexpected lines for #{down}: #{lines[down]}"
-  exit 1
 end
 
 unless lines[:other].flat_map(&:keys).uniq.sort == ["message", "monitor_metrics"]


### PR DESCRIPTION
The main change here is renaming MonitorRepartitioner to Repartitioner, and making it generic.

While working on this, I found that monitor_smoke_test has been failing since the change to log the first 5 up responses. It wasn't caught by CI because the Rakefile used `system` instead of `sh`. This was also true for respirate_smoke_test. Fix the Rakefile to use `sh`, and also fix the monitor_smoke_test to work with the recent change.

I also was notified about a nondeterministic test failure in the dispatcher specs, which I traced to the repartitioner allowing removal of it's own partition in a race condition. While it would never happen in development or production, we still want to avoid the issue when testing. I changed the repartitioner to not remove its own partition, even if it hasn't been notified about it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames `MonitorRepartitioner` to `Repartitioner`, fixes test issues, and addresses race conditions in partition handling.
> 
>   - **Renaming and Refactoring**:
>     - Rename `MonitorRepartitioner` to `Repartitioner` in `lib/repartitioner.rb` and update its initialization to be more generic.
>     - Update references in `bin/monitor`, `scheduling/dispatcher.rb`, and `spec/lib/monitor_runner_spec.rb`.
>   - **Test Fixes**:
>     - Fix `monitor_smoke_test` in `spec/monitor_smoke_test.rb` to handle recent changes in logging.
>     - Update `Rakefile` to use `sh` instead of `system` for better error handling in `monitor_smoke_test` and `respirate_smoke_test`.
>   - **Race Condition Fix**:
>     - Modify `Repartitioner` to prevent removal of its own partition in race conditions in `lib/repartitioner.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b5f79520b5236eab95e2d8f823c1c9665b6a2f6c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->