### PR TITLE
Reload services_lb before checking for CCM related changes

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -76,6 +76,7 @@ class Kubernetes::Client
   def any_lb_services_modified?
     k8s_svc_raw = kubectl("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson")
     svc_list = JSON.parse(k8s_svc_raw)["items"]
+    @load_balancer.reload
 
     return true if svc_list.empty? && !@load_balancer.ports.empty?
 


### PR DESCRIPTION
We regularly check to make sure the loadbalancer we have provisioned in Clover is in sync with the LoadBalancers defined inside the k8s cluster. In the current implementation the loadbalancer could get cached and represent the clover lb wrongly and as a result, it would increment the sync_kubernetes_service semaphores which would make no changes.

With this commit, we reload the loadbalancer before checking for changes making sure we have the latest change.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `@load_balancer.reload` in `any_lb_services_modified?()` to ensure the latest load balancer state is used, preventing unnecessary semaphore increments.
> 
>   - **Behavior**:
>     - Adds `@load_balancer.reload` in `any_lb_services_modified?()` in `client.rb` to ensure the latest load balancer state is used.
>     - Prevents unnecessary semaphore increments when the load balancer state is cached and outdated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 73c58e371fe1339ce6a415b59aa3e8d05566df9a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->