### PR TITLE
Add project-level postgres hostname override

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -47,21 +47,25 @@ class PostgresResource < Sequel::Model
     "creating"
   end
 
+  def hostname_suffix
+    project.get_ff_postgres_hostname_override || Config.postgres_service_hostname
+  end
+
   def dns_zone
-    @dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
+    @dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: hostname_suffix]
   end
 
   def hostname
     if dns_zone
-      return "#{name}.#{Config.postgres_service_hostname}" if hostname_version == "v1"
-      "#{name}.#{ubid}.#{Config.postgres_service_hostname}"
+      return "#{name}.#{hostname_suffix}" if hostname_version == "v1"
+      "#{name}.#{ubid}.#{hostname_suffix}"
     else
       representative_server&.vm&.ephemeral_net4&.to_s
     end
   end
 
   def identity
-    "#{ubid}.#{Config.postgres_service_hostname}"
+    "#{ubid}.#{hostname_suffix}"
   end
 
   def connection_string

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -47,8 +47,12 @@ class PostgresResource < Sequel::Model
     "creating"
   end
 
+  def dns_zone
+    @dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: Config.postgres_service_hostname]
+  end
+
   def hostname
-    if Prog::Postgres::PostgresResourceNexus.dns_zone
+    if dns_zone
       return "#{name}.#{Config.postgres_service_hostname}" if hostname_version == "v1"
       "#{name}.#{ubid}.#{Config.postgres_service_hostname}"
     else

--- a/model/project.rb
+++ b/model/project.rb
@@ -173,7 +173,7 @@ class Project < Sequel::Model
   feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics
   feature_flag :private_locations, :enable_c6gd, :enable_m6gd, :enable_m8gd
   feature_flag :free_runner_upgrade_until, :gpu_vm, :postgres_lantern, :aws_cloudwatch_logs
-  feature_flag :aws_alien_runners_ratio, :ipv6_disabled, :skip_runner_pool
+  feature_flag :aws_alien_runners_ratio, :ipv6_disabled, :skip_runner_pool, :postgres_hostname_override
 end
 
 # Table: project

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe PostgresResource do
   }
 
   it "returns connection string without ubid qualifier" do
-    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return("something").at_least(:once)
+    expect(postgres_resource).to receive(:dns_zone).and_return("something").at_least(:once)
     expect(postgres_resource).to receive(:hostname_version).and_return("v1")
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.postgres.ubicloud.com:5432/postgres?sslmode=require")
   end
 
   it "returns connection string with ubid qualifier" do
-    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return("something").at_least(:once)
+    expect(postgres_resource).to receive(:dns_zone).and_return("something").at_least(:once)
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@pg-name.pgc60xvcr00a5kbnggj1js4kkq.postgres.ubicloud.com:5432/postgres?sslmode=require")
   end
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe PostgresResource do
     ) { it.id = "6181ddb3-0002-8ad0-9aeb-084832c9273b" }
   }
 
+  before do
+    allow(postgres_resource).to receive(:project).and_return(instance_double(Project, get_ff_postgres_hostname_override: nil))
+  end
+
   it "returns connection string without ubid qualifier" do
     expect(postgres_resource).to receive(:dns_zone).and_return("something").at_least(:once)
     expect(postgres_resource).to receive(:hostname_version).and_return("v1")

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -206,8 +206,9 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
   describe "#initialize_certificates" do
     it "hops to wait_servers after creating certificates" do
+      project = Project.create(name: "default")
       postgres_resource = PostgresResource.create(
-        project_id: "e3e333dd-bd9a-82d2-acc1-1c7c1ee9781f",
+        project_id: project.id,
         location_id: Location::HETZNER_FSN1_ID,
         name: "pg-name",
         target_vm_size: "standard-2",

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       dns_zone = instance_double(DnsZone)
       expect(dns_zone).to receive(:delete_record).with(record_name: "pg-name.postgres.ubicloud.com.")
       expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "A", ttl: 10, data: "1.1.1.1")
-      expect(described_class).to receive(:dns_zone).and_return(dns_zone).twice
+      expect(postgres_resource).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
       expect(nx).to receive(:when_initial_provisioning_set?).and_yield
       expect { nx.refresh_dns_record }.to hop("initialize_certificates")
     end
