### PR TITLE
Remove role="form" attribute on form tags

### DIFF
--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -10,7 +10,7 @@
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Change Email Address</h2>
-            <% form(action: rodauth.change_login_path, role: :form, method: :post) do %>
+            <% form(action: rodauth.change_login_path, method: :post) do %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/form/text", label: "Current Email", value: current_account.email, extra_class: "bg-gray-50 text-gray-500 ring-gray-200 ", attributes: {disabled: true}) %>

--- a/views/account/change_password.erb
+++ b/views/account/change_password.erb
@@ -11,7 +11,7 @@
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900"><%= action %> Password</h2>
-            <% form(action: rodauth.change_password_path, role: :form, method: :post) do %>
+            <% form(action: rodauth.change_password_path, method: :post) do %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.change_password_requires_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">

--- a/views/account/close_account.erb
+++ b/views/account/close_account.erb
@@ -11,7 +11,7 @@
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Close Account</h2>
             <p class="mt-1 text-sm text-gray-500">This action will permanently delete this account. Deleted data cannot be recovered. Use it carefully.</p>
-            <% form(action: rodauth.close_account_path, role: :form, method: :post) do %>
+            <% form(action: rodauth.close_account_path, method: :post) do %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.close_account_requires_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">

--- a/views/account/login_method.erb
+++ b/views/account/login_method.erb
@@ -24,12 +24,12 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
                 </div>
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                   <% if uid = @identities[provider.to_s] %>
-                    <% form(action: "/account/login-method/disconnect", role: :form, method: :post, class: :grow) do %>
+                    <% form(action: "/account/login-method/disconnect", method: :post, class: :grow) do %>
                       <%== hidden_inputs(provider:, uid:) %>
                       <%== part("components/button", text: "Disconnect", type: "danger") %>
                     <% end %>
                   <% else %>
-                    <% form(action: rodauth.omniauth_request_path(provider, redirect_url: "/account/login-method"), role: :form, method: :post, class: :grow) do %>
+                    <% form(action: rodauth.omniauth_request_path(provider, redirect_url: "/account/login-method"), method: :post, class: :grow) do %>
                       <%== part("components/button", text: "Connect") %>
                     <% end %>
                   <% end %>
@@ -50,7 +50,7 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
                     account to log in to your Ubicloud account using OIDC</p>
                 </div>
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
-                  <% form(action: "/account/login-method/disconnect", role: :form, method: :post, class: :grow) do %>
+                  <% form(action: "/account/login-method/disconnect", method: :post, class: :grow) do %>
                     <%== hidden_inputs(provider:, uid:) %>
                     <%== part("components/button", text: "Disconnect", type: "danger") %>
                   <% end %>
@@ -60,7 +60,7 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
           <% end %>
 
           <div id="login-method-connect-oidc" class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <form action="/account/login-method/oidc" role="form" method="GET" class="grow">
+            <form action="/account/login-method/oidc" method="GET" class="grow">
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
                   <div class="text-lg font-medium leading-6 text-gray-900">Login using an OIDC provider</div>
@@ -90,7 +90,7 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
               <div class="col-span-6 sm:col-span-2 text-right space-y-2">
                 <%== part("components/button", text: rodauth.has_password? ? "Change" : "Create", link: "/account/change-password") %>
                 <% if rodauth.has_password? %>
-                  <% form(action: "/account/login-method/disconnect", role: :form, method: :post, class: :grow) do %>
+                  <% form(action: "/account/login-method/disconnect", method: :post, class: :grow) do %>
                     <%== hidden_inputs(provider: "password") %>
                     <%== part("components/button", text: "Delete", type: "danger") %>
                   <% end %>

--- a/views/account/multifactor/otp_disable.erb
+++ b/views/account/multifactor/otp_disable.erb
@@ -10,7 +10,7 @@
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Disable One-Time Password Authentication</h2>
-            <% form(action: rodauth.otp_disable_path, role: :form, method: :post) do %>
+            <% form(action: rodauth.otp_disable_path, method: :post) do %>
               <%== rodauth.otp_disable_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.two_factor_modifications_require_password? %>

