### PR TITLE
Attempt to fix dispatcher spec nondeterminism

### DIFF
--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -33,7 +33,7 @@ class Scheduling::Dispatcher
   # pool_size :: The number of threads in the thread pool.
   # partition_number :: The partition number of the current respirate process. A nil
   #                     value means the process does not use partitioning.
-  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.dispatcher_max_threads, partition_number: nil, listen_timeout: 1)
+  def initialize(apoptosis_timeout: Strand::LEASE_EXPIRATION - 29, pool_size: Config.dispatcher_max_threads, partition_number: nil, listen_timeout: 1, recheck_seconds: listen_timeout * 2, stale_seconds: listen_timeout * 4)
     @shutting_down = false
 
     # How long to wait in seconds from the start of strand run
@@ -114,7 +114,7 @@ class Scheduling::Dispatcher
       # go stale.
       @repartitioner = Repartitioner.new(partition_number:, channel: :respirate,
         max_partition: 256, dispatcher: self, listen_timeout:,
-        recheck_seconds: listen_timeout * 2, stale_seconds: listen_timeout * 4)
+        recheck_seconds:, stale_seconds:)
 
       # The thread that listens for changes in the number of respirate processes
       # and adjusts the partition range accordingly.


### PR DESCRIPTION
Have dispatcher accept recheck_seconds and stale_seconds keyword arguments, and set these to higher values in the specs to avoid losing the race.

While here, add a new_dispatcher method in the specs to DRY things up.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The PR modifies `Dispatcher` to accept `recheck_seconds` and `stale_seconds` as keyword arguments and updates specs to use a `new_dispatcher` method for consistency and reduced race conditions.
> 
>   - **Behavior**:
>     - `Dispatcher` class in `dispatcher.rb` now accepts `recheck_seconds` and `stale_seconds` as keyword arguments, defaulting to `listen_timeout * 2` and `listen_timeout * 4` respectively.
>     - Adjusts these parameters in specs to higher values to mitigate race conditions.
>   - **Testing**:
>     - Introduces `new_dispatcher` method in `dispatcher_spec.rb` to streamline dispatcher instantiation with common parameters.
>     - Replaces direct `Dispatcher` instantiation with `new_dispatcher` in multiple tests to reduce redundancy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 68f2b9fc6580e576a0e7ed5bccda67ef5d258c5b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->