### PR TITLE
Use KubernetesNode instead of Vm in Kubernetes progs

### DIFF
--- a/migrate/20250825_create_kubernetes_node_objects.rb
+++ b/migrate/20250825_create_kubernetes_node_objects.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    DB[:kubernetes_node].insert_ignore.insert(
+      [:id, :vm_id, :kubernetes_cluster_id],
+      DB[:kubernetes_clusters_cp_vms].select(
+        Sequel.function(:gen_random_ubid_uuid, 621).as(:id),
+        :cp_vm_id,
+        :kubernetes_cluster_id
+      )
+    )
+
+    DB[:kubernetes_node].insert_ignore.insert(
+      [:id, :vm_id, :kubernetes_cluster_id, :kubernetes_nodepool_id],
+      DB[:kubernetes_nodepools_vms]
+        .join(:kubernetes_nodepool, id: :kubernetes_nodepool_id)
+        .select(
+          Sequel.function(:gen_random_ubid_uuid, 621).as(:id),
+          :vm_id,
+          :kubernetes_cluster_id,
+          :kubernetes_nodepool_id
+        )
+    )
+
+    DB[:strand].insert_ignore.insert(
+      [:id, :prog, :label],
+      DB[:kubernetes_node]
+        .select(
+          :id,
+          "Kubernetes::KubernetesNodeNexus",
+          "wait"
+        )
+    )
+  end
+end

--- a/model/kubernetes/kubernetes_node.rb
+++ b/model/kubernetes/kubernetes_node.rb
@@ -10,6 +10,35 @@ class KubernetesNode < Sequel::Model
 
   plugin ResourceMethods
   plugin SemaphoreMethods, :destroy
+
+  def sshable
+    vm.sshable
+  end
+
+  def billing_record
+    if kubernetes_nodepool
+      worker_billing_records
+    else
+      control_plane_billing_record
+    end
+  end
+
+  def worker_billing_records
+    [
+      {type: "KubernetesWorkerVCpu", family: vm.family, amount: vm.vcpus},
+      {type: "KubernetesWorkerStorage", family: "standard", amount: vm.storage_size_gib}
+    ]
+  end
+
+  def control_plane_billing_record
+    [
+      {type: "KubernetesControlPlaneVCpu", family: vm.family, amount: vm.vcpus}
+    ]
+  end
+
+  def name
+    vm.name
+  end
 end
 
 # Table: kubernetes_node

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -6,6 +6,7 @@ class KubernetesNodepool < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :cluster, key: :kubernetes_cluster_id, class: :KubernetesCluster
   many_to_many :vms, order: :created_at
+  many_to_many :vms_via_nodes, join_table: :kubernetes_node, right_key: :vm_id, class: :Vm, order: :created_at
   one_to_many :nodes, class: :KubernetesNode, order: :created_at
 
   plugin ResourceMethods

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -102,12 +102,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   label def bootstrap_control_plane_nodes
     nap 5 unless kubernetes_cluster.endpoint
 
-    # In 1-node control plane setup, we will wait until it's over
-    # In 3-node control plane setup, we start the bootstrapping after
-    # the first CP bootstrap
-    ready_to_bootstrap_workers =
-      kubernetes_cluster.nodes.count >= kubernetes_cluster.cp_node_count ||
-      (kubernetes_cluster.cp_node_count == 3 && kubernetes_cluster.nodes.count == 1)
+    ready_to_bootstrap_workers = kubernetes_cluster.nodes.count >= 1
     kubernetes_cluster.nodepools.each(&:incr_start_bootstrapping) if ready_to_bootstrap_workers
 
     hop_wait_nodes if kubernetes_cluster.nodes.count >= kubernetes_cluster.cp_node_count

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -30,7 +30,7 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
   end
 
   label def destroy
-    kubernetes_node.vm.incr_destroy
+    kubernetes_node.vm&.incr_destroy
     kubernetes_node.destroy
     pop "kubernetes node is deleted"
   end

--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -86,7 +86,7 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
   end
 
   label def delete_node_object
-    res = kubernetes_cluster.client.delete_node(old_node.name)
+    res = kubernetes_cluster.client(session: kubernetes_cluster.nodes.last.sshable.connect).delete_node(old_node.name)
     fail "delete node object failed: #{res}" unless res.exitstatus.zero?
     hop_destroy_node
   end

