### PR TITLE
Update to Sequel 5.96.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", github: "jeremyevans/sequel", ref: "e370b682c927a37eec19b5cf3f0fef972fa1d9d6"
+gem "sequel", ">= 5.96"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,14 +16,6 @@ GIT
       rack
 
 GIT
-  remote: https://github.com/jeremyevans/sequel.git
-  revision: e370b682c927a37eec19b5cf3f0fef972fa1d9d6
-  ref: e370b682c927a37eec19b5cf3f0fef972fa1d9d6
-  specs:
-    sequel (5.95.1)
-      bigdecimal
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -388,6 +380,8 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
+    sequel (5.96.0)
+      bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
     sequel_pg (1.17.2)
@@ -523,7 +517,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel!
+  sequel (>= 5.96)
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords


### PR DESCRIPTION
The pg_range auto parameterization fix has been released, so switch to the released version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `sequel` gem in `Gemfile` to version `>= 5.96`.
> 
>   - **Gemfile Update**:
>     - Update `sequel` gem from a specific commit reference to version `>= 5.96`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 17bb83da50dd31183746de0b75589a52af93e9c2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->