### PR TITLE
Allow application_name in PG configs

### DIFF
--- a/lib/validation/postgres_config_validator_schema.rb
+++ b/lib/validation/postgres_config_validator_schema.rb
@@ -34,6 +34,11 @@ module Validation
         type: :bool,
         default: "off"
       },
+      "application_name" => {
+        description: "Sets the application name for the session.",
+        type: :string,
+        default: ""
+      },
       "archive_cleanup_command" => {
         description: "Sets the shell command that will be executed at every restart point.",
         type: :string
@@ -2144,6 +2149,11 @@ module Validation
         description: "Allows modifications of the structure of system tables.",
         type: :bool,
         default: "off"
+      },
+      "application_name" => {
+        description: "Sets the application name for the session.",
+        type: :string,
+        default: ""
       },
       "archive_cleanup_command" => {
         description: "Sets the shell command that will be executed at every restart point.",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `application_name` configuration to PostgreSQL schemas for PG 16 and PG 17, allowing session-specific application names.
> 
>   - **Behavior**:
>     - Adds `application_name` configuration to `PG_17_CONFIG_SCHEMA` and `PG_16_CONFIG_SCHEMA` in `postgres_config_validator_schema.rb`.
>     - `application_name` allows setting a session-specific application name, defaulting to an empty string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1b721f824ebeb2e3bc76a150d610de71e8a2bd1b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->