### PR TITLE
Require vm attached to load balancer be in same location

### DIFF
--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -27,8 +27,8 @@ class Clover
         authorize("LoadBalancer:edit", lb.id)
         handle_validation_failure("networking/load_balancer/show")
 
-        unless (vm = authorized_vm)
-          fail Validation::ValidationFailed.new("vm_id" => "VM not found")
+        unless (vm = authorized_vm(location_id: lb.private_subnet.location_id))
+          fail Validation::ValidationFailed.new("vm_id" => "No matching VM found in #{lb.display_location}")
         end
 
         actioned = nil

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -243,6 +243,13 @@ RSpec.describe Clover, "load-balancer" do
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: vm_id")
       end
+
+      it "fails for vm in different location" do
+        vm.update(location_id: Location::HETZNER_HEL1_ID)
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: vm.ubid}.to_json
+
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: vm_id")
+      end
     end
 
     describe "detach-vm" do

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Clover, "load balancer" do
         click_button "Attach"
 
         expect(page.title).to eq("Ubicloud - #{lb.name}")
-        expect(page).to have_content "VM not found"
+        expect(page).to have_content "No matching VM found in eu-central-h1"
         expect(lb.vms.count).to eq(0)
       end
 
@@ -325,7 +325,7 @@ RSpec.describe Clover, "load balancer" do
         click_button "Detach"
 
         expect(page.title).to eq("Ubicloud - #{lb.name}")
-        expect(page).to have_content "VM not found"
+        expect(page).to have_content "No matching VM found in eu-central-h1"
         expect(lb.reload.vms.count).to eq(0)
       end
     end


### PR DESCRIPTION
The web UI only showed VMs in the same location, but a backend check that the location matched was missing.