### PR TITLE
Fix missing base64 library in csi gemspec

### DIFF
--- a/kubernetes/csi/Gemfile
+++ b/kubernetes/csi/Gemfile
@@ -2,8 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "grpc", "~> 1.73"
-gem "grpc-tools", "~> 1.73"
-gem "base64"
-
 gemspec

--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ubi-csi (0.1.0)
+      base64
       grpc (~> 1.73)
       grpc-tools (~> 1.73)
 
@@ -70,9 +71,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  base64
-  grpc (~> 1.73)
-  grpc-tools (~> 1.73)
   rspec (~> 3.12)
   simplecov (~> 0.22)
   simplecov-console (~> 0.9)

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables = ["ubi-csi-server"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "base64"
   spec.add_dependency "grpc", "~> 1.73"
   spec.add_dependency "grpc-tools", "~> 1.73"
 


### PR DESCRIPTION
While here, remove unnecessary Gemfile entries, since they can be pulled from the gemspec.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `base64` to `ubi-csi.gemspec` and remove redundant entries from `Gemfile`.
> 
>   - **Dependencies**:
>     - Add `base64` dependency to `ubi-csi.gemspec`.
>     - Remove `grpc`, `grpc-tools`, and `base64` from `Gemfile` as they are now managed in the gemspec.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 362a56905d0ad648bb67ed03e37cfd18afd27fdb. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->