### PR TITLE
Support Ubiblk v0.2.0.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,6 +114,7 @@ jobs:
         SMTP_TLS: false
         STRIPE_PUBLIC_KEY: ${{ secrets.STRIPE_PUBLIC_KEY }}
         STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+        VHOST_BLOCK_BACKEND_VERSION: v0.2.0
       run: |
         set -o pipefail
         timeout 55m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -5,7 +5,9 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
     ["v0.1-7", "x64"],
-    ["v0.1-7", "arm64"]
+    ["v0.1-7", "arm64"],
+    ["v0.2.0", "x64"],
+    ["v0.2.0", "arm64"]
   ].freeze.each(&:freeze)
 
   def self.assemble(vm_host_id, version, allocation_weight: 0)

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -13,6 +13,10 @@ class VhostBlockBackend
       "114119bc78609db3795bcd426a386eb97a623ba78e9177de6b375b9616927ca6"
     elsif @version == "v0.1-7" && Arch.arm64?
       "aa92b91130de6e086332c4ad8dcb76e233624055532d5494db0a987883adee0f"
+    elsif @version == "v0.2.0" && Arch.x64?
+      "68638b779a227424cbe81674de4b26122ea27a337f1c6d81db895a1ffa3a917a"
+    elsif @version == "v0.2.0" && Arch.arm64?
+      "6b15ca96cd3134524a639d3c913b43b794423a8dddc897c1604a5085625d44e3"
     else
       fail "Unsupported version: #{@version}, #{Arch.sym}"
     end


### PR DESCRIPTION
Ubiblk v0.2.0 made several performance improvements:

- Reduced number of syscalls per IO,
- Improved flush performance by avoiding unnecessary metadata flushes,
- Added cpu pinning,
- Added write-through mode.

We'll keep v0.1-7 as supported and the default version while v0.2.0 is being tested.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for Ubiblk v0.2.0, updating supported versions, SHA256 checksums, and GitHub workflow for testing.
> 
>   - **Version Support**:
>     - Add Ubiblk v0.2.0 support in `setup_vhost_block_backend.rb` and `vhost_block_backend.rb` for x64 and arm64.
>     - Update `SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS` to include v0.2.0.
>   - **SHA256 Checksums**:
>     - Add SHA256 checksums for v0.2.0 in `vhost_block_backend.rb`.
>   - **GitHub Workflow**:
>     - Update `e2e.yml` to set `VHOST_BLOCK_BACKEND_VERSION` to v0.2.0 for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e2df625b912868d8c241e1bb7f4f4094827185f3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->