### PR TITLE
Make `StorageKeyEncryption.read_encrypted_dek` backward compatible.

### DIFF
--- a/rhizome/host/lib/storage_key_encryption.rb
+++ b/rhizome/host/lib/storage_key_encryption.rb
@@ -28,8 +28,8 @@ class StorageKeyEncryption
     data_encryption_key = JSON.parse(File.read(key_file))
     wrapped_key1_b64 = data_encryption_key["key"]
     wrapped_key2_b64 = data_encryption_key["key2"]
-    wrapped_key1 = wrapped_key1_b64.map { |s| Base64.strict_decode64(s) }
-    wrapped_key2 = wrapped_key2_b64.map { |s| Base64.strict_decode64(s) }
+    wrapped_key1 = wrapped_key1_b64.map { |s| Base64.decode64(s) }
+    wrapped_key2 = wrapped_key2_b64.map { |s| Base64.decode64(s) }
     {
       cipher: data_encryption_key["cipher"],
       key: unwrap_key(wrapped_key1),


### PR DESCRIPTION
Previously, wrapped DEKs written to `data_encryption_key.json` were encoded using `Base64.encode64`, which inserted a newline every 60 characters and always appended a trailing newline. Later, this was changed to `Base64.strict_encode64`, which produces a single uninterrupted string.

While `Base64.decode64` can handle both formats, `Base64.strict_decode64` fails if newlines are present.

Since `StorageKeyEncryption.read_encrypted_dek` is called when starting old VMs after a server reboot, it must remain backward compatible.

This change updates `StorageKeyEncryption.read_encrypted_dek` to use `Base64.decode64`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `StorageKeyEncryption.read_encrypted_dek` now uses `Base64.decode64` for backward compatibility with newline-encoded DEKs.
> 
>   - **Behavior**:
>     - `StorageKeyEncryption.read_encrypted_dek` now uses `Base64.decode64` instead of `Base64.strict_decode64` to handle DEKs with or without newlines.
>     - Ensures backward compatibility for DEKs encoded with `Base64.encode64`.
>   - **Tests**:
>     - Added tests in `storage_key_encryption_spec.rb` to verify `read_encrypted_dek` can read DEKs encoded with both `Base64.encode64` and `Base64.strict_encode64`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5c905c39c4101d44927233823cabd1c29dba8ed2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->