### PR TITLE
Add new image for Kubernetes 1.34 and remove 1.32 from version options

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -184,6 +184,7 @@ module Config
   override :ai_ubuntu_2404_nvidia_version, "20250505.1.0", string
   override :kubernetes_v1_32_version, "20250320.1.0", string
   override :kubernetes_v1_33_version, "20250506.1.0", string
+  override :kubernetes_v1_34_version, "20250828.1.0", string
 
   override :aws_based_postgres_16_ubuntu_2204_ami_version, "ami-0c15093fa829f190a", string
   override :aws_based_postgres_17_ubuntu_2204_ami_version, "ami-0c8f8ddefeb7bd695", string

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -15,7 +15,7 @@ module Option
   end
 
   def self.kubernetes_versions
-    ["v1.33", "v1.32"].freeze
+    ["v1.34", "v1.33"].freeze
   end
 
   def self.families

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -120,7 +120,8 @@ class Prog::DownloadBootImage < Prog::Base
     ["ai-model-ms-phi-4", "x64", "20250213.1.0"] => "0e998c4916c837c0992c4546404ecb51d0c5d5923f998f7cff0a9cddc5bf1689",
     ["ai-model-mistral-small-3", "x64", "20250217.1.0"] => "01ce8d1d0b7b0f717c51c26590234f4cb7971a9a5276de92b6cb4dc2c7a085e5",
     ["kubernetes-v1_32", "x64", "20250320.1.0"] => "369c7c869bba690771a1dcbbae52159defaa3fd3540f008ba6feea291e7a220a",
-    ["kubernetes-v1_33", "x64", "20250506.1.0"] => "35ca03c19385227117fa6579f58c73a362970359fa9486024ca393b134a698d4"
+    ["kubernetes-v1_33", "x64", "20250506.1.0"] => "35ca03c19385227117fa6579f58c73a362970359fa9486024ca393b134a698d4",
+    ["kubernetes-v1_34", "x64", "20250828.1.0"] => "3a29122a3836109df78778df24899f864bc8beff7d92d86dc4ab8b99314f520c"
   }.freeze
   BOOT_IMAGE_SHA256.each_key(&:freeze)
 

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   subject_is :kubernetes_cluster
 
