### PR TITLE
Avoid use of Time.now in FreeQuota

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", ">= 5.95"
+gem "sequel", github: "jeremyevans/sequel", ref: "e370b682c927a37eec19b5cf3f0fef972fa1d9d6"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,14 @@ GIT
       rack
 
 GIT
+  remote: https://github.com/jeremyevans/sequel.git
+  revision: e370b682c927a37eec19b5cf3f0fef972fa1d9d6
+  ref: e370b682c927a37eec19b5cf3f0fef972fa1d9d6
+  specs:
+    sequel (5.95.1)
+      bigdecimal
+
+GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -373,8 +381,6 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
-    sequel (5.95.0)
-      bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
     sequel_pg (1.17.1)
@@ -510,7 +516,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel (>= 5.95)
+  sequel!
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords

--- a/spec/routes/web/inference_endpoint_spec.rb
+++ b/spec/routes/web/inference_endpoint_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Clover, "inference-endpoint" do
         project_id: project.id,
         resource_id: ie.id,
         resource_name: ie.name,
-        span: Sequel::Postgres::PGRange.new(Time.now, nil),
+        span: Sequel::Postgres::PGRange.new(Sequel::CURRENT_TIMESTAMP, nil),
         billing_rate_id: BillingRate.from_resource_type("InferenceTokens").first["id"],
         amount: 100000
       )
@@ -186,7 +186,7 @@ RSpec.describe Clover, "inference-endpoint" do
         project_id: project.id,
         resource_id: ie.id,
         resource_name: ie.name,
-        span: Sequel::Postgres::PGRange.new(Time.now, nil),
+        span: Sequel::Postgres::PGRange.new(Sequel::CURRENT_TIMESTAMP, nil),
         billing_rate_id: BillingRate.from_resource_type("InferenceTokens").first["id"],
         amount: 99999999
       )


### PR DESCRIPTION
Use Sequel::CURRENT_TIMESTAMP instead. To get the start of the month, use the date_trunc PostgreSQL function.

For this to work correctly requires the latest Sequel commit, so update to that.