### PR TITLE
Log exceptions in VmHost monitor

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -373,7 +373,8 @@ class VmHost < Sequel::Model
   def check_pulse(session:, previous_pulse:)
     reading = begin
       perform_health_checks(session[:ssh_session]) ? "up" : "down"
-    rescue
+    rescue => e
+      Clog.emit("Exception in VmHost #{ubid}") { Util.exception_to_hash(e) }
       "down"
     end
     pulse = aggregate_readings(previous_pulse: previous_pulse, reading: reading)


### PR DESCRIPTION
Log exceptions in VmHost monitor
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add exception logging to `check_pulse` method in `vm_host.rb` for improved error tracking.
> 
>   - **Error Handling**:
>     - In `vm_host.rb`, `check_pulse` method now logs exceptions using `Clog.emit` with `Util.exception_to_hash(e)` for better error tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 051cc6b561e3e06cfdf113c3974982f4e7a98b1e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->