### PR TITLE
Improve k8s services loadbalancer

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -76,15 +76,11 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       custom_hostname_prefix: custom_apiserver_hostname_prefix
     ).subject
 
-    services_lb = Prog::Vnet::LoadBalancerNexus.assemble(
+    services_lb = Prog::Vnet::LoadBalancerNexus.assemble_with_multiple_ports(
       kubernetes_cluster.private_subnet_id,
+      ports: [],
       name: kubernetes_cluster.services_load_balancer_name,
       algorithm: "hash_based",
-      # TODO: change the api to support LBs without ports
-      # The next two fields will be later modified by the sync_kubernetes_services label
-      # These are just set for passing the creation validations
-      src_port: 443,
-      dst_port: 6443,
       health_check_endpoint: "/",
       health_check_protocol: "tcp",
       custom_hostname_dns_zone_id:,

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -84,8 +84,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       health_check_endpoint: "/",
       health_check_protocol: "tcp",
       custom_hostname_dns_zone_id:,
-      custom_hostname_prefix: custom_services_hostname_prefix,
-      stack: LoadBalancer::Stack::IPV4 # TODO: Can we change this to DUAL?
+      custom_hostname_prefix: custom_services_hostname_prefix
     ).subject
 
     kubernetes_cluster.update(api_server_lb_id: api_server_lb.id, services_lb_id: services_lb.id)

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect(kubernetes_cluster.services_lb.name).to eq "#{kubernetes_cluster.ubid}-services"
       expect(kubernetes_cluster.services_lb.stack).to eq LoadBalancer::Stack::IPV4
+      expect(kubernetes_cluster.services_lb.ports.count).to eq 0
       expect(kubernetes_cluster.services_lb.private_subnet_id).to eq subnet.id
       expect(kubernetes_cluster.services_lb.custom_hostname_dns_zone_id).to eq dns_zone.id
       expect(kubernetes_cluster.services_lb.custom_hostname).to eq "k8scluster-services-#{kubernetes_cluster.ubid[-5...]}.k8s.ubicloud.com"

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kubernetes_cluster.api_server_lb.custom_hostname).to eq "k8scluster-apiserver-#{kubernetes_cluster.ubid[-5...]}.k8s.ubicloud.com"
 
       expect(kubernetes_cluster.services_lb.name).to eq "#{kubernetes_cluster.ubid}-services"
-      expect(kubernetes_cluster.services_lb.stack).to eq LoadBalancer::Stack::IPV4
+      expect(kubernetes_cluster.services_lb.stack).to eq LoadBalancer::Stack::DUAL
       expect(kubernetes_cluster.services_lb.ports.count).to eq 0
       expect(kubernetes_cluster.services_lb.private_subnet_id).to eq subnet.id
       expect(kubernetes_cluster.services_lb.custom_hostname_dns_zone_id).to eq dns_zone.id


### PR DESCRIPTION
Create the k8s services loadbalancer without ports

When we bootstrap a cluster, there are no LoadBalancer services and with the current model we had, the monitor would keep detecting that there are ports in the services_lb in which there are no Services inside kuberentes. This commit fixes that.

Use dual loadbalancers(IPV4 and IPV6) for services_lb