--- a/views/account/multifactor/otp_setup.erb
+++ b/views/account/multifactor/otp_setup.erb
@@ -10,7 +10,7 @@
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Setup One-Time Password Authentication</h2>
-            <% form(action: rodauth.otp_setup_path, role: :form, method: :post) do %>
+            <% form(action: rodauth.otp_setup_path, method: :post) do %>
               <%== rodauth.otp_setup_additional_form_tags %>
               <input type="hidden" id="otp-key" name="<%= rodauth.otp_setup_param %>" value="<%= rodauth.otp_user_key %>"/>
               <input type="hidden" id="otp-hmac-secretkey" name="<%= rodauth.otp_setup_raw_param %>" value="<%= rodauth.otp_key %>"/>

--- a/views/account/multifactor/recovery_codes.erb
+++ b/views/account/multifactor/recovery_codes.erb
@@ -11,7 +11,7 @@
           <% if rodauth.two_factor_modifications_require_password? %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <h2 class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</h2>
-              <% form(action: rodauth.recovery_codes_path, role: :form, method: :post) do %>
+              <% form(action: rodauth.recovery_codes_path, method: :post) do %>
                 <div class="mt-6 grid grid-cols-6 gap-6">
                   <div class="col-span-6 sm:col-span-2">
                     <%== render("components/rodauth/password_field") %>
@@ -51,7 +51,7 @@
             <% if rodauth.can_add_recovery_codes? %>
               <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
                 <h2 class="text-lg font-medium leading-6 text-gray-900"><%== rodauth.add_recovery_codes_heading %></h2>
-                <% form(action: rodauth.recovery_codes_path, role: :form, method: :post) do %>
+                <% form(action: rodauth.recovery_codes_path, method: :post) do %>
                   <div class="mt-6 grid grid-cols-6 gap-6">
                     <div class="col-span-6">
                       <%== part("components/form/submit_button", text: rodauth.add_recovery_codes_button, name: rodauth.add_recovery_codes_param) %>

--- a/views/account/multifactor/webauthn_remove.erb
+++ b/views/account/multifactor/webauthn_remove.erb
@@ -10,7 +10,7 @@
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Remove Security Key</h2>
-            <% form(action: rodauth.webauthn_remove_path, role: :form, method: :post, id: "webauthn-remove-form") do %>
+            <% form(action: rodauth.webauthn_remove_path, method: :post, id: "webauthn-remove-form") do %>
               <%== rodauth.webauthn_remove_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.two_factor_modifications_require_password? %>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -10,7 +10,7 @@
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Setup Security Key</h2>
-            <% form(:action => rodauth.webauthn_setup_path, :role => :form, :method => :post, :id => "webauthn-setup-form", "data-credential-options" => (cred = rodauth.new_webauthn_credential).as_json.to_json) do %>
+            <% form(:action => rodauth.webauthn_setup_path, :method => :post, :id => "webauthn-setup-form", "data-credential-options" => (cred = rodauth.new_webauthn_credential).as_json.to_json) do %>
               <%== rodauth.webauthn_setup_additional_form_tags %>
               <%== hidden_inputs(rodauth.webauthn_setup_challenge_param => cred.challenge, rodauth.webauthn_setup_challenge_hmac_param => rodauth.compute_hmac(cred.challenge)) %>
               <input id="webauthn-setup" class="hidden" type="text" name="<%= rodauth.webauthn_setup_param %>" value="" hidden/>

--- a/views/auth/create_account.erb
+++ b/views/auth/create_account.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Create a new account" %>
 
