### PR TITLE
Add support for renaming objects to api/sdk/cli

### DIFF
--- a/cli-commands/fw/post/rename.rb
+++ b/cli-commands/fw/post/rename.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.rename("fw")

--- a/cli-commands/kc/post/rename.rb
+++ b/cli-commands/kc/post/rename.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.rename("kc")

--- a/cli-commands/lb/post/rename.rb
+++ b/cli-commands/lb/post/rename.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.rename("lb")

--- a/cli-commands/pg/post/rename.rb
+++ b/cli-commands/pg/post/rename.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.rename("pg")

--- a/cli-commands/ps/post/rename.rb
+++ b/cli-commands/ps/post/rename.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.rename("ps")

--- a/cli-commands/vm/post/rename.rb
+++ b/cli-commands/vm/post/rename.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+UbiCli.rename("vm")

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -159,6 +159,21 @@ class UbiCli
     end
   end
 
+  def self.rename(cmd)
+    on(cmd).run_on("rename") do
+      desc "Rename a #{LOWERCASE_LABELS[cmd]}"
+
+      banner "ubi #{cmd} (location/#{cmd}-name | #{cmd}-id) rename new-name"
+
+      args 1
+
+      run do |name|
+        sdk_object.rename_to(name)
+        response("#{CAPITALIZED_LABELS[cmd]} renamed to #{name}")
+      end
+    end
+  end
+
   def self.destroy(cmd)
     on(cmd).run_on("destroy") do
       desc "Destroy a #{LOWERCASE_LABELS[cmd]}"

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -552,6 +552,34 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Firewall Rule
+  '/project/{project_id}/location/{location}/firewall/{firewall_reference}/rename':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/firewall_reference'
+    post:
+      operationId: renameFirewall
+      summary: Rename a firewall
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: New name for firewall
+                  type: string
+              additionalProperties: false
+              required:
+                - name
+      responses:
+        '200':
+          $ref: '#/components/responses/Firewall'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Firewall
   '/project/{project_id}/location/{location}/kubernetes-cluster':
     get:
       operationId: listLocationKubernetesClusters
@@ -638,6 +666,34 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Kubeconfig'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Kubernetes Cluster
+  '/project/{project_id}/location/{location}/kubernetes-cluster/{kubernetes_cluster_reference}/rename':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/kubernetes_cluster_reference'
+    post:
+      operationId: renameKubernetesCluster
+      summary: Rename a kubernetes cluster
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: New name for kubernetes cluster
+                  type: string
+              additionalProperties: false
+              required:
+                - name
+      responses:
+        '200':
+          $ref: '#/components/responses/KubernetesCluster'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -822,6 +878,34 @@ paths:
               additionalProperties: false
               required:
                 - vm_id
+      responses:
+        '200':
+          $ref: '#/components/responses/LoadBalancer'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Load Balancer
+  '/project/{project_id}/location/{location}/load-balancer/{load_balancer_reference}/rename':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/load_balancer_reference'
+    post:
+      operationId: renameLoadBalancer
+      summary: Rename a load balancer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: New name for load balancer
+                  type: string
+              additionalProperties: false
+              required:
+                - name
       responses:
         '200':
           $ref: '#/components/responses/LoadBalancer'
@@ -1245,6 +1329,34 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Postgres Database
+  '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/rename':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_reference'
+    post:
+      operationId: renamePostgres
+      summary: Rename a Postgres database
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: New name for postgres database
+                  type: string
+              additionalProperties: false
+              required:
+                - name
+      responses:
+        '200':
+          $ref: '#/components/responses/PostgresDatabase'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   '/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/reset-superuser-password':
     post:
       operationId: resetSuperuserPassword
@@ -1445,6 +1557,34 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Private Subnet
+  '/project/{project_id}/location/{location}/private-subnet/{private_subnet_reference}/rename':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/private_subnet_reference'
+    post:
+      operationId: renamePrivateSubnet
+      summary: Rename a private subnet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: New name for private subnet
+                  type: string
+              additionalProperties: false
+              required:
+                - name
+      responses:
+        '200':
+          $ref: '#/components/responses/PrivateSubnet'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Private Subnet
   '/project/{project_id}/location/{location}/vm':
     get:
       operationId: listLocationVMs
@@ -1524,6 +1664,34 @@ paths:
               additionalProperties: false
               required:
                 - public_key
