### PR TITLE
Add raise_web_error method to DRY up web-specific CloverError raising

### DIFF
--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -45,6 +45,10 @@ class Clover < Roda
     part("components/form/hidden", name: csrf_field, value: csrf_token(*))
   end
 
+  def raise_web_error(message)
+    raise CloverError.new(400, nil, message)
+  end
+
   def handle_validation_failure(template, &block)
     return unless web?
     @validation_failure_template = template

--- a/routes/account.rb
+++ b/routes/account.rb
@@ -18,7 +18,7 @@ class Clover
           no_authorization_needed
           handle_validation_failure("account/login_method")
           unless (id = typecast_params.ubid_uuid("provider")) && (oidc_provider = OidcProvider[id])
-            raise CloverError.new(400, nil, "No valid OIDC provider with that ID")
+            raise_web_error("No valid OIDC provider with that ID")
           end
 
           r.redirect "/auth/#{oidc_provider.ubid}?redirect_url=/account/login-method"
@@ -31,7 +31,7 @@ class Clover
           provider, uid = typecast_params.nonempty_str(["provider", "uid"])
           identities = current_account.identities
           unless identities.length > (rodauth.has_password? ? 0 : 1)
-            raise CloverError.new(400, nil, "You must have at least one login method")
+            raise_web_error("You must have at least one login method")
           end
           if provider == "password"
             DB[:account_password_hashes].where(id: current_account.id).delete
@@ -41,7 +41,7 @@ class Clover
             identity.destroy
             flash[:notice] = "Your account has been disconnected from #{omniauth_provider_name(provider)}"
           else
-            raise CloverError.new(400, nil, "Your account already has been disconnected from #{omniauth_provider_name(provider)}")
+            raise_web_error("Your account already has been disconnected from #{omniauth_provider_name(provider)}")
           end
 
           r.redirect "/account/login-method"

--- a/routes/project/discount_code.rb
+++ b/routes/project/discount_code.rb
@@ -17,7 +17,7 @@ class Clover
 
       unless discount
         Clog.emit("Invalid discount code attempted") { {invalid_discount_code: {project_id: @project.id, code: discount_code}} }
-        raise CloverError.new(400, nil, "Discount code not found.")
+        raise_web_error("Discount code not found.")
       end
 
       begin
@@ -31,7 +31,7 @@ class Clover
           audit_log(ProjectDiscountCode.call(hash), "create")
         end
       rescue Sequel::UniqueConstraintViolation
-        raise CloverError.new(400, nil, "Discount code has already been applied to this project.")
+        raise_web_error("Discount code has already been applied to this project.")
       end
 
       unless @project.billing_info

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -21,7 +21,7 @@ class Clover
       r.get "create" do
         handle_validation_failure("github/index")
         unless @project.has_valid_payment_method?
-          raise CloverError.new(400, nil, "Project doesn't have valid billing information")
+          raise_web_error("Project doesn't have valid billing information")
         end
         session[:github_installation_project_id] = @project.id
 

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -21,14 +21,14 @@ class Clover
           handle_validation_failure("project/user")
 
           if ProjectInvitation[project_id: @project.id, email: email]
-            raise CloverError.new(400, nil, "'#{email}' already invited to join the project.")
+            raise_web_error("'#{email}' already invited to join the project.")
           elsif @project.invitations_dataset.count >= 50
-            raise CloverError.new(400, nil, "You can't have more than 50 pending invitations.")
+            raise_web_error("You can't have more than 50 pending invitations.")
           end
 
           if (policy = typecast_params.nonempty_str("policy"))
             unless (tag = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").first(name: policy))
-              raise CloverError.new(400, nil, "You don't have permission to invite users with this subject tag.")
+              raise_web_error("You don't have permission to invite users with this subject tag.")
             end
           end
 
@@ -43,7 +43,7 @@ class Clover
               audit_log(@project, "add_account", user)
 
               if result.empty?
-                raise CloverError.new(400, nil, "The requested user already has access to this project")
+                raise_web_error("The requested user already has access to this project")
               end
 
               if tag
@@ -138,7 +138,7 @@ class Clover
           removals.transform_keys!(&:name)
 
           if @project.subject_tags_dataset.first(name: "Admin").member_ids.empty?
-            raise CloverError.new(400, nil, "The project must have at least one admin.")
+            raise_web_error("The project must have at least one admin.")
           end
 
           invitatation_map = @project
@@ -290,7 +290,7 @@ class Clover
 
               if @tag_type == "subject" && @tag.name == "Admin"
                 handle_validation_failure("project/tag-list")
-                raise CloverError.new(400, nil, "Cannot modify Admin subject tag")
+                raise_web_error("Cannot modify Admin subject tag")
               end
 
               r.post do
@@ -381,7 +381,7 @@ class Clover
         next unless (user = @project.accounts_dataset[id:])
 
         unless @project.accounts_dataset.count > 1
-          raise CloverError.new(400, nil, "You can't remove the last user from '#{@project.name}' project. Delete project instead.")
+          raise_web_error("You can't remove the last user from '#{@project.name}' project. Delete project instead.")
         end
 
         @project.disassociate_subject(user.id)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `raise_web_error` method in `helpers/web.rb` to standardize error raising across web routes, replacing direct `CloverError` instantiations.
> 
>   - **New Method**:
>     - Adds `raise_web_error(message)` in `helpers/web.rb` to raise `CloverError` with a 400 status code and a custom message.
>   - **Refactoring**:
>     - Replaces `raise CloverError.new(400, nil, message)` with `raise_web_error(message)` in `routes/account.rb`, `routes/project/billing.rb`, and `routes/project/discount_code.rb`.
>     - Updates `routes/project/github.rb` and `routes/project/user.rb` to use `raise_web_error` for error handling.
>   - **Behavior**:
>     - No change in functionality, only refactoring for code consistency and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 47dffc11aaf12138e2ad22614e452d73cb09a0b7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->