### PR TITLE
Avoid unsynchronized setting of monitorable resource session to nil

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -63,12 +63,9 @@ monitor_resources = MonitorResourceType.create(
   MonitorableResource,
   monitor_pulse_info,
   Config.max_health_monitor_threads,
-  monitor_models
-) do
-  it.process_event_loop
-  it.check_pulse
-end
-
+  monitor_models,
+  &:check_pulse
+)
 metric_export_resources = MonitorResourceType.create(
   MetricsTargetResource,
   metric_export_pulse_info,


### PR DESCRIPTION
Merge the process_event_loop method into the check_pulse method. Have the pulse thread change a local variable if there was an error during the event loop.  Have the monitor thread (not the pulse thread) clear the session, after the pulse thread has ended, if the event loop failed.

Don't sleep until run_event_loop is true. With the merged code, run_event_loop would be set immediately after the start of the thread, so there is no reason to sleep. Even before this change, I don't think there was a reason to sleep previously.