### PR TITLE
Only attempt to enable YJIT if RubyVM::YJIT is defined

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -243,6 +243,6 @@ def clover_freeze
     Validation::ValidationFailed
   ].each(&:freeze)
 
-  RubyVM::YJIT.enable
+  RubyVM::YJIT.enable if defined?(RubyVM::YJIT)
   Refrigerator.freeze_core
 end


### PR DESCRIPTION
This should allow Ubicloud to run on non-amd64, non-arm64 Ruby implementations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `clover_freeze` in `loader.rb` to conditionally enable `RubyVM::YJIT`, allowing Ubicloud to run on non-amd64, non-arm64 Ruby implementations.
> 
>   - **Behavior**:
>     - Modify `clover_freeze` in `loader.rb` to enable `RubyVM::YJIT` only if `RubyVM::YJIT` is defined.
>     - Allows Ubicloud to run on non-amd64, non-arm64 Ruby implementations without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0d3eecc2bbb61398169839f99adc3d084b8c573b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->