+      responses:
+        '200':
+          $ref: '#/components/responses/Vm'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Virtual Machine
+  '/project/{project_id}/location/{location}/vm/{vm_reference}/rename':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/vm_reference'
+    post:
+      operationId: renameVM
+      summary: Rename a VM
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: New name for VM
+                  type: string
+              additionalProperties: false
+              required:
+                - name
       responses:
         '200':
           $ref: '#/components/responses/Vm'

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -48,6 +48,8 @@ class Clover
         end
       end
 
+      r.rename firewall, perm: "Firewall:edit", serializer: Serializers::Firewall
+
       r.post %w[attach-subnet detach-subnet] do |action|
         authorize("Firewall:view", firewall.id)
         handle_validation_failure("networking/firewall/show")

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -44,6 +44,8 @@ class Clover
         end
       end
 
+      r.rename kc, perm: "KubernetesCluster:edit", serializer: Serializers::KubernetesCluster
+
       r.get "kubeconfig" do
         authorize("KubernetesCluster:edit", kc.id)
 

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -112,6 +112,8 @@ class Clover
           Serializers::LoadBalancer.serialize(lb.reload, {detailed: true})
         end
       end
+
+      r.rename lb, perm: "LoadBalancer:edit", serializer: Serializers::LoadBalancer
     end
   end
 end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -100,6 +100,8 @@ class Clover
         end
       end
 
+      r.rename pg, perm: "Postgres:edit", serializer: Serializers::Postgres
+
       r.get web?, %w[overview connection charts networking resize high-availability read-replica backup-restore config settings] do |page|
         authorize("Postgres:view", pg.id)
 

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -97,6 +97,8 @@ class Clover
           204
         end
       end
+
+      r.rename ps, perm: "PrivateSubnet:edit", serializer: Serializers::PrivateSubnet
     end
   end
 end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -39,6 +39,8 @@ class Clover
         204
       end
 
+      r.rename vm, perm: "Vm:edit", serializer: Serializers::Vm
+
       r.post "restart" do
         authorize("Vm:edit", vm.id)
 

--- a/sdk/ruby/lib/ubicloud/model.rb
+++ b/sdk/ruby/lib/ubicloud/model.rb
@@ -147,6 +147,11 @@ module Ubicloud
       @values[key]
     end
 
+    # Rename the object to the given name.
+    def rename_to(name)
+      merge_into_values(adapter.post(_path("/rename"), name:))
+    end
+
     # Destroy the given model instance in Ubicloud.  It is not possible to restore
     # objects that have been destroyed, so only use this if you are sure you want
     # to destroy the object.

--- a/spec/routes/api/cli/fw/rename_spec.rb
+++ b/spec/routes/api/cli/fw/rename_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli fw rename" do
+  before do
+    cli(%w[fw eu-central-h1/test-fw create])
+    @fw = Firewall.first
+  end
+
+  it "renames object" do
+    expect(cli(%w[fw eu-central-h1/test-fw rename new-name])).to eq "Firewall renamed to new-name\n"
+    expect(@fw.reload.name).to eq "new-name"
+  end
+
+  it "handles failure when renaming object" do
+    expect(cli(%w[fw eu-central-h1/test-fw rename] << "new name", status: 400)).to eq <<~END
+      ! Unexpected response status: 400
+      Details: Validation failed for following fields: name
+        name: Name must only contain lowercase letters, numbers, and hyphens and have max length 63.
+    END
+    expect(@fw.reload.name).to eq "test-fw"
+  end
+end

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -10,6 +10,7 @@ Commands:
 Post Commands:
     create     Create a virtual machine
     destroy    Destroy a virtual machine
+    rename     Rename a virtual machine
     restart    Restart a virtual machine
     scp        Copy files to or from virtual machine using `scp`
     sftp       Copy files to or from virtual machine using `sftp`
@@ -67,6 +68,12 @@ Usage:
 
 Options:
     -f, --force                      do not require confirmation
+
+
+Rename a virtual machine
+
+Usage:
+    ubi vm (location/vm-name | vm-id) rename new-name
 
 
 Restart a virtual machine

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -89,6 +89,7 @@ Post Commands:
     delete-rule      Remove a firewall rule
     destroy          Destroy a firewall
     detach-subnet    Detch a private subnet from a firewall
+    rename           Rename a firewall
     show             Show details for a firewall
 
 
