### PR TITLE
Reduce size of the cloud-init NoCloud disk

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -553,7 +553,7 @@ EOS
     write_user_data(unix_user, public_keys, swap_size_bytes, boot_image)
 
     FileUtils.rm_rf(vp.cloudinit_img)
-    r "mkdosfs -n CIDATA -C #{vp.q_cloudinit_img} 8192"
+    r "mkdosfs -n CIDATA -C #{vp.q_cloudinit_img} 128"
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_user_data} ::"
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_meta_data} ::"
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_network_config} ::"


### PR DESCRIPTION
When I wrote the first copy in the ancient era
e22112d86deda025f63402ef50979e80ab928c5b, I made a mistake in the units: it's not in bytes, but in kilobytes. A multi-megabyte cloud-init is overkill.  128K seems generous enough.