### PR TITLE
Use the Roda response_content_type plugin

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -67,6 +67,14 @@ class Clover < Roda
     UBID.to_uuid(s)
   end
 
+  plugin :response_content_type,
+    mime_types: {
+      json: "application/json",
+      pdf: "application/pdf",
+      pem: "application/x-pem-file",
+      text: "text/plain"
+    }
+
   # :nocov:
   if Config.test? && defined?(SimpleCov)
     plugin :render_coverage
@@ -855,7 +863,7 @@ class Clover < Roda
     if api?
       unless /\ABearer:?\s+pat-/i.match?(env["HTTP_AUTHORIZATION"].to_s)
         if r.path_info == "/cli"
-          response["content-type"] = "text/plain"
+          response.content_type = :text
           response.status = 400
           next "! Invalid request: No valid personal access token provided\n"
         else

--- a/routes/cli.rb
+++ b/routes/cli.rb
@@ -5,7 +5,7 @@ class Clover
     r.post api? do
       no_authorization_needed
       no_audit_log
-      response["content-type"] = "text/plain"
+      response.content_type = :text
 
       unless (argv = r.POST["argv"]).is_a?(Array) && argv.all?(String)
         response.status = 400

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -8,7 +8,7 @@ class Clover
     r.web do
       unless (Stripe.api_key = Config.stripe_secret_key)
         response.status = 501
-        response["content-type"] = "text/plain"
+        response.content_type = :text
         next "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
       end
 
@@ -175,7 +175,7 @@ class Clover
         if invoice.status == "current"
           view "project/invoice"
         else
-          response["content-type"] = "application/pdf"
+          response.content_type = :pdf
           response["content-disposition"] = "inline; filename=\"#{invoice.filename}\""
           begin
             Invoice.blob_storage_client.get_object(bucket: Config.invoices_bucket_name, key: invoice.blob_key).body.read

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -5,7 +5,7 @@ class Clover
     r.web do
       unless Config.github_app_name
         response.status = 501
-        response["content-type"] = "text/plain"
+        response.content_type = :text
         next "GitHub Action Runner integration is not enabled. Set GITHUB_APP_NAME to enable it."
       end
 

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -47,7 +47,7 @@ class Clover
       r.get "kubeconfig" do
         authorize("KubernetesCluster:edit", kc.id)
 
-        response["content-type"] = "text/plain"
+        response.content_type = :text
         response["content-disposition"] = "attachment; filename=\"#{kc.name}-kubeconfig.yaml\""
         kc.kubeconfig
       end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -386,7 +386,7 @@ class Clover
         next unless (certs = pg.ca_certificates)
 
         response.headers["content-disposition"] = "attachment; filename=\"#{pg.name}.pem\""
-        response.headers["content-type"] = "application/x-pem-file"
+        response.content_type = :pem
         certs
       end
 

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -6,7 +6,7 @@ class Clover
       body = r.body.read
       next 401 unless check_signature(r.headers["x-hub-signature-256"], body)
 
-      response.headers["content-type"] = "application/json"
+      response.content_type = :json
 
       data = JSON.parse(body)
       case r.headers["x-github-event"]


### PR DESCRIPTION
This results in slightly simpler code in the routes. It also allows you to see what non-html mime types Clover uses in a single place.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce `response_content_type` plugin to centralize MIME type handling and simplify response content type setting across routes.
> 
>   - **Plugins**:
>     - Add `response_content_type` plugin in `clover.rb` with MIME types for `json`, `pdf`, `pem`, and `text`.
>   - **Routes**:
>     - Replace `response["content-type"]` with `response.content_type` in `clover.rb`, `routes/cli.rb`, `routes/project/billing.rb`, `routes/project/github.rb`, `routes/project/location/kubernetes_cluster.rb`, `routes/project/location/postgres.rb`, and `routes/webhook/github.rb`.
>     - Specific changes include setting `response.content_type = :text` for plain text responses and `response.content_type = :pdf` for PDF responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 93d3a3325408000bbf7024d8b75d81a389ecfc9c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->