### PR TITLE
Prevent restart action due to misclick on admin site, and support more actions

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -151,6 +151,14 @@ class CloverAdmin < Roda
     },
     "Vm" => {
       "restart" => object_action("Restart", "Restart scheduled for Vm", &:incr_restart)
+    },
+    "VmHost" => {
+      "accept" => object_action("Move to Accepting", "Host allocation state changed to accepting") do |obj|
+        obj.update(allocation_state: "accepting")
+      end,
+      "drain" => object_action("Move to Draining", "Host allocation state changed to draining") do |obj|
+        obj.update(allocation_state: "draining")
+      end
     }
   }.freeze
   OBJECT_ACTIONS.each_value(&:freeze)

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -158,7 +158,9 @@ class CloverAdmin < Roda
       end,
       "drain" => object_action("Move to Draining", "Host allocation state changed to draining") do |obj|
         obj.update(allocation_state: "draining")
-      end
+      end,
+      "reset" => object_action("Hardware Reset", "Hardware reset scheduled for VmHost", &:incr_hardware_reset),
+      "reboot" => object_action("Reboot", "Reboot scheduled for VmHost", &:incr_reboot)
     }
   }.freeze
   OBJECT_ACTIONS.each_value(&:freeze)

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -141,6 +141,9 @@ class CloverAdmin < Roda
   end
 
   OBJECT_ACTIONS = {
+    "GithubRunner" => {
+      "provision" => object_action("Provision Spare Runner", "Spare runner provisioned", &:provision_spare_runner)
+    },
     "PostgresResource" => {
       "restart" => object_action("Restart", "Restart scheduled for PostgresResource", &:incr_restart)
     },

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -124,8 +124,15 @@ code {
   display: inline-block;
 }
 
-#restart-button {
-  float: right;
+#action-list a {
+  display: inline-block;
+  border-left: 1px solid black;
+  padding-left: 10px;
+  padding-right: 5px;
+  &:first-child {
+    padding-left: 0;
+    border-left: none;
+  }
 }
 
 .rodauth {

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -306,4 +306,32 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
     expect(vmh.reload.allocation_state).to eq "accepting"
   end
+
+  it "supports rebooting VmHosts" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    fill_in "UBID", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq []
+    click_link "Reboot"
+    click_button "Reboot"
+    expect(page).to have_flash_notice("Reboot scheduled for VmHost")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq ["reboot"]
+  end
+
+  it "supports hardware reseting VmHosts" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    fill_in "UBID", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq []
+    click_link "Hardware Reset"
+    click_button "Hardware Reset"
+    expect(page).to have_flash_notice("Hardware reset scheduled for VmHost")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.semaphores_dataset.select_map(:name)).to eq ["hardware_reset"]
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -334,4 +334,21 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
     expect(vmh.semaphores_dataset.select_map(:name)).to eq ["hardware_reset"]
   end
+
+  it "supports provisioning spare GitHubRunner" do
+    ins = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    ghr = GithubRunner.create(repository_name: "test-repo", label: "ubicloud", installation_id: ins.id)
+
+    fill_in "UBID", with: ghr.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - GithubRunner #{ghr.ubid}"
+
+    expect(GithubRunner.count).to eq 1
+    click_link "Provision Spare Runner"
+    click_button "Provision Spare Runner"
+    expect(page).to have_flash_notice("Spare runner provisioned")
+    expect(page.title).to eq "Ubicloud Admin - GithubRunner #{ghr.ubid}"
+    expect(GithubRunner.count).to eq 2
+    expect(GithubRunner.select_map([:repository_name, :label, :installation_id])).to eq([["test-repo", "ubicloud", ins.id]] * 2)
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -286,4 +286,24 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg.ubid}"
     expect(Semaphore.where(strand_id: pg.servers_dataset.select_map(:id)).select_map(:name)).to eq ["restart"]
   end
