### PR TITLE
Update to Puma 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)
     public_suffix (6.0.2)
-    puma (6.6.1)
+    puma (7.0.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.0)

--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -46,7 +46,7 @@ require "tilt/string"
 
 queue = Queue.new
 server = Puma::CLI.new(["-s", "-e", "test", "-b", "tcp://localhost:#{PORT}", "-t", "1:1", "config.ru"])
-server.launcher.events.on_booted { queue.push(nil) }
+server.launcher.events.after_booted { queue.push(nil) }
 Thread.new do
   server.launcher.run
 end

--- a/puma_config.rb
+++ b/puma_config.rb
@@ -5,13 +5,11 @@ environment ENV["RACK_ENV"] || "development"
 port ENV["PORT"] || "3000"
 threads 15, 15
 enable_keep_alives false
+silence_fork_callback_warning
+silence_single_worker_warning
+preload_app!
 
-if @config.options[:workers] > 0
-  silence_single_worker_warning
-  preload_app!
-
-  before_fork do
-    Sequel::DATABASES.each(&:disconnect)
-  end
+before_fork do
+  Sequel::DATABASES.each(&:disconnect)
 end
 # :nocov:

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "bin/ubi" do
     port = 8484
     queue = Queue.new
     @server = Puma::CLI.new(["-s", "-e", "test", "-b", "tcp://localhost:#{port}", "-t", "1:1", "spec/cli_config.ru"])
-    @server.launcher.events.on_booted { queue.push(nil) }
+    @server.launcher.events.after_booted { queue.push(nil) }
     Thread.new do
       @server.launcher.run
     end


### PR DESCRIPTION
This requires changes to puma_config.rb. Puma changed their configuration code such that calling options here raises an error. They still don't offer a way to check what the configured workers is, and specifying before_fork if workers are not configured results in a warning. So to avoid the warning, we need to look at the internals.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update to Puma 7 with configuration and event handling changes in `puma_config.rb`, `bin/regen-screenshots`, and `spec/cli_spec.rb`.
> 
>   - **Configuration**:
>     - Update `puma_config.rb` to use `silence_fork_callback_warning` and `silence_single_worker_warning`.
>     - Always execute `before_fork` block to disconnect Sequel databases.
>   - **Event Handling**:
>     - Replace `on_booted` with `after_booted` in `bin/regen-screenshots` and `spec/cli_spec.rb` to align with Puma 7 changes.
>   - **Misc**:
>     - Update Puma version to 7.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for af1dd3719d6b96cee89211455ed3368b57c6bf35. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->