### PR TITLE
Replace components/form/hidden template with hidden_inputs method

### DIFF
--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -227,4 +227,8 @@ class Clover < Roda
   def money(amount)
     "$%0.02f" % amount
   end
+
+  def hidden_inputs(hash)
+    hash.map { |name, value| "<input #{html_attrs(type: "hidden", name:, value:)} />" }.join("\n")
+  end
 end

--- a/views/account/login_method.erb
+++ b/views/account/login_method.erb
@@ -25,8 +25,7 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                   <% if uid = @identities[provider.to_s] %>
                     <% form(action: "/account/login-method/disconnect", role: :form, method: :post, class: :grow) do %>
-                      <%== part("components/form/hidden", name: "provider", value: provider) %>
-                      <%== part("components/form/hidden", name: "uid", value: uid) %>
+                      <%== hidden_inputs(provider:, uid:) %>
                       <%== part("components/button", text: "Disconnect", type: "danger") %>
                     <% end %>
                   <% else %>
@@ -52,8 +51,7 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
                 </div>
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                   <% form(action: "/account/login-method/disconnect", role: :form, method: :post, class: :grow) do %>
-                    <%== part("components/form/hidden", name: "provider", value: provider) %>
-                    <%== part("components/form/hidden", name: "uid", value: uid) %>
+                    <%== hidden_inputs(provider:, uid:) %>
                     <%== part("components/button", text: "Disconnect", type: "danger") %>
                   <% end %>
                 </div>
@@ -93,7 +91,7 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
                 <%== part("components/button", text: rodauth.has_password? ? "Change" : "Create", link: "/account/change-password") %>
                 <% if rodauth.has_password? %>
                   <% form(action: "/account/login-method/disconnect", role: :form, method: :post, class: :grow) do %>
-                    <%== part("components/form/hidden", name: "provider", value: "password") %>
+                    <%== hidden_inputs(provider: "password") %>
                     <%== part("components/button", text: "Delete", type: "danger") %>
                   <% end %>
                 <% end %>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -12,12 +12,7 @@
             <h2 class="text-lg font-medium leading-6 text-gray-900">Setup Security Key</h2>
             <% form(:action => rodauth.webauthn_setup_path, :role => :form, :method => :post, :id => "webauthn-setup-form", "data-credential-options" => (cred = rodauth.new_webauthn_credential).as_json.to_json) do %>
               <%== rodauth.webauthn_setup_additional_form_tags %>
-              <%== part("components/form/hidden", name: rodauth.webauthn_setup_challenge_param, value: cred.challenge) %>
-              <%== part(
-                "components/form/hidden",
-                name: rodauth.webauthn_setup_challenge_hmac_param,
-                value: rodauth.compute_hmac(cred.challenge)
-              ) %>
+              <%== hidden_inputs(rodauth.webauthn_setup_challenge_param => cred.challenge, rodauth.webauthn_setup_challenge_hmac_param => rodauth.compute_hmac(cred.challenge)) %>
               <input id="webauthn-setup" class="hidden" type="text" name="<%= rodauth.webauthn_setup_param %>" value="" hidden/>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">

--- a/views/auth/verify_account_resend.erb
+++ b/views/auth/verify_account_resend.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <% if rodauth.param_or_nil(rodauth.login_param) %>
-    <%== part("components/form/hidden", name: rodauth.login_param, value: rodauth.param(rodauth.login_param)) %>
+    <%== hidden_inputs(rodauth.login_param => rodauth.param(rodauth.login_param)) %>
   <% else %>
     <%== render("components/rodauth/login_field") %>
   <% end %>

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -4,12 +4,7 @@
 
 <% form(:action => rodauth.webauthn_auth_form_path, :role => :form, :method => :post, :class => "rodauth space-y-6", :id => "webauthn-auth-form", "data-credential-options" => (cred = rodauth.webauthn_credential_options_for_get).as_json.to_json) do %>
   <%== rodauth.webauthn_auth_additional_form_tags %>
-  <%== part("components/form/hidden", name: rodauth.webauthn_auth_challenge_param, value: cred.challenge) %>
-  <%== part(
-    "components/form/hidden",
-    name: rodauth.webauthn_auth_challenge_hmac_param,
-    value: rodauth.compute_hmac(cred.challenge)
-  ) %>
+  <%== hidden_inputs(rodauth.webauthn_auth_challenge_param => cred.challenge, rodauth.webauthn_auth_challenge_hmac_param => rodauth.compute_hmac(cred.challenge)) %>
   <input id="webauthn-auth" class="hidden" type="text" name="<%= rodauth.webauthn_auth_param %>" value="" hidden/>
   <div id="webauthn-auth-button" class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.webauthn_auth_button) %>

--- a/views/components/form/hidden.erb
+++ b/views/components/form/hidden.erb
@@ -1,2 +1,2 @@
-<%# locals: (name:, value:) %>
-<input type="hidden" name="<%= name %>" value="<%= value %>" hidden/>
+<%# locals: (**) %>
+<%== hidden_inputs(**) %>

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -77,7 +77,7 @@ let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_o
       locals = {name:, label:, description: element[:description], attributes: attributes.merge!({placeholder:, rows: 3})}
     when "hidden"
       selected_options[name] = element[:value]
-      locals = {name:, value: element[:value]}
+      locals = {name => element[:value]}
       container_opening_tag, container_closing_tag = "", ""
     when "partnership_notice"
       description, tos_text = content_generator.call(@flavor)

--- a/views/components/form/toggle_form.erb
+++ b/views/components/form/toggle_form.erb
@@ -1,7 +1,7 @@
 <%# locals: (name:, action:, active:) %>
 
 <% form(action:, role: :form, method: :post, id: "#{name}_toggle") do %>
-  <%== part("components/form/hidden", name:, value: !active) %>
+  <%== hidden_inputs(name => !active) %>
   <div class="group <%= active ? "active" : "" %>">
     <button
       type="submit"

--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -96,7 +96,7 @@ end
                     </td>
                   <% end %>
                   <td class="py-4 px-3 text-right">
-                    <%== part("components/form/hidden", name: "aces[][ubid]", value: ubid) %>
+                    <%== hidden_inputs("aces[][ubid]" => ubid) %>
                     <%== part("components/form/checkbox", id_prefix: "ace-#{ubid}-", name: "aces[][deleted]", options: [%w[true Delete]]) %>
                   </td>
                 <% else %>


### PR DESCRIPTION
The hidden_inputs method accepts a hash, so it supports multiple hidden attributes in the same call, and provides a simpler interface.