+
+  it "supports moving VmHost to draining/accepting state" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    fill_in "UBID", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.allocation_state).to eq "unprepared"
+
+    click_link "Move to Draining"
+    click_button "Move to Draining"
+    expect(page).to have_flash_notice("Host allocation state changed to draining")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.reload.allocation_state).to eq "draining"
+
+    click_link "Move to Accepting"
+    click_button "Move to Accepting"
+    expect(page).to have_flash_notice("Host allocation state changed to accepting")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(vmh.reload.allocation_state).to eq "accepting"
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -232,6 +232,12 @@ RSpec.describe CloverAdmin do
     expect(st.reload.schedule).not_to be_within(5).of(Time.now)
   end
 
+  it "raises for 404 by default for missing action" do
+    account = create_account(with_project: false)
+    path = "/model/Account/#{account.ubid}/invalid"
+    expect { visit path }.to raise_error(RuntimeError, "admin route not handled: #{path}")
+  end
+
   it "supports scheduling strands to run immediately" do
     schedule = Time.now + 10
     st = Strand.create(prog: "Test", label: "hop_entry", schedule:)
@@ -252,7 +258,8 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
 
     expect(vm.semaphores_dataset.select_map(:name)).to eq []
-    click_button "Restart Vm"
+    click_link "Restart"
+    click_button "Restart"
     expect(page).to have_flash_notice("Restart scheduled for Vm")
     expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
     expect(vm.semaphores_dataset.select_map(:name)).to eq ["restart"]
@@ -273,7 +280,8 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg.ubid}"
 
     expect(Semaphore.where(strand_id: pg.servers_dataset.select_map(:id)).select_map(:name)).to eq []
-    click_button "Restart PostgresResource"
+    click_link "Restart"
+    click_button "Restart"
     expect(page).to have_flash_notice("Restart scheduled for PostgresResource")
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg.ubid}"
     expect(Semaphore.where(strand_id: pg.servers_dataset.select_map(:id)).select_map(:name)).to eq ["restart"]

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -1,9 +1,5 @@
 <% @page_title = "#{@klass.name} #{@obj.ubid}" %>
 
-<% if @obj.is_a?(Vm) || @obj.is_a?(PostgresResource) %>
-  <%== form({action: "/model/#{@obj.class}/#{@obj.ubid}/restart", method: :post, id: "restart-button"}, button: "Restart #{@obj.class}") %>
-<% end %>
-
 <% if @klass.associations.include?(:sshable) && (sshable = @obj.sshable) %>
   <p>SSH Command: <code>ssh -i &lt;PRIVATE_KEY_PATH&gt; <%= sshable.unix_user %>@<%= sshable.host %></code></p>
 <% end %>
@@ -25,6 +21,14 @@
 
 <% if @klass.associations.include?(:semaphores) && !(semaphores = @obj.semaphores_dataset.select_order_map(:name)).empty? %>
   <p>Semaphores Set: <%= semaphores.join(", ") %></p>
+<% end %>
+
+<% if actions = OBJECT_ACTIONS[@obj.class.name] %>
+  <p id="action-list">Actions:
+    <% actions.each do |key, action| %>
+      <a href="/model/<%= @obj.class.name %>/<%= @obj.ubid %>/<%= key %>"><%= action.label %></a>
+    <% end %>
+  </p>
 <% end %>
 
 <table class="object-table">

--- a/views/admin/object_action.erb
+++ b/views/admin/object_action.erb
@@ -1,0 +1,3 @@
+<% @page_title = "#{@klass.name} #{@obj.ubid}" %>
+
+<%== form({method: :post, id: "action-button"}, button: @label) %>


### PR DESCRIPTION
This switches the button on the object page to a link that takes you to a page with the button.

It also adds support for the following actions on the admin site:

* VmHost
  * Move to accepting
  * Move to draining
  * Reboot
  * Hardware Reset
* GitHubRunner
  * Provision spare runner

This refactors the model-specific action code on the admin site to require minimal code for model-specific actions.