### PR TITLE
More complete fix for invalid account names during social login account creation

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -546,7 +546,19 @@ class Clover < Roda
         .strip
         .squeeze(" ")
         .slice(0...63)
-      name = "Unknown" unless Validation::ALLOWED_ACCOUNT_NAME.match?(name)
+      unless Validation::ALLOWED_ACCOUNT_NAME.match?(name)
+        Clog.emit("invalid social login account name") do
+          {
+            invalid_social_login_account_name: {
+              omniauth_name:,
+              email: account[:email],
+              name:
+            }
+          }
+        end
+        name = "Unknown"
+      end
+
       scope.before_rodauth_create_account(account, name)
     end
 

--- a/clover.rb
+++ b/clover.rb
@@ -546,7 +546,7 @@ class Clover < Roda
         .strip
         .squeeze(" ")
         .slice(0...63)
-      name = "Unknown" if name.empty?
+      name = "Unknown" unless Validation::ALLOWED_ACCOUNT_NAME.match?(name)
       scope.before_rodauth_create_account(account, name)
     end
 


### PR DESCRIPTION
Even after e4a6cb0895f7d09a4d41c93f9adb653c5eb3ec5d, we still had a couple cases where the account name during social login account creation was inactive. Unfortunately, the logs didn't show the account name that was attempted. I'm not sure how the account name was invalid after the preceding munging, but this change should fix the remaining cases.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds validation and logging for invalid account names during social login account creation in `clover.rb`.
> 
>   - **Behavior**:
>     - Adds validation for account names in `before_omniauth_create_account` in `clover.rb`.
>     - Logs invalid account names with `Clog.emit` and sets name to "Unknown" if invalid.
>   - **Logging**:
>     - Logs `invalid_social_login_account_name` with `omniauth_name`, `email`, and attempted `name` if invalid.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7ca0f8c3521cea0745adc6c399c8eaffa79202fe. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->