-<% form(class: "rodauth space-y-6", role: :form, method: :post) do %>
+<% form(class: "rodauth space-y-6", method: :post) do %>
 
   <%== part(
     "components/form/text",

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -3,7 +3,7 @@
 <% @page_message = "Sign in to your account" %>
 
 <div class="space-y-6">
-  <% form(class: "rodauth space-y-6", role: :form, method: :post, id: "login-form") do %>
+  <% form(class: "rodauth space-y-6", method: :post, id: "login-form") do %>
 
     <%== render("components/rodauth/login_field") %>
     <% if rodauth.valid_login_entered? %>
@@ -28,7 +28,7 @@
         <% provider_name = provider.display_name %>
         <% content_security_policy.add_form_action(provider.url) %>
       <% end %>
-      <% form(action: rodauth.omniauth_request_path(identity.provider), role: :form, method: :post, class: "grow") do %>
+      <% form(action: rodauth.omniauth_request_path(identity.provider), method: :post, class: "grow") do %>
         <button
           class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
           type="submit"

--- a/views/auth/oidc_login.erb
+++ b/views/auth/oidc_login.erb
@@ -9,7 +9,7 @@ else
   @page_message = "Sign in to your account on #{@oidc_provider.display_name} using OpenID Connect"
 end %>
 
-<% form(action: form_action, role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(action: form_action, method: :post, class: "rodauth space-y-6") do %>
   <button
     class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
     type="submit"

--- a/views/auth/otp_auth.erb
+++ b/views/auth/otp_auth.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Verify your sign in" %>
 
-<% form(action: rodauth.otp_auth_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(action: rodauth.otp_auth_path, method: :post, class: "rodauth space-y-6") do %>
 
   <%== render("components/rodauth/otp_auth_code_field") %>
 

--- a/views/auth/otp_unlock.erb
+++ b/views/auth/otp_unlock.erb
@@ -1,6 +1,6 @@
 <% @page_message = "Your one-time password authentication has been locked out, and must be unlocked to be used." %>
 
-<% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(method: :post, class: "rodauth space-y-6") do %>
 
   <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
   <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>

--- a/views/auth/recovery_auth.erb
+++ b/views/auth/recovery_auth.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Verify your sign in" %>
 
-<% form(action: rodauth.recovery_auth_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(action: rodauth.recovery_auth_path, method: :post, class: "rodauth space-y-6") do %>
 
   <%== part(
     "components/form/text",

--- a/views/auth/reset_password.erb
+++ b/views/auth/reset_password.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Reset your password" %>
 
-<% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(method: :post, class: "rodauth space-y-6") do %>
 
   <%== render("components/rodauth/password_field") %>
   <%== part("components/rodauth/password_field", confirm: true) %>

--- a/views/auth/reset_password_request.erb
+++ b/views/auth/reset_password_request.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Request password reset" %>
 
-<% form(action: rodauth.reset_password_request_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(action: rodauth.reset_password_request_path, method: :post, class: "rodauth space-y-6") do %>
 
   <div>
     <p class="leading-6 text-sm"><%== rodauth.reset_password_explanatory_text %></p>

--- a/views/auth/social_buttons.erb
+++ b/views/auth/social_buttons.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="mt-4 grid sm:grid-cols-<%= omniauth_providers.length %> gap-4">
       <% omniauth_providers.each do |provider, name| %>
-        <% form(action: rodauth.omniauth_request_path(provider), role: :form, method: :post, class: :grow) do %>
+        <% form(action: rodauth.omniauth_request_path(provider), method: :post, class: :grow) do %>
           <button
             class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
             type="submit"

--- a/views/auth/verify_account.erb
+++ b/views/auth/verify_account.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Verify your account" %>
 
-<% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(method: :post, class: "rodauth space-y-6") do %>
 
   <div class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: "Verify Account") %>

--- a/views/auth/verify_account_resend.erb
+++ b/views/auth/verify_account_resend.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Resend account verification" %>
 
-<% form(action: rodauth.verify_account_resend_path, role: :form, method: :post, class: "rodauth space-y-6") do %>
+<% form(action: rodauth.verify_account_resend_path, method: :post, class: "rodauth space-y-6") do %>
   <% recently_sent = rodauth.verify_account_email_recently_sent? if rodauth.account %>
 
   <% if !rodauth.account || recently_sent %>

--- a/views/auth/verify_login_change.erb
+++ b/views/auth/verify_login_change.erb
@@ -11,7 +11,7 @@
           <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <h2 class="text-lg font-medium leading-6 text-gray-900">Verify New Email</h2>
-              <% form(role: :form, method: :post) do %>
+              <% form(method: :post) do %>
                 <div class="mt-6 grid grid-cols-6 gap-6">
                   <div class="col-span-6">
                     <%== part("components/form/submit_button", text: "Click to Verify New Email") %>
@@ -27,7 +27,7 @@
 <% else %>
   <% @page_message = "Verify your new email" %>
 
-  <% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
+  <% form(method: :post, class: "rodauth space-y-6") do %>
     <div class="flex flex-col text-center">
       <%== part("components/form/submit_button", text: "Click to Verify New Email") %>
       <a href="/login" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Sign in to another account</a>

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -2,7 +2,7 @@
 
 <% @page_message = "Verify your sign in" %>
 
-<% form(:action => rodauth.webauthn_auth_form_path, :role => :form, :method => :post, :class => "rodauth space-y-6", :id => "webauthn-auth-form", "data-credential-options" => (cred = rodauth.webauthn_credential_options_for_get).as_json.to_json) do %>
+<% form(:action => rodauth.webauthn_auth_form_path, :method => :post, :class => "rodauth space-y-6", :id => "webauthn-auth-form", "data-credential-options" => (cred = rodauth.webauthn_credential_options_for_get).as_json.to_json) do %>
   <%== hidden_inputs(rodauth.webauthn_auth_challenge_param => cred.challenge, rodauth.webauthn_auth_challenge_hmac_param => rodauth.compute_hmac(cred.challenge)) %>
   <input id="webauthn-auth" class="hidden" type="text" name="<%= rodauth.webauthn_auth_param %>" value="" hidden/>
   <div id="webauthn-auth-button" class="flex flex-col text-center">

--- a/views/cli.erb
+++ b/views/cli.erb
@@ -26,7 +26,7 @@
     </div>
   <% end %>
 
-  <% form(action: request.path_info, role: :form, method: :post) do %>
+  <% form(action: request.path_info, method: :post) do %>
     <div class="flex gap-2 justify-between mb-6">
       <div class="font-mono flex-1">
         <% if multi %>

--- a/views/components/form/toggle_form.erb
+++ b/views/components/form/toggle_form.erb
@@ -1,6 +1,6 @@
 <%# locals: (name:, action:, active:) %>
 
-<% form(action:, role: :form, method: :post, id: "#{name}_toggle") do %>
+<% form(action:, method: :post, id: "#{name}_toggle") do %>
   <%== hidden_inputs(name => !active) %>
   <div class="group <%= active ? "active" : "" %>">
     <button

--- a/views/inference/api_key/index.erb
+++ b/views/inference/api_key/index.erb
@@ -40,7 +40,7 @@
 
   <% if has_project_permission("InferenceApiKey:create") && @inference_api_keys.size < 10 %>
   <div class="flex justify-end space-y-1 mt-6">
-    <% form(action: "#{@project.path}/inference-api-key", method: :post, role: :form, id: "create-inference-api-key") do %>
+    <% form(action: "#{@project.path}/inference-api-key", method: :post, id: "create-inference-api-key") do %>
       <%== part("components/form/submit_button", text: "Create API Key") %>
     <% end %>
   </div>

--- a/views/networking/firewall/networking.erb
+++ b/views/networking/firewall/networking.erb
@@ -70,7 +70,7 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
               ) %>
             </td>
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-              <% form(action: "#{firewall_path}/firewall-rule", method: :post, role: :form, id: "form-fw-create-rule-#{@firewall.ubid}") do %>
+              <% form(action: "#{firewall_path}/firewall-rule", method: :post, id: "form-fw-create-rule-#{@firewall.ubid}") do %>
                 <%== part("components/form/submit_button", text: "Create") %>
               <% end %>
             </td>
@@ -108,7 +108,7 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
             </td>
             <% if edit_perm %>
               <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                <% form(action: "#{firewall_path}/detach-subnet", method: :post, role: :form) do %>
+                <% form(action: "#{firewall_path}/detach-subnet", method: :post) do %>
                   <input type="hidden" name="private_subnet_id" value="<%= ps.ubid %>">
                   <%== part("components/form/submit_button", text: "Detach") %>
                 <% end %>
@@ -131,7 +131,7 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
               ) %>
             </td>
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-              <% form(action: "#{firewall_path}/attach-subnet", method: :post, role: :form, id: "form-fw-attach-#{@firewall.ubid}") do %>
+              <% form(action: "#{firewall_path}/attach-subnet", method: :post, id: "form-fw-attach-#{@firewall.ubid}") do %>
                 <%== part("components/form/submit_button", text: "Attach") %>
               <% end %>
             </td>

--- a/views/networking/load_balancer/vms.erb
+++ b/views/networking/load_balancer/vms.erb
@@ -33,7 +33,7 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb.ubid) %>
               <%= vm.load_balancer_state %>
             </td>
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-              <% form(action: "#{load_balancer_path}/detach-vm", role: :form, method: :post) do %>
+              <% form(action: "#{load_balancer_path}/detach-vm", method: :post) do %>
                 <input type="hidden" name="vm_id" value="<%= vm.ubid %>">
                 <%== part("components/form/submit_button", text: "Detach") %>
               <% end %>
@@ -57,7 +57,7 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb.ubid) %>
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
             </td>
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-              <% form(action: "#{load_balancer_path}/attach-vm", role: :form, method: :post, id: "form-lb-#{@lb.ubid}") do %>
+              <% form(action: "#{load_balancer_path}/attach-vm", method: :post, id: "form-lb-#{@lb.ubid}") do %>
                 <%== part("components/form/submit_button", text: "Attach") %>
               <% end %>
             </td>

--- a/views/networking/private_subnet/networking.erb
+++ b/views/networking/private_subnet/networking.erb
@@ -91,7 +91,7 @@ viewable_fws, viewable_subnets =
             ) %>
           </td>
           <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-            <% form(action: "#{ps_path}/connect", role: :form, method: :post, id: "form-connect-subnet") do %>
