### PR TITLE
Use Rodauth 2.40.0 instead of git checkout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "rake"
 gem "refrigerator", ">= 1"
 gem "reline" # Remove it when pry adds it as a dependency
 gem "roda", ">= 3.95"
-gem "rodauth", github: "jeremyevans/rodauth", ref: "a1780cd64e947d4531771e272ed97eb4f33058b9"
+gem "rodauth", ">= 2.40"
 gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"
 gem "rodish", ">= 2.0.1"
 gem "rotp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,6 @@ GIT
       rodauth (~> 2.36)
 
 GIT
-  remote: https://github.com/jeremyevans/rodauth.git
-  revision: a1780cd64e947d4531771e272ed97eb4f33058b9
-  ref: a1780cd64e947d4531771e272ed97eb4f33058b9
-  specs:
-    rodauth (2.39.0)
-      roda (>= 2.6.0)
-      sequel (>= 4)
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -312,6 +303,9 @@ GEM
     rexml (3.4.1)
     roda (3.95.0)
       rack
+    rodauth (2.40.0)
+      roda (>= 2.6.0)
+      sequel (>= 4)
     rodish (2.0.1)
       optparse
     rotp (6.3.0)
@@ -498,7 +492,7 @@ DEPENDENCIES
   refrigerator (>= 1)
   reline
   roda (>= 3.95)
-  rodauth!
+  rodauth (>= 2.40)
   rodauth-omniauth!
   rodish (>= 2.0.1)
   rotp


### PR DESCRIPTION
This has the otp refresh http header usage that we were relying on.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `rodauth` gem in `Gemfile` to version 2.40.0 for OTP refresh HTTP header support.
> 
>   - **Dependencies**:
>     - Update `rodauth` gem in `Gemfile` from git reference to version `2.40.0`.
>     - This version includes the OTP refresh HTTP header feature previously relied upon.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a906ab93d526aff739ed95ccd4b2156edf4aeefe. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->