### PR TITLE
Improve k8s upgrades

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -31,7 +31,9 @@ class Kubernetes::Client
   end
 
   def kubectl(cmd)
-    @session.exec!("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf #{cmd}")
+    output = @session.exec!("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf #{cmd}")
+    raise output if output.exitstatus != 0
+    output
   end
 
   def version

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -10,6 +10,7 @@ class KubernetesCluster < Sequel::Model
   many_to_one :project
   many_to_many :cp_vms, join_table: :kubernetes_node, right_key: :vm_id, class: :Vm, order: :created_at, conditions: {kubernetes_nodepool_id: nil}
   one_to_many :nodes, class: :KubernetesNode, order: :created_at, conditions: {kubernetes_nodepool_id: nil}
+  one_to_many :functional_nodes, class: :KubernetesNode, order: :created_at, conditions: {kubernetes_nodepool_id: nil, state: "active"}
   one_to_many :nodepools, class: :KubernetesNodepool
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, &:active
   many_to_one :location, key: :location_id
@@ -50,7 +51,7 @@ class KubernetesCluster < Sequel::Model
   end
 
   def sshable
-    cp_vms.first.sshable
+    functional_nodes.first.sshable
   end
 
   def services_load_balancer_name

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -47,7 +47,7 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
 
   label def drain
     unit_name = "drain_node_#{kubernetes_node.name}"
-    sshable = cluster.cp_vms.last.sshable
+    sshable = cluster.sshable
     case sshable.d_check(unit_name)
     when "Succeeded"
       hop_remove_node_from_cluster
@@ -77,7 +77,8 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
       cluster.api_server_lb.detach_vm(kubernetes_node.vm)
     end
 
-    cluster.client(session: cluster.nodes.last.sshable.connect).delete_node(kubernetes_node.name)
+    cluster.client.delete_node(kubernetes_node.name)
+
     hop_destroy
   end
 

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -83,9 +83,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     let(:unit_name) { "drain_node_#{kd.name}" }
 
     before do
-      vm = create_vm
-      expect(kd.kubernetes_cluster).to receive(:cp_vms).and_return([vm]).at_least(:once)
-      expect(vm).to receive(:sshable).and_return(sshable).at_least(:once)
+      expect(kd.kubernetes_cluster).to receive(:sshable).and_return(sshable).at_least(:once)
     end
 
     it "starts the drain process when run for the first time and naps" do
@@ -130,8 +128,6 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
     before do
       expect(kd.kubernetes_cluster).to receive(:client).and_return(client)
-      expect(kd.kubernetes_cluster.nodes.last).to receive(:sshable).and_return(sshable)
-      expect(sshable).to receive(:connect)
       expect(kd).to receive(:sshable).and_return(sshable).twice
     end
 

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -245,7 +245,7 @@ table ip6 pod_access {
       expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("NotStarted")
 
       sshable = instance_double(Sshable)
-      allow(kubernetes_cluster.cp_vms.first).to receive(:sshable).and_return(sshable)
+      expect(kubernetes_cluster.functional_nodes.first).to receive(:sshable).and_return(sshable)
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("jt\n")
       expect(sshable).to receive(:cmd).with("sudo kubeadm init phase upload-certs --upload-certs", log: false).and_return("something\ncertificate key:\nck")
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
@@ -289,7 +289,7 @@ table ip6 pod_access {
       expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("NotStarted")
 
       sshable = instance_double(Sshable)
-      allow(kubernetes_cluster.cp_vms.first).to receive(:sshable).and_return(sshable)
+      expect(kubernetes_cluster.functional_nodes.first).to receive(:sshable).and_return(sshable)
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("\njt\n")
       expect(sshable).to receive(:cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
       expect(prog.vm.sshable).to receive(:d_run).with(


### PR DESCRIPTION
Do not silently fail on kubernetes commands

Prior to this commit, we were not checking the existatus code of commands we would run using the client. From now on, a RuntimeError will be raised.

Use the first functional node for KubernetesCluster#sshable

We were using the last vm as the cluster's sshable but by introducing functional_nodes association, we make sure we are not choosing a draining node during upgrade as the cluster's sshable.

This case would have happened if we were upgrading a cluster with 1 control plane node Fix issue in kubernetes upgrade delete node step.

Fix issue in Kubernetes upgrade process

Prior to this commit, we would run the drain/delete command on the last node of the cluster but in a setup where we have 1 control plane node, by the time we are running the delete command, we have already run the kubeadm reset resulting in errors since there are no kubeconfigs there.

With this commit, we make sure we are choosing a functional node and not a draining one.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve Kubernetes upgrades by handling command failures and refining node selection logic in `client.rb`, `kubernetes_cluster.rb`, and `kubernetes_node_nexus.rb`.
> 
>   - **Behavior**:
>     - `kubectl` in `client.rb` now raises `RuntimeError` on non-zero exit status to prevent silent failures.
>     - `sshable` method in `kubernetes_cluster.rb` now uses `functional_nodes` instead of `cp_vms` to select nodes.
>     - `drain` method in `kubernetes_node_nexus.rb` now uses `cluster.sshable` for node selection.
>   - **Models**:
>     - Added `functional_nodes` association to `KubernetesCluster` in `kubernetes_cluster.rb`.
>   - **Tests**:
>     - Updated `kubectl` tests in `client_spec.rb` to check for raised errors on command failure.
>     - Modified `kubernetes_node_nexus_spec.rb` to test new `sshable` logic in `drain` method.
>     - Adjusted `provision_kubernetes_node_spec.rb` to use `functional_nodes` for node selection in `join_control_plane` and `join_worker` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d950079a0e7b3e4ea7503ff7000164d10623768f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->