### PR TITLE
Include information about the error in the emit message for missing handle_validation_failure

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -223,14 +223,14 @@ class Clover < Roda
 
       if e.is_a?(Sequel::ValidationFailed) || e.is_a?(DependencyError) || e.is_a?(Roda::RodaPlugins::TypecastParams::Error)
         flash["error"] = message
-        redirect_back_with_inputs
+        redirect_back_with_inputs(e)
       elsif e.is_a?(Sequel::SerializationFailure)
         flash["error"] = "There was a temporary error attempting to make this change, please try again."
-        redirect_back_with_inputs
+        redirect_back_with_inputs(e)
       elsif e.is_a?(CloverError) && !e.is_a?(Authorization::Unauthorized)
         flash["error"] = message
         flash["errors"] = (flash["errors"] || {}).merge(details || {}).transform_keys(&:to_s)
-        redirect_back_with_inputs
+        redirect_back_with_inputs(e)
       end
 
       # :nocov:
@@ -780,6 +780,11 @@ class Clover < Roda
     hash_branch(:webhook_prefix, "test-typecast-error-during-validation-failure") do |r|
       r.POST["a"] = {}
       handle_validation_failure(inline: "<%= typecast_body_params.str('a') %>")
+      typecast_body_params.str("a")
+    end
+
+    hash_branch(:webhook_prefix, "test-missing-handle-validation-failure") do |r|
+      r.POST["a"] = {}
       typecast_body_params.str("a")
     end
 

--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -55,7 +55,7 @@ class Clover < Roda
     @validation_failure_block = block
   end
 
-  def redirect_back_with_inputs
+  def redirect_back_with_inputs(error)
     # :nocov:
     if (template = @validation_failure_template)
       # :nocov:
@@ -70,6 +70,22 @@ class Clover < Roda
       end
     end
 
+    # Emit error if no validation failure template was registered. This will allow
+    # detection of errors in production for cases where we don't have specs that cover
+    # the error. These errors will be monitored and specs will be added for them.
+    Clog.emit("web error without handle_validation_failure") do
+      {
+        missing_handle_validation_failure: {
+          request_method: request.request_method,
+          path_info: request.path_info,
+          referrer: env["HTTP_REFERER"],
+          error_class: error.class,
+          error_message: error.message,
+          backtrace: error.backtrace
+        }
+      }
+    end
+
     # :nocov:
     # This code path is deprecated and will be removed after all routes have been updated
     # to use handle_validation_failure.
@@ -78,19 +94,6 @@ class Clover < Roda
       # Raise error in the tests if we get here. If this error is raised, the route
       # should be fixed to call handle_validation_failure.
       raise "Request failure without handle_validation_failure: #{request.request_method} #{request.path_info}"
-    else
-      # Emit error messages in other environments. This will allow detection of errors in production
-      # for cases where we don't have specs that cover the error. These errors will be
-      # monitored and specs will be added for them.
-      Clog.emit("web error without handle_validation_failure") do
-        {
-          missing_handle_validation_failure: {
-            request_method: request.request_method,
-            path_info: request.path_info,
-            referrer: env["HTTP_REFERER"]
-          }
-        }
-      end
     end
 
     referrer = flash["referrer"] || env["HTTP_REFERER"]

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe Clover do
     expect(page.status_code).to eq(400)
   end
 
+  it "handles missing handle_validation_failure_call" do
+    expect(Clog).to receive(:emit).with("web error without handle_validation_failure").and_call_original
+    expect { visit "/webhook/test-missing-handle-validation-failure" }.to raise_error(RuntimeError, /Request failure without handle_validation_failure/)
+  end
+
   it "handles expected errors" do
     expect(Clog).to receive(:emit).with("route exception").and_call_original
 


### PR DESCRIPTION
This also moves the emit above the exception raising, and adds a test that covers the emit.