-  def self.assemble(name:, project_id:, location_id:, version: "v1.32", private_subnet_id: nil, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
+  def self.assemble(name:, project_id:, location_id:, version: Option.kubernetes_versions.first, private_subnet_id: nil, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
     DB.transaction do
       unless (project = Project[project_id])
         fail "No existing project"

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Kubernetes::Client do
   let(:kubernetes_cluster) {
     KubernetesCluster.create(
       name: "test",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: private_subnet.id,
       location_id: Location::HETZNER_FSN1_ID,

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe KubernetesCluster do
     private_subnet = PrivateSubnet.create(project_id: project.id, name: "test", location_id: Location::HETZNER_FSN1_ID, net6: "fe80::/64", net4: "192.168.0.0/24")
     described_class.create(
       name: "kc-name",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       location_id: Location::HETZNER_FSN1_ID,
       cp_node_count: 3,
       project_id: project.id,
@@ -102,11 +102,11 @@ RSpec.describe KubernetesCluster do
     end
 
     it "validates version" do
-      kc.version = "v1.34"
+      kc.version = "v1.30"
       expect(kc.valid?).to be false
       expect(kc.errors[:version]).to eq(["must be a valid Kubernetes version"])
 
-      kc.version = "v1.32"
+      kc.version = Option.kubernetes_versions.first
       expect(kc.valid?).to be true
     end
 

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   let(:kc) {
     kc = KubernetesCluster.create(
       name: "cluster",
-      version: "v1.33",
+      version: Option.kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   let(:kc) {
     kc = KubernetesCluster.create(
       name: "k8scluster",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   let(:kubernetes_cluster) {
     kc = KubernetesCluster.create(
       name: "k8scluster",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
@@ -97,7 +97,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(4)
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq(37)
-      expect(new_vm.boot_image).to eq("kubernetes-v1_32")
+      expect(new_vm.boot_image).to eq("kubernetes-#{Option.kubernetes_versions.first.tr(".", "_")}")
     end
 
     it "creates a worker node and hops if a nodepool is given" do
@@ -113,7 +113,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(8)
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq(78)
-      expect(new_vm.boot_image).to eq("kubernetes-v1_32")
+      expect(new_vm.boot_image).to eq("kubernetes-#{Option.kubernetes_versions.first.tr(".", "_")}")
     end
 
     it "assigns the default storage size if not specified" do

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   let(:kubernetes_cluster) {
     kc = KubernetesCluster.create(
       name: "k8scluster",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -230,7 +230,7 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.33 v1.32
+    Version: v1.34 v1.33
     Control Plane Node Count: 1 3
 
 

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c 1 -w bad.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c 1 -w bad.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.33 v1.32
+    Version: v1.34 v1.33
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c a.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c a.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.33 v1.32
+    Version: v1.34 v1.33
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create invalid.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create invalid.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.33 v1.32
+    Version: v1.34 v1.33
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
@@ -1,5 +1,5 @@
 node_size: standard-2
-version: v1.32
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display_state: creating
 cp_node_count: 1
 node_size: standard-2
-version: v1.32
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display_state: creating
 cp_node_count: 1
 node_size: standard-2
-version: v1.32
+version: v1.34
 nodepool 1:
   node_size: standard-2
   vm 1:

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display_state: creating
 cp_node_count: 1
 node_size: standard-2
-version: v1.32
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display_state: creating
 cp_node_count: 1
 node_size: standard-2
-version: v1.32
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display_state: creating
 cp_node_count: 1
 node_size: standard-2
-version: v1.32
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
+++ b/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display_state: creating
 cp_node_count: 1
 node_size: standard-2
-version: v1.32
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc list -N.txt
+++ b/spec/routes/api/cli/golden-files/kc list -N.txt
@@ -1,1 +1,1 @@
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating  v1.32  1
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating  v1.34  1

--- a/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
@@ -1,2 +1,2 @@
 location       name     id                          display_state  version  cp_node_count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.32    1            
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1

--- a/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
@@ -1,2 +1,2 @@
 location       name     id                          display_state  version  cp_node_count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            

--- a/spec/routes/api/cli/golden-files/kc list.txt
+++ b/spec/routes/api/cli/golden-files/kc list.txt
@@ -1,2 +1,2 @@
 location       name     id                          display_state  version  cp_node_count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.32    1            
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1

--- a/spec/routes/api/cli/golden-files/kc list.txt
+++ b/spec/routes/api/cli/golden-files/kc list.txt
@@ -1,2 +1,2 @@
 location       name     id                          display_state  version  cp_node_count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Clover, "cli" do
     expect(Firewall).to receive(:generate_uuid).and_return("850f5687-1a76-8dfc-8949-a115826d20e7")
     expect(FirewallRule).to receive(:generate_uuid).and_return("d5889073-4aed-89f8-8894-1c376ebea8f6", "0803b040-d565-81f8-b2ed-f4d28df19f7c")
     expect(PrivateSubnet).to receive(:generate_ubid).and_return(UBID.parse("ps788q81w5w26h900k13ad8bkx"))
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v v1.32])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
 
     expect(Vm).to receive(:generate_ubid).and_return(UBID.parse("vmgbbazmznfa0mp49nzh5v0z25"), UBID.parse("vmnwfmjk5k462kkzsfa4n1h4xm"))
     expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("ncnqx1bbxgra7k8r9k9qwvspwd"), UBID.parse("nc1c3bggqpxt5kqqrdtkym1g03"))

--- a/spec/routes/api/cli/kc/create_spec.rb
+++ b/spec/routes/api/cli/kc/create_spec.rb
@@ -9,37 +9,37 @@ RSpec.describe Clover, "cli kc create" do
 
   it "creates kubernetes cluster with minimal options" do
     expect(KubernetesCluster.count).to eq 0
-    body = cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v v1.32])
+    body = cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(kc).to be_a KubernetesCluster
     expect(kc.name).to eq "test-kc"
-    expect(kc.version).to eq "v1.32"
+    expect(kc.version).to eq Option.kubernetes_versions.first
     expect(body).to eq "Kubernetes cluster created with id: #{kc.ubid}\n"
   end
 
   it "creates kubernetes cluster without --cp-node-count" do
     expect(KubernetesCluster.count).to eq 0
-    body = cli(%W[kc eu-central-h1/test-kc create -z standard-2 -w 1 -v v1.32])
+    body = cli(%W[kc eu-central-h1/test-kc create -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(kc).to be_a KubernetesCluster
     expect(kc.name).to eq "test-kc"
     expect(kc.cp_node_count).to eq 1
-    expect(kc.version).to eq "v1.32"
+    expect(kc.version).to eq Option.kubernetes_versions.first
     expect(body).to eq "Kubernetes cluster created with id: #{kc.ubid}\n"
   end
 
   it "creates kubernetes cluster without --worker-node-count" do
     expect(KubernetesCluster.count).to eq 0
-    body = cli(%W[kc eu-central-h1/test-kc create -c 3 -z standard-2 -v v1.32])
+    body = cli(%W[kc eu-central-h1/test-kc create -c 3 -z standard-2 -v #{Option.kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(kc).to be_a KubernetesCluster
     expect(kc.name).to eq "test-kc"
     expect(kc.cp_node_count).to eq 3
     expect(kc.nodepools.sum(&:node_count)).to eq 1
-    expect(kc.version).to eq "v1.32"
+    expect(kc.version).to eq Option.kubernetes_versions.first
     expect(body).to eq "Kubernetes cluster created with id: #{kc.ubid}\n"
   end
 

--- a/spec/routes/api/cli/kc/destroy_spec.rb
+++ b/spec/routes/api/cli/kc/destroy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Clover, "cli kc destroy" do
 
   it "destroys kubernetes cluster" do
     expect(KubernetesCluster.count).to eq 0
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v v1.32])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(Semaphore.where(strand_id: kc.id, name: "destroy")).to be_empty

--- a/spec/routes/api/cli/kc/rename_spec.rb
+++ b/spec/routes/api/cli/kc/rename_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 RSpec.describe Clover, "cli kc rename" do
   it "renames kubernetes cluster" do
     expect(Config).to receive(:kubernetes_service_project_id).and_return(@project.id).at_least(:once)
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v v1.32])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
     expect(cli(%W[kc eu-central-h1/test-kc rename new-name])).to eq "Kubernetes cluster renamed to new-name\n"
     expect(KubernetesCluster.select_order_map(:name)).to eq ["new-name"]
   end

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
   let(:kc) {
     Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "cluster",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       cp_node_count: 3,
       project_id: project.id,
       private_subnet_id: subnet.id,
@@ -55,7 +55,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
         expect(parsed_body["items"].length).to eq(1)
         expect(parsed_body["count"]).to eq(1)
         expect(parsed_body["items"][0]["name"]).to eq("cluster")
-        expect(parsed_body["items"][0]["version"]).to eq("v1.32")
+        expect(parsed_body["items"][0]["version"]).to eq(Option.kubernetes_versions.first)
       end
     end
 

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Clover, "Kubernetes" do
   let(:kc) do
     cluster = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "myk8s",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       project_id: project.id,
       private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "mysubnet", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id).id,
       location_id: Location::HETZNER_FSN1_ID
@@ -39,7 +39,7 @@ RSpec.describe Clover, "Kubernetes" do
   let(:kc_no_perm) do
     Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "not-my-k8s",
-      version: "v1.32",
+      version: Option.kubernetes_versions.first,
       project_id: project_wo_permissions.id,
       private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "othersubnet", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id).id,
       location_id: Location::HETZNER_FSN1_ID

--- a/spec/serializers/kubernetes_cluster_spec.rb
+++ b/spec/serializers/kubernetes_cluster_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Serializers::KubernetesCluster do
     it "serializes a KubernetesCluster without the detailed option" do
       project = Project.create(name: "default")
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
-      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: "v1.32", private_subnet_id: subnet.id).subject
+      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.kubernetes_versions.first, private_subnet_id: subnet.id).subject
       kn = KubernetesNodepool.create(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
       KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
@@ -22,7 +22,7 @@ RSpec.describe Serializers::KubernetesCluster do
         display_state: "creating",
         cp_node_count: 3,
         node_size: "standard-2",
-        version: "v1.32"
+        version: Option.kubernetes_versions.first
       }
 
       expect(described_class.serialize_internal(kc)).to eq(expected_result)
@@ -31,7 +31,7 @@ RSpec.describe Serializers::KubernetesCluster do
     it "serializes a KubernetesNodepool without the detailed option" do
       project = Project.create(name: "default")
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
-      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: "v1.32", private_subnet_id: subnet.id).subject
+      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.kubernetes_versions.first, private_subnet_id: subnet.id).subject
       kn = KubernetesNodepool.create(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
       cp_vm = create_vm
       KubernetesNode.create(vm_id: cp_vm.id, kubernetes_cluster_id: kc.id)
@@ -44,7 +44,7 @@ RSpec.describe Serializers::KubernetesCluster do
         display_state: "creating",
         cp_node_count: 3,
         node_size: "standard-2",
-        version: "v1.32",
+        version: Option.kubernetes_versions.first,
         cp_vms: Serializers::Vm.serialize([cp_vm]),
         nodepools: Serializers::KubernetesNodepool.serialize([kn], {detailed: true})
       }

--- a/spec/serializers/kubernetes_nodepool_spec.rb
+++ b/spec/serializers/kubernetes_nodepool_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Serializers::KubernetesNodepool do
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
       kc = KubernetesCluster.create(
         name: "cluster",
-        version: "v1.32",
+        version: Option.kubernetes_versions.first,
         cp_node_count: 3,
         private_subnet_id: subnet.id,
         location_id: Location::HETZNER_FSN1_ID,
@@ -37,7 +37,7 @@ RSpec.describe Serializers::KubernetesNodepool do
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
       kc = KubernetesCluster.create(
         name: "cluster",
-        version: "v1.32",
+        version: Option.kubernetes_versions.first,
         cp_node_count: 3,
         private_subnet_id: subnet.id,
         location_id: Location::HETZNER_FSN1_ID,


### PR DESCRIPTION
New image is added to support kubernetes 1.34

Update k8s tests so we won't have to update tests on version releases

Before this commit, on every new version, we had to update the tests to use to the new version. With this new approach we would use the first option of the kubernetes versions list.