### PR TITLE
Improve AWS instance creation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -168,7 +168,7 @@ module Config
   override :github_ubuntu_2404_version, "20250821.1.0", string
   override :github_ubuntu_2204_version, "20250821.1.0", string
   override :github_gpu_ubuntu_2204_version, "20250821.1.0", string
-  override :github_ubuntu_2204_aws_ami_version, "ami-08b71dd98be505433", string
+  override :github_ubuntu_2204_aws_ami_version, "ami-012d564b2a41c98c8", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string
   override :postgres16_paradedb_ubuntu_2204_version, "20250425.1.1", string

--- a/prog/aws/instance.rb
+++ b/prog/aws/instance.rb
@@ -156,7 +156,7 @@ class Prog::Aws::Instance < Prog::Base
       },
       min_count: 1,
       max_count: 1,
-      user_data: Base64.encode64(user_data),
+      user_data: Base64.encode64(user_data.gsub(/^(\s*# .*)?\n/, "")),
       tag_specifications: Util.aws_tag_specifications("instance", vm.name),
       iam_instance_profile: {
         name: "#{vm.name}-instance-profile"

--- a/prog/aws/instance.rb
+++ b/prog/aws/instance.rb
@@ -169,11 +169,12 @@ class Prog::Aws::Instance < Prog::Base
       nap 1 if e.message.include?("Invalid IAM Instance Profile name")
       raise
     end
-    instance_id = instance_response.instances[0].instance_id
-    subnet_id = instance_response.instances[0].network_interfaces[0].subnet_id
+    instance = instance_response.instances.first
+    instance_id = instance.instance_id
+    subnet_id = instance.network_interfaces.first.subnet_id
     subnet_response = client.describe_subnets(subnet_ids: [subnet_id])
-    az_id = subnet_response.subnets[0].availability_zone_id
-    ipv4_dns_name = instance_response.instances[0].public_dns_name
+    az_id = subnet_response.subnets.first.availability_zone_id
+    ipv4_dns_name = instance.public_dns_name
 
     AwsInstance.create_with_id(vm.id, instance_id:, az_id:, ipv4_dns_name:)
 

--- a/spec/prog/aws/instance_spec.rb
+++ b/spec/prog/aws/instance_spec.rb
@@ -33,13 +33,9 @@ RSpec.describe Prog::Aws::Instance do
 #!/bin/bash
 custom_user="test-user-aws"
 if [ ! -d /home/$custom_user ]; then
-  # Create the custom user
   adduser $custom_user --disabled-password --gecos ""
-  # Add the custom user to the sudo group
   usermod -aG sudo $custom_user
-  # disable password for the custom user
   echo "$custom_user ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/$custom_user
-  # Set up SSH access for the custom user
   mkdir -p /home/$custom_user/.ssh
   cp /home/ubuntu/.ssh/authorized_keys /home/$custom_user/.ssh/
   chown -R $custom_user:$custom_user /home/$custom_user/.ssh

--- a/spec/prog/aws/instance_spec.rb
+++ b/spec/prog/aws/instance_spec.rb
@@ -32,18 +32,20 @@ RSpec.describe Prog::Aws::Instance do
     <<~USER_DATA
 #!/bin/bash
 custom_user="test-user-aws"
-# Create the custom user
-adduser $custom_user --disabled-password --gecos ""
-# Add the custom user to the sudo group
-usermod -aG sudo $custom_user
-# disable password for the custom user
-echo "$custom_user ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/$custom_user
-# Set up SSH access for the custom user
-mkdir -p /home/$custom_user/.ssh
-cp /home/ubuntu/.ssh/authorized_keys /home/$custom_user/.ssh/
-chown -R $custom_user:$custom_user /home/$custom_user/.ssh
-chmod 700 /home/$custom_user/.ssh
-chmod 600 /home/$custom_user/.ssh/authorized_keys
+if [ ! -d /home/$custom_user ]; then
+  # Create the custom user
+  adduser $custom_user --disabled-password --gecos ""
+  # Add the custom user to the sudo group
+  usermod -aG sudo $custom_user
+  # disable password for the custom user
+  echo "$custom_user ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/$custom_user
+  # Set up SSH access for the custom user
+  mkdir -p /home/$custom_user/.ssh
+  cp /home/ubuntu/.ssh/authorized_keys /home/$custom_user/.ssh/
+  chown -R $custom_user:$custom_user /home/$custom_user/.ssh
+  chmod 700 /home/$custom_user/.ssh
+  chmod 600 /home/$custom_user/.ssh/authorized_keys
+fi
 echo dummy-public-key > /home/$custom_user/.ssh/authorized_keys
 usermod -L ubuntu
     USER_DATA


### PR DESCRIPTION
- **Do not create the user if it already exists on the AWS instance**
  A significant portion of provisioning time is spent creating users in
  our AWS runner image. We have moved the user creation process for the
  `ubuntu` user, which is the default user in AWS EC2, and the
  `runneradmin` user to the image generation process. This approach
  eliminates the overhead of creating a user home directory every time we
  start a new instance.
  
  Squiggly HEREDOC "<<~" strips the leading whitespace. We can indent the
  commands for better readability.
  
  cloudinit does not apply most of the provided configuration if the user
  already exists. Similarly, if the user directory already exists, we do
  not create a home directory again and only set the SSH public keys.
  
  Ref: https://cloudinit.readthedocs.io/en/latest/reference/examples.html
  
      Note: Most of these configuration options will not be honored if the user
            already exists. Following options are the exceptions and they are
            applicable on already-existing users:
            - 'plain_text_passwd', 'hashed_passwd', 'lock_passwd', 'sudo',
              'ssh_authorized_keys', 'ssh_redirect_user'.
  

- **Strip comments from AWS init script**
  When we pass multiline SSH commands to a virtual machine, we remove
  empty lines and comments. This way, we transfer less data. We can
  achieve a similar effect in our `user_data` script and make it shorter.
  

- **Suppress invalid IAM instance profile name error while creating AWS instance**
  While provisioning a virtual machine at AWS, even if an IAM instance
  profile is created, the create_instances command may fail due to the
  following exception:
  
      Aws::EC2::Errors::InvalidParameterValue - Value
      (gr8x4mbvjdey2mdxh1fn7zzgtr-instance-profile) for parameter
      iamInstanceProfile.name is invalid. Invalid IAM Instance Profile
      name
  
  This error is intermittent and disappears when the instance profile is
  successfully propagated. We can ignore this error and retry the instance
  creation, which makes the logs cleaner.
  

- **Use a variable to store instance instead of repeatedly accessing**
  

- **Use aws_instance as subject**
  Since `vm` and `aws_instance` have the same ID as `strand`, we can use
  `aws_instance` as the subject, similar to `vm`.
  

- **Reduce the indentation in the aws_instance.wait_instance_created**
  An early return helps eliminate unnecessary indentation.
  

- **Omit parameters at aws/instance.rb**
  We generate some strings repeatedly in different labels. We can move
  these strings to methods and omit them from the values.
  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve AWS instance creation by optimizing user creation, handling IAM profile errors, and refactoring code in `prog/aws/instance.rb`.
> 
>   - **Behavior**:
>     - Skip user creation if user exists in `prog/aws/instance.rb`.
>     - Strip comments from `user_data` script in `prog/aws/instance.rb`.
>     - Handle `Invalid IAM Instance Profile name` error in `create_instance` in `prog/aws/instance.rb` by retrying.
>   - **Refactoring**:
>     - Use `aws_instance` instead of `vm` in `prog/aws/instance.rb`.
>     - Reduce indentation in `wait_instance_created` in `prog/aws/instance.rb`.
>     - Use methods for repeated strings in `prog/aws/instance.rb`.
>   - **Testing**:
>     - Update tests in `instance_spec.rb` to reflect changes in `prog/aws/instance.rb`.
>     - Add tests for handling `Invalid IAM Instance Profile name` error in `instance_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f57731315f22cf7c4812f6babd0b83d8e20e8788. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->