### PR TITLE
Log blob storage setup completion

### DIFF
--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -79,6 +79,7 @@ class GithubRepository < Sequel::Model
 
       token_id, token = CloudflareClient.new(Config.github_cache_blob_storage_api_key).create_token("#{bucket_name}-token", policies)
       update(access_key: token_id, secret_key: Digest::SHA256.hexdigest(token))
+      Clog.emit("Blob storage setup completed") { {blob_storage_setup_completed: {bucket_name:}} }
     end
   end
 

--- a/spec/model/github/github_repository_spec.rb
+++ b/spec/model/github/github_repository_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe GithubRepository do
       expect(cloudflare_client).to receive(:create_token).with("gph0hh0ahdbj6ng2cc3rvdecr8-token", expected_policy).and_return(["test-key", "test-secret"])
       expect(github_repository).to receive(:update).with(access_key: "test-key", secret_key: Digest::SHA256.hexdigest("test-secret"))
       expect(github_repository).to receive(:lock!)
+      expect(Clog).to receive(:emit).with("Blob storage setup completed").and_return({blob_storage_setup_completed: {bucket_name: "gph0hh0ahdbj6ng2cc3rvdecr8"}})
       github_repository.setup_blob_storage
     end
 


### PR DESCRIPTION
We delete buckets if they have a blob storage created but no cache entries used for 7 days. For some buckets deletion keeps being triggered even though no cache entries exist. My suspicion is that these buckets are created through cache endpoints that don’t actually create entries which then triggers the deletion logic.

To validate this theory, I’m adding a log to capture when buckets are created.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add logging to `setup_blob_storage` in `github_repository.rb` to track blob storage setup completion and update tests accordingly.
> 
>   - **Behavior**:
>     - Adds logging in `setup_blob_storage` in `github_repository.rb` to emit "Blob storage setup completed" with `bucket_name`.
>   - **Tests**:
>     - Updates `setup_blob_storage` test in `github_repository_spec.rb` to expect `Clog.emit` call with "Blob storage setup completed" and `bucket_name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9fd2b945b2011c331f1a035a5b2865a1f67ffced. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->