### PR TITLE
Allow authorization methods to accept objects in addition to ids

### DIFF
--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -15,7 +15,7 @@ class Clover
   end
 
   def firewall_post(firewall_name)
-    authorize("Firewall:create", @project.id)
+    authorize("Firewall:create", @project)
     Validation.validate_name(firewall_name)
 
     description = typecast_params.str("description") || ""

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def kubernetes_cluster_post(name)
-    authorize("KubernetesCluster:create", @project.id)
+    authorize("KubernetesCluster:create", @project)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
     version, target_node_size = typecast_params.nonempty_str!(["version", "worker_size"])

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -13,7 +13,7 @@ class Clover
   end
 
   def load_balancer_post(name)
-    authorize("LoadBalancer:create", @project.id)
+    authorize("LoadBalancer:create", @project)
 
     algorithm, health_check_protocol, stack = typecast_params.nonempty_str!(%w[algorithm health_check_protocol stack])
     src_port, dst_port = typecast_params.pos_int!(%w[src_port dst_port])

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def postgres_post(name)
-    authorize("Postgres:create", @project.id)
+    authorize("Postgres:create", @project)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
     flavor = typecast_params.nonempty_str("flavor", PostgresResource::Flavor::STANDARD)

--- a/helpers/private_subnet.rb
+++ b/helpers/private_subnet.rb
@@ -18,7 +18,7 @@ class Clover
   end
 
   def private_subnet_post(name)
-    authorize("PrivateSubnet:create", @project.id)
+    authorize("PrivateSubnet:create", @project)
 
     if (firewall_id = typecast_params.nonempty_str("firewall_id"))
       unless (firewall = authorized_firewall(location_id: @location.id))

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -16,7 +16,7 @@ class Clover
 
   def vm_post(name)
     project = @project
-    authorize("Vm:create", project.id)
+    authorize("Vm:create", project)
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless project.has_valid_payment_method?
 
     public_key = typecast_params.nonempty_str!("public_key")

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -161,7 +161,7 @@ class Invoice < Sequel::Model
   def send_failure_email(errors)
     data = Serializers::Invoice.serialize(self)
     receivers = [data.billing_email]
