### PR TITLE
Change load balancer IP stack order

### DIFF
--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -52,7 +52,7 @@ class Clover
     options.add_option(name: "description")
     options.add_option(name: "private_subnet_id", values: dataset_authorize(@project.private_subnets_dataset, "PrivateSubnet:view").map { {value: it.ubid, display_name: it.name} })
     options.add_option(name: "algorithm", values: ["Round Robin", "Hash Based"].map { {value: it.downcase.tr(" ", "_"), display_name: it} })
-    options.add_option(name: "stack", values: [LoadBalancer::Stack::IPV4, LoadBalancer::Stack::IPV6, LoadBalancer::Stack::DUAL].map { {value: it.downcase, display_name: it.gsub("ip", "IP")} })
+    options.add_option(name: "stack", values: [LoadBalancer::Stack::DUAL, LoadBalancer::Stack::IPV4, LoadBalancer::Stack::IPV6].map { {value: it.downcase, display_name: it.gsub("ip", "IP")} })
     options.add_option(name: "src_port")
     options.add_option(name: "dst_port")
     options.add_option(name: "health_check_endpoint")


### PR DESCRIPTION
It was IPv4, IPv6, dual, but a more practical order is dual, IPv4, IPv6: everything needs IPv4 fallback, but there's no need to default to contributing to CGNAT pressure on ISPs, especially for mobile broadband providers.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorder IP stack options in `generate_load_balancer_options` to prioritize dual-stack over IPv4 and IPv6.
> 
>   - **Behavior**:
>     - Change IP stack order in `generate_load_balancer_options` in `helpers/load_balancer.rb` to prioritize `DUAL`, then `IPV4`, then `IPV6`.
>     - Affects load balancer creation by defaulting to dual-stack, reducing CGNAT pressure on ISPs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9635763a6fc7d45b373b400b3aa20d925f0c88a8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->