### PR TITLE
Enforce password length requirements

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -348,7 +348,7 @@ class Clover < Roda
       password_minimum_length 8
       password_maximum_bytes 72
       password_meets_requirements? do |password|
-        password.match?(/[a-z]/) && password.match?(/[A-Z]/) && password.match?(/[0-9]/)
+        super(password) && password.match?(/[a-z]/) && password.match?(/[A-Z]/) && password.match?(/[0-9]/)
       end
 
       invalid_password_message = "Password must have 8 characters minimum and contain at least one lowercase letter, one uppercase letter, and one digit."

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -433,12 +433,22 @@ RSpec.describe Clover, "auth" do
         visit "/account/change-password"
 
         fill_in "Current Password", with: TEST_USER_PASSWORD if clear_last_password_entry
-        fill_in "New Password", with: "#{TEST_USER_PASSWORD}_new"
-        fill_in "New Password Confirmation", with: "#{TEST_USER_PASSWORD}_new"
+        bad_pass = "aA0"
+        fill_in "New Password", with: bad_pass
+        fill_in "New Password Confirmation", with: bad_pass
 
         click_button "Change Password"
 
         expect(page.title).to eq("Ubicloud - Change Password")
+        expect(page).to have_flash_error("There was an error changing your password")
+        expect(page).to have_content("Password must have 8 characters minimum and contain at least one lowercase letter, one uppercase letter, and one digit.")
+
+        new_pass = TEST_USER_EMAIL + "New0"
+        fill_in "New Password", with: new_pass
+        fill_in "New Password Confirmation", with: new_pass
+
+        click_button "Change Password"
+        expect(page).to have_flash_notice("Your password has been changed")
 
         click_button "Log out"
 
@@ -446,9 +456,10 @@ RSpec.describe Clover, "auth" do
 
         fill_in "Email Address", with: TEST_USER_EMAIL
         click_button "Sign in"
-        fill_in "Password", with: "#{TEST_USER_PASSWORD}_new"
+        fill_in "Password", with: new_pass
 
         click_button "Sign in"
+        expect(page).to have_flash_notice("You have been logged in")
       end
 
       it "can close account when password entry is #{"not " unless clear_last_password_entry}required" do


### PR DESCRIPTION
Previously, without the super call, the min/max length requirements were ignored.

The related spec was not testing the password was actually changed, since the password it was testing did not contain a number or uppercase letter. Fix the spec to actually test the handling of both an invalid and a valid password.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforces password length requirements and updates tests to validate password changes correctly.
> 
>   - **Behavior**:
>     - Enforces password length requirements in `clover.rb` by adding `super(password)` to `password_meets_requirements?`.
>     - Updates error message for invalid passwords to include length and character requirements.
>   - **Tests**:
>     - Fixes test in `auth_spec.rb` to correctly validate password changes by using a valid password format.
>     - Adds checks for both invalid and valid password scenarios in `auth_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 453508a32819806fb965e2341427a2adac71284b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->