-    receivers += project.accounts.select { Authorization.has_permission?(project.id, it.id, "Project:billing", project.id) }.map(&:email)
+    receivers += project.accounts.select { Authorization.has_permission?(project, it, "Project:billing", project) }.map(&:email)
     Util.send_email(receivers.uniq, "Urgent: Action Required to Prevent Service Disruption",
       cc: Config.mail_from,
       greeting: "Dear #{data.billing_name},",

--- a/routes/github.rb
+++ b/routes/github.rb
@@ -11,7 +11,7 @@ class Clover
 
       if (installation = GithubInstallation[installation_id: installation_id])
         @project = installation.project
-        authorize("Project:github", installation.project.id)
+        authorize("Project:github", installation.project)
         flash["notice"] = "GitHub runner integration is already enabled for #{installation.project.name} project."
         Clog.emit("GitHub installation already exists") { {installation_failed: {id: installation_id, account_ubid: current_account.ubid}} }
         r.redirect installation, "/runner"
@@ -23,7 +23,7 @@ class Clover
         r.redirect "/project"
       end
 
-      authorize("Project:github", project.id)
+      authorize("Project:github", project)
 
       if setup_action == "request"
         flash["notice"] = "The GitHub App installation request is awaiting approval from the GitHub organization's administrator. As GitHub will redirect your admin back to the Ubicloud console, the admin needs to have an Ubicloud account with the necessary permissions to finalize the installation. Please invite the admin to your project if they don't have an account yet."

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -50,7 +50,7 @@ class Clover
 
       r.is do
         r.get do
-          authorize("Project:view", @project.id)
+          authorize("Project:view", @project)
 
           if api?
             Serializers::Project.serialize(@project)
@@ -60,7 +60,7 @@ class Clover
         end
 
         r.delete do
-          authorize("Project:delete", @project.id)
+          authorize("Project:delete", @project)
 
           if @project.has_resources?
             fail DependencyError.new("'#{@project.name}' project has some resources. Delete all related resources first.")
@@ -75,7 +75,7 @@ class Clover
         end
 
         r.post web? do
-          authorize("Project:edit", @project.id)
+          authorize("Project:edit", @project)
 
           handle_validation_failure("project/show")
 

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -12,7 +12,7 @@ class Clover
         next "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
       end
 
-      authorize("Project:billing", @project.id)
+      authorize("Project:billing", @project)
 
       r.get true do
         view "project/billing"

--- a/routes/project/discount_code.rb
+++ b/routes/project/discount_code.rb
@@ -3,7 +3,7 @@
 class Clover
   hash_branch(:project_prefix, "discount-code") do |r|
     r.post r.web? do
-      authorize("Project:billing", @project.id)
+      authorize("Project:billing", @project)
       handle_validation_failure("project/billing")
 
       if (discount_code = typecast_params.nonempty_str("discount_code"))

--- a/routes/project/firewall.rb
+++ b/routes/project/firewall.rb
@@ -15,7 +15,7 @@ class Clover
 
     r.web do
       r.get "create" do
-        authorize("Firewall:create", @project.id)
+        authorize("Firewall:create", @project)
         view "networking/firewall/create"
       end
 

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -9,7 +9,7 @@ class Clover
         next "GitHub Action Runner integration is not enabled. Set GITHUB_APP_NAME to enable it."
       end
 
-      authorize("Project:github", @project.id)
+      authorize("Project:github", @project)
 
       r.get true do
         if (installation = @project.github_installations_dataset.first)

--- a/routes/project/inference_api_key.rb
+++ b/routes/project/inference_api_key.rb
@@ -17,7 +17,7 @@ class Clover
       end
 
       r.post do
-        authorize("InferenceApiKey:create", @project.id)
+        authorize("InferenceApiKey:create", @project)
         iak = nil
         DB.transaction do
           iak = ApiKey.create_inference_api_key(@project)
@@ -44,7 +44,7 @@ class Clover
 
       r.delete do
         if iak
-          authorize("InferenceApiKey:delete", iak.id)
+          authorize("InferenceApiKey:delete", iak)
           DB.transaction do
             iak.destroy
             audit_log(iak, "destroy")

--- a/routes/project/kubernetes_cluster.rb
+++ b/routes/project/kubernetes_cluster.rb
@@ -14,7 +14,7 @@ class Clover
       end
 
       r.get "create" do
-        authorize("KubernetesCluster:create", @project.id)
+        authorize("KubernetesCluster:create", @project)
         view "kubernetes-cluster/create"
       end
     end

--- a/routes/project/load_balancer.rb
+++ b/routes/project/load_balancer.rb
@@ -13,7 +13,7 @@ class Clover
       end
 
       r.get "create" do
-        authorize("LoadBalancer:create", @project.id)
+        authorize("LoadBalancer:create", @project)
         view "networking/load_balancer/create"
       end
     end

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -24,7 +24,7 @@ class Clover
 
       r.is do
         r.delete do
-          authorize("Firewall:delete", firewall.id)
+          authorize("Firewall:delete", firewall)
           ds = firewall.private_subnets_dataset
           unless ds.exclude(id: dataset_authorize(ds, "PrivateSubnet:edit").select(:id)).empty?
             fail Authorization::Unauthorized
@@ -38,7 +38,7 @@ class Clover
         end
 
         r.get do
-          authorize("Firewall:view", firewall.id)
+          authorize("Firewall:view", firewall)
 
           if api?
             Serializers::Firewall.serialize(firewall, {detailed: true})
@@ -53,7 +53,7 @@ class Clover
       r.show_object(firewall, actions: %w[overview networking settings], perm: "Firewall:view", template: "networking/firewall/show")
 
       r.post %w[attach-subnet detach-subnet] do |action|
-        authorize("Firewall:view", firewall.id)
+        authorize("Firewall:view", firewall)
         handle_validation_failure("networking/firewall/show") { @page = "networking" }
 
         unless (private_subnet = authorized_private_subnet(location_id: @location.id, perm: "PrivateSubnet:edit"))
@@ -84,7 +84,7 @@ class Clover
 
       r.on "firewall-rule" do
         r.post true do
-          authorize("Firewall:edit", firewall.id)
+          authorize("Firewall:edit", firewall)
           handle_validation_failure("networking/firewall/show") { @page = "networking" }
 
           parsed_cidr = Validation.validate_cidr(typecast_params.str!("cidr"))
@@ -110,7 +110,7 @@ class Clover
           check_found_object(firewall_rule)
 
           r.delete do
-            authorize("Firewall:edit", firewall.id)
+            authorize("Firewall:edit", firewall)
             DB.transaction do
               firewall.remove_firewall_rule(firewall_rule)
               audit_log(firewall_rule, "destroy", firewall)
@@ -124,7 +124,7 @@ class Clover
           end
 
           r.get api? do
-            authorize("Firewall:view", firewall.id)
+            authorize("Firewall:view", firewall)
             Serializers::FirewallRule.serialize(firewall_rule)
           end
         end

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -25,7 +25,7 @@ class Clover
 
       r.is do
         r.get do
-          authorize("KubernetesCluster:view", kc.id)
+          authorize("KubernetesCluster:view", kc)
           if api?
             Serializers::KubernetesCluster.serialize(kc, {detailed: true})
           else
@@ -34,7 +34,7 @@ class Clover
         end
 
         r.delete do
-          authorize("KubernetesCluster:delete", kc.id)
+          authorize("KubernetesCluster:delete", kc)
           DB.transaction do
             kc.incr_destroy
             audit_log(kc, "destroy")
@@ -48,7 +48,7 @@ class Clover
       r.show_object(kc, actions: %w[overview nodes settings], perm: "KubernetesCluster:view", template: "kubernetes-cluster/show")
 
       r.get "kubeconfig" do
-        authorize("KubernetesCluster:edit", kc.id)
+        authorize("KubernetesCluster:edit", kc)
 
         response.content_type = :text
         response["content-disposition"] = "attachment; filename=\"#{kc.name}-kubeconfig.yaml\""

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -24,7 +24,7 @@ class Clover
       check_found_object(lb)
 
       r.post %w[attach-vm detach-vm] do |action|
-        authorize("LoadBalancer:edit", lb.id)
+        authorize("LoadBalancer:edit", lb)
         handle_validation_failure("networking/load_balancer/show") { @page = "vms" }
 
         unless (vm = authorized_vm(location_id: lb.private_subnet.location_id))
@@ -58,7 +58,7 @@ class Clover
 
       r.is do
         r.get do
-          authorize("LoadBalancer:view", lb.id)
+          authorize("LoadBalancer:view", lb)
           if api?
             Serializers::LoadBalancer.serialize(lb, {detailed: true})
           else
@@ -67,7 +67,7 @@ class Clover
         end
 
         r.delete do
-          authorize("LoadBalancer:delete", lb.id)
+          authorize("LoadBalancer:delete", lb)
           DB.transaction do
             lb.incr_destroy
             audit_log(lb, "destroy")
@@ -76,7 +76,7 @@ class Clover
         end
 
         r.patch api? do
-          authorize("LoadBalancer:edit", lb.id)
+          authorize("LoadBalancer:edit", lb)
           algorithm, health_check_endpoint = typecast_params.nonempty_str!(%w[algorithm health_check_endpoint])
           src_port, dst_port = typecast_params.pos_int!(%w[src_port dst_port])
           vm_ids = typecast_params.array(:ubid_uuid, "vms")

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -24,7 +24,7 @@ class Clover
 
       r.is do
         r.get do
-          authorize("Postgres:view", pg.id)
+          authorize("Postgres:view", pg)
 
           if api?
             response.headers["cache-control"] = "no-store"
@@ -35,7 +35,7 @@ class Clover
         end
 
         r.delete do
-          authorize("Postgres:delete", pg.id)
+          authorize("Postgres:delete", pg)
           DB.transaction do
             pg.incr_destroy
             audit_log(pg, "destroy")
@@ -44,7 +44,7 @@ class Clover
         end
 
         r.patch do
-          authorize("Postgres:edit", pg.id)
+          authorize("Postgres:edit", pg)
 
           size = typecast_params.nonempty_str("size", pg.target_vm_size)
           target_storage_size_gib = typecast_params.pos_int("storage_size", pg.target_storage_size_gib)
@@ -113,7 +113,7 @@ class Clover
       r.show_object(pg, actions: show_actions, perm: "Postgres:view", template: "postgres/show")
 
       r.post "restart" do
-        authorize("Postgres:edit", pg.id)
+        authorize("Postgres:edit", pg)
         DB.transaction do
           pg.incr_restart
           audit_log(pg, "restart")
@@ -130,7 +130,7 @@ class Clover
       r.on "firewall-rule" do
         r.is do
           r.get api? do
-            authorize("Postgres:view", pg.id)
+            authorize("Postgres:view", pg)
             {
               items: Serializers::PostgresFirewallRule.serialize(pg.firewall_rules),
               count: pg.firewall_rules.count
@@ -138,7 +138,7 @@ class Clover
           end
 
           r.post do
-            authorize("Postgres:edit", pg.id)
+            authorize("Postgres:edit", pg)
             handle_validation_failure("postgres/show") { @page = "networking" }
 
             parsed_cidr = Validation.validate_cidr(typecast_params.nonempty_str!("cidr"))
@@ -164,7 +164,7 @@ class Clover
         end
 
         r.is :ubid_uuid do |id|
-          authorize("Postgres:edit", pg.id)
+          authorize("Postgres:edit", pg)
           fwr = pg.firewall_rules_dataset[id:]
           check_found_object(fwr)
 
@@ -203,7 +203,7 @@ class Clover
 
       r.on "metric-destination" do
         r.post true do
-          authorize("Postgres:edit", pg.id)
+          authorize("Postgres:edit", pg)
           handle_validation_failure("postgres/show") { @page = "charts" }
 
           password_param = (api? ? "password" : "metric-destination-password")
@@ -226,7 +226,7 @@ class Clover
         end
 
         r.delete :ubid_uuid do |id|
-          authorize("Postgres:edit", pg.id)
+          authorize("Postgres:edit", pg)
 
           if (md = pg.metric_destinations_dataset[id:])
             DB.transaction do
@@ -241,7 +241,7 @@ class Clover
       end
 
       r.post "read-replica" do
-        authorize("Postgres:edit", pg.id)
+        authorize("Postgres:edit", pg)
         handle_validation_failure("postgres/show") { @page = "read-replica" }
 
         name = typecast_params.nonempty_str!("name")
@@ -281,7 +281,7 @@ class Clover
       end
 
       r.post "promote" do
-        authorize("Postgres:edit", pg.id)
+        authorize("Postgres:edit", pg)
         handle_validation_failure("postgres/show") { @page = "settings" }
 
         unless pg.read_replica?
@@ -303,8 +303,8 @@ class Clover
       end
 
       r.post "restore" do
-        authorize("Postgres:create", @project.id)
-        authorize("Postgres:view", pg.id)
+        authorize("Postgres:create", @project)
+        authorize("Postgres:view", pg)
         handle_validation_failure("postgres/show") { @page = "backup_restore" }
 
         name, restore_target = typecast_params.nonempty_str!(["name", "restore_target"])
@@ -339,7 +339,7 @@ class Clover
       end
 
       r.post "reset-superuser-password" do
-        authorize("Postgres:view", pg.id)
+        authorize("Postgres:view", pg)
         handle_validation_failure("postgres/show") { @page = "settings" }
 
         if pg.read_replica?
@@ -365,7 +365,7 @@ class Clover
       end
 
       r.post "set-maintenance-window" do
-        authorize("Postgres:edit", pg.id)
+        authorize("Postgres:edit", pg)
         maintenance_window_start_at = typecast_params.int("maintenance_window_start_at")
 
         DB.transaction do
@@ -382,7 +382,7 @@ class Clover
       end
 
       r.get "ca-certificates" do
-        authorize("Postgres:view", pg.id)
+        authorize("Postgres:view", pg)
 
         next unless (certs = pg.ca_certificates)
 
@@ -392,7 +392,7 @@ class Clover
       end
 
       r.get "metrics", r.accepts_json? do
-        authorize("Postgres:view", pg.id)
+        authorize("Postgres:view", pg)
 
         start_time, end_time = typecast_params.str(%w[start end])
         start_time ||= (DateTime.now.new_offset(0) - 30.0 / 1440).rfc3339
@@ -481,7 +481,7 @@ class Clover
 
       r.is "config" do
         r.get do
-          authorize("Postgres:view", pg.id)
+          authorize("Postgres:view", pg)
 
           {
             pg_config: pg.user_config,
@@ -490,7 +490,7 @@ class Clover
         end
 
         r.on method: [:post, :patch] do
-          authorize("Postgres:edit", pg.id)
+          authorize("Postgres:edit", pg)
           handle_validation_failure("postgres/show") { @page = "config" }
 
           if web?

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -23,7 +23,7 @@ class Clover
       check_found_object(ps)
 
       r.post "connect" do
-        authorize("PrivateSubnet:connect", ps.id)
+        authorize("PrivateSubnet:connect", ps)
         handle_validation_failure("networking/private_subnet/show") { @page = "networking" }
         unless (subnet = authorized_private_subnet(key: "connected-subnet-id", perm: "PrivateSubnet:connect"))
           raise CloverError.new(400, "InvalidRequest", "Subnet to be connected not found")
@@ -43,7 +43,7 @@ class Clover
       end
 
       r.post "disconnect", :ubid_uuid do |id|
-        authorize("PrivateSubnet:disconnect", ps.id)
+        authorize("PrivateSubnet:disconnect", ps)
         handle_validation_failure("networking/private_subnet/show") { @page = "networking" }
         unless (subnet = authorized_private_subnet(id:, perm: "PrivateSubnet:disconnect"))
           raise CloverError.new(400, "InvalidRequest", "Subnet to be disconnected not found")
@@ -64,7 +64,7 @@ class Clover
 
       r.is do
         r.get do
-          authorize("PrivateSubnet:view", ps.id)
+          authorize("PrivateSubnet:view", ps)
           if api?
             Serializers::PrivateSubnet.serialize(ps)
           else
@@ -73,7 +73,7 @@ class Clover
         end
 
         r.delete do
-          authorize("PrivateSubnet:delete", ps.id)
+          authorize("PrivateSubnet:delete", ps)
 
           vms_dataset = ps.vms_dataset
             .association_join(:strand)

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -23,7 +23,7 @@ class Clover
       check_found_object(vm)
 
       r.get true do
-        authorize("Vm:view", vm.id)
+        authorize("Vm:view", vm)
 
         if api?
           Serializers::Vm.serialize(vm, {detailed: true})
@@ -33,7 +33,7 @@ class Clover
       end
 
       r.delete true do
-        authorize("Vm:delete", vm.id)
+        authorize("Vm:delete", vm)
 
         DB.transaction do
           vm.incr_destroy
@@ -48,7 +48,7 @@ class Clover
       r.show_object(vm, actions: %w[overview networking settings], perm: "Vm:view", template: "vm/show")
 
       r.post "restart" do
-        authorize("Vm:edit", vm.id)
+        authorize("Vm:edit", vm)
 
         DB.transaction do
           vm.incr_restart

--- a/routes/project/postgres.rb
+++ b/routes/project/postgres.rb
@@ -14,7 +14,7 @@ class Clover
       end
 
       r.get "create" do
-        authorize("Postgres:create", @project.id)
+        authorize("Postgres:create", @project)
         view "postgres/create"
       end
     end

--- a/routes/project/private_location.rb
+++ b/routes/project/private_location.rb
@@ -4,7 +4,7 @@ class Clover
   hash_branch(:project_prefix, "private-location") do |r|
     r.is do
       r.get do
-        authorize("Location:view", @project.id)
+        authorize("Location:view", @project)
 
         @dataset = @project.locations_dataset
 
@@ -17,7 +17,7 @@ class Clover
       end
 
       r.post do
-        authorize("Location:create", @project.id)
+        authorize("Location:create", @project)
         handle_validation_failure("private-location/create")
         name, provider_location_name, access_key, secret_key = typecast_params.nonempty_str!(["name", "provider_location_name", "access_key", "secret_key"])
 
@@ -47,7 +47,7 @@ class Clover
     end
 
     r.get(web?, "create") do
-      authorize("Location:create", @project.id)
+      authorize("Location:create", @project)
       view "private-location/create"
     end
 
@@ -56,7 +56,7 @@ class Clover
       check_found_object(@location)
 
       r.get do
-        authorize("Location:view", @project.id)
+        authorize("Location:view", @project)
 
         if api?
           Serializers::PrivateLocation.serialize(@location)
@@ -66,7 +66,7 @@ class Clover
       end
 
       r.delete do
-        authorize("Location:delete", @project.id)
+        authorize("Location:delete", @project)
 
         if @location.has_resources?
           fail DependencyError.new("Private location '#{@location.ui_name}' has some resources, first, delete them.")
@@ -82,7 +82,7 @@ class Clover
       end
 
       r.post do
-        authorize("Location:edit", @project.id)
+        authorize("Location:edit", @project)
         name = typecast_params.nonempty_str("name")
         Validation.validate_name(name)
 

--- a/routes/project/private_subnet.rb
+++ b/routes/project/private_subnet.rb
@@ -14,7 +14,7 @@ class Clover
       end
 
       r.get "create" do
-        authorize("PrivateSubnet:create", @project.id)
+        authorize("PrivateSubnet:create", @project)
         view "networking/private_subnet/create"
       end
     end

--- a/routes/project/token.rb
+++ b/routes/project/token.rb
@@ -3,7 +3,7 @@
 class Clover
   hash_branch(:project_prefix, "token") do |r|
     r.web do
-      authorize("Project:token", @project.id)
+      authorize("Project:token", @project)
       token_ds = current_account
         .api_keys_dataset
         .where(project_id: @project.id)

--- a/routes/project/usage_alert.rb
+++ b/routes/project/usage_alert.rb
@@ -3,7 +3,7 @@
 class Clover
   hash_branch(:project_prefix, "usage-alert") do |r|
     r.web do
-      authorize("Project:billing", @project.id)
+      authorize("Project:billing", @project)
 
       r.post true do
         handle_validation_failure("project/billing")

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -10,7 +10,7 @@ class Clover
   hash_branch(:project_prefix, "user") do |r|
     r.web do
       r.is do
-        authorize("Project:user", @project.id)
+        authorize("Project:user", @project)
 
         r.get do
           view "project/user"
@@ -79,7 +79,7 @@ class Clover
       end
 
       r.post "policy/managed" do
-        authorize("Project:user", @project.id)
+        authorize("Project:user", @project)
         handle_validation_failure("project/user")
         user_policies = typecast_params.Hash("user_policies") || {}
         invitation_policies = typecast_params.Hash("invitation_policies") || {}
@@ -187,7 +187,7 @@ class Clover
       r.on "access-control" do
         r.is do
           r.get do
-            authorize("Project:viewaccess", @project.id)
+            authorize("Project:viewaccess", @project)
 
             uuids = {}
             @project.access_control_entries.each do |ace|
@@ -213,7 +213,7 @@ class Clover
           end
 
           r.post do
-            authorize("Project:editaccess", @project.id)
+            authorize("Project:editaccess", @project)
 
             DB.transaction do
               typecast_params.array!(:Hash, "aces").each do
@@ -257,12 +257,12 @@ class Clover
 
           r.is do
             r.get do
-              authorize("Project:viewaccess", @project.id)
+              authorize("Project:viewaccess", @project)
               view "project/tag-list"
             end
 
             r.post do
-              authorize(tag_perm_map[tag_type], @project.id)
+              authorize(tag_perm_map[tag_type], @project)
               handle_validation_failure("project/tag-list")
               DB.transaction do
                 tag = @tag_model.create(project_id: @project.id, name: typecast_params.nonempty_str("name"))
@@ -286,7 +286,7 @@ class Clover
                 view "project/tag"
               end
 
-              authorize(tag_perm_map[tag_type], @project.id)
+              authorize(tag_perm_map[tag_type], @project)
 
               if @tag_type == "subject" && @tag.name == "Admin"
                 handle_validation_failure("project/tag-list")
@@ -366,7 +366,7 @@ class Clover
       end
 
       r.delete "invitation", String do |email|
-        authorize("Project:user", @project.id)
+        authorize("Project:user", @project)
 
         @project.invitations_dataset.where(email: email).destroy
         audit_log(@project, "destroy_invitation")
@@ -376,7 +376,7 @@ class Clover
       end
 
       r.delete :ubid_uuid do |id|
-        authorize("Project:user", @project.id)
+        authorize("Project:user", @project)
 
         next unless (user = @project.accounts_dataset[id:])
 

--- a/routes/project/vm.rb
+++ b/routes/project/vm.rb
@@ -24,7 +24,7 @@ class Clover
       end
 
       r.get "create" do
-        authorize("Vm:create", @project.id)
+        authorize("Vm:create", @project)
         view "vm/create"
       end
     end

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -194,6 +194,10 @@ RSpec.describe Authorization do
       expect(described_class.has_permission?(projects[0].id, users[0].id, "Vm:view", vms[0].id)).to be(true)
     end
 
+    it "works when arguments are model objects" do
+      expect(described_class.has_permission?(projects[0], users[0], "Vm:view", vms[0])).to be(true)
+    end
+
     it "returns false when has no matched policies" do
       AccessControlEntry.dataset.destroy
       expect(described_class.has_permission?(projects[0].id, users[0].id, "Vm:view", vms[0].id)).to be(false)

--- a/spec/model/object_metatag_spec.rb
+++ b/spec/model/object_metatag_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe ObjectMetatag do
     project = account.create_project_with_default_policy("Default", default_policy: false)
     tag = ObjectTag.create(project_id: project.id, name: "T")
     ace = AccessControlEntry.create(project_id: project.id, subject_id: account.id, object_id: tag.id)
-    expect(Authorization.has_permission?(project.id, account.id, "ObjectTag:view", tag.metatag_uuid)).to be false
+    expect(Authorization.has_permission?(project, account, "ObjectTag:view", tag.metatag_uuid)).to be false
     ace.update(object_id: tag.metatag_uuid)
-    expect(Authorization.has_permission?(project.id, account.id, "ObjectTag:view", tag.metatag_uuid)).to be true
+    expect(Authorization.has_permission?(project, account, "ObjectTag:view", tag.metatag_uuid)).to be true
 
     ot = ObjectTag.create(project_id: project.id, name: "S")
     ot.destroy
-    expect(Authorization.has_permission?(project.id, account.id, "ObjectTag:view", ot.metatag_uuid)).to be false
+    expect(Authorization.has_permission?(project, account, "ObjectTag:view", ot.metatag_uuid)).to be false
   end
 
   it "supports only valid metatag when creating AccessControlEntry" do

--- a/views/kubernetes-cluster/settings.erb
+++ b/views/kubernetes-cluster/settings.erb
@@ -1,10 +1,10 @@
-<% if has_permission?("KubernetesCluster:edit", @kc.id) %>
+<% if has_permission?("KubernetesCluster:edit", @kc) %>
   <div class="p-6">
     <%== part("components/rename_object", object: @kc, type: "Kubernetes Cluster") %>
   </div>
 <% end %>
 
-<% if has_permission?("KubernetesCluster:delete", @kc.ubid) %>
+<% if has_permission?("KubernetesCluster:delete", @kc) %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">

--- a/views/networking/firewall/networking.erb
+++ b/views/networking/firewall/networking.erb
@@ -10,7 +10,7 @@ viewable_subnet_map = dataset_authorize(@firewall.private_subnets_dataset, "Priv
   .select_hash(:id, Sequel.as(true, :v))
 
 firewall_path = path(@firewall)
-edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
+edit_perm = has_permission?("Firewall:edit", @firewall) %>
 
 <div class="p-6 grid gap-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">

--- a/views/networking/firewall/settings.erb
+++ b/views/networking/firewall/settings.erb
@@ -1,4 +1,4 @@
-<% if has_permission?("Firewall:edit", @firewall.id) %>
+<% if has_permission?("Firewall:edit", @firewall) %>
   <div class="p-6">
     <%== part("components/rename_object", object: @firewall, type: "firewall") %>
   </div>
@@ -13,7 +13,7 @@
     </div>
   </div>
 
-  <% if has_permission?("Firewall:delete", @firewall.ubid) %>
+  <% if has_permission?("Firewall:delete", @firewall) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/networking/load_balancer/settings.erb
+++ b/views/networking/load_balancer/settings.erb
@@ -1,5 +1,5 @@
-<% edit_perm = has_permission?("LoadBalancer:edit", @lb.id)
-delete_perm = has_permission?("LoadBalancer:delete", @lb.ubid) %>
+<% edit_perm = has_permission?("LoadBalancer:edit", @lb)
+delete_perm = has_permission?("LoadBalancer:delete", @lb) %>
 
 <% if edit_perm || delete_perm %>
   <div class="p-6">

--- a/views/networking/load_balancer/vms.erb
+++ b/views/networking/load_balancer/vms.erb
@@ -2,7 +2,7 @@
   .exclude(Sequel[:vm][:id] => @lb.vms_dataset.select(Sequel[:vm][:id]))
   .all
 load_balancer_path = "#{@project.path}#{@lb.path}"
-edit_perm = has_permission?("LoadBalancer:edit", @lb.ubid) %>
+edit_perm = has_permission?("LoadBalancer:edit", @lb) %>
 
 <div class="p-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">

--- a/views/networking/private_subnet/settings.erb
+++ b/views/networking/private_subnet/settings.erb
@@ -1,10 +1,10 @@
-<% if has_permission?("PrivateSubnet:edit", @ps.id) %>
+<% if has_permission?("PrivateSubnet:edit", @ps) %>
   <div class="p-6">
     <%== part("components/rename_object", object: @ps, type: "private subnet") %>
   </div>
 <% end %>
 
-<% if has_permission?("PrivateSubnet:delete", @ps.ubid) %>
+<% if has_permission?("PrivateSubnet:delete", @ps) %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -1,3 +1,5 @@
+<% delete_perm = has_permission?("Postgres:delete", @pg) %>
+
 <% if @edit_perm %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
@@ -36,7 +38,7 @@
   </div>
 <% end %>
 <!-- Danger Zone -->
-<% if @edit_perm || @delete_perm %>
+<% if @edit_perm || delete_perm %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
@@ -135,7 +137,7 @@
         </div>
       <% end %>
       <!-- Delete Card -->
-      <% if @delete_perm %>
+      <% if delete_perm %>
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -1,5 +1,5 @@
-<% @edit_perm = has_permission?("Postgres:edit", @pg.ubid)
-@delete_perm = has_permission?("Postgres:delete", @pg.ubid)
+<% @edit_perm = has_permission?("Postgres:edit", @pg)
+@delete_perm = has_permission?("Postgres:delete", @pg)
 @page_title = @pg.name
 
 tabs = [

--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -1,5 +1,4 @@
 <% @edit_perm = has_permission?("Postgres:edit", @pg)
-@delete_perm = has_permission?("Postgres:delete", @pg)
 @page_title = @pg.name
 
 tabs = [

--- a/views/private-location/show.erb
+++ b/views/private-location/show.erb
@@ -33,7 +33,7 @@
     ) %>
   <% end %>
   <!-- Danger Zone -->
-  <% if has_permission?("Location:delete", @project.ubid) %>
+  <% if has_permission?("Location:delete", @project) %>
     <div>
       <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
         <div class="min-w-0 flex-1">

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -22,7 +22,7 @@
       data: [
         ["ID", @project.ubid],
         (
-          if has_permission?("Project:edit", @project.ubid)
+          if has_permission?("Project:edit", @project)
             [
               "Name",
               part(
@@ -68,7 +68,7 @@
 
   </div>
   <!-- Delete Card -->
-  <% if has_permission?("Project:delete", @project.ubid) %>
+  <% if has_permission?("Project:delete", @project) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -1,4 +1,4 @@
-<% edit_perm = has_permission?("Vm:edit", @vm.id) %>
+<% edit_perm = has_permission?("Vm:edit", @vm) %>
 
 <% if edit_perm %>
   <div class="p-6">
@@ -36,7 +36,7 @@
       </div>
     <% end %>
     <!-- Delete Card -->
-    <% if has_permission?("Vm:delete", @vm.ubid) %>
+    <% if has_permission?("Vm:delete", @vm) %>
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>


### PR DESCRIPTION
Previously, project_id and subject_id needed to be a uuid, and object_id could be a uuid or ubid. This allows accepting an object for all three. This simplifies almost all callers of these methods. It also doesn't require either parsing a ubid or generating a ubid. Previously, even if a uuid was given, it would turn it into a ubid in order to extract the class, and guess ApiKey if it was an et ubid.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor authorization methods to accept objects directly, updating routes, views, and tests for improved flexibility and simplicity.
> 
>   - **Behavior**:
>     - `authorize` and `has_permission?` methods now accept objects directly, not just IDs, in `general.rb` and `authorization.rb`.
>     - Updated `authorize` calls in `firewall.rb`, `kubernetes_cluster.rb`, `load_balancer.rb`, `postgres.rb`, `private_subnet.rb`, `vm.rb`, and `github.rb` to pass objects instead of IDs.
>     - Adjusted `has_permission?` checks in `settings.erb` files for `kubernetes-cluster`, `firewall`, `load_balancer`, `private_subnet`, `postgres`, `vm`, and `project` to use objects.
>   - **Tests**:
>     - Added test cases in `authorization_spec.rb` and `object_metatag_spec.rb` to verify object-based authorization.
>   - **Misc**:
>     - Removed unnecessary ID conversions in `authorization.rb` and `invoice.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for dbda6720ec2c9869fa04411dd1467fa1b3dd08bf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->