### PR TITLE
Support hosts without IPv6

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -173,7 +173,7 @@ class Project < Sequel::Model
   feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics
   feature_flag :private_locations, :enable_c6gd, :enable_m6gd, :enable_m8gd
   feature_flag :free_runner_upgrade_until, :gpu_vm, :postgres_lantern, :aws_cloudwatch_logs
-  feature_flag :aws_alien_runners_ratio
+  feature_flag :aws_alien_runners_ratio, :ipv6_disabled
 end
 
 # Table: project

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -221,7 +221,7 @@ class Vm < Sequel::Model
     # shouldn't be stored in the host for security reasons.
     JSON.pretty_generate(
       vm_name: name,
-      public_ipv6: ephemeral_net6.to_s,
+      public_ipv6: project.get_ff_ipv6_disabled ? nic.private_subnet.random_private_ipv6.to_s : ephemeral_net6.to_s,
       public_ipv4: ip4.to_s || "",
       local_ipv4: local_vetho_ip.to_s.shellescape || "",
       dns_ipv4: nic.private_subnet.net4.nth(2).to_s,
@@ -241,7 +241,8 @@ class Vm < Sequel::Model
       cpu_burst_percent_limit: cpu_burst_percent_limit || 0,
       ch_version:,
       firmware_version:,
-      hugepages:
+      hugepages:,
+      ipv6_disabled: project.get_ff_ipv6_disabled || false
     )
   end
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -77,6 +77,7 @@ class VmHost < Sequel::Model
   # Generate a random network that is a slice of the host's network
   # for delegation to a VM.
   def ip6_random_vm_network
+    return nil unless net6
     prefix = host_prefix + 15
     # We generate 2 bytes of entropy for the lower bits
     # and append them to the host's network. This way,

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -21,10 +21,12 @@ class Prog::LearnNetwork < Prog::Base
     # Maybe we can improve support for inet in a fork later, NetAddr
     # is not a fast moving project, there is room to improve it, but
     # some would be backwards-incompatible.
-    vm_host.update(
-      ip6: ip6.addr,
-      net6: NetAddr::IPv6Net.new(NetAddr.parse_ip(ip6.addr), NetAddr::Mask128.new(ip6.prefixlen)).to_s
-    )
+    if ip6
+      vm_host.update(
+        ip6: ip6.addr,
+        net6: NetAddr::IPv6Net.new(NetAddr.parse_ip(ip6.addr), NetAddr::Mask128.new(ip6.prefixlen)).to_s
+      )
+    end
     pop "learned network information"
   end
 
@@ -43,8 +45,10 @@ class Prog::LearnNetwork < Prog::Base
       else
         fail "only one global unique address prefix supported on interface"
       end
+    in []
+      nil
     else
-      fail "only one one interface supported"
+      fail "only one interface supported"
     end
   end
 end

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -68,6 +68,7 @@ begin
   slice_name = params.fetch("slice_name", "system.slice")
   cpu_percent_limit = params.fetch("cpu_percent_limit", 0)
   cpu_burst_percent_limit = params.fetch("cpu_burst_percent_limit", 0)
+  ipv6_disabled = params.fetch("ipv6_disabled", false)
 rescue KeyError => e
   puts "Needed #{e.key} in parameters json"
   exit 1
@@ -85,7 +86,7 @@ when "prep"
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes,
     pci_devices, boot_image, dns_ipv4,
-    slice_name, cpu_percent_limit, cpu_burst_percent_limit)
+    slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled)
 when "recreate-unpersisted"
   secrets = JSON.parse($stdin.read)
   unless (storage_secrets = secrets["storage"])

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -89,6 +89,11 @@ RSpec.describe VmHost do
     expect(vh.ip6_random_vm_network.to_s).to eq("::8000:0:0:0/79")
   end
 
+  it "returns nil if there is no ip6 address" do
+    vh.net6 = nil
+    expect(vh.ip6_random_vm_network).to be_nil
+  end
+
   it "has a shortcut to install Rhizome" do
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     expect(Strand).to receive(:create) do |args|

--- a/spec/prog/learn_network_spec.rb
+++ b/spec/prog/learn_network_spec.rb
@@ -61,7 +61,7 @@ JSON
   }
 ]
 JSON
-      }.to raise_error RuntimeError, "only one one interface supported"
+      }.to raise_error RuntimeError, "only one interface supported"
     end
 
     it "crashes if more than one global unique address prefix is provided" do
@@ -84,6 +84,13 @@ JSON
 ]
 JSON
       }.to raise_error RuntimeError, "only one global unique address prefix supported on interface"
+    end
+
+    it "pops if there is no global unique address prefix provided" do
+      sshable = instance_double(Sshable)
+      expect(sshable).to receive(:cmd).with("/usr/sbin/ip -j -6 addr show scope global").and_return("[]")
+      expect(lm).to receive(:sshable).and_return(sshable)
+      expect { lm.start }.to exit({"msg" => "learned network information"})
     end
   end
 end


### PR DESCRIPTION
## VmHost learn network without IPv6

## Add project flag for disabled IPv6

## Support VMs without IPv6

## Support FirewallRule updates on IPv6 disabled VMs

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for VMs and hosts without IPv6 by introducing an `ipv6_disabled` feature flag and updating network, firewall, and VM setup processes.
> 
>   - **Feature Flag**:
>     - Add `ipv6_disabled` feature flag to `project.rb`.
>   - **VM Configuration**:
>     - Update `params_json` in `vm.rb` to use private IPv6 if `ipv6_disabled` is true.
>     - Modify `setup-vm` and `vm_setup.rb` to handle `ipv6_disabled` parameter.
>   - **Network Handling**:
>     - Update `ip6_random_vm_network` in `vm_host.rb` to return `nil` if `net6` is absent.
>     - Adjust `learn_network.rb` to skip IPv6 updates if not present.
>   - **Firewall Rules**:
>     - Modify `update_firewall_rules.rb` to handle cases where IPv6 is disabled, ensuring no IPv6 rules are applied.
>   - **Testing**:
>     - Add tests in `vm_host_spec.rb`, `learn_network_spec.rb`, and `update_firewall_rules_spec.rb` to cover scenarios with `ipv6_disabled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 26e89976da7c4ac5a172fcfb2c2db16f59e43368. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->