@@ -187,17 +187,18 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       dns_zone = instance_double(DnsZone)
       expect(dns_zone).to receive(:delete_record).with(record_name: "pg-name.postgres.ubicloud.com.")
       expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "CNAME", ttl: 10, data: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com.")
-      expect(described_class).to receive(:dns_zone).and_return(dns_zone).twice
+      expect(postgres_resource).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
       expect(nx).to receive(:when_initial_provisioning_set?).and_yield
       expect { nx.refresh_dns_record }.to hop("initialize_certificates")
     end
 
     it "hops even if dns zone is not configured" do
-      expect(described_class).to receive(:dns_zone).and_return(nil).twice
+      expect(postgres_resource).to receive(:dns_zone).and_return(nil).at_least(:once)
       expect { nx.refresh_dns_record }.to hop("wait")
     end
 
     it "hops to wait if initial_provisioning is not set" do
+      expect(postgres_resource).to receive(:dns_zone).and_return(nil).at_least(:once)
       expect(nx).to receive(:when_initial_provisioning_set?)
       expect { nx.refresh_dns_record }.to hop("wait")
     end
@@ -215,7 +216,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       )
 
       expect(nx).to receive(:postgres_resource).and_return(postgres_resource).at_least(:once)
-      expect(described_class).to receive(:dns_zone).and_return("something").at_least(:once)
+      expect(postgres_resource).to receive(:dns_zone).and_return("something").at_least(:once)
 
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 5, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
       expect(Util).to receive(:create_root_certificate).with(duration: 60 * 60 * 24 * 365 * 10, common_name: "#{postgres_resource.ubid} Root Certificate Authority").and_call_original
@@ -375,7 +376,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   describe "#destroy" do
     it "triggers server deletion and waits until it is deleted" do
       dns_zone = instance_double(DnsZone)
-      expect(described_class).to receive(:dns_zone).and_return(dns_zone)
+      expect(postgres_resource).to receive(:dns_zone).and_return(dns_zone)
 
       expect(postgres_resource.private_subnet.firewalls).to all(receive(:destroy))
       expect(postgres_resource.private_subnet).to receive(:incr_destroy)
@@ -389,7 +390,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "completes destroy even if dns zone is not configured" do
-      expect(described_class).to receive(:dns_zone).and_return(nil)
+      expect(postgres_resource).to receive(:dns_zone).and_return(nil)
       expect(postgres_resource.private_subnet.firewalls).to all(receive(:destroy))
       expect(postgres_resource.private_subnet).to receive(:incr_destroy)
       expect(postgres_resource).to receive(:servers).and_return([])

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe Clover, "cli" do
     @ps.update(net4: "172.27.99.128/26", net6: "fdd9:1ea7:125d:5fa4::/64")
 
     expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
-    @dns_zone = DnsZone.new
     expect(Vm).to receive(:generate_ubid).and_return(UBID.parse("vma9rnygexga6jns6x3yj9a6b2"))
-    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
+    DnsZone.create(project_id: postgres_project.id, name: "pg.example.com")
     expect(PrivateSubnet).to receive(:generate_ubid).and_return(UBID.parse("psnqtahcasrj1hn16kh1ygekmn"))
     expect(Firewall).to receive(:generate_uuid).and_return("30a3eec9-afb5-81fc-bbb5-8691d252ef03")
     expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("nc2kyevjaqey6h0et8qj89zvm1"))

--- a/spec/routes/api/cli/pg/pg_dumpall_spec.rb
+++ b/spec/routes/api/cli/pg/pg_dumpall_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Clover, "cli pg pg_dumpall" do
     @ref = [@pg.display_location, @pg.name].join("/")
     @conn_string = URI("postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?sslmode=require")
     expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
-    @dns_zone = DnsZone.new
-    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
+    DnsZone.create(project_id: @project.id, name: "pg.example.com")
   end
 
   it "connects to database via pg_dumpall" do

--- a/spec/routes/api/cli/pg/psql_pg_dump_spec.rb
+++ b/spec/routes/api/cli/pg/psql_pg_dump_spec.rb
@@ -16,8 +16,7 @@ require_relative "../spec_helper"
       @ref = [@pg.display_location, @pg.name].join("/")
       @conn_string = URI("postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?sslmode=require")
       expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
