### PR TITLE
Fix flakiness in runner tests

### DIFF
--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     it "create a new record for a new day" do
       today = Time.now
       tomorrow = today + 24 * 60 * 60
-      expect(Time).to receive(:now).and_return(today).exactly(6)
+      expect(Time).to receive(:now).and_return(today)
       expect(runner).to receive(:ready_at).and_return(today - 5 * 60).twice
       expect(BillingRecord).to receive(:create).and_call_original
       # Create today record


### PR DESCRIPTION
Time.now is a very common class to use in code. Exact count of run for it too strict, it can be called from anywhere. It's enough for us to called at least once. We have following cases in CI a few times:

    (#<Object:0x0000ff21dae3b1f0>).now(*(any args))
    expected: 6 times with any arguments
    received: 7 times with any arguments
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Relax `Time.now` call expectation in `github_runner_spec.rb` to address test flakiness.
> 
>   - **Tests**:
>     - In `github_runner_spec.rb`, relax `Time.now` call expectation from exactly 6 times to at least once in `update_billing_record` test case to address flakiness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0ac705dca027edde017b893dce44d00b8e27767a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->