### PR TITLE
Allow customers to add additional note to invoice

### DIFF
--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -27,7 +27,8 @@ class BillingInfo < Sequel::Model
           "state" => address["state"],
           "postal_code" => address["postal_code"],
           "tax_id" => metadata["tax_id"],
-          "company_name" => metadata["company_name"]
+          "company_name" => metadata["company_name"],
+          "note" => metadata["note"]
         }
       end
     end

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -232,12 +232,13 @@ class Invoice < Sequel::Model
       end
     end
 
-    # Row 2, Right Column: Invoice dates
+    # Row 2, Right Column: Invoice dates and note
     pdf.bounding_box([right_column_x, row_y], width: column_width) do
-      dates = [["Invoice date:", data.date], ["Due date:", data.date]]
-      pdf.table(dates, position: :right) do
-        style(row(0..1).columns(0..1), padding: [2, 5, 2, 5], borders: [])
-        style(column(0), align: :right, font_style: :semibold, text_color: dark_gray)
+      right_data = [["Invoice date:", data.date], ["Due date:", data.date]]
+      right_data << ["Note:", data.note] if data.note
+      pdf.table(right_data, position: :right) do
+        style(row(0..2).columns(0..2), padding: [2, 5, 2, 5], borders: [])
+        style(column(0), align: :right, width: 90, text_wrap: :right, font_style: :semibold, text_color: dark_gray)
         style(column(1), align: :right)
       end
     end

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -39,7 +39,8 @@ class Clover
               },
               metadata: {
                 tax_id: new_tax_id,
-                company_name: tp.str!("company_name")
+                company_name: tp.str!("company_name"),
+                note: tp.nonempty_str("note")
               }
             })
             if new_tax_id != current_tax_id

--- a/serializers/invoice.rb
+++ b/serializers/invoice.rb
@@ -6,7 +6,7 @@ class Serializers::Invoice < Serializers::Base
   InvoiceData = Data.define(:ubid, :path, :name, :date, :begin_time, :end_time, :subtotal, :credit,
     :free_inference_tokens_credit, :discount, :total, :status, :invoice_number, :billing_name,
     :billing_email, :billing_address, :billing_country, :billing_city, :billing_state, :billing_postal_code,
-    :billing_in_eu_vat, :tax_id, :company_name, :issuer_name, :issuer_address, :issuer_country,
+    :billing_in_eu_vat, :tax_id, :company_name, :note, :issuer_name, :issuer_address, :issuer_country,
     :issuer_city, :issuer_state, :issuer_postal_code, :issuer_tax_id, :issuer_trade_id, :issuer_in_eu_vat,
     :vat_rate, :vat_amount, :vat_amount_eur, :vat_reversed, :items)
 
@@ -37,6 +37,7 @@ class Serializers::Invoice < Serializers::Base
       billing_in_eu_vat: inv.content.dig("billing_info", "in_eu_vat"),
       tax_id: inv.content.dig("billing_info", "tax_id"),
       company_name: inv.content.dig("billing_info", "company_name"),
+      note: inv.content.dig("billing_info", "note"),
       issuer_name: inv.content.dig("issuer_info", "name"),
       issuer_address: inv.content.dig("issuer_info", "address"),
       issuer_country: ISO3166::Country.new(inv.content.dig("issuer_info", "country"))&.common_name,

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -551,7 +551,7 @@ RSpec.describe Clover, "billing" do
       end
 
       it "show finalized invoice as PDF from US issuer without VAT" do
-        expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "John Doe", "address" => {"country" => "US"}, "metadata" => {"company_name" => "Acme Inc.", "tax_id" => "123123123"}}).at_least(:once)
+        expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "John Doe", "address" => {"country" => "US"}, "metadata" => {"company_name" => "Acme Inc.", "tax_id" => "123123123", "note" => "PO123123"}}).at_least(:once)
         bi = billing_record(Time.utc(2023, 6), Time.utc(2023, 7))
         invoice = InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true, eur_rate: 1.1).run.first
 
@@ -565,6 +565,7 @@ RSpec.describe Clover, "billing" do
         expect(text).not_to include("John Doe")
         expect(text).to include("test-vm")
         expect(text).not_to include("VAT")
+        expect(text).to include("PO123123")
       end
 
       it "show finalized invoice as PDF from EU issuer with 21% VAT" do

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -136,6 +136,17 @@ end
                 <div class="sm:col-span-4">
                   <%== part("components/form/text", name: "company_name", label: "Company Name", value: stripe_data["company_name"]) %>
                 </div>
+                <div class="col-span-full">
+                  <%== part(
+                    "components/form/textarea",
+                    name: "note",
+                    label: "Invoice Note",
+                    value: stripe_data["note"],
+                    attributes: {
+                      placeholder: "Enter details for your invoices, such as a PO number, tax information, or special instructions"
+                    }
+                  ) %>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Customers want to add additional notes to their invoices for various reasons, such as providing PO numbers, special instructions, or personalized messages.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add functionality for customers to include a note in invoices, displayed in the PDF and handled in the billing process.
> 
>   - **Behavior**:
>     - Allow customers to add a `note` to invoices via `billing_info.rb` and `billing.rb`.
>     - Display `note` in invoice PDF in `invoice.rb`.
>   - **Data Handling**:
>     - Add `note` to `stripe_data` in `billing_info.rb`.
>     - Include `note` in `InvoiceData` in `serializers/invoice.rb`.
>   - **UI**:
>     - Add `Invoice Note` textarea in `billing.erb`.
>   - **Testing**:
>     - Update `billing_spec.rb` to test `note` inclusion in invoices.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 283f9c2cfaaabe24f8e0d5ec7a96330a0597a765. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->