-      @dns_zone = DnsZone.new
-      expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
+      DnsZone.create(project_id: @project.id, name: "pg.example.com")
     end
 
     it "connects to database via #{cmd}" do

--- a/spec/routes/api/cli/pg/show_spec.rb
+++ b/spec/routes/api/cli/pg/show_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe Clover, "cli pg show" do
 
   it "shows information for PostgreSQL database" do
     expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
-    @dns_zone = DnsZone.new
-    expect(Prog::Postgres::PostgresResourceNexus).to receive(:dns_zone).and_return(@dns_zone).at_least(:once)
+    DnsZone.create(project_id: @project.id, name: "pg.example.com")
     @pg.add_metric_destination(username: "md-user", password: "1", url: "https://md.example.com")
     @pg.update(root_cert_1: "a", root_cert_2: "b")
     @pg.representative_server.vm.add_vm_storage_volume(boot: false, size_gib: 64, disk_index: 0)

--- a/spec/serializers/postgres_spec.rb
+++ b/spec/serializers/postgres_spec.rb
@@ -5,6 +5,10 @@ require_relative "../spec_helper"
 RSpec.describe Serializers::Postgres do
   let(:pg) { PostgresResource.new(name: "pg-name", location_id: Location::HETZNER_FSN1_ID).tap { it.id = "69c0f4cd-99c1-8ed0-acfe-7b013ce2fa0b" } }
 
+  before do
+    allow(pg).to receive(:project).and_return(instance_double(Project, get_ff_postgres_hostname_override: nil))
+  end
+
   it "can serialize when no earliest/latest restore times" do
     expect(pg).to receive(:strand).and_return(instance_double(Strand, label: "start", children: [])).at_least(:once)
     expect(pg).to receive(:timeline).and_return(instance_double(PostgresTimeline, earliest_restore_time: nil, latest_restore_time: nil)).exactly(3)

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -100,7 +100,7 @@ module ThawedMock
   allow_mocking(Prog::Github::DestroyGithubInstallation, :assemble)
   allow_mocking(Prog::Minio::MinioClusterNexus, :assemble)
   allow_mocking(Prog::PageNexus, :assemble)
-  allow_mocking(Prog::Postgres::PostgresResourceNexus, :assemble, :dns_zone)
+  allow_mocking(Prog::Postgres::PostgresResourceNexus, :assemble)
   allow_mocking(Prog::Postgres::PostgresServerNexus, :assemble)
   allow_mocking(Prog::Postgres::PostgresTimelineNexus, :assemble)
   allow_mocking(Prog::Vm::GithubRunner, :assemble)


### PR DESCRIPTION
**Move dns_zone helper to PostgresResource model**
The dns_zone helper was previously a static method in PostgresResourceNexus,
based on the assumption that all PostgresResource instances used the same
global DNS Zone. Since we plan to support project-level hostname overrides,
this assumption no longer holds. Moving the helper to the PostgresResource
model allows it to access the project context and retrieve project-specific
DNS Zone information when needed.

**Add project-level postgres hostname override**
This allows each project to specify its own Postgres hostname suffix, rather
than relying on a global default. This change is necessary to support white
label deployments where branded Postgres hostnames are necessary.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add project-level Postgres hostname override by moving `dns_zone` to `PostgresResource` and updating related methods and tests.
> 
>   - **Behavior**:
>     - Add project-level Postgres hostname override in `postgres_resource.rb` using `hostname_suffix` method.
>     - Update `dns_zone` method in `postgres_resource.rb` to use project-specific DNS Zone.
>     - Modify `hostname`, `identity`, and `connection_string` methods in `postgres_resource.rb` to use `hostname_suffix`.
>   - **Models**:
>     - Move `dns_zone` helper from `PostgresResourceNexus` to `PostgresResource`.
>     - Add `postgres_hostname_override` feature flag in `project.rb`.
>   - **Tests**:
>     - Update tests in `postgres_resource_spec.rb` and `postgres_resource_nexus_spec.rb` to reflect changes in DNS handling.
>     - Modify CLI tests in `golden_files_spec.rb`, `pg_dumpall_spec.rb`, `psql_pg_dump_spec.rb`, and `show_spec.rb` to use project-specific DNS zones.
>     - Adjust mocking in `thawed_mock.rb` to accommodate changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e7602783a092f7c9fa4ea1742b37cefe5c5003ef. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->