--- a/serializers/kubernetes_cluster.rb
+++ b/serializers/kubernetes_cluster.rb
@@ -12,7 +12,7 @@ class Serializers::KubernetesCluster < Serializers::Base
       version: kc.version
     }
     if options[:detailed]
-      base[:cp_vms] = Serializers::Vm.serialize(kc.cp_vms_dataset.all)
+      base[:cp_vms] = Serializers::Vm.serialize(kc.cp_vms_via_nodes_dataset.all)
       base[:nodepools] = Serializers::KubernetesNodepool.serialize(kc.nodepools_dataset.all, {detailed: true})
     end
     base

--- a/serializers/kubernetes_nodepool.rb
+++ b/serializers/kubernetes_nodepool.rb
@@ -10,7 +10,7 @@ class Serializers::KubernetesNodepool < Serializers::Base
       node_size: kn.target_node_size
     }
     if options[:detailed]
-      base[:vms] = Serializers::Vm.serialize(kn.vms_dataset.all)
+      base[:vms] = Serializers::Vm.serialize(kn.vms_via_nodes_dataset.all)
     end
     base
   end

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -74,5 +74,11 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect(kd).to receive(:destroy)
       expect { nx.destroy }.to exit({"msg" => "kubernetes node is deleted"})
     end
+
+    it "skips destroying the vm if it is already destroyed" do
+      expect(kd).to receive(:vm).and_return(nil)
+      expect(kd).to receive(:destroy)
+      expect { nx.destroy }.to exit({"msg" => "kubernetes node is deleted"})
+    end
   end
 end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     Prog::Vnet::SubnetNexus.assemble(Config.kubernetes_service_project_id, name: "test", ipv4_range: "172.19.0.0/16", ipv6_range: "fd40:1a0a:8d48:182a::/64").subject
   }
 
