### PR TITLE
Set MinIO parity properly and upgrade the version

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -123,7 +123,7 @@ module Config
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string
   optional :minio_service_project_id, string
-  override :minio_version, "minio_20240406052602.0.0_amd64"
+  override :minio_version, "minio_20250723155402.0.0_amd64"
 
   # VictoriaMetrics
   optional :victoria_metrics_service_project_id, string

--- a/prog/minio/setup_minio.rb
+++ b/prog/minio/setup_minio.rb
@@ -26,6 +26,7 @@ MINIO_OPTS="--console-address :9001"
 MINIO_ROOT_USER="#{minio_server.cluster.admin_user}"
 MINIO_ROOT_PASSWORD="#{minio_server.cluster.admin_password}"
 #{server_url_config}
+MINIO_STORAGE_CLASS_STANDARD="EC:#{[minio_server.pool.per_server_drive_count * minio_server.pool.servers.count / 2, 8].min}"
 ECHO
 
       hosts = <<ECHO

--- a/spec/prog/minio/setup_minio_spec.rb
+++ b/spec/prog/minio/setup_minio_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Prog::Minio::SetupMinio do
 
     it "installs minio if failed" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check install_minio").and_return("Failed")
-      expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'minio/bin/install_minio minio_20240406052602.0.0_amd64' install_minio")
+      expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'minio/bin/install_minio minio_20250723155402.0.0_amd64' install_minio")
       expect { nx.install_minio }.to nap(5)
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Prog::Minio::SetupMinio do
 
     it "installs minio if NotStarted" do
       expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer --check install_minio").and_return("NotStarted")
-      expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'minio/bin/install_minio minio_20240406052602.0.0_amd64' install_minio")
+      expect(nx.minio_server.vm.sshable).to receive(:cmd).with("common/bin/daemonizer 'minio/bin/install_minio minio_20250723155402.0.0_amd64' install_minio")
       expect { nx.install_minio }.to nap(5)
     end
   end
@@ -78,6 +78,7 @@ MINIO_OPTS="--console-address :9001"
 MINIO_ROOT_USER="minio-admin"
 MINIO_ROOT_PASSWORD="dummy-password"
 MINIO_SERVER_URL="https://minio-cluster-name.minio.ubicloud.com:9000"
+MINIO_STORAGE_CLASS_STANDARD="EC:0"
 ECHO
       minio_hosts = <<ECHO
 ::1 ip6-localhost ip6-loopback


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update MinIO version and add parity configuration, with corresponding test updates.
> 
>   - **MinIO Version Update**:
>     - Update `minio_version` to `minio_20250723155402.0.0_amd64` in `config.rb` and `setup_minio_spec.rb`.
>   - **MinIO Parity Configuration**:
>     - Add `MINIO_STORAGE_CLASS_STANDARD` configuration in `setup_minio.rb` to set parity based on server and drive count.
>   - **Tests**:
>     - Update tests in `setup_minio_spec.rb` to reflect new MinIO version and parity configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9ef2a90fdf66582204899e9e43a83837a334ef2b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->