### PR TITLE
Fix validation/generation account names for social login

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -515,7 +515,14 @@ class Clover < Roda
         redirect "/login"
       end
 
-      scope.before_rodauth_create_account(account, omniauth_name || account[:email].split("@", 2)[0].gsub(/[^A-Za-z]+/, " ").capitalize)
+      name = (omniauth_name || account[:email].split("@", 2)[0])
+        .gsub(/[^\p{L}0-9\- ]+/, " ")
+        .gsub(/\A[^\p{L}]+/, "")
+        .strip
+        .squeeze(" ")
+        .slice(0...63)
+      name = "Unknown" if name.empty?
+      scope.before_rodauth_create_account(account, name)
     end
 
     after_omniauth_create_account do

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -741,7 +741,35 @@ RSpec.describe Clover, "auth" do
       visit "/login"
       click_button "GitHub"
 
-      expect(Account[email: TEST_USER_EMAIL].name).to eq "User"
+      expect(Account[email: TEST_USER_EMAIL].name).to eq "user"
+    end
+
+    it "can create new account even if social account has a name that isn't a valid Ubicloud name" do
+      mock_provider(:github, name: "123Foo..\u1234Bar")
+
+      visit "/login"
+      click_button "GitHub"
+
+      expect(Account[email: TEST_USER_EMAIL].name).to eq "Foo \u1234Bar"
+    end
+
+    it "can create new account even if social account has a name is too long" do
+      mock_provider(:github, name: "F" * 100)
+
+      visit "/login"
+      click_button "GitHub"
+
+      expect(Account[email: TEST_USER_EMAIL].name).to eq("F" * 63)
+    end
+
+    it "can create new account even if name for social login cannot be determined" do
+      email = ".@example.com"
+      mock_provider(:github, email, name: nil)
+
+      visit "/login"
+      click_button "GitHub"
+
+      expect(Account[email:].name).to eq "Unknown"
     end
 
     it "can create new account" do


### PR DESCRIPTION
The social login may already have a name that it is invalid, so don't just munge the email, munge the name instead if it is present.

Remove excess whitespace in the name. Limit name to 63 characters. If the name would be empty, use Unknown as the name. Do not capitalize the name, as that has the effect of removing capitalization from characters other than the first.