### PR TITLE
Replace remaining rodauth *_route method calls with *_path method calls

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -969,7 +969,7 @@ class Clover < Roda
         if current_account
           redirect_default_project_dashboard
         else
-          r.redirect rodauth.login_route
+          r.redirect rodauth.login_path
         end
       end
     end

--- a/views/auth/otp_auth.erb
+++ b/views/auth/otp_auth.erb
@@ -12,7 +12,7 @@
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your authentication app?
       <br>
-      <a href="/<%= rodauth.recovery_auth_route %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
+      <a href="<%= rodauth.recovery_auth_path %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
       or
       <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
     </p>

--- a/views/auth/otp_unlock.erb
+++ b/views/auth/otp_unlock.erb
@@ -14,7 +14,7 @@
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your authentication app?
       <br>
-      <a href="/<%= rodauth.recovery_auth_route %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
+      <a href="<%= rodauth.recovery_auth_path %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
       or
       <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
     </p>

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -17,7 +17,7 @@
   <p class="mt-10 text-center text-sm text-gray-400">
     Can't access your authentication app?
     <br>
-    <a href="/<%= rodauth.recovery_auth_route %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
+    <a href="<%= rodauth.recovery_auth_path %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
     or
     <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
   </p>


### PR DESCRIPTION
In all of these cases, a path is desired as opposed to a route name.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `*_route` method calls with `*_path` method calls in `clover.rb` and authentication views for path-based redirects and links.
> 
>   - **Behavior**:
>     - Replace `rodauth.login_route` with `rodauth.login_path` in `clover.rb` for redirecting to login.
>     - Replace `rodauth.recovery_auth_route` with `rodauth.recovery_auth_path` in `otp_auth.erb`, `otp_unlock.erb`, and `webauthn_auth.erb` for recovery code links.
>   - **Misc**:
>     - Update `webauthn_auth.erb` to use `rodauth.webauthn_auth_form_path` instead of `rodauth.webauthn_auth_form_route` for form action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 16052325f4c3a7af77849c5bcff0e42003ae603f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->