### PR TITLE
Clarify hetzner env variables in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To get the user credentials, create a user according to
 The SSH key is the one you set when you created the robot server.
 
 The first thing to make sure is you use the hetzner robot rescue system to
-install ubuntu. Either 22.04 or 24.04 is fine.
+install ubuntu 24.04.
 
 Then, run the following script for each instance to cloudify it.
 Currently, the script cloudifies bare metal instances leased from Hetzner.


### PR DESCRIPTION
I was following the tutorial setting up with my own hetzner hardware, and it took me a while to figure out which user the docs were referring to when setting the hetzner env variables, when cloudifying the server.

I've clarified that in this commit, to hopefully save someone else some figuring out
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies Hetzner user credentials and SSH key usage in `README.md` for setting environment variables.
> 
>   - **Documentation**:
>     - Clarifies user credentials for Hetzner environment variables in `README.md`.
>     - Adds link to Hetzner user creation instructions and specifies SSH key usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 81f0505f4b2eefb143b05cab394c4e677ab9c34e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->