### PR TITLE
Support restart of Vm/PostgresResource on admin site

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -62,6 +62,7 @@ class CloverAdmin < Roda
   symbol_matcher(:ubid, /([a-tv-z0-9]{26})/)
 
   plugin :not_found do
+    raise "admin route not handled: #{request.path}" if Config.test? && !ENV["DONT_RAISE_ADMIN_ERRORS"]
     @page_title = "File Not Found"
     view(content: "")
   end

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -151,6 +151,14 @@ class CloverAdmin < Roda
     },
     "Vm" => {
       "restart" => object_action("Restart", "Restart scheduled for Vm", &:incr_restart)
+    },
+    "VmHost" => {
+      "accept" => object_action("Move to Accepting", "Host allocation state changed to accepting") do |obj|
+        obj.update(allocation_state: "accepting")
+      end,
+      "drain" => object_action("Move to Draining", "Host allocation state changed to draining") do |obj|
+        obj.update(allocation_state: "draining")
+      end
     }
   }.freeze
   OBJECT_ACTIONS.each_value(&:freeze)

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -73,7 +73,7 @@ class CloverAdmin < Roda
   end
 
   plugin :error_handler do |e|
-    raise e if Config.test? && ENV["SHOW_ERRORS"]
+    raise e if Config.test? && !ENV["DONT_RAISE_ADMIN_ERRORS"]
     Clog.emit("admin route exception") { Util.exception_to_hash(e) }
     @page_title = "Internal Server Error"
     view(content: "")

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -158,7 +158,9 @@ class CloverAdmin < Roda
       end,
       "drain" => object_action("Move to Draining", "Host allocation state changed to draining") do |obj|
         obj.update(allocation_state: "draining")
-      end
+      end,
+      "reset" => object_action("Hardware Reset", "Hardware reset scheduled for VmHost", &:incr_hardware_reset),
+      "reboot" => object_action("Reboot", "Reboot scheduled for VmHost", &:incr_reboot)
     }
   }.freeze
   OBJECT_ACTIONS.each_value(&:freeze)

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -176,6 +176,12 @@ class CloverAdmin < Roda
           flash["notice"] = "Scheduled strand to run immediately"
           r.redirect("/model/#{UBID.class_for_ubid(ubid)}/#{ubid}")
         end
+
+        r.post(Vm === @obj || PostgresResource === @obj, "restart") do
+          @obj.incr_restart
+          flash["notice"] = "Restart scheduled for #{@obj.class}"
+          r.redirect("/model/#{@obj.class}/#{ubid}")
+        end
       end
     end
 

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -141,6 +141,9 @@ class CloverAdmin < Roda
   end
 
   OBJECT_ACTIONS = {
+    "GithubRunner" => {
+      "provision" => object_action("Provision Spare Runner", "Spare runner provisioned", &:provision_spare_runner)
+    },
     "PostgresResource" => {
       "restart" => object_action("Restart", "Restart scheduled for PostgresResource", &:incr_restart)
     },

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -137,6 +137,10 @@ class PostgresResource < Sequel::Model
     servers.any? { it.taking_over? }
   end
 
+  def incr_restart
+    Semaphore.incr(servers_dataset.select(:id), "restart")
+  end
+
   module HaType
     NONE = "none"
     ASYNC = "async"

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -112,8 +112,12 @@ code {
   }
 }
 
-#model-class-list, #object-list {
+#model-class-list {
   columns: 5;
+}
+
+#object-list {
+  columns: 4;
 }
 
 #strand-info form {

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -120,6 +120,10 @@ code {
   display: inline-block;
 }
 
