### PR TITLE
Admin site improvements

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -161,10 +161,18 @@ class CloverAdmin < Roda
         view("objects")
       end
 
-      r.get :ubid do |ubid|
+      r.on :ubid do |ubid|
         next unless (@obj = @klass[ubid])
 
-        view("object")
+        r.get true do
+          view("object")
+        end
+
+        r.post(Strand === @obj, "schedule") do
+          @obj.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
+          flash["notice"] = "Scheduled strand to run immediately"
+          r.redirect("/model/#{UBID.class_for_ubid(ubid)}/#{ubid}")
+        end
       end
     end
 

--- a/lib/resource_methods.rb
+++ b/lib/resource_methods.rb
@@ -34,6 +34,10 @@ module ResourceMethods
       @ubid ||= UBID.from_uuidish(id).to_s.downcase
     end
 
+    def admin_label
+      defined?(name) ? name : ubid
+    end
+
     def to_s
       inspect_prefix
     end

--- a/model/account.rb
+++ b/model/account.rb
@@ -13,6 +13,8 @@ class Account < Sequel::Model(:accounts)
   plugin ResourceMethods
   include SubjectTag::Cleanup
 
+  alias_method :admin_label, :email
+
   def create_project_with_default_policy(name, default_policy: true)
     project = Project.create(name: name)
     add_project(project)

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -112,6 +112,10 @@ code {
   }
 }
 
+#model-class-list, #object-list {
+  columns: 5;
+}
+
 .rodauth {
   div { margin-bottom: 10px; }
   label { min-width: 100px; }

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -116,6 +116,10 @@ code {
   columns: 5;
 }
 
+#strand-info form {
+  display: inline-block;
+}
+
 .rodauth {
   div { margin-bottom: 10px; }
   label { min-width: 100px; }

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -215,4 +215,17 @@ RSpec.describe CloverAdmin do
     visit "/error"
     expect(page.title).to eq "Ubicloud Admin - Internal Server Error"
   end
+
+  it "supports scheduling strands to run immediately" do
+    schedule = Time.now + 10
+    st = Strand.create(prog: "Test", label: "hop_entry", schedule:)
+    fill_in "UBID", with: st.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Strand #{st.ubid}"
+
+    click_button "Schedule Strand to Run Now"
+    expect(page).to have_flash_notice("Scheduled strand to run immediately")
+    expect(page.title).to eq "Ubicloud Admin - Strand #{st.ubid}"
+    expect(st.reload.schedule).to be_within(5).of(Time.now)
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -41,17 +41,17 @@ RSpec.describe CloverAdmin do
     expect(object_data).to eq(email: "user@example.com", name: "", status_id: "2", suspended_at: "")
 
     project = account.projects.first
-    click_link project.ubid
+    click_link project.name
     expect(page.title).to eq "Ubicloud Admin - Project #{project.ubid}"
     expect(object_data).to eq(billable: "true", billing_info_id: "", credit: "0.0", discount: "0", feature_flags: "{}", name: "Default", reputation: "new", visible: "true")
 
     subject_tag = project.subject_tags.first
-    click_link subject_tag.ubid
+    click_link subject_tag.name
     expect(page.title).to eq "Ubicloud Admin - SubjectTag #{subject_tag.ubid}"
-    expect(object_data).to eq(name: "Admin", project_id: project.ubid)
+    expect(object_data).to eq(name: "Admin", project_id: "Default")
 
     # Column Link
-    click_link project.ubid
+    click_link project.name
     expect(page.title).to eq "Ubicloud Admin - Project #{project.ubid}"
   end
 

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -49,6 +49,18 @@
 <% end %>
 
 <div class="container">
-  <p><a href="/change-password">Change Password</a></p>
-  <p><a href="/multifactor-manage">Manage Multifactor Authentication</a></p>
+  <h2>Browse by Model Class</h2>
+
+  <ul id="model-class-list">
+    <% @classes.each do |klass| %>
+      <li><a href="/model/<%= klass %>"><%= klass %></a></li>
+    <% end %>
+  </ul>
+
+  <h2 class="container">Manage</h2>
+
+  <ul>
+    <li><a href="/change-password">Change Password</a></li>
+    <li><a href="/multifactor-manage">Manage Multifactor Authentication</a></li>
+  </ul>
 </div>

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -4,15 +4,20 @@
   <p>SSH Command: <code>ssh -i &lt;PRIVATE_KEY_PATH&gt; <%= sshable.unix_user %>@<%= sshable.host %></code></p>
 <% end %>
 
-<% if @klass.associations.include?(:strand) && (strand = @obj.strand) %>
-  <p>
-    <a href="/model/Strand/<%= strand.ubid %>">Strand</a>: <%= strand.prog %>#<%= strand.label %>
-    | schedule: <%= strand.schedule.strftime("%F %T") %>
-    <% if strand.try > 0 %>
-      | try: <%= strand.try %>
-    <% end %>
-  </p>
-<% end %>
+<div id="strand-info">
+  <% if @klass.associations.include?(:strand) && (strand = @obj.strand) %>
+      <a href="/model/Strand/<%= strand.ubid %>">Strand</a>: <%= strand.prog %>#<%= strand.label %>
+      | schedule: <%= strand.schedule.strftime("%F %T") %>
+      <% if strand.try > 0 %>
+        | try: <%= strand.try %>
+      <% end %>
+  <% end %>
+
+  <% if strand || @obj.is_a?(Strand) %>
+    <% strand ||= @obj %>
+    <%== form({action: "/model/Strand/#{strand.ubid}/schedule", method: :post}, button: "Schedule Strand to Run Now") %>
+  <% end %>
+</div>
 
 <% if @klass.associations.include?(:semaphores) && !(semaphores = @obj.semaphores_dataset.select_order_map(:name)).empty? %>
   <p>Semaphores Set: <%= semaphores.join(", ") %></p>

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -31,8 +31,8 @@
     <tr>
       <td><%= k %></td>
       <td>
-        <% if v.is_a?(String) && v.bytesize == 26 && (column_class = UBID.class_for_ubid(v)) %>
-          <a href="/model/<%= column_class %>/<%= v %>"><%= v %></a>
+        <% if v.is_a?(String) && v.bytesize == 26 && (column_class = UBID.class_for_ubid(v)) && column_class.method_defined?(:ubid) && (obj = UBID.decode(v)) %>
+          <a href="/model/<%= column_class %>/<%= v %>"><%= obj.admin_label %></a>
         <% else %>
           <%= v %>
         <% end %>
@@ -61,7 +61,7 @@
       <h3><%= assoc %></h3>
       <ul>
       <% assoc_objs.each do %>
-	<li><a href="/model/<%= associated_class %>/<%= it.ubid %>"><%= it.ubid %></a></li>
+        <li><a href="/model/<%= associated_class %>/<%= it.ubid %>"><%= it.admin_label %></a></li>
       <% end %>
       </ul>
     </div>

--- a/views/admin/objects.erb
+++ b/views/admin/objects.erb
@@ -1,0 +1,11 @@
+<% @page_title = @klass.name %>
+
+<ul id="object-list">
+  <% @objects.each do |object| %>
+    <li><a href="/model/<%= @klass %>/<%= object.ubid %>"><%= object.admin_label %></a></li>
+  <% end %>
+</ul>
+
+<% if @after %>
+  <p><a href="?after=<%= @after %>">More</a></p>
+<% end %>


### PR DESCRIPTION
This adds the following:

* Configurable link text on the admin side, instead of always using ubid. For models that support it, name is used. For accounts, email is used.
* Browsing objects by class
* A button for immediate scheduling a strand