### PR TITLE
Attempt to fix repartitioner spec nondeterminism

### DIFF
--- a/spec/lib/repartitioner_spec.rb
+++ b/spec/lib/repartitioner_spec.rb
@@ -22,17 +22,17 @@ RSpec.describe Repartitioner do
   end
 
   describe "#notify" do
-    it "uses NOTIFY to notify listeners on monitor channel" do
+    it "uses NOTIFY to notify listeners on given channel" do
       q = Queue.new
       th = Thread.new do
         payload = nil
-        DB.listen(:monitor, after_listen: proc { q.push nil }, timeout: 1) do |_, _, pl|
+        DB.listen(:monitor_notify_spec, after_listen: proc { q.push nil }, timeout: 1) do |_, _, pl|
           payload = pl
         end
         payload
       end
       q.pop(timeout: 1)
-      Thread.new { repartitioner.notify }.join(1)
+      Thread.new { repartitioner(channel: :monitor_notify_spec).notify }.join(1)
       expect(th.value).to eq "1"
     end
   end


### PR DESCRIPTION
This attempts to fix the following nondeterministic spec failure:

```
  1) Repartitioner#notify uses NOTIFY to notify listeners on monitor channel
     Failure/Error: expect(th.value).to eq "1"

       expected: "1"
            got: "2"
```

One possible cause is there is still a thread notifying on the channel before the spec starts. I looked at the other specs and could not see where that was happening, though. However, one way to work around this is to have the spec listen and notify on a different channel.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix nondeterministic test in `repartitioner_spec.rb` by changing notification channel in `#notify` test.
> 
>   - **Test Fix**:
>     - In `repartitioner_spec.rb`, change channel in `#notify` test from `:monitor` to `:monitor_notify_spec` to avoid interference from other threads.
>     - Update test description to "uses NOTIFY to notify listeners on given channel".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 740d1b8838ca8373b52ac0b0c0a43bb2ef591348. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->