### PR TITLE
Print warning if specs leak threads

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -37,10 +37,12 @@ RSpec.describe "bin/ubi" do
       "UBI_PSQL" => RbConfig.ruby
     }.freeze
     @debug_env = @env.merge("UBI_DEBUG" => "1")
+    @skip_leaked_thread_check = true
   end
 
   after(:all) do
     @server.launcher.send(:stop)
+    @skip_leaked_thread_check = false
   end
   # rubocop:enable RSpec/BeforeAfterAll
 

--- a/spec/lib/log_dna_batcher_spec.rb
+++ b/spec/lib/log_dna_batcher_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe LogDnaBatcher do
     let(:log_dna_batcher) { described_class.new("dummy-key") }
     let(:http) { log_dna_batcher.ensure_connection }
 
+    after { log_dna_batcher.stop }
+
     describe "#send_batch" do
       it "prints failure message when response is not success" do
         expect(http).to receive(:request).and_return(Net::HTTPBadRequest.new(nil, 400, "Bad Request"))
@@ -56,6 +58,8 @@ RSpec.describe LogDnaBatcher do
 
         log_dna_batcher.ensure_connection
         log_dna_batcher.ensure_connection
+      ensure
+        log_dna_batcher.stop
       end
     end
   end
@@ -64,6 +68,8 @@ RSpec.describe LogDnaBatcher do
     let(:log_dna_batcher) { described_class.new("dummy-key", base_url: "https://localhost/logdna/ingest", flush_interval: 10000, max_batch_size: 100) }
     let(:http) { log_dna_batcher.ensure_connection }
 
+    after { log_dna_batcher.stop }
+
     before do
       allow(http).to receive(:request).and_return(Net::HTTPSuccess.new(nil, nil, nil))
     end
@@ -71,6 +77,21 @@ RSpec.describe LogDnaBatcher do
     it "sends batch when input queue is closed" do
       expect(log_dna_batcher).to receive(:send_batch).exactly(:once)
       log_dna_batcher.stop
+    end
+
+    it "adds to batch if not over the limit" do
+      expected = false
+      q = Queue.new
+      log_dna_batcher.instance_variable_set(:@max_batch_size, 2)
+      log_dna_batcher.define_singleton_method(:send_batch) do |batch|
+        raise unless expected
+        q.push(batch.dup)
+        super(batch)
+      end
+      log_dna_batcher.log("test log")
+      expected = true
+      log_dna_batcher.log("test log 2")
+      expect(q.pop.map { it[:line] }).to eq ["test log", "test log 2"]
     end
 
     it "sends the batch when flush interval is exceeded" do
@@ -106,10 +127,16 @@ RSpec.describe LogDnaBatcher do
         m.call(*args)
       end
 
-      expect(log_dna_batcher).to receive(:send_batch).at_least(:once).and_wrap_original do |m, *args|
+      first_time = true
+      expect(log_dna_batcher).to receive(:send_batch).at_least(:once).and_wrap_original do |m, batch|
         # Reset max batch size to a high value to avoid immediate re-send(s)
         log_dna_batcher.instance_variable_set(:@max_batch_size, 100)
         q.push(true)
+        m.call(batch)
+        if first_time
+          first_time = false
+          batch << "test log"
+        end
       end
 
       log_dna_batcher.log("test log")
@@ -119,25 +146,33 @@ RSpec.describe LogDnaBatcher do
     end
 
     it "does not send the batch until one of the pre-conditions are satisfied" do
-      expect(log_dna_batcher).not_to receive(:send_batch)
+      called = false
+      log_dna_batcher.define_singleton_method(:send_batch) do
+        called = true
+        super(it)
+      end
       log_dna_batcher.log("test log")
+      expect(called).to be false
     end
 
     it "logs error in case of an exception during batch processing" do
       q = Queue.new
 
       expect(log_dna_batcher.instance_variable_get(:@input_queue)).to receive(:closed?).at_least(:once).and_wrap_original do |m, *args|
-        q.push(true)
         m.call(*args)
         true
       end
 
-      log_dna_batcher.log("test log")
-
       expect(log_dna_batcher.instance_variable_get(:@input_queue)).to receive(:empty?).and_raise(StandardError, "Unexpected error")
       expect(log_dna_batcher).to receive(:puts).with("Error in processor: Unexpected error").ordered
       expect(log_dna_batcher).to receive(:puts).with(anything).ordered
-      expect(log_dna_batcher).to receive(:exit).with(1)
+      expect(log_dna_batcher).to receive(:exit) do |status|
+        expect(status).to eq 1
+        q.push(true)
+        raise StopIteration
+      end
+
+      log_dna_batcher.log("test log")
 
       expect(q.pop(timeout: 5)).to be true
       expect(q.empty?).to be(true)
@@ -149,6 +184,8 @@ RSpec.describe LogDnaBatcher do
       log_dna_batcher = described_class.new("dummy-key", base_url: "https://localhost/logdna/ingest?param=test")
 
       expect { log_dna_batcher.close_connection }.not_to raise_error
+    ensure
+      log_dna_batcher.stop
     end
   end
 end

--- a/spec/lib/thread_printer_spec.rb
+++ b/spec/lib/thread_printer_spec.rb
@@ -20,14 +20,18 @@ RSpec.describe ThreadPrinter do
       # The documentation calls out that the backtrace is an array or
       # nil.
       expect(described_class).to receive(:puts).with(/--BEGIN THREAD DUMP, .*/)
-      expect(described_class).to receive(:puts).with(/Thread: #<InstanceDouble.*>/)
+      expect(described_class).to receive(:puts).with(/Thread: #<Thread:.*>/)
       expect(described_class).to receive(:puts).with(/Created at: .*/)
       expect(described_class).to receive(:puts).with(nil)
       expect(described_class).to receive(:puts).with(/--END THREAD DUMP, .*/)
-      th = instance_double(Thread, backtrace: nil)
+      q = Queue.new
+      th = Thread.new { q.pop }
+      expect(th).to receive(:backtrace).and_return(nil)
       expect(th).to receive(:[]).with(:created_at).and_return(Time.now - 30)
       expect(Thread).to receive(:list).and_return([th])
       described_class.run
+      q.push nil
+      th.join(1)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,10 +61,12 @@ RSpec.configure do |config|
     end
     Mail::TestMailer.deliveries.clear if defined?(Mail)
 
-    Thread.list.each do
-      next if leaked_threads[it]
-      p [:leaked_thread, it]
-      leaked_threads[it] = true
+    unless @skip_leaked_thread_check
+      Thread.list.each do
+        next if leaked_threads[it]
+        p [:leaked_thread, it]
+        leaked_threads[it] = true
+      end
     end
   end
 


### PR DESCRIPTION
This can be the cause of spec nondeterminism.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds thread leak detection in RSpec tests and updates tests to manage threads properly.
> 
>   - **Behavior**:
>     - Adds a check for leaked threads in `spec_helper.rb` using `ObjectSpace::WeakMap` to track threads and print warnings for any new threads after tests.
>     - Sets `@skip_leaked_thread_check` to `true` in `cli_spec.rb` before tests and `false` after tests to control thread leak checks.
>   - **Tests**:
>     - Ensures `log_dna_batcher.stop` is called in `log_dna_batcher_spec.rb` after tests to prevent thread leaks.
>     - Updates `thread_printer_spec.rb` to handle threads with nil backtrace and created_at attributes.
>   - **Misc**:
>     - Minor changes in `cli_spec.rb` to manage server lifecycle and thread checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for db28dbef7a85cc9253cba0a34ff860f14dbf2a30. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->