+            <% form(action: "#{ps_path}/connect", method: :post, id: "form-connect-subnet") do %>
               <%== part("components/form/submit_button", text: "Connect") %>
             <% end %>
           </td>

--- a/views/postgres/backup_restore.erb
+++ b/views/postgres/backup_restore.erb
@@ -3,7 +3,7 @@ max_date = @pg.timeline.latest_restore_time %>
 
 <% if min_date && max_date > min_date %>
   <div class="p-6">
-    <% form(action: "#{path(@pg)}/restore", role: :form, method: :post) do %>
+    <% form(action: "#{path(@pg)}/restore", method: :post) do %>
       <div class="space-y-4">
         <div>
           <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Fork PostgreSQL database</h3>

--- a/views/postgres/charts.erb
+++ b/views/postgres/charts.erb
@@ -96,7 +96,7 @@
               ) %>
           </td>
           <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-            <% form(action: "#{path(@pg)}/metric-destination", role: :form, method: :post, id: "form-pg-md-create") do %>
+            <% form(action: "#{path(@pg)}/metric-destination", method: :post, id: "form-pg-md-create") do %>
               <%== part("components/form/submit_button", text: "Create", extra_class: "metric-destination-create-button") %>
             <% end %>
           </td>

--- a/views/postgres/config.erb
+++ b/views/postgres/config.erb
@@ -16,7 +16,7 @@
   end
 %>
 