+#restart-button {
+  float: right;
+}
+
 .rodauth {
   div { margin-bottom: 10px; }
   label { min-width: 100px; }

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -124,8 +124,15 @@ code {
   display: inline-block;
 }
 
-#restart-button {
-  float: right;
+#action-list a {
+  display: inline-block;
+  border-left: 1px solid black;
+  padding-left: 10px;
+  padding-right: 5px;
+  &:first-child {
+    padding-left: 0;
+    border-left: none;
+  }
 }
 
 .rodauth {

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -112,7 +112,7 @@ class Clover
       r.post "restart" do
         authorize("Postgres:edit", pg.id)
         DB.transaction do
-          Semaphore.incr(pg.servers_dataset.select(:id), "restart")
+          pg.incr_restart
           audit_log(pg, "restart")
         end
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -183,24 +183,27 @@ RSpec.describe CloverAdmin do
     expect(page).to have_flash_error("Invalid ubid provided")
 
     fill_in "UBID", with: "ts1cyaqvp5ha6j5jt8ypbyagw9"
-    click_button "Show Object"
-    expect(page.title).to eq "Ubicloud Admin - File Not Found"
+    expect { click_button "Show Object" }.to raise_error(RuntimeError, "admin route not handled: /model/SubjectTag/ts1cyaqvp5ha6j5jt8ypbyagw9")
   end
 
   it "handles request for invalid model or missing object" do
-    visit "/model/Foo/ts1cyaqvp5ha6j5jt8ypbyagw9"
-    expect(page.title).to eq "Ubicloud Admin - File Not Found"
-
-    visit "/model/ArchivedRecord/ts1cyaqvp5ha6j5jt8ypbyagw9"
-    expect(page.title).to eq "Ubicloud Admin - File Not Found"
-
-    visit "/model/SubjectTag/ts1cyaqvp5ha6j5jt8ypbyagw9"
-    expect(page.title).to eq "Ubicloud Admin - File Not Found"
+    %w[/model/Foo/ts1cyaqvp5ha6j5jt8ypbyagw9
+      /model/ArchivedRecord/ts1cyaqvp5ha6j5jt8ypbyagw9
+      /model/SubjectTag/ts1cyaqvp5ha6j5jt8ypbyagw9].each do |path|
+      expect { visit path }.to raise_error(RuntimeError, "admin route not handled: #{path}")
+    end
   end
 
-  it "handles 404 page" do
+  it "raises for 404 by default in tests" do
+    expect { visit "/invalid-page" }.to raise_error(RuntimeError)
+  end
+
+  it "shows 404 page if DONT_RAISE_ADMIN_ERRORS environment variable is set" do
+    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
     visit "/invalid-page"
     expect(page.title).to eq "Ubicloud Admin - File Not Found"
+  ensure
+    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
   end
 
   it "raises errors by default in tests" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -306,4 +306,32 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
     expect(vmh.reload.allocation_state).to eq "accepting"
   end
+
+  it "supports rebooting VmHosts" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    fill_in "UBID", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq []
+    click_link "Reboot"
+    click_button "Reboot"
+    expect(page).to have_flash_notice("Reboot scheduled for VmHost")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq ["reboot"]
+  end
+
+  it "supports hardware reseting VmHosts" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    fill_in "UBID", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq []
+    click_link "Hardware Reset"
+    click_button "Hardware Reset"
+    expect(page).to have_flash_notice("Hardware reset scheduled for VmHost")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq ["hardware_reset"]
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -334,4 +334,21 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
     expect(vmh.semaphores_dataset.select_map(:name)).to eq ["hardware_reset"]
   end
+
+  it "supports provisioning spare GitHubRunner" do
+    ins = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    ghr = GithubRunner.create(repository_name: "test-repo", label: "ubicloud", installation_id: ins.id)
+
+    fill_in "UBID", with: ghr.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - GithubRunner #{ghr.ubid}"
+
+    expect(GithubRunner.count).to eq 1
+    click_link "Provision Spare Runner"
+    click_button "Provision Spare Runner"
+    expect(page).to have_flash_notice("Spare runner provisioned")
+    expect(page.title).to eq "Ubicloud Admin - GithubRunner #{ghr.ubid}"
+    expect(GithubRunner.count).to eq 2
+    expect(GithubRunner.select_map([:repository_name, :label, :installation_id])).to eq([["test-repo", "ubicloud", ins.id]] * 2)
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -286,4 +286,24 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg.ubid}"
     expect(Semaphore.where(strand_id: pg.servers_dataset.select_map(:id)).select_map(:name)).to eq ["restart"]
   end
+
+  it "supports moving VmHost to draining/accepting state" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    fill_in "UBID", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.allocation_state).to eq "unprepared"
+
+    click_link "Move to Draining"
+    click_button "Move to Draining"
+    expect(page).to have_flash_notice("Host allocation state changed to draining")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.reload.allocation_state).to eq "draining"
+
+    click_link "Move to Accepting"
+    click_button "Move to Accepting"
+    expect(page).to have_flash_notice("Host allocation state changed to accepting")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.reload.allocation_state).to eq "accepting"
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -203,17 +203,17 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - File Not Found"
   end
 
-  it "raises errors if SHOW_ERRORS environment variable is set" do
-    show_errors, ENV["SHOW_ERRORS"] = ENV["SHOW_ERRORS"], "1"
+  it "raises errors by default in tests" do
     expect { visit "/error" }.to raise_error(RuntimeError)
-  ensure
-    ENV.delete("SHOW_ERRORS") unless show_errors
   end
 
-  it "shows error page for errors if SHOW_ERRORS environment variable is not set" do
+  it "shows error page for errors if DONT_RAISE_ADMIN_ERRORS environment variable is set" do
+    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
     expect(Clog).to receive(:emit).with("admin route exception").and_call_original
     visit "/error"
     expect(page.title).to eq "Ubicloud Admin - Internal Server Error"
+  ensure
+    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
   end
 
   it "handles incorrect/missing CSRF tokens" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -232,6 +232,12 @@ RSpec.describe CloverAdmin do
     expect(st.reload.schedule).not_to be_within(5).of(Time.now)
   end
 
