### PR TITLE
Skip runner pool if feature flag is enabled

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -173,7 +173,7 @@ class Project < Sequel::Model
   feature_flag :vm_public_ssh_keys, :location_latitude_fra, :access_all_cache_scopes, :allocator_diagnostics
   feature_flag :private_locations, :enable_c6gd, :enable_m6gd, :enable_m8gd
   feature_flag :free_runner_upgrade_until, :gpu_vm, :postgres_lantern, :aws_cloudwatch_logs
-  feature_flag :aws_alien_runners_ratio, :ipv6_disabled
+  feature_flag :aws_alien_runners_ratio, :ipv6_disabled, :skip_runner_pool
 end
 
 # Table: project

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -32,7 +32,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     else
       label_data["vm_size"]
     end
-    pool = VmPool.where(
+    pool = installation.project.get_ff_skip_runner_pool ? nil : VmPool.where(
       vm_size:,
       boot_image: label_data["boot_image"],
       location_id: Location::GITHUB_RUNNERS_ID,


### PR DESCRIPTION
We apply special allocation logic for certain GitHub installations, and in some cases, we can provision an alien runner for them.

However, if the pool has available runners, it uses a VM from the pool instead of provisioning a new one, which bypasses the special logic.

With this feature flag, we can skip the pool and always provision a new VM for specific installations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `skip_runner_pool` feature flag to control VM provisioning, skipping the pool if enabled, with tests verifying behavior.
> 
>   - **Feature Flag**:
>     - Adds `skip_runner_pool` feature flag in `project.rb`.
>   - **VM Provisioning**:
>     - Modifies `pick_vm` in `github_runner.rb` to skip VM pool if `skip_runner_pool` flag is enabled.
>   - **Tests**:
>     - Adds test in `github_runner_spec.rb` to verify pool is skipped when `skip_runner_pool` is enabled, even if a VM is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fdfcb298c025bafcd1537d09913c9ae75558eca7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->