### PR TITLE
Add Pay Now button to unpaid invoices

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -111,6 +111,7 @@ class Clover < Roda
 
   path("Project", class_name: true, &:path)
   path("GithubInstallation", class_name: true) { "#{it.project.path}/github/#{it.ubid}" }
+  path("Invoice", class_name: true) { "#{it.project.path}/billing#{it.path}" }
 
   # :nocov:
   if Config.test? && defined?(SimpleCov)

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -31,6 +31,10 @@ class Invoice < Sequel::Model
     define_method(meth) { content[str] }
   end
 
+  def payable?
+    cost > 0 && status == "unpaid" && ubid != "current"
+  end
+
   def blob_key
     group = if status == "below_minimum_threshold"
       "below_minimum_threshold"

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -652,6 +652,76 @@ RSpec.describe Clover, "billing" do
         expect(text).to include("ACME Inc.")
       end
 
+      it "can pay unpaid invoice" do
+        expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"line1" => "Some Rd", "country" => "NL"}, "metadata" => {"company_name" => "Foo Company Name"}}).at_least(:once)
+        bi = billing_record(Time.utc(2023, 6), Time.utc(2023, 7))
+        invoice = InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true, eur_rate: 1.1).run.first
+        # rubocop:disable RSpec/VerifiedDoubles
+        expect(Stripe::Checkout::Session).to receive(:create).with(
+          hash_including(billing_address_collection: "auto")
+        ).and_return(double(Stripe::Checkout::Session, url: "#{project.path}/billing/invoice/#{invoice.ubid}/success?session_id=session_123"))
+        # rubocop:enable RSpec/VerifiedDoubles
+        expect(Stripe::Checkout::Session).to receive(:retrieve).with("session_123").and_return(stripe_object("customer" => "cs_1234567890", "metadata" => {"invoice" => invoice.ubid}, "payment_status" => "paid"))
+
+        visit "#{project.path}/billing"
+
+        within("#invoice-#{invoice.ubid}") do
+          expect(page).to have_content "unpaid"
+          click_button "Pay Now"
+        end
+
+        expect(page.status_code).to eq(200)
+        expect(page.title).to eq("Ubicloud - Project Billing")
+        expect(page).to have_flash_notice "Invoice #{invoice.invoice_number} paid successfully"
+        within("#invoice-#{invoice.ubid}") do
+          expect(page).to have_content "paid"
+          expect(page).to have_no_content "Pay Now"
+        end
+      end
+
+      it "fails if the invoice id doesn’t match the invoice id in the checkout session" do
+        expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"line1" => "Some Rd", "country" => "NL"}, "metadata" => {"company_name" => "Foo Company Name"}}).at_least(:once)
+        bi = billing_record(Time.utc(2023, 6), Time.utc(2023, 7))
+        invoice = InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true, eur_rate: 1.1).run.first
+        # rubocop:disable RSpec/VerifiedDoubles
+        expect(Stripe::Checkout::Session).to receive(:create).with(
+          hash_including(billing_address_collection: "auto")
+        ).and_return(double(Stripe::Checkout::Session, url: "#{project.path}/billing/invoice/#{invoice.ubid}/success?session_id=session_123"))
+        # rubocop:enable RSpec/VerifiedDoubles
+        expect(Stripe::Checkout::Session).to receive(:retrieve).with("session_123").and_return(stripe_object("metadata" => {"invoice" => "1vvc31wac0za4gx65xd6mt2a42"}, "payment_status" => "paid"))
+
+        visit "#{project.path}/billing"
+
+        within("#invoice-#{invoice.ubid}") do
+          expect(page).to have_content "unpaid"
+          click_button "Pay Now"
+        end
+
+        expect(page.status_code).to eq(400)
+        expect(page.title).to eq("Ubicloud - Project Billing")
+        expect(page).to have_flash_error "Invoice payment was not successful"
+        within("#invoice-#{invoice.ubid}") do
+          expect(page).to have_content "unpaid"
+          expect(page).to have_content "Pay Now"
+        end
+      end
+
+      it "raises not found if invoice already paid" do
+        expect(Stripe::Customer).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"line1" => "Some Rd", "country" => "NL"}, "metadata" => {"company_name" => "Foo Company Name"}}).at_least(:once)
+        bi = billing_record(Time.utc(2023, 6), Time.utc(2023, 7))
+        invoice = InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true, eur_rate: 1.1).run.first
+
+        visit "#{project.path}/billing"
+
+        invoice.update(status: "paid")
+        within("#invoice-#{invoice.ubid}") do
+          expect(page).to have_content "unpaid"
+          click_button "Pay Now"
+        end
+
+        expect(page.status_code).to eq(404)
+      end
+
       it "raises not found when invoice not exists" do
         visit "#{project.path}/billing/invoice/1vfp96nprnxe7gneajmxn5ncnh"
 

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -229,8 +229,13 @@ end
                     <span class="text-xs italic">(<%= money(inv.subtotal) %>)</span>
                   <% end %>
                 </td>
