### PR TITLE
Only accept json requests for the postgres metrics routes

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -136,7 +136,7 @@ class Clover < Roda
       message: "Sorry, we couldn’t find the resource you’re looking for."
     }
 
-    if api? || request.headers["accept"] == "application/json"
+    if api? || request.accepts_json?
       {error: @error}.to_json
     else
       view "/error"
@@ -216,7 +216,7 @@ class Clover < Roda
 
     if runtime?
       error
-    elsif api? || request.headers["accept"] == "application/json" || !%w[GET POST].include?(request.request_method)
+    elsif api? || request.accepts_json? || !%w[GET POST].include?(request.request_method)
       {error:}
     else
       @error = error

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -14,6 +14,12 @@ class Clover < Roda
     account.projects_dataset[Sequel[:project][:id] => project_id, :visible => true]
   end
 
+  class RodaRequest
+    def accepts_json?
+      env["HTTP_ACCEPT"]&.include?("application/json")
+    end
+  end
+
   class RodaResponse
     API_DEFAULT_HEADERS = DEFAULT_HEADERS.merge("content-type" => "application/json").freeze
     WEB_DEFAULT_HEADERS = DEFAULT_HEADERS.merge(

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -390,7 +390,7 @@ class Clover
         certs
       end
 
-      r.get "metrics" do
+      r.get "metrics", r.accepts_json? do
         authorize("Postgres:view", pg.id)
 
         start_time, end_time = typecast_params.str(%w[start end])


### PR DESCRIPTION
Previously, this would have accepted a normal request, and returned a json response. However, if there were any errors in the request (and it is easy to introduce errors with invalid start/end times), it would result in using the fallback web error handler. Since we never want this route to handle non-json requests, it's easiest to just enforce that, so we don't have to worry about error handling for non-json requests.

Implement this by adding request.accepts_json?. Also use the method to DRY up some code.