@@ -152,6 +153,12 @@ Usage:
     ubi fw (location/fw-name | fw-id) detach-subnet ps-id
 
 
+Rename a firewall
+
+Usage:
+    ubi fw (location/fw-name | fw-id) rename new-name
+
+
 Show details for a firewall
 
 Usage:
@@ -193,6 +200,7 @@ Post Commands:
     create        Create a Kubernetes cluster
     destroy       Destroy a Kubernetes cluster
     kubeconfig    Print kubeconfig.yaml for a Kubernetes cluster
+    rename        Rename a Kubernetes cluster
     show          Show details for a Kubernetes cluster
 
 
@@ -241,6 +249,12 @@ Usage:
     ubi kc (location/kc-name | kc-id) kubeconfig
 
 
+Rename a Kubernetes cluster
+
+Usage:
+    ubi kc (location/kc-name | kc-id) rename new-name
+
+
 Show details for a Kubernetes cluster
 
 Usage:
@@ -273,6 +287,7 @@ Post Commands:
     create       Create a load balancer
     destroy      Destroy a load balancer
     detach-vm    Detach a virtual machine from a load balancer
+    rename       Rename a load balancer
     show         Show details for a load balancer
     update       Update a load balancer
 
@@ -329,6 +344,12 @@ Usage:
     ubi lb (location/lb-name | lb-id) detach-vm vm-id
 
 
+Rename a load balancer
+
+Usage:
+    ubi lb (location/lb-name | lb-id) rename new-name
+
+
 Show details for a load balancer
 
 Usage:
@@ -377,6 +398,7 @@ Post Commands:
     psql                               Connect to a PostgreSQL database using `psql`
     remove-config-entries              Remove configuration entries from a PostgreSQL database
     remove-pgbouncer-config-entries    Remove pgbouncer configuration entries from a PostgreSQL database
+    rename                             Rename a PostgreSQL database
     reset-superuser-password           Reset the superuser password for a PostgreSQL database
     restart                            Restart a PostgreSQL database cluster
     restore                            Restore a PostgreSQL database backup to a new database
@@ -560,6 +582,12 @@ Usage:
     ubi pg (location/pg-name | pg-id) remove-pgbouncer-config-entries key [...]
 
 
+Rename a PostgreSQL database
+
+Usage:
+    ubi pg (location/pg-name | pg-id) rename new-name
+
+
 Reset the superuser password for a PostgreSQL database
 
 Usage:
@@ -631,6 +659,7 @@ Post Commands:
     create        Create a private subnet
     destroy       Destroy a private subnet
     disconnect    Disconnect a private subnet from another private subnet
+    rename        Rename a private subnet
     show          Show details for a private subnet
 
 
@@ -678,6 +707,12 @@ Usage:
     ubi ps (location/ps-name | ps-id) disconnect ps-id
 
 
+Rename a private subnet
+
+Usage:
+    ubi ps (location/ps-name | ps-id) rename new-name
+
+
 Show details for a private subnet
 
 Usage:
@@ -714,6 +749,7 @@ Commands:
 Post Commands:
     create     Create a virtual machine
     destroy    Destroy a virtual machine
+    rename     Rename a virtual machine
     restart    Restart a virtual machine
     scp        Copy files to or from virtual machine using `scp`
     sftp       Copy files to or from virtual machine using `sftp`
@@ -771,6 +807,12 @@ Usage:
 
 Options:
     -f, --force                      do not require confirmation
+
+
+Rename a virtual machine
+
+Usage:
+    ubi vm (location/vm-name | vm-id) rename new-name
 
 
 Restart a virtual machine

--- a/spec/routes/api/cli/golden-files/help -ru vm.txt
+++ b/spec/routes/api/cli/golden-files/help -ru vm.txt
@@ -3,6 +3,7 @@ ubi vm (location/vm-name | vm-id) [post-options] post-command [...]
 ubi vm list [options]
 ubi vm location/vm-name create [options] public_key
 ubi vm (location/vm-name | vm-id) destroy [options]
+ubi vm (location/vm-name | vm-id) rename new-name
 ubi vm (location/vm-name | vm-id) restart
 ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -15,6 +15,7 @@ ubi fw location/fw-name create [options]
 ubi fw (location/fw-name | fw-id) delete-rule rule-id
 ubi fw (location/fw-name | fw-id) destroy [options]
 ubi fw (location/fw-name | fw-id) detach-subnet ps-id
