### PR TITLE
Don't set cache-control no-store for a redirect

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -25,9 +25,9 @@ class Clover
       r.is do
         r.get do
           authorize("Postgres:view", pg.id)
-          response.headers["cache-control"] = "no-store"
 
           if api?
+            response.headers["cache-control"] = "no-store"
             Serializers::Postgres.serialize(pg, {detailed: true})
           else
             r.redirect "#{@project.path}#{pg.path}/overview"


### PR DESCRIPTION
This was originally set in 60f76c1994745f7a48a7d7eb509c3f664e24005a to avoid caching pages with sensitive data.  However, when the postgres show page was split into separate pages, this route changed to a redirect in the web case.

The postgres show page already has the no-store setting for all pages, not just ones with sensitive data.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `cache-control: no-store` header for web redirects in `postgres.rb`, retaining it for API requests.
> 
>   - **Behavior**:
>     - Removes `cache-control: no-store` header for web redirects in `postgres.rb`.
>     - Retains `cache-control: no-store` for API requests to prevent caching sensitive data.
>   - **Context**:
>     - Aligns with existing behavior of Postgres show page, which handles `no-store` for sensitive data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5bc74110c61cbc218b09ffd1b3e5bf800337697c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->