### PR TITLE
Fix flaky test in k8s node provisioning

### DIFF
--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   let(:node) {
     nic = Prog::Vnet::NicNexus.assemble(subnet.id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
     vm = Prog::Vm::Nexus.assemble("pub key", Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
-    vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79")
+    vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79", created_at: Time.now - 1)
     KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
   }
 


### PR DESCRIPTION
There is an association which sorts the vms based on their created_at field and in the specs, we were creating all the nodes almost at the same time and scenarios where a node is added last and must be placed as the last element failed. With this fix, we make sure the nodes are in the right order
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix flaky test in `provision_kubernetes_node_spec.rb` by adjusting `created_at` for VMs to ensure correct order.
> 
>   - **Test Fix**:
>     - In `provision_kubernetes_node_spec.rb`, update `created_at` for VMs to `Time.now - 1` to ensure correct order in tests based on `created_at` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 253423b3260c79c152dcf262dcd103b50be9301f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->