### PR TITLE
Update bundler version to 2.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,4 +533,4 @@ RUBY VERSION
    ruby 3.4.5p51
 
 BUNDLED WITH
-   2.6.8
+   2.7.1


### PR DESCRIPTION
Bundler is 2.6.9 or older will result in a lot of redefinition warnings.

https://github.com/rubygems/rubygems/pull/8760
https://github.com/rubygems/rubygems/pull/8832


```
RUBYOPT=-w RACK_ENV=test FORCE_AUTOLOAD=1 COVERAGE=1 RODA_RENDER_COMPILED_METHOD_SUPPORT=no bundle exec turbo_tests -n 10 2>&1 | tee coverage/output.txt
10 processes for 265 specs, ~ 27 specs per process
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/enescakir/.local/share/mise/installs/ruby/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
```