### PR TITLE
Image download prog improvements

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -141,7 +141,7 @@ class Prog::DownloadBootImage < Prog::Base
     # a sanity check here to make sure version is not passed as nil.
     fail "Version can not be passed as nil" if version.nil?
 
-    fail "Image already exists on host" if vm_host.boot_images_dataset.where(name: image_name, version: version).count > 0
+    pop "Image already exists on host" unless vm_host.boot_images_dataset.where(name: image_name, version:).empty?
 
     BootImage.create(
       vm_host_id: vm_host.id,

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Prog::DownloadBootImage do
       expect(BootImage.where(vm_host_id: vm_host.id, name: "my-image", version: "20230303").count).to eq(1)
     end
 
-    it "fails if image already exists" do
+    it "exits if image already exists" do
       BootImage.create_with_id(vm_host.id, vm_host_id: vm_host.id, name: "my-image", version: "20230303", size_gib: 3)
-      expect { dbi.start }.to raise_error RuntimeError, "Image already exists on host"
+      expect { dbi.start }.to exit({"msg" => "Image already exists on host"})
     end
 
     it "fails if image unknown" do


### PR DESCRIPTION
- **Add deadline for image download**
  In production, we noticed one image download failed due to insufficient
  disk space and went unnoticed for 4 days until a customer ticket was
  raised. To avoid such issues, enforce a 1-day deadline so failures are
  detected and flagged promptly.
  

- **Pop image download prog if the image is already exists**
  I found a few cases where we triggered image downloads for the same
  version multiple times, usually due to operator error. We had to
  manually destroy these strands. Instead, we now pop the prog if the
  image already exists on the host.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add 1-day deadline for image downloads and prevent redundant downloads if image exists in `prog/download_boot_image.rb`.
> 
>   - **Behavior**:
>     - Enforce a 1-day deadline for image downloads in `start` method of `prog/download_boot_image.rb` to detect failures promptly.
>     - Modify `start` method to exit if the image already exists on the host, preventing redundant downloads.
>   - **Tests**:
>     - Update `spec/prog/download_boot_image_spec.rb` to test new behavior: exiting if image exists and handling download deadlines.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d9bfc3e3ae4d7625c94b8701bb287b3fb177e816. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->