-  let(:vm) {
-    nic = Prog::Vnet::NicNexus.assemble(subnet.id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
-    vm = Prog::Vm::Nexus.assemble("pub key", Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
-    vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79")
-  }
-
   let(:kubernetes_cluster) {
     kc = KubernetesCluster.create(
       name: "k8scluster",
@@ -34,18 +28,22 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
     lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
-    kc.add_cp_vm(vm)
-    kc.add_cp_vm(create_vm)
-
+    KubernetesNode.create(vm_id: create_vm(created_at: Time.now - 1).id, kubernetes_cluster_id: kc.id)
     kc.update(api_server_lb_id: lb.id)
-    kc
+  }
+
+  let(:node) {
+    nic = Prog::Vnet::NicNexus.assemble(subnet.id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
+    vm = Prog::Vm::Nexus.assemble("pub key", Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
+    vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79")
+    KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
   }
 
   let(:kubernetes_nodepool) { KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kubernetes_cluster.id, target_node_size: "standard-8", target_node_storage_size_gib: 78) }
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
-    allow(prog).to receive_messages(kubernetes_cluster: kubernetes_cluster, frame: {"vm_id" => vm.id})
+    allow(prog).to receive_messages(kubernetes_cluster: kubernetes_cluster, frame: {"node_id" => node.id})
   end
 
   describe "random_ula_cidr" do
@@ -85,16 +83,16 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#start" do
-    it "creates a CP VM and hops if a nodepool is not given" do
+    it "creates a control plane node and hops if a nodepool is not given" do
       expect(prog.kubernetes_nodepool).to be_nil
-      expect(kubernetes_cluster.cp_vms.count).to eq(2)
-      expect(kubernetes_cluster.api_server_lb).to receive(:add_vm)
+      expect(kubernetes_cluster.nodes.count).to eq(2)
 
       expect { prog.start }.to hop("bootstrap_rhizome")
+      kubernetes_cluster.reload
 
-      expect(kubernetes_cluster.cp_vms.count).to eq(3)
+      expect(kubernetes_cluster.nodes.count).to eq(3)
 
-      new_vm = kubernetes_cluster.cp_vms.last
+      new_vm = kubernetes_cluster.cp_vms_via_nodes.last
       expect(new_vm.name).to start_with("#{kubernetes_cluster.ubid}-")
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(4)
@@ -102,15 +100,15 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(new_vm.boot_image).to eq("kubernetes-v1_32")
     end
 
-    it "creates a worker VM and hops if a nodepool is given" do
+    it "creates a worker node and hops if a nodepool is given" do
       expect(prog).to receive(:frame).and_return({"nodepool_id" => kubernetes_nodepool.id})
-      expect(kubernetes_nodepool.vms.count).to eq(0)
+      expect(kubernetes_nodepool.nodes.count).to eq(0)
 
       expect { prog.start }.to hop("bootstrap_rhizome")
 
-      expect(kubernetes_nodepool.reload.vms.count).to eq(1)
+      expect(kubernetes_nodepool.reload.nodes.count).to eq(1)
 
-      new_vm = kubernetes_nodepool.vms.last
+      new_vm = kubernetes_nodepool.nodes.last.vm
       expect(new_vm.name).to start_with("#{kubernetes_nodepool.ubid}-")
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(8)
@@ -120,30 +118,31 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
     it "assigns the default storage size if not specified" do
       kubernetes_cluster.update(target_node_storage_size_gib: nil)
-      expect(kubernetes_cluster.api_server_lb).to receive(:add_vm)
 
-      expect(kubernetes_cluster.cp_vms.count).to eq(2)
+      expect(kubernetes_cluster.nodes.count).to eq(2)
 
       expect { prog.start }.to hop("bootstrap_rhizome")
+      kubernetes_cluster.reload
 
-      expect(kubernetes_cluster.cp_vms.count).to eq(3)
+      expect(kubernetes_cluster.nodes.count).to eq(3)
 
-      new_vm = kubernetes_cluster.cp_vms.last
+      new_vm = kubernetes_cluster.cp_vms_via_nodes.last
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq 80
     end
   end
 
   describe "#bootstrap_rhizome" do
-    it "waits until the VM is ready" do
+    it "waits until the node is ready" do
       st = instance_double(Strand, label: "non-wait")
-      expect(prog.vm).to receive(:strand).and_return(st)
+      expect(prog.node.vm).to receive(:strand).and_return(st)
       expect { prog.bootstrap_rhizome }.to nap(5)
     end
 
     it "enables kubelet and buds a bootstrap rhizome process" do
       sshable = instance_double(Sshable)
       st = instance_double(Strand, label: "wait")
-      expect(prog.vm).to receive_messages(sshable: sshable, strand: st)
+      expect(prog.node.vm).to receive(:strand).and_return(st)
+      expect(prog.vm).to receive(:sshable).and_return(sshable).thrice
       expect(sshable).to receive(:cmd).with("sudo iptables-nft -t nat -A POSTROUTING -s 172.19.145.64/26 -o ens3 -j MASQUERADE")
       expect(sshable).to receive(:cmd).with(
         "sudo nft --file -",
@@ -170,7 +169,7 @@ table ip6 pod_access {
       )
       expect(sshable).to receive(:cmd).with("sudo systemctl enable --now kubelet")
 
-      expect(prog).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => prog.vm.id, "user" => "ubi"})
+      expect(prog).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => prog.node.vm.id, "user" => "ubi"})
       expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
     end
   end
@@ -189,13 +188,13 @@ table ip6 pod_access {
   end
 
   describe "#assign_role" do
-    it "hops to init_cluster if this is the first vm of the cluster" do
-      expect(prog.kubernetes_cluster.cp_vms).to receive(:count).and_return(1)
+    it "hops to init_cluster if this is the first node of the cluster" do
+      expect(prog.kubernetes_cluster.nodes).to receive(:count).and_return(1)
       expect { prog.assign_role }.to hop("init_cluster")
     end
 
-    it "hops to join_control_plane if this is the not the first vm of the cluster" do
-      expect(prog.kubernetes_cluster.cp_vms.count).to eq(2)
+    it "hops to join_control_plane if this is the not the first node of the cluster" do
+      expect(prog.kubernetes_cluster.nodes.count).to eq(2)
       expect { prog.assign_role }.to hop("join_control_plane")
     end
 
@@ -246,7 +245,7 @@ table ip6 pod_access {
       expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("NotStarted")
 
       sshable = instance_double(Sshable)
-      allow(kubernetes_cluster.cp_vms.first).to receive(:sshable).and_return(sshable)
+      allow(kubernetes_cluster.cp_vms_via_nodes.first).to receive(:sshable).and_return(sshable)
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("jt\n")
       expect(sshable).to receive(:cmd).with("sudo kubeadm init phase upload-certs --upload-certs", log: false).and_return("something\ncertificate key:\nck")
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
@@ -290,7 +289,7 @@ table ip6 pod_access {
       expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("NotStarted")
 
       sshable = instance_double(Sshable)
-      allow(kubernetes_cluster.cp_vms.first).to receive(:sshable).and_return(sshable)
+      allow(kubernetes_cluster.cp_vms_via_nodes.first).to receive(:sshable).and_return(sshable)
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("\njt\n")
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
       expect(prog.vm.sshable).to receive(:d_run).with(
@@ -326,16 +325,14 @@ table ip6 pod_access {
   describe "#install_cni" do
     it "configures ubicni" do
       sshable = instance_double(Sshable)
-      allow(prog.vm).to receive_messages(
-        sshable: sshable,
+      expect(prog.vm).to receive(:sshable).and_return(sshable)
+      expect(prog.node.vm).to receive_messages(
         nics: [instance_double(Nic, private_ipv4: "10.0.0.37", private_ipv6: "0::1")],
         ephemeral_net6: NetAddr::IPv6Net.new(NetAddr::IPv6.parse("2001:db8::"), NetAddr::Mask128.new(64))
       )
-      node = KubernetesNode.create(vm_id: prog.vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
-      expect(prog).to receive(:node).and_return(node).twice
 
       expect(sshable).to receive(:cmd).with("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: /"type": "ubicni"/)
-      expect { prog.install_cni }.to exit({vm_id: prog.vm.id, node_id: prog.node.id})
+      expect { prog.install_cni }.to exit({node_id: prog.node.id})
     end
   end
 end

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -169,6 +169,9 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
     it "deletes the node object from kubernetes" do
       client = instance_double(Kubernetes::Client)
       expect(kubernetes_cluster).to receive(:client).and_return(client)
+      sshable = instance_double(Sshable)
+      expect(kubernetes_cluster.nodes.last).to receive(:sshable).and_return(sshable)
+      expect(sshable).to receive(:connect)
       expect(client).to receive(:delete_node).with(prog.old_node.name).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("success", 0))
       expect { prog.delete_node_object }.to hop("destroy_node")
     end
@@ -176,6 +179,9 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
     it "raises if the error of delete node command is not successful" do
       client = instance_double(Kubernetes::Client)
       expect(kubernetes_cluster).to receive(:client).and_return(client)
+      sshable = instance_double(Sshable)
+      expect(kubernetes_cluster.nodes.last).to receive(:sshable).and_return(sshable)
+      expect(sshable).to receive(:connect)
       expect(client).to receive(:delete_node).with(prog.old_node.name).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("failed", 1))
       expect { prog.delete_node_object }.to raise_error(RuntimeError)
     end

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe Clover, "cli" do
     vms[1].update(ephemeral_net6: "bbab:de77:9a94:fa69::/64")
     add_ipv4_to_vm(vms[0], "129.0.0.2")
     add_ipv4_to_vm(vms[1], "130.0.0.3")
-    kubernetes_cluster.add_cp_vm(vms[0])
-    KubernetesNodepool.first.add_vm(vms[1])
+    KubernetesNode.create(vm_id: vms[0].id, kubernetes_cluster_id: kubernetes_cluster.id)
+    KubernetesNode.create(vm_id: vms[1].id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: KubernetesNodepool.first.id)
     expect(KubernetesCluster).to receive(:kubeconfig).and_return("example-kubeconfig").at_least(:once)
 
     expect(Vm).to receive(:generate_ubid).and_return(UBID.parse("vmz7b0dxt40t4g7rnmag9hct7c")).at_least(:once)

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -230,8 +230,8 @@ RSpec.describe Clover, "Kubernetes" do
         expect(page).to have_content kc.display_location
         expect(page).to have_content kc.version
 
-        kc.add_cp_vm(create_vm(name: "cp1"))
-        kc.add_cp_vm(create_vm(name: "cp2"))
+        KubernetesNode.create(vm_id: create_vm(name: "cp1").id, kubernetes_cluster_id: kc.id)
+        KubernetesNode.create(vm_id: create_vm(name: "cp2").id, kubernetes_cluster_id: kc.id)
 
         kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
           name: "kn",
@@ -239,7 +239,7 @@ RSpec.describe Clover, "Kubernetes" do
           kubernetes_cluster_id: kc.id
         ).subject
 
-        kn.add_vm(create_vm(name: "node1"))
+        KubernetesNode.create(vm_id: create_vm(name: "node1").id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
         kc.reload
         page.refresh

--- a/spec/serializers/kubernetes_cluster_spec.rb
+++ b/spec/serializers/kubernetes_cluster_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Serializers::KubernetesCluster do
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: "v1.32", private_subnet_id: subnet.id).subject
       kn = KubernetesNodepool.create(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
-      vm = create_vm
-      kn.add_vm(vm)
+      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
       expected_result = {
         id: kc.ubid,
@@ -35,9 +34,8 @@ RSpec.describe Serializers::KubernetesCluster do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: "v1.32", private_subnet_id: subnet.id).subject
       kn = KubernetesNodepool.create(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
       cp_vm = create_vm
-      kc.add_cp_vm(cp_vm)
-
-      kn.add_vm(create_vm)
+      KubernetesNode.create(vm_id: cp_vm.id, kubernetes_cluster_id: kc.id)
+      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
       expected_result = {
         id: kc.ubid,

--- a/spec/serializers/kubernetes_nodepool_spec.rb
+++ b/spec/serializers/kubernetes_nodepool_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Serializers::KubernetesNodepool do
       )
       kn = KubernetesNodepool.create(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
       vm = create_vm
-      kn.add_vm(vm)
+      KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
       expected_result = {
         id: kn.ubid,

--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -38,7 +38,7 @@
   <% @nodes = []
   
   @nodes +=
-    @kc.cp_vms.map do |vm|
+    @kc.cp_vms_via_nodes.map do |vm|
       { name: vm.name, role: "Control Plane", state: vm.display_state, hostname: vm.ephemeral_net4.to_s }
     end
   
@@ -47,7 +47,7 @@
       .nodepools_dataset
       .eager(:vms)
       .flat_map do |np|
-        np.vms.map { |vm| { name: vm.name, role: "Worker", state: vm.display_state, hostname: vm.ephemeral_net4.to_s } }
+        np.vms_via_nodes.map { |vm| { name: vm.name, role: "Worker", state: vm.display_state, hostname: vm.ephemeral_net4.to_s } }
       end %>
 
   <%== part(


### PR DESCRIPTION
All the logics related to k8s (provisioning, bootstrapping, upgrades) now all rely on the KuberneteNode object. The former methods for Vm are still kept in place until the code is deployed and in another commit those parts with their DB tables will be removed altogether.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace `Vm` with `KubernetesNode` in Kubernetes logic, adding migration and updating models, programs, serializers, tests, and views.
> 
>   - **Behavior**:
>     - Replace `Vm` with `KubernetesNode` in Kubernetes provisioning, bootstrapping, and upgrade logic.
>     - Migration script `20250825_create_kubernetes_node_objects.rb` creates `KubernetesNode` objects from existing VMs.
>     - Old `Vm` methods retained temporarily for backward compatibility.
>   - **Models**:
>     - Add `cp_vms_via_nodes` and `nodes` associations to `KubernetesCluster`.
>     - Add `vms_via_nodes` association to `KubernetesNodepool`.
>     - Update `KubernetesNode` to include `vm` association and methods for SSH and billing.
>   - **Programs**:
>     - Update `kubernetes_cluster_nexus.rb`, `kubernetes_node_nexus.rb`, `kubernetes_nodepool_nexus.rb`, `provision_kubernetes_node.rb`, and `upgrade_kubernetes_node.rb` to use `KubernetesNode`.
>   - **Serializers**:
>     - Update `kubernetes_cluster.rb` and `kubernetes_nodepool.rb` to serialize `KubernetesNode` instead of `Vm`.
>   - **Tests**:
>     - Update tests in `kubernetes_cluster_spec.rb`, `kubernetes_cluster_nexus_spec.rb`, `kubernetes_node_nexus_spec.rb`, `kubernetes_nodepool_nexus_spec.rb`, `provision_kubernetes_node_spec.rb`, `upgrade_kubernetes_node_spec.rb`, `golden_files_spec.rb`, `kubernetes_cluster_spec.rb`, and `kubernetes_nodepool_spec.rb` to reflect changes.
>   - **Views**:
>     - Update `show.erb` to display `KubernetesNode` details instead of `Vm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6b2769eac0b927d269bf5ec5a92878e1b636d757. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->