### PR TITLE
Remove emit with database information when loading

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -10,7 +10,6 @@ db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "db_ca_bundle.cr
 Util.safe_write_to_file(db_ca_bundle_filename, Config.clover_database_root_certs)
 max_connections = (Util.monitor_process? ? Config.db_pool_monitor : Config.db_pool) - 1
 max_connections = 1 if ENV["SHARED_CONNECTION"] == "1"
-Clog.emit("Setting max_connections for Clover database") { {max_connections:, config_db_pool: Config.db_pool, config_db_pool_monitor: Config.db_pool_monitor, is_monitor_process: Util.monitor_process?, shared_connection: ENV["SHARED_CONNECTION"] == "1"} }
 pg_auto_parameterize_min_array_size = 1 if Config.test? && ENV["CLOVER_FREEZE"] == "1"
 DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:)
 


### PR DESCRIPTION
When added, this was useful to test the Config.db_pool_monitor setting was being respected.  However, I don't think it still necessary.