### PR TITLE
Add LoadBalancer#health_check_url

### DIFF
--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -39,6 +39,10 @@ class LoadBalancer < Sequel::Model
     first_port&.dst_port
   end
 
+  def health_check_url(use_endpoint: false, path: (health_check_endpoint if use_endpoint))
+    "#{health_check_protocol}://#{hostname}#{":#{dst_port}" if use_endpoint}#{path}"
+  end
+
   def path
     "/location/#{display_location}/load-balancer/#{name}"
   end

--- a/model/load_balancer_vm_port.rb
+++ b/model/load_balancer_vm_port.rb
@@ -67,7 +67,7 @@ class LoadBalancerVmPort < Sequel::Model
     if load_balancer.health_check_protocol == "tcp"
       "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{address} #{load_balancer_port.dst_port} >/dev/null 2>&1 && echo 200 || echo 400"
     else
-      "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer_port.dst_port}:#{(address.version == 6) ? "[#{address}]" : address} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_protocol}://#{load_balancer.hostname}:#{load_balancer_port.dst_port}#{load_balancer.health_check_endpoint}"
+      "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer_port.dst_port}:#{(address.version == 6) ? "[#{address}]" : address} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_url(use_endpoint: true)}"
     end
   end
 

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -24,7 +24,7 @@ MSG
 
 
     curl_snippet = <<-CURL
-curl #{ie.load_balancer.health_check_protocol}://#{ie.load_balancer.hostname}#{path} \\
+curl #{ie.load_balancer.health_check_url(path:)} \\
   -H <span class="text-green-400">"Content-Type: application/json"</span> \\
   -H <span class="text-green-400">"Authorization: Bearer <span class="text-orange-500">$INFERENCE_API_KEY</span>"</span> \\
   -d <span class="text-green-400">'{
@@ -66,7 +66,7 @@ curl #{ie.load_balancer.health_check_protocol}://#{ie.load_balancer.hostname}#{p
       </div>
       <div class="sm:col-span-2">
         <h3 class="text-sm font-semibold text-gray-900">URL</h3>
-        <div class="text-gray-500"><%== part("components/copyable_content", content: "#{ie.load_balancer.health_check_protocol}://#{ie.load_balancer.hostname}", message: "Copied URL") %></div>
+        <div class="text-gray-500"><%== part("components/copyable_content", content: ie.load_balancer.health_check_url, message: "Copied URL") %></div>
       </div>
       <div class="sm:col-span-2">
         <h3 class="text-sm font-semibold text-gray-900">

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -14,7 +14,7 @@
           options: @inference_models.map { |ie|
             [ie.model_name, ie.model_name, nil, {
               "data-id": ie.ubid,
-              "data-url": "#{ie.load_balancer.health_check_protocol}://#{ie.load_balancer.hostname}",
+              "data-url": ie.load_balancer.health_check_url,
               "data-tags": ie.tags.to_json
             }]
           },


### PR DESCRIPTION
Use it DRY up some calls that use the protocol and hostname, and optionally the dst_port and path.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `health_check_url` method to `LoadBalancer` for consistent URL construction, replacing manual constructions in several files.
> 
>   - **Behavior**:
>     - Adds `health_check_url` method to `LoadBalancer` in `load_balancer.rb` to construct URLs using protocol, hostname, and optionally `dst_port` and `path`.
>     - Replaces manual URL construction with `health_check_url` in `health_check_cmd` in `load_balancer_vm_port.rb`.
>     - Updates `index.erb` and `playground.erb` to use `health_check_url` for URL generation.
>   - **Misc**:
>     - Ensures consistent URL construction across the codebase, reducing duplication and potential errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4a31afd2d400087ebe3f92159f0c50734236c641. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->