-<% form(action: "#{path(@pg)}/config", role: :form, method: :post, class: "min-w-2/3 pg-config") do %>
+<% form(action: "#{path(@pg)}/config", method: :post, class: "min-w-2/3 pg-config") do %>
   <%== part("components/config_card", title: "PostgreSQL Configuration", config: pg_config, extra_class: "pg-config-card", name: "pg_config", errors: errors) %>
   <%== part("components/config_card", title: "PgBouncer Configuration", config: pgbouncer_config, extra_class: "pgbouncer-config-card", name: "pgbouncer_config", errors: errors) %>
   <div class="flex justify-end">

--- a/views/postgres/networking.erb
+++ b/views/postgres/networking.erb
@@ -49,7 +49,7 @@
           </td>
           <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">5432, 6432</td>
           <td class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-            <% form(action: "#{path(@pg)}/firewall-rule", role: :form, method: :post, id: "form-pg-fwr-create") do %>
+            <% form(action: "#{path(@pg)}/firewall-rule", method: :post, id: "form-pg-fwr-create") do %>
               <%== part("components/form/submit_button", text: "Create", extra_class: "firewall-rule-create-button") %>
             <% end %>
           </td>

--- a/views/postgres/read_replica.erb
+++ b/views/postgres/read_replica.erb
@@ -32,7 +32,7 @@
                 <%== part("components/form/text", name: "name", attributes: { placeholder: @pg.name + "-read-replica", required: true, form: "form-pg-read-replica-create" }) %>
               </td>
               <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                <% form(action: "#{path(@pg)}/read-replica", role: :form, method: :post, id: "form-pg-read-replica-create") do %>
