### PR TITLE
Fix deadline pages in postgres server nexus

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -538,7 +538,7 @@ SQL
       hop_wait
     end
 
-    bud self.class, frame, :restart
+    bud self.class, {}, :restart
     nap 5
   end
 


### PR DESCRIPTION
Previously we used to bud using the same frame, which also contains potentially expired deadline metadata, which causes lots of deadline exceeded pages during unavailability. This commit fixes that by using a fresh, empty, frame.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue with expired deadline metadata causing deadline exceeded pages by using an empty frame in `postgres_server_nexus.rb`.
> 
>   - **Behavior**:
>     - Fixes issue with expired deadline metadata causing deadline exceeded pages by using an empty frame in `switch_to_new_timeline` and `unavailable` methods in `postgres_server_nexus.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7f7ef2f51e78a10320abc1222965c9e1f0a62ec7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->