### PR TITLE
Synchronise VM removal from load balancer in case of destroy

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -33,7 +33,7 @@ class Vm < Sequel::Model
 
   plugin ResourceMethods, redacted_columns: :public_key
   plugin SemaphoreMethods, :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules,
-    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :stop
+    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :stop, :removed_from_lb
   include HealthMonitorMethods
 
   include ObjectTag::Cleanup

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -588,6 +588,7 @@ class Prog::Vm::Nexus < Prog::Base
       end
       lb.remove_vm(vm)
     end
+    nap 5 unless vm.removed_from_lb_set?
 
     vm.vm_host.sshable.cmd("sudo host/bin/setup-vm delete_net #{q_vm}")
 

--- a/prog/vnet/cert_server.rb
+++ b/prog/vnet/cert_server.rb
@@ -31,6 +31,7 @@ class Prog::Vnet::CertServer < Prog::Base
 
   label def remove_cert_server
     vm.vm_host.sshable.cmd("sudo host/bin/setup-cert-server stop_and_remove #{vm.inhost_name}")
+    vm.incr_removed_from_lb
     pop "certificate resources and server are removed"
   end
 

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -167,7 +167,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   label def wait_destroy
     reap(nap: 5) do
       load_balancer.destroy
-
+      load_balancer.vms.map(&:incr_removed_from_lb)
       pop "load balancer deleted"
     end
   end

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Prog::Vnet::CertServer do
   describe "#remove_cert_server" do
     it "removes the certificate files, server and hops to remove_load_balancer" do
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-cert-server stop_and_remove test-vm")
+      expect(vm).to receive(:incr_removed_from_lb)
 
       expect { nx.remove_cert_server }.to exit({"msg" => "certificate resources and server are removed"})
     end


### PR DESCRIPTION
When we try to destroy the VM completely before the load balancer
completes the metadata endpoint clean-up, the vm gets stuck on removal.
With this commit, we make sure the related networking cleanup is done
only after load balancer completes its cleanup.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Synchronize VM removal with load balancer cleanup to prevent VM removal issues by adding checks and semaphores in `nexus.rb`, `cert_server.rb`, and `load_balancer_nexus.rb`.
> 
>   - **Behavior**:
>     - Ensure VM network cleanup occurs after load balancer cleanup in `nexus.rb` and `cert_server.rb`.
>     - Add `removed_from_lb` semaphore to `vm.rb` to track load balancer removal status.
>   - **Functions**:
>     - Add `incr_removed_from_lb` in `cert_server.rb` and `load_balancer_nexus.rb` to increment removal status.
>     - Add `removed_from_lb_set?` check in `nexus.rb` to verify load balancer removal completion.
>   - **Tests**:
>     - Add tests in `nexus_spec.rb` for `wait_lb_expiry` to verify behavior when VM is not fully removed from load balancer.
>     - Add tests in `cert_server_spec.rb` for `remove_cert_server` to ensure `incr_removed_from_lb` is called.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a886f37ba86efe485024d74924f84add99f2f038. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->