-                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 flex items-center gap-2 justify-between">
                   <%= inv.status %>
+                  <% if inv.payable? %>
+                    <% form(action: "#{path(inv)}/pay", method: :post) do %>
+                      <%== part("components/form/submit_button", text: "Pay Now") %>
+                    <% end %>
+                  <% end %>
                 </td>
               </tr>
             <% end %>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -212,7 +212,7 @@ end
             <% @invoices.each do |inv| %>
               <tr id="invoice-<%= inv.path_id %>">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-                  <a href="<%= billing_path + inv.path %>" target="_blank" class="text-orange-600 hover:text-orange-700">
+                  <a href="<%= path(inv) %>" target="_blank" class="text-orange-600 hover:text-orange-700">
                     <%= inv.name %>
                   </a>
                   <span class="text-xs text-gray-400 italic">


### PR DESCRIPTION
- **Add invoice route helper**

- **Add Pay Now button to unpaid invoices**
  Unfortunately, credit cards sometimes encounter issues with offline
  recurring payments because they require 3D Secure. Several customers
  have experienced this problem.
  
  Currently, we manually create payment links for them after the invoice
  is finalized at the start of the month. Once they complete the payment,
  we mark the invoice as paid.
  
  To automate this, I've added a "Pay Now" button to unpaid invoices.
  Clicking it creates a checkout session and redirects the customer to
  Stripe’s hosted payment page. This uses logic similar to adding credit
  cards, but instead of "setup" mode, we now use "payment" mode. On the
  success URL, we check the status of the session and the invoice ID to
  mark the invoice as paid.
  
<img width="2410" height="956" alt="CleanShot 2025-09-04 at 20 44 15@2x" src="https://github.com/user-attachments/assets/c5f9afa6-d12d-445e-a2e5-b60d4a0efdaa" />

<img width="2144" height="1552" alt="CleanShot 2025-09-04 at 20 44 41@2x" src="https://github.com/user-attachments/assets/5f19efb1-7498-4221-9494-9aa1cc0754a8" />



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds 'Pay Now' button for unpaid invoices, automating payment via Stripe and updating invoice status upon successful payment.
> 
>   - **Behavior**:
>     - Adds 'Pay Now' button to unpaid invoices in `billing.erb`, allowing users to initiate payment via Stripe.
>     - New route in `billing.rb` to handle invoice payment, creating a Stripe checkout session and redirecting to payment page.
>     - Updates invoice status to 'paid' upon successful payment verification.
>   - **Models**:
>     - Adds `payable?` method to `Invoice` in `invoice.rb` to check if an invoice can be paid.
>   - **Tests**:
>     - Adds tests in `billing_spec.rb` for successful and unsuccessful invoice payments, including cases for mismatched invoice IDs and already paid invoices.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7b5e4df3bd49b09d60fae74de8ef044b410af499. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->