+  it "raises for 404 by default for missing action" do
+    account = create_account(with_project: false)
+    path = "/model/Account/#{account.ubid}/invalid"
+    expect { visit path }.to raise_error(RuntimeError, "admin route not handled: #{path}")
+  end
+
   it "supports scheduling strands to run immediately" do
     schedule = Time.now + 10
     st = Strand.create(prog: "Test", label: "hop_entry", schedule:)
@@ -252,7 +258,8 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
 
     expect(vm.semaphores_dataset.select_map(:name)).to eq []
-    click_button "Restart Vm"
+    click_link "Restart"
+    click_button "Restart"
     expect(page).to have_flash_notice("Restart scheduled for Vm")
     expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
     expect(vm.semaphores_dataset.select_map(:name)).to eq ["restart"]
@@ -273,7 +280,8 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg.ubid}"
 
     expect(Semaphore.where(strand_id: pg.servers_dataset.select_map(:id)).select_map(:name)).to eq []
-    click_button "Restart PostgresResource"
+    click_link "Restart"
+    click_button "Restart"
     expect(page).to have_flash_notice("Restart scheduled for PostgresResource")
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg.ubid}"
     expect(Semaphore.where(strand_id: pg.servers_dataset.select_map(:id)).select_map(:name)).to eq ["restart"]

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -1,5 +1,9 @@
 <% @page_title = "#{@klass.name} #{@obj.ubid}" %>
 
+<% if @obj.is_a?(Vm) || @obj.is_a?(PostgresResource) %>
+  <%== form({action: "/model/#{@obj.class}/#{@obj.ubid}/restart", method: :post, id: "restart-button"}, button: "Restart #{@obj.class}") %>
+<% end %>
+
 <% if @klass.associations.include?(:sshable) && (sshable = @obj.sshable) %>
   <p>SSH Command: <code>ssh -i &lt;PRIVATE_KEY_PATH&gt; <%= sshable.unix_user %>@<%= sshable.host %></code></p>
 <% end %>

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -1,9 +1,5 @@
 <% @page_title = "#{@klass.name} #{@obj.ubid}" %>
 
-<% if @obj.is_a?(Vm) || @obj.is_a?(PostgresResource) %>
-  <%== form({action: "/model/#{@obj.class}/#{@obj.ubid}/restart", method: :post, id: "restart-button"}, button: "Restart #{@obj.class}") %>
-<% end %>
-
 <% if @klass.associations.include?(:sshable) && (sshable = @obj.sshable) %>
   <p>SSH Command: <code>ssh -i &lt;PRIVATE_KEY_PATH&gt; <%= sshable.unix_user %>@<%= sshable.host %></code></p>
 <% end %>
@@ -25,6 +21,14 @@
 
 <% if @klass.associations.include?(:semaphores) && !(semaphores = @obj.semaphores_dataset.select_order_map(:name)).empty? %>
   <p>Semaphores Set: <%= semaphores.join(", ") %></p>
+<% end %>
+
+<% if actions = OBJECT_ACTIONS[@obj.class.name] %>
+  <p id="action-list">Actions:
+    <% actions.each do |key, action| %>
+      <a href="/model/<%= @obj.class.name %>/<%= @obj.ubid %>/<%= key %>"><%= action.label %></a>
+    <% end %>
+  </p>
 <% end %>
 
 <table class="object-table">

--- a/views/admin/object_action.erb
+++ b/views/admin/object_action.erb
@@ -1,0 +1,3 @@
+<% @page_title = "#{@klass.name} #{@obj.ubid}" %>
+
+<%== form({method: :post, id: "action-button"}, button: @label) %>


### PR DESCRIPTION
Also, make admin tests raise exceptions for 500/404 instead of swallowing them. Unlike Clover, CloverAdmin does not use the error handler as a general-purpose way of handling validation errors.

This adds PostgresResource#incr_restart so that the same code works for both Vm and PostgresResource.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for restarting VMs and PostgresResource on the admin site and improve error handling in tests.
> 
>   - **Behavior**:
>     - Add support for restarting `Vm` and `PostgresResource` via `OBJECT_ACTIONS` in `clover_admin.rb`.
>     - Implement `incr_restart` method in `PostgresResource` to increment restart semaphore.
>     - Modify admin tests to raise exceptions for 500/404 errors by default, unless `DONT_RAISE_ADMIN_ERRORS` is set.
>   - **Routes**:
>     - Update `routes/project/location/postgres.rb` to use `incr_restart` for `PostgresResource` restart.
>   - **CSS**:
>     - Adjust column layout in `app.css` for `#model-class-list` and `#object-list`.
>   - **Tests**:
>     - Add tests for restarting `Vm` and `PostgresResource` in `admin_spec.rb`.
>     - Ensure tests raise errors for unhandled routes and missing actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2306848945f6816b83a906e9a30687cd06323120. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->