### PR TITLE
Add underline to hyperlinks in the web shell output

### DIFF
--- a/routes/project/cli.rb
+++ b/routes/project/cli.rb
@@ -56,7 +56,7 @@ class Clover
             UBID.resolve_map(ubids)
             h(body).gsub(UbiCli::OBJECT_INFO_REGEXP) do
               if (obj = ubids[UBID.to_uuid(it)]) && obj.respond_to?(:path)
-                "<a class=\"text-orange-600\" href=\"#{@project.path}#{obj.path}\">#{it}</a>"
+                "<a class=\"text-orange-600 underline\" href=\"#{@project.path}#{obj.path}\">#{it}</a>"
               else
                 it
               end


### PR DESCRIPTION
UBIDs in the web shell output are actually clickable links, which is a very cool feature. However, it’s hard to notice at first glance, I only realized it when I tried to copy one.

Let's add underlines to hyperlinks in the web shell output to make them more visible.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds underline to hyperlinks in web shell output in `Clover` class to improve visibility.
> 
>   - **Behavior**:
>     - Adds underline to hyperlinks in web shell output in `Clover` class in `routes/project/cli.rb` to improve visibility.
>     - Specifically modifies the HTML anchor tag to include `underline` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for eb448a02592c427be4547f8e81e312e4d8923146. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->