### PR TITLE
Self destruct Postgres Timelines when it's safe enough.

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -65,7 +65,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
 
   label def wait
     leader = postgres_timeline.leader
-    backups = leader.nil? ? [] : postgres_timeline.backups
+    backups = leader ? postgres_timeline.backups : []
     if leader.nil? && backups.empty? && Time.now - postgres_timeline.created_at > 10 * 24 * 60 * 60
       Clog.emit("Self-destructing timeline as no leader or backups are present and it is older than 10 days") { postgres_timeline }
       hop_destroy

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -64,13 +64,19 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   label def wait
+    leader = postgres_timeline.leader
+    if leader.nil? && postgres_timeline.backups.empty? && Time.now - postgres_timeline.created_at > 10 * 24 * 60 * 60
+      Clog.emit("Self-destructing timeline as no leader or backups are present and it is older than 10 days") { postgres_timeline }
+      hop_destroy
+    end
+
     nap 20 * 60 if postgres_timeline.blob_storage.nil?
 
     # For the purpose of missing backup pages, we act like the very first backup
     # is taken at the creation, which ensures that we would get a page if and only
     # if no backup is taken for 2 days.
     latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max || postgres_timeline.created_at
-    if postgres_timeline.leader && latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60 # 2 days
+    if leader && latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60 # 2 days
       Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid)
     else
       Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve


### PR DESCRIPTION
We used to let PG timelines linger around when servers get destroyed and do manual clean-up every once in a while. This change adds some logic to PG timeline to initiate a self-destruct if there's no leader and the timeline is old enough.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add self-destruct logic for Postgres timelines without a leader or backups older than 10 days.
> 
>   - **Behavior**:
>     - Adds self-destruct logic to `wait` in `postgres_timeline_nexus.rb` for timelines with no leader, no backups, and older than 10 days.
>     - Emits a log message before self-destructing.
>   - **Tests**:
>     - Adds test for self-destruct condition in `wait` method in `postgres_timeline_nexus_spec.rb`.
>     - Verifies no API calls for backups if no leader is present.
>   - **Misc**:
>     - Fixes typo in test description in `postgres_timeline_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for eefa6eb6fbca8795265cead607a2e9b047562d89. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->