### PR TITLE
Update to Roda 3.95.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "rack-unreloader", ">= 1.8"
 gem "rake"
 gem "refrigerator", ">= 1"
 gem "reline" # Remove it when pry adds it as a dependency
-gem "roda", github: "jeremyevans/roda", ref: "f4317ebfe15de8126267d33023ffb9f320dc9020"
+gem "roda", ">= 3.95"
 gem "rodauth", github: "jeremyevans/rodauth", ref: "a1780cd64e947d4531771e272ed97eb4f33058b9"
 gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"
 gem "rodish", ">= 2.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,6 @@ GIT
       rodauth (~> 2.36)
 
 GIT
-  remote: https://github.com/jeremyevans/roda.git
-  revision: f4317ebfe15de8126267d33023ffb9f320dc9020
-  ref: f4317ebfe15de8126267d33023ffb9f320dc9020
-  specs:
-    roda (3.94.0)
-      rack
-
-GIT
   remote: https://github.com/jeremyevans/rodauth.git
   revision: a1780cd64e947d4531771e272ed97eb4f33058b9
   ref: a1780cd64e947d4531771e272ed97eb4f33058b9
@@ -318,6 +310,8 @@ GEM
     reline (0.6.1)
       io-console (~> 0.5)
     rexml (3.4.1)
+    roda (3.95.0)
+      rack
     rodish (2.0.1)
       optparse
     rotp (6.3.0)
@@ -503,7 +497,7 @@ DEPENDENCIES
   rake
   refrigerator (>= 1)
   reline
-  roda!
+  roda (>= 3.95)
   rodauth!
   rodauth-omniauth!
   rodish (>= 2.0.1)


### PR DESCRIPTION
We were using a github ref for typecast_body_params, but that has now been released.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `roda` gem in `Gemfile` to released version `>= 3.95`.
> 
>   - **Gemfile Update**:
>     - Update `roda` gem from GitHub ref to released version `>= 3.95`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fc481b1bee6d3075b43d5cfe3c7fa2d7ebcf57df. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->