### PR TITLE
Install git as build dependency

### DIFF
--- a/prog/install_dnsmasq.rb
+++ b/prog/install_dnsmasq.rb
@@ -23,7 +23,7 @@ class Prog::InstallDnsmasq < Prog::Base
   end
 
   label def install_build_dependencies
-    sshable.cmd("sudo apt-get -y install make gcc")
+    sshable.cmd("sudo apt-get -y install make gcc git")
     pop "installed build dependencies"
   end
 


### PR DESCRIPTION
Git is used by another step in the cloudify process to clone dnsmasq
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `git` to build dependencies in `install_dnsmasq.rb` for cloning `dnsmasq`.
> 
>   - **Dependencies**:
>     - Add `git` to build dependencies in `install_build_dependencies` method in `install_dnsmasq.rb`.
>   - **Reason**:
>     - `git` is required for cloning `dnsmasq` in `git_clone_dnsmasq` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 22f1cb3baebd025d37ad68f799b88f97ec5b29dd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->