### PR TITLE
Allow creating a PostgreSQL database without firewall rules in api/sdk/cli

### DIFF
--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -10,6 +10,7 @@ UbiCli.on("pg").run_on("create") do
     on("-S", "--storage-size=size", Option::POSTGRES_STORAGE_SIZE_OPTIONS, "storage size GB")
     on("-v", "--version=version", Option::POSTGRES_VERSION_OPTIONS, "PostgreSQL version")
     on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
+    on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")
   end
   help_option_values("Flavor:", Option::POSTGRES_FLAVOR_OPTIONS.keys)
   help_option_values("Replication Type:", Option::POSTGRES_HA_OPTIONS.keys)

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -11,6 +11,7 @@ class Clover
     ha_type = typecast_params.nonempty_str("ha_type", PostgresResource::HaType::NONE)
     version = typecast_params.nonempty_str("version", PostgresResource::DEFAULT_VERSION)
     tags = typecast_params.array(:Hash, "tags", [])
+    with_firewall_rules = !typecast_params.bool("restrict_by_default")
 
     postgres_params = {
       "flavor" => flavor,
@@ -39,6 +40,7 @@ class Clover
         target_storage_size_gib: storage_size,
         ha_type:,
         version:,
+        with_firewall_rules:,
         flavor:
       ).subject
       pg.update(tags:)

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -838,6 +838,9 @@ paths:
                 version:
                   description: PostgreSQL version
                   type: string
+                restrict_by_default:
+                  description: 'Whether to restrict access by default (if so, firewall rules must be added to access)'
+                  type: boolean
                 tags:
                   description: Tags for the Postgres Database
                   type: array

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -477,6 +477,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
@@ -12,6 +12,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
@@ -12,6 +12,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
@@ -12,6 +12,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
@@ -12,6 +12,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
@@ -12,6 +12,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
@@ -12,6 +12,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
@@ -12,6 +12,7 @@ Options:
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
+    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.ha_type).to eq "none"
     expect(pg.version).to eq "17"
     expect(pg.flavor).to eq "standard"
+    expect(PostgresFirewallRule.count).to eq 2
     expect(pg.tags).to eq([])
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end
 
   it "creates PostgreSQL database with all options" do
     expect(PostgresResource.count).to eq 0
-    body = cli(%w[pg eu-central-h1/test-pg create -s standard-4 -S 128 -h async -v 17 -f paradedb -t foo=bar,baz=quux])
+    body = cli(%w[pg eu-central-h1/test-pg create -s standard-4 -S 128 -h async -v 17 -f paradedb -R -t foo=bar,baz=quux])
     expect(PostgresResource.count).to eq 1
     pg = PostgresResource.first
     expect(pg).to be_a PostgresResource
@@ -37,6 +38,7 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.ha_type).to eq "async"
     expect(pg.version).to eq "17"
     expect(pg.flavor).to eq "paradedb"
+    expect(PostgresFirewallRule.count).to eq 0
     expect(pg.tags).to eq([{"key" => "foo", "value" => "bar"}, {"key" => "baz", "value" => "quux"}])
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end


### PR DESCRIPTION
The reason for allowing this is it allows you to create a locked-down PostgreSQL database without parsing output of previous commands. Previously, to create a locked-down database, you needed to create the database, then remove the default firewall rules for it, then add your own. Using this, you add the database without rules, and then add the rules you need.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `--restrict-by-default` option to create PostgreSQL databases without default firewall rules in CLI, API, and backend logic.
> 
>   - **Behavior**:
>     - Adds `--restrict-by-default` option in `create.rb` to create PostgreSQL databases without default firewall rules.
>     - Updates `postgres_post` in `postgres.rb` to handle `restrict_by_default` parameter, setting `with_firewall_rules` accordingly.
>     - Modifies `assemble` in `postgres_resource_nexus.rb` to conditionally create default firewall rules based on `with_firewall_rules`.
>   - **API**:
>     - Adds `restrict_by_default` boolean to `openapi.yml` for PostgreSQL database creation.
>   - **Tests**:
>     - Updates `create_spec.rb` to test database creation with and without `--restrict-by-default` option.
>     - Updates CLI help text in `help -r.txt` and other golden files to include `--restrict-by-default` option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for dbd584ab25fa89db58275cafcb026860fe726ce0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->