+                <% form(action: "#{path(@pg)}/read-replica", method: :post, id: "form-pg-read-replica-create") do %>
                   <%== part("components/form/submit_button", text: "Create", extra_class: "pg-read-replica-create-btn") %>
                 <% end %>
               </td>

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -13,7 +13,7 @@
     </div>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
-        <% form(action: "#{path(@pg)}/set-maintenance-window", role: :form, method: :post) do %>
+        <% form(action: "#{path(@pg)}/set-maintenance-window", method: :post) do %>
           <div class="space-y-4">
             <div class="grid grid-cols-12 gap-6">
               <div class="col-span-12 sm:col-span-7">
@@ -53,7 +53,7 @@
       <!-- Promote -->
       <% if @edit_perm && @pg.read_replica? %>
         <div class="px-4 py-5 sm:p-6">
-          <% form(action: "#{path(@pg)}/promote", role: :form, method: :post) do %>
+          <% form(action: "#{path(@pg)}/promote", method: :post) do %>
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Promote PostgreSQL read replica database</h3>
@@ -74,7 +74,7 @@
       <!-- Reset password -->
       <% if @edit_perm && !@pg.read_replica? %>
         <div class="px-4 py-5 sm:p-6">
-          <% form(action: "#{path(@pg)}/reset-superuser-password", role: :form, method: :post) do %>
+          <% form(action: "#{path(@pg)}/reset-superuser-password", method: :post) do %>
             <div class="space-y-4">
               <div>
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Reset superuser password</h3>
@@ -115,7 +115,7 @@
       <!-- Restart Card -->
       <% if @edit_perm %>
         <div class="px-4 py-5 sm:p-6">
-          <% form(action: "#{path(@pg)}/restart", role: :form, method: :post) do %>
+          <% form(action: "#{path(@pg)}/restart", method: :post) do %>
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Restart PostgreSQL database</h3>

--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -52,7 +52,7 @@ end
       </div>
     <% end %>
 
-    <% form(action: form_action, role: :form, method: :post, id: "access-control-form") do %>
+    <% form(action: form_action, method: :post, id: "access-control-form") do %>
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
         <table id="access-control-entries" class="min-w-full divide-y divide-gray-300 group">
           <thead class="bg-gray-50 <% if @token %> hidden group-[&:has(tr:nth-child(n+3))]:table-header-group <% end %>">
@@ -137,7 +137,7 @@ end
   <% if @token %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
-        <% form(action: restriction_path, role: :form, method: :post) do %>
+        <% form(action: restriction_path, method: :post) do %>
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900"><%= restriction_title %>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -274,7 +274,7 @@ end
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <!-- Add usage alert -->
       <div class="px-4 py-5 sm:p-6">
-        <% form(action: "#{@project.path}/usage-alert", role: :form, method: :post) do %>
+        <% form(action: "#{@project.path}/usage-alert", method: :post) do %>
           <div class="space-y-4">
             <div>
               <h2 class="text-lg font-medium leading-6 text-gray-900">Add new usage alert</h2>

--- a/views/project/tag-list.erb
+++ b/views/project/tag-list.erb
@@ -45,7 +45,7 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
             tags, recursively, to allow for easier management.
           </p>
 
-          <% form(action: "#{@project.path}/user/access-control/tag/#{@tag_type}", role: :form, method: :post) do %>
+          <% form(action: "#{@project.path}/user/access-control/tag/#{@tag_type}", method: :post) do %>
             <div class="grid grid-cols-12 gap-3">
               <div class="col-span-12 md:col-span-5">
                 <%== part("components/form/text", name: "name", button_title: "Create", attributes: { required: true, placeholder: "Name" }) %>

--- a/views/project/tag.erb
+++ b/views/project/tag.erb
@@ -59,7 +59,7 @@ current_members.sort! %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6 space-y-2">
         <h3 class="text-lg font-medium leading-6 text-gray-900"><%= "Update #{@display_tag_type} Tag" %></h3>
