### PR TITLE
Allow CLI arguments/options to accept name instead of id

### DIFF
--- a/cli-commands/fw/post/attach-subnet.rb
+++ b/cli-commands/fw/post/attach-subnet.rb
@@ -3,12 +3,12 @@
 UbiCli.on("fw").run_on("attach-subnet") do
   desc "Attach a private subnet to a firewall"
 
-  banner "ubi fw (location/fw-name | fw-id) attach-subnet ps-id"
+  banner "ubi fw (location/fw-name | fw-id) attach-subnet (ps-name | ps-id)"
 
   args 1
 
   run do |subnet_id|
-    id = sdk_object.attach_subnet(subnet_id).id
-    response("Attached private subnet with id #{subnet_id} to firewall with id #{id}")
+    id = sdk_object.attach_subnet(convert_name_to_id(sdk.private_subnet, subnet_id)).id
+    response("Attached private subnet #{subnet_id} to firewall with id #{id}")
   end
 end

--- a/cli-commands/fw/post/detach-subnet.rb
+++ b/cli-commands/fw/post/detach-subnet.rb
@@ -3,12 +3,12 @@
 UbiCli.on("fw").run_on("detach-subnet") do
   desc "Detch a private subnet from a firewall"
 
-  banner "ubi fw (location/fw-name | fw-id) detach-subnet ps-id"
+  banner "ubi fw (location/fw-name | fw-id) detach-subnet (ps-name | ps-id)"
 
   args 1
 
   run do |subnet_id|
-    id = sdk_object.detach_subnet(subnet_id).id
-    response("Detached private subnet with id #{subnet_id} from firewall with id #{id}")
+    id = sdk_object.detach_subnet(convert_name_to_id(sdk.private_subnet, subnet_id)).id
+    response("Detached private subnet #{subnet_id} from firewall with id #{id}")
   end
 end

--- a/cli-commands/lb/post/attach-vm.rb
+++ b/cli-commands/lb/post/attach-vm.rb
@@ -3,12 +3,12 @@
 UbiCli.on("lb").run_on("attach-vm") do
   desc "Attach a virtual machine to a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) attach-vm vm-id"
+  banner "ubi lb (location/lb-name | lb-id) attach-vm (vm-name | vm-id)"
 
   args 1
 
   run do |vm_id|
-    id = sdk_object.attach_vm(vm_id).id
-    response("Attached VM with id #{vm_id} to load balancer with id #{id}")
+    id = sdk_object.attach_vm(convert_name_to_id(sdk.vm, vm_id)).id
+    response("Attached VM #{vm_id} to load balancer with id #{id}")
   end
 end

--- a/cli-commands/lb/post/create.rb
+++ b/cli-commands/lb/post/create.rb
@@ -6,7 +6,7 @@ UbiCli.on("lb").run_on("create") do
   health_check_protocols = %w[http https tcp].freeze.each(&:freeze)
   stacks = %w[dual ipv4 ipv6].freeze.each(&:freeze)
 
-  options("ubi lb location/lb-name create [options] ps-id src-port dst-port", key: :lb_create) do
+  options("ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port", key: :lb_create) do
     on("-a", "--algorithm=alg", algorithms, "set the algorithm to use")
     on("-e", "--check-endpoint=path", "set the health check endpoint (default: #{Prog::Vnet::LoadBalancerNexus::DEFAULT_HEALTH_CHECK_ENDPOINT})")
     on("-p", "--check-protocol=proto", health_check_protocols, "set the health check protocol")
@@ -19,6 +19,7 @@ UbiCli.on("lb").run_on("create") do
   args 3
 
   run do |private_subnet_id, src_port, dst_port, opts, cmd|
+    private_subnet_id = convert_name_to_id(sdk.private_subnet, private_subnet_id)
     params = underscore_keys(opts[:lb_create])
     if (endpoint = params.delete(:check_endpoint))
       params[:health_check_endpoint] = endpoint

--- a/cli-commands/lb/post/detach-vm.rb
+++ b/cli-commands/lb/post/detach-vm.rb
@@ -3,12 +3,12 @@
 UbiCli.on("lb").run_on("detach-vm") do
   desc "Detach a virtual machine from a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) detach-vm vm-id"
+  banner "ubi lb (location/lb-name | lb-id) detach-vm (vm-name | vm-id)"
 
   args 1
 
   run do |vm_id|
-    id = sdk_object.detach_vm(vm_id).id
-    response("Detached VM with id #{vm_id} from load balancer with id #{id}")
+    id = sdk_object.detach_vm(convert_name_to_id(sdk.vm, vm_id)).id
+    response("Detached VM #{vm_id} from load balancer with id #{id}")
   end
 end

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -3,7 +3,7 @@
 UbiCli.on("lb").run_on("update") do
   desc "Update a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]"
+  banner "ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [(vm-name | vm-id) [...]]"
 
   args(4...)
 
@@ -11,7 +11,7 @@ UbiCli.on("lb").run_on("update") do
     algorithm, src_port, dst_port, health_check_endpoint, *vms = argv
     src_port = need_integer_arg(src_port, "src-port", cmd)
     dst_port = need_integer_arg(dst_port, "dst-port", cmd)
-    id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, vms:).id
+    id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, vms: vms.map { convert_name_to_id(sdk.vm, it) }).id
     response("Updated load balancer with id #{id}")
   end
 end

--- a/cli-commands/ps/post/connect.rb
+++ b/cli-commands/ps/post/connect.rb
@@ -3,12 +3,12 @@
 UbiCli.on("ps").run_on("connect") do
   desc "Connect a private subnet to another private subnet"
 
-  banner "ubi ps (location/ps-name | ps-id) connect ps-id"
+  banner "ubi ps (location/ps-name | ps-id) connect (location/ps-name | ps-id)"
 
   args 1
 
   run do |ps_id|
