### PR TITLE
Fix nondeterministic failure in ps connect/disconnect cli spec

### DIFF
--- a/spec/routes/api/cli/ps/connect_spec.rb
+++ b/spec/routes/api/cli/ps/connect_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Clover, "cli ps connect" do
   before do
     cli(%w[ps eu-central-h1/test-ps create])
     cli(%w[ps eu-central-h1/test-ps2 create])
-    @ps1, @ps2 = PrivateSubnet.all
+    @ps1, @ps2 = PrivateSubnet.order(:name).all
   end
 
   it "connects requested private subnet to this subnet by id" do

--- a/spec/routes/api/cli/ps/disconnect_spec.rb
+++ b/spec/routes/api/cli/ps/disconnect_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Clover, "cli ps connect" do
   before do
     cli(%w[ps eu-central-h1/test-ps create])
     cli(%w[ps eu-central-h1/test-ps2 create])
-    @ps1, @ps2 = PrivateSubnet.all
+    @ps1, @ps2 = PrivateSubnet.order(:name).all
     cli(%W[ps eu-central-h1/#{@ps1.name} connect #{@ps2.ubid}])
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes nondeterministic failure in CLI specs by ordering subnets by name in `connect_spec.rb` and `disconnect_spec.rb`.
> 
>   - **Behavior**:
>     - Fixes nondeterministic failure in `ps connect` and `ps disconnect` CLI specs by ordering subnets by name.
>   - **Tests**:
>     - Updates `connect_spec.rb` and `disconnect_spec.rb` to use `PrivateSubnet.order(:name).all` instead of `PrivateSubnet.all` to ensure consistent test setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3e860fc4d4ee5c575c63652b059f3c993b7d503e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->