-        <% form(action: path(@tag), role: :form, method: :post) do %>
+        <% form(action: path(@tag), method: :post) do %>
           <div class="grid grid-cols-12 gap-3">
             <div class="col-span-12 md:col-span-5">
               <%== part(
@@ -92,7 +92,7 @@ current_members.sort! %>
           <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Current Members</h3>
         </div>
       </div>
-      <% form(action: disassociate_path, role: :form, method: :post) do %>
+      <% form(action: disassociate_path, method: :post) do %>
         <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
           <table id="tag-membership-remove" class="min-w-full divide-y divide-gray-300">
             <thead class="bg-gray-50">

--- a/views/project/token.erb
+++ b/views/project/token.erb
@@ -4,7 +4,7 @@
   "components/page_header",
   title: "Personal Access Tokens",
   breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Personal Access Tokens", "#"]],
-  right_items: [form(nil, {action: "#{@project.path}/token", role: :form, method: :post, id: "create-pat"}, emit: false) do |f|
+  right_items: [form(nil, {action: "#{@project.path}/token", method: :post, id: "create-pat"}, emit: false) do |f|
     f << part("components/form/submit_button", text: "Create Token")
   end]
 ) %>

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -25,7 +25,7 @@
     </div>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
-        <% form(action: user_path, role: :form, method: :post) do %>
+        <% form(action: user_path, method: :post) do %>
           <div class="space-y-4">
             <div>
               <p class="mt-1 text-sm text-gray-500">
@@ -50,7 +50,7 @@
   </div>
   <!-- User List -->
   <div>
-    <% form(action: "#{user_path}/policy/managed", role: :form, method: :post, id: "managed-policy") do %>
+    <% form(action: "#{user_path}/policy/managed", method: :post, id: "managed-policy") do %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
           <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -18,7 +18,7 @@
     <!-- Restart Card -->
     <% if edit_perm %>
       <div class="px-4 py-5 sm:p-6">
-        <% form(action: "#{path(@vm)}/restart", role: :form, method: :post) do %>
+        <% form(action: "#{path(@vm)}/restart", method: :post) do %>
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">Restart virtual machine</h3>


### PR DESCRIPTION
It is redundant. role="form" should be set on non-form tags that operate as forms, and if a form tag is used that doesn't operate as a form, you could potentially use a different role, but the assumption is that a form tag has a form role, so there is no benefit to being explicit about it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove redundant `role="form"` attribute from `form` tags across multiple view files for cleaner HTML.
> 
>   - **HTML Changes**:
>     - Removed `role="form"` attribute from `form` tags in `views/account/change_login.erb`, `views/account/change_password.erb`, and `views/account/close_account.erb`.
>     - Similar removal in `views/account/login_method.erb`, `views/account/multifactor/otp_disable.erb`, and `views/account/multifactor/otp_setup.erb`.
>     - Continued removal in `views/auth/create_account.erb`, `views/auth/login.erb`, and `views/auth/oidc_login.erb`.
>     - Further removals in `views/auth/otp_auth.erb`, `views/auth/otp_unlock.erb`, and `views/auth/recovery_auth.erb`.
>     - Additional removals in `views/auth/reset_password.erb`, `views/auth/reset_password_request.erb`, and `views/auth/social_buttons.erb`.
>     - Final removals in `views/auth/verify_account.erb`, `views/auth/verify_account_resend.erb`, and `views/auth/verify_login_change.erb`.
>     - Also removed in `views/auth/webauthn_auth.erb`, `views/cli.erb`, and `views/components/form/toggle_form.erb`.
>     - Applied to `views/inference/api_key/index.erb`, `views/networking/firewall/networking.erb`, and `views/networking/load_balancer/vms.erb`.
>     - Included in `views/networking/private_subnet/networking.erb`, `views/postgres/backup_restore.erb`, and `views/postgres/charts.erb`.
>     - Extended to `views/postgres/config.erb`, `views/postgres/networking.erb`, and `views/postgres/read_replica.erb`.
>     - Concluded in `views/postgres/settings.erb`, `views/project/access-control.erb`, and `views/project/billing.erb`.
>     - Finalized in `views/project/tag-list.erb`, `views/project/tag.erb`, and `views/project/token.erb`.
>     - Completed in `views/project/user.erb` and `views/vm/settings.erb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for df2951696ade958468b0fc13c780927fb7d68e7e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->