-    id = sdk_object.connect(ps_id).id
-    response("Connected private subnets with ids #{ps_id} and #{id}")
+    id = sdk_object.connect(convert_loc_name_to_id(sdk.private_subnet, ps_id)).id
+    response("Connected private subnet #{ps_id} to #{id}")
   end
 end

--- a/cli-commands/ps/post/create.rb
+++ b/cli-commands/ps/post/create.rb
@@ -4,11 +4,14 @@ UbiCli.on("ps").run_on("create") do
   desc "Create a private subnet"
 
   options("ubi ps location/ps-name create [options]", key: :ps_create) do
-    on("-f", "--firewall-id=id", "add to given firewall")
+    on("-f", "--firewall-id=fw-id-or-name", "add to given firewall")
   end
 
   run do |opts|
     params = underscore_keys(opts[:ps_create])
+    if params[:firewall_id]
+      params[:firewall_id] = convert_name_to_id(sdk.firewall, params[:firewall_id])
+    end
     id = sdk.private_subnet.create(location: @location, name: @name, **params).id
     response("Private subnet created with id: #{id}")
   end

--- a/cli-commands/ps/post/disconnect.rb
+++ b/cli-commands/ps/post/disconnect.rb
@@ -3,13 +3,15 @@
 UbiCli.on("ps").run_on("disconnect") do
   desc "Disconnect a private subnet from another private subnet"
 
-  banner "ubi ps (location/ps-name | ps-id) disconnect ps-id"
+  banner "ubi ps (location/ps-name | ps-id) disconnect (location/ps-name | ps-id)"
 
   args 1
 
   run do |ps_id, _, cmd|
+    arg = ps_id
+    ps_id = convert_loc_name_to_id(sdk.private_subnet, ps_id)
     check_no_slash(ps_id, "invalid private subnet id format", cmd)
     id = sdk_object.disconnect(ps_id).id
-    response("Disconnected private subnets with ids #{ps_id} and #{id}")
+    response("Disconnected private subnet #{arg} from #{id}")
   end
 end

--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -10,7 +10,7 @@ UbiCli.on("vm").run_on("create") do
   options("ubi vm location/vm-name create [options] public_key", key: :vm_create) do
     on("-6", "--ipv6-only", "do not enable IPv4")
     on("-b", "--boot-image=image_name", Option::BootImages.map(&:name), "boot image")
-    on("-p", "--private-subnet-id=id", "place VM into specific private subnet")
+    on("-p", "--private-subnet-id=ps-id", "place VM into specific private subnet (also accepts ps-name)")
     on("-s", "--size=size", server_sizes, "server size")
     on("-S", "--storage-size=size", storage_sizes, "storage size")
     on("-u", "--unix-user=username", "username (default: ubi)")
@@ -28,6 +28,9 @@ UbiCli.on("vm").run_on("create") do
     params = underscore_keys(opts[:vm_create])
     unless params.delete(:ipv6_only)
       params[:enable_ip4] = "1"
+    end
+    if params[:private_subnet_id]
+      params[:private_subnet_id] = convert_name_to_id(sdk.private_subnet, params[:private_subnet_id])
     end
 
     unless Vm::VALID_SSH_AUTHORIZED_KEYS.match?(public_key)

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -430,6 +430,12 @@ class UbiCli
     end || name
   end
 
+  def convert_loc_name_to_id(model_adapter, loc_name)
+    if !model_adapter.id_regexp.match?(loc_name) && loc_name.count("/") == 1
+      id_for_loc_name(model_adapter, loc_name)
+    end || loc_name
+  end
+
   def id_for_loc_name(model_adapter, loc_name)
     _, name, extra = loc_name.split("/", 3)
     if name && !extra

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -32,7 +32,8 @@ class UbiCli
   LOWERCASE_LABELS["ak"] = "inference API key"
   LOWERCASE_LABELS.freeze
 
-  OBJECT_INFO_REGEXP = /((fw|kc|1b|pg|ps|vm)[a-z0-9]{24})/
+  OBJECT_INFO_REGEXP = /((fw|kc|1b|pg|ps|vm)[a-tv-z0-9]{24})/
+  EXACT_OBJECT_INFO_REGEXP = /\A#{OBJECT_INFO_REGEXP}\z/
   UBI_VERSION_REGEXP = /\A\d{1,4}\.\d{1,4}\.\d{1,4}\z/
 
   Rodish.processor(self)
@@ -111,7 +112,7 @@ class UbiCli
 
         @location, @name, extra = ref.split("/", 3)
 
-        if !@name && OBJECT_INFO_REGEXP.match?(@location)
+        if !@name && EXACT_OBJECT_INFO_REGEXP.match?(@location)
           unless (object = sdk[@location])
             raise Rodish::CommandFailure.new("no #{label} with id #{@location} exists", command)
           end

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -424,6 +424,21 @@ class UbiCli
     sdk.send(@sdk_method).new("#{@location}/#{@name}")
   end
 
+  def convert_name_to_id(model_adapter, name)
+    unless model_adapter.id_regexp.match?(name)
+      id_for_loc_name(model_adapter, "#{@location}/#{name}")
+    end || name
+  end
+
+  def id_for_loc_name(model_adapter, loc_name)
+    _, name, extra = loc_name.split("/", 3)
+    if name && !extra
+      obj = model_adapter.new(loc_name)
+      obj.info
+      obj.id
+    end
+  end
+
   def finalize_response(res)
     headers = res[1]
     body = res[2]

--- a/sdk/ruby/lib/ubicloud/model_adapter.rb
+++ b/sdk/ruby/lib/ubicloud/model_adapter.rb
@@ -11,6 +11,11 @@ module Ubicloud
       @adapter = adapter
     end
 
+    # Return the id regexp for the model.
+    def id_regexp
+      @model.id_regexp
+    end
+
     # Forward methods to the model class, but include the
     # adapter as the first argument.
     def method_missing(meth, ...)

--- a/spec/routes/api/cli/fw/attach-subnet_spec.rb
+++ b/spec/routes/api/cli/fw/attach-subnet_spec.rb
@@ -11,9 +11,15 @@ RSpec.describe Clover, "cli fw attach-subnet" do
     @fw = Firewall.exclude(id: fw.id).first
   end
 
-  it "attaches firewall to subnet" do
+  it "attaches firewall to subnet by id" do
     expect(@fw.private_subnets).to be_empty
-    expect(cli(%W[fw eu-central-h1/test-fw attach-subnet #{@ps.ubid}])).to eq "Attached private subnet with id #{@ps.ubid} to firewall with id #{@fw.ubid}\n"
+    expect(cli(%W[fw eu-central-h1/test-fw attach-subnet #{@ps.ubid}])).to eq "Attached private subnet #{@ps.ubid} to firewall with id #{@fw.ubid}\n"
+    expect(@fw.reload.private_subnets.map(&:ubid)).to eq [@ps.ubid]
+  end
+
+  it "attaches firewall to subnet by name" do
+    expect(@fw.private_subnets).to be_empty
+    expect(cli(%W[fw eu-central-h1/test-fw attach-subnet test-ps])).to eq "Attached private subnet test-ps to firewall with id #{@fw.ubid}\n"
     expect(@fw.reload.private_subnets.map(&:ubid)).to eq [@ps.ubid]
   end
 end

--- a/spec/routes/api/cli/fw/detach-subnet_spec.rb
+++ b/spec/routes/api/cli/fw/detach-subnet_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe Clover, "cli fw attach-subnet" do
     @fw = Firewall.first
   end
 
-  it "detaches firewall from subnet" do
+  it "detaches firewall from subnet by id" do
     expect(@fw.private_subnets.map(&:ubid)).to eq [@ps.ubid]
-    expect(cli(%W[fw eu-central-h1/#{@fw.name} detach-subnet #{@ps.ubid}])).to eq "Detached private subnet with id #{@ps.ubid} from firewall with id #{@fw.ubid}\n"
+    expect(cli(%W[fw eu-central-h1/#{@fw.name} detach-subnet #{@ps.ubid}])).to eq "Detached private subnet #{@ps.ubid} from firewall with id #{@fw.ubid}\n"
+    expect(@fw.reload.private_subnets).to be_empty
+  end
+
+  it "detaches firewall from subnet by name" do
+    expect(@fw.private_subnets.map(&:ubid)).to eq [@ps.ubid]
+    expect(cli(%W[fw eu-central-h1/#{@fw.name} detach-subnet test-ps])).to eq "Detached private subnet test-ps from firewall with id #{@fw.ubid}\n"
     expect(@fw.reload.private_subnets).to be_empty
   end
 end

--- a/spec/routes/api/cli/golden-file-commands/error.txt
+++ b/spec/routes/api/cli/golden-file-commands/error.txt
@@ -35,6 +35,7 @@ lb eu-central-h1/test2-lb create -p bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321
 lb eu-central-h1/test2-lb create -s bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321
 lb eu-central-h1/test-lb show -f bad
 lb eu-central-h1/test-lb attach-vm vmdzyppz6j166jh5e9t2dwrfas
+lb eu-central-h1/test-lb attach-vm foo/vmdzyppz6j166jh5e9t2dwrfas
 lb eu-central-h1/test-lb update bad 1234 54321 /up2 vmdzyppz6j166jh5e9t2dwrfas
 lb eu-central-h1/test-lb update https a 54321 /up2 vmdzyppz6j166jh5e9t2dwrfas
 lb eu-central-h1/test-lb update https 54321 a /up2 vmdzyppz6j166jh5e9t2dwrfas

--- a/spec/routes/api/cli/golden-file-commands/error.txt
+++ b/spec/routes/api/cli/golden-file-commands/error.txt
@@ -69,7 +69,6 @@ pg eu-central-h1/test-pg -X pg_dump
 pg list -f invalid
 pg list invalid
 ps eu-central-h1/test-ps connect psfzm3e26xky5m9ggetw4dpqe2
-ps eu-central-h1/test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2/foo
 ps eu-central-h1/test-ps disconnect psfzm3e26xky5m9ggetw4dpqe2
 ps eu-central-h1/test2-ps create invalid
 ps eu-central-h1/test-ps destroy invalid

--- a/spec/routes/api/cli/golden-file-commands/error.txt
+++ b/spec/routes/api/cli/golden-file-commands/error.txt
@@ -88,6 +88,7 @@ vm eu-central-h1/test-vm -X sftp
 vm list invalid
 vm vmdzyppz6j166jh5e9t0dwrfas show
 vm vmdzyppz6j166jh5e9t0dwrfa show
+vm vmdzyppz6j166jh5e9t2dwrfasa show
 kc eu-central-h1/test-kc create invalid
 kc eu-central-h1/test-kc create -c a
 kc eu-central-h1/test-kc create -c 1 -w bad

--- a/spec/routes/api/cli/golden-file-commands/missing.txt
+++ b/spec/routes/api/cli/golden-file-commands/missing.txt
@@ -1,0 +1,1 @@
+ps eu-central-h1/test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2/foo

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default detach-subnet psfzm9e26xky5m9ggetw4dpqe2.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default detach-subnet psfzm9e26xky5m9ggetw4dpqe2.txt
@@ -1,1 +1,1 @@
-Detached private subnet with id psfzm9e26xky5m9ggetw4dpqe2 from firewall with id fw4gj2v4h1fe3q28q0hnf7g8n1
+Detached private subnet psfzm9e26xky5m9ggetw4dpqe2 from firewall with id fw4gj2v4h1fe3q28q0hnf7g8n1

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default attach-subnet psfzm9e26xky5m9ggetw4dpqe2.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_test-ps-default attach-subnet psfzm9e26xky5m9ggetw4dpqe2.txt
@@ -1,1 +1,1 @@
-Attached private subnet with id psfzm9e26xky5m9ggetw4dpqe2 to firewall with id fwx623er9tyy2q9n1e2c55kvkc
+Attached private subnet psfzm9e26xky5m9ggetw4dpqe2 to firewall with id fwx623er9tyy2q9n1e2c55kvkc

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -49,7 +49,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -120,7 +120,7 @@ Options:
 Attach a private subnet to a firewall
 
 Usage:
-    ubi fw (location/fw-name | fw-id) attach-subnet ps-id
+    ubi fw (location/fw-name | fw-id) attach-subnet (ps-name | ps-id)
 
 
 Create a firewall

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -788,7 +788,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -315,7 +315,7 @@ Usage:
 Create a load balancer
 
 Usage:
-    ubi lb location/lb-name create [options] ps-id src-port dst-port
+    ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 
 Options:
     -a, --algorithm=alg              set the algorithm to use

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -704,7 +704,7 @@ Options:
 Disconnect a private subnet from another private subnet
 
 Usage:
-    ubi ps (location/ps-name | ps-id) disconnect ps-id
+    ubi ps (location/ps-name | ps-id) disconnect (location/ps-name | ps-id)
 
 
 Rename a private subnet

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -367,7 +367,7 @@ Allowed Option Values:
 Update a load balancer
 
 Usage:
-    ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+    ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [(vm-name | vm-id) [...]]
 
 
 Manage PostgreSQL databases

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -689,7 +689,7 @@ Usage:
     ubi ps location/ps-name create [options]
 
 Options:
-    -f, --firewall-id=id             add to given firewall
+    -f, --firewall-id=fw-id-or-name  add to given firewall
 
 
 Destroy a private subnet

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -341,7 +341,7 @@ Options:
 Detach a virtual machine from a load balancer
 
 Usage:
-    ubi lb (location/lb-name | lb-id) detach-vm vm-id
+    ubi lb (location/lb-name | lb-id) detach-vm (vm-name | vm-id)
 
 
 Rename a load balancer

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -680,7 +680,7 @@ Allowed Option Values:
 Connect a private subnet to another private subnet
 
 Usage:
-    ubi ps (location/ps-name | ps-id) connect ps-id
+    ubi ps (location/ps-name | ps-id) connect (location/ps-name | ps-id)
 
 
 Create a private subnet

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -309,7 +309,7 @@ Allowed Option Values:
 Attach a virtual machine to a load balancer
 
 Usage:
-    ubi lb (location/lb-name | lb-id) attach-vm vm-id
+    ubi lb (location/lb-name | lb-id) attach-vm (vm-name | vm-id)
 
 
 Create a load balancer

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -150,7 +150,7 @@ Options:
 Detch a private subnet from a firewall
 
 Usage:
-    ubi fw (location/fw-name | fw-id) detach-subnet ps-id
+    ubi fw (location/fw-name | fw-id) detach-subnet (ps-name | ps-id)
 
 
 Rename a firewall

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -29,7 +29,7 @@ ubi kc (location/kc-name | kc-id) show [options]
 ubi lb command [...]
 ubi lb (location/lb-name | lb-id) post-command [...]
 ubi lb list [options]
-ubi lb (location/lb-name | lb-id) attach-vm vm-id
+ubi lb (location/lb-name | lb-id) attach-vm (vm-name | vm-id)
 ubi lb location/lb-name create [options] ps-id src-port dst-port
 ubi lb (location/lb-name | lb-id) destroy [options]
 ubi lb (location/lb-name | lb-id) detach-vm vm-id

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -14,7 +14,7 @@ ubi fw (location/fw-name | fw-id) attach-subnet (ps-name | ps-id)
 ubi fw location/fw-name create [options]
 ubi fw (location/fw-name | fw-id) delete-rule rule-id
 ubi fw (location/fw-name | fw-id) destroy [options]
-ubi fw (location/fw-name | fw-id) detach-subnet ps-id
+ubi fw (location/fw-name | fw-id) detach-subnet (ps-name | ps-id)
 ubi fw (location/fw-name | fw-id) rename new-name
 ubi fw (location/fw-name | fw-id) show [options]
 ubi help [options] [command [subcommand]]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -71,7 +71,7 @@ ubi ps list [options]
 ubi ps (location/ps-name | ps-id) connect (location/ps-name | ps-id)
 ubi ps location/ps-name create [options]
 ubi ps (location/ps-name | ps-id) destroy [options]
-ubi ps (location/ps-name | ps-id) disconnect ps-id
+ubi ps (location/ps-name | ps-id) disconnect (location/ps-name | ps-id)
 ubi ps (location/ps-name | ps-id) rename new-name
 ubi ps (location/ps-name | ps-id) show [options]
 ubi version

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -10,7 +10,7 @@ ubi fw command [...]
 ubi fw (location/fw-name | fw-id) post-command [...]
 ubi fw list [options]
 ubi fw (location/fw-name | fw-id) add-rule [options] cidr
-ubi fw (location/fw-name | fw-id) attach-subnet ps-id
+ubi fw (location/fw-name | fw-id) attach-subnet (ps-name | ps-id)
 ubi fw location/fw-name create [options]
 ubi fw (location/fw-name | fw-id) delete-rule rule-id
 ubi fw (location/fw-name | fw-id) destroy [options]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -35,7 +35,7 @@ ubi lb (location/lb-name | lb-id) destroy [options]
 ubi lb (location/lb-name | lb-id) detach-vm (vm-name | vm-id)
 ubi lb (location/lb-name | lb-id) rename new-name
 ubi lb (location/lb-name | lb-id) show [options]
-ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [(vm-name | vm-id) [...]]
 ubi pg command [...]
 ubi pg (location/pg-name | pg-id) [post-options] post-command [...]
 ubi pg list [options]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -68,7 +68,7 @@ ubi pg (location/pg-name | pg-id) show [options]
 ubi ps command [...]
 ubi ps (location/ps-name | ps-id) post-command [...]
 ubi ps list [options]
-ubi ps (location/ps-name | ps-id) connect ps-id
+ubi ps (location/ps-name | ps-id) connect (location/ps-name | ps-id)
 ubi ps location/ps-name create [options]
 ubi ps (location/ps-name | ps-id) destroy [options]
 ubi ps (location/ps-name | ps-id) disconnect ps-id

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -30,7 +30,7 @@ ubi lb command [...]
 ubi lb (location/lb-name | lb-id) post-command [...]
 ubi lb list [options]
 ubi lb (location/lb-name | lb-id) attach-vm (vm-name | vm-id)
-ubi lb location/lb-name create [options] ps-id src-port dst-port
+ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 ubi lb (location/lb-name | lb-id) destroy [options]
 ubi lb (location/lb-name | lb-id) detach-vm (vm-name | vm-id)
 ubi lb (location/lb-name | lb-id) rename new-name

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -32,7 +32,7 @@ ubi lb list [options]
 ubi lb (location/lb-name | lb-id) attach-vm (vm-name | vm-id)
 ubi lb location/lb-name create [options] ps-id src-port dst-port
 ubi lb (location/lb-name | lb-id) destroy [options]
-ubi lb (location/lb-name | lb-id) detach-vm vm-id
+ubi lb (location/lb-name | lb-id) detach-vm (vm-name | vm-id)
 ubi lb (location/lb-name | lb-id) rename new-name
 ubi lb (location/lb-name | lb-id) show [options]
 ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb attach-vm foo_vmdzyppz6j166jh5e9t2dwrfas.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb attach-vm foo_vmdzyppz6j166jh5e9t2dwrfas.txt
@@ -1,0 +1,3 @@
+! Unexpected response status: 400
+Details: Validation failed for following fields: vm_id
+  vm_id: No matching VM found in eu-central-h1

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb detach-vm vmdzyppz6j166jh5e9t2dwrfas.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb detach-vm vmdzyppz6j166jh5e9t2dwrfas.txt
@@ -1,1 +1,1 @@
-Detached VM with id vmdzyppz6j166jh5e9t2dwrfas from load balancer with id 1bvp8yk1karj4ngwhtgrfh6esd
+Detached VM vmdzyppz6j166jh5e9t2dwrfas from load balancer with id 1bvp8yk1karj4ngwhtgrfh6esd

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb update https 54321 a _up2 vmdzyppz6j166jh5e9t2dwrfas.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb update https 54321 a _up2 vmdzyppz6j166jh5e9t2dwrfas.txt
@@ -3,4 +3,4 @@
 Update a load balancer
 
 Usage:
-    ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+    ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [(vm-name | vm-id) [...]]

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb update https a 54321 _up2 vmdzyppz6j166jh5e9t2dwrfas.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb update https a 54321 _up2 vmdzyppz6j166jh5e9t2dwrfas.txt
@@ -3,4 +3,4 @@
 Update a load balancer
 
 Usage:
-    ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
+    ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [(vm-name | vm-id) [...]]

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create -a bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create -a bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321.txt
@@ -3,7 +3,7 @@
 Create a load balancer
 
 Usage:
-    ubi lb location/lb-name create [options] ps-id src-port dst-port
+    ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 
 Options:
     -a, --algorithm=alg              set the algorithm to use

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create -p bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create -p bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321.txt
@@ -3,7 +3,7 @@
 Create a load balancer
 
 Usage:
-    ubi lb location/lb-name create [options] ps-id src-port dst-port
+    ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 
 Options:
     -a, --algorithm=alg              set the algorithm to use

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create -s bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create -s bad psfzm9e26xky5m9ggetw4dpqe2 12345 54321.txt
@@ -3,7 +3,7 @@
 Create a load balancer
 
 Usage:
-    ubi lb location/lb-name create [options] ps-id src-port dst-port
+    ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 
 Options:
     -a, --algorithm=alg              set the algorithm to use

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create psfzm9e26xky5m9ggetw4dpqe2 54321 a.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create psfzm9e26xky5m9ggetw4dpqe2 54321 a.txt
@@ -3,7 +3,7 @@
 Create a load balancer
 
 Usage:
-    ubi lb location/lb-name create [options] ps-id src-port dst-port
+    ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 
 Options:
     -a, --algorithm=alg              set the algorithm to use

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create psfzm9e26xky5m9ggetw4dpqe2 a 54321.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create psfzm9e26xky5m9ggetw4dpqe2 a 54321.txt
@@ -3,7 +3,7 @@
 Create a load balancer
 
 Usage:
-    ubi lb location/lb-name create [options] ps-id src-port dst-port
+    ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 
 Options:
     -a, --algorithm=alg              set the algorithm to use

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test2-lb create.txt
@@ -3,7 +3,7 @@
 Create a load balancer
 
 Usage:
-    ubi lb location/lb-name create [options] ps-id src-port dst-port
+    ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port
 
 Options:
     -a, --algorithm=alg              set the algorithm to use

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps connect psfzm9e26xky5m9ggetw4dpqe2.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps connect psfzm9e26xky5m9ggetw4dpqe2.txt
@@ -1,1 +1,1 @@
-Connected private subnets with ids psfzm9e26xky5m9ggetw4dpqe2 and pshfgpzvs0t20gpezmz2kkk8e4
+Connected private subnet psfzm9e26xky5m9ggetw4dpqe2 to pshfgpzvs0t20gpezmz2kkk8e4

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2_foo.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2_foo.txt
@@ -1,6 +1,3 @@
-! Invalid private subnet id format
-
-Disconnect a private subnet from another private subnet
-
-Usage:
-    ubi ps (location/ps-name | ps-id) disconnect ps-id
+! Unexpected response status: 404
+Details: Validation failed for following path components: location
+  location: Given location is not a valid location. Available locations: eu-central-h1, eu-north-h1, us-east-a2

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_test2-ps create invalid.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_test2-ps create invalid.txt
@@ -6,4 +6,4 @@ Usage:
     ubi ps location/ps-name create [options]
 
 Options:
-    -f, --firewall-id=id             add to given firewall
+    -f, --firewall-id=fw-id-or-name  add to given firewall

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create  -s bad "a a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create  -s bad "a a".txt
@@ -12,7 +12,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create "# a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create "# a".txt
@@ -12,7 +12,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -S bad "a a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -S bad "a a".txt
@@ -12,7 +12,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -b bad "a a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -b bad "a a".txt
@@ -12,7 +12,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create a.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create a.txt
@@ -12,7 +12,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create.txt
@@ -12,7 +12,7 @@ Examples:
 Options:
     -6, --ipv6-only                  do not enable IPv4
     -b, --boot-image=image_name      boot image
-    -p, --private-subnet-id=id       place VM into specific private subnet
+    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
     -s, --size=size                  server size
     -S, --storage-size=size          storage size
     -u, --unix-user=username         username (default: ubi)

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfasa show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfasa show.txt
@@ -1,0 +1,24 @@
+! Invalid vm reference ("vmdzyppz6j166jh5e9t2dwrfasa"), should be in location/vm-name or vm-id format
+
+Manage virtual machines
+
+Usage:
+    ubi vm command [...]
+    ubi vm (location/vm-name | vm-id) [post-options] post-command [...]
+
+Commands:
+    list       List virtual machines
+
+Post Commands:
+    create     Create a virtual machine
+    destroy    Destroy a virtual machine
+    restart    Restart a virtual machine
+    scp        Copy files to or from virtual machine using `scp`
+    sftp       Copy files to or from virtual machine using `sftp`
+    show       Show details for a virtual machine
+    ssh        Connect to a virtual machine using `ssh`
+
+Post Options:
+    -4, --ip4                        use IPv4 address
+    -6, --ip6                        use IPv6 address
+    -u, --user user                  override username

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfasa show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfasa show.txt
@@ -12,6 +12,7 @@ Commands:
 Post Commands:
     create     Create a virtual machine
     destroy    Destroy a virtual machine
+    rename     Rename a virtual machine
     restart    Restart a virtual machine
     scp        Copy files to or from virtual machine using `scp`
     sftp       Copy files to or from virtual machine using `sftp`

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe Clover, "cli" do
     cli_commands = []
     cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/success.txt").map { [it, {}] }
     cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/error.txt").map { [it, {status: 400}] }
+    cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/missing.txt").map { [it, {status: 404}] }
     cli_commands.concat File.readlines("spec/routes/api/cli/golden-file-commands/confirm.txt").map { [it, {confirm_prompt: "Confirmation"}] }
     Dir["spec/routes/api/cli/golden-file-commands/execute/*.txt"].each do |f|
       cmd = File.basename(f).delete_suffix(".txt")

--- a/spec/routes/api/cli/lb/attach-vm_spec.rb
+++ b/spec/routes/api/cli/lb/attach-vm_spec.rb
@@ -12,9 +12,15 @@ RSpec.describe Clover, "cli lb attach-vm" do
     @lb = LoadBalancer.first
   end
 
-  it "attaches VM to load balancer" do
+  it "attaches VM to load balancer by id" do
     expect(@lb.vms).to be_empty
-    expect(cli(%W[lb eu-central-h1/test-lb attach-vm #{@vm.ubid}])).to eq "Attached VM with id #{@vm.ubid} to load balancer with id #{@lb.ubid}\n"
+    expect(cli(%W[lb eu-central-h1/test-lb attach-vm #{@vm.ubid}])).to eq "Attached VM #{@vm.ubid} to load balancer with id #{@lb.ubid}\n"
+    expect(@lb.reload.vms.map(&:ubid)).to eq [@vm.ubid]
+  end
+
+  it "attaches VM to load balancer by name" do
+    expect(@lb.vms).to be_empty
+    expect(cli(%W[lb eu-central-h1/test-lb attach-vm test-vm])).to eq "Attached VM test-vm to load balancer with id #{@lb.ubid}\n"
     expect(@lb.reload.vms.map(&:ubid)).to eq [@vm.ubid]
   end
 end

--- a/spec/routes/api/cli/lb/create_spec.rb
+++ b/spec/routes/api/cli/lb/create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Clover, "cli lb create" do
     @ps = PrivateSubnet.first
   end
 
-  it "creates load balancer with no option" do
+  it "creates load balancer with no option and private subnet by id" do
     expect(LoadBalancer.count).to eq 0
     body = cli(%W[lb eu-central-h1/test-lb create #{@ps.ubid} 12345 54321])
     expect(LoadBalancer.count).to eq 1
@@ -25,9 +25,9 @@ RSpec.describe Clover, "cli lb create" do
     expect(body).to eq "Load balancer created with id: #{lb.ubid}\n"
   end
 
-  it "creates load balancer with -aeps options" do
+  it "creates load balancer with -aeps options and private subnet by name" do
     expect(LoadBalancer.count).to eq 0
-    body = cli(%W[lb eu-central-h1/test-lb create -a hash_based -e /up2 -p https -s ipv4 #{@ps.ubid} 1234 5432])
+    body = cli(%W[lb eu-central-h1/test-lb create -a hash_based -e /up2 -p https -s ipv4 test-ps 1234 5432])
     expect(LoadBalancer.count).to eq 1
     lb = LoadBalancer.first
     expect(lb).to be_a LoadBalancer

--- a/spec/routes/api/cli/lb/detach-vm_spec.rb
+++ b/spec/routes/api/cli/lb/detach-vm_spec.rb
@@ -13,9 +13,15 @@ RSpec.describe Clover, "cli lb attach-vm" do
     @lb = LoadBalancer.first
   end
 
-  it "detaches VM from load balancer" do
+  it "detaches VM from load balancer by id" do
     expect(@lb.vm_ports_dataset.select_map(:state)).to eq ["down"]
-    expect(cli(%W[lb eu-central-h1/test-lb detach-vm #{@vm.ubid}])).to eq "Detached VM with id #{@vm.ubid} from load balancer with id #{@lb.ubid}\n"
+    expect(cli(%W[lb eu-central-h1/test-lb detach-vm #{@vm.ubid}])).to eq "Detached VM #{@vm.ubid} from load balancer with id #{@lb.ubid}\n"
+    expect(@lb.vm_ports_dataset.select_map(:state)).to eq ["detaching"]
+  end
+
+  it "detaches VM from load balancer by name" do
+    expect(@lb.vm_ports_dataset.select_map(:state)).to eq ["down"]
+    expect(cli(%W[lb eu-central-h1/test-lb detach-vm test-vm])).to eq "Detached VM test-vm from load balancer with id #{@lb.ubid}\n"
     expect(@lb.vm_ports_dataset.select_map(:state)).to eq ["detaching"]
   end
 end

--- a/spec/routes/api/cli/lb/update_spec.rb
+++ b/spec/routes/api/cli/lb/update_spec.rb
@@ -25,9 +25,20 @@ RSpec.describe Clover, "cli lb update" do
     expect(@lb.vms.map(&:ubid)).to eq [@vm1.ubid]
   end
 
-  it "adds new VMs the load balancer" do
+  it "adds new VMs the load balancer by id" do
     expect(@lb.vms.map(&:ubid)).to eq [@vm1.ubid]
     expect(cli(%W[lb eu-central-h1/test-lb update hash_based 1234 5432 /up2 #{@vm1.ubid} #{@vm2.ubid}])).to eq "Updated load balancer with id #{@lb.ubid}\n"
+    @lb.reload
+    expect(@lb.ports.first.src_port).to eq 1234
+    expect(@lb.ports.first.dst_port).to eq 5432
+    expect(@lb.algorithm).to eq "hash_based"
+    expect(@lb.health_check_endpoint).to eq "/up2"
+    expect(@lb.vms.map(&:ubid).sort).to eq [@vm1.ubid, @vm2.ubid].sort
+  end
+
+  it "adds new VMs the load balancer by name" do
+    expect(@lb.vms.map(&:ubid)).to eq [@vm1.ubid]
+    expect(cli(%W[lb eu-central-h1/test-lb update hash_based 1234 5432 /up2 test-vm test-vm2])).to eq "Updated load balancer with id #{@lb.ubid}\n"
     @lb.reload
     expect(@lb.ports.first.src_port).to eq 1234
     expect(@lb.ports.first.dst_port).to eq 5432

--- a/spec/routes/api/cli/ps/connect_spec.rb
+++ b/spec/routes/api/cli/ps/connect_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe Clover, "cli ps connect" do
     @ps1, @ps2 = PrivateSubnet.all
   end
 
-  it "connects requested private subnet to this subnet" do
+  it "connects requested private subnet to this subnet by id" do
     expect(ConnectedSubnet.count).to eq 0
-    expect(cli(%W[ps eu-central-h1/#{@ps1.name} connect #{@ps2.ubid}])).to eq "Connected private subnets with ids #{@ps2.ubid} and #{@ps1.ubid}\n"
+    expect(cli(%W[ps eu-central-h1/test-ps connect #{@ps2.ubid}])).to eq "Connected private subnet #{@ps2.ubid} to #{@ps1.ubid}\n"
+    expect(ConnectedSubnet.count).to eq 1
+  end
+
+  it "connects requested private subnet to this subnet by name" do
+    expect(ConnectedSubnet.count).to eq 0
+    expect(cli(%W[ps eu-central-h1/test-ps connect eu-central-h1/test-ps2])).to eq "Connected private subnet eu-central-h1/test-ps2 to #{@ps1.ubid}\n"
     expect(ConnectedSubnet.count).to eq 1
   end
 end

--- a/spec/routes/api/cli/ps/create_spec.rb
+++ b/spec/routes/api/cli/ps/create_spec.rb
@@ -17,10 +17,22 @@ RSpec.describe Clover, "cli ps create" do
     expect(body).to eq "Private subnet created with id: #{ps.ubid}\n"
   end
 
-  it "creates ps with -f option" do
+  it "creates ps with -f option with id" do
     fw = Firewall.create(project_id: @project.id, location_id: "1f214853-0bc4-8020-b910-dffb867ef44f")
     Firewall.create(project_id: @project.id, location_id: "1f214853-0bc4-8020-b910-dffb867ef44f", name: "test-fw")
     body = cli(%W[ps eu-north-h1/test-ps2 create -f #{fw.ubid}])
+    expect(PrivateSubnet.count).to eq 1
+    ps = PrivateSubnet.first
+    expect(ps.name).to eq "test-ps2"
+    expect(ps.display_location).to eq "eu-north-h1"
+    expect(ps.firewalls).to eq [fw]
+    expect(body).to eq "Private subnet created with id: #{ps.ubid}\n"
+  end
+
+  it "creates ps with -f option with name" do
+    fw = Firewall.create(project_id: @project.id, location_id: "1f214853-0bc4-8020-b910-dffb867ef44f", name: "test-fw2")
+    Firewall.create(project_id: @project.id, location_id: "1f214853-0bc4-8020-b910-dffb867ef44f", name: "test-fw")
+    body = cli(%W[ps eu-north-h1/test-ps2 create -f test-fw2])
     expect(PrivateSubnet.count).to eq 1
     ps = PrivateSubnet.first
     expect(ps.name).to eq "test-ps2"

--- a/spec/routes/api/cli/ps/disconnect_spec.rb
+++ b/spec/routes/api/cli/ps/disconnect_spec.rb
@@ -10,9 +10,15 @@ RSpec.describe Clover, "cli ps connect" do
     cli(%W[ps eu-central-h1/#{@ps1.name} connect #{@ps2.ubid}])
   end
 
-  it "disconnects requested private subnet from this subnet" do
+  it "disconnects requested private subnet from this subnet by id" do
     expect(ConnectedSubnet.count).to eq 1
-    expect(cli(%W[ps eu-central-h1/#{@ps1.name} disconnect #{@ps2.ubid}])).to eq "Disconnected private subnets with ids #{@ps2.ubid} and #{@ps1.ubid}\n"
+    expect(cli(%W[ps eu-central-h1/test-ps disconnect #{@ps2.ubid}])).to eq "Disconnected private subnet #{@ps2.ubid} from #{@ps1.ubid}\n"
+    expect(ConnectedSubnet.count).to eq 0
+  end
+
+  it "disconnects requested private subnet from this subnet by name" do
+    expect(ConnectedSubnet.count).to eq 1
+    expect(cli(%W[ps eu-central-h1/test-ps disconnect eu-central-h1/test-ps2])).to eq "Disconnected private subnet eu-central-h1/test-ps2 from #{@ps1.ubid}\n"
     expect(ConnectedSubnet.count).to eq 0
   end
 end

--- a/spec/routes/api/cli/vm/create_spec.rb
+++ b/spec/routes/api/cli/vm/create_spec.rb
@@ -24,10 +24,29 @@ RSpec.describe Clover, "cli vm create" do
     expect(body).to eq "VM created with id: #{vm.ubid}\n"
   end
 
-  it "creates vm with all options" do
+  it "creates vm with all options, specifying private subnet by id" do
     expect(Vm.count).to eq 0
     ps = PrivateSubnet.create(project_id: @project.id, name: "test-ps", location_id: Location[name: "hetzner-hel1"].id, net6: "fe80::/64", net4: "192.168.0.0/24")
     body = cli(%W[vm eu-north-h1/test-vm2 create -6 -b debian-12 -u foo -s standard-4 -S 80 -p #{ps.ubid}] << "b b")
+    vm = Vm.first
+    expect(Vm.count).to eq 1
+    expect(PrivateSubnet.count).to eq 1
+    expect(vm).to be_a Vm
+    expect(vm.name).to eq "test-vm2"
+    expect(vm.public_key).to eq "b b"
+    expect(vm.display_location).to eq "eu-north-h1"
+    expect(vm.display_size).to eq "standard-4"
+    expect(vm.boot_image).to eq "debian-12"
+    expect(vm.ip4_enabled).to be false
+    expect(vm.strand.stack[0]["storage_volumes"][0]["size_gib"]).to eq 80
+    expect(vm.nics.first.private_subnet_id).to eq ps.id
+    expect(body).to eq "VM created with id: #{vm.ubid}\n"
+  end
+
+  it "creates vm with all options, specifying private subnet by name" do
+    expect(Vm.count).to eq 0
+    ps = PrivateSubnet.create(project_id: @project.id, name: "test-ps", location_id: Location[name: "hetzner-hel1"].id, net6: "fe80::/64", net4: "192.168.0.0/24")
+    body = cli(%W[vm eu-north-h1/test-vm2 create -6 -b debian-12 -u foo -s standard-4 -S 80 -p test-ps] << "b b")
     vm = Vm.first
     expect(Vm.count).to eq 1
     expect(PrivateSubnet.count).to eq 1


### PR DESCRIPTION
Previously, if you wanted (for example) to create a vm and a load balancer and attach the vm to the load balancer in a script, it required parsing the output of of the vm create command in order to get the id to provide to the attach-vm command. Using this approach, there isn't a need to parse the output of previous commands, you can just specify vm by name, which is known up front.

This affects the following commands:

* fw attach-subnet
* fw detach-subnet
* lb attach-vm
* lb create
* lb detach-vm
* lb update
* ps connect
* ps create -f option
* ps disconnect
* vm create -p option


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance CLI commands to accept resource names instead of IDs, improving usability by eliminating the need to parse command outputs for IDs.
> 
>   - **Behavior**:
>     - CLI commands now accept names instead of IDs for operations on firewalls, load balancers, private subnets, and virtual machines.
>     - Commands affected include `fw attach-subnet`, `fw detach-subnet`, `lb attach-vm`, `lb create`, `lb detach-vm`, `lb update`, `ps connect`, `ps create -f option`, `ps disconnect`, and `vm create -p option`.
>     - Conversion functions `convert_name_to_id` and `convert_loc_name_to_id` added to `lib/ubi_cli.rb` to handle name to ID conversion.
>   - **Code Changes**:
>     - Updated command banners in `cli-commands` to reflect name or ID usage.
>     - Modified logic in `cli-commands` to use conversion functions for name inputs.
>     - Added `id_regexp` method to `ModelAdapter` in `model_adapter.rb` to support ID validation.
>   - **Tests**:
>     - Updated tests in `spec/routes/api/cli` to cover both name and ID inputs for affected commands.
>     - Added new test cases to ensure correct behavior when using names instead of IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for be3049827f9f59bd1daa89bab4ab29a718b73246. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->