### PR TITLE
Check CSRF token on admin site

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -108,6 +108,7 @@ class CloverAdmin < Roda
     login_redirect do
       uses_two_factor_authentication? ? "/webauthn-auth" : "/webauthn-setup"
     end
+    check_csrf? false
     require_bcrypt? false
     title_instance_variable :@page_title
     argon2_secret OpenSSL::HMAC.digest("SHA256", Config.clover_session_secret, "admin-argon2-secret")
@@ -126,6 +127,7 @@ class CloverAdmin < Roda
 
   route do |r|
     r.public
+    check_csrf!
     r.rodauth
     rodauth.require_authentication
     rodauth.require_two_factor_setup

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -216,6 +216,19 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Internal Server Error"
   end
 
+  it "handles incorrect/missing CSRF tokens" do
+    schedule = Time.now + 10
+    st = Strand.create(prog: "Test", label: "hop_entry", schedule:)
+    fill_in "UBID", with: st.ubid
+    click_button "Show Object"
+
+    find("#strand-info input[name=_csrf]", visible: false).set("")
+    click_button "Schedule Strand to Run Now"
+    expect(page.title).to eq "Ubicloud Admin - Invalid Security Token"
+    expect(page).to have_flash_error("An invalid security token submitted with this request, please try again")
+    expect(st.reload.schedule).not_to be_within(5).of(Time.now)
+  end
+
   it "supports scheduling strands to run immediately" do
     schedule = Time.now + 10
     st = Strand.create(prog: "Test", label: "hop_entry", schedule:)


### PR DESCRIPTION
When the admin site was originally added, the only forms were Rodauth forms, and Rodauth handled the CSRF checks.  However, as we are adding other forms, we need to check the CSRF even for non-Rodauth forms.

Use the same approach as in Clover, where Rodauth no longer checks the CSRF, and the CSRF is checked before calling r.rodauth.