+ubi fw (location/fw-name | fw-id) rename new-name
 ubi fw (location/fw-name | fw-id) show [options]
 ubi help [options] [command [subcommand]]
 ubi kc command [...]
@@ -23,6 +24,7 @@ ubi kc list [options]
 ubi kc location/kc-name create [options]
 ubi kc (location/kc-name | kc-id) destroy [options]
 ubi kc (location/kc-name | kc-id) kubeconfig
+ubi kc (location/kc-name | kc-id) rename new-name
 ubi kc (location/kc-name | kc-id) show [options]
 ubi lb command [...]
 ubi lb (location/lb-name | lb-id) post-command [...]
@@ -31,6 +33,7 @@ ubi lb (location/lb-name | lb-id) attach-vm vm-id
 ubi lb location/lb-name create [options] ps-id src-port dst-port
 ubi lb (location/lb-name | lb-id) destroy [options]
 ubi lb (location/lb-name | lb-id) detach-vm vm-id
+ubi lb (location/lb-name | lb-id) rename new-name
 ubi lb (location/lb-name | lb-id) show [options]
 ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint [vm-id [...]]
 ubi pg command [...]
@@ -54,6 +57,7 @@ ubi pg (location/pg-name | pg-id) promote-read-replica
 ubi pg (location/pg-name | pg-id) [options] psql [psql-options]
 ubi pg (location/pg-name | pg-id) remove-config-entries key [...]
 ubi pg (location/pg-name | pg-id) remove-pgbouncer-config-entries key [...]
+ubi pg (location/pg-name | pg-id) rename new-name
 ubi pg (location/pg-name | pg-id) reset-superuser-password new-password
 ubi pg (location/pg-name | pg-id) restart
 ubi pg (location/pg-name | pg-id) restore new-db-name restore-time
@@ -68,6 +72,7 @@ ubi ps (location/ps-name | ps-id) connect ps-id
 ubi ps location/ps-name create [options]
 ubi ps (location/ps-name | ps-id) destroy [options]
 ubi ps (location/ps-name | ps-id) disconnect ps-id
+ubi ps (location/ps-name | ps-id) rename new-name
 ubi ps (location/ps-name | ps-id) show [options]
 ubi version
 ubi vm command [...]
@@ -75,6 +80,7 @@ ubi vm (location/vm-name | vm-id) [post-options] post-command [...]
 ubi vm list [options]
 ubi vm location/vm-name create [options] public_key
 ubi vm (location/vm-name | vm-id) destroy [options]
+ubi vm (location/vm-name | vm-id) rename new-name
 ubi vm (location/vm-name | vm-id) restart
 ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)
 ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]

--- a/spec/routes/api/cli/golden-files/help vm.txt
+++ b/spec/routes/api/cli/golden-files/help vm.txt
@@ -10,6 +10,7 @@ Commands:
 Post Commands:
     create     Create a virtual machine
     destroy    Destroy a virtual machine
+    rename     Rename a virtual machine
     restart    Restart a virtual machine
     scp        Copy files to or from virtual machine using `scp`
     sftp       Copy files to or from virtual machine using `sftp`

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
@@ -28,6 +28,7 @@ Post Commands:
     psql                               Connect to a PostgreSQL database using `psql`
     remove-config-entries              Remove configuration entries from a PostgreSQL database
     remove-pgbouncer-config-entries    Remove pgbouncer configuration entries from a PostgreSQL database
+    rename                             Rename a PostgreSQL database
     reset-superuser-password           Reset the superuser password for a PostgreSQL database
     restart                            Restart a PostgreSQL database cluster
     restore                            Restore a PostgreSQL database backup to a new database

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
@@ -12,6 +12,7 @@ Commands:
 Post Commands:
     create     Create a virtual machine
     destroy    Destroy a virtual machine
+    rename     Rename a virtual machine
     restart    Restart a virtual machine
     scp        Copy files to or from virtual machine using `scp`
     sftp       Copy files to or from virtual machine using `sftp`

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfa show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfa show.txt
@@ -12,6 +12,7 @@ Commands:
 Post Commands:
     create     Create a virtual machine
     destroy    Destroy a virtual machine
+    rename     Rename a virtual machine
     restart    Restart a virtual machine
     scp        Copy files to or from virtual machine using `scp`
     sftp       Copy files to or from virtual machine using `sftp`

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
@@ -12,6 +12,7 @@ Commands:
 Post Commands:
     create     Create a virtual machine
     destroy    Destroy a virtual machine
+    rename     Rename a virtual machine
     restart    Restart a virtual machine
     scp        Copy files to or from virtual machine using `scp`
     sftp       Copy files to or from virtual machine using `sftp`

--- a/spec/routes/api/cli/kc/rename_spec.rb
+++ b/spec/routes/api/cli/kc/rename_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli kc rename" do
+  it "renames kubernetes cluster" do
+    expect(Config).to receive(:kubernetes_service_project_id).and_return(@project.id).at_least(:once)
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v v1.32])
+    expect(cli(%W[kc eu-central-h1/test-kc rename new-name])).to eq "Kubernetes cluster renamed to new-name\n"
+    expect(KubernetesCluster.select_order_map(:name)).to eq ["new-name"]
+  end
+end

--- a/spec/routes/api/cli/lb/rename_spec.rb
+++ b/spec/routes/api/cli/lb/rename_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli lb rename" do
+  it "renames load balancer" do
+    cli(%w[ps eu-central-h1/test-ps create])
+    cli(%W[lb eu-central-h1/test-lb create #{PrivateSubnet.first.ubid} 12345 54321])
+    expect(cli(%w[lb eu-central-h1/test-lb rename new-name])).to eq "Load balancer renamed to new-name\n"
+    expect(LoadBalancer.first.name).to eq "new-name"
+  end
+end

--- a/spec/routes/api/cli/pg/rename_spec.rb
+++ b/spec/routes/api/cli/pg/rename_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli pg rename" do
+  it "renames PostgreSQL database" do
+    expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64])
+    expect(cli(%w[pg eu-central-h1/test-pg rename new-name])).to eq "PostgreSQL database renamed to new-name\n"
+    expect(PostgresResource.first.name).to eq "new-name"
+  end
+end

--- a/spec/routes/api/cli/ps/rename_spec.rb
+++ b/spec/routes/api/cli/ps/rename_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli ps rename" do
+  it "renames private subnet" do
+    cli(%w[ps eu-central-h1/test-ps create])
+    expect(cli(%w[ps eu-central-h1/test-ps rename new-name])).to eq "Private subnet renamed to new-name\n"
+    expect(PrivateSubnet.first.name).to eq "new-name"
+  end
+end

--- a/spec/routes/api/cli/vm/rename_spec.rb
+++ b/spec/routes/api/cli/vm/rename_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli vm rename" do
+  it "renames vm" do
+    cli(%w[vm eu-central-h1/test-vm create] << "a a")
+    expect(cli(%w[vm eu-central-h1/test-vm rename new-name])).to eq "Virtual machine renamed to new-name\n"
+    expect(Vm.first.name).to eq "new-name"
+  end
+end


### PR DESCRIPTION
This uses a shared route for all 6 objects, as well as shared cli and sdk code. Unfortunately, there is not a way to share such code in openapi.yml, so that part ends up quite verbose.

Eventually, we should add a web interface for this, but it's best to wait until we refactor the web interfaces for the objects to consistently use the current postgres web interface.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for renaming objects (firewall, kubernetes cluster, load balancer, postgres, private subnet, vm) in API, SDK, and CLI with shared route and command.
> 
>   - **Behavior**:
>     - Adds support for renaming `firewall`, `kubernetes cluster`, `load balancer`, `postgres`, `private subnet`, and `vm` via shared route and CLI command.
>     - OpenAPI specification updated to include rename endpoints for each object type.
>   - **CLI**:
>     - New CLI command `rename` added for each object type in `lib/ubi_cli.rb`.
>     - CLI command files added for each object type in `cli-commands/*/post/rename.rb`.
>   - **Routes**:
>     - Adds `r.rename` method call in `firewall.rb`, `kubernetes_cluster.rb`, `load_balancer.rb`, `postgres.rb`, `private_subnet.rb`, and `vm.rb`.
>   - **SDK**:
>     - Adds `rename_to` method in `model.rb` to handle renaming via SDK.
>   - **Tests**:
>     - Adds RSpec tests for renaming functionality in `rename_spec.rb` for each object type.
>     - Updates CLI help files to include `rename` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4d142b9d1ab841a6298cc9deabfbdec99ee534b3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->