### PR TITLE
Update nodejs to 24.6 from 23.6

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 ruby 3.4.5
 postgres 15.8
-nodejs 23.6.0
+nodejs 24.6.0
 golang 1.24.0
 victoria-metrics v1.113.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:23.6-alpine3.21 AS frontend-builder
+FROM docker.io/library/node:24.6-alpine3.21 AS frontend-builder
 WORKDIR /app
 COPY tailwind.config.js package.json package-lock.json ./
 COPY views/ ./views/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "tailwindcss": "^3.4.17"
       },
       "engines": {
-        "node": "23.6.0",
-        "npm": "10.9.2"
+        "node": "24.6.0",
+        "npm": "11.5.2"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "devDependencies": {
     "@redocly/cli": "^1.34.5",
     "@stoplight/spectral-cli": "^6.15.0",
-    "openapi-format": "^1.27.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
+    "openapi-format": "^1.27.2",
     "tailwindcss": "^3.4.17"
   },
   "scripts": {
@@ -13,7 +13,7 @@
     "watch": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --watch"
   },
   "engines": {
-    "node": "23.6.0",
-    "npm": "10.9.2"
+    "node": "24.6.0",
+    "npm": "11.5.2"
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Node.js to version 24.6 and npm to 11.5.2 across configuration files.
> 
>   - **Node.js Version Update**:
>     - Update Node.js from 23.6 to 24.6 in `.tool-versions`, `Dockerfile`, and `package.json`.
>     - Update npm version to 11.5.2 in `package.json`.
>   - **Dockerfile**:
>     - Change base image to `node:24.6-alpine3.21` for `frontend-builder` stage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 77844c84d17c1ade1ef5c2e723f6e7093616ad64. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->