### PR TITLE
Remove rodauth.*_additional_form_tags calls in views

### DIFF
--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -11,7 +11,6 @@
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Change Email Address</h2>
             <% form(action: rodauth.change_login_path, role: :form, method: :post) do %>
-              <%== rodauth.change_login_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/form/text", label: "Current Email", value: current_account.email, extra_class: "bg-gray-50 text-gray-500 ring-gray-200 ", attributes: {disabled: true}) %>

--- a/views/account/change_password.erb
+++ b/views/account/change_password.erb
@@ -12,7 +12,6 @@
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900"><%= action %> Password</h2>
             <% form(action: rodauth.change_password_path, role: :form, method: :post) do %>
-              <%== rodauth.change_password_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.change_password_requires_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">

--- a/views/account/close_account.erb
+++ b/views/account/close_account.erb
@@ -12,7 +12,6 @@
             <h2 class="text-lg font-medium leading-6 text-gray-900">Close Account</h2>
             <p class="mt-1 text-sm text-gray-500">This action will permanently delete this account. Deleted data cannot be recovered. Use it carefully.</p>
             <% form(action: rodauth.close_account_path, role: :form, method: :post) do %>
-              <%== rodauth.close_account_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.close_account_requires_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">

--- a/views/auth/create_account.erb
+++ b/views/auth/create_account.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Create a new account" %>
 
 <% form(class: "rodauth space-y-6", role: :form, method: :post) do %>
-  <%== rodauth.create_account_additional_form_tags %>
 
   <%== part(
     "components/form/text",

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -4,7 +4,6 @@
 
 <div class="space-y-6">
   <% form(class: "rodauth space-y-6", role: :form, method: :post, id: "login-form") do %>
-    <%== rodauth.login_additional_form_tags %>
 
     <%== render("components/rodauth/login_field") %>
     <% if rodauth.valid_login_entered? %>

--- a/views/auth/otp_auth.erb
+++ b/views/auth/otp_auth.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Verify your sign in" %>
 
 <% form(action: rodauth.otp_auth_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
-  <%== rodauth.otp_auth_additional_form_tags %>
 
   <%== render("components/rodauth/otp_auth_code_field") %>
 

--- a/views/auth/otp_unlock.erb
+++ b/views/auth/otp_unlock.erb
@@ -1,7 +1,6 @@
 <% @page_message = "Your one-time password authentication has been locked out, and must be unlocked to be used." %>
 
 <% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
-  <%== rodauth.otp_unlock_additional_form_tags %>
 
   <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
   <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>

--- a/views/auth/recovery_auth.erb
+++ b/views/auth/recovery_auth.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Verify your sign in" %>
 
 <% form(action: rodauth.recovery_auth_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
-  <%== rodauth.recovery_auth_additional_form_tags %>
 
   <%== part(
     "components/form/text",

--- a/views/auth/reset_password.erb
+++ b/views/auth/reset_password.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Reset your password" %>
 
 <% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
-  <%== rodauth.reset_password_additional_form_tags %>
 
   <%== render("components/rodauth/password_field") %>
   <%== part("components/rodauth/password_field", confirm: true) %>

--- a/views/auth/reset_password_request.erb
+++ b/views/auth/reset_password_request.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Request password reset" %>
 
 <% form(action: rodauth.reset_password_request_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
-  <%== rodauth.reset_password_request_additional_form_tags %>
 
   <div>
     <p class="leading-6 text-sm"><%== rodauth.reset_password_explanatory_text %></p>

--- a/views/auth/verify_account.erb
+++ b/views/auth/verify_account.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Verify your account" %>
 
 <% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
-  <%== rodauth.verify_account_additional_form_tags %>
 
   <div class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: "Verify Account") %>

--- a/views/auth/verify_account_resend.erb
+++ b/views/auth/verify_account_resend.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Resend account verification" %>
 
 <% form(action: rodauth.verify_account_resend_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
-  <%== rodauth.verify_account_resend_additional_form_tags %>
   <% recently_sent = rodauth.verify_account_email_recently_sent? if rodauth.account %>
 
   <% if !rodauth.account || recently_sent %>

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Verify your sign in" %>
 
 <% form(:action => rodauth.webauthn_auth_form_path, :role => :form, :method => :post, :class => "rodauth space-y-6", :id => "webauthn-auth-form", "data-credential-options" => (cred = rodauth.webauthn_credential_options_for_get).as_json.to_json) do %>
-  <%== rodauth.webauthn_auth_additional_form_tags %>
   <%== hidden_inputs(rodauth.webauthn_auth_challenge_param => cred.challenge, rodauth.webauthn_auth_challenge_hmac_param => rodauth.compute_hmac(cred.challenge)) %>
   <input id="webauthn-auth" class="hidden" type="text" name="<%= rodauth.webauthn_auth_param %>" value="" hidden/>
   <div id="webauthn-auth-button" class="flex flex-col text-center">


### PR DESCRIPTION
There is no reason to have these in custom rodauth views, considering that we don't set any additional form tags in Clover.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove unnecessary `rodauth.*_additional_form_tags` calls from various authentication-related view files.
> 
>   - **Views**:
>     - Removed `rodauth.*_additional_form_tags` calls from forms in `change_login.erb`, `change_password.erb`, and `close_account.erb`.
>     - Removed `rodauth.*_additional_form_tags` calls from forms in `create_account.erb`, `login.erb`, and `otp_auth.erb`.
>     - Removed `rodauth.*_additional_form_tags` calls from forms in `otp_unlock.erb`, `recovery_auth.erb`, and `reset_password.erb`.
>     - Removed `rodauth.*_additional_form_tags` calls from forms in `reset_password_request.erb`, `verify_account.erb`, and `verify_account_resend.erb`.
>     - Removed `rodauth.*_additional_form_tags` calls from forms in `webauthn_auth.erb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b10749680e99b2ed558809111517c5eef875da4c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->