### PR TITLE
Include [options] in cli fw add-rule usage

### DIFF
--- a/cli-commands/fw/post/add-rule.rb
+++ b/cli-commands/fw/post/add-rule.rb
@@ -3,7 +3,7 @@
 UbiCli.on("fw").run_on("add-rule") do
   desc "Add a firewall rule"
 
-  options("ubi fw (location/fw-name | fw-id) add-rule cidr", key: :fw_add_rule) do
+  options("ubi fw (location/fw-name | fw-id) add-rule [options] cidr", key: :fw_add_rule) do
     on("-s", "--start-port=port", Integer, "starting (or only) port to allow (default: 0)")
     on("-e", "--end-port=port", Integer, "ending port to allow (default: 65535)")
   end

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -e a 10.10.10.0.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -e a 10.10.10.0.txt
@@ -3,7 +3,7 @@
 Add a firewall rule
 
 Usage:
-    ubi fw (location/fw-name | fw-id) add-rule cidr
+    ubi fw (location/fw-name | fw-id) add-rule [options] cidr
 
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -s a 10.10.10.0.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -s a 10.10.10.0.txt
@@ -3,7 +3,7 @@
 Add a firewall rule
 
 Usage:
-    ubi fw (location/fw-name | fw-id) add-rule cidr
+    ubi fw (location/fw-name | fw-id) add-rule [options] cidr
 
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -109,7 +109,7 @@ Allowed Option Values:
 Add a firewall rule
 
 Usage:
-    ubi fw (location/fw-name | fw-id) add-rule cidr
+    ubi fw (location/fw-name | fw-id) add-rule [options] cidr
 
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -9,7 +9,7 @@ ubi ai api-key api-key-id show
 ubi fw command [...]
 ubi fw (location/fw-name | fw-id) post-command [...]
 ubi fw list [options]
-ubi fw (location/fw-name | fw-id) add-rule cidr
+ubi fw (location/fw-name | fw-id) add-rule [options] cidr
 ubi fw (location/fw-name | fw-id) attach-subnet ps-id
 ubi fw location/fw-name create [options]
 ubi fw (location/fw-name | fw-id) delete-rule rule-id


### PR DESCRIPTION
I checked the existing commands and this is the only one that supported options and didn't have [options] in the usage.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add '[options]' to the 'add-rule' command usage in CLI and documentation for consistency.
> 
>   - **CLI Command**:
>     - Updated `options` string in `add-rule` command in `add-rule.rb` to include `[options]`.
>   - **Documentation**:
>     - Updated usage examples in `fw eu-central-h1_default-eu-central-h1-default add-rule -e a 10.10.10.0.txt`, `fw eu-central-h1_default-eu-central-h1-default add-rule -s a 10.10.10.0.txt`, `help -r.txt`, and `help -ru.txt` to include `[options]` in the `add-rule` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6e708ab43ed72b9be3da40111ea02c00821dc6d4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->