### PR TITLE
Use herb formatter/linter instead of erb_formatter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,3 +108,6 @@ RSpec/IndexedLet:
 
 RSpec/NestedGroups:
   Enabled: false
+
+Layout/AssignmentIndentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,6 @@ end
 
 group :lint do
   gem "brakeman"
-  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "df3174476986706828f7baf3e5e6f5ec8ecd849b"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,13 +15,6 @@ GIT
     roda (3.95.0)
       rack
 
-GIT
-  remote: https://github.com/ubicloud/erb-formatter.git
-  revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
-  ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
-  specs:
-    erb-formatter (0.7.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -482,7 +475,6 @@ DEPENDENCIES
   countries
   cuprite
   ed25519
-  erb-formatter!
   erubi (>= 1.5)
   excon
   foreman

--- a/Rakefile
+++ b/Rakefile
@@ -460,15 +460,8 @@ namespace :linter do
 
   desc "Run ERB::Formatter"
   task :erb_formatter do
-    # "fdr/erb-formatter" can't be required without bundler setup because of custom repository.
-    require "bundler"
-    Bundler.setup(:lint)
-    puts "Running ERB::Formatter..."
-    require "erb/formatter/command_line"
-    files = Dir.glob("views/**/[!icon]*.erb").entries
-    files.delete("views/components/form/select.erb")
-    files.delete("views/github/runner.erb")
-    ERB::Formatter::CommandLine.new(files + ["--write", "--print-width", "120"]).run
+    # Temporarily disable due to bugs in herb formatter
+    # sh "npm run format-erb"
   end
 
   desc "Run golangci-lint"

--- a/Rakefile
+++ b/Rakefile
@@ -462,6 +462,8 @@ namespace :linter do
   task :erb_formatter do
     # Temporarily disable due to bugs in herb formatter
     # sh "npm run format-erb"
+    # Temporarily disable due to bugs in herb linter
+    # sh "npm run lint-erb"
   end
 
   desc "Run golangci-lint"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@herb-tools/formatter": "^0.7.0",
+        "@herb-tools/linter": "^0.7.0",
         "@redocly/cli": "^2.0.8",
         "@stoplight/spectral-cli": "^6.15.0",
         "@tailwindcss/forms": "^0.5.10",
@@ -114,6 +116,249 @@
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@herb-tools/core": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@herb-tools/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-vGyn2qGuXAofHTW4+0QbMcgMBfmVnPELqt+LhUi90dmPiR/9wjN7zA/x/pof8MPIBnSSJsMTrzjaLnrwHJYPjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@herb-tools/formatter": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@herb-tools/formatter/-/formatter-0.7.0.tgz",
+      "integrity": "sha512-9xR7A0TNXFbcP9eOGBkTNt4mp0Yg0b2xXb/gcNfGjnA9H+lm7kCUKhznXbrnGN6db2IDkr6cPD/BIsguoTYWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.7.0",
+        "@herb-tools/printer": "0.7.0"
+      },
+      "bin": {
+        "herb-format": "bin/herb-format"
+      }
+    },
+    "node_modules/@herb-tools/highlighter": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@herb-tools/highlighter/-/highlighter-0.7.0.tgz",
+      "integrity": "sha512-abDVp8syG62MgiD2gG9qj1tbJIwoQ/NWeFq713GuA4LbHz3jbB4v+Bzwwo2h0300oC3Tz128sphB94/iyZgXGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.7.0",
+        "@herb-tools/node-wasm": "0.7.0",
+        "glob": "^11.0.3"
+      },
+      "bin": {
+        "herb-highlight": "bin/herb-highlight"
+      }
+    },
+    "node_modules/@herb-tools/highlighter/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/highlighter/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/highlighter/node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@herb-tools/highlighter/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/highlighter/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/linter": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@herb-tools/linter/-/linter-0.7.0.tgz",
+      "integrity": "sha512-6jDNrB+6Kf3/0t7E2rZ0VeeDFf0KTPg+IZmWeBR3G/wh0ZiT+yb0xGlBKDFx47+ilaK1wJWdbYc2ODgMrjTESg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.7.0",
+        "@herb-tools/highlighter": "0.7.0",
+        "@herb-tools/node-wasm": "0.7.0",
+        "@herb-tools/printer": "0.7.0",
+        "glob": "^11.0.3"
+      },
+      "bin": {
+        "herb-lint": "bin/herb-lint"
+      }
+    },
+    "node_modules/@herb-tools/linter/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/linter/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/linter/node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@herb-tools/linter/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/linter/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@herb-tools/node-wasm": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@herb-tools/node-wasm/-/node-wasm-0.7.0.tgz",
+      "integrity": "sha512-t+LiBJd1BNF52wJR7Vx9rpLJunnJH1OgB0vU1gXBt6PFIaett85Pt67VK5M2335L3zl94vBznmo9pHRA3NR6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.7.0"
+      }
+    },
+    "node_modules/@herb-tools/printer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@herb-tools/printer/-/printer-0.7.0.tgz",
+      "integrity": "sha512-C1JAdsOFE10MLwuHZ4YXE0S9JqcckMNh7ahYMWbcyvewMIYUfmFEbORDUExFlgMsZ3XR5tnA71SAQ5/W6tvEwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.7.0",
+        "glob": "^10.3.10"
+      },
+      "bin": {
+        "herb-print": "bin/herb-print"
       }
     },
     "node_modules/@humanwhocodes/momoa": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "openapi-format": "^1.27.3",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "@herb-tools/linter": "^0.7.0",
+    "@herb-tools/formatter": "^0.7.0"
   },
   "scripts": {
     "dev": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css",
     "prod": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --minify",
-    "watch": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --watch"
+    "watch": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --watch",
+    "format-erb": "npx @herb-tools/formatter 'views/**/*.erb'"
   },
   "engines": {
     "node": "24.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css",
     "prod": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --minify",
     "watch": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --watch",
-    "format-erb": "npx @herb-tools/formatter 'views/**/*.erb'"
+    "format-erb": "npx @herb-tools/formatter 'views/**/*.erb'",
+    "lint-erb": "npx @herb-tools/linter 'views/**/*.erb'"
   },
   "engines": {
     "node": "24.6.0",

--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -5,25 +5,40 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <h2 class="text-lg font-medium leading-6 text-gray-900">Change Email Address</h2>
+            <h2 class="text-lg font-medium leading-6 text-gray-900">
+              Change Email Address
+            </h2>
             <% form(action: rodauth.change_login_path, role: :form, method: :post) do %>
               <%== rodauth.change_login_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/form/text", label: "Current Email", value: current_account.email, extra_class: "bg-gray-50 text-gray-500 ring-gray-200 ", attributes: {disabled: true}) %>
                 </div>
+
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/rodauth/login_field", label: "New Email Address") %>
                 </div>
+
                 <% if rodauth.change_login_requires_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: "Change Email") %>
                 </div>

--- a/views/account/change_password.erb
+++ b/views/account/change_password.erb
@@ -6,11 +6,23 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <h2 class="text-lg font-medium leading-6 text-gray-900"><%= action %> Password</h2>
+            <h2 class="text-lg font-medium leading-6 text-gray-900">
+              <%= action %> Password
+            </h2>
             <% form(action: rodauth.change_password_path, role: :form, method: :post) do %>
               <%== rodauth.change_password_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
@@ -19,12 +31,15 @@
                     <%== part("components/rodauth/password_field", label: "Current Password") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/rodauth/password_field", label: "#{rodauth.new_password_label}#{rodauth.input_field_label_suffix}", name: rodauth.new_password_param, autocomplete: "new-password") %>
                 </div>
+
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/rodauth/password_field", label: "New Password Confirmation", confirm: true) %>
                 </div>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: "#{action} Password") %>
                 </div>

--- a/views/account/close_account.erb
+++ b/views/account/close_account.erb
@@ -5,12 +5,29 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <h2 class="text-lg font-medium leading-6 text-gray-900">Close Account</h2>
-            <p class="mt-1 text-sm text-gray-500">This action will permanently delete this account. Deleted data cannot be recovered. Use it carefully.</p>
+            <h2 class="text-lg font-medium leading-6 text-gray-900">
+              Close Account
+            </h2>
+
+            <p class="mt-1 text-sm text-gray-500">
+              This action will permanently delete this account. Deleted data
+              cannot be recovered. Use it carefully.
+            </p>
+
             <% form(action: rodauth.close_account_path, role: :form, method: :post) do %>
               <%== rodauth.close_account_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">

--- a/views/account/login_method.erb
+++ b/views/account/login_method.erb
@@ -9,18 +9,32 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <% omniauth_providers.each do |provider, name| %>
-            <div id="login-method-<%= provider %>" class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
+            <div
+              id="login-method-<%= provider %>"
+              class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4"
+            >
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
-                  <div class="text-lg font-medium leading-6 text-gray-900">Login with
-                    <%= name %></div>
-                  <p class="mt-1 text-sm text-gray-500">Connect your
-                    <%= name %>
-                    to log in to your Ubicloud account</p>
+                  <div class="text-lg font-medium leading-6 text-gray-900">
+                    Login with <%= name %>
+                  </div>
+                  <p class="mt-1 text-sm text-gray-500">
+                    Connect your <%= name %> to log in to your Ubicloud account
+                  </p>
                 </div>
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                   <% if uid = @identities[provider.to_s] %>
@@ -41,14 +55,18 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
 
           <% @oidc_identities.each do |provider, uid| %>
             <% display_name = @oidc_identity_names[UBID.to_uuid(provider)] %>
-            <div id="login-method-disconnect-oidc-<%= provider %>" class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
+            <div
+              id="login-method-disconnect-oidc-<%= provider %>"
+              class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4"
+            >
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
-                  <div class="text-lg font-medium leading-6 text-gray-900">Login with
-                    <%= display_name %></div>
-                  <p class="mt-1 text-sm text-gray-500">You currently allow your
-                    <%= display_name %>
-                    account to log in to your Ubicloud account using OIDC</p>
+                  <div class="text-lg font-medium leading-6 text-gray-900">
+                    Login with <%= display_name %>
+                  </div>
+                  <p class="mt-1 text-sm text-gray-500">
+                    You currently allow your <%= display_name %> account to log in to your Ubicloud account using OIDC
+                  </p>
                 </div>
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                   <% form(action: "/account/login-method/disconnect", role: :form, method: :post, class: :grow) do %>
@@ -61,12 +79,27 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
             </div>
           <% end %>
 
-          <div id="login-method-connect-oidc" class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <form action="/account/login-method/oidc" role="form" method="GET" class="grow">
+          <div
+            id="login-method-connect-oidc"
+            class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4"
+          >
+            <form
+              action="/account/login-method/oidc"
+              role="form"
+              method="GET"
+              class="grow"
+            >
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
-                  <div class="text-lg font-medium leading-6 text-gray-900">Login using an OIDC provider</div>
-                  <p class="mt-1 text-sm text-gray-500 mb-2">Allow logging into your Ubicloud account using an OIDC provider</p>
+                  <div class="text-lg font-medium leading-6 text-gray-900">
+                    Login using an OIDC provider
+                  </div>
+
+                  <p class="mt-1 text-sm text-gray-500 mb-2">
+                    Allow logging into your Ubicloud account using an OIDC
+                    provider
+                  </p>
+
                   <%== part("components/form/text", name: "provider", label: "OIDC Provider ID", attributes: {placeholder: "0p..."}) %>
                 </div>
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1 mt-8">
@@ -76,14 +109,19 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
             </form>
           </div>
 
-          <div id="login-method-password" class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
+          <div
+            id="login-method-password"
+            class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4"
+          >
             <div class="mt-6 grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-4">
-                <div class="text-lg font-medium leading-6 text-gray-900">Login with Password</div>
+                <div class="text-lg font-medium leading-6 text-gray-900">
+                  Login with Password
+                </div>
                 <p class="mt-1 text-sm text-gray-500">
                   <% if rodauth.has_password? %>
-                    Change or delete your password. If you delete your password, you can only log in with other
-                    methods.
+                    Change or delete your password. If you delete your password,
+                    you can only log in with other methods.
                   <% else %>
                     Create a password to log in to your Ubicloud account
                   <% end %>
@@ -100,7 +138,6 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
               </div>
             </div>
           </div>
-
         </div>
       </div>
     </div>

--- a/views/account/multifactor/otp_disable.erb
+++ b/views/account/multifactor/otp_disable.erb
@@ -5,11 +5,23 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <h2 class="text-lg font-medium leading-6 text-gray-900">Disable One-Time Password Authentication</h2>
+            <h2 class="text-lg font-medium leading-6 text-gray-900">
+              Disable One-Time Password Authentication
+            </h2>
             <% form(action: rodauth.otp_disable_path, role: :form, method: :post) do %>
               <%== rodauth.otp_disable_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">

--- a/views/account/multifactor/otp_setup.erb
+++ b/views/account/multifactor/otp_setup.erb
@@ -5,20 +5,46 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <h2 class="text-lg font-medium leading-6 text-gray-900">Setup One-Time Password Authentication</h2>
+            <h2 class="text-lg font-medium leading-6 text-gray-900">
+              Setup One-Time Password Authentication
+            </h2>
             <% form(action: rodauth.otp_setup_path, role: :form, method: :post) do %>
               <%== rodauth.otp_setup_additional_form_tags %>
-              <input type="hidden" id="otp-key" name="<%= rodauth.otp_setup_param %>" value="<%= rodauth.otp_user_key %>"/>
-              <input type="hidden" id="otp-hmac-secretkey" name="<%= rodauth.otp_setup_raw_param %>" value="<%= rodauth.otp_key %>"/>
+              <input
+                type="hidden"
+                id="otp-key"
+                name="<%= rodauth.otp_setup_param %>"
+                value="<%= rodauth.otp_user_key %>"
+              />
+
+              <input
+                type="hidden"
+                id="otp-hmac-secretkey"
+                name="<%= rodauth.otp_setup_raw_param %>"
+                value="<%= rodauth.otp_key %>"
+              />
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 md:col-span-3">
                   <%== rodauth.otp_qr_code %>
                   <p class="mt-2 text-sm text-gray-500 text-center">
-                    If you can't scan the QR code, please enter the following secret in your authenticator app manually: <br>
+                    If you can't scan the QR code, please enter the following
+                    secret in your authenticator app manually:
+                    <br>
                     <span id="otp-secret" class="font-bold break-words"><%= rodauth.otp_user_key %></span>
                   </p>
                 </div>
@@ -27,6 +53,7 @@
                   <% if rodauth.two_factor_modifications_require_password? %>
                     <%== render("components/rodauth/password_field") %>
                   <% end %>
+
                   <%== part("components/form/submit_button", text: rodauth.otp_setup_button) %>
                 </div>
               </div>

--- a/views/account/multifactor/otp_setup.erb
+++ b/views/account/multifactor/otp_setup.erb
@@ -29,14 +29,14 @@
                 id="otp-key"
                 name="<%= rodauth.otp_setup_param %>"
                 value="<%= rodauth.otp_user_key %>"
-              />
+              >
 
               <input
                 type="hidden"
                 id="otp-hmac-secretkey"
                 name="<%= rodauth.otp_setup_raw_param %>"
                 value="<%= rodauth.otp_key %>"
-              />
+              >
 
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 md:col-span-3">

--- a/views/account/multifactor/recovery_codes.erb
+++ b/views/account/multifactor/recovery_codes.erb
@@ -5,12 +5,24 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <% if rodauth.two_factor_modifications_require_password? %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-              <h2 class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</h2>
+              <h2 class="text-lg font-medium leading-6 text-gray-900">
+                Recovery Codes
+              </h2>
               <% form(action: rodauth.recovery_codes_path, role: :form, method: :post) do %>
                 <div class="mt-6 grid grid-cols-6 gap-6">
                   <div class="col-span-6 sm:col-span-2">
@@ -24,21 +36,35 @@
             </div>
           <% else %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-              <h2 class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</h2>
+              <h2 class="text-lg font-medium leading-6 text-gray-900">
+                Recovery Codes
+              </h2>
+
               <p class="mt-1 text-sm text-gray-500">
-                Copy these recovery codes to a safe location. You can also download them
+                Copy these recovery codes to a safe location. You can also
+                download them
                 <a
-                  class="font-medium text-orange-500 hover:text-orange-600 underline underline-offset-2"
+                  class="
+                    font-medium text-orange-500 hover:text-orange-600
+                    underline underline-offset-2
+                  "
                   href="data:text/plain;base64,<%= Base64.encode64(rodauth.recovery_codes.join("\n")) %>"
                   download="ubicloud-recovery-codes.txt"
-                >here</a>.
+                >
+                  here
+                </a>
+                .
               </p>
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-6">
                   <% if rodauth.recovery_codes.any? %>
                     <div
                       id="recovery-codes-text"
-                      class="w-fit text-sm xl:text-base whitespace-nowrap border p-3 bg-slate-100 text-rose-500 font-mono rounded"
+                      class="
+                        w-fit text-sm xl:text-base whitespace-nowrap border
+                        p-3 bg-slate-100 text-rose-500 font-mono rounded
+                      "
                     >
                       <% rodauth.recovery_codes.each do |code| %>
                         <div><%= code %></div>
@@ -50,7 +76,9 @@
             </div>
             <% if rodauth.can_add_recovery_codes? %>
               <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-                <h2 class="text-lg font-medium leading-6 text-gray-900"><%== rodauth.add_recovery_codes_heading %></h2>
+                <h2 class="text-lg font-medium leading-6 text-gray-900">
+                  <%== rodauth.add_recovery_codes_heading %>
+                </h2>
                 <% form(action: rodauth.recovery_codes_path, role: :form, method: :post) do %>
                   <div class="mt-6 grid grid-cols-6 gap-6">
                     <div class="col-span-6">

--- a/views/account/multifactor/webauthn_remove.erb
+++ b/views/account/multifactor/webauthn_remove.erb
@@ -5,11 +5,23 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <h2 class="text-lg font-medium leading-6 text-gray-900">Remove Security Key</h2>
+            <h2 class="text-lg font-medium leading-6 text-gray-900">
+              Remove Security Key
+            </h2>
             <% form(action: rodauth.webauthn_remove_path, role: :form, method: :post, id: "webauthn-remove-form") do %>
               <%== rodauth.webauthn_remove_additional_form_tags %>
               <div class="mt-6 grid grid-cols-6 gap-6">
@@ -18,6 +30,7 @@
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6 sm:col-span-6">
                   <fieldset>
                     <div class="space-y-5">
@@ -32,15 +45,25 @@
                               name="<%= rodauth.webauthn_remove_param %>"
                               value="<%= id %>"
                               type="radio"
-                              class="h-4 w-4 border-gray-300 text-orange-600 focus:ring-orange-600"
+                              class="
+                                h-4 w-4 border-gray-300 text-orange-600
+                                focus:ring-orange-600
+                              "
                               required
                             >
                           </div>
                           <div class="ml-3 text-sm leading-6">
-                            <label for="webauthn-remove-<%= id %>" class="font-medium text-gray-900"><%= name %></label>
-                            <span id="webauthn-remove-<%= id %>-description" class="text-gray-500">
-                              (Last Usage:
-                              <%= last_use.strftime("%F %T") %>)
+                            <label
+                              for="webauthn-remove-<%= id %>"
+                              class="font-medium text-gray-900"
+                            >
+                              <%= name %>
+                            </label>
+                            <span
+                              id="webauthn-remove-<%= id %>-description"
+                              class="text-gray-500"
+                            >
+                              (Last Usage: <%= last_use.strftime("%F %T") %>)
                             </span>
                           </div>
                         </div>
@@ -48,9 +71,15 @@
                     </div>
                   </fieldset>
                   <% if error = rodauth.field_error(rodauth.webauthn_remove_param) %>
-                    <p class="mt-2 text-sm text-red-600 leading-6" id="<%= rodauth.webauthn_remove_param %>-error"><%= error %></p>
+                    <p
+                      class="mt-2 text-sm text-red-600 leading-6"
+                      id="<%= rodauth.webauthn_remove_param %>-error"
+                    >
+                      <%= error %>
+                    </p>
                   <% end %>
                 </div>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: rodauth.webauthn_remove_button) %>
                 </div>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -5,11 +5,23 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-            <h2 class="text-lg font-medium leading-6 text-gray-900">Setup Security Key</h2>
+            <h2 class="text-lg font-medium leading-6 text-gray-900">
+              Setup Security Key
+            </h2>
             <% form(:action => rodauth.webauthn_setup_path, :role => :form, :method => :post, :id => "webauthn-setup-form", "data-credential-options" => (cred = rodauth.new_webauthn_credential).as_json.to_json) do %>
               <%== rodauth.webauthn_setup_additional_form_tags %>
               <%== part("components/form/hidden", name: rodauth.webauthn_setup_challenge_param, value: cred.challenge) %>
@@ -18,16 +30,26 @@
                 name: rodauth.webauthn_setup_challenge_hmac_param,
                 value: rodauth.compute_hmac(cred.challenge)
               ) %>
-              <input id="webauthn-setup" class="hidden" type="text" name="<%= rodauth.webauthn_setup_param %>" value="" hidden/>
+              <input
+                id="webauthn-setup"
+                class="hidden"
+                type="text"
+                name="<%= rodauth.webauthn_setup_param %>"
+                value=""
+                hidden
+              />
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/form/text", name: "name", label: "Key Name", attributes: { required: true }) %>
                 </div>
+
                 <% if rodauth.two_factor_modifications_require_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6">
                   <div id="webauthn-setup-button">
                     <%== part("components/form/submit_button", text: rodauth.webauthn_setup_button) %>
@@ -41,4 +63,7 @@
     </div>
   </div>
 </main>
-<script src="<%= "#{rodauth.webauthn_js_host}#{rodauth.webauthn_setup_js_path}" %>"></script>
+
+<script
+  src="<%= "#{rodauth.webauthn_js_host}#{rodauth.webauthn_setup_js_path}" %>"
+></script>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -37,7 +37,7 @@
                 name="<%= rodauth.webauthn_setup_param %>"
                 value=""
                 hidden
-              />
+              >
 
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">

--- a/views/account/submenu.erb
+++ b/views/account/submenu.erb
@@ -9,28 +9,36 @@
         ["Close Account", "/account/close-account", "hero-x-circle"]
       ].each do |label, url, icon, disallowed| %>
       <% next if disallowed %>
-      <% if request.path == url %>
-        <a
-          href="<%= url %>"
-          class="border-orange-600 bg-orange-50 text-orange-600 hover:bg-orange-50 hover:text-orange-700 group flex items-center border-l-4 px-3 py-2 text-sm font-medium"
-          aria-current="page"
-        >
-          <%== part(
+        <% if request.path == url %>
+          <a
+            href="<%= url %>"
+            class="
+              border-orange-600 bg-orange-50 text-orange-600
+              hover:bg-orange-50 hover:text-orange-700 group flex
+              items-center border-l-4 px-3 py-2 text-sm font-medium
+            "
+            aria-current="page"
+          >
+            <%== part(
             "components/icon",
             name: icon,
             classes: "text-orange-600 group-hover:text-orange-600 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
           ) %>
-          <span class="truncate"><%= label %></span>
-        </a>
-      <% else %>
-        <a
-          href="<%= url %>"
-          class="border-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900 group flex items-center border-l-4 px-3 py-2 text-sm font-medium"
-        >
-          <%== part("components/icon", name: icon, classes: "text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0") %>
-          <span class="truncate"><%= label %></span>
-        </a>
+            <span class="truncate"><%= label %></span>
+          </a>
+        <% else %>
+          <a
+            href="<%= url %>"
+            class="
+              border-transparent text-gray-900 hover:bg-gray-50
+              hover:text-gray-900 group flex items-center border-l-4 px-3
+              py-2 text-sm font-medium
+            "
+          >
+            <%== part("components/icon", name: icon, classes: "text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0") %>
+            <span class="truncate"><%= label %></span>
+          </a>
+        <% end %>
       <% end %>
-    <% end %>
   </nav>
 </aside>

--- a/views/account/two_factor_manage.erb
+++ b/views/account/two_factor_manage.erb
@@ -5,14 +5,29 @@
 <main>
   <div class="max-w-screen-xl pb-6 lg:pb-16">
     <div class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+      <div
+        class="
+          divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+          lg:divide-y-0
+        "
+      >
         <%== render("account/submenu") %>
-        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+        <div
+          class="
+            divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+            2xl:col-span-10 pb-10
+          "
+        >
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <div class="mt-6 grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-4">
-                <div class="text-lg font-medium leading-6 text-gray-900">One-Time Password Generator</div>
-                <p class="mt-1 text-sm text-gray-500">Connect an authenticator app that generates verification codes.</p>
+                <div class="text-lg font-medium leading-6 text-gray-900">
+                  One-Time Password Generator
+                </div>
+                <p class="mt-1 text-sm text-gray-500">
+                  Connect an authenticator app that generates verification
+                  codes.
+                </p>
               </div>
               <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                 <% if rodauth.otp_exists? %>
@@ -23,11 +38,16 @@
               </div>
             </div>
           </div>
+
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <div class="mt-6 grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-4">
-                <div class="text-lg font-medium leading-6 text-gray-900">Security Keys</div>
-                <p class="mt-1 text-sm text-gray-500">Connect a security key to your account.</p>
+                <div class="text-lg font-medium leading-6 text-gray-900">
+                  Security Keys
+                </div>
+                <p class="mt-1 text-sm text-gray-500">
+                  Connect a security key to your account.
+                </p>
               </div>
               <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                 <%== part("components/button", text: rodauth.webauthn_setup_link_text, link: rodauth.webauthn_setup_path) %>
@@ -37,12 +57,17 @@
               </div>
             </div>
           </div>
+
           <% if rodauth.uses_two_factor_authentication? %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
-                  <div class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</div>
-                  <p class="mt-1 text-sm text-gray-500">Single-use recovery codes for your account.</p>
+                  <div class="text-lg font-medium leading-6 text-gray-900">
+                    Recovery Codes
+                  </div>
+                  <p class="mt-1 text-sm text-gray-500">
+                    Single-use recovery codes for your account.
+                  </p>
                 </div>
                 <div class="col-span-6 sm:col-span-2 text-right">
                   <%== part("components/button", text: rodauth.recovery_codes_link_text, link: rodauth.recovery_codes_path) %>
@@ -50,6 +75,7 @@
               </div>
             </div>
           <% end %>
+
           <% if rodauth.two_factor_remove_links.length > 1 %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <%== part(

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -1,16 +1,15 @@
 <% @content_class = "" %>
 
-
 <% unless @grouped_pages.empty? %>
   <table class="page-table">
     <caption>Active Pages</caption>
     <thead>
       <tr>
-	<th>VmHost</th>
-	<th>UBID</th>
-	<th>Created At</th>
-	<th>Summary</th>
-	<th>Details</th>
+        <th>VmHost</th>
+        <th>UBID</th>
+        <th>Created At</th>
+        <th>Summary</th>
+        <th>Details</th>
       </tr>
     </thead>
     <tbody>
@@ -21,23 +20,25 @@
               <td rowspan="<%= pages.size %>">
                 <% if vmh_ubid %>
                   <a href="/model/VmHost/<%= vmh_ubid %>"><%= vmh_ubid %></a>
-                <% end%>
+                <% end %>
               </td>
             <% end %>
 
             <td><a href="/model/Page/<%= page.ubid %>"><%= page.ubid %></a></td>
             <td><%= page.created_at.strftime("%F %T") %></td>
             <td><%= page.summary %></td>
-            <td><%== h(page.details).gsub(/\b[a-tv-z0-9]{26}\b/) do
+            <td>
+              <%== h(page.details).gsub(/\b[a-tv-z0-9]{26}\b/) do
               if (klass = UBID.class_for_ubid(it))
                 "<a href=\"/model/#{klass}/#{it}\">#{it}</a>"
               else
                 it
               end
-            end %></td>
+            end %>
+            </td>
           </tr>
-         <% end %>
-       <% end %>
+        <% end %>
+      <% end %>
     </tbody>
   </table>
 <% end %>

--- a/views/admin/layout.erb
+++ b/views/admin/layout.erb
@@ -1,22 +1,33 @@
 <!DOCTYPE html>
+
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
     <title>Ubicloud Admin<%= " - " if @page_title %><%= @page_title %></title>
-    <link rel="stylesheet" href="/admin/app.css?m=<%= File.mtime("public/admin/app.css").to_i %>"/>
+
+    <link
+      rel="stylesheet"
+      href="/admin/app.css?m=<%= File.mtime("public/admin/app.css").to_i %>"
+    />
   </head>
 
   <body>
     <nav class="navbar" role="navigation">
       <div class="container">
         <a class="navbar-brand" href="/">Ubicloud Admin</a>
+
         <% form(id: "ubid_form", action: "/") do |f| %>
           <%== f.input("text", key: "ubid", placeholder: "UBID", attr: {pattern: "[a-tv-z0-9]{26}", title: "UBID format: [a-tv-z0-9]{26}"}) %>
           <%== f.button("Show Object") %>
         <% end %>
+
         <% if rodauth.logged_in? %>
           <% form(action: "/logout", method: :post, id: :logout_form) do |f| %>
             <%== f.button("Logout") %>
@@ -27,14 +38,21 @@
 
     <div class="<%= @content_class || "container" %>" id="content">
       <% if flash["notice"] %>
-        <div class="alert alert-success" role="alert" id="flash-notice"><%= flash["notice"] %></div>
+        <div class="alert alert-success" role="alert" id="flash-notice">
+          <%= flash["notice"] %>
+        </div>
       <% end %>
+
       <% if flash["error"] %>
-        <div class="alert alert-danger" role="alert" id="flash-error"><%= flash["error"] %></div>
+        <div class="alert alert-danger" role="alert" id="flash-error">
+          <%= flash["error"] %>
+        </div>
       <% end %>
+
       <% if @page_title %>
         <h1><%= @page_title %></h1>
       <% end %>
+
       <%== yield %>
     </div>
   </body>

--- a/views/admin/layout.erb
+++ b/views/admin/layout.erb
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8">
 
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -15,7 +15,7 @@
     <link
       rel="stylesheet"
       href="/admin/app.css?m=<%= File.mtime("public/admin/app.css").to_i %>"
-    />
+    >
   </head>
 
   <body>

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -1,16 +1,22 @@
 <% @page_title = "#{@klass.name} #{@obj.ubid}" %>
 
 <% if @klass.associations.include?(:sshable) && (sshable = @obj.sshable) %>
-  <p>SSH Command: <code>ssh -i &lt;PRIVATE_KEY_PATH&gt; <%= sshable.unix_user %>@<%= sshable.host %></code></p>
+  <p>
+    SSH Command:
+    <code>ssh -i &lt;PRIVATE_KEY_PATH&gt; <%= sshable.unix_user %>@<%= sshable.host %></code>
+  </p>
 <% end %>
 
 <div id="strand-info">
   <% if @klass.associations.include?(:strand) && (strand = @obj.strand) %>
-      <a href="/model/Strand/<%= strand.ubid %>">Strand</a>: <%= strand.prog %>#<%= strand.label %>
-      | schedule: <%= strand.schedule.strftime("%F %T") %>
-      <% if strand.try > 0 %>
-        | try: <%= strand.try %>
-      <% end %>
+    <a href="/model/Strand/<%= strand.ubid %>">Strand</a>:
+    <%= strand.prog %>#<%= strand.label %>
+    | schedule:
+    <%= strand.schedule.strftime("%F %T") %>
+    <% if strand.try > 0 %>
+      | try:
+      <%= strand.try %>
+    <% end %>
   <% end %>
 
   <% if strand || @obj.is_a?(Strand) %>
@@ -24,7 +30,8 @@
 <% end %>
 
 <% if actions = OBJECT_ACTIONS[@obj.class.name] %>
-  <p id="action-list">Actions:
+  <p id="action-list">
+    Actions:
     <% actions.each do |key, action| %>
       <a href="/model/<%= @obj.class.name %>/<%= @obj.ubid %>/<%= key %>"><%= action.label %></a>
     <% end %>
@@ -32,34 +39,34 @@
 <% end %>
 
 <table class="object-table">
-<caption>Data</caption>
-<thead>
-  <tr>
-    <th>Column</th>
-    <th>Value</th>
-  </tr>
-</thead>
-<tbody>
-  <% @obj.inspect_values_hash.each do |k, v| %>
+  <caption>Data</caption>
+  <thead>
     <tr>
-      <td><%= k %></td>
-      <td>
-        <% if v.is_a?(String) && v.bytesize == 26 && (column_class = UBID.class_for_ubid(v)) && column_class.method_defined?(:ubid) && (obj = UBID.decode(v)) %>
-          <a href="/model/<%= column_class %>/<%= v %>"><%= obj.admin_label %></a>
-        <% else %>
-          <%= v %>
-        <% end %>
-      </td>
+      <th>Column</th>
+      <th>Value</th>
     </tr>
-  <% end %>
-</tbody>
+  </thead>
+  <tbody>
+    <% @obj.inspect_values_hash.each do |k, v| %>
+      <tr>
+        <td><%= k %></td>
+        <td>
+          <% if v.is_a?(String) && v.bytesize == 26 && (column_class = UBID.class_for_ubid(v)) && column_class.method_defined?(:ubid) && (obj = UBID.decode(v)) %>
+            <a href="/model/<%= column_class %>/<%= v %>"><%= obj.admin_label %></a>
+          <% else %>
+            <%= v %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
 </table>
 
 <h2 id="associations-header">Associations</h2>
+
 <div class="associations">
   <% @klass.associations.sort.each do |assoc| %>
-    <%
-    reflection = @klass.association_reflection(assoc)
+    <% reflection = @klass.association_reflection(assoc)
     associated_class = reflection.associated_class
     next unless associated_class.method_defined?(:ubid)
     assoc_objs = if reflection.returns_array?
@@ -67,16 +74,16 @@
     else
       Array(@obj.send(assoc))
     end
-    next if assoc_objs.empty?
-    %>
-
-    <div class="association">
-      <h3><%= assoc %></h3>
-      <ul>
-      <% assoc_objs.each do %>
-        <li><a href="/model/<%= associated_class %>/<%= it.ubid %>"><%= it.admin_label %></a></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+    next if assoc_objs.empty? %>
+      <div class="association">
+        <h3><%= assoc %></h3>
+        <ul>
+          <% assoc_objs.each do %>
+            <li>
+              <a href="/model/<%= associated_class %>/<%= it.ubid %>"><%= it.admin_label %></a>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 </div>

--- a/views/admin/objects.erb
+++ b/views/admin/objects.erb
@@ -2,7 +2,9 @@
 
 <ul id="object-list">
   <% @objects.each do |object| %>
-    <li><a href="/model/<%= @klass %>/<%= object.ubid %>"><%= object.admin_label %></a></li>
+    <li>
+      <a href="/model/<%= @klass %>/<%= object.ubid %>"><%= object.admin_label %></a>
+    </li>
   <% end %>
 </ul>
 

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -18,11 +18,9 @@
     <% identities = AccountIdentity.where(account_id: rodauth.account_id).all %>
     <% unless identities.empty? %>
       <div class="relative flex justify-center text-sm font-medium leading-6">
-        <span class="bg-white px-6 text-gray-900"><%= rodauth.has_password? ? "Or login" : "Login" %>
-          with:</span>
+        <span class="bg-white px-6 text-gray-900"><%= rodauth.has_password? ? "Or login" : "Login" %> with:</span>
       </div>
     <% end %>
-
     <% identities.each do |identity| %>
       <% if identity.provider.start_with?("0p") %>
         <% provider = OidcProvider.with_pk!(UBID.to_uuid(identity.provider)) %>
@@ -31,7 +29,11 @@
       <% end %>
       <% form(action: rodauth.omniauth_request_path(identity.provider), role: :form, method: :post, class: "grow") do %>
         <button
-          class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+          class="
+            flex w-full items-center justify-center gap-3 rounded-md
+            bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset
+            ring-gray-300 hover:bg-gray-50
+          "
           type="submit"
         >
           <%== part("components/icon", name: identity.provider.to_s) unless provider_name %>
@@ -48,7 +50,10 @@
           id="remember-me"
           name="remember-me"
           type="checkbox"
-          class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
+          class="
+            h-4 w-4 rounded border-gray-300 text-orange-600
+            focus:ring-orange-600
+          "
           form="login-form"
         >
         <label for="remember-me" class="ml-2 block text-sm text-gray-900">Remember me</label>
@@ -58,7 +63,9 @@
         <a
           href="/reset-password-request?login=<%= Rack::Utils.escape(rodauth.param("login")) %>"
           class="font-medium text-orange-600 hover:text-orange-700"
-        >Forgot your password?</a>
+        >
+          Forgot your password?
+        </a>
       </div>
     </div>
   <% end %>
@@ -68,7 +75,12 @@
       <%== part("components/form/submit_button", text: "Sign in", attributes: {form: "login-form"}) %>
     <% end %>
     <% unless rodauth.valid_login_entered? %>
-      <a href="/create-account" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Create a new account</a>
+      <a
+        href="/create-account"
+        class="mt-2 text-sm font-semibold leading-6 text-gray-900"
+      >
+        Create a new account
+      </a>
     <% end %>
   </div>
 </div>

--- a/views/auth/oidc_login.erb
+++ b/views/auth/oidc_login.erb
@@ -11,7 +11,11 @@ end %>
 
 <% form(action: form_action, role: :form, method: :post, class: "rodauth space-y-6") do %>
   <button
-    class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+    class="
+      flex w-full items-center justify-center gap-3 rounded-md bg-white px-3
+      py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300
+      hover:bg-gray-50
+    "
     type="submit"
   >
     <span class="text-sm font-semibold leading-6"><%= button %></span>

--- a/views/auth/otp_auth.erb
+++ b/views/auth/otp_auth.erb
@@ -12,9 +12,21 @@
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your authentication app?
       <br>
-      <a href="/<%= rodauth.recovery_auth_route %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
+      Can't access your authentication app?
+      <br>
+      <a
+        href="/<%= rodauth.recovery_auth_route %>"
+        class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+      >
+        Enter a recovery code
+      </a>
       or
-      <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
+      <a
+        href="mailto:support@ubicloud.com"
+        class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+      >
+        contact support
+      </a>
     </p>
   </div>
 <% end %>

--- a/views/auth/otp_unlock.erb
+++ b/views/auth/otp_unlock.erb
@@ -3,9 +3,17 @@
 <% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
   <%== rodauth.otp_unlock_additional_form_tags %>
 
-  <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
-  <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>
-  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds</p>
+  <p>
+    <%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %>
+  </p>
+
+  <p>
+    <%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %>
+  </p>
+
+  <p>
+    <%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds
+  </p>
 
   <%== render("components/rodauth/otp_auth_code_field") %>
 
@@ -14,9 +22,21 @@
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your authentication app?
       <br>
-      <a href="/<%= rodauth.recovery_auth_route %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
+      Can't access your authentication app?
+      <br>
+      <a
+        href="/<%= rodauth.recovery_auth_route %>"
+        class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+      >
+        Enter a recovery code
+      </a>
       or
-      <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
+      <a
+        href="mailto:support@ubicloud.com"
+        class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+      >
+        contact support
+      </a>
     </p>
   </div>
 <% end %>

--- a/views/auth/otp_unlock_not_available.erb
+++ b/views/auth/otp_unlock_not_available.erb
@@ -1,9 +1,21 @@
 <% @page_message = "Your one-time password authentication has been locked out, and you must wait to unlock it." %>
 
 <div class="space-y-6">
-  <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
-  <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>
-  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds</p>
+  <p>
+    <%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %>
+  </p>
 
-  <p>Page will automatically refresh when authentication is possible (in <%= (rodauth.otp_unlock_next_auth_attempt_after - Time.now).to_i + 1 %> seconds).</p>
+  <p>
+    <%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %>
+  </p>
+
+  <p>
+    <%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds
+  </p>
+
+  <p>
+    Page will automatically refresh when authentication is possible (in
+    <%= (rodauth.otp_unlock_next_auth_attempt_after - Time.now).to_i + 1 %>
+    seconds).
+  </p>
 </div>

--- a/views/auth/recovery_auth.erb
+++ b/views/auth/recovery_auth.erb
@@ -20,7 +20,14 @@
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your recovery codes?
       <br>
-      <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
+      Can't access your recovery codes?
+      <br>
+      <a
+        href="mailto:support@ubicloud.com"
+        class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+      >
+        contact support
+      </a>
     </p>
   </div>
 <% end %>

--- a/views/auth/reset_password_request.erb
+++ b/views/auth/reset_password_request.erb
@@ -6,7 +6,9 @@
   <%== rodauth.reset_password_request_additional_form_tags %>
 
   <div>
-    <p class="leading-6 text-sm"><%== rodauth.reset_password_explanatory_text %></p>
+    <p class="leading-6 text-sm">
+      <%== rodauth.reset_password_explanatory_text %>
+    </p>
   </div>
 
   <%== render("components/rodauth/login_field") %>

--- a/views/auth/social_buttons.erb
+++ b/views/auth/social_buttons.erb
@@ -12,7 +12,11 @@
       <% omniauth_providers.each do |provider, name| %>
         <% form(action: rodauth.omniauth_request_path(provider), role: :form, method: :post, class: :grow) do %>
           <button
-            class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+            class="
+              flex w-full items-center justify-center gap-3 rounded-md
+              bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset
+              ring-gray-300 hover:bg-gray-50
+            "
             type="submit"
           >
             <%== part("components/icon", name: provider.to_s) %>

--- a/views/auth/verify_account_resend.erb
+++ b/views/auth/verify_account_resend.erb
@@ -7,7 +7,9 @@
   <% recently_sent = rodauth.verify_account_email_recently_sent? if rodauth.account %>
 
   <% if !rodauth.account || recently_sent %>
-    <div class="leading-6 text-sm"><%== rodauth.verify_account_resend_explanatory_text %></div>
+    <div class="leading-6 text-sm">
+      <%== rodauth.verify_account_resend_explanatory_text %>
+    </div>
   <% end %>
 
   <% if rodauth.param_or_nil(rodauth.login_param) %>

--- a/views/auth/verify_login_change.erb
+++ b/views/auth/verify_login_change.erb
@@ -2,15 +2,26 @@
 
 <% if rodauth.authenticated? %>
   <%== part("components/page_header", title: "My Account") %>
-
   <main>
     <div class="max-w-screen-xl pb-6 lg:pb-16">
       <div class="overflow-hidden rounded-lg bg-white shadow">
-        <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+        <div
+          class="
+            divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x
+            lg:divide-y-0
+          "
+        >
           <%== render("account/submenu") %>
-          <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+          <div
+            class="
+              divide-y divide-gray-200 lg:col-span-8 xl:col-span-9
+              2xl:col-span-10 pb-10
+            "
+          >
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
-              <h2 class="text-lg font-medium leading-6 text-gray-900">Verify New Email</h2>
+              <h2 class="text-lg font-medium leading-6 text-gray-900">
+                Verify New Email
+              </h2>
               <% form(role: :form, method: :post) do %>
                 <div class="mt-6 grid grid-cols-6 gap-6">
                   <div class="col-span-6">
@@ -26,11 +37,15 @@
   </main>
 <% else %>
   <% @page_message = "Verify your new email" %>
-
   <% form(role: :form, method: :post, class: "rodauth space-y-6") do %>
     <div class="flex flex-col text-center">
       <%== part("components/form/submit_button", text: "Click to Verify New Email") %>
-      <a href="/login" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Sign in to another account</a>
+      <a
+        href="/login"
+        class="mt-2 text-sm font-semibold leading-6 text-gray-900"
+      >
+        Sign in to another account
+      </a>
     </div>
   <% end %>
 <% end %>

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -10,16 +10,40 @@
     name: rodauth.webauthn_auth_challenge_hmac_param,
     value: rodauth.compute_hmac(cred.challenge)
   ) %>
-  <input id="webauthn-auth" class="hidden" type="text" name="<%= rodauth.webauthn_auth_param %>" value="" hidden/>
+  <input
+    id="webauthn-auth"
+    class="hidden"
+    type="text"
+    name="<%= rodauth.webauthn_auth_param %>"
+    value=""
+    hidden
+  />
+
   <div id="webauthn-auth-button" class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.webauthn_auth_button) %>
   </div>
+
   <p class="mt-10 text-center text-sm text-gray-400">
     Can't access your authentication app?
     <br>
-    <a href="/<%= rodauth.recovery_auth_route %>" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">Enter a recovery code</a>
+    Can't access your authentication app?
+    <br>
+    <a
+      href="/<%= rodauth.recovery_auth_route %>"
+      class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+    >
+      Enter a recovery code
+    </a>
     or
-    <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
+    <a
+      href="mailto:support@ubicloud.com"
+      class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+    >
+      contact support
+    </a>
   </p>
 <% end %>
-<script src="<%= "#{rodauth.webauthn_js_host}#{rodauth.webauthn_auth_js_path}" %>"></script>
+
+<script
+  src="<%= "#{rodauth.webauthn_js_host}#{rodauth.webauthn_auth_js_path}" %>"
+></script>

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -17,7 +17,7 @@
     name="<%= rodauth.webauthn_auth_param %>"
     value=""
     hidden
-  />
+  >
 
   <div id="webauthn-auth-button" class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.webauthn_auth_button) %>

--- a/views/cli.erb
+++ b/views/cli.erb
@@ -46,7 +46,7 @@
       <%== part("components/form/submit_button", text: "Run") %>
     </div>
 
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 <%= (multi && !@cli) ? "hidden" : ""%>">
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 <%= (multi && !@cli) ? "hidden" : "" %>">
       <div class="px-4 py-5 sm:p-6 space-y-6">
         <% if @clis && !@clis.empty? %>
           <div class="space-y-2">

--- a/views/cli.erb
+++ b/views/cli.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Web Shell" %>
+
 <% multi = typecast_query_params.bool("multi") %>
 
 <%== part(
@@ -16,11 +17,18 @@
       <div class="min-w-0 flex-1">
         <% unless multi %>
           This page provides access to a web version of
-          <a class="font-medium text-orange-600 hover:text-orange-700" href="https://www.ubicloud.com/docs/quick-start/cli">Ubicloud's CLI</a>. You can use it without installing the CLI. All features are available, except ones that execute external
-          programs.
+          <a
+            class="font-medium text-orange-600 hover:text-orange-700"
+            href="https://www.ubicloud.com/docs/quick-start/cli"
+          >
+            Ubicloud's CLI
+          </a>
+          . You can use it without installing the CLI. All features are
+          available, except ones that execute external programs.
         <% else %>
-          This page allows scheduling the execution of multiple commands, one per line. It will run the command on the
-          first line and display the output, and the set the next command for execution.
+          This page allows scheduling the execution of multiple commands, one
+          per line. It will run the command on the first line and display the
+          output, and the set the next command for execution.
         <% end %>
       </div>
     </div>
@@ -38,14 +46,17 @@
       <%== part("components/form/submit_button", text: "Run") %>
     </div>
 
-    <div
-      class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 <%= (multi && !@cli) ? "hidden" : ""%>"
-    >
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 <%= (multi && !@cli) ? "hidden" : ""%>">
       <div class="px-4 py-5 sm:p-6 space-y-6">
         <% if @clis && !@clis.empty? %>
           <div class="space-y-2">
             <p class="text-xl font-semibold">Remaining commands:</p>
-            <div class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
+            <div
+              class="
+                w-full text-sm border p-3 bg-slate-100 text-rose-500
+                font-mono rounded
+              "
+            >
               <% @clis.each do %>
                 <pre><tt class="next-clis"><%= it %></tt></pre>
                 <input type="hidden" name="clis[]" value="<%= it %>">
@@ -57,14 +68,25 @@
         <% if @last_cli %>
           <div class="space-y-2">
             <p class="text-xl font-semibold">Ran command:</p>
-            <div class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
+            <div
+              class="
+                w-full text-sm border p-3 bg-slate-100 text-rose-500
+                font-mono rounded
+              "
+            >
               <pre><tt id="cli-executed"><%= @last_cli %></tt></pre>
             </div>
           </div>
-
           <div class="space-y-2">
-            <p class="text-xl font-semibold"><%= @ubi_command_execute ? "Would execute" : "Output" %>:</p>
-            <div class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
+            <p class="text-xl font-semibold">
+              <%= @ubi_command_execute ? "Would execute" : "Output" %>:
+            </p>
+            <div
+              class="
+                w-full text-sm border p-3 bg-slate-100 text-rose-500
+                font-mono rounded
+              "
+            >
               <pre><tt id="cli-output"><%== @output %></tt></pre>
             </div>
           </div>
@@ -77,19 +99,34 @@
           <% unless multi %>
             <div class="space-y-2">
               <h2 class="text-xl font-semibold">Examples</h2>
-              <dl class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
+              <dl
+                class="
+                  w-full text-sm border p-3 bg-slate-100 text-rose-500
+                  font-mono rounded
+                "
+              >
                 <dt><code>help -ru</code></dt>
-                <dd class="inline-block ml-6 mb-4">Display the syntax for all supported commands</dd>
+                <dd class="inline-block ml-6 mb-4">
+                  Display the syntax for all supported commands
+                </dd>
                 <dt><code>help -r</code></dt>
-                <dd class="inline-block ml-6 mb-4">Show full help for all supported commands</dd>
+                <dd class="inline-block ml-6 mb-4">
+                  Show full help for all supported commands
+                </dd>
                 <dt><code>vm list</code></dt>
                 <dd class="inline-block ml-6">List all virtual machines</dd>
               </dl>
             </div>
-
             <p>
-              This page allows execution of a single command. However, you can also
-              <a class="font-medium text-orange-600 hover:text-orange-700" href="?multi=t">schedule execution of multiple commands</a>.
+              This page allows execution of a single command. However, you can
+              also
+              <a
+                class="font-medium text-orange-600 hover:text-orange-700"
+                href="?multi=t"
+              >
+                schedule execution of multiple commands
+              </a>
+              .
             </p>
           <% end %>
         <% end %>

--- a/views/components/billing_warning.erb
+++ b/views/components/billing_warning.erb
@@ -8,6 +8,9 @@
         <h3 class="text-sm font-medium text-red-700">
           Project doesn't have valid billing information. You have to create project's billing details first.
           <br>
+          Project doesn't have valid billing information. You have to create
+          project's billing details first.
+          <br>
           <a href="<%= @project.path %>/billing" class="font-bold text-red-800">Click here</a>
           to create billing details.
         </h3>

--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -1,4 +1,5 @@
 <%# locals: (text:, type: "primary", link: nil, icon: nil, attributes: {}, extra_class: nil, right_icon: nil) %>
+
 <% color = BUTTON_COLOR[type] %>
 
 <% if link %>
@@ -6,8 +7,8 @@
     href="<%= link %>"
     class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
     <% attributes.each do |atr_key, atr_value| %>
-    <%= atr_key %>="<%= atr_value %>"
-    <% end%>
+      <%= atr_key %>="<%= atr_value %>"
+    <% end %>
   >
     <% if icon %>
       <%== part("components/icon", name: icon, classes: "h-5 w-5") %>
@@ -18,8 +19,8 @@
   <button
     class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
     <% attributes.compact.each do |atr_key, atr_value| %>
-    <%= atr_key %>="<%= atr_value %>"
-    <% end%>
+      <%= atr_key %>="<%= atr_value %>"
+    <% end %>
   >
     <% if icon %>
       <%== part("components/icon", name: icon, classes: "h-5 w-5 #{(text && !text.empty?) ? "ml-0.5 mr-1.5" : "mx-0"}") %>

--- a/views/components/config_card.erb
+++ b/views/components/config_card.erb
@@ -21,14 +21,14 @@
                 value="<%= key %>"
                 name="<%= name %>_keys[]"
                 required
-              />
+              >
 
               <input
                 type="text"
                 value="<%= value %>"
                 class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 <%= error ? "border-red-500" : "" %>"
                 name="<%= name %>_values[]"
-              />
+              >
 
               <% if error %>
                 <span
@@ -41,7 +41,7 @@
                   <% if error.is_a?(Array) %>
                     <% error.each do |error| %>
                       <%= error %>
-                      <br />
+                      <br>
                     <% end %>
                   <% else %>
                     <%= error %>
@@ -75,7 +75,7 @@
               value=""
               name="<%= name %>_keys[]"
               disabled
-            />
+            >
 
             <input
               type="text"
@@ -86,7 +86,7 @@
               "
               name="<%= name %>_values[]"
               disabled
-            />
+            >
             <span
               class="
                 error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs
@@ -114,7 +114,7 @@
                 "
                 placeholder="New Key"
                 name="<%= name %>_keys[]"
-              />
+              >
 
               <input
                 type="text"
@@ -124,7 +124,7 @@
                   focus:border-blue-500
                 "
                 name="<%= name %>_values[]"
-              />
+              >
               <span
                 class="
                   error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs

--- a/views/components/config_card.erb
+++ b/views/components/config_card.erb
@@ -9,89 +9,135 @@
     <% config.each_with_index do |(key, value), index| %>
       <% error = errors[name + "." + key] %>
       <% next if key.empty? && value.empty? %>
-      <div class="px-6 py-2 hover:bg-gray-50 config-group group font-mono" data-config-id="<%= index %>">
+        <div
+          class="px-6 py-2 hover:bg-gray-50 config-group group font-mono"
+          data-config-id="<%= index %>"
+        >
+          <div class="flex items-center justify-between">
+            <div class="flex flex-wrap items-center config-entry">
+              <input
+                type="text"
+                class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 mr-2 <%= (error && !error.is_a?(Array)) ? "border-red-500" : "" %>"
+                value="<%= key %>"
+                name="<%= name %>_keys[]"
+                required
+              />
+
+              <input
+                type="text"
+                value="<%= value %>"
+                class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 <%= error ? "border-red-500" : "" %>"
+                name="<%= name %>_values[]"
+              />
+
+              <% if error %>
+                <span
+                  class="
+                    error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs
+                    text-red-600 bg-red-100 rounded
+                  "
+                  aria-live="polite"
+                >
+                  <% if error.is_a?(Array) %>
+                    <% error.each do |error| %>
+                      <%= error %>
+                      <br />
+                    <% end %>
+                  <% else %>
+                    <%= error %>
+                  <% end %>
+                </span>
+              <% end %>
+            </div>
+            <div class="min-w-16 flex items-center ml-2">
+              <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-config-btn") if @edit_perm %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <!-- Hidden row for generating new entries -->
+      <div
+        class="
+          px-6 py-2 hover:bg-gray-50 group config-placeholder-group
+          font-mono hidden
+        "
+        data-config-id=""
+      >
         <div class="flex items-center justify-between">
           <div class="flex flex-wrap items-center config-entry">
             <input
               type="text"
-              class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 mr-2 <%= (error && !error.is_a?(Array)) ? "border-red-500" : "" %>"
-              value="<%= key %>"
+              class="
+                border rounded py-1 focus:ring-blue-500
+                focus:border-blue-500 mr-2
+              "
+              value=""
               name="<%= name %>_keys[]"
-              required
+              disabled
             />
+
             <input
               type="text"
-              value="<%= value %>"
-              class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 <%= error ? "border-red-500" : "" %>"
+              value=""
+              class="
+                border rounded py-1 focus:ring-blue-500
+                focus:border-blue-500
+              "
               name="<%= name %>_values[]"
+              disabled
             />
-            <% if error %>
-              <span class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 bg-red-100 rounded" aria-live="polite">
-                <% if error.is_a?(Array) %>
-                  <% error.each do |error| %>
-                    <%= error %><br/>
-                  <% end %>
-                <% else %>
-                  <%= error %>
-                <% end %>
-              </span>
-            <% end %>
+            <span
+              class="
+                error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs
+                text-red-600 hidden bg-red-100 rounded
+              "
+              aria-live="polite"
+            ></span>
           </div>
           <div class="min-w-16 flex items-center ml-2">
-            <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-config-btn") if @edit_perm %>
+            <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-config-btn") %>
           </div>
         </div>
       </div>
-    <% end %>
-    <!-- Hidden row for generating new entries -->
-    <div class="px-6 py-2 hover:bg-gray-50 group config-placeholder-group font-mono hidden" data-config-id="">
-      <div class="flex items-center justify-between">
-        <div class="flex flex-wrap items-center config-entry">
-          <input
-            type="text"
-            class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 mr-2"
-            value=""
-            name="<%= name %>_keys[]"
-            disabled
-          />
-          <input
-            type="text"
-            value=""
-            class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500"
-            name="<%= name %>_values[]"
-            disabled
-          />
-          <span class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded" aria-live="polite"></span>
-        </div>
-        <div class="min-w-16 flex items-center ml-2">
-          <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-config-btn") %>
-        </div>
-      </div>
-    </div>
-    <!-- Empty row for new configuration -->
-    <% if @edit_perm %>
-      <div class="px-6 py-2 hover:bg-gray-50 group new-config font-mono">
-        <div class="flex items-center justify-between">
-          <div class="flex flex-wrap items-center">
-            <input
-              type="text"
-              class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 mr-2"
-              placeholder="New Key"
-              name="<%= name %>_keys[]"
-            />
-            <input
-              type="text"
-              placeholder="New Value"
-              class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500"
-              name="<%= name %>_values[]"
-            />
-            <span class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded" aria-live="polite"></span>
-          </div>
-          <div class="min-w-16 flex items-center ml-2">
-            <%== part("components/button", text: "", type: "safe", icon: "hero-plus", extra_class: "add-config-btn") %>
+
+      <!-- Empty row for new configuration -->
+      <% if @edit_perm %>
+        <div class="px-6 py-2 hover:bg-gray-50 group new-config font-mono">
+          <div class="flex items-center justify-between">
+            <div class="flex flex-wrap items-center">
+              <input
+                type="text"
+                class="
+                  border rounded py-1 focus:ring-blue-500
+                  focus:border-blue-500 mr-2
+                "
+                placeholder="New Key"
+                name="<%= name %>_keys[]"
+              />
+
+              <input
+                type="text"
+                placeholder="New Value"
+                class="
+                  border rounded py-1 focus:ring-blue-500
+                  focus:border-blue-500
+                "
+                name="<%= name %>_values[]"
+              />
+              <span
+                class="
+                  error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs
+                  text-red-600 hidden bg-red-100 rounded
+                "
+                aria-live="polite"
+              ></span>
+            </div>
+            <div class="min-w-16 flex items-center ml-2">
+              <%== part("components/button", text: "", type: "safe", icon: "hero-plus", extra_class: "add-config-btn") %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
   </div>
 </div>

--- a/views/components/copyable_content.erb
+++ b/views/components/copyable_content.erb
@@ -1,10 +1,18 @@
 <%# locals: (content:, message: "Copied", revealable: false, classes: "") %>
 
-<div class="copyable-content inline-flex items-center gap-1 <%= classes %>" data-content="<%= content %>" data-message="<%= message %>">
+<div
+  class="copyable-content inline-flex items-center gap-1 <%= classes %>"
+  data-content="<%= content %>"
+  data-message="<%= message %>"
+>
   <% if revealable %>
     <%== part("components/revealable_content", content:) %>
   <% else %>
     <%= content %>
   <% end %>
-  <img src="/icons/hero-clipboard-document.svg" width="18px" class="inline-block copy-button cursor-pointer ms1"/>
+  <img
+    src="/icons/hero-clipboard-document.svg"
+    width="18px"
+    class="inline-block copy-button cursor-pointer ms1"
+  />
 </div>

--- a/views/components/copyable_content.erb
+++ b/views/components/copyable_content.erb
@@ -11,8 +11,9 @@
     <%= content %>
   <% end %>
   <img
+    alt=""
     src="/icons/hero-clipboard-document.svg"
     width="18px"
     class="inline-block copy-button cursor-pointer ms1"
-  />
+  >
 </div>

--- a/views/components/discount_code.erb
+++ b/views/components/discount_code.erb
@@ -1,4 +1,9 @@
-<div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+<div
+  class="
+    overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+    bg-white divide-y divide-gray-200
+  "
+>
   <% form(action: "#{@project.path}/discount-code", method: :post) do %>
     <div class="px-4 py-5 sm:p-6">
       <div class="space-y-12">

--- a/views/components/empty_state.erb
+++ b/views/components/empty_state.erb
@@ -3,7 +3,9 @@
 <div class="text-center empty-state">
   <%== part("components/icon", name: icon, classes: "mx-auto h-12 w-12 text-gray-400") %>
   <h3 class="mt-2 text-sm font-semibold text-gray-900"><%= title %></h3>
+
   <p class="mt-1 text-sm text-gray-500"><%= description %></p>
+
   <div class="mt-6">
     <% if buttons %>
       <% buttons.each do |text, link| %>

--- a/views/components/flash_message.erb
+++ b/views/components/flash_message.erb
@@ -4,15 +4,20 @@
     ["error", "hero-x-circle-mini", "bg-red-50", "text-red-800", "text-red-400"]
   ].each do |type, icon, bg_color, text_color, icon_color| %>
     <% next unless flash[type] %>
-    <div class="rounded-md <%= bg_color %> p-4">
-      <div class="flex">
-        <div class="flex-shrink-0">
-          <%== part("components/icon", name: icon, classes: "h-5 w-5 #{icon_color}") %>
-        </div>
-        <div class="ml-3">
-          <h3 id="flash-<%= type %>" class="text-sm font-medium <%= text_color %>"><%= flash[type] %></h3>
+      <div class="rounded-md <%= bg_color %> p-4">
+        <div class="flex">
+          <div class="flex-shrink-0">
+            <%== part("components/icon", name: icon, classes: "h-5 w-5 #{icon_color}") %>
+          </div>
+          <div class="ml-3">
+            <h3
+              id="flash-<%= type %>"
+              class="text-sm font-medium <%= text_color %>"
+            >
+              <%= flash[type] %>
+            </h3>
+          </div>
         </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
 </div>

--- a/views/components/form/checkbox.erb
+++ b/views/components/form/checkbox.erb
@@ -4,6 +4,7 @@
   <% if label %>
     <label class="block text-sm font-medium leading-6"><%== label %></label>
   <% end %>
+
   <fieldset>
     <div class="space-y-5">
       <% options.each_with_index do |(opt_val, opt_text, opt_classes, opt_attrs), idx| %>
@@ -15,7 +16,10 @@
               name="<%= name %>"
               type="checkbox"
               value="<%= opt_val %>"
-              class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
+              class="
+                h-4 w-4 rounded border-gray-300 text-orange-600
+                focus:ring-orange-600
+              "
               <%== html_attrs(opt_attrs || {}) %>
             >
           </div>
@@ -28,6 +32,7 @@
       <% end %>
     </div>
   </fieldset>
+
   <% if description %>
     <p class="text-sm text-gray-500 leading-6"><%== description %></p>
   <% end %>

--- a/views/components/form/datepicker.erb
+++ b/views/components/form/datepicker.erb
@@ -1,4 +1,5 @@
 <%# locals: (name: nil, label: nil, default_date: nil, min_date: nil, max_date: nil) %>
+
 <% @enable_datepicker = true %>
 
 <%== part(

--- a/views/components/form/hidden.erb
+++ b/views/components/form/hidden.erb
@@ -1,2 +1,8 @@
 <%# locals: (name:, value:) %>
-<input type="hidden" name="<%= name %>" value="<%= value %>" hidden/>
+
+<input
+  type="hidden"
+  name="<%= name %>"
+  value="<%= value %>"
+  hidden
+/>

--- a/views/components/form/hidden.erb
+++ b/views/components/form/hidden.erb
@@ -5,4 +5,4 @@
   name="<%= name %>"
   value="<%= value %>"
   hidden
-/>
+>

--- a/views/components/form/partnership_notice.erb
+++ b/views/components/form/partnership_notice.erb
@@ -1,12 +1,15 @@
 <%# locals: (description:, tos_text:) %>
+
 <div class="col-span-full">
   <div class="space-y-2">
     <label class="text-sm font-medium leading-6 text-gray-900">Partnership Notice</label>
+
     <div class="space-y-1 text-sm leading-6 text-gray-600">
       <% Array(description).each do |desc| %>
         <p><%== desc %></p>
       <% end %>
     </div>
+
     <%== part("components/form/checkbox", options: [["1", tos_text, {}, { required: true }]]) %>
   </div>
 </div>

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -1,10 +1,12 @@
 <%# locals: (name:, label:, options:, attributes:) %>
+
 <% selected = typecast_body_params.str(name) || selected
 error = flash.dig("errors", name)
 is_content_array = options[0][1].is_a?(Array) %>
 
 <div class="space-y-2">
   <label class="text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+
   <fieldset class="radio-small-cards">
     <legend class="sr-only"><%= label %></legend>
     <div class="grid gap-3 grid-cols-[repeat(auto-fill,minmax(285px,1fr))]">
@@ -35,7 +37,10 @@ is_content_array = options[0][1].is_a?(Array) %>
       <% end %>
     </div>
   </fieldset>
+
   <% if error %>
-    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
+    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">
+      <%= error %>
+    </p>
   <% end %>
 </div>

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -3,10 +3,10 @@
 <% nonce = SecureRandom.base64(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
-<script nonce="<%==nonce%>">
-let option_tree = <%==JSON.generate(option_tree)%>
-let option_children = <%==JSON.generate(option_parents.each_with_object(Hash.new { |h, k| h[k] = [] }) { |(child, parents), h| h[parents.last] << child if parents.any? })%>
-let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_object(Hash.new { |h, k| h[k] = [] }) { |option, h| h[option] = typecast_body_params.str(option) || pre_selected_values[option] })%>
+<script nonce="<%== nonce %>">
+let option_tree = <%== JSON.generate(option_tree) %>
+let option_children = <%== JSON.generate(option_parents.each_with_object(Hash.new { |h, k| h[k] = [] }) { |(child, parents), h| h[parents.last] << child if parents.any? }) %>
+let option_dirty = <%== JSON.generate(form_elements.map { it[:name] }.each_with_object(Hash.new { |h, k| h[k] = [] }) { |option, h| h[option] = typecast_body_params.str(option) || pre_selected_values[option] }) %>
 </script>
 
 <div>

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,5 @@
 <%# locals: (action:, form_elements:, option_tree:, option_parents:, method: "POST", pre_selected_values: {}, mode: "create") %>
+
 <% nonce = SecureRandom.base64(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
@@ -100,7 +101,12 @@ let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_o
         <div class="px-4 py-5 sm:p-6">
           <div class="flex items-center justify-end gap-x-6">
             <% if mode == "create" %>
-              <a href="<%= action %>" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>
+              <a
+                href="<%= action %>"
+                class="text-sm font-semibold leading-6 text-gray-900"
+              >
+                Cancel
+              </a>
               <%== part("components/form/submit_button", text: "Create") %>
             <% else %>
               <%== part("components/form/submit_button", text: "Update") %>

--- a/views/components/form/section.erb
+++ b/views/components/form/section.erb
@@ -1,6 +1,9 @@
 <%# locals: (label:, content:, separator: false) %>
+
 <% if separator %>
   <hr class="h-px mb-8 bg-gray-200 border-0 dark:bg-gray-700">
 <% end %>
+
 <h2 class="text-base font-semibold leading-7 text-gray-900"><%= label %></h2>
+
 <p class="mt-1 text-sm leading-6 text-gray-600"><%= content %></p>

--- a/views/components/form/select.erb
+++ b/views/components/form/select.erb
@@ -1,4 +1,5 @@
 <%# locals: (name: nil, id: name, classes: nil, label: nil, options: {}, selected: nil, placeholder: nil, error: nil, description_html: nil, attributes: {}) %>
+
 <% selected = typecast_body_params.str(name) || selected if name
 error ||= flash.dig("errors", name) %>
 
@@ -6,6 +7,7 @@ error ||= flash.dig("errors", name) %>
   <% if label %>
     <label for="<%= name %>" class="text-sm font-medium leading-6"><%= label %></label>
   <% end %>
+
   <select
     id="<%= id %>"
     name="<%= name %>"
@@ -13,34 +15,36 @@ error ||= flash.dig("errors", name) %>
     <%== html_attrs(attributes) %>
   >
     <% if placeholder %>
-      <option class="always-visible" value>
-        <%= placeholder %>
-      </option>
+      <option class="always-visible" value><%= placeholder %></option>
     <% end %>
     <% options = {nil => options} unless options.is_a?(Hash) %>
     <% options.each do |group_name, opts| %>
       <% next if opts.empty? %>
-      <% if group_name %>
-        <% opt_group_attributes = group_name.is_a?(Hash) ? group_name : {"label" => group_name}  %>
-        <optgroup <%== html_attrs(opt_group_attributes) %>>
+        <% if group_name %>
+          <% opt_group_attributes = group_name.is_a?(Hash) ? group_name : {"label" => group_name} %>
+          <optgroup <%== html_attrs(opt_group_attributes) %>>
+            <% end %>
+            <% opts.each do |opt_val, opt_text, opt_classes, opt_attrs| %>
+              <option
+                value="<%= opt_val %>"
+                class="<%= opt_classes %>"
+                <%= (opt_val == selected) ? "selected" : "" %>
+                <%== html_attrs(opt_attrs || {}) %>
+              >
+                <%= opt_text %>
+              </option>
+            <% end %>
+            <% if group_name %>
+          </optgroup>
+        <% end %>
       <% end %>
-      <% opts.each do |opt_val, opt_text, opt_classes, opt_attrs| %>
-        <option
-          value="<%= opt_val %>"
-          class="<%= opt_classes %>"
-          <%= (opt_val == selected) ? "selected" : "" %>
-          <%== html_attrs(opt_attrs || {}) %>
-        >
-          <%= opt_text %>
-        </option>
-      <% end %>
-      <% if group_name %>
-        </optgroup>
-      <% end %>
-    <% end %>
   </select>
+
   <% if error %>
-    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
+    <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">
+      <%= error %>
+    </p>
   <% end %>
+
   <%== description_html %>
 </div>

--- a/views/components/form/select.erb
+++ b/views/components/form/select.erb
@@ -11,11 +11,11 @@ error ||= flash.dig("errors", name) %>
   <select
     id="<%= id %>"
     name="<%= name %>"
-    class="<%= classes %> block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%>"
+    class="<%= classes %> block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600" %>"
     <%== html_attrs(attributes) %>
   >
     <% if placeholder %>
-      <option class="always-visible" value><%= placeholder %></option>
+      <option class="always-visible" value=""><%= placeholder %></option>
     <% end %>
     <% options = {nil => options} unless options.is_a?(Hash) %>
     <% options.each do |group_name, opts| %>

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -1,4 +1,5 @@
 <%# locals: (name: nil, label: nil, type: "text", value: nil, attributes: {}, extra_class: nil, button_title: nil, prefix: nil) %>
+
 <% value = typecast_body_params.str(name) || value if name
 error = rodauth.field_error(name) || flash.dig("errors", name) %>
 
@@ -6,35 +7,48 @@ error = rodauth.field_error(name) || flash.dig("errors", name) %>
   <% if label %>
     <label for="<%= name %>" class="block text-sm font-medium leading-6"><%= label %></label>
   <% end %>
+
   <div class="flex">
     <% if prefix %>
       <div
-        class="flex shrink-0 items-center rounded-l-md bg-gray-50 px-3 text-base text-gray-500 outline outline-1 -outline-offset-1 outline-gray-300 sm:text-sm/6"
-      ><%= prefix %></div>
+        class="
+          flex shrink-0 items-center rounded-l-md bg-gray-50 px-3 text-base
+          text-gray-500 outline outline-1 -outline-offset-1 outline-gray-300
+          sm:text-sm/6
+        "
+      >
+        <%= prefix %>
+      </div>
     <% end %>
+
     <input
       id="<%= name %>"
       type="<%= type %>"
       name="<%= name %>"
       <% if value %>
-      value="<%= value %>"
+        value="<%= value %>"
       <% end %>
       class="block w-full border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%> <%= prefix ? "rounded-r-md" : "rounded-md" %> <%= extra_class %>"
       <%== html_attrs(attributes) %>
     >
+
     <% if button_title %>
       <%== part("components/form/submit_button", text: button_title) %>
     <% end %>
   </div>
+
   <% if error %>
     <% if error.is_a?(Array) %>
       <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">
         <% error.each do |e| %>
-          <%= e %><br/>
+          <%= e %>
+          <br />
         <% end %>
       </p>
     <% else %>
-      <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
+      <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">
+        <%= error %>
+      </p>
     <% end %>
   <% end %>
 </div>

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -28,7 +28,7 @@ error = rodauth.field_error(name) || flash.dig("errors", name) %>
       <% if value %>
         value="<%= value %>"
       <% end %>
-      class="block w-full border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%> <%= prefix ? "rounded-r-md" : "rounded-md" %> <%= extra_class %>"
+      class="block w-full border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600" %> <%= prefix ? "rounded-r-md" : "rounded-md" %> <%= extra_class %>"
       <%== html_attrs(attributes) %>
     >
 
@@ -42,7 +42,7 @@ error = rodauth.field_error(name) || flash.dig("errors", name) %>
       <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">
         <% error.each do |e| %>
           <%= e %>
-          <br />
+          <br>
         <% end %>
       </p>
     <% else %>

--- a/views/components/form/textarea.erb
+++ b/views/components/form/textarea.erb
@@ -1,17 +1,31 @@
 <%# locals: (name:, value: nil, label: nil, description: nil, attributes: {}) %>
+
 <% value = typecast_body_params.str(name) || value %>
 
 <div class="space-y-2">
   <% if label %>
-    <label for="<%= name %>" class="block text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+    <label
+      for="<%= name %>"
+      class="block text-sm font-medium leading-6 text-gray-900"
+    >
+      <%= label %>
+    </label>
   <% end %>
+
   <textarea
     id="<%= name %>"
     name="<%= name %>"
-    class="block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset text-sm sm:leading-6 text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"
+    class="
+      block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset
+      focus:ring-2 focus:ring-inset text-sm sm:leading-6 text-gray-900
+      ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600
+    "
     <%== html_attrs(attributes) %>
   ><%= value %></textarea>
+
   <% if description %>
-    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%= description %></p>
+    <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description">
+      <%= description %>
+    </p>
   <% end %>
 </div>

--- a/views/components/form/toggle_form.erb
+++ b/views/components/form/toggle_form.erb
@@ -5,10 +5,20 @@
   <div class="group <%= active ? "active" : "" %>">
     <button
       type="submit"
-      class="toggle-parent-to-active relative inline-flex h-8 w-16 shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 group-[.active]:bg-orange-600 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-600 focus:ring-offset-2"
+      class="
+        toggle-parent-to-active relative inline-flex h-8 w-16 shrink-0
+        cursor-pointer rounded-full border-2 border-transparent bg-gray-200
+        group-[.active]:bg-orange-600 transition-colors duration-200
+        ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-600
+        focus:ring-offset-2
+      "
     >
       <span
-        class="pointer-events-none inline-block size-7 translate-x-0 group-[.active]:translate-x-8 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+        class="
+          pointer-events-none inline-block size-7 translate-x-0
+          group-[.active]:translate-x-8 transform rounded-full bg-white
+          shadow ring-0 transition duration-200 ease-in-out
+        "
       ></span>
     </button>
   </div>

--- a/views/components/free_quota.erb
+++ b/views/components/free_quota.erb
@@ -1,5 +1,7 @@
 <% warning_style = !@has_valid_payment_method %>
+
 <% bold_text_color = warning_style ? "text-orange-700" : "text-green-900" %>
+
 <div class="mb-2 rounded-md p-4 <%= warning_style ? "bg-orange-50" : "bg-green-50" %>">
   <div class="flex items-center <%= warning_style ? "text-orange-600" : "text-green-800" %>">
     <div class="flex-shrink-0">
@@ -7,19 +9,27 @@
     </div>
     <div class="ml-3">
       <h3 class="text-sm font-medium">
-        <span>You have
-          <%= @remaining_free_quota.to_i %>
-          free
-          <%= @free_quota_unit %>
-          available (few-minute delay).</span>
+        <span>
+          You have <%= @remaining_free_quota.to_i %> free <%= @free_quota_unit %> available (few-minute delay).
+        </span>
         <span>Free quota refreshes next month.</span>
         <br>
         <% if @has_valid_payment_method %>
-          <a href="<%= billing_path %>" class="font-bold <%= bold_text_color %>">Billing</a>
+          <a
+            href="<%= billing_path %>"
+            class="font-bold <%= bold_text_color %>"
+          >
+            Billing
+          </a>
           <span>information is valid. Charges start after the free quota.</span>
         <% else %>
           <span>To avoid service interruption, please</span>
-          <a href="<%= billing_path %>" class="font-bold <%= bold_text_color %>">click here</a>
+          <a
+            href="<%= billing_path %>"
+            class="font-bold <%= bold_text_color %>"
+          >
+            click here
+          </a>
           <span>to add a valid billing method.</span>
         <% end %>
       </h3>

--- a/views/components/icon.erb
+++ b/views/components/icon.erb
@@ -2,234 +2,820 @@
 
 <% case name %>
 <% when "hero-arrow-up-right" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="<%= classes %>">
-    <path d="M20 4h1a1 1 0 00-1-1v1zm-1 12a1 1 0 102 0h-2zM8 3a1 1 0 000 2V3zM3.293 19.293a1 1 0 101.414 1.414l-1.414-1.414zM19 4v12h2V4h-2zm1-1H8v2h12V3zm-.707.293l-16 16 1.414 1.414 16-16-1.414-1.414z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    class="<%= classes %>"
+  >
+    <path
+      d="M20 4h1a1 1 0 00-1-1v1zm-1 12a1 1 0 102 0h-2zM8 3a1 1 0 000 2V3zM3.293 19.293a1 1 0 101.414 1.414l-1.414-1.414zM19 4v12h2V4h-2zm1-1H8v2h12V3zm-.707.293l-16 16 1.414 1.414 16-16-1.414-1.414z"
+    />
   </svg>
 <% when "hero-server-stack" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z"
+    />
   </svg>
 <% when "hero-folder-open" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776"
+    />
   </svg>
 <% when "hero-cog-6-tooth" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
-    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
+    />
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+    />
   </svg>
 <% when "hero-users" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+    />
   </svg>
 <% when "hero-key" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z"
+    />
   </svg>
 <% when "hero-chevron-up-down" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+    />
   </svg>
 <% when "hero-plus" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M12 4.5v15m7.5-7.5h-15"
+    />
   </svg>
 <% when "github" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="<%= classes %>">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+    />
   </svg>
 <% when "google" %>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="14 14 18 18" class="w-5 h-5">
     <g fill="none" fill-rule="evenodd">
-      <path d="M31.64 23.205c0-.639-.057-1.252-.164-1.841H23v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"></path>
-      <path d="M23 32c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711h-3.007v2.332A8.997 8.997 0 0 0 23 32z" fill="#34A853"></path>
-      <path d="M17.964 24.71a5.41 5.41 0 0 1-.282-1.71c0-.593.102-1.17.282-1.71v-2.332h-3.007A8.996 8.996 0 0 0 14 23c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"></path>
-      <path d="M23 17.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C27.463 14.891 25.426 14 23 14a8.997 8.997 0 0 0-8.043 4.958l3.007 2.332c.708-2.127 2.692-3.71 5.036-3.71z" fill="#EA4335"></path>
+      <path
+        d="M31.64 23.205c0-.639-.057-1.252-.164-1.841H23v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
+        fill="#4285F4"
+      ></path>
+
+      <path
+        d="M23 32c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711h-3.007v2.332A8.997 8.997 0 0 0 23 32z"
+        fill="#34A853"
+      ></path>
+
+      <path
+        d="M17.964 24.71a5.41 5.41 0 0 1-.282-1.71c0-.593.102-1.17.282-1.71v-2.332h-3.007A8.996 8.996 0 0 0 14 23c0 1.452.348 2.827.957 4.042l3.007-2.332z"
+        fill="#FBBC05"
+      ></path>
+
+      <path
+        d="M23 17.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C27.463 14.891 25.426 14 23 14a8.997 8.997 0 0 0-8.043 4.958l3.007 2.332c.708-2.127 2.692-3.71 5.036-3.71z"
+        fill="#EA4335"
+      ></path>
+
       <path d="M14 14h18v18H14V14z"></path>
     </g>
   </svg>
 <% when "hero-chevron-right" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" class="<%= classes %>">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+    />
   </svg>
 <% when "hero-chevron-left" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" class="<%= classes %>">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z"
+    />
   </svg>
 <% when "hero-bars-3" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+    />
   </svg>
 <% when "hero-user-circle" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z"
+    />
   </svg>
 <% when "hero-chevron-down" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"  class="<%= classes %>">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+    />
   </svg>
 <% when "hero-home" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+    />
   </svg>
 <% when "hero-globe-alt" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418"
+    />
   </svg>
 <% when "hero-user" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
+    />
   </svg>
 <% when "hero-trash" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+    />
   </svg>
 <% when "hero-x-circle" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+    />
   </svg>
 <% when "hero-check-circle-mini" %>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="<%= classes %>">
-    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+      clip-rule="evenodd"
+    />
   </svg>
 <% when "hero-x-circle-mini" %>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="<%= classes %>">
-    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z"
+      clip-rule="evenodd"
+    />
   </svg>
 <% when "hero-x-mark" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M6 18L18 6M6 6l12 12"
+    />
   </svg>
 <% when "dot" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 8 8" class="<%= classes %>">
-    <circle cx="4" cy="4" r="3"/>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 8 8"
+    class="<%= classes %>"
+  >
+    <circle cx="4" cy="4" r="3" />
   </svg>
 <% when "hero-banknotes" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z"
+    />
   </svg>
 <% when "hero-envelope" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+    />
   </svg>
 <% when "hero-circle-stack" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
+    />
   </svg>
 <% when "hero-lock-closed" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"
+    />
   </svg>
 <% when "hero-firewall" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M 4 3 l 17 0 m -17 5 l 17 0 m -17 5 h 10.86 m 2.54 0 h 2.28 m -15.68 5 l 7.68 0 m -3.68 -15 l 0 5 m 0 5 l 0 5 m 4 -10 l 0 5 m 5 -10 l 0 5 m -13 -5 l 0 15 m 17 -15 l 0 8 m -4 9 m -1 3 c -1 0 -3 -1 -4 -3 c -1 -3 0.6667 -4.6667 1 -7 c 0 2 1 4 2 5 c -1 -3 0 -7 2 -10 c 0 3 0 6 2 8 c 0 -2 1 -4 2 -5 c 0 2 0.551 3.254 1 4 c 1.476 2.665 0.601 5.412 -0.973 7.004 c -1.54 1.207 -3 1 -5 1" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M 4 3 l 17 0 m -17 5 l 17 0 m -17 5 h 10.86 m 2.54 0 h 2.28 m -15.68 5 l 7.68 0 m -3.68 -15 l 0 5 m 0 5 l 0 5 m 4 -10 l 0 5 m 5 -10 l 0 5 m -13 -5 l 0 15 m 17 -15 l 0 8 m -4 9 m -1 3 c -1 0 -3 -1 -4 -3 c -1 -3 0.6667 -4.6667 1 -7 c 0 2 1 4 2 5 c -1 -3 0 -7 2 -10 c 0 3 0 6 2 8 c 0 -2 1 -4 2 -5 c 0 2 0.551 3.254 1 4 c 1.476 2.665 0.601 5.412 -0.973 7.004 c -1.54 1.207 -3 1 -5 1"
+    />
   </svg>
 <% when "hero-arrows-pointing-out" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15"
+    />
   </svg>
 <% when "hero-chat-bubble-bottom-center-text" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"
+    />
+  </svg>
 <% when "hero-document-arrow-down" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+    />
   </svg>
 <% when "tabler-robot" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"  class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M6 4m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z M12 2v2 M9 12v9 M15 12v9 M5 16l4 -2 M15 14l4 2 M9 18h6 M10 8v.01 M14 8v.01" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="2"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M6 4m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z M12 2v2 M9 12v9 M15 12v9 M5 16l4 -2 M15 14l4 2 M9 18h6 M10 8v.01 M14 8v.01"
+    />
   </svg>
 <% when "hero-document-text" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+    />
   </svg>
 <% when "hero-finger-print" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0 1 19.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 0 0 4.5 10.5a7.464 7.464 0 0 1-1.15 3.993m1.989 3.559A11.209 11.209 0 0 0 8.25 10.5a3.75 3.75 0 1 1 7.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 0 1-3.6 9.75m6.633-4.596a18.666 18.666 0 0 1-2.485 5.33" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M7.864 4.243A7.5 7.5 0 0 1 19.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 0 0 4.5 10.5a7.464 7.464 0 0 1-1.15 3.993m1.989 3.559A11.209 11.209 0 0 0 8.25 10.5a3.75 3.75 0 1 1 7.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 0 1-3.6 9.75m6.633-4.596a18.666 18.666 0 0 1-2.485 5.33"
+    />
   </svg>
 <% when "hero-map-pin" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+    />
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
+    />
   </svg>
 <% when "hero-check" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="m4.5 12.75 6 6 9-13.5"
+    />
   </svg>
 <% when "kubernetes" %>
-  <svg viewBox="0 0 92 91" fill="none" xmlns="http://www.w3.org/2000/svg" class="<%= classes %>">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9 1.30005C43.9 0.800049 45.0016 0.600098 46.0016 0.600098H46.0992C47.2008 0.600098 48.2008 0.800049 49.2008 1.30005L80.0992 16.2002C82.0016 17.2002 83.4 18.9001 83.9 21L91.5016 54.6001C91.9 56.6001 91.4 58.8 90.0992 60.5L68.7008 87.4001C67.4 89.1001 65.3023 90.1001 63.2008 90.1001H28.9C26.8023 90.1001 24.7008 89.1001 23.4 87.4001L2.00155 60.5C0.599211 58.9001 0.0992108 56.7002 0.599211 54.6001L8.20077 21C8.70077 18.9001 10.0992 17.1001 12.0016 16.2002L42.9 1.30005ZM46.2828 7.70386L46.0016 7.69995C45.5992 7.69995 45.2008 7.80005 44.8023 8L16.3023 21.8C15.5016 22.2 15.0016 22.8999 14.8023 23.7L7.80234 54.5999C7.68124 55.1323 7.70468 55.6296 7.8453 56.092C7.94296 56.4114 8.09921 56.7141 8.30234 57L28.0016 81.8C28.5016 82.5 29.3023 82.8999 30.2008 82.8999H61.8023C62.7008 82.8999 63.5016 82.5 64.0016 81.8L83.7008 57C84.2008 56.3 84.4 55.3999 84.2008 54.5999L77.2008 23.7C77.0016 22.8999 76.5016 22.2 75.7008 21.8L47.2008 8C46.8961 7.77124 46.5875 7.7168 46.2828 7.70386Z" fill="white"/>
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M46.0006 13C45.8834 13 45.7662 13 45.6529 13.0122C45.481 13.031 45.3209 13.0786 45.1998 13.2C44.0982 13.7 43.5982 15 44.0982 16.1001C44.5904 17.1841 44.6998 18.2683 44.7975 19.2566V19.3V20.9001C44.7975 21.4001 44.5982 22 44.1998 22.5C44.0318 22.7087 43.9185 22.9348 43.8404 23.1638C43.7975 23.2952 43.7662 23.4277 43.7428 23.5583L43.7154 23.7734C43.7037 23.8855 43.6998 23.9951 43.6998 24.1001C38.1998 24.6001 33.2975 27 29.5006 30.7C29.0006 30.4001 28.5982 30.1001 27.899 30.1001C27.3287 30.1001 26.8248 29.9678 26.4928 29.7029C26.4185 29.6421 26.3521 29.5745 26.2975 29.5C25.9146 29.2112 25.5318 28.8298 25.1451 28.4448L25.0982 28.4001C24.2975 27.6001 23.5982 26.8 23.0006 25.8C22.8873 25.6089 22.7584 25.4324 22.606 25.2761L22.5006 25.1716L22.3795 25.0667C22.274 24.9839 22.1607 24.9094 22.0396 24.8447L21.8365 24.7515L21.6998 24.7C20.5006 24.4001 19.2975 25 19.0006 26.2C18.9537 26.3779 18.9303 26.561 18.9264 26.7441C18.9225 26.9023 18.9381 27.0608 18.9654 27.2161C19.0162 27.4731 19.106 27.7217 19.2389 27.9468C19.5084 28.4014 19.9381 28.76 20.5006 28.9001C21.5982 29.2 22.5982 29.8 23.5006 30.4001L23.8717 30.6663L23.9185 30.6973C24.2115 30.9065 24.5279 31.1306 24.7975 31.4001C24.9693 31.5039 25.11 31.644 25.2232 31.8076L25.3209 31.969L25.3795 32.073C25.5084 32.3269 25.606 32.6135 25.6998 32.9001C25.7975 33.5 26.1998 33.9001 26.5982 34.3C23.899 38.2 22.1998 42.9001 22.1998 48.1001V50.646C21.8209 50.8188 21.3678 50.9392 21.0006 51.4001C20.7935 51.6592 20.5592 51.8911 20.2975 52.0547C20.1607 52.1409 20.0162 52.2083 19.8639 52.2502C19.7935 52.27 19.7193 52.2842 19.6412 52.2922L19.5006 52.3L18.6998 52.4502L17.899 52.6001C16.7975 52.7 15.6998 52.8 14.5982 52.6001C14.0006 52.6001 13.399 52.6001 12.899 53C12.4967 53.2827 12.2232 53.6636 12.0865 54.083C11.8834 54.7017 11.981 55.4041 12.399 56C13.0982 57 14.5006 57.2 15.399 56.5C16.399 55.8 17.399 55.4001 18.399 55.1001C18.899 54.9001 19.399 54.8 20.0006 54.7C20.5006 54.5 21.0982 54.7 21.6998 54.9001C22.1998 55.2 22.6998 55.1001 23.0982 55.1001C24.899 60.8 28.6998 65.6001 33.6998 68.6001C33.5006 69.1001 33.399 69.6001 33.5006 70.2C33.5982 70.9001 33.5982 71.5 33.399 71.9001C33.2975 72.1501 33.1725 72.4001 33.0475 72.6501C32.9225 72.9001 32.7975 73.1501 32.6998 73.4001C32.0982 74.3 31.5006 75.2 30.6998 76C30.2975 76.4001 30.0006 76.9001 30.0006 77.5C30.0006 77.8628 30.0826 78.2073 30.231 78.5112C30.356 78.7708 30.5318 79.0007 30.7428 79.1877C30.8209 79.2561 30.9029 79.3186 30.9889 79.3745C31.1178 79.4592 31.2545 79.5293 31.4068 79.5825C31.6217 79.6584 31.856 79.7 32.0982 79.7C33.2975 79.7 34.2975 78.8 34.399 77.6001C34.399 76.927 34.4928 76.3169 34.6451 75.7168C34.7662 75.2471 34.9225 74.7832 35.0982 74.3L35.6998 72.8C35.7545 72.6614 35.8326 72.5305 35.9264 72.4072C35.985 72.3323 36.0514 72.2603 36.1178 72.1912L36.2896 72.033L36.442 71.9089C36.5865 71.7964 36.7428 71.6934 36.899 71.6001C37.1451 71.4778 37.3248 71.3391 37.4693 71.1838C37.6803 70.9578 37.8209 70.6965 38.0006 70.4001C40.5006 71.3 43.1998 71.8 46.0982 71.8C49.0006 71.8 51.6998 71.3 54.2975 70.3L54.3678 70.4231C54.6334 70.8662 54.8482 71.2251 55.399 71.5C55.735 71.668 56.0396 71.8669 56.2623 72.0974C56.4342 72.2788 56.5553 72.4797 56.5982 72.7L57.1998 74.2C57.5982 75.2 57.899 76.3 57.899 77.5C57.899 78.1001 58.0982 78.6001 58.5982 79.1001C59.0123 79.4673 59.5318 79.645 60.0475 79.6523C60.3678 79.6567 60.6881 79.5955 60.985 79.4727C61.1529 79.4036 61.3131 79.3152 61.4576 79.2083C61.5435 79.1453 61.6256 79.0757 61.6998 79C62.5006 78.1001 62.399 76.7 61.5982 75.9001C61.2232 75.5659 60.899 75.2144 60.6139 74.8452C60.2154 74.3306 59.8912 73.7822 59.5982 73.2C59.5045 73.0447 59.4185 72.8894 59.3443 72.7373C59.2506 72.5527 59.1685 72.3723 59.0904 72.2017L58.899 71.8C58.7232 71.5076 58.649 71.1809 58.6607 70.8401C58.6685 70.5981 58.7154 70.3491 58.7975 70.1001C59.0006 69.4001 58.7975 68.9001 58.5982 68.4001C63.5982 65.3 67.399 60.5 69.0982 54.8C69.6998 54.8 70.1998 54.9001 70.7975 54.6001C71.1959 54.4016 71.5943 54.2905 71.9654 54.2671C72.1529 54.2551 72.3326 54.2661 72.5006 54.3C73.0006 54.3 73.5982 54.5 74.0982 54.6001C74.4537 54.7065 74.8209 54.8254 75.192 54.9614C75.8678 55.209 76.5553 55.5129 77.1998 55.9001C77.3834 56.011 77.5826 56.0947 77.7896 56.1509C77.9576 56.1965 78.1334 56.2241 78.3092 56.2336C78.5045 56.2441 78.6998 56.2329 78.899 56.2C80.0982 55.9001 80.7975 54.8 80.5982 53.6001C80.2975 52.4001 79.1998 51.7 78.0006 51.9001C77.8053 51.9487 77.6178 51.9868 77.4342 52.0161C77.1451 52.0613 76.8678 52.0854 76.5943 52.095L76.2076 52.0994C75.7271 52.0938 75.2584 52.0508 74.7701 52.0059L74.6998 52C74.1998 52 73.5982 51.9001 73.0982 51.7C72.817 51.7 72.5357 51.5745 72.2545 51.3762C72.0357 51.2205 71.817 51.02 71.5982 50.8C71.0982 50.3 70.5982 50.1001 70.0982 50C70.0982 49.6001 70.1256 49.2251 70.149 48.8501C70.1725 48.4751 70.1998 48.1001 70.1998 47.7C70.1998 42.7 68.6998 38.1001 66.0982 34.3C66.5006 33.9001 66.899 33.5 67.0006 32.8C67.1998 32.2 67.399 31.6001 67.899 31.3L68.2154 31.0076C68.3248 30.9089 68.4381 30.8162 68.5592 30.7268C68.7584 30.5779 68.9693 30.439 69.1998 30.3L69.8834 29.8538C70.0592 29.7419 70.2389 29.6331 70.4225 29.5291C70.9537 29.2275 71.5318 28.9673 72.1998 28.8C73.1568 28.5608 73.2232 28.3853 73.3639 28.02C73.399 27.927 73.4381 27.8218 73.5006 27.7C74.0982 26.6001 73.5982 25.3 72.5982 24.8C71.5006 24.2 70.1998 24.7 69.6998 25.7C69.1998 26.7 68.399 27.6001 67.6998 28.3C67.2975 28.7 66.899 29 66.5006 29.4001C66.0982 29.8 65.5006 29.9001 64.899 30C64.1998 30 63.7975 30.3 63.2975 30.6001C59.5006 26.8 54.399 24.3 48.7975 23.8C48.7975 23.48 48.7975 23.1189 48.6685 22.7693C48.5943 22.5728 48.4771 22.3799 48.2975 22.2C47.899 21.7 47.5982 21.1001 47.6998 20.6001V19C47.7232 18.7336 47.7545 18.4673 47.7935 18.2024L47.8482 17.8342C47.8834 17.615 47.9264 17.3972 47.9732 17.1819C48.0123 17.0122 48.0553 16.844 48.106 16.6775L48.1646 16.4775L48.2389 16.25L48.399 15.8C48.5982 15.3 48.5982 14.7 48.399 14.1001C48.1412 13.5859 47.7193 13.1958 47.2389 12.9827C46.9693 12.864 46.6842 12.8 46.399 12.8L46.0006 13ZM22.2975 50.6001L22.2389 50.6292C22.2545 50.4785 22.2701 50.3877 22.2975 50.6001ZM43.0982 28.2V29C42.6998 31.2 42.5006 33.3 42.2975 35.5L42.0006 38.8999L39.0006 36.8C37.1998 35.5999 35.399 34.3999 33.5006 33.2L32.899 32.8C35.6998 30.3999 39.1998 28.7 43.0982 28.2ZM49.0006 28.2156L48.899 28.2002L49.0006 28.1001V28.2156ZM49.0006 28.2156C50.2857 28.4146 51.5318 28.7275 52.7232 29.1475C53.5982 29.4561 54.4459 29.8225 55.2623 30.2444C56.7545 31.0166 58.1412 31.9739 59.399 33.1001L58.6998 33.5L53.2975 37.1001L51.1998 38.6001C50.6998 39 49.899 38.6001 49.899 38C49.899 37.1001 49.7975 36.3 49.6998 35.4001C49.5006 33.2002 49.2975 31.1001 49.0006 28.9001V28.2156ZM29.2037 37.2L29.2584 37.2651C27.2818 40.3518 26.1021 44.0281 26.1021 48V49.0999L27.0006 48.8C29.1021 48 31.1021 47.3999 33.2037 46.7C34.1021 46.3999 35.1021 46.0999 36.1021 45.8C36.3053 45.7322 36.4615 45.5957 36.5631 45.4292C36.606 45.3577 36.6373 45.2805 36.6568 45.2007C36.6881 45.0825 36.6959 44.9587 36.6725 44.8398C36.6412 44.6753 36.5514 44.5198 36.4029 44.3999C35.7037 43.8 35.1021 43.2 34.4029 42.5L32.8795 41C31.8482 39.9915 30.8014 38.968 29.8014 37.8999L29.2584 37.2651L29.3014 37.2H29.2037ZM66.0006 49V48C66.0006 44.2002 64.899 40.6001 63.0982 37.6001L62.5982 38.2002C61.7701 39.0842 60.9107 39.9683 60.0553 40.8354L58.0006 42.9001C57.0006 43.9001 55.899 44.8 54.899 45.8C56.2975 46.1001 57.5982 46.5 59.0006 46.9001C60.235 47.2537 61.4732 47.6074 62.7076 47.9814L64.0084 48.3831L65.2975 48.8L66.0006 49ZM44.8014 44H47.2037C47.6021 44 47.9029 44.2 48.1021 44.5L49.7037 46.5C49.8014 46.6492 49.8756 46.7983 49.9107 46.9597C49.9498 47.123 49.9537 47.2988 49.9029 47.5L49.3014 49.8999C49.3014 50.3 49.0006 50.6001 48.7037 50.8L46.5006 51.8C46.4303 51.8489 46.3482 51.8857 46.2662 51.9106C46.1959 51.9316 46.1256 51.9443 46.0553 51.9485C45.8639 51.9597 45.6646 51.9102 45.5006 51.8L43.3014 50.8C43.0006 50.6001 42.7037 50.3 42.7037 49.8999L42.1021 47.5C42.1021 47.2 42.1021 46.8 42.3014 46.5L43.9029 44.5C44.1021 44.2 44.5006 44 44.8014 44ZM38.4029 54.6001C38.6021 54 38.1021 53.5 37.5006 53.5V53.6001C36.6021 53.8 35.6021 54 34.7037 54C33.5787 54.1021 32.485 54.2302 31.3873 54.3711L28.9146 54.7026L28.2037 54.8H27.1021C28.6021 58.8999 31.3014 62.3 34.9029 64.7L35.2037 63.8C35.8014 61.7 36.6021 59.7 37.3014 57.6001C37.5006 57.1001 37.6764 56.6001 37.8521 56.1001C38.0279 55.6001 38.2037 55.1001 38.4029 54.6001ZM54.8014 53.8C55.1998 53.8 55.6178 53.8394 56.0396 53.8918L56.7154 53.9834C57.0162 54.0259 57.3131 54.0681 57.6021 54.1001L58.1178 54.147C60.1295 54.3306 62.0709 54.5078 64.1021 54.6001H64.8014C63.399 58.7 60.6998 62.1001 57.1998 64.5L57.0006 63.8C56.6295 62.6851 56.2584 61.5981 55.8834 60.5095L54.899 57.6001C54.6021 56.7 54.3014 55.8 53.899 54.9001C53.7935 54.5879 53.8795 54.2756 54.0709 54.062C54.2467 53.865 54.5123 53.752 54.8014 53.8ZM46.5201 57.885C46.3951 57.8245 46.2467 57.8 46.1021 57.8H46.0006C45.6998 57.8 45.5006 57.9001 45.3014 58.2C44.899 59 44.399 59.9001 43.899 60.7C42.8014 62.6001 41.6998 64.5 40.5006 66.3L40.0006 67.1001C41.899 67.7 43.6998 68 45.899 68C46.8131 68 47.6959 67.9482 48.5475 67.8445C49.7467 67.6987 50.8912 67.4507 52.0006 67.1001L51.5006 66.3C50.8131 65.1736 50.1256 64.0081 49.4381 62.8279L48.1998 60.7C47.6998 59.9001 47.1998 59 46.8014 58.2C46.7506 58.0479 46.649 57.9473 46.5201 57.885Z" fill="white"/>
+  <svg
+    viewBox="0 0 92 91"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M42.9 1.30005C43.9 0.800049 45.0016 0.600098 46.0016 0.600098H46.0992C47.2008 0.600098 48.2008 0.800049 49.2008 1.30005L80.0992 16.2002C82.0016 17.2002 83.4 18.9001 83.9 21L91.5016 54.6001C91.9 56.6001 91.4 58.8 90.0992 60.5L68.7008 87.4001C67.4 89.1001 65.3023 90.1001 63.2008 90.1001H28.9C26.8023 90.1001 24.7008 89.1001 23.4 87.4001L2.00155 60.5C0.599211 58.9001 0.0992108 56.7002 0.599211 54.6001L8.20077 21C8.70077 18.9001 10.0992 17.1001 12.0016 16.2002L42.9 1.30005ZM46.2828 7.70386L46.0016 7.69995C45.5992 7.69995 45.2008 7.80005 44.8023 8L16.3023 21.8C15.5016 22.2 15.0016 22.8999 14.8023 23.7L7.80234 54.5999C7.68124 55.1323 7.70468 55.6296 7.8453 56.092C7.94296 56.4114 8.09921 56.7141 8.30234 57L28.0016 81.8C28.5016 82.5 29.3023 82.8999 30.2008 82.8999H61.8023C62.7008 82.8999 63.5016 82.5 64.0016 81.8L83.7008 57C84.2008 56.3 84.4 55.3999 84.2008 54.5999L77.2008 23.7C77.0016 22.8999 76.5016 22.2 75.7008 21.8L47.2008 8C46.8961 7.77124 46.5875 7.7168 46.2828 7.70386Z"
+      fill="white"
+    />
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M46.0006 13C45.8834 13 45.7662 13 45.6529 13.0122C45.481 13.031 45.3209 13.0786 45.1998 13.2C44.0982 13.7 43.5982 15 44.0982 16.1001C44.5904 17.1841 44.6998 18.2683 44.7975 19.2566V19.3V20.9001C44.7975 21.4001 44.5982 22 44.1998 22.5C44.0318 22.7087 43.9185 22.9348 43.8404 23.1638C43.7975 23.2952 43.7662 23.4277 43.7428 23.5583L43.7154 23.7734C43.7037 23.8855 43.6998 23.9951 43.6998 24.1001C38.1998 24.6001 33.2975 27 29.5006 30.7C29.0006 30.4001 28.5982 30.1001 27.899 30.1001C27.3287 30.1001 26.8248 29.9678 26.4928 29.7029C26.4185 29.6421 26.3521 29.5745 26.2975 29.5C25.9146 29.2112 25.5318 28.8298 25.1451 28.4448L25.0982 28.4001C24.2975 27.6001 23.5982 26.8 23.0006 25.8C22.8873 25.6089 22.7584 25.4324 22.606 25.2761L22.5006 25.1716L22.3795 25.0667C22.274 24.9839 22.1607 24.9094 22.0396 24.8447L21.8365 24.7515L21.6998 24.7C20.5006 24.4001 19.2975 25 19.0006 26.2C18.9537 26.3779 18.9303 26.561 18.9264 26.7441C18.9225 26.9023 18.9381 27.0608 18.9654 27.2161C19.0162 27.4731 19.106 27.7217 19.2389 27.9468C19.5084 28.4014 19.9381 28.76 20.5006 28.9001C21.5982 29.2 22.5982 29.8 23.5006 30.4001L23.8717 30.6663L23.9185 30.6973C24.2115 30.9065 24.5279 31.1306 24.7975 31.4001C24.9693 31.5039 25.11 31.644 25.2232 31.8076L25.3209 31.969L25.3795 32.073C25.5084 32.3269 25.606 32.6135 25.6998 32.9001C25.7975 33.5 26.1998 33.9001 26.5982 34.3C23.899 38.2 22.1998 42.9001 22.1998 48.1001V50.646C21.8209 50.8188 21.3678 50.9392 21.0006 51.4001C20.7935 51.6592 20.5592 51.8911 20.2975 52.0547C20.1607 52.1409 20.0162 52.2083 19.8639 52.2502C19.7935 52.27 19.7193 52.2842 19.6412 52.2922L19.5006 52.3L18.6998 52.4502L17.899 52.6001C16.7975 52.7 15.6998 52.8 14.5982 52.6001C14.0006 52.6001 13.399 52.6001 12.899 53C12.4967 53.2827 12.2232 53.6636 12.0865 54.083C11.8834 54.7017 11.981 55.4041 12.399 56C13.0982 57 14.5006 57.2 15.399 56.5C16.399 55.8 17.399 55.4001 18.399 55.1001C18.899 54.9001 19.399 54.8 20.0006 54.7C20.5006 54.5 21.0982 54.7 21.6998 54.9001C22.1998 55.2 22.6998 55.1001 23.0982 55.1001C24.899 60.8 28.6998 65.6001 33.6998 68.6001C33.5006 69.1001 33.399 69.6001 33.5006 70.2C33.5982 70.9001 33.5982 71.5 33.399 71.9001C33.2975 72.1501 33.1725 72.4001 33.0475 72.6501C32.9225 72.9001 32.7975 73.1501 32.6998 73.4001C32.0982 74.3 31.5006 75.2 30.6998 76C30.2975 76.4001 30.0006 76.9001 30.0006 77.5C30.0006 77.8628 30.0826 78.2073 30.231 78.5112C30.356 78.7708 30.5318 79.0007 30.7428 79.1877C30.8209 79.2561 30.9029 79.3186 30.9889 79.3745C31.1178 79.4592 31.2545 79.5293 31.4068 79.5825C31.6217 79.6584 31.856 79.7 32.0982 79.7C33.2975 79.7 34.2975 78.8 34.399 77.6001C34.399 76.927 34.4928 76.3169 34.6451 75.7168C34.7662 75.2471 34.9225 74.7832 35.0982 74.3L35.6998 72.8C35.7545 72.6614 35.8326 72.5305 35.9264 72.4072C35.985 72.3323 36.0514 72.2603 36.1178 72.1912L36.2896 72.033L36.442 71.9089C36.5865 71.7964 36.7428 71.6934 36.899 71.6001C37.1451 71.4778 37.3248 71.3391 37.4693 71.1838C37.6803 70.9578 37.8209 70.6965 38.0006 70.4001C40.5006 71.3 43.1998 71.8 46.0982 71.8C49.0006 71.8 51.6998 71.3 54.2975 70.3L54.3678 70.4231C54.6334 70.8662 54.8482 71.2251 55.399 71.5C55.735 71.668 56.0396 71.8669 56.2623 72.0974C56.4342 72.2788 56.5553 72.4797 56.5982 72.7L57.1998 74.2C57.5982 75.2 57.899 76.3 57.899 77.5C57.899 78.1001 58.0982 78.6001 58.5982 79.1001C59.0123 79.4673 59.5318 79.645 60.0475 79.6523C60.3678 79.6567 60.6881 79.5955 60.985 79.4727C61.1529 79.4036 61.3131 79.3152 61.4576 79.2083C61.5435 79.1453 61.6256 79.0757 61.6998 79C62.5006 78.1001 62.399 76.7 61.5982 75.9001C61.2232 75.5659 60.899 75.2144 60.6139 74.8452C60.2154 74.3306 59.8912 73.7822 59.5982 73.2C59.5045 73.0447 59.4185 72.8894 59.3443 72.7373C59.2506 72.5527 59.1685 72.3723 59.0904 72.2017L58.899 71.8C58.7232 71.5076 58.649 71.1809 58.6607 70.8401C58.6685 70.5981 58.7154 70.3491 58.7975 70.1001C59.0006 69.4001 58.7975 68.9001 58.5982 68.4001C63.5982 65.3 67.399 60.5 69.0982 54.8C69.6998 54.8 70.1998 54.9001 70.7975 54.6001C71.1959 54.4016 71.5943 54.2905 71.9654 54.2671C72.1529 54.2551 72.3326 54.2661 72.5006 54.3C73.0006 54.3 73.5982 54.5 74.0982 54.6001C74.4537 54.7065 74.8209 54.8254 75.192 54.9614C75.8678 55.209 76.5553 55.5129 77.1998 55.9001C77.3834 56.011 77.5826 56.0947 77.7896 56.1509C77.9576 56.1965 78.1334 56.2241 78.3092 56.2336C78.5045 56.2441 78.6998 56.2329 78.899 56.2C80.0982 55.9001 80.7975 54.8 80.5982 53.6001C80.2975 52.4001 79.1998 51.7 78.0006 51.9001C77.8053 51.9487 77.6178 51.9868 77.4342 52.0161C77.1451 52.0613 76.8678 52.0854 76.5943 52.095L76.2076 52.0994C75.7271 52.0938 75.2584 52.0508 74.7701 52.0059L74.6998 52C74.1998 52 73.5982 51.9001 73.0982 51.7C72.817 51.7 72.5357 51.5745 72.2545 51.3762C72.0357 51.2205 71.817 51.02 71.5982 50.8C71.0982 50.3 70.5982 50.1001 70.0982 50C70.0982 49.6001 70.1256 49.2251 70.149 48.8501C70.1725 48.4751 70.1998 48.1001 70.1998 47.7C70.1998 42.7 68.6998 38.1001 66.0982 34.3C66.5006 33.9001 66.899 33.5 67.0006 32.8C67.1998 32.2 67.399 31.6001 67.899 31.3L68.2154 31.0076C68.3248 30.9089 68.4381 30.8162 68.5592 30.7268C68.7584 30.5779 68.9693 30.439 69.1998 30.3L69.8834 29.8538C70.0592 29.7419 70.2389 29.6331 70.4225 29.5291C70.9537 29.2275 71.5318 28.9673 72.1998 28.8C73.1568 28.5608 73.2232 28.3853 73.3639 28.02C73.399 27.927 73.4381 27.8218 73.5006 27.7C74.0982 26.6001 73.5982 25.3 72.5982 24.8C71.5006 24.2 70.1998 24.7 69.6998 25.7C69.1998 26.7 68.399 27.6001 67.6998 28.3C67.2975 28.7 66.899 29 66.5006 29.4001C66.0982 29.8 65.5006 29.9001 64.899 30C64.1998 30 63.7975 30.3 63.2975 30.6001C59.5006 26.8 54.399 24.3 48.7975 23.8C48.7975 23.48 48.7975 23.1189 48.6685 22.7693C48.5943 22.5728 48.4771 22.3799 48.2975 22.2C47.899 21.7 47.5982 21.1001 47.6998 20.6001V19C47.7232 18.7336 47.7545 18.4673 47.7935 18.2024L47.8482 17.8342C47.8834 17.615 47.9264 17.3972 47.9732 17.1819C48.0123 17.0122 48.0553 16.844 48.106 16.6775L48.1646 16.4775L48.2389 16.25L48.399 15.8C48.5982 15.3 48.5982 14.7 48.399 14.1001C48.1412 13.5859 47.7193 13.1958 47.2389 12.9827C46.9693 12.864 46.6842 12.8 46.399 12.8L46.0006 13ZM22.2975 50.6001L22.2389 50.6292C22.2545 50.4785 22.2701 50.3877 22.2975 50.6001ZM43.0982 28.2V29C42.6998 31.2 42.5006 33.3 42.2975 35.5L42.0006 38.8999L39.0006 36.8C37.1998 35.5999 35.399 34.3999 33.5006 33.2L32.899 32.8C35.6998 30.3999 39.1998 28.7 43.0982 28.2ZM49.0006 28.2156L48.899 28.2002L49.0006 28.1001V28.2156ZM49.0006 28.2156C50.2857 28.4146 51.5318 28.7275 52.7232 29.1475C53.5982 29.4561 54.4459 29.8225 55.2623 30.2444C56.7545 31.0166 58.1412 31.9739 59.399 33.1001L58.6998 33.5L53.2975 37.1001L51.1998 38.6001C50.6998 39 49.899 38.6001 49.899 38C49.899 37.1001 49.7975 36.3 49.6998 35.4001C49.5006 33.2002 49.2975 31.1001 49.0006 28.9001V28.2156ZM29.2037 37.2L29.2584 37.2651C27.2818 40.3518 26.1021 44.0281 26.1021 48V49.0999L27.0006 48.8C29.1021 48 31.1021 47.3999 33.2037 46.7C34.1021 46.3999 35.1021 46.0999 36.1021 45.8C36.3053 45.7322 36.4615 45.5957 36.5631 45.4292C36.606 45.3577 36.6373 45.2805 36.6568 45.2007C36.6881 45.0825 36.6959 44.9587 36.6725 44.8398C36.6412 44.6753 36.5514 44.5198 36.4029 44.3999C35.7037 43.8 35.1021 43.2 34.4029 42.5L32.8795 41C31.8482 39.9915 30.8014 38.968 29.8014 37.8999L29.2584 37.2651L29.3014 37.2H29.2037ZM66.0006 49V48C66.0006 44.2002 64.899 40.6001 63.0982 37.6001L62.5982 38.2002C61.7701 39.0842 60.9107 39.9683 60.0553 40.8354L58.0006 42.9001C57.0006 43.9001 55.899 44.8 54.899 45.8C56.2975 46.1001 57.5982 46.5 59.0006 46.9001C60.235 47.2537 61.4732 47.6074 62.7076 47.9814L64.0084 48.3831L65.2975 48.8L66.0006 49ZM44.8014 44H47.2037C47.6021 44 47.9029 44.2 48.1021 44.5L49.7037 46.5C49.8014 46.6492 49.8756 46.7983 49.9107 46.9597C49.9498 47.123 49.9537 47.2988 49.9029 47.5L49.3014 49.8999C49.3014 50.3 49.0006 50.6001 48.7037 50.8L46.5006 51.8C46.4303 51.8489 46.3482 51.8857 46.2662 51.9106C46.1959 51.9316 46.1256 51.9443 46.0553 51.9485C45.8639 51.9597 45.6646 51.9102 45.5006 51.8L43.3014 50.8C43.0006 50.6001 42.7037 50.3 42.7037 49.8999L42.1021 47.5C42.1021 47.2 42.1021 46.8 42.3014 46.5L43.9029 44.5C44.1021 44.2 44.5006 44 44.8014 44ZM38.4029 54.6001C38.6021 54 38.1021 53.5 37.5006 53.5V53.6001C36.6021 53.8 35.6021 54 34.7037 54C33.5787 54.1021 32.485 54.2302 31.3873 54.3711L28.9146 54.7026L28.2037 54.8H27.1021C28.6021 58.8999 31.3014 62.3 34.9029 64.7L35.2037 63.8C35.8014 61.7 36.6021 59.7 37.3014 57.6001C37.5006 57.1001 37.6764 56.6001 37.8521 56.1001C38.0279 55.6001 38.2037 55.1001 38.4029 54.6001ZM54.8014 53.8C55.1998 53.8 55.6178 53.8394 56.0396 53.8918L56.7154 53.9834C57.0162 54.0259 57.3131 54.0681 57.6021 54.1001L58.1178 54.147C60.1295 54.3306 62.0709 54.5078 64.1021 54.6001H64.8014C63.399 58.7 60.6998 62.1001 57.1998 64.5L57.0006 63.8C56.6295 62.6851 56.2584 61.5981 55.8834 60.5095L54.899 57.6001C54.6021 56.7 54.3014 55.8 53.899 54.9001C53.7935 54.5879 53.8795 54.2756 54.0709 54.062C54.2467 53.865 54.5123 53.752 54.8014 53.8ZM46.5201 57.885C46.3951 57.8245 46.2467 57.8 46.1021 57.8H46.0006C45.6998 57.8 45.5006 57.9001 45.3014 58.2C44.899 59 44.399 59.9001 43.899 60.7C42.8014 62.6001 41.6998 64.5 40.5006 66.3L40.0006 67.1001C41.899 67.7 43.6998 68 45.899 68C46.8131 68 47.6959 67.9482 48.5475 67.8445C49.7467 67.6987 50.8912 67.4507 52.0006 67.1001L51.5006 66.3C50.8131 65.1736 50.1256 64.0081 49.4381 62.8279L48.1998 60.7C47.6998 59.9001 47.1998 59 46.8014 58.2C46.7506 58.0479 46.649 57.9473 46.5201 57.885Z"
+      fill="white"
+    />
   </svg>
-  <% when "kubernetes-filled" %>
-  <svg fill="currentColor" viewBox="0 0 92 91" xmlns="http://www.w3.org/2000/svg" class="<%= classes %>">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9 1.30005C43.9 0.800049 45.0016 0.600098 46.0016 0.600098H46.0992C47.2008 0.600098 48.2008 0.800049 49.2008 1.30005L80.0992 16.2002C82.0016 17.2002 83.4 18.9001 83.9 21L91.5016 54.6001C91.9 56.6001 91.4 58.8 90.0992 60.5L68.7008 87.4001C67.4 89.1001 65.3023 90.1001 63.2008 90.1001H28.9C26.8023 90.1001 24.7008 89.1001 23.4 87.4001L2.00155 60.5C0.599211 58.9001 0.0992108 56.7002 0.599211 54.6001L8.20077 21C8.70077 18.9001 10.0992 17.1001 12.0016 16.2002L42.9 1.30005ZM46.2828 7.70386L46.0016 7.69995C45.5992 7.69995 45.2008 7.80005 44.8023 8L16.3023 21.8C15.5016 22.2 15.0016 22.8999 14.8023 23.7L7.80234 54.5999C7.68124 55.1323 7.70468 55.6296 7.8453 56.092C7.94296 56.4114 8.09921 56.7141 8.30234 57L28.0016 81.8C28.5016 82.5 29.3023 82.8999 30.2008 82.8999H61.8023C62.7008 82.8999 63.5016 82.5 64.0016 81.8L83.7008 57C84.2008 56.3 84.4 55.3999 84.2008 54.5999L77.2008 23.7C77.0016 22.8999 76.5016 22.2 75.7008 21.8L47.2008 8C46.8961 7.77124 46.5875 7.7168 46.2828 7.70386Z" />
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M46.0006 13C45.8834 13 45.7662 13 45.6529 13.0122C45.481 13.031 45.3209 13.0786 45.1998 13.2C44.0982 13.7 43.5982 15 44.0982 16.1001C44.5904 17.1841 44.6998 18.2683 44.7975 19.2566V19.3V20.9001C44.7975 21.4001 44.5982 22 44.1998 22.5C44.0318 22.7087 43.9185 22.9348 43.8404 23.1638C43.7975 23.2952 43.7662 23.4277 43.7428 23.5583L43.7154 23.7734C43.7037 23.8855 43.6998 23.9951 43.6998 24.1001C38.1998 24.6001 33.2975 27 29.5006 30.7C29.0006 30.4001 28.5982 30.1001 27.899 30.1001C27.3287 30.1001 26.8248 29.9678 26.4928 29.7029C26.4185 29.6421 26.3521 29.5745 26.2975 29.5C25.9146 29.2112 25.5318 28.8298 25.1451 28.4448L25.0982 28.4001C24.2975 27.6001 23.5982 26.8 23.0006 25.8C22.8873 25.6089 22.7584 25.4324 22.606 25.2761L22.5006 25.1716L22.3795 25.0667C22.274 24.9839 22.1607 24.9094 22.0396 24.8447L21.8365 24.7515L21.6998 24.7C20.5006 24.4001 19.2975 25 19.0006 26.2C18.9537 26.3779 18.9303 26.561 18.9264 26.7441C18.9225 26.9023 18.9381 27.0608 18.9654 27.2161C19.0162 27.4731 19.106 27.7217 19.2389 27.9468C19.5084 28.4014 19.9381 28.76 20.5006 28.9001C21.5982 29.2 22.5982 29.8 23.5006 30.4001L23.8717 30.6663L23.9185 30.6973C24.2115 30.9065 24.5279 31.1306 24.7975 31.4001C24.9693 31.5039 25.11 31.644 25.2232 31.8076L25.3209 31.969L25.3795 32.073C25.5084 32.3269 25.606 32.6135 25.6998 32.9001C25.7975 33.5 26.1998 33.9001 26.5982 34.3C23.899 38.2 22.1998 42.9001 22.1998 48.1001V50.646C21.8209 50.8188 21.3678 50.9392 21.0006 51.4001C20.7935 51.6592 20.5592 51.8911 20.2975 52.0547C20.1607 52.1409 20.0162 52.2083 19.8639 52.2502C19.7935 52.27 19.7193 52.2842 19.6412 52.2922L19.5006 52.3L18.6998 52.4502L17.899 52.6001C16.7975 52.7 15.6998 52.8 14.5982 52.6001C14.0006 52.6001 13.399 52.6001 12.899 53C12.4967 53.2827 12.2232 53.6636 12.0865 54.083C11.8834 54.7017 11.981 55.4041 12.399 56C13.0982 57 14.5006 57.2 15.399 56.5C16.399 55.8 17.399 55.4001 18.399 55.1001C18.899 54.9001 19.399 54.8 20.0006 54.7C20.5006 54.5 21.0982 54.7 21.6998 54.9001C22.1998 55.2 22.6998 55.1001 23.0982 55.1001C24.899 60.8 28.6998 65.6001 33.6998 68.6001C33.5006 69.1001 33.399 69.6001 33.5006 70.2C33.5982 70.9001 33.5982 71.5 33.399 71.9001C33.2975 72.1501 33.1725 72.4001 33.0475 72.6501C32.9225 72.9001 32.7975 73.1501 32.6998 73.4001C32.0982 74.3 31.5006 75.2 30.6998 76C30.2975 76.4001 30.0006 76.9001 30.0006 77.5C30.0006 77.8628 30.0826 78.2073 30.231 78.5112C30.356 78.7708 30.5318 79.0007 30.7428 79.1877C30.8209 79.2561 30.9029 79.3186 30.9889 79.3745C31.1178 79.4592 31.2545 79.5293 31.4068 79.5825C31.6217 79.6584 31.856 79.7 32.0982 79.7C33.2975 79.7 34.2975 78.8 34.399 77.6001C34.399 76.927 34.4928 76.3169 34.6451 75.7168C34.7662 75.2471 34.9225 74.7832 35.0982 74.3L35.6998 72.8C35.7545 72.6614 35.8326 72.5305 35.9264 72.4072C35.985 72.3323 36.0514 72.2603 36.1178 72.1912L36.2896 72.033L36.442 71.9089C36.5865 71.7964 36.7428 71.6934 36.899 71.6001C37.1451 71.4778 37.3248 71.3391 37.4693 71.1838C37.6803 70.9578 37.8209 70.6965 38.0006 70.4001C40.5006 71.3 43.1998 71.8 46.0982 71.8C49.0006 71.8 51.6998 71.3 54.2975 70.3L54.3678 70.4231C54.6334 70.8662 54.8482 71.2251 55.399 71.5C55.735 71.668 56.0396 71.8669 56.2623 72.0974C56.4342 72.2788 56.5553 72.4797 56.5982 72.7L57.1998 74.2C57.5982 75.2 57.899 76.3 57.899 77.5C57.899 78.1001 58.0982 78.6001 58.5982 79.1001C59.0123 79.4673 59.5318 79.645 60.0475 79.6523C60.3678 79.6567 60.6881 79.5955 60.985 79.4727C61.1529 79.4036 61.3131 79.3152 61.4576 79.2083C61.5435 79.1453 61.6256 79.0757 61.6998 79C62.5006 78.1001 62.399 76.7 61.5982 75.9001C61.2232 75.5659 60.899 75.2144 60.6139 74.8452C60.2154 74.3306 59.8912 73.7822 59.5982 73.2C59.5045 73.0447 59.4185 72.8894 59.3443 72.7373C59.2506 72.5527 59.1685 72.3723 59.0904 72.2017L58.899 71.8C58.7232 71.5076 58.649 71.1809 58.6607 70.8401C58.6685 70.5981 58.7154 70.3491 58.7975 70.1001C59.0006 69.4001 58.7975 68.9001 58.5982 68.4001C63.5982 65.3 67.399 60.5 69.0982 54.8C69.6998 54.8 70.1998 54.9001 70.7975 54.6001C71.1959 54.4016 71.5943 54.2905 71.9654 54.2671C72.1529 54.2551 72.3326 54.2661 72.5006 54.3C73.0006 54.3 73.5982 54.5 74.0982 54.6001C74.4537 54.7065 74.8209 54.8254 75.192 54.9614C75.8678 55.209 76.5553 55.5129 77.1998 55.9001C77.3834 56.011 77.5826 56.0947 77.7896 56.1509C77.9576 56.1965 78.1334 56.2241 78.3092 56.2336C78.5045 56.2441 78.6998 56.2329 78.899 56.2C80.0982 55.9001 80.7975 54.8 80.5982 53.6001C80.2975 52.4001 79.1998 51.7 78.0006 51.9001C77.8053 51.9487 77.6178 51.9868 77.4342 52.0161C77.1451 52.0613 76.8678 52.0854 76.5943 52.095L76.2076 52.0994C75.7271 52.0938 75.2584 52.0508 74.7701 52.0059L74.6998 52C74.1998 52 73.5982 51.9001 73.0982 51.7C72.817 51.7 72.5357 51.5745 72.2545 51.3762C72.0357 51.2205 71.817 51.02 71.5982 50.8C71.0982 50.3 70.5982 50.1001 70.0982 50C70.0982 49.6001 70.1256 49.2251 70.149 48.8501C70.1725 48.4751 70.1998 48.1001 70.1998 47.7C70.1998 42.7 68.6998 38.1001 66.0982 34.3C66.5006 33.9001 66.899 33.5 67.0006 32.8C67.1998 32.2 67.399 31.6001 67.899 31.3L68.2154 31.0076C68.3248 30.9089 68.4381 30.8162 68.5592 30.7268C68.7584 30.5779 68.9693 30.439 69.1998 30.3L69.8834 29.8538C70.0592 29.7419 70.2389 29.6331 70.4225 29.5291C70.9537 29.2275 71.5318 28.9673 72.1998 28.8C73.1568 28.5608 73.2232 28.3853 73.3639 28.02C73.399 27.927 73.4381 27.8218 73.5006 27.7C74.0982 26.6001 73.5982 25.3 72.5982 24.8C71.5006 24.2 70.1998 24.7 69.6998 25.7C69.1998 26.7 68.399 27.6001 67.6998 28.3C67.2975 28.7 66.899 29 66.5006 29.4001C66.0982 29.8 65.5006 29.9001 64.899 30C64.1998 30 63.7975 30.3 63.2975 30.6001C59.5006 26.8 54.399 24.3 48.7975 23.8C48.7975 23.48 48.7975 23.1189 48.6685 22.7693C48.5943 22.5728 48.4771 22.3799 48.2975 22.2C47.899 21.7 47.5982 21.1001 47.6998 20.6001V19C47.7232 18.7336 47.7545 18.4673 47.7935 18.2024L47.8482 17.8342C47.8834 17.615 47.9264 17.3972 47.9732 17.1819C48.0123 17.0122 48.0553 16.844 48.106 16.6775L48.1646 16.4775L48.2389 16.25L48.399 15.8C48.5982 15.3 48.5982 14.7 48.399 14.1001C48.1412 13.5859 47.7193 13.1958 47.2389 12.9827C46.9693 12.864 46.6842 12.8 46.399 12.8L46.0006 13ZM22.2975 50.6001L22.2389 50.6292C22.2545 50.4785 22.2701 50.3877 22.2975 50.6001ZM43.0982 28.2V29C42.6998 31.2 42.5006 33.3 42.2975 35.5L42.0006 38.8999L39.0006 36.8C37.1998 35.5999 35.399 34.3999 33.5006 33.2L32.899 32.8C35.6998 30.3999 39.1998 28.7 43.0982 28.2ZM49.0006 28.2156L48.899 28.2002L49.0006 28.1001V28.2156ZM49.0006 28.2156C50.2857 28.4146 51.5318 28.7275 52.7232 29.1475C53.5982 29.4561 54.4459 29.8225 55.2623 30.2444C56.7545 31.0166 58.1412 31.9739 59.399 33.1001L58.6998 33.5L53.2975 37.1001L51.1998 38.6001C50.6998 39 49.899 38.6001 49.899 38C49.899 37.1001 49.7975 36.3 49.6998 35.4001C49.5006 33.2002 49.2975 31.1001 49.0006 28.9001V28.2156ZM29.2037 37.2L29.2584 37.2651C27.2818 40.3518 26.1021 44.0281 26.1021 48V49.0999L27.0006 48.8C29.1021 48 31.1021 47.3999 33.2037 46.7C34.1021 46.3999 35.1021 46.0999 36.1021 45.8C36.3053 45.7322 36.4615 45.5957 36.5631 45.4292C36.606 45.3577 36.6373 45.2805 36.6568 45.2007C36.6881 45.0825 36.6959 44.9587 36.6725 44.8398C36.6412 44.6753 36.5514 44.5198 36.4029 44.3999C35.7037 43.8 35.1021 43.2 34.4029 42.5L32.8795 41C31.8482 39.9915 30.8014 38.968 29.8014 37.8999L29.2584 37.2651L29.3014 37.2H29.2037ZM66.0006 49V48C66.0006 44.2002 64.899 40.6001 63.0982 37.6001L62.5982 38.2002C61.7701 39.0842 60.9107 39.9683 60.0553 40.8354L58.0006 42.9001C57.0006 43.9001 55.899 44.8 54.899 45.8C56.2975 46.1001 57.5982 46.5 59.0006 46.9001C60.235 47.2537 61.4732 47.6074 62.7076 47.9814L64.0084 48.3831L65.2975 48.8L66.0006 49ZM44.8014 44H47.2037C47.6021 44 47.9029 44.2 48.1021 44.5L49.7037 46.5C49.8014 46.6492 49.8756 46.7983 49.9107 46.9597C49.9498 47.123 49.9537 47.2988 49.9029 47.5L49.3014 49.8999C49.3014 50.3 49.0006 50.6001 48.7037 50.8L46.5006 51.8C46.4303 51.8489 46.3482 51.8857 46.2662 51.9106C46.1959 51.9316 46.1256 51.9443 46.0553 51.9485C45.8639 51.9597 45.6646 51.9102 45.5006 51.8L43.3014 50.8C43.0006 50.6001 42.7037 50.3 42.7037 49.8999L42.1021 47.5C42.1021 47.2 42.1021 46.8 42.3014 46.5L43.9029 44.5C44.1021 44.2 44.5006 44 44.8014 44ZM38.4029 54.6001C38.6021 54 38.1021 53.5 37.5006 53.5V53.6001C36.6021 53.8 35.6021 54 34.7037 54C33.5787 54.1021 32.485 54.2302 31.3873 54.3711L28.9146 54.7026L28.2037 54.8H27.1021C28.6021 58.8999 31.3014 62.3 34.9029 64.7L35.2037 63.8C35.8014 61.7 36.6021 59.7 37.3014 57.6001C37.5006 57.1001 37.6764 56.6001 37.8521 56.1001C38.0279 55.6001 38.2037 55.1001 38.4029 54.6001ZM54.8014 53.8C55.1998 53.8 55.6178 53.8394 56.0396 53.8918L56.7154 53.9834C57.0162 54.0259 57.3131 54.0681 57.6021 54.1001L58.1178 54.147C60.1295 54.3306 62.0709 54.5078 64.1021 54.6001H64.8014C63.399 58.7 60.6998 62.1001 57.1998 64.5L57.0006 63.8C56.6295 62.6851 56.2584 61.5981 55.8834 60.5095L54.899 57.6001C54.6021 56.7 54.3014 55.8 53.899 54.9001C53.7935 54.5879 53.8795 54.2756 54.0709 54.062C54.2467 53.865 54.5123 53.752 54.8014 53.8ZM46.5201 57.885C46.3951 57.8245 46.2467 57.8 46.1021 57.8H46.0006C45.6998 57.8 45.5006 57.9001 45.3014 58.2C44.899 59 44.399 59.9001 43.899 60.7C42.8014 62.6001 41.6998 64.5 40.5006 66.3L40.0006 67.1001C41.899 67.7 43.6998 68 45.899 68C46.8131 68 47.6959 67.9482 48.5475 67.8445C49.7467 67.6987 50.8912 67.4507 52.0006 67.1001L51.5006 66.3C50.8131 65.1736 50.1256 64.0081 49.4381 62.8279L48.1998 60.7C47.6998 59.9001 47.1998 59 46.8014 58.2C46.7506 58.0479 46.649 57.9473 46.5201 57.885Z"/>
+<% when "kubernetes-filled" %>
+  <svg
+    fill="currentColor"
+    viewBox="0 0 92 91"
+    xmlns="http://www.w3.org/2000/svg"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M42.9 1.30005C43.9 0.800049 45.0016 0.600098 46.0016 0.600098H46.0992C47.2008 0.600098 48.2008 0.800049 49.2008 1.30005L80.0992 16.2002C82.0016 17.2002 83.4 18.9001 83.9 21L91.5016 54.6001C91.9 56.6001 91.4 58.8 90.0992 60.5L68.7008 87.4001C67.4 89.1001 65.3023 90.1001 63.2008 90.1001H28.9C26.8023 90.1001 24.7008 89.1001 23.4 87.4001L2.00155 60.5C0.599211 58.9001 0.0992108 56.7002 0.599211 54.6001L8.20077 21C8.70077 18.9001 10.0992 17.1001 12.0016 16.2002L42.9 1.30005ZM46.2828 7.70386L46.0016 7.69995C45.5992 7.69995 45.2008 7.80005 44.8023 8L16.3023 21.8C15.5016 22.2 15.0016 22.8999 14.8023 23.7L7.80234 54.5999C7.68124 55.1323 7.70468 55.6296 7.8453 56.092C7.94296 56.4114 8.09921 56.7141 8.30234 57L28.0016 81.8C28.5016 82.5 29.3023 82.8999 30.2008 82.8999H61.8023C62.7008 82.8999 63.5016 82.5 64.0016 81.8L83.7008 57C84.2008 56.3 84.4 55.3999 84.2008 54.5999L77.2008 23.7C77.0016 22.8999 76.5016 22.2 75.7008 21.8L47.2008 8C46.8961 7.77124 46.5875 7.7168 46.2828 7.70386Z"
+    />
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M46.0006 13C45.8834 13 45.7662 13 45.6529 13.0122C45.481 13.031 45.3209 13.0786 45.1998 13.2C44.0982 13.7 43.5982 15 44.0982 16.1001C44.5904 17.1841 44.6998 18.2683 44.7975 19.2566V19.3V20.9001C44.7975 21.4001 44.5982 22 44.1998 22.5C44.0318 22.7087 43.9185 22.9348 43.8404 23.1638C43.7975 23.2952 43.7662 23.4277 43.7428 23.5583L43.7154 23.7734C43.7037 23.8855 43.6998 23.9951 43.6998 24.1001C38.1998 24.6001 33.2975 27 29.5006 30.7C29.0006 30.4001 28.5982 30.1001 27.899 30.1001C27.3287 30.1001 26.8248 29.9678 26.4928 29.7029C26.4185 29.6421 26.3521 29.5745 26.2975 29.5C25.9146 29.2112 25.5318 28.8298 25.1451 28.4448L25.0982 28.4001C24.2975 27.6001 23.5982 26.8 23.0006 25.8C22.8873 25.6089 22.7584 25.4324 22.606 25.2761L22.5006 25.1716L22.3795 25.0667C22.274 24.9839 22.1607 24.9094 22.0396 24.8447L21.8365 24.7515L21.6998 24.7C20.5006 24.4001 19.2975 25 19.0006 26.2C18.9537 26.3779 18.9303 26.561 18.9264 26.7441C18.9225 26.9023 18.9381 27.0608 18.9654 27.2161C19.0162 27.4731 19.106 27.7217 19.2389 27.9468C19.5084 28.4014 19.9381 28.76 20.5006 28.9001C21.5982 29.2 22.5982 29.8 23.5006 30.4001L23.8717 30.6663L23.9185 30.6973C24.2115 30.9065 24.5279 31.1306 24.7975 31.4001C24.9693 31.5039 25.11 31.644 25.2232 31.8076L25.3209 31.969L25.3795 32.073C25.5084 32.3269 25.606 32.6135 25.6998 32.9001C25.7975 33.5 26.1998 33.9001 26.5982 34.3C23.899 38.2 22.1998 42.9001 22.1998 48.1001V50.646C21.8209 50.8188 21.3678 50.9392 21.0006 51.4001C20.7935 51.6592 20.5592 51.8911 20.2975 52.0547C20.1607 52.1409 20.0162 52.2083 19.8639 52.2502C19.7935 52.27 19.7193 52.2842 19.6412 52.2922L19.5006 52.3L18.6998 52.4502L17.899 52.6001C16.7975 52.7 15.6998 52.8 14.5982 52.6001C14.0006 52.6001 13.399 52.6001 12.899 53C12.4967 53.2827 12.2232 53.6636 12.0865 54.083C11.8834 54.7017 11.981 55.4041 12.399 56C13.0982 57 14.5006 57.2 15.399 56.5C16.399 55.8 17.399 55.4001 18.399 55.1001C18.899 54.9001 19.399 54.8 20.0006 54.7C20.5006 54.5 21.0982 54.7 21.6998 54.9001C22.1998 55.2 22.6998 55.1001 23.0982 55.1001C24.899 60.8 28.6998 65.6001 33.6998 68.6001C33.5006 69.1001 33.399 69.6001 33.5006 70.2C33.5982 70.9001 33.5982 71.5 33.399 71.9001C33.2975 72.1501 33.1725 72.4001 33.0475 72.6501C32.9225 72.9001 32.7975 73.1501 32.6998 73.4001C32.0982 74.3 31.5006 75.2 30.6998 76C30.2975 76.4001 30.0006 76.9001 30.0006 77.5C30.0006 77.8628 30.0826 78.2073 30.231 78.5112C30.356 78.7708 30.5318 79.0007 30.7428 79.1877C30.8209 79.2561 30.9029 79.3186 30.9889 79.3745C31.1178 79.4592 31.2545 79.5293 31.4068 79.5825C31.6217 79.6584 31.856 79.7 32.0982 79.7C33.2975 79.7 34.2975 78.8 34.399 77.6001C34.399 76.927 34.4928 76.3169 34.6451 75.7168C34.7662 75.2471 34.9225 74.7832 35.0982 74.3L35.6998 72.8C35.7545 72.6614 35.8326 72.5305 35.9264 72.4072C35.985 72.3323 36.0514 72.2603 36.1178 72.1912L36.2896 72.033L36.442 71.9089C36.5865 71.7964 36.7428 71.6934 36.899 71.6001C37.1451 71.4778 37.3248 71.3391 37.4693 71.1838C37.6803 70.9578 37.8209 70.6965 38.0006 70.4001C40.5006 71.3 43.1998 71.8 46.0982 71.8C49.0006 71.8 51.6998 71.3 54.2975 70.3L54.3678 70.4231C54.6334 70.8662 54.8482 71.2251 55.399 71.5C55.735 71.668 56.0396 71.8669 56.2623 72.0974C56.4342 72.2788 56.5553 72.4797 56.5982 72.7L57.1998 74.2C57.5982 75.2 57.899 76.3 57.899 77.5C57.899 78.1001 58.0982 78.6001 58.5982 79.1001C59.0123 79.4673 59.5318 79.645 60.0475 79.6523C60.3678 79.6567 60.6881 79.5955 60.985 79.4727C61.1529 79.4036 61.3131 79.3152 61.4576 79.2083C61.5435 79.1453 61.6256 79.0757 61.6998 79C62.5006 78.1001 62.399 76.7 61.5982 75.9001C61.2232 75.5659 60.899 75.2144 60.6139 74.8452C60.2154 74.3306 59.8912 73.7822 59.5982 73.2C59.5045 73.0447 59.4185 72.8894 59.3443 72.7373C59.2506 72.5527 59.1685 72.3723 59.0904 72.2017L58.899 71.8C58.7232 71.5076 58.649 71.1809 58.6607 70.8401C58.6685 70.5981 58.7154 70.3491 58.7975 70.1001C59.0006 69.4001 58.7975 68.9001 58.5982 68.4001C63.5982 65.3 67.399 60.5 69.0982 54.8C69.6998 54.8 70.1998 54.9001 70.7975 54.6001C71.1959 54.4016 71.5943 54.2905 71.9654 54.2671C72.1529 54.2551 72.3326 54.2661 72.5006 54.3C73.0006 54.3 73.5982 54.5 74.0982 54.6001C74.4537 54.7065 74.8209 54.8254 75.192 54.9614C75.8678 55.209 76.5553 55.5129 77.1998 55.9001C77.3834 56.011 77.5826 56.0947 77.7896 56.1509C77.9576 56.1965 78.1334 56.2241 78.3092 56.2336C78.5045 56.2441 78.6998 56.2329 78.899 56.2C80.0982 55.9001 80.7975 54.8 80.5982 53.6001C80.2975 52.4001 79.1998 51.7 78.0006 51.9001C77.8053 51.9487 77.6178 51.9868 77.4342 52.0161C77.1451 52.0613 76.8678 52.0854 76.5943 52.095L76.2076 52.0994C75.7271 52.0938 75.2584 52.0508 74.7701 52.0059L74.6998 52C74.1998 52 73.5982 51.9001 73.0982 51.7C72.817 51.7 72.5357 51.5745 72.2545 51.3762C72.0357 51.2205 71.817 51.02 71.5982 50.8C71.0982 50.3 70.5982 50.1001 70.0982 50C70.0982 49.6001 70.1256 49.2251 70.149 48.8501C70.1725 48.4751 70.1998 48.1001 70.1998 47.7C70.1998 42.7 68.6998 38.1001 66.0982 34.3C66.5006 33.9001 66.899 33.5 67.0006 32.8C67.1998 32.2 67.399 31.6001 67.899 31.3L68.2154 31.0076C68.3248 30.9089 68.4381 30.8162 68.5592 30.7268C68.7584 30.5779 68.9693 30.439 69.1998 30.3L69.8834 29.8538C70.0592 29.7419 70.2389 29.6331 70.4225 29.5291C70.9537 29.2275 71.5318 28.9673 72.1998 28.8C73.1568 28.5608 73.2232 28.3853 73.3639 28.02C73.399 27.927 73.4381 27.8218 73.5006 27.7C74.0982 26.6001 73.5982 25.3 72.5982 24.8C71.5006 24.2 70.1998 24.7 69.6998 25.7C69.1998 26.7 68.399 27.6001 67.6998 28.3C67.2975 28.7 66.899 29 66.5006 29.4001C66.0982 29.8 65.5006 29.9001 64.899 30C64.1998 30 63.7975 30.3 63.2975 30.6001C59.5006 26.8 54.399 24.3 48.7975 23.8C48.7975 23.48 48.7975 23.1189 48.6685 22.7693C48.5943 22.5728 48.4771 22.3799 48.2975 22.2C47.899 21.7 47.5982 21.1001 47.6998 20.6001V19C47.7232 18.7336 47.7545 18.4673 47.7935 18.2024L47.8482 17.8342C47.8834 17.615 47.9264 17.3972 47.9732 17.1819C48.0123 17.0122 48.0553 16.844 48.106 16.6775L48.1646 16.4775L48.2389 16.25L48.399 15.8C48.5982 15.3 48.5982 14.7 48.399 14.1001C48.1412 13.5859 47.7193 13.1958 47.2389 12.9827C46.9693 12.864 46.6842 12.8 46.399 12.8L46.0006 13ZM22.2975 50.6001L22.2389 50.6292C22.2545 50.4785 22.2701 50.3877 22.2975 50.6001ZM43.0982 28.2V29C42.6998 31.2 42.5006 33.3 42.2975 35.5L42.0006 38.8999L39.0006 36.8C37.1998 35.5999 35.399 34.3999 33.5006 33.2L32.899 32.8C35.6998 30.3999 39.1998 28.7 43.0982 28.2ZM49.0006 28.2156L48.899 28.2002L49.0006 28.1001V28.2156ZM49.0006 28.2156C50.2857 28.4146 51.5318 28.7275 52.7232 29.1475C53.5982 29.4561 54.4459 29.8225 55.2623 30.2444C56.7545 31.0166 58.1412 31.9739 59.399 33.1001L58.6998 33.5L53.2975 37.1001L51.1998 38.6001C50.6998 39 49.899 38.6001 49.899 38C49.899 37.1001 49.7975 36.3 49.6998 35.4001C49.5006 33.2002 49.2975 31.1001 49.0006 28.9001V28.2156ZM29.2037 37.2L29.2584 37.2651C27.2818 40.3518 26.1021 44.0281 26.1021 48V49.0999L27.0006 48.8C29.1021 48 31.1021 47.3999 33.2037 46.7C34.1021 46.3999 35.1021 46.0999 36.1021 45.8C36.3053 45.7322 36.4615 45.5957 36.5631 45.4292C36.606 45.3577 36.6373 45.2805 36.6568 45.2007C36.6881 45.0825 36.6959 44.9587 36.6725 44.8398C36.6412 44.6753 36.5514 44.5198 36.4029 44.3999C35.7037 43.8 35.1021 43.2 34.4029 42.5L32.8795 41C31.8482 39.9915 30.8014 38.968 29.8014 37.8999L29.2584 37.2651L29.3014 37.2H29.2037ZM66.0006 49V48C66.0006 44.2002 64.899 40.6001 63.0982 37.6001L62.5982 38.2002C61.7701 39.0842 60.9107 39.9683 60.0553 40.8354L58.0006 42.9001C57.0006 43.9001 55.899 44.8 54.899 45.8C56.2975 46.1001 57.5982 46.5 59.0006 46.9001C60.235 47.2537 61.4732 47.6074 62.7076 47.9814L64.0084 48.3831L65.2975 48.8L66.0006 49ZM44.8014 44H47.2037C47.6021 44 47.9029 44.2 48.1021 44.5L49.7037 46.5C49.8014 46.6492 49.8756 46.7983 49.9107 46.9597C49.9498 47.123 49.9537 47.2988 49.9029 47.5L49.3014 49.8999C49.3014 50.3 49.0006 50.6001 48.7037 50.8L46.5006 51.8C46.4303 51.8489 46.3482 51.8857 46.2662 51.9106C46.1959 51.9316 46.1256 51.9443 46.0553 51.9485C45.8639 51.9597 45.6646 51.9102 45.5006 51.8L43.3014 50.8C43.0006 50.6001 42.7037 50.3 42.7037 49.8999L42.1021 47.5C42.1021 47.2 42.1021 46.8 42.3014 46.5L43.9029 44.5C44.1021 44.2 44.5006 44 44.8014 44ZM38.4029 54.6001C38.6021 54 38.1021 53.5 37.5006 53.5V53.6001C36.6021 53.8 35.6021 54 34.7037 54C33.5787 54.1021 32.485 54.2302 31.3873 54.3711L28.9146 54.7026L28.2037 54.8H27.1021C28.6021 58.8999 31.3014 62.3 34.9029 64.7L35.2037 63.8C35.8014 61.7 36.6021 59.7 37.3014 57.6001C37.5006 57.1001 37.6764 56.6001 37.8521 56.1001C38.0279 55.6001 38.2037 55.1001 38.4029 54.6001ZM54.8014 53.8C55.1998 53.8 55.6178 53.8394 56.0396 53.8918L56.7154 53.9834C57.0162 54.0259 57.3131 54.0681 57.6021 54.1001L58.1178 54.147C60.1295 54.3306 62.0709 54.5078 64.1021 54.6001H64.8014C63.399 58.7 60.6998 62.1001 57.1998 64.5L57.0006 63.8C56.6295 62.6851 56.2584 61.5981 55.8834 60.5095L54.899 57.6001C54.6021 56.7 54.3014 55.8 53.899 54.9001C53.7935 54.5879 53.8795 54.2756 54.0709 54.062C54.2467 53.865 54.5123 53.752 54.8014 53.8ZM46.5201 57.885C46.3951 57.8245 46.2467 57.8 46.1021 57.8H46.0006C45.6998 57.8 45.5006 57.9001 45.3014 58.2C44.899 59 44.399 59.9001 43.899 60.7C42.8014 62.6001 41.6998 64.5 40.5006 66.3L40.0006 67.1001C41.899 67.7 43.6998 68 45.899 68C46.8131 68 47.6959 67.9482 48.5475 67.8445C49.7467 67.6987 50.8912 67.4507 52.0006 67.1001L51.5006 66.3C50.8131 65.1736 50.1256 64.0081 49.4381 62.8279L48.1998 60.7C47.6998 59.9001 47.1998 59 46.8014 58.2C46.7506 58.0479 46.649 57.9473 46.5201 57.885Z"
+    />
   </svg>
 <% when "hero-refresh" %>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+    />
   </svg>
 <% when "hero-pencil" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path d="m 11 4 h -7 a 2 2 0 0 0 -2 2 v 14 a 2 2 0 0 0 2 2 h 14 a 2 2 0 0 0 2 -2 v -7"/>
-  <path d="M 18.5 2.5 A 2.121 2.121 0 0 1 21.5 5.5 L 12 15 L 8 16 L 9 12 L 18.5 2.5 Z"/>
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      d="m 11 4 h -7 a 2 2 0 0 0 -2 2 v 14 a 2 2 0 0 0 2 2 h 14 a 2 2 0 0 0 2 -2 v -7"
+    />
+    <path
+      d="M 18.5 2.5 A 2.121 2.121 0 0 1 21.5 5.5 L 12 15 L 8 16 L 9 12 L 18.5 2.5 Z"
+    />
+  </svg>
 <% when "hero-check-circle" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
+  </svg>
 <% when "hero-squares-plus" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z"
+    />
+  </svg>
 <% when "hero-cpu-chip" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Zm.75-12h9v9h-9v-9Z" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Zm.75-12h9v9h-9v-9Z"
+    />
+  </svg>
 <% when "hero-square-2-stack-modified" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M7 6.25A2.25 2.25 90 019.25 3.75M12 3.75H14.5M17.5 3.75A2.25 2.25 90 0119.75 6M19.75 9V11.25M19.75 14.25A2.25 2.25 90 0117.5 16.5M7 8.25H5.5A2.25 2.25 90 003.25 10.5V18A2.25 2.25 90 005.5 20.25H13A2.25 2.25 90 0015.25 18V16.5M7 8.25H13A2.25 2.25 90 0115.25 10.5V16.5" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M7 6.25A2.25 2.25 90 019.25 3.75M12 3.75H14.5M17.5 3.75A2.25 2.25 90 0119.75 6M19.75 9V11.25M19.75 14.25A2.25 2.25 90 0117.5 16.5M7 8.25H5.5A2.25 2.25 90 003.25 10.5V18A2.25 2.25 90 005.5 20.25H13A2.25 2.25 90 0015.25 18V16.5M7 8.25H13A2.25 2.25 90 0115.25 10.5V16.5"
+    />
+  </svg>
 <% when "postgres-logo" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 512 512" stroke-width="10" stroke="currentColor" class="<%= classes %>">
-    <path stroke-linecap="round" stroke-linejoin="round"  d="M500.5,310.1c-5.5-6.3-14.8-4.6-22-3.2c-17.3,3.1-36.2,6.7-53-0.5c30-47.3,53.6-99,66.8-153.6 c4.8-20.7,8.5-42,7.8-63.3c-0.5-11.9-2.2-24.7-9.5-34.6c-18.1-23.8-44.3-41.2-73.2-49c-36.1-9.8-74.8-6.9-110.3,4.1 c-2.9,0.6-5.8-0.7-8.7-1.1c-32.2-6.5-67.7-4-95.6,14.7C169.3,11.6,133.3,4.3,97.6,8C71,10.8,44.4,23.1,29.1,45.7 C9.9,73.9,7.3,109.9,10.4,143c6.2,43.9,16.9,87.1,30.5,129.2c9,26.3,18.8,52.7,34.8,75.7c8.1,11.3,18.9,22.6,33.4,24.4 c12.9,1.6,24.5-6.4,32.4-15.9c13.7-16.3,27.7-32.4,42.3-47.9c9.5,4.7,19.9,7.3,30.4,8.1c-5.7,6.8-10.4,15.6-19.5,18.3 c-12.3,4.7-26.6,4.1-37.4,12.3c-6.2,4.5-6.5,14.2-0.9,19.3c10.1,9.8,25.1,11.9,38.5,13.1c19.1,1.5,38.4-5,52.9-17.5 c-0.1,30.4,0,60.8,3.5,91c1.7,17.7,9.3,35.3,22.8,47.2c12.7,11.1,30.7,13.4,46.8,10.6c15.8-3,32-7.7,44.4-18.5 c13.1-11.6,18.7-29,21.3-45.8c4.7-30,8.3-60.2,11.7-90.3c33.8,5.7,71.9-0.8,97.2-25.4C500.7,325.8,505.8,317,500.5,310.1z  M425.6,24.6c20.3,7.7,38.3,21.1,51.8,38c6.4,8.1,7.3,18.9,7.7,28.9c0.3,23.7-4.5,47-10.6,69.8c-11.6,42.1-29.3,82.5-51.5,120.1 c-2.2,3.7-4.6,7.3-7.2,10.7l-0.8-4.2c2.8-7.2,6.8-14.1,8.4-21.8c5.5-21.7,0.9-44-1.1-65.8c-2.1-20.6,4.9-40.7,4.8-61.2 c0.8-10.1-3.2-19.6-7.1-28.6c-14-31.3-36.3-59.1-64.8-78.3c-7-4.8-14.7-8.1-21.7-12.9C363.7,12.7,396.3,13.5,425.6,24.6L425.6,24.6 z M407.1,200.3c1.8,24.4,8.9,50.5-2.6,73.7c-15.4-30.7-35.3-59.9-42.3-94.1c-2-10.9-2.5-24.6,7.2-32.2c12.2-8.7,28.2-6.7,42.4-5.9 C411.1,161.4,405.1,180.6,407.1,200.3L407.1,200.3z M131.6,344.7c-5.5,6.5-13,14.3-22.4,12.3c-11-3.2-18-13.2-24.2-22.3 c-16.6-26.5-26.6-56.5-35.8-86.3c-10.3-35.2-18.9-71-23.9-107.4c-2.5-27.7-0.9-57.4,13.2-82c10.6-18.7,30.4-30.6,51.2-34.5 c33.3-6.4,67.4,0.4,99.3,10.1C175,50.2,164,68.5,157.6,88.4c-8.7,26.7-12.7,55-10.6,83c1.2,19.7,0.7,39.6-2.1,59.1 c-3.5,25.6,6.8,51.8,25.8,69.1C157.8,314.8,144.1,329.2,131.6,344.7L131.6,344.7z M160.7,253.1c-3.3-14.5,1-29,1.5-43.5 c1.1-16.4,0-32.8-0.4-49.3c15.3-9.9,33.3-17.7,51.9-16.6c9.6,0.4,18.5,7.2,20.8,16.7c8.4,33.6,11.1,71-5.1,102.9 c-5.6,12.3-10.2,25-14.2,37.9C188.3,301.5,165.5,278.7,160.7,253.1L160.7,253.1z M244.4,343.1c-16.9,22.9-50.7,27.2-75.1,14.8 c12-5.6,26.1-5.1,37.8-12c11.2-6.1,15.7-19.4,26.2-26.2C244.8,318,253.1,335.1,244.4,343.1L244.4,343.1z M389.3,316.4 c-6.4,10.3-4.2,22.9-5.7,34.4c-3.7,32.2-7.3,64.4-12.5,96.3c-2.5,15.3-9,31.6-23.4,39.2c-14.8,7.5-32,12.3-48.7,9.7 c-15.8-2.8-25.8-17.5-30.3-31.9c-3.3-12-3.6-24.6-4.5-37c-1.6-29.9-1.6-59.9-0.8-89.9c0.7-11.7-5.3-23.9-15.8-29.6 c-5.1-2.8-11-3.2-16.6-3.7c4.4-22,17.8-41,22.4-63c6-27.2,2.7-55.5-3.4-82.4c-3-13.4-13.2-25.3-26.8-28.5 c-20.9-5.3-42,2.9-60.7,11.6c2.4-30.4,10.5-61.5,29.1-86.1C205.2,37.3,226.4,25,249,22.1c37.4-4.8,76.6,5.5,106.3,28.9 c24.5,19.4,43.9,45.7,54.4,75.2c-17.4-0.6-37.1-1.3-51.1,10.7c-12.7,10.7-14.4,29.1-11.5,44.5c6.6,36.6,28.3,67.7,44.2,100.6 c4.2,7.7,9.9,14.5,15.3,21.4C400.2,306.7,393,309.8,389.3,316.4L389.3,316.4z M434,342.3c-11.5,1.4-23.4,1.8-34.5-2 c0-6.3-0.3-13.7,4.7-18.3c4-2.9,9.6-5.6,14.2-2.4c19.6,10.3,42.3,5.3,63.2,2.8C469,334.6,451.3,340.4,434,342.3z M373.9,152.3 c-4.1,3.4,0.3,8.4,3.8,9.9c8.5,5,20.1-2,20.4-11.7C390.4,146.9,380.8,147.3,373.9,152.3L373.9,152.3z M223.6,167.7 c3.6-2,7.4-7.7,3.2-11.1c-6-4.8-14.6-5.8-21.9-3.8c-2.3,0.8-4.8,2.4-4.3,5.3C202.3,167.9,215.3,173.8,223.6,167.7L223.6,167.7z"/>
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    stroke-width="10"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M500.5,310.1c-5.5-6.3-14.8-4.6-22-3.2c-17.3,3.1-36.2,6.7-53-0.5c30-47.3,53.6-99,66.8-153.6 c4.8-20.7,8.5-42,7.8-63.3c-0.5-11.9-2.2-24.7-9.5-34.6c-18.1-23.8-44.3-41.2-73.2-49c-36.1-9.8-74.8-6.9-110.3,4.1 c-2.9,0.6-5.8-0.7-8.7-1.1c-32.2-6.5-67.7-4-95.6,14.7C169.3,11.6,133.3,4.3,97.6,8C71,10.8,44.4,23.1,29.1,45.7 C9.9,73.9,7.3,109.9,10.4,143c6.2,43.9,16.9,87.1,30.5,129.2c9,26.3,18.8,52.7,34.8,75.7c8.1,11.3,18.9,22.6,33.4,24.4 c12.9,1.6,24.5-6.4,32.4-15.9c13.7-16.3,27.7-32.4,42.3-47.9c9.5,4.7,19.9,7.3,30.4,8.1c-5.7,6.8-10.4,15.6-19.5,18.3 c-12.3,4.7-26.6,4.1-37.4,12.3c-6.2,4.5-6.5,14.2-0.9,19.3c10.1,9.8,25.1,11.9,38.5,13.1c19.1,1.5,38.4-5,52.9-17.5 c-0.1,30.4,0,60.8,3.5,91c1.7,17.7,9.3,35.3,22.8,47.2c12.7,11.1,30.7,13.4,46.8,10.6c15.8-3,32-7.7,44.4-18.5 c13.1-11.6,18.7-29,21.3-45.8c4.7-30,8.3-60.2,11.7-90.3c33.8,5.7,71.9-0.8,97.2-25.4C500.7,325.8,505.8,317,500.5,310.1z  M425.6,24.6c20.3,7.7,38.3,21.1,51.8,38c6.4,8.1,7.3,18.9,7.7,28.9c0.3,23.7-4.5,47-10.6,69.8c-11.6,42.1-29.3,82.5-51.5,120.1 c-2.2,3.7-4.6,7.3-7.2,10.7l-0.8-4.2c2.8-7.2,6.8-14.1,8.4-21.8c5.5-21.7,0.9-44-1.1-65.8c-2.1-20.6,4.9-40.7,4.8-61.2 c0.8-10.1-3.2-19.6-7.1-28.6c-14-31.3-36.3-59.1-64.8-78.3c-7-4.8-14.7-8.1-21.7-12.9C363.7,12.7,396.3,13.5,425.6,24.6L425.6,24.6 z M407.1,200.3c1.8,24.4,8.9,50.5-2.6,73.7c-15.4-30.7-35.3-59.9-42.3-94.1c-2-10.9-2.5-24.6,7.2-32.2c12.2-8.7,28.2-6.7,42.4-5.9 C411.1,161.4,405.1,180.6,407.1,200.3L407.1,200.3z M131.6,344.7c-5.5,6.5-13,14.3-22.4,12.3c-11-3.2-18-13.2-24.2-22.3 c-16.6-26.5-26.6-56.5-35.8-86.3c-10.3-35.2-18.9-71-23.9-107.4c-2.5-27.7-0.9-57.4,13.2-82c10.6-18.7,30.4-30.6,51.2-34.5 c33.3-6.4,67.4,0.4,99.3,10.1C175,50.2,164,68.5,157.6,88.4c-8.7,26.7-12.7,55-10.6,83c1.2,19.7,0.7,39.6-2.1,59.1 c-3.5,25.6,6.8,51.8,25.8,69.1C157.8,314.8,144.1,329.2,131.6,344.7L131.6,344.7z M160.7,253.1c-3.3-14.5,1-29,1.5-43.5 c1.1-16.4,0-32.8-0.4-49.3c15.3-9.9,33.3-17.7,51.9-16.6c9.6,0.4,18.5,7.2,20.8,16.7c8.4,33.6,11.1,71-5.1,102.9 c-5.6,12.3-10.2,25-14.2,37.9C188.3,301.5,165.5,278.7,160.7,253.1L160.7,253.1z M244.4,343.1c-16.9,22.9-50.7,27.2-75.1,14.8 c12-5.6,26.1-5.1,37.8-12c11.2-6.1,15.7-19.4,26.2-26.2C244.8,318,253.1,335.1,244.4,343.1L244.4,343.1z M389.3,316.4 c-6.4,10.3-4.2,22.9-5.7,34.4c-3.7,32.2-7.3,64.4-12.5,96.3c-2.5,15.3-9,31.6-23.4,39.2c-14.8,7.5-32,12.3-48.7,9.7 c-15.8-2.8-25.8-17.5-30.3-31.9c-3.3-12-3.6-24.6-4.5-37c-1.6-29.9-1.6-59.9-0.8-89.9c0.7-11.7-5.3-23.9-15.8-29.6 c-5.1-2.8-11-3.2-16.6-3.7c4.4-22,17.8-41,22.4-63c6-27.2,2.7-55.5-3.4-82.4c-3-13.4-13.2-25.3-26.8-28.5 c-20.9-5.3-42,2.9-60.7,11.6c2.4-30.4,10.5-61.5,29.1-86.1C205.2,37.3,226.4,25,249,22.1c37.4-4.8,76.6,5.5,106.3,28.9 c24.5,19.4,43.9,45.7,54.4,75.2c-17.4-0.6-37.1-1.3-51.1,10.7c-12.7,10.7-14.4,29.1-11.5,44.5c6.6,36.6,28.3,67.7,44.2,100.6 c4.2,7.7,9.9,14.5,15.3,21.4C400.2,306.7,393,309.8,389.3,316.4L389.3,316.4z M434,342.3c-11.5,1.4-23.4,1.8-34.5-2 c0-6.3-0.3-13.7,4.7-18.3c4-2.9,9.6-5.6,14.2-2.4c19.6,10.3,42.3,5.3,63.2,2.8C469,334.6,451.3,340.4,434,342.3z M373.9,152.3 c-4.1,3.4,0.3,8.4,3.8,9.9c8.5,5,20.1-2,20.4-11.7C390.4,146.9,380.8,147.3,373.9,152.3L373.9,152.3z M223.6,167.7 c3.6-2,7.4-7.7,3.2-11.1c-6-4.8-14.6-5.8-21.9-3.8c-2.3,0.8-4.8,2.4-4.3,5.3C202.3,167.9,215.3,173.8,223.6,167.7L223.6,167.7z"
+    />
+  </svg>
 <% when "plug-disconnected" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="<%= classes %>">
-  <path d="M21.78 3.28a.75.75 0 0 0-1.06-1.06l-2.012 2.012a4.251 4.251 0 0 0-5.463.462l-1.068 1.069a1.75 1.75 0 0 0 0 2.474l3.585 3.586a1.75 1.75 0 0 0 2.475 0l1.068-1.068a4.251 4.251 0 0 0 .463-5.463L21.78 3.28Zm-3.585 2.475l.022.023l.003.002l.002.003l.023.022a2.75 2.75 0 0 1 0 3.89l-1.068 1.067a.25.25 0 0 1-.354 0l-3.586-3.585a.25.25 0 0 1 0-.354l1.068-1.068a2.75 2.75 0 0 1 3.89 0ZM10.78 11.28a.75.75 0 1 0-1.06-1.06L8 11.94l-.47-.47a.75.75 0 0 0-1.06 0l-1.775 1.775a4.251 4.251 0 0 0-.463 5.463L2.22 20.72a.75.75 0 1 0 1.06 1.06l2.012-2.012a4.251 4.251 0 0 0 5.463-.463l1.775-1.775a.75.75 0 0 0 0-1.06l-.47-.47l1.72-1.72a.75.75 0 1 0-1.06-1.06L11 14.94L9.06 13l1.72-1.72Zm-3.314 2.247l.004.003l.003.004l2.993 2.993l.004.003l.003.004l.466.466l-1.244 1.245a2.75 2.75 0 0 1-3.89 0l-.05-.05a2.75 2.75 0 0 1 0-3.89L7 13.062l.466.466Z"/>
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    class="<%= classes %>"
+  >
+    <path
+      d="M21.78 3.28a.75.75 0 0 0-1.06-1.06l-2.012 2.012a4.251 4.251 0 0 0-5.463.462l-1.068 1.069a1.75 1.75 0 0 0 0 2.474l3.585 3.586a1.75 1.75 0 0 0 2.475 0l1.068-1.068a4.251 4.251 0 0 0 .463-5.463L21.78 3.28Zm-3.585 2.475l.022.023l.003.002l.002.003l.023.022a2.75 2.75 0 0 1 0 3.89l-1.068 1.067a.25.25 0 0 1-.354 0l-3.586-3.585a.25.25 0 0 1 0-.354l1.068-1.068a2.75 2.75 0 0 1 3.89 0ZM10.78 11.28a.75.75 0 1 0-1.06-1.06L8 11.94l-.47-.47a.75.75 0 0 0-1.06 0l-1.775 1.775a4.251 4.251 0 0 0-.463 5.463L2.22 20.72a.75.75 0 1 0 1.06 1.06l2.012-2.012a4.251 4.251 0 0 0 5.463-.463l1.775-1.775a.75.75 0 0 0 0-1.06l-.47-.47l1.72-1.72a.75.75 0 1 0-1.06-1.06L11 14.94L9.06 13l1.72-1.72Zm-3.314 2.247l.004.003l.003.004l2.993 2.993l.004.003l.003.004l.466.466l-1.244 1.245a2.75 2.75 0 0 1-3.89 0l-.05-.05a2.75 2.75 0 0 1 0-3.89L7 13.062l.466.466Z"
+    />
+  </svg>
 <% when "hero-chart-pie" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
-  <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z"
+    />
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"
+    />
+  </svg>
 <% when "hero-arrow-top-right-on-square" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+    />
+  </svg>
 <% when "read-replica" %>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="<%= classes %>">
-  <path fill="currentColor" d="m9.1 19.7l-.3-.7l.2-.4c-1.9-.5-3-1.3-3-1.6v-2.2c1.3.6 2.8 1 4.6 1.2c.7-.8 1.6-1.5 2.5-2H12c-2.4 0-4.7-.6-6-1.5V9.6c1.5.8 3.6 1.4 6 1.4s4.5-.5 6-1.4v2.8c-.3.2-.6.4-1 .6c1 0 2 .2 3 .6V7c0-2.2-3.6-4-8-4S4 4.8 4 7v10c0 1.8 2.4 3.3 5.7 3.8c-.2-.3-.4-.7-.6-1.1M12 5c3.9 0 6 1.5 6 2s-2.1 2-6 2s-6-1.5-6-2s2.1-2 6-2m5 13c.6 0 1 .4 1 1s-.4 1-1 1s-1-.4-1-1s.4-1 1-1m0-3c-2.7 0-5.1 1.7-6 4c.9 2.3 3.3 4 6 4s5.1-1.7 6-4c-.9-2.3-3.3-4-6-4m0 6.5c-1.4 0-2.5-1.1-2.5-2.5s1.1-2.5 2.5-2.5s2.5 1.1 2.5 2.5s-1.1 2.5-2.5 2.5Z"/>
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    class="<%= classes %>"
+  >
+    <path
+      fill="currentColor"
+      d="m9.1 19.7l-.3-.7l.2-.4c-1.9-.5-3-1.3-3-1.6v-2.2c1.3.6 2.8 1 4.6 1.2c.7-.8 1.6-1.5 2.5-2H12c-2.4 0-4.7-.6-6-1.5V9.6c1.5.8 3.6 1.4 6 1.4s4.5-.5 6-1.4v2.8c-.3.2-.6.4-1 .6c1 0 2 .2 3 .6V7c0-2.2-3.6-4-8-4S4 4.8 4 7v10c0 1.8 2.4 3.3 5.7 3.8c-.2-.3-.4-.7-.6-1.1M12 5c3.9 0 6 1.5 6 2s-2.1 2-6 2s-6-1.5-6-2s2.1-2 6-2m5 13c.6 0 1 .4 1 1s-.4 1-1 1s-1-.4-1-1s.4-1 1-1m0-3c-2.7 0-5.1 1.7-6 4c.9 2.3 3.3 4 6 4s5.1-1.7 6-4c-.9-2.3-3.3-4-6-4m0 6.5c-1.4 0-2.5-1.1-2.5-2.5s1.1-2.5 2.5-2.5s2.5 1.1 2.5 2.5s-1.1 2.5-2.5 2.5Z"
+    />
+  </svg>
 <% when "hero-cloud-arrow-up" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z"
+    />
+  </svg>
 <% when "fork" %>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" stroke="currentColor" class="<%= classes %>">
-  <path d="M124 166.291v179.418a76 76 0 1 0 32 0V282h152a80.091 80.091 0 0 0 80-80v-36.689a75.983 75.983 0 1 0-32 1.733V202a48.055 48.055 0 0 1-48 48H156v-83.709a76 76 0 1 0-32 0ZM324 92a44 44 0 1 1 44 44a44.049 44.049 0 0 1-44-44ZM184 420a44 44 0 1 1-44-44a44.049 44.049 0 0 1 44 44ZM140 48a44 44 0 1 1-44 44a44.049 44.049 0 0 1 44-44Z"/>
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 512 512"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      d="M124 166.291v179.418a76 76 0 1 0 32 0V282h152a80.091 80.091 0 0 0 80-80v-36.689a75.983 75.983 0 1 0-32 1.733V202a48.055 48.055 0 0 1-48 48H156v-83.709a76 76 0 1 0-32 0ZM324 92a44 44 0 1 1 44 44a44.049 44.049 0 0 1-44-44ZM184 420a44 44 0 1 1-44-44a44.049 44.049 0 0 1 44 44ZM140 48a44 44 0 1 1-44 44a44.049 44.049 0 0 1 44-44Z"
+    />
+  </svg>
 <% when "hero-cog-8-tooth" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%= classes %>">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.559.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.894.149c-.424.07-.764.383-.929.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.398.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.272-.806.108-1.204-.165-.397-.506-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.108-1.204l-.526-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894Z" />
-  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.559.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.894.149c-.424.07-.764.383-.929.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.398.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.272-.806.108-1.204-.165-.397-.506-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.108-1.204l-.526-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894Z"
+    />
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+    />
+  </svg>
 <% when "shell" %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 24 24" stroke-width="0.1" stroke="currentColor" class="<%= classes %>">
-<path fill-rule="evenodd" d="M2 6C2 4.34315 3.34315 3 5 3H19C20.6569 3 22 4.34315 22 6V18C22 19.6569 20.6569 21 19 21H5C3.34315 21 2 19.6569 2 18V6ZM5 5C4.44772 5 4 5.44772 4 6V7H20V6C20 5.44772 19.5523 5 19 5H5ZM4 18V9H20V18C20 18.5523 19.5523 19 19 19H5C4.44772 19 4 18.5523 4 18ZM7.70711 11.2929C7.31658 10.9024 6.68342 10.9024 6.29289 11.2929C5.90237 11.6834 5.90237 12.3166 6.29289 12.7071L7.58579 14L6.29289 15.2929C5.90237 15.6834 5.90237 16.3166 6.29289 16.7071C6.68342 17.0976 7.31658 17.0976 7.70711 16.7071L9.70711 14.7071C10.0976 14.3166 10.0976 13.6834 9.70711 13.2929L7.70711 11.2929Z"/>
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="white"
+    viewBox="0 0 24 24"
+    stroke-width="0.1"
+    stroke="currentColor"
+    class="<%= classes %>"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M2 6C2 4.34315 3.34315 3 5 3H19C20.6569 3 22 4.34315 22 6V18C22 19.6569 20.6569 21 19 21H5C3.34315 21 2 19.6569 2 18V6ZM5 5C4.44772 5 4 5.44772 4 6V7H20V6C20 5.44772 19.5523 5 19 5H5ZM4 18V9H20V18C20 18.5523 19.5523 19 19 19H5C4.44772 19 4 18.5523 4 18ZM7.70711 11.2929C7.31658 10.9024 6.68342 10.9024 6.29289 11.2929C5.90237 11.6834 5.90237 12.3166 6.29289 12.7071L7.58579 14L6.29289 15.2929C5.90237 15.6834 5.90237 16.3166 6.29289 16.7071C6.68342 17.0976 7.31658 17.0976 7.70711 16.7071L9.70711 14.7071C10.0976 14.3166 10.0976 13.6834 9.70711 13.2929L7.70711 11.2929Z"
+    />
+  </svg>
 <%
 #:nocov:
 else

--- a/views/components/icon_with_text.erb
+++ b/views/components/icon_with_text.erb
@@ -1,11 +1,11 @@
 <%# locals: (icon:, text:, subtext:) %>
 
 <div class="flex gap-3 items-center">
-    <div>
-        <%== part("components/icon", name: icon, classes: "text-orange-600 h-8 w-8") %>
-    </div>
-    <div>
-        <div class="font-bold text-gray-900"><%== text %></div>
-        <div class="text-gray-600"><%== subtext %></div>
-    </div>
+  <div>
+    <%== part("components/icon", name: icon, classes: "text-orange-600 h-8 w-8") %>
+  </div>
+  <div>
+    <div class="font-bold text-gray-900"><%== text %></div>
+    <div class="text-gray-600"><%== subtext %></div>
+  </div>
 </div>

--- a/views/components/inline_edit_buttons.erb
+++ b/views/components/inline_edit_buttons.erb
@@ -1,7 +1,7 @@
 <%# locals: (url: request.path, csrf_url: url, confirmation_message: nil) %>
 
 <div class="group-[.active]/inline-editable:hidden block">
-<%== part(
+  <%== part(
   "components/button",
   text: "",
   icon: "hero-pencil",
@@ -11,7 +11,7 @@
 </div>
 
 <div class="group-[.active]/inline-editable:block hidden">
-<%== part(
+  <%== part(
   "components/button",
   text: "",
   icon: "hero-check-circle",
@@ -24,7 +24,7 @@
   }
 ) %>
 
-<%== part(
+  <%== part(
   "components/button",
   text: "",
   icon: "hero-x-circle",

--- a/views/components/kubernetes_state_label.erb
+++ b/views/components/kubernetes_state_label.erb
@@ -1,2 +1,3 @@
 <%# locals: (state:, extra_class: nil) %>
+
 <%== part("components/state_label", state:, color: KUBERNETES_STATE_LABEL_COLOR[state], extra_class:) %>

--- a/views/components/kv_data_card.erb
+++ b/views/components/kv_data_card.erb
@@ -1,5 +1,11 @@
 <%# locals: (data:) %>
-<div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+
+<div
+  class="
+    overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+    bg-white divide-y divide-gray-200
+  "
+>
   <div class="px-4 py-5 sm:p-0">
     <dl class="sm:divide-y sm:divide-gray-200">
       <% data.reject { !it }.each do |name, value, opts| %>

--- a/views/components/page_header.erb
+++ b/views/components/page_header.erb
@@ -4,7 +4,13 @@
   <% unless breadcrumbs.empty? %>
     <div>
       <nav class="sm:hidden" aria-label="Back">
-        <a href="<%= back %>" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700">
+        <a
+          href="<%= back %>"
+          class="
+            flex items-center text-sm font-medium text-gray-500
+            hover:text-gray-700
+          "
+        >
           <div class="-ml-1 mr-1 flex-shrink-0 text-gray-400">
             <%== part("components/icon", name: "hero-chevron-left", classes: "w-5 h-5") %>
           </div>
@@ -19,7 +25,12 @@
                 <% if index > 0 %>
                   <%== part("components/icon", name: "hero-chevron-right", classes: "w-5 h-5 flex-shrink-0 text-gray-400 mr-4") %>
                 <% end %>
-                <a href="<%= url %>" class="text-sm font-medium text-gray-500 hover:text-gray-700"><%= name %></a>
+                <a
+                  href="<%= url %>"
+                  class="text-sm font-medium text-gray-500 hover:text-gray-700"
+                >
+                  <%= name %>
+                </a>
               </div>
             </li>
           <% end %>
@@ -30,12 +41,17 @@
 
   <div class="md:flex md:items-center md:justify-between pb-4">
     <div class="min-w-0">
-      <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:tracking-tight"><%= title %></h2>
+      <h2
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:text-3xl
+          sm:tracking-tight
+        "
+      >
+        <%= title %>
+      </h2>
     </div>
     <% if right_items %>
-      <div class="mt-4 flex md:ml-4 md:mt-0">
-        <%== right_items.join %>
-      </div>
+      <div class="mt-4 flex md:ml-4 md:mt-0"><%== right_items.join %></div>
     <% end %>
   </div>
 </div>

--- a/views/components/pg_state_label.erb
+++ b/views/components/pg_state_label.erb
@@ -1,2 +1,3 @@
 <%# locals: (state:, extra_class: nil) %>
+
 <%== part("components/state_label", state:, color: PG_STATE_LABEL_COLOR[state], extra_class:) %>

--- a/views/components/progress_bar.erb
+++ b/views/components/progress_bar.erb
@@ -1,12 +1,13 @@
 <%# locals: (numerator:, denominator:, title:) %>
+
 <% progress = [100, denominator.zero? ? 100 : 100 * numerator / denominator].min
 color = (progress < 60) ? "bg-blue-500" : (progress < 80) ? "bg-yellow-500" : "bg-red-500" %>
 
 <div class="flex justify-between mb-1">
   <span class="text-base font-medium"><%= title %></span>
-  <span class="text-sm font-medium"><%= numerator %>/<%= denominator %>
-    (<%= progress %>%)</span>
+  <span class="text-sm font-medium"><%= numerator %>/<%= denominator %> (<%= progress %>%)</span>
 </div>
+
 <div class="w-full bg-gray-200 rounded-full h-3">
   <div class="<%= color %> h-3 rounded-full w-[<%= progress %>%]"></div>
 </div>

--- a/views/components/ps_state_label.erb
+++ b/views/components/ps_state_label.erb
@@ -1,2 +1,3 @@
 <%# locals: (state:, extra_class: nil) %>
+
 <%== part("components/state_label", state:, color: PS_STATE_LABEL_COLOR[state], extra_class:) %>

--- a/views/components/rename_object.erb
+++ b/views/components/rename_object.erb
@@ -2,19 +2,30 @@
 
 <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
   <div class="min-w-0 flex-1">
-    <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+    <h3
+      class="
+        text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+        sm:tracking-tight
+      "
+    >
       Rename
     </h3>
   </div>
 </div>
 
 <% form(action: "#{path(object)}/rename", method: :post) do %>
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <div class="px-4 py-5 sm:p-6">
       <div class="sm:flex sm:items-center sm:justify-between">
         <div>
-          <h3 class="text-base font-semibold leading-6 text-gray-900">Rename
-            <%= type %></h3>
+          <h3 class="text-base font-semibold leading-6 text-gray-900">
+            Rename <%= type %>
+          </h3>
           <div class="mt-2 text-sm text-gray-500">
             <%== part(
                 "components/form/text",

--- a/views/components/revealable_content.erb
+++ b/views/components/revealable_content.erb
@@ -1,13 +1,29 @@
 <%# locals: (content:) %>
+
 <div class="revealable-content group flex-grow">
-  <div class="shadow-content justify-between items-center gap-2 flex group-[.active]:hidden">
+  <div
+    class="
+      shadow-content justify-between items-center gap-2 flex
+      group-[.active]:hidden
+    "
+  >
     ●●●●●●
-    <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1"/>
+    <img
+      src="/icons/hero-eye.svg"
+      width="18px"
+      class="revealable-button inline-block cursor-pointer ms1"
+    />
   </div>
   <div class="revealed-content hidden group-[.active]:block break-all">
     <div class="flex gap-2 items-center justify-between">
-      <div class="revealed-content-text whitespace-pre-line"><%= content %></div>
-      <img src="/icons/hero-eye-slash.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1"/>
+      <div class="revealed-content-text whitespace-pre-line">
+        <%= content %>
+      </div>
+      <img
+        src="/icons/hero-eye-slash.svg"
+        width="18px"
+        class="revealable-button inline-block cursor-pointer ms1"
+      />
     </div>
   </div>
 </div>

--- a/views/components/revealable_content.erb
+++ b/views/components/revealable_content.erb
@@ -9,10 +9,11 @@
   >
     ●●●●●●
     <img
+      alt=""
       src="/icons/hero-eye.svg"
       width="18px"
       class="revealable-button inline-block cursor-pointer ms1"
-    />
+    >
   </div>
   <div class="revealed-content hidden group-[.active]:block break-all">
     <div class="flex gap-2 items-center justify-between">
@@ -20,10 +21,11 @@
         <%= content %>
       </div>
       <img
+        alt=""
         src="/icons/hero-eye-slash.svg"
         width="18px"
         class="revealable-button inline-block cursor-pointer ms1"
-      />
+      >
     </div>
   </div>
 </div>

--- a/views/components/rodauth/password_field.erb
+++ b/views/components/rodauth/password_field.erb
@@ -1,4 +1,5 @@
 <%# locals: (confirm: false, label: nil, name: nil, autocomplete: nil) %>
+
 <% if confirm
   label ||= "#{rodauth.password_confirm_label}#{rodauth.input_field_label_suffix}"
   name ||= rodauth.password_confirm_param

--- a/views/components/state_label.erb
+++ b/views/components/state_label.erb
@@ -1,8 +1,6 @@
 <%# locals: (state:, color:, extra_class: nil) %>
 
-<span
-  class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>"
->
+<span class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>">
   <%== part("components/icon", name: "dot", classes: "mr-1.5 h-2 w-2") %>
   <%= state %>
 </span>

--- a/views/components/tabbar.erb
+++ b/views/components/tabbar.erb
@@ -1,6 +1,10 @@
 <%# locals: (tabs:) %>
+
 <div class="sm:block mb-6">
-  <nav class="isolate flex divide-x divide-gray-200 rounded-lg shadow" aria-label="Tabs">
+  <nav
+    class="isolate flex divide-x divide-gray-200 rounded-lg shadow"
+    aria-label="Tabs"
+  >
     <% tabs.each_with_index do |(label, url, active), i| %>
       <% active = (request.path == url) if active.nil? %>
       <a
@@ -8,7 +12,10 @@
         class="group flex items-center justify-center relative min-w-0 flex-1 overflow-hidden <%= (i == 0) ? "rounded-l-lg" : ((i == tabs.size - 1) ? "rounded-r-lg" : "") %> px-4 py-4 text-center text-sm bg-white font-medium focus:z-10 <%= active ? "text-orange-600 hover:text-orange-700 hover:bg-orange-50" : "text-gray-500 hover:text-orange-500 hover:bg-orange-50" %>"
       >
         <span><%= label %></span>
-        <span aria-hidden="true" class="absolute inset-x-0 bottom-0 h-0.5 <%= active ? "bg-orange-600" : "bg-transparent" %>"></span>
+        <span
+          aria-hidden="true"
+          class="absolute inset-x-0 bottom-0 h-0.5 <%= active ? "bg-orange-600" : "bg-transparent" %>"
+        ></span>
       </a>
     <% end %>
   </nav>

--- a/views/components/table_card.erb
+++ b/views/components/table_card.erb
@@ -4,19 +4,27 @@
   <% if title || right_items %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           <%= title %>
         </h3>
       </div>
       <% if right_items %>
-        <div class="mt-4 flex md:ml-4 md:mt-0">
-          <%== right_items.join %>
-        </div>
+        <div class="mt-4 flex md:ml-4 md:mt-0"><%== right_items.join %></div>
       <% end %>
     </div>
   <% end %>
 
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <% unless headers.empty? || rows.empty? %>
         <thead class="bg-gray-50">
@@ -25,11 +33,17 @@
               <th
                 scope="col"
                 <% if i == 0 %>
-                class="pl-4 pr-3 sm:pl-6 py-3.5 text-left text-sm font-semibold text-gray-900"
+                  class="
+                    pl-4 pr-3 sm:pl-6 py-3.5 text-left text-sm font-semibold
+                    text-gray-900
+                  "
                 <% elsif i + 1 == headers.length %>
-                class="pl-3 pr-4 sm:pr-6 py-3.5 text-left text-sm font-semibold text-gray-900"
+                  class="
+                    pl-3 pr-4 sm:pr-6 py-3.5 text-left text-sm font-semibold
+                    text-gray-900
+                  "
                 <% else %>
-                class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                  class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                 <% end %>
               >
                 <%= name %>
@@ -41,7 +55,10 @@
       <tbody class="divide-y divide-gray-200 bg-white">
         <% if rows.empty? %>
           <tr>
-            <td colspan="<%= headers.length %>" class="text-center py-4 px-8 lg:px-32">
+            <td
+              colspan="<%= headers.length %>"
+              class="text-center py-4 px-8 lg:px-32"
+            >
               <% if empty_state.is_a?(Hash) %>
                 <%== part("components/empty_state", **empty_state) %>
               <% else %>
@@ -55,17 +72,13 @@
             <tr id="<%= row_opts[:id] %>">
               <% columns.each_with_index do |(value, col_opts), i| %>
                 <% col_opts ||= {} %>
-                <td
-                  <% if i == 0
+                <td <% if i == 0
                       cls="pl-4 pr-3 sm:pl-6 py-4 text-gray-900 font-medium whitespace-nowrap text-sm"
                     elsif i + 1 == columns.length
                       cls="pl-3 pr-4 sm:pr-6 py-4 text-gray-500 whitespace-nowrap text-sm"
                     else
                       cls="px-3 py-4 text-gray-500 whitespace-nowrap text-sm"
-                    end
-                  %>
-                  class="<%= cls %> <%= col_opts[:extra_class] %>"
-                >
+                    end %> class="<%= cls %> <%= col_opts[:extra_class] %>">
                   <% if value.is_a?(Array) %>
                     <% (first_value, first_opts), (second_value, second_opts) = value %>
                     <div class="font-medium text-gray-900">

--- a/views/components/value_content.erb
+++ b/views/components/value_content.erb
@@ -1,9 +1,14 @@
 <%# locals: (content:, opts: nil) %>
+
 <% opts ||= {} %>
+
 <% if opts[:copyable] && content %>
   <%== part("components/copyable_content", content:, revealable: opts[:revealable]) %>
 <% elsif opts[:link] %>
-  <a href="<%= opts[:link] %>" class="font-medium text-orange-600 hover:text-orange-700">
+  <a
+    href="<%= opts[:link] %>"
+    class="font-medium text-orange-600 hover:text-orange-700"
+  >
     <%= content %>
   </a>
 <% elsif opts[:component] %>

--- a/views/components/vm_state_label.erb
+++ b/views/components/vm_state_label.erb
@@ -1,2 +1,3 @@
 <%# locals: (state:, extra_class: nil) %>
+
 <%== render("components/state_label", locals: { state:, color: VM_STATE_LABEL_COLOR[state], extra_class: }) %>

--- a/views/email/button.erb
+++ b/views/email/button.erb
@@ -1,13 +1,42 @@
-<%# locals: (title:, link:) %><table class="action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<%# locals: (title:, link:) %>
+
+<table
+  class="action"
+  align="center"
+  width="100%"
+  cellpadding="0"
+  cellspacing="0"
+  role="presentation"
+>
   <tr>
     <td align="center">
-      <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+      <table
+        width="100%"
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+      >
         <tr>
           <td align="center">
-            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+            <table
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
               <tr>
                 <td>
-                  <a href="<%= link %>" class="button button-primary" target="_blank" rel="noopener" style="color: #FFFFFF"><%= title %></a>
+                  <a
+                    href="<%= link %>"
+                    class="button button-primary"
+                    target="_blank"
+                    rel="noopener"
+                    style="color: #FFFFFF"
+                  >
+                    <%= title %>
+                  </a>
                 </td>
               </tr>
             </table>

--- a/views/email/footer.erb
+++ b/views/email/footer.erb
@@ -1,13 +1,19 @@
 <% require "date" %>
+
 <tr>
   <td>
-    <table class="footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+    <table
+      class="footer"
+      align="center"
+      width="570"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+    >
       <tr>
         <td align="left">
           <p>
-            ©
-            <%= Date.today.year %>
-            Ubicloud. All rights reserved.
+            © <%= Date.today.year %> Ubicloud. All rights reserved.
           </p>
         </td>
         <td align="right">
@@ -16,8 +22,7 @@
           </a>
         </td>
       </tr>
-      <tr>
-      </tr>
+      <tr></tr>
     </table>
   </td>
 </tr>

--- a/views/email/header.erb
+++ b/views/email/header.erb
@@ -1,7 +1,14 @@
 <tr>
   <td class="header">
-    <a href="<%= Config.base_url %>/logo-primary.png" style="display: inline-block;">
-      <img src="<%= Config.base_url %>/logo-primary.png" class="logo" alt="Ubicloud">
+    <a
+      href="<%= Config.base_url %>/logo-primary.png"
+      style="display: inline-block;"
+    >
+      <img
+        src="<%= Config.base_url %>/logo-primary.png"
+        class="logo"
+        alt="Ubicloud"
+      >
     </a>
   </td>
 </tr>

--- a/views/email/layout.erb
+++ b/views/email/layout.erb
@@ -7,9 +7,9 @@
   <head>
     <title><%= subject %></title>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
     <meta name="color-scheme" content="light">
 

--- a/views/email/layout.erb
+++ b/views/email/layout.erb
@@ -1,29 +1,60 @@
-<%# locals: (subject:, greeting:, body:, button_title:, button_link:) %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+<%# locals: (subject:, greeting:, body:, button_title:, button_link:) %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title><%= subject %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
     <meta name="color-scheme" content="light">
+
     <meta name="supported-color-schemes" content="light">
+
     <%== File.read("views/email/style.html") %>
   </head>
   <body>
-
-    <table class="wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+    <table
+      class="wrapper"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+    >
       <tr>
         <td align="center">
-          <table class="content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+          <table
+            class="content"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+          >
             <%== render("email/header") %>
             <!-- Email Body -->
             <tr>
-              <td class="body" width="100%" cellpadding="0" cellspacing="0" style="border: hidden !important;">
-                <table class="inner-body" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+              <td
+                class="body"
+                width="100%"
+                cellpadding="0"
+                cellspacing="0"
+                style="border: hidden !important;"
+              >
+                <table
+                  class="inner-body"
+                  align="center"
+                  width="570"
+                  cellpadding="0"
+                  cellspacing="0"
+                  role="presentation"
+                >
                   <!-- Body content -->
                   <tr>
                     <td class="content-cell">
-
                       <h1><%= greeting %></h1>
 
                       <% Array(body).each do |line| %>
@@ -33,18 +64,27 @@
                       <% if button_link %>
                         <%== part("email/button", title: button_title, link: button_link) %>
                       <% end %>
+
                       <p>
-                        Regards,<br>
+                        Regards,
+                        <br>
                         Ubicloud
                       </p>
 
                       <% if button_link %>
-                        <table class="subcopy" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+                        <table
+                          class="subcopy"
+                          width="100%"
+                          cellpadding="0"
+                          cellspacing="0"
+                          role="presentation"
+                        >
                           <tr>
                             <td>
                               <p>
-                                If you're having trouble clicking the button, copy and paste the URL below into your
-                                web browser:
+                                If you're having trouble clicking the button,
+                                copy and paste the URL below into your web
+                                browser:
                                 <span class="break-all"><a href="<%= button_link %>"><%= button_link %></a></span>
                               </p>
                             </td>

--- a/views/error.erb
+++ b/views/error.erb
@@ -3,13 +3,27 @@
 <main class="grid min-h-full place-items-center px-6 py-24 sm:py-32 lg:px-8">
   <div class="text-center">
     <p class="text-base font-semibold text-orange-600"><%= @error[:code] %></p>
-    <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl"><%= @error[:type] %></h1>
-    <p class="mt-6 text-base leading-7 text-gray-600"><%= @error[:message] %></p>
+
+    <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+      <%= @error[:type] %>
+    </h1>
+
+    <p class="mt-6 text-base leading-7 text-gray-600">
+      <%= @error[:message] %>
+    </p>
+
     <div class="mt-10 flex items-center justify-center gap-x-6">
       <button
         type="button"
-        class="back-btn rounded-md bg-orange-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600"
-      >Go back</button>
+        class="
+          back-btn rounded-md bg-orange-600 px-3.5 py-2.5 text-sm
+          font-semibold text-white shadow-sm hover:bg-orange-700
+          focus-visible:outline focus-visible:outline-2
+          focus-visible:outline-offset-2 focus-visible:outline-orange-600
+        "
+      >
+        Go back
+      </button>
     </div>
   </div>
 </main>

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -3,43 +3,91 @@
 <%== render("github/tabbar") %>
 
 <div class="grid gap-6">
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <tbody class="divide-y divide-gray-200 bg-white">
         <% if @entries_by_repo.count > 0 %>
           <% @entries_by_repo.each do |repository_id, entries| %>
-            <tr class="cache-group-row cursor-pointer group" data-repository="<%= repository_id %>">
-              <th scope="colgroup" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 w-full group-[.active]:bg-gray-50">
+            <tr
+              class="cache-group-row cursor-pointer group"
+              data-repository="<%= repository_id %>"
+            >
+              <th
+                scope="colgroup"
+                class="
+                  py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                  text-gray-900 w-full group-[.active]:bg-gray-50
+                "
+              >
                 <div class="flex">
                   <%== part("components/icon", name: "hero-chevron-right", classes: "w-5 h-5 group-[.active]:rotate-90") %>
                   <%= entries.first.repository.name %>
                 </div>
               </th>
-              <th scope="colgroup" class="py-3.5 pl-3 pr-3 text-right text-sm font-semibold text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50" colspan="2">
+              <th
+                scope="colgroup"
+                class="
+                  py-3.5 pl-3 pr-3 text-right text-sm font-semibold
+                  text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50
+                "
+                colspan="2"
+              >
                 <%= entries.count %> cache entries
               </th>
-              <th scope="colgroup" class="py-3.5 pl-3 pr-4 text-right text-sm font-semibold text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50" colspan="2">
+              <th
+                scope="colgroup"
+                class="
+                  py-3.5 pl-3 pr-4 text-right text-sm font-semibold
+                  text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50
+                "
+                colspan="2"
+              >
                 <%= humanize_size(entries.sum { it.size.to_i }) %> used of <%= @quota_per_repo %>
               </th>
             </tr>
             <% entries.each do |entry| %>
-              <tr id="entry-<%= entry.ubid %>" class="hidden cache-group-<%= repository_id %>">
+              <tr
+                id="entry-<%= entry.ubid %>"
+                class="hidden cache-group-<%= repository_id %>"
+              >
                 <td class="py-3 pl-4 pr-3 text-sm sm:pl-6 w-full" scope="row">
                   <div class="font-medium text-gray-900"><%= entry.key %></div>
-                  <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry.created_at.strftime("%Y-%m-%d %H:%M UTC") %>"><%= humanize_time(entry.created_at) %></span></div>
+                  <div class="mt-1 text-gray-500 text-xs">
+                    created
+                    <span
+                      title="<%= entry.created_at.strftime("%Y-%m-%d %H:%M UTC") %>"
+                    >
+                      <%= humanize_time(entry.created_at) %>
+                    </span>
+                  </div>
                 </td>
                 <td class="px-3 py-3 text-sm text-gray-500">
                   <div><%= entry.scope %></div>
                 </td>
                 <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
-                  <div class="inline-flex items-baseline rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800" title="<%= entry.size %> bytes">
+                  <div
+                    class="
+                      inline-flex items-baseline rounded-md px-2 text-xs
+                      font-medium leading-5 bg-slate-100 text-slate-800
+                    "
+                    title="<%= entry.size %> bytes"
+                  >
                     <%= humanize_size(entry.size) %>
                   </div>
                 </td>
                 <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
                   <% if entry.last_accessed_at %>
                     <div>Last used</div>
-                    <div title="<%= entry.last_accessed_at.strftime("%Y-%m-%d %H:%M UTC") %>"> <%= humanize_time(entry.last_accessed_at) %></div>
+                    <div
+                      title="<%= entry.last_accessed_at.strftime("%Y-%m-%d %H:%M UTC") %>"
+                    >
+                      <%= humanize_time(entry.last_accessed_at) %>
+                    </div>
                   <% else %>
                     <div>Never used</div>
                   <% end %>
@@ -58,9 +106,18 @@
           <tr>
             <td colspan="6">
               <div class="text-center py-4 px-8 lg:px-32">
-                <h3 class="text-xl leading-10 font-medium mb-3">No cache entries</h3>
+                <h3 class="text-xl leading-10 font-medium mb-3">
+                  No cache entries
+                </h3>
                 <p class="leading-6">
-                  Check out <a href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache" class="text-orange-500 font-medium">our documentation</a> to use Ubicloud Cache for faster caching.
+                  Check out
+                  <a
+                    href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache"
+                    class="text-orange-500 font-medium"
+                  >
+                    our documentation
+                  </a>
+                  to use Ubicloud Cache for faster caching.
                 </p>
               </div>
             </td>

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -5,8 +5,7 @@
 <%== render("github/tabbar") %>
 
 <div class="grid gap-6">
-  <%
-    free_upgrade_badge = if @installation.free_runner_upgrade?
+  <% free_upgrade_badge = if @installation.free_runner_upgrade?
       <<~CONTENT
         <a href="#{path(@installation)}/setting">
           <span class="rounded-full bg-green-600/10 px-2.5 py-1 text-xs/5 font-medium text-green-600">
@@ -15,8 +14,7 @@
           </span>
         </a>
       CONTENT
-    end
-  %>
+    end %>
   <%== part(
     "components/table_card",
     headers: ["Repository", "Runner", "Workflow Job", "", ""],

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -4,36 +4,66 @@
 
 <div class="grid gap-6">
   <!-- Premium runners -->
-  <div class="overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5 bg-white lg:flex shadow">
+  <div
+    class="
+      overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5 bg-white
+      lg:flex shadow
+    "
+  >
     <div class="p-8 sm:p-10 lg:flex-auto">
       <div class="flex items-center">
-        <h3 class="text-3xl font-semibold tracking-tight text-gray-900 whitespace-nowrap">
+        <h3
+          class="
+            text-3xl font-semibold tracking-tight text-gray-900
+            whitespace-nowrap
+          "
+        >
           Premium Runners
         </h3>
         <% if @installation.premium_runner_enabled? %>
-          <span class="rounded-full bg-orange-600/10 px-2.5 py-1 text-xs/5 font-semibold text-orange-600 ml-2">
+          <span
+            class="
+              rounded-full bg-orange-600/10 px-2.5 py-1 text-xs/5
+              font-semibold text-orange-600 ml-2
+            "
+          >
             Enabled
           </span>
         <% end %>
       </div>
+
       <% if @installation.free_runner_upgrade? %>
-        <span class="rounded-full bg-green-600/10 px-2.5 py-1 text-xs/5 font-medium text-green-600">
+        <span
+          class="
+            rounded-full bg-green-600/10 px-2.5 py-1 text-xs/5 font-medium
+            text-green-600
+          "
+        >
           You’re eligible for an exclusive
           <span class="font-semibold">50% off</span>
           premium runners until
           <span class="font-semibold"><%= @installation.free_runner_upgrade_expires_at.strftime("%B %d, %Y") %></span>
         </span>
       <% end %>
+
       <p class="mt-4 text-base/7 text-gray-600">
-        Speed up your builds with cutting edge gaming CPUs! We automatically route your jobs to premium machines. If
-        capacity's full, you seamlessly fall back to standard runners with no extra wait time. You always get billed by
-        the minute and for the runner type you're using.
+        Speed up your builds with cutting edge gaming CPUs! We automatically
+        route your jobs to premium machines. If capacity's full, you seamlessly
+        fall back to standard runners with no extra wait time. You always get
+        billed by the minute and for the runner type you're using.
       </p>
+
       <div class="mt-6 flex items-center gap-x-4">
-        <h4 class="flex-none text-sm/6 font-semibold text-orange-600">What’s different</h4>
+        <h4 class="flex-none text-sm/6 font-semibold text-orange-600">
+          What’s different
+        </h4>
         <div class="h-px flex-auto bg-gray-100"></div>
       </div>
-      <ul role="list" class="mt-4 grid grid-cols-1 gap-4 text-sm/6 text-gray-600 sm:grid-cols-2">
+
+      <ul
+        role="list"
+        class="mt-4 grid grid-cols-1 gap-4 text-sm/6 text-gray-600 sm:grid-cols-2"
+      >
         <% [
           "Twice as fast",
           "One fifth the cost",
@@ -49,40 +79,67 @@
     </div>
     <div class="-mt-2 p-2 lg:mt-0 lg:w-full lg:max-w-sm lg:shrink-0">
       <div
-        class="rounded-lg h-full bg-gray-50 py-10 text-center ring-1 ring-inset ring-gray-900/5 lg:flex lg:flex-col lg:justify-center lg:py-16"
+        class="
+          rounded-lg h-full bg-gray-50 py-10 text-center ring-1 ring-inset
+          ring-gray-900/5 lg:flex lg:flex-col lg:justify-center lg:py-16
+        "
       >
         <div class="mx-auto max-w-sm px-8 space-y-8">
           <p class="flex items-baseline justify-center gap-x-2">
             <span class="text-4xl font-semibold tracking-tight text-gray-900">Boost your builds</span>
           </p>
+
           <%== part("components/form/toggle_form", name: "premium_runner_enabled", action: "#{@project.path}/github/#{@installation.ubid}", active: @installation.premium_runner_enabled?) %>
           <div class="mt-6 text-sm/5 text-gray-600 italic">
             <p class="font-semibold">1/5th the cost of GitHub runners</p>
-            <p>For example, 2 gaming vCPUs, 8GB of RAM, 80GB of NVMe storage comes at $0.0016/min.</p>
+            <p>
+              For example, 2 gaming vCPUs, 8GB of RAM, 80GB of NVMe storage
+              comes at $0.0016/min.
+            </p>
           </div>
         </div>
       </div>
     </div>
   </div>
+
   <div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <!-- Transparent Cache Card -->
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <div class="flex items-center">
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Ubicloud Transparent Cache</h3>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">
+                Ubicloud Transparent Cache
+              </h3>
               <% if @installation.cache_enabled %>
-                <span class="rounded-full bg-orange-600/10 px-2.5 py-1 text-xs font-semibold text-orange-600 ml-2">
+                <span
+                  class="
+                    rounded-full bg-orange-600/10 px-2.5 py-1 text-xs
+                    font-semibold text-orange-600 ml-2
+                  "
+                >
                   Enabled
                 </span>
               <% end %>
             </div>
             <div class="mt-2 text-sm text-gray-500">
-              <p>Transparent cache allows you to use Ubicloud’s cache service without modifying your workflow files.
-                Check out
-                <a href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache" class="text-orange-500 font-medium">our documentation</a>
-                for information.</p>
+              <p>
+                Transparent cache allows you to use Ubicloud’s cache service
+                without modifying your workflow files. Check out
+                <a
+                  href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache"
+                  class="text-orange-500 font-medium"
+                >
+                  our documentation
+                </a>
+                for information.
+              </p>
             </div>
           </div>
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
@@ -92,16 +149,25 @@
           </div>
         </div>
       </div>
+
       <!-- Configure Repositories -->
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Repository Access</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">
+              Repository Access
+            </h3>
             <div class="mt-2 text-sm text-gray-500">
-              <p>Configure the list of repositories that Ubicloud can access on GitHub's UI.</p>
+              <p>
+                Configure the list of repositories that Ubicloud can access on
+                GitHub's UI.
+              </p>
             </div>
           </div>
-          <div id="configure-<%=@installation.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+          <div
+            id="configure-<%=@installation.ubid%>"
+            class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+          >
             <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
               <%== part("components/button", text: "Configure", link: "https://github.com/apps/#{Config.github_app_name}/installations/#{@installation.installation_id}") %>
             </div>

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -165,7 +165,7 @@
             </div>
           </div>
           <div
-            id="configure-<%=@installation.ubid%>"
+            id="configure-<%= @installation.ubid %>"
             class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
           >
             <div class="col-span-12 sm:col-span-2 flex justify-end items-end">

--- a/views/github/tabbar.erb
+++ b/views/github/tabbar.erb
@@ -39,6 +39,7 @@
 ) %>
 
 <% installation_path = path(@installation) %>
+
 <%== part(
   "components/tabbar",
   tabs: [

--- a/views/inference/api_key/index.erb
+++ b/views/inference/api_key/index.erb
@@ -1,5 +1,7 @@
 <% @page_title = "Inference API Keys" %>
+
 <%== render("components/free_quota") %>
+
 <%== render("inference/tabbar") %>
 
 <div>
@@ -39,10 +41,10 @@
   ) %>
 
   <% if has_project_permission("InferenceApiKey:create") && @inference_api_keys.size < 10 %>
-  <div class="flex justify-end space-y-1 mt-6">
-    <% form(action: "#{@project.path}/inference-api-key", method: :post, role: :form, id: "create-inference-api-key") do %>
-      <%== part("components/form/submit_button", text: "Create API Key") %>
-    <% end %>
-  </div>
+    <div class="flex justify-end space-y-1 mt-6">
+      <% form(action: "#{@project.path}/inference-api-key", method: :post, role: :form, id: "create-inference-api-key") do %>
+        <%== part("components/form/submit_button", text: "Create API Key") %>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/views/inference/endpoint/index.erb
+++ b/views/inference/endpoint/index.erb
@@ -1,5 +1,7 @@
 <% @page_title = "Inference Endpoints" %>
+
 <%== render("components/free_quota") %>
+
 <%== render("inference/tabbar") %>
 
 <div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">
@@ -31,53 +33,77 @@ curl #{ie.load_balancer.health_check_url(path:)} \\
     "model": "#{ie.model_name}",
     #{curl_message}   }'</span>
   CURL
-    %>
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white p-4">
-    <h2 class="text-lg font-bold mb-4 text-gray-800 line-clamp-1"><%= ie.tags["display_name"] || ie.model_name %></h2>
-    <div class="grid sm:grid-cols-2 gap-4">
-      <div>
-        <h3 class="text-sm font-semibold text-gray-900">Model card</h3>
-        <div class="flex items-center gap-1 text-gray-500">
-          <%if hf_model = ie.tags["hf_model"]%>
-          <a target="_blank" rel="noreferrer" href="https://huggingface.co/<%= hf_model %>" class="text-orange-600 line-clamp-2">🤗 <%= hf_model %></a>
-          <%else%>
-          <p class="text-gray-500">Not available</p>
-          <%end%>
+%>
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white p-4
+      "
+    >
+      <h2 class="text-lg font-bold mb-4 text-gray-800 line-clamp-1">
+        <%= ie.tags["display_name"] || ie.model_name %>
+      </h2>
+      <div class="grid sm:grid-cols-2 gap-4">
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900">Model card</h3>
+          <div class="flex items-center gap-1 text-gray-500">
+            <% if hf_model = ie.tags["hf_model"] %>
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://huggingface.co/<%= hf_model %>"
+                class="text-orange-600 line-clamp-2"
+              >
+                🤗 <%= hf_model %>
+              </a>
+            <% else %>
+              <p class="text-gray-500">Not available</p>
+            <% end %>
+          </div>
         </div>
-      </div>
-      <div>
-        <h3 class="text-sm font-semibold text-gray-900">Price</h3>
-        <p class="text-gray-500">
-          Input: $<%= "%0.02f" % million_token_price(ie.prompt_billing_resource) %> / 1M tokens
-          <br>
-          Output: $<%= "%0.02f" % million_token_price(ie.completion_billing_resource) %> / 1M tokens
-        </p>
-      </div>
-      <div>
-        <h3 class="text-sm font-semibold text-gray-900">Capability</h3>
-        <div class="flex items-center gap-1 text-gray-500">
-          <%== part("components/icon", name: model_icon, classes: "w-5 h-5 text-gray-400") %>
-          <%= ie.tags["capability"] %>
+
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900">Price</h3>
+          <p class="text-gray-500">
+            Input: $<%= "%0.02f" % million_token_price(ie.prompt_billing_resource) %> / 1M tokens
+            <br>
+            Output: $<%= "%0.02f" % million_token_price(ie.completion_billing_resource) %> / 1M tokens
+          </p>
         </div>
-      </div>
-      <div>
-        <h3 class="text-sm font-semibold text-gray-900">Context length</h3>
-        <p class="text-gray-500"><%= ie.tags.fetch("context_length", "Full") %></p>
-      </div>
-      <div class="sm:col-span-2">
-        <h3 class="text-sm font-semibold text-gray-900">URL</h3>
-        <div class="text-gray-500"><%== part("components/copyable_content", content: ie.load_balancer.health_check_url, message: "Copied URL") %></div>
-      </div>
-      <div class="sm:col-span-2">
-        <h3 class="text-sm font-semibold text-gray-900">
-          CURL usage example
-        </h3>
-        <div class="mt-2">
-          <pre class="text-sm bg-gray-800 text-white p-2 rounded-lg overflow-scroll"><%== curl_snippet %></pre>
+
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900">Capability</h3>
+          <div class="flex items-center gap-1 text-gray-500">
+            <%== part("components/icon", name: model_icon, classes: "w-5 h-5 text-gray-400") %>
+            <%= ie.tags["capability"] %>
+          </div>
         </div>
-      </div>
-      <% if ie.tags["capability"] == "Text Generation" %>
-      <%== render(
+
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900">Context length</h3>
+          <p class="text-gray-500">
+            <%= ie.tags.fetch("context_length", "Full") %>
+          </p>
+        </div>
+
+        <div class="sm:col-span-2">
+          <h3 class="text-sm font-semibold text-gray-900">URL</h3>
+          <div class="text-gray-500">
+            <%== part("components/copyable_content", content: ie.load_balancer.health_check_url, message: "Copied URL") %>
+          </div>
+        </div>
+
+        <div class="sm:col-span-2">
+          <h3 class="text-sm font-semibold text-gray-900">
+            CURL usage example
+          </h3>
+          <div class="mt-2">
+            <pre class="text-sm bg-gray-800 text-white p-2 rounded-lg overflow-scroll"><%== curl_snippet %></pre>
+          </div>
+        </div>
+
+        <% if ie.tags["capability"] == "Text Generation" %>
+          <%== render(
         "components/button",
         locals: {
           text: "Try in Playground",
@@ -87,9 +113,8 @@ curl #{ie.load_balancer.health_check_url(path:)} \\
           }
         }
       ) %>
-      <% end %>
+        <% end %>
+      </div>
     </div>
-  </div>
   <% end %>
-
 </div>

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -1,8 +1,17 @@
 <% @page_title = "Playground" %>
+
 <%== render("components/free_quota") %>
+
 <% @enable_marked = true %>
+
 <%== render("inference/tabbar") %>
-<div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+
+<div
+  class="
+    overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+    bg-white divide-y divide-gray-200
+  "
+>
   <div class="px-4 py-5 sm:p-6 grid gap-6">
     <div class="grid sm:grid-cols-2 gap-6 text-gray-900">
       <%== render(
@@ -32,6 +41,7 @@
         }
       ) %>
     </div>
+
     <%== part(
       "components/form/checkbox",
       name: "inference_config",
@@ -96,12 +106,19 @@
         }
       ) %>
     </div>
+
     <div>
-      <div class="block text-sm font-medium leading-6 text-gray-900 mb-2">Previous Messages</div>
-      <div id="inference_previous_empty" class="text-sm text-gray-500">There are no messages yet.</div>
-      <div id="inference_previous">
+      <div class="block text-sm font-medium leading-6 text-gray-900 mb-2">
+        Previous Messages
       </div>
+
+      <div id="inference_previous_empty" class="text-sm text-gray-500">
+        There are no messages yet.
+      </div>
+
+      <div id="inference_previous"></div>
     </div>
+
     <div>
       <%== render(
         "components/form/textarea",

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -14,8 +14,7 @@
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Cluster Name", required: "required", placeholder: "Enter cluster name"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:location)},
     {name: "version", type: "radio_small_cards", label: "Version", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:version)},
@@ -24,7 +23,6 @@
     {name: "worker_nodes", type: "select", label: "Worker Nodes", required: "required", placeholder: "Select number of worker nodes", content_generator: ContentGenerator::KubernetesCluster.method(:worker_nodes), opening_tag: "<div class='sm:col-span-3'>"},
   ]
 
-  action = "#{@project.path}/kubernetes-cluster"
-%>
+  action = "#{@project.path}/kubernetes-cluster" %>
 
-<%==part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents)%>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/kubernetes-cluster/settings.erb
+++ b/views/kubernetes-cluster/settings.erb
@@ -8,22 +8,40 @@
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           Danger Zone
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <!-- Delete Card -->
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete Kubernetes Cluster</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">
+              Delete Kubernetes Cluster
+            </h3>
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this cluster. Deleted data cannot be recovered. Use it carefully.</p>
+              <p>
+                This action will permanently delete this cluster. Deleted data
+                cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
-          <div id="kc-delete-<%=@kc.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+          <div
+            id="kc-delete-<%=@kc.ubid%>"
+            class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+          >
             <%== part("components/delete_button", url: path(@kc), confirmation: @kc.name, redirect: "#{@project.path}/kubernetes-cluster") %>
           </div>
         </div>

--- a/views/kubernetes-cluster/settings.erb
+++ b/views/kubernetes-cluster/settings.erb
@@ -39,7 +39,7 @@
             </div>
           </div>
           <div
-            id="kc-delete-<%=@kc.ubid%>"
+            id="kc-delete-<%= @kc.ubid %>"
             class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
           >
             <%== part("components/delete_button", url: path(@kc), confirmation: @kc.name, redirect: "#{@project.path}/kubernetes-cluster") %>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8">
 
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -85,7 +85,7 @@
       <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
           <div class="flex shrink-0 items-center px-10 py-4">
-            <img class="" src="/logo-primary.png" alt="Ubicloud">
+            <img src="/logo-primary.png" alt="Ubicloud">
           </div>
           <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900">
             <%= @page_message %>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -1,22 +1,30 @@
 <!DOCTYPE html>
+
 <html class="h-full bg-gray-50">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
     <title><%= ["Ubicloud", @page_title].compact.join(" - ") %></title>
+
     <%== assets(:css) %>
     <script
       src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"
       integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g="
       crossorigin="anonymous"
     ></script>
+
     <script
       src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
       integrity="sha256-QigBQMy2be3IqJD2ezKJUJ5gycSmyYlRHj2VGBuITpU="
       crossorigin="anonymous"
     ></script>
+
     <% if @enable_datepicker %>
       <link
         rel="stylesheet"
@@ -30,9 +38,11 @@
         crossorigin="anonymous"
       ></script>
     <% end %>
+
     <% if @enable_cloudflare_turnstile %>
       <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
     <% end %>
+
     <% if @enable_marked %>
       <script
         src="https://cdn.jsdelivr.net/npm/marked@15.0.5/marked.min.js"
@@ -40,6 +50,7 @@
         crossorigin="anonymous"
       ></script>
     <% end %>
+
     <% if @enable_echarts %>
       <script
         src="https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"
@@ -48,7 +59,6 @@
       >
       </script>
     <% end %>
-
   </head>
 
   <body class="h-full">
@@ -77,25 +87,38 @@
           <div class="flex shrink-0 items-center px-10 py-4">
             <img class="" src="/logo-primary.png" alt="Ubicloud">
           </div>
-          <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900"><%= @page_message %></h2>
+          <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900">
+            <%= @page_message %>
+          </h2>
         </div>
 
         <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
           <div class="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10">
-            <div class="pt-4 empty:hidden"><%== render("components/flash_message") %></div>
+            <div class="pt-4 empty:hidden">
+              <%== render("components/flash_message") %>
+            </div>
             <%== yield %>
           </div>
         </div>
+
         <div class="mt-10 flex justify-center space-x-5">
-          <a href="https://github.com/ubicloud/ubicloud" target="_blank" class="text-gray-400 hover:text-gray-500">
+          <a
+            href="https://github.com/ubicloud/ubicloud"
+            target="_blank"
+            class="text-gray-400 hover:text-gray-500"
+          >
             <span class="sr-only">GitHub</span>
             <%== part("components/icon", name: "github") %>
           </a>
-          <a href="mailto:support@ubicloud.com" class="text-gray-400 hover:text-gray-500">
+          <a
+            href="mailto:support@ubicloud.com"
+            class="text-gray-400 hover:text-gray-500"
+          >
             <span class="sr-only">Support</span>
             <%== part("components/icon", name: "hero-envelope") %>
           </a>
         </div>
+
         <% if Config.managed_service %>
           <div class="text-sm text-gray-500 text-center mt-10 w-full">
             By using Ubicloud console you agree to our

--- a/views/layouts/notifications.erb
+++ b/views/layouts/notifications.erb
@@ -1,8 +1,18 @@
-<div class="pointer-events-none fixed top-10 inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6">
+<div
+  class="
+    pointer-events-none fixed top-10 inset-0 flex items-end px-4 py-6
+    sm:items-start sm:p-6
+  "
+>
   <div class="flex w-full flex-col items-center space-y-4 sm:items-end">
     <div
       id="notification-template"
-      class="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5 transform ease-out duration-300 transition translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2 hidden"
+      class="
+        pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg
+        bg-white shadow-lg ring-1 ring-black ring-opacity-5 transform
+        ease-out duration-300 transition translate-y-2 opacity-0
+        sm:translate-y-0 sm:translate-x-2 hidden
+      "
     >
       <div class="p-4">
         <div class="flex items-center">

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -1,6 +1,8 @@
 <div class="flex grow flex-col gap-y-5 overflow-y-auto bg-orange-600 px-6">
   <div class="flex h-16 shrink-0 items-center">
-    <a href="<%= @project_permissions ? "#{@project.path}/dashboard" : "/project" %>">
+    <a
+      href="<%= @project_permissions ? "#{@project.path}/dashboard" : "/project" %>"
+    >
       <img class="h-6 w-auto" src="/logo-white.png" alt="Ubicloud">
     </a>
   </div>
@@ -81,7 +83,9 @@
       </li>
       <% if @project_permissions && has_project_permission(["Project:user", "Project:billing", "Project:view", "Project:viewaccess", "Project:token"]) %>
         <li>
-          <div class="text-xs font-semibold leading-6 text-orange-200">Project Details</div>
+          <div class="text-xs font-semibold leading-6 text-orange-200">
+            Project Details
+          </div>
           <ul role="list" class="-mx-2 mt-2 space-y-1">
             <%== if has_project_permission("Project:user")
                    users_url = "#{@project.path}/user"
@@ -141,8 +145,10 @@
         </li>
       <% end %>
       <% if @project_permissions && has_project_permission("Project:github") %>
-              <li>
-          <div class="text-xs font-semibold leading-6 text-orange-200">Integrations</div>
+        <li>
+          <div class="text-xs font-semibold leading-6 text-orange-200">
+            Integrations
+          </div>
           <ul role="list" class="-mx-2 mt-2 space-y-1">
             <% if Config.github_app_name %>
               <%== part(
@@ -156,7 +162,6 @@
             <% end %>
           </ul>
         </li>
-
       <% end %>
       <li class="-mx-6 mt-auto">
         <%== render("layouts/sidebar/project_switcher") %>

--- a/views/layouts/sidebar/desktop.erb
+++ b/views/layouts/sidebar/desktop.erb
@@ -1,3 +1,6 @@
-<div id="desktop-menu" class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+<div
+  id="desktop-menu"
+  class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col"
+>
   <%== render("layouts/sidebar/content") %>
 </div>

--- a/views/layouts/sidebar/group.erb
+++ b/views/layouts/sidebar/group.erb
@@ -2,7 +2,11 @@
   <div class="group <%= items.compact.map { it[2] }.any? ? "active" : "" %>">
     <button
       type="button"
-      class="toggle-parent-to-active w-full text-orange-100 hover:text-white hover:bg-orange-700 flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"
+      class="
+        toggle-parent-to-active w-full text-orange-100 hover:text-white
+        hover:bg-orange-700 flex gap-x-3 rounded-md p-2 text-sm leading-6
+        font-semibold
+      "
     >
       <%== part("components/icon", name: icon, classes: "text-white h-6 w-6 shrink-0") %>
       <%= name %>

--- a/views/layouts/sidebar/mobile.erb
+++ b/views/layouts/sidebar/mobile.erb
@@ -1,13 +1,28 @@
-<div id="mobile-menu" class="relative z-50 hidden group" role="dialog" aria-modal="true">
+<div
+  id="mobile-menu"
+  class="relative z-50 hidden group"
+  role="dialog"
+  aria-modal="true"
+>
   <div
-    class="fixed inset-0 bg-gray-900/80 transition-opacity ease-linear duration-300 opacity-0 group-[.mobile-menu-open]:opacity-100"
+    class="
+      fixed inset-0 bg-gray-900/80 transition-opacity ease-linear
+      duration-300 opacity-0 group-[.mobile-menu-open]:opacity-100
+    "
   ></div>
   <div class="fixed inset-0 flex">
     <div
-      class="relative mr-16 flex w-full max-w-xs flex-1 transition ease-in-out duration-300 transform -translate-x-full group-[.mobile-menu-open]:translate-x-0"
+      class="
+        relative mr-16 flex w-full max-w-xs flex-1 transition ease-in-out
+        duration-300 transform -translate-x-full
+        group-[.mobile-menu-open]:translate-x-0
+      "
     >
       <div
-        class="absolute left-full top-0 flex w-16 justify-center pt-5 ease-in-out duration-300 opacity-0 group-[.mobile-menu-open]:opacity-100"
+        class="
+          absolute left-full top-0 flex w-16 justify-center pt-5 ease-in-out
+          duration-300 opacity-0 group-[.mobile-menu-open]:opacity-100
+        "
       >
         <button type="button" class="toggle-mobile-menu -m-2.5 p-2.5">
           <span class="sr-only">Close sidebar</span>

--- a/views/layouts/sidebar/project_switcher.erb
+++ b/views/layouts/sidebar/project_switcher.erb
@@ -2,7 +2,10 @@
   <div>
     <button
       type="button"
-      class="inline-flex w-full items-center gap-x-4 px-6 py-3 text-md font-semibold leading-6 text-white bg-orange-700 hover:bg-orange-800"
+      class="
+        inline-flex w-full items-center gap-x-4 px-6 py-3 text-md
+        font-semibold leading-6 text-white bg-orange-700 hover:bg-orange-800
+      "
       id="menu-button"
     >
       <%== part("components/icon", name: "hero-folder-open", classes: "h-8 w-8 rounded-full") %>
@@ -11,7 +14,13 @@
     </button>
   </div>
   <div
-    class="hidden opacity-0 scale-95 group-[.active]:block group-[.active]:opacity-100 group-[.active]:scale-100 transition ease-out duration-100 absolute bottom-12 left-12 z-10 mt-2 w-64 origin-bottom divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none text-gray-800"
+    class="
+      hidden opacity-0 scale-95 group-[.active]:block
+      group-[.active]:opacity-100 group-[.active]:scale-100 transition
+      ease-out duration-100 absolute bottom-12 left-12 z-10 mt-2 w-64
+      origin-bottom divide-y divide-gray-100 rounded-md bg-white shadow-lg
+      ring-1 ring-black ring-opacity-5 focus:outline-none text-gray-800
+    "
     role="menu"
     tabindex="-1"
   >
@@ -22,13 +31,18 @@
           class="block px-4 py-2 hover:bg-gray-100 hover:text-gray-900 <% if p.id == @project&.id %> bg-orange-50 text-orange-600 hover:bg-orange-50 hover:text-orange-700 <% end %>"
           role="menuitem"
           tabindex="-1"
-        ><%= p.name %></a>
+        >
+          <%= p.name %>
+        </a>
       <% end %>
     </div>
     <div class="py-1" role="none">
       <a
         href="/project/create"
-        class="group flex items-center px-4 py-2 hover:bg-gray-100 hover:text-gray-900"
+        class="
+          group flex items-center px-4 py-2 hover:bg-gray-100
+          hover:text-gray-900
+        "
         role="menuitem"
         tabindex="-1"
       >

--- a/views/layouts/topbar.erb
+++ b/views/layouts/topbar.erb
@@ -1,20 +1,34 @@
 <div
-  class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8"
+  class="
+    sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b
+    border-gray-200 bg-white px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8
+  "
 >
-  <button type="button" class="toggle-mobile-menu -m-2.5 p-2.5 text-gray-700 lg:hidden">
+  <button
+    type="button"
+    class="toggle-mobile-menu -m-2.5 p-2.5 text-gray-700 lg:hidden"
+  >
     <span class="sr-only">Open sidebar</span>
     <%== part("components/icon", name: "hero-bars-3") %>
   </button>
+
   <!-- Separator -->
   <div class="h-6 w-px bg-gray-900/10 lg:hidden"></div>
-  <a href="<%= @project_permissions ? "#{@project.path}/dashboard" : "/project" %>">
+  <a
+    href="<%= @project_permissions ? "#{@project.path}/dashboard" : "/project" %>"
+  >
     <img class="h-5 w-auto lg:hidden" src="/logo-primary.png" alt="Ubicloud">
   </a>
+
   <div class="flex flex-1 gap-x-4 self-stretch justify-end lg:gap-x-6">
     <div class="flex items-center gap-x-4 lg:gap-x-6">
       <!-- Profile dropdown -->
       <div class="relative group dropdown text-sm leading-6 text-gray-900">
-        <button type="button" class="-m-1.5 flex items-center p-1.5" title="<%= current_account.email %>">
+        <button
+          type="button"
+          class="-m-1.5 flex items-center p-1.5"
+          title="<%= current_account.email %>"
+        >
           <%== part("components/icon", name: "hero-user-circle", classes: "h-8 w-8 rounded-full bg-gray-50") %>
           <span class="hidden lg:flex lg:items-center">
             <span class="ml-3 font-semibold" aria-hidden="true"><%= current_account.name %></span>
@@ -22,22 +36,50 @@
           </span>
         </button>
         <div
-          class="hidden group-[.active]:block absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-md bg-white pb-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none divide-y divide-gray-100"
+          class="
+            hidden group-[.active]:block absolute right-0 z-10 mt-2.5 w-48
+            origin-top-right rounded-md bg-white pb-2 shadow-lg ring-1
+            ring-gray-900/5 focus:outline-none divide-y divide-gray-100
+          "
           role="menu"
           tabindex="-1"
         >
           <div class="px-3 py-2">
             <p class="text-sm">Signed in as</p>
             <p class="truncate text-sm font-medium text-gray-900">
-              <%= current_account.email %></p>
+              <%= current_account.email %>
+            </p>
           </div>
+
           <div>
-            <a href="/account" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">My Account</a>
-            <a href="/project" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">Projects</a>
+            <a
+              href="/account"
+              class="block px-3 py-1 hover:bg-gray-100"
+              role="menuitem"
+              tabindex="-1"
+            >
+              My Account
+            </a>
+            <a
+              href="/project"
+              class="block px-3 py-1 hover:bg-gray-100"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Projects
+            </a>
           </div>
+
           <div>
             <% form(action: "/logout", method: :post) do %>
-              <button type="submit" class="block px-3 py-1 hover:bg-gray-100 w-full text-left" role="menuitem" tabindex="-1">Log out</button>
+              <button
+                type="submit"
+                class="block px-3 py-1 hover:bg-gray-100 w-full text-left"
+                role="menuitem"
+                tabindex="-1"
+              >
+                Log out
+              </button>
             <% end %>
           </div>
         </div>

--- a/views/networking/firewall/create.erb
+++ b/views/networking/firewall/create.erb
@@ -1,7 +1,6 @@
 <% @page_title = "Create Firewall"
 @option_tree, @option_parents = generate_firewall_options
-@default_location = @project.default_location
-%>
+@default_location = @project.default_location %>
 
 <%== part(
   "components/page_header",
@@ -13,15 +12,13 @@
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-2'>"},
     {name: "description", type: "text", label: "Description", required: "required", placeholder: "Enter description", opening_tag: "<div class='sm:col-span-2'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
     {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", content_generator: ContentGenerator::Vm.method(:private_subnet), opening_tag: "<div class='sm:col-span-2'>"},
   ]
 
-  action = "#{@project.path}/firewall"
-%>
+  action = "#{@project.path}/firewall" %>
 
-<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents)%>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/networking/firewall/index.erb
+++ b/views/networking/firewall/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Firewalls" %>
+
 <%== render("networking/tabbar") %>
 
 <div class="grid gap-6">

--- a/views/networking/firewall/networking.erb
+++ b/views/networking/firewall/networking.erb
@@ -15,31 +15,80 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
 <div class="p-6 grid gap-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Firewall Rules
       </h3>
     </div>
   </div>
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Port range</th>
+          <th
+            scope="col"
+            class="
+              py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900
+              sm:pl-6
+            "
+          >
+            CIDR
+          </th>
+          <th
+            scope="col"
+            class="
+              py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900
+              sm:pl-6
+            "
+          >
+            Port range
+          </th>
           <% if edit_perm %>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+            <th
+              scope="col"
+              class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+            ></th>
           <% end %>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white">
         <% @firewall.firewall_rules.sort_by { [it.cidr.version, it.cidr.to_s] }.each do |fwr| %>
           <tr>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr.cidr %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr.display_port_range %></td>
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
+              <%= fwr.cidr %>
+            </td>
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
+              <%= fwr.display_port_range %>
+            </td>
             <% if edit_perm %>
               <td
                 id="fwr-delete-<%= fwr.ubid %>"
-                class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+                class="
+                  relative whitespace-nowrap py-4 pl-3 pr-4 text-right
+                  text-sm font-medium sm:pr-6
+                "
               >
                 <%== part("components/delete_button", url: "#{firewall_path}/firewall-rule/#{fwr.ubid}", text: "") %>
               </td>
@@ -48,7 +97,13 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
         <% end %>
         <% if edit_perm %>
           <tr>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
               <%== part(
                 "components/form/text",
                 name: "cidr",
@@ -59,7 +114,13 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
                 }
               ) %>
             </td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
               <%== part(
                 "components/form/text",
                 name: "port_range",
@@ -69,7 +130,12 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
                 }
               ) %>
             </td>
-            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+            <td
+              class="
+                relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+                font-medium sm:pr-6
+              "
+            >
               <% form(action: "#{firewall_path}/firewall-rule", method: :post, role: :form, id: "form-fw-create-rule-#{@firewall.ubid}") do %>
                 <%== part("components/form/submit_button", text: "Create") %>
               <% end %>
@@ -79,37 +145,81 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
       </tbody>
     </table>
   </div>
+
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Attached Private Subnets
       </h3>
     </div>
   </div>
-  <div id="fw-private-subnets" class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+
+  <div
+    id="fw-private-subnets"
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
+          <th
+            scope="col"
+            class="
+              py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900
+              sm:pl-6
+            "
+          >
+            Name
+          </th>
           <% if edit_perm %>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+            <th
+              scope="col"
+              class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+            ></th>
           <% end %>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white">
         <% @firewall.private_subnets.each do |ps| %>
           <tr>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
               <% if viewable_subnet_map[ps.id] %>
-                <a href="<%= path(ps) %>" class="text-orange-600 hover:text-orange-700"><%= ps.name %></a>
+                <a
+                  href="<%= path(ps) %>"
+                  class="text-orange-600 hover:text-orange-700"
+                >
+                  <%= ps.name %>
+                </a>
               <% else %>
                 <%= ps.name %>
               <% end %>
             </td>
             <% if edit_perm %>
-              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+              <td
+                class="
+                  relative whitespace-nowrap py-4 pl-3 pr-4 text-right
+                  text-sm font-medium sm:pr-6
+                "
+              >
                 <% form(action: "#{firewall_path}/detach-subnet", method: :post, role: :form) do %>
-                  <input type="hidden" name="private_subnet_id" value="<%= ps.ubid %>">
+                  <input
+                    type="hidden"
+                    name="private_subnet_id"
+                    value="<%= ps.ubid %>"
+                  >
                   <%== part("components/form/submit_button", text: "Detach") %>
                 <% end %>
               </td>
@@ -118,7 +228,13 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
         <% end %>
         <% if edit_perm %>
           <tr>
-            <td class="whitespace-nowrap py-4 pl-2 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+            <td
+              class="
+                whitespace-nowrap py-4 pl-2 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
               <%== part(
                 "components/form/select",
                 name: "private_subnet_id",
@@ -130,7 +246,12 @@ edit_perm = has_permission?("Firewall:edit", @firewall.ubid) %>
                 }
               ) %>
             </td>
-            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+            <td
+              class="
+                relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+                font-medium sm:pr-6
+              "
+            >
               <% form(action: "#{firewall_path}/attach-subnet", method: :post, role: :form, id: "form-fw-attach-#{@firewall.ubid}") do %>
                 <%== part("components/form/submit_button", text: "Attach") %>
               <% end %>

--- a/views/networking/firewall/settings.erb
+++ b/views/networking/firewall/settings.erb
@@ -7,21 +7,35 @@
 <div class="p-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Danger Zone
       </h3>
     </div>
   </div>
 
   <% if has_permission?("Firewall:delete", @firewall.ubid) %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete firewall</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">
+              Delete firewall
+            </h3>
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this firewall. Deleted firewall cannot be recovered. Use it
-                carefully.</p>
+              <p>
+                This action will permanently delete this firewall. Deleted
+                firewall cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -11,8 +11,7 @@
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "algorithm", type: "select", label: "Load Balancing Algorithm", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
@@ -25,7 +24,6 @@
     {name: "health_check_protocol", type: "select", label: "Health Check Protocol", required: "required", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-start-3 md:col-end-5'>"}
   ]
 
-  action = "#{@project.path}/load-balancer"
-%>
+  action = "#{@project.path}/load-balancer" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/networking/load_balancer/index.erb
+++ b/views/networking/load_balancer/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Load Balancers" %>
+
 <%== render("networking/tabbar") %>
 
 <div class="grid gap-6">
@@ -25,7 +26,7 @@
     } : {})
   ) %>
 
-  <% if @lbs.count > 0 && has_project_permission("LoadBalancer:create")%>
+  <% if @lbs.count > 0 && has_project_permission("LoadBalancer:create") %>
     <div class="flex justify-end">
       <%== part("components/button", text: "Create Load Balancer", link: "load-balancer/create") %>
     </div>

--- a/views/networking/load_balancer/settings.erb
+++ b/views/networking/load_balancer/settings.erb
@@ -8,19 +8,33 @@
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           Danger Zone
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete load balancer</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">
+              Delete load balancer
+            </h3>
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this load balancer. Deleted load balancer cannot be recovered. Use
-                it carefully.</p>
+              <p>
+                This action will permanently delete this load balancer. Deleted
+                load balancer cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">

--- a/views/networking/load_balancer/vms.erb
+++ b/views/networking/load_balancer/vms.erb
@@ -7,32 +7,71 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb.ubid) %>
 <div class="p-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Attached VMs
       </h3>
     </div>
   </div>
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">VM</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Application State</th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          >
+            VM
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          >
+            Application State
+          </th>
           <% if edit_perm %>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+            <th
+              scope="col"
+              class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+            ></th>
           <% end %>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white" id="lb-vms">
         <% @lb.vms(eager: :load_balancer_vm_ports).each do |vm| %>
           <tr>
-            <td class="whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-              <a href="<%= path(vm) %>" class="text-orange-600 hover:text-orange-700"><%= vm.name %></a>
+            <td
+              class="
+                whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
+              <a
+                href="<%= path(vm) %>"
+                class="text-orange-600 hover:text-orange-700"
+              >
+                <%= vm.name %>
+              </a>
             </td>
             <td class="px-3 py-3.5 whitespace-nowrap text-sm text-gray-900">
               <%= vm.load_balancer_state %>
             </td>
-            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+            <td
+              class="
+                relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+                font-medium sm:pr-6
+              "
+            >
               <% form(action: "#{load_balancer_path}/detach-vm", role: :form, method: :post) do %>
                 <input type="hidden" name="vm_id" value="<%= vm.ubid %>">
                 <%== part("components/form/submit_button", text: "Detach") %>
@@ -42,7 +81,13 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb.ubid) %>
         <% end %>
         <% if edit_perm %>
           <tr>
-            <td class="whitespace-nowrap py-4 pl-2 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+            <td
+              class="
+                whitespace-nowrap py-4 pl-2 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
               <%== part(
                 "components/form/select",
                 name: "vm_id",
@@ -54,9 +99,18 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb.ubid) %>
                 }
               ) %>
             </td>
-            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-            </td>
-            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+            <td
+              class="
+                relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+                font-medium sm:pr-6
+              "
+            ></td>
+            <td
+              class="
+                relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+                font-medium sm:pr-6
+              "
+            >
               <% form(action: "#{load_balancer_path}/attach-vm", role: :form, method: :post, id: "form-lb-#{@lb.ubid}") do %>
                 <%== part("components/form/submit_button", text: "Attach") %>
               <% end %>

--- a/views/networking/private_subnet/create.erb
+++ b/views/networking/private_subnet/create.erb
@@ -11,13 +11,11 @@
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
   ]
 
-  action = "#{@project.path}/private-subnet"
-%>
+  action = "#{@project.path}/private-subnet" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/networking/private_subnet/index.erb
+++ b/views/networking/private_subnet/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Private Subnets" %>
+
 <%== render("networking/tabbar") %>
 
 <div class="grid gap-6">
@@ -26,8 +27,8 @@
     } : {})
   ) %>
   <% if @pss.count > 0 && has_project_permission("PrivateSubnet:create") %>
-  <div class="flex justify-end">
-    <%== part("components/button", text: "Create Private Subnet", link: "private-subnet/create") %>
-  </div>
+    <div class="flex justify-end">
+      <%== part("components/button", text: "Create Private Subnet", link: "private-subnet/create") %>
+    </div>
   <% end %>
 </div>

--- a/views/networking/private_subnet/networking.erb
+++ b/views/networking/private_subnet/networking.erb
@@ -39,32 +39,68 @@ viewable_fws, viewable_subnets =
   <!-- Connected Private Subnets List -->
   <div class="mt-6 md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Connected Subnets
       </h3>
     </div>
   </div>
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+          <th
+            scope="col"
+            class="
+              py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900
+              sm:pl-6
+            "
+          >
+            Name
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          ></th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white">
         <% @connected_subnets.each do |subnet| %>
           <tr>
-            <td class="whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+            <td
+              class="
+                whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+              scope="row"
+            >
               <% if viewable_subnets[subnet.ubid] %>
-                <a href="<%= path(subnet) %>" class="text-orange-600 hover:text-orange-700"><%= subnet.name %></a>
+                <a
+                  href="<%= path(subnet) %>"
+                  class="text-orange-600 hover:text-orange-700"
+                >
+                  <%= subnet.name %>
+                </a>
               <% else %>
                 <%= subnet.name %>
               <% end %>
             </td>
             <td
               id="cps-delete-<%= subnet.ubid %>"
-              class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+              class="
+                relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+                font-medium sm:pr-6
+              "
             >
               <%== part(
                 "components/delete_button",
@@ -78,7 +114,13 @@ viewable_fws, viewable_subnets =
           </tr>
         <% end %>
         <tr>
-          <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+          <td
+            class="
+              whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+              text-gray-900 sm:pl-6
+            "
+            scope="row"
+          >
             <%== part(
               "components/form/select",
               name: "connected-subnet-id",
@@ -90,7 +132,12 @@ viewable_fws, viewable_subnets =
               }
             ) %>
           </td>
-          <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+          <td
+            class="
+              relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+              font-medium sm:pr-6
+            "
+          >
             <% form(action: "#{ps_path}/connect", role: :form, method: :post, id: "form-connect-subnet") do %>
               <%== part("components/form/submit_button", text: "Connect") %>
             <% end %>

--- a/views/networking/private_subnet/settings.erb
+++ b/views/networking/private_subnet/settings.erb
@@ -8,19 +8,33 @@
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           Danger Zone
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete private subnet</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">
+              Delete private subnet
+            </h3>
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this private subnet. Deleted subnet cannot be recovered. Use it
-                carefully.</p>
+              <p>
+                This action will permanently delete this private subnet. Deleted
+                subnet cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">

--- a/views/object/show.erb
+++ b/views/object/show.erb
@@ -36,14 +36,18 @@
       <div class="divide-y">
         <div class="pb-6 flex items-center justify-between">
           <div>
-            <span class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:tracking-tight"><%= object.name %></span>
-            <span>(id:
-              <%= object.ubid %>)</span>
+            <span
+              class="
+                text-2xl font-bold leading-7 text-gray-900 sm:text-3xl
+                sm:tracking-tight
+              "
+            >
+              <%= object.name %>
+            </span>
+            <span>(id: <%= object.ubid %>)</span>
           </div>
           <% if right_header %>
-            <div>
-              <%== right_header %>
-            </div>
+            <div><%== right_header %></div>
           <% end %>
         </div>
         <%== render("#{prefix}/#{@page.tr("-", "_")}") %>

--- a/views/postgres/backup_restore.erb
+++ b/views/postgres/backup_restore.erb
@@ -6,18 +6,28 @@ max_date = @pg.timeline.latest_restore_time %>
     <% form(action: "#{path(@pg)}/restore", role: :form, method: :post) do %>
       <div class="space-y-4">
         <div>
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Fork PostgreSQL database</h3>
+          <h3
+            class="
+              text-2xl font-bold leading-7 text-gray-900 sm:truncate
+              sm:text-2xl sm:tracking-tight
+            "
+          >
+            Fork PostgreSQL database
+          </h3>
           <p class="mt-1 text-sm text-gray-500">
-            When you fork your existing PostgreSQL database, a new server will be provisioned.
+            When you fork your existing PostgreSQL database, a new server will
+            be provisioned.
           </p>
         </div>
         <div class="grid grid-cols-12 gap-6">
           <div class="col-span-12 sm:col-span-5">
             <%== part("components/form/text", label: "New server name", name: "name", attributes: { placeholder: @pg.name + "-fork", required: true }) %>
           </div>
+
           <div class="col-span-12 sm:col-span-5">
             <%== part("components/form/datepicker", label: "Target Time (UTC)", name: "restore_target", default_date: max_date, max_date:, min_date:) %>
           </div>
+
           <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
             <%== part("components/form/submit_button", text: "Fork") %>
           </div>
@@ -34,30 +44,68 @@ max_date = @pg.timeline.latest_restore_time %>
 <% end %>
 
 <% backups = @pg.timeline.backups %>
+
 <% if backups.count > 0 %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Backups</h3>
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
+          Backups
+        </h3>
       </div>
     </div>
 
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">
           <tr>
-            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Backup Time</th>
-            <th scope="col" class="py-3.5 text-left text-sm font-semibold text-gray-900">Type</th>
-            <th scope="col" class="py-3.5 text-left text-sm font-semibold text-gray-900">Fork</th>
+            <th
+              scope="col"
+              class="
+                py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                text-gray-900 sm:pl-6
+              "
+            >
+              Backup Time
+            </th>
+            <th
+              scope="col"
+              class="py-3.5 text-left text-sm font-semibold text-gray-900"
+            >
+              Type
+            </th>
+            <th
+              scope="col"
+              class="py-3.5 text-left text-sm font-semibold text-gray-900"
+            >
+              Fork
+            </th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           <% backups.each do %>
             <tr>
-              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= it.last_modified %></td>
-              <td class="py-4 text-sm font-medium text-gray-900">Full Backup</td>
+              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                <%= it.last_modified %>
+              </td>
               <td class="py-4 text-sm font-medium text-gray-900">
-                <div class="cursor-pointer fork-icon" data-target-datetime="<%= it.last_modified %>">
+                Full Backup
+              </td>
+              <td class="py-4 text-sm font-medium text-gray-900">
+                <div
+                  class="cursor-pointer fork-icon"
+                  data-target-datetime="<%= it.last_modified %>"
+                >
                   <%== part("components/icon", name: "fork", classes: "text-black-600 h-6 w-6") %>
                 </div>
               </td>

--- a/views/postgres/charts.erb
+++ b/views/postgres/charts.erb
@@ -129,7 +129,7 @@
               -
             </td>
             <td
-              id="md-delete-<%=md.ubid %>"
+              id="md-delete-<%= md.ubid %>"
               class="
                 relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
                 font-medium sm:pr-6

--- a/views/postgres/charts.erb
+++ b/views/postgres/charts.erb
@@ -5,7 +5,11 @@
     <div class="mb-4 flex gap-2 justify-end">
       <select
         id="time-range"
-        class="py-1.5 md:align-top rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+        class="
+          py-1.5 md:align-top rounded-md border-gray-300 shadow-sm
+          focus:border-indigo-300 focus:ring focus:ring-indigo-200
+          focus:ring-opacity-50
+        "
         name="time-range"
       >
         <option value="30m">Last 30 minutes</option>
@@ -23,22 +27,27 @@
     <div class="grid grid-cols-1 xl:grid-cols-2 gap-4 border-t-0">
       <% Metrics::POSTGRES_METRICS.each do |key, metric| %>
         <div class="p-4 bg-gray-50 rounded-lg border border-gray-100">
-          <h4 class="text-sm font-medium text-gray-900 mb-2"><%= metric.name %></h4>
+          <h4 class="text-sm font-medium text-gray-900 mb-2">
+            <%= metric.name %>
+          </h4>
+
           <p class="text-xs text-gray-500 mt-2"><%= metric.description %></p>
+
           <div
             class="metric-chart h-64 w-full"
             id="<%= key %>-chart"
             data-metric-key="<%= key %>"
             data-metric-unit="<%= metric.unit %>"
-          >
-          </div>
+          ></div>
         </div>
       <% end %>
     </div>
   <% else %>
     <div class="flex flex-col items-center justify-center h-full">
       <h2 class="text-2xl font-semibold text-gray-900">No metrics available</h2>
-      <p class="text-gray-500 mt-2">Metrics will be available once the database is running.</p>
+      <p class="text-gray-500 mt-2">
+        Metrics will be available once the database is running.
+      </p>
     </div>
   <% end %>
 </div>
@@ -46,43 +55,113 @@
 <div class="p-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Metric Destinations
       </h3>
     </div>
   </div>
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">URL</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Username</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Password</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+          <th
+            scope="col"
+            class="
+              py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900
+              sm:pl-6
+            "
+          >
+            URL
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          >
+            Username
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          >
+            Password
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          ></th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white">
         <% @pg.metric_destinations.each do |md| %>
           <tr>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= md.url %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= md.username %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">-</td>
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+            >
+              <%= md.url %>
+            </td>
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+            >
+              <%= md.username %>
+            </td>
+            <td
+              class="
+                whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                text-gray-900 sm:pl-6
+              "
+            >
+              -
+            </td>
             <td
               id="md-delete-<%=md.ubid %>"
-              class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+              class="
+                relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+                font-medium sm:pr-6
+              "
             >
               <%== part("components/delete_button", url: "#{path(@pg)}/metric-destination/#{md.ubid}", text: "") %>
             </td>
           </tr>
         <% end %>
         <tr>
-          <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+          <td
+            class="
+              whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+              text-gray-900 sm:pl-6
+            "
+          >
             <%== part("components/form/text", name: "url", attributes: { form: "form-pg-md-create", required: true }) %>
           </td>
-          <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+          <td
+            class="
+              whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+              text-gray-900 sm:pl-6
+            "
+          >
             <%== part("components/form/text", name: "username", attributes: { form: "form-pg-md-create", required: true }) %>
           </td>
-          <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+          <td
+            class="
+              whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+              text-gray-900 sm:pl-6
+            "
+          >
             <%== part(
                 "components/form/text",
                 name: "metric-destination-password",
@@ -95,7 +174,12 @@
                 extra_class: "metric-destination-password"
               ) %>
           </td>
-          <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+          <td
+            class="
+              relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm
+              font-medium sm:pr-6
+            "
+          >
             <% form(action: "#{path(@pg)}/metric-destination", role: :form, method: :post, id: "form-pg-md-create") do %>
               <%== part("components/form/submit_button", text: "Create", extra_class: "metric-destination-create-button") %>
             <% end %>

--- a/views/postgres/config.erb
+++ b/views/postgres/config.erb
@@ -1,5 +1,4 @@
-<% 
-  pg_config = @pg.user_config || {}
+<% pg_config = @pg.user_config || {}
   pgbouncer_config = @pg.pgbouncer_user_config || {}
 
   errors = flash.now["errors"] || {}
@@ -13,8 +12,7 @@
 
     pg_config = pg_keys.zip(pg_values).to_h
     pgbouncer_config = pgbouncer_keys.zip(pgbouncer_values).to_h
-  end
-%>
+  end %>
 
 <% form(action: "#{path(@pg)}/config", role: :form, method: :post, class: "min-w-2/3 pg-config") do %>
   <%== part("components/config_card", title: "PostgreSQL Configuration", config: pg_config, extra_class: "pg-config-card", name: "pg_config", errors: errors) %>

--- a/views/postgres/connection.erb
+++ b/views/postgres/connection.erb
@@ -1,5 +1,4 @@
-<%
-  hostname = @pg.hostname
+<% hostname = @pg.hostname
   password = URI.encode_uri_component(@pg.superuser_password)
 
   connection_infos = {
@@ -13,9 +12,7 @@
     "yaml-6432" => "host: #{hostname}\nport: 6432\nuser: postgres\npassword: #{password}\ndatabase: postgres",
     "jdbc-5432" => "jdbc:postgresql://#{hostname}:5432/postgres?user=postgres&password=#{password}&ssl=true",
     "jdbc-6432" => "jdbc:postgresql://#{hostname}:6432/postgres?user=postgres&password=#{password}&ssl=true"
-  }
-
-%>
+  } %>
 
 <div class="p-6">
   <% if @pg.display_state != "creating" %>
@@ -35,27 +32,27 @@
           ) %>
         </div>
       </div>
-      <div><%== part("components/form/checkbox", options: [["1", "Use pgBouncer?", "", {}]]) %></div>
+      <div>
+        <%== part("components/form/checkbox", options: [["1", "Use pgBouncer?", "", {}]]) %>
+      </div>
     </div>
-
-    <%
-      connection_infos.each_with_index do |(key, value), index|
-      hidden_class = index == 0 ? "" : "hidden"
-    %>
+    <% connection_infos.each_with_index do |(key, value), index|
+      hidden_class = index == 0 ? "" : "hidden" %>
       <div class="bg-gray-200 rounded-md p-6 mt-5 connection-info-box connection-info-box-<%= key %> <%= hidden_class %>">
-      <%== part("components/copyable_content", content: value, revealable: true, classes: "!flex justify-between") %>
+        <%== part("components/copyable_content", content: value, revealable: true, classes: "!flex justify-between") %>
       </div>
     <% end %>
-
     <div class="mt-5 flex items-center gap-2">
-      CA Certificates: <%== part("components/download_button", link: "#{path(@pg)}/ca-certificates")%>
+      CA Certificates: <%== part("components/download_button", link: "#{path(@pg)}/ca-certificates") %>
     </div>
   <% else %>
     <div class="flex flex-col items-center justify-center h-full">
-      <h2 class="text-2xl font-semibold text-gray-900">No connection information available</h2>
-      <p class="text-gray-500 mt-2">Connection information will be available once the database is running.</p>
+      <h2 class="text-2xl font-semibold text-gray-900">
+        No connection information available
+      </h2>
+      <p class="text-gray-500 mt-2">
+        Connection information will be available once the database is running.
+      </p>
     </div>
   <% end %>
 </div>
-
-

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -1,5 +1,4 @@
-<%
-  @flavor = typecast_params.nonempty_str("flavor", PostgresResource::Flavor::STANDARD)
+<% @flavor = typecast_params.nonempty_str("flavor", PostgresResource::Flavor::STANDARD)
   @flavor = PostgresResource::Flavor::STANDARD unless Option::POSTGRES_FLAVOR_OPTIONS.any? { |k,| k == @flavor }
   @prices = fetch_location_based_prices("PostgresVCpu", "PostgresStorage")
   @has_valid_payment_method = @project.has_valid_payment_method?
@@ -7,8 +6,7 @@
   @option_tree, @option_parents = generate_postgres_options(flavor: @flavor)
 
   @page_title, logo = postgres_flavors[@flavor].yield_self { ["Create #{it.title}", "logo-#{it.brand}.png"] }
-  logo = nil if @flavor == PostgresResource::Flavor::STANDARD
-%>
+  logo = nil if @flavor == PostgresResource::Flavor::STANDARD %>
 
 <%== render("components/billing_warning") %>
 
@@ -23,8 +21,7 @@
   right_items: [logo ? "<img src=\"/#{logo}\" class=\"h-6 object-contain\"/>" : nil]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "flavor", type: "hidden", value: @flavor},
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Postgres.method(:location)},
@@ -39,7 +36,6 @@
     form_elements << {name: "partnership_notice", type: "partnership_notice", label: "Partnership Notice", required: "required", content_generator: ContentGenerator::Postgres.method(:partnership_notice)}
   end
 
-  action = "#{@project.path}/postgres"
-%>
+  action = "#{@project.path}/postgres" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -61,9 +61,10 @@
           <div>
             <span class="inline-flex rounded-lg overflow-hidden w-12 h-12">
               <img
+                alt=""
                 src="/icons/pg-<%= it.brand.downcase %>.png"
                 class="object-cover"
-              />
+              >
             </span>
           </div>
 

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -23,7 +23,6 @@
       </div>
     DROPDOWN
   ) %>
-
   <div class="grid gap-6">
     <%== part(
       "components/table_card",
@@ -50,30 +49,46 @@
     title: "Create PostgreSQL Database",
     breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["PostgreSQL Databases", "#"]]
   ) %>
-
   <div class="grid gap-6">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 lg:gap-10">
+    <div
+      class="
+        grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6
+        lg:gap-10
+      "
+    >
       <% postgres_flavors.values.each do %>
         <div class="rounded-lg shadow group relative bg-white p-6">
           <div>
             <span class="inline-flex rounded-lg overflow-hidden w-12 h-12">
-              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover"/>
+              <img
+                src="/icons/pg-<%= it.brand.downcase %>.png"
+                class="object-cover"
+              />
             </span>
           </div>
+
           <div class="mt-4">
             <h3 class="text-base font-semibold leading-6 text-gray-900">
-              <a href="<%= @project.path %>/postgres/create?flavor=<%= it.name %>" class="focus:outline-none">
+              <a
+                href="<%= @project.path %>/postgres/create?flavor=<%= it.name %>"
+                class="focus:outline-none"
+              >
                 <span class="absolute inset-0" aria-hidden="true"></span>
                 Create <%= it.title %>
               </a>
             </h3>
             <p class="mt-2 text-sm text-gray-500"><%= it.description %></p>
           </div>
-          <span class="pointer-events-none absolute right-6 top-6 text-gray-300 group-hover:text-gray-400">
+          <span
+            class="
+              pointer-events-none absolute right-6 top-6 text-gray-300
+              group-hover:text-gray-400
+            "
+          >
             <%== part("components/icon", name: "hero-arrow-up-right") %>
           </span>
         </div>
-    <% end %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/views/postgres/networking.erb
+++ b/views/postgres/networking.erb
@@ -1,59 +1,126 @@
 <div class="p-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Firewall Rules</h3>
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
+        Firewall Rules
+      </h3>
     </div>
   </div>
 
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">CIDR</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Description</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Port Range</th>
+          <th
+            scope="col"
+            class="
+              py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900
+              sm:pl-6
+            "
+          >
+            CIDR
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          >
+            Description
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+          >
+            Port Range
+          </th>
           <% if @edit_perm %>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+            <th
+              scope="col"
+              class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+            ></th>
           <% end %>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white">
         <% @pg.firewall_rules.each do |fwr| %>
-        <tr class="group/inline-editable">
-          <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 inline-editable">
-            <div class="inline-editable-text group-[.active]/inline-editable:hidden block"><%= fwr.cidr %></div>
-            <%== part("components/form/text", name: "cidr", attributes: {required: true}, extra_class: "inline-editable-input group-[.active]/inline-editable:block hidden") %>
-          </td>
-          <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 inline-editable">
-            <div class="inline-editable-text group-[.active]/inline-editable:hidden block"><%= fwr.description %></div>
-            <%== part("components/form/text", name: "description", extra_class: "inline-editable-input group-[.active]/inline-editable:block hidden") %>
-          </td>
-          <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">5432, 6432</td>
-          <% if @edit_perm %>
-          <td id="fwr-buttons-<%= fwr.ubid %>" class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 flex gap-2 items-center justify-end">
-            <%== part("components/inline_edit_buttons", url: "#{path(@pg)}/firewall-rule/#{fwr.ubid}", confirmation_message: "Firewall rule is updated successfully.") %>
-            <div class="group-[.active]/inline-editable:hidden block">
-              <%== part("components/delete_button", url: "#{path(@pg)}/firewall-rule/#{fwr.ubid}", text: "") %>
-            </div>
-          </td>
-          <% end %>
-        </tr>
+          <tr class="group/inline-editable">
+            <td
+              class="
+                py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6
+                inline-editable
+              "
+            >
+              <div
+                class="
+                  inline-editable-text
+                  group-[.active]/inline-editable:hidden block
+                "
+              >
+                <%= fwr.cidr %>
+              </div>
+              <%== part("components/form/text", name: "cidr", attributes: {required: true}, extra_class: "inline-editable-input group-[.active]/inline-editable:block hidden") %>
+            </td>
+            <td
+              class="
+                py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6
+                inline-editable
+              "
+            >
+              <div
+                class="
+                  inline-editable-text
+                  group-[.active]/inline-editable:hidden block
+                "
+              >
+                <%= fwr.description %>
+              </div>
+              <%== part("components/form/text", name: "description", extra_class: "inline-editable-input group-[.active]/inline-editable:block hidden") %>
+            </td>
+            <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              5432, 6432
+            </td>
+            <% if @edit_perm %>
+              <td
+                id="fwr-buttons-<%= fwr.ubid %>"
+                class="
+                  py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 flex
+                  gap-2 items-center justify-end
+                "
+              >
+                <%== part("components/inline_edit_buttons", url: "#{path(@pg)}/firewall-rule/#{fwr.ubid}", confirmation_message: "Firewall rule is updated successfully.") %>
+                <div class="group-[.active]/inline-editable:hidden block">
+                  <%== part("components/delete_button", url: "#{path(@pg)}/firewall-rule/#{fwr.ubid}", text: "") %>
+                </div>
+              </td>
+            <% end %>
+          </tr>
         <% end %>
         <% if @edit_perm %>
-        <tr>
-          <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-            <%== part("components/form/text", name: "cidr", attributes: { placeholder: "0.0.0.0/0", required: true, form: "form-pg-fwr-create" }) %>
-          </td>
-          <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-            <%== part("components/form/text", name: "description", attributes: { placeholder: "Description", form: "form-pg-fwr-create" }) %>
-          </td>
-          <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">5432, 6432</td>
-          <td class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-            <% form(action: "#{path(@pg)}/firewall-rule", role: :form, method: :post, id: "form-pg-fwr-create") do %>
-              <%== part("components/form/submit_button", text: "Create", extra_class: "firewall-rule-create-button") %>
-            <% end %>
-          </td>
-        </tr>
+          <tr>
+            <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              <%== part("components/form/text", name: "cidr", attributes: { placeholder: "0.0.0.0/0", required: true, form: "form-pg-fwr-create" }) %>
+            </td>
+            <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              <%== part("components/form/text", name: "description", attributes: { placeholder: "Description", form: "form-pg-fwr-create" }) %>
+            </td>
+            <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              5432, 6432
+            </td>
+            <td class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+              <% form(action: "#{path(@pg)}/firewall-rule", role: :form, method: :post, id: "form-pg-fwr-create") do %>
+                <%== part("components/form/submit_button", text: "Create", extra_class: "firewall-rule-create-button") %>
+              <% end %>
+            </td>
+          </tr>
         <% end %>
       </tbody>
     </table>

--- a/views/postgres/overview.erb
+++ b/views/postgres/overview.erb
@@ -1,10 +1,7 @@
-<%
-vm = @pg.representative_server.vm
-%>
+<% vm = @pg.representative_server.vm %>
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 p-6 database-overview">
-  <%
-    vmr = VictoriaMetricsResource.first(project_id: @pg.representative_server.metrics_config[:project_id])
+  <% vmr = VictoriaMetricsResource.first(project_id: @pg.representative_server.metrics_config[:project_id])
     if vmr
       tsdb_client = vmr.servers.first.client
       query = Metrics::POSTGRES_METRICS[:disk_usage].series[0].query.gsub("$ubicloud_resource_id", @pg.ubid)
@@ -41,12 +38,9 @@ vm = @pg.representative_server.vm
       ["hero-square-2-stack-modified", ha_option.description, ""],
       ["hero-map-pin", @pg.location.display_name, "#{location_details} (#{provider})"],
       ["postgres-logo", "Version #{@pg.version}", ""],
-    ].each do |icon, text, subtext|
-  %>
-  <%== part("components/icon_with_text", icon:, text:, subtext:) %>
-  <%
-    end
-  %>
+    ].each do |icon, text, subtext| %>
+    <%== part("components/icon_with_text", icon:, text:, subtext:) %>
+  <% end %>
 </div>
 
 <% @enable_echarts = true %>
@@ -54,29 +48,41 @@ vm = @pg.representative_server.vm
 <div id="metrics-container" class="p-6" data-metrics-url="<%= path(@pg) %>">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Metrics Summary</h3>
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
+        Metrics Summary
+      </h3>
     </div>
   </div>
   <% if @pg.display_state != "creating" %>
     <div class="grid grid-cols-1 xl:grid-cols-2 gap-4 border-t-0">
       <% Metrics::POSTGRES_METRICS.slice(:cpu_usage, :disk_usage).each do |key, metric| %>
         <div class="p-4 bg-gray-50 rounded-lg border border-gray-100">
-          <h4 class="text-sm font-medium text-gray-900 mb-2"><%= metric.name %></h4>
+          <h4 class="text-sm font-medium text-gray-900 mb-2">
+            <%= metric.name %>
+          </h4>
+
           <p class="text-xs text-gray-500 mt-2"><%= metric.description %></p>
+
           <div
             class="metric-chart h-64 w-full"
             id="<%= key %>-chart"
             data-metric-key="<%= key %>"
             data-metric-unit="<%= metric.unit %>"
-          >
-          </div>
+          ></div>
         </div>
       <% end %>
     </div>
   <% else %>
     <div class="flex flex-col items-center justify-center h-full">
       <h2 class="text-2xl font-semibold text-gray-900">No metrics available</h2>
-      <p class="text-gray-500 mt-2">Metrics will be available once the database is running.</p>
+      <p class="text-gray-500 mt-2">
+        Metrics will be available once the database is running.
+      </p>
     </div>
   <% end %>
 </div>

--- a/views/postgres/read_replica.erb
+++ b/views/postgres/read_replica.erb
@@ -2,36 +2,84 @@
   <% if @pg.timeline.earliest_restore_time %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Read Replicas</h3>
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
+          Read Replicas
+        </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">
           <tr>
-            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
+            <th
+              scope="col"
+              class="
+                py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                text-gray-900 sm:pl-6
+              "
+            >
+              Name
+            </th>
+            <th
+              scope="col"
+              class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+            >
+              State
+            </th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           <% @pg.read_replicas.each do |read_replica| %>
             <tr>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                <a href="<%= path(read_replica) %>/overview" class="text-orange-600 hover:text-orange-700">
+              <td
+                class="
+                  whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                  text-gray-900 sm:pl-6
+                "
+              >
+                <a
+                  href="<%= path(read_replica) %>/overview"
+                  class="text-orange-600 hover:text-orange-700"
+                >
                   <%= read_replica.name %>
                 </a>
               </td>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              <td
+                class="
+                  whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                  text-gray-900 sm:pl-6
+                "
+              >
                 <%== part("components/pg_state_label", state: read_replica.display_state, extra_class: "text-md") %>
               </td>
             </tr>
           <% end %>
           <% if @edit_perm %>
             <tr>
-              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              <td
+                class="
+                  whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                  text-gray-900 sm:pl-6
+                "
+              >
                 <%== part("components/form/text", name: "name", attributes: { placeholder: @pg.name + "-read-replica", required: true, form: "form-pg-read-replica-create" }) %>
               </td>
-              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+              <td
+                class="
+                  relative whitespace-nowrap py-4 pl-3 pr-4 text-right
+                  text-sm font-medium sm:pr-6
+                "
+              >
                 <% form(action: "#{path(@pg)}/read-replica", role: :form, method: :post, id: "form-pg-read-replica-create") do %>
                   <%== part("components/form/submit_button", text: "Create", extra_class: "pg-read-replica-create-btn") %>
                 <% end %>

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -90,7 +90,7 @@
                 </div>
               </div>
               <div
-                id="postgres-replica-promote-<%=@pg.ubid %>"
+                id="postgres-replica-promote-<%= @pg.ubid %>"
                 class="
                   mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
                   sm:items-center
@@ -169,7 +169,7 @@
                 </div>
               </div>
               <div
-                id="postgres-restart-<%=@pg.ubid %>"
+                id="postgres-restart-<%= @pg.ubid %>"
                 class="
                   mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
                   sm:items-center
@@ -199,7 +199,7 @@
               </div>
             </div>
             <div
-              id="postgres-delete-<%=@pg.ubid %>"
+              id="postgres-delete-<%= @pg.ubid %>"
               class="
                 mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
                 sm:items-center

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -2,16 +2,25 @@
   <div class="p-6">
     <%== part("components/rename_object", object: @pg, type: "PostgreSQL database") %>
   </div>
-
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           Maintenance Window
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <% form(action: "#{path(@pg)}/set-maintenance-window", role: :form, method: :post) do %>
           <div class="space-y-4">
@@ -39,30 +48,54 @@
     </div>
   </div>
 <% end %>
+
 <!-- Danger Zone -->
+
 <% if @edit_perm || @delete_perm %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           Danger Zone
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <!-- Promote -->
       <% if @edit_perm && @pg.read_replica? %>
         <div class="px-4 py-5 sm:p-6">
           <% form(action: "#{path(@pg)}/promote", role: :form, method: :post) do %>
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Promote PostgreSQL read replica database</h3>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">
+                  Promote PostgreSQL read replica database
+                </h3>
                 <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will promote and restart the PostgreSQL database. The database will stop replicating
-                    permanently. It will be offline momentarily, and all connections will be dropped.</p>
+                  <p>
+                    This action will promote and restart the PostgreSQL
+                    database. The database will stop replicating permanently. It
+                    will be offline momentarily, and all connections will be
+                    dropped.
+                  </p>
                 </div>
               </div>
-              <div id="postgres-replica-promote-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <div
+                id="postgres-replica-promote-<%=@pg.ubid %>"
+                class="
+                  mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
+                  sm:items-center
+                "
+              >
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Promote", extra_class: "promote-btn") %>
                 </div>
@@ -71,13 +104,16 @@
           <% end %>
         </div>
       <% end %>
+
       <!-- Reset password -->
       <% if @edit_perm && !@pg.read_replica? %>
         <div class="px-4 py-5 sm:p-6">
           <% form(action: "#{path(@pg)}/reset-superuser-password", role: :form, method: :post) do %>
             <div class="space-y-4">
               <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Reset superuser password</h3>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">
+                  Reset superuser password
+                </h3>
               </div>
               <div class="grid grid-cols-12 gap-6">
                 <div class="col-span-12 sm:col-span-5">
@@ -92,6 +128,7 @@
                       extra_class: "reset-superuser-password-new-password"
                     ) %>
                 </div>
+
                 <div class="col-span-12 sm:col-span-5">
                   <%== part(
                       "components/form/text",
@@ -104,6 +141,7 @@
                       extra_class: "reset-superuser-password-new-password-repeat"
                     ) %>
                 </div>
+
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Reset") %>
                 </div>
@@ -112,19 +150,31 @@
           <% end %>
         </div>
       <% end %>
+
       <!-- Restart Card -->
       <% if @edit_perm %>
         <div class="px-4 py-5 sm:p-6">
           <% form(action: "#{path(@pg)}/restart", role: :form, method: :post) do %>
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Restart PostgreSQL database</h3>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">
+                  Restart PostgreSQL database
+                </h3>
                 <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will restart the PostgreSQL database. The database will be offline momentarily, and all
-                    connections will be dropped.</p>
+                  <p>
+                    This action will restart the PostgreSQL database. The
+                    database will be offline momentarily, and all connections
+                    will be dropped.
+                  </p>
                 </div>
               </div>
-              <div id="postgres-restart-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <div
+                id="postgres-restart-<%=@pg.ubid %>"
+                class="
+                  mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
+                  sm:items-center
+                "
+              >
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Restart", extra_class: "restart-btn") %>
                 </div>
@@ -133,17 +183,28 @@
           <% end %>
         </div>
       <% end %>
+
       <!-- Delete Card -->
       <% if @delete_perm %>
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Delete PostgreSQL database</h3>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">
+                Delete PostgreSQL database
+              </h3>
               <div class="mt-2 text-sm text-gray-500">
-                <p>This action will permanently delete this PostgreSQL database.</p>
+                <p>
+                  This action will permanently delete this PostgreSQL database.
+                </p>
               </div>
             </div>
-            <div id="postgres-delete-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+            <div
+              id="postgres-delete-<%=@pg.ubid %>"
+              class="
+                mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
+                sm:items-center
+              "
+            >
               <%== part("components/delete_button", url: path(@pg), confirmation: @pg.name, redirect: "#{@project.path}/postgres") %>
             </div>
           </div>

--- a/views/private-location/create.erb
+++ b/views/private-location/create.erb
@@ -7,7 +7,6 @@ options.add_option(name: "access_key")
 options.add_option(name: "secret_key")
 @option_tree, @option_parents = options.serialize %>
 
-
 <%== part(
   "components/page_header",
   breadcrumbs: [
@@ -18,14 +17,12 @@ options.add_option(name: "secret_key")
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Ubicloud Region Name", required: "required", placeholder: "Enter name"},
     {name: "provider_location_name", type: "select", label: "AWS Region Name", required: "required", content_generator: ContentGenerator::PrivateLocation.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "access_key", type: "text", label: "AWS Access Key", required: "required", placeholder: "Enter AWS access key"},
     {name: "secret_key", type: "text", label: "AWS Secret Key", required: "required", placeholder: "Enter AWS secret key"}
   ]
-  action = "#{@project.path}/private-location"
-%>
+  action = "#{@project.path}/private-location" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/private-location/show.erb
+++ b/views/private-location/show.erb
@@ -32,27 +32,49 @@
       ]
     ) %>
   <% end %>
+
   <!-- Danger Zone -->
   <% if has_permission?("Location:delete", @project.ubid) %>
     <div>
       <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
         <div class="min-w-0 flex-1">
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          <h3
+            class="
+              text-2xl font-bold leading-7 text-gray-900 sm:truncate
+              sm:text-2xl sm:tracking-tight
+            "
+          >
             Danger Zone
           </h3>
         </div>
       </div>
-      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div
+        class="
+          overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+          bg-white divide-y divide-gray-200
+        "
+      >
         <!-- Delete Card -->
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Delete region</h3>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">
+                Delete region
+              </h3>
               <div class="mt-2 text-sm text-gray-500">
-                <p>This action will permanently delete this region. Deleted data cannot be recovered. Use it carefully.</p>
+                <p>
+                  This action will permanently delete this region. Deleted data
+                  cannot be recovered. Use it carefully.
+                </p>
               </div>
             </div>
-            <div id="region-delete-<%=@location.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+            <div
+              id="region-delete-<%=@location.ubid%>"
+              class="
+                mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
+                sm:items-center
+              "
+            >
               <%== part("components/delete_button", confirmation: @location.ui_name, redirect: "#{@project.path}/private-location") %>
             </div>
           </div>

--- a/views/private-location/show.erb
+++ b/views/private-location/show.erb
@@ -69,7 +69,7 @@
               </div>
             </div>
             <div
-              id="region-delete-<%=@location.ubid%>"
+              id="region-delete-<%= @location.ubid %>"
               class="
                 mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
                 sm:items-center

--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -196,7 +196,7 @@ end
               </div>
             </div>
             <div
-              id="restrict-<%=@token.ubid%>"
+              id="restrict-<%= @token.ubid %>"
               class="
                 mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
                 sm:items-center

--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -43,22 +43,35 @@ end
     <% if @token.nil? && edit_perm %>
       <div class="md:flex md:items-center md:justify-between">
         <div class="min-w-0 flex-1">
-          Access is allowed if there is an access control entry allowing the subject to take the action on the object.
-          Subjects, actions, and objects can all be tags, which are used for grouping. The recommended way to handle
-          access control in Ubicloud is to create appropriate tags, add the subjects, actions, and objects to the tags,
-          and create the minimum number of access control entries you need to enforce the access you want. However, you
-          can create access control entries referencing specific subjects, actions, or objects.
+          Access is allowed if there is an access control entry allowing the
+          subject to take the action on the object. Subjects, actions, and
+          objects can all be tags, which are used for grouping. The recommended
+          way to handle access control in Ubicloud is to create appropriate
+          tags, add the subjects, actions, and objects to the tags, and create
+          the minimum number of access control entries you need to enforce the
+          access you want. However, you can create access control entries
+          referencing specific subjects, actions, or objects.
         </div>
       </div>
     <% end %>
-
     <% form(action: form_action, role: :form, method: :post, id: "access-control-form") do %>
-      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-        <table id="access-control-entries" class="min-w-full divide-y divide-gray-300 group">
+      <div
+        class="
+          overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+          bg-white divide-y divide-gray-200
+        "
+      >
+        <table
+          id="access-control-entries"
+          class="min-w-full divide-y divide-gray-300 group"
+        >
           <thead class="bg-gray-50 <% if @token %> hidden group-[&:has(tr:nth-child(n+3))]:table-header-group <% end %>">
             <tr>
               <% table_headers.each do |type| %>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                <th
+                  scope="col"
+                  class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                >
                   <%= type %>
                   <% unless @token %>
                     <a
@@ -72,14 +85,20 @@ end
                 </th>
               <% end %>
               <% if edit_perm %>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+                <th
+                  scope="col"
+                  class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                ></th>
               <% end %>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @aces.append(["template", [], true]).each do |ubid, tags, editable| %>
               <% editable &&= edit_perm %>
-              <tr id="ace-<%= ubid %>" class="<%= "existing-aces#{"-view" unless editable}" unless ubid == "template" %>">
+              <tr
+                id="ace-<%= ubid %>"
+                class="<%= "existing-aces#{"-view" unless editable}" unless ubid == "template" %>"
+              >
                 <% if editable %>
                   <% ace_options.each_with_index do | (name, options), index| %>
                     <% attributes = (!@token && index == 0 && ubid != "template") ? { required: "required" } : {} %>
@@ -114,12 +133,19 @@ end
             <% if @aces.count == 1 %>
               <tr class="group-[&:has(tr:nth-child(n+3))]:hidden">
                 <td colspan="3" class="py-4 px-8">
-                  <p class="mb-4">Currently, this token has no access to the project.</p>
-                  <p>You should grant the token the access you think the token should have. Be aware that the token can
-                    never have more access to the project than your account has. Each access control entry has a single
-                    action and object. Access is allowed if there is an access control entry allowing the token to take
-                    the action on the object. Actions and objects can be tags, which are used for grouping multiple
-                    actions or multiple objects into a single entity.</p>
+                  <p class="mb-4">
+                    Currently, this token has no access to the project.
+                  </p>
+                  <p>
+                    You should grant the token the access you think the token
+                    should have. Be aware that the token can never have more
+                    access to the project than your account has. Each access
+                    control entry has a single action and object. Access is
+                    allowed if there is an access control entry allowing the
+                    token to take the action on the object. Actions and objects
+                    can be tags, which are used for grouping multiple actions or
+                    multiple objects into a single entity.
+                  </p>
                 </td>
               </tr>
             <% end %>
@@ -135,30 +161,47 @@ end
     <% end %>
   <% end %>
   <% if @token %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <% form(action: restriction_path, role: :form, method: :post) do %>
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900"><%= restriction_title %>
-                Personal Access Token</h3>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">
+                <%= restriction_title %> Personal Access Token
+              </h3>
               <div class="mt-2 text-sm text-gray-500">
                 <p>
                   <% if unrestricted %>
-                    This token currently has the same access to this project that your account has. If you would like
-                    to restrict the access of this token, use the "Restrict Token Access" button. After restricting
-                    token access, the token will have no access to the project, and you can grant the specific access
-                    you want the token to have. Be aware that the token can never have more access to the project than
-                    your account has.
+                    This token currently has the same access to this project
+                    that your account has. If you would like to restrict the
+                    access of this token, use the "Restrict Token Access"
+                    button. After restricting token access, the token will have
+                    no access to the project, and you can grant the specific
+                    access you want the token to have. Be aware that the token
+                    can never have more access to the project than your account
+                    has.
                   <% else %>
-                    This token currently has access to the project based on the access control entries above. If you
-                    would like to remove access control restrictions, and grant the token full access to your account,
-                    click on the "Unrestrict Token Access" button.
+                    This token currently has access to the project based on the
+                    access control entries above. If you would like to remove
+                    access control restrictions, and grant the token full access
+                    to your account, click on the "Unrestrict Token Access"
+                    button.
                   <% end %>
                 </p>
               </div>
             </div>
-            <div id="restrict-<%=@token.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+            <div
+              id="restrict-<%=@token.ubid%>"
+              class="
+                mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
+                sm:items-center
+              "
+            >
               <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                 <%== part("components/form/submit_button", text: "#{restriction_title} Token Access") %>
               </div>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -336,11 +336,11 @@ end
       button_title: "Add new billing information"
     ) %>
   <% end %>
-  <br />
+  <br>
   <%== part("components/discount_code") %>
 <% end %>
 
-<br />
+<br>
 
 <!-- Usage alerts -->
 
@@ -376,8 +376,8 @@ end
                 Usage alerts will be sent to your email address. If you want to
                 send alerts to specific email addresses, you need to log in with
                 that email address.
-                <br />
-                <br />
+                <br>
+                <br>
                 Please note that alerts are only for informational purposes and
                 no action is taken automatically.
               </p>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -11,41 +11,64 @@ end
     "components/page_header",
     breadcrumbs: [%w[Projects /project], [@project.name, @project.path], %w[Billing #]]
   ) %>
-
   <div class="grid gap-6">
     <!-- Summary -->
     <div>
       <dl class="grid grid-cols-2 gap-5 <%= (@project.discount > 0) ? "sm:grid-cols-4" : "sm:grid-cols-3" %>">
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-          <dt class="truncate text-sm font-medium text-gray-500">Current Usage</dt>
-          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= money(@invoices.first.subtotal) %></dd>
+          <dt class="truncate text-sm font-medium text-gray-500">
+            Current Usage
+          </dt>
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+            <%= money(@invoices.first.subtotal) %>
+          </dd>
         </div>
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
           <dt class="truncate text-sm font-medium text-gray-500">Last Month</dt>
-          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= (@invoices.count > 1) ? money(@invoices[1].subtotal) : "-" %></dd>
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+            <%= (@invoices.count > 1) ? money(@invoices[1].subtotal) : "-" %>
+          </dd>
         </div>
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-          <dt class="truncate text-sm font-medium text-gray-500">Remaining Credit</dt>
-          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= money(@project.credit.to_f) %></dd>
+          <dt class="truncate text-sm font-medium text-gray-500">
+            Remaining Credit
+          </dt>
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+            <%= money(@project.credit.to_f) %>
+          </dd>
         </div>
         <% if @project.discount > 0 %>
           <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
             <dt class="truncate text-sm font-medium text-gray-500">Discount</dt>
-            <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= @project.discount %>%</dd>
+            <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+              <%= @project.discount %>%
+            </dd>
           </div>
         <% end %>
       </dl>
     </div>
+
     <!-- Billing Info Update Card -->
     <% stripe_data = billing_info.stripe_data %>
     <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           Billing Details
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <% form(action: billing_path, method: :post) do %>
         <div class="px-4 py-5 sm:p-6">
           <div class="space-y-12">
@@ -62,6 +85,7 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4">
                   <%== part(
                     "components/form/text",
@@ -73,6 +97,7 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part(
                     "components/form/select",
@@ -93,15 +118,19 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part("components/form/text", name: "state", label: "State", value: stripe_data["state"]) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part("components/form/text", name: "city", label: "City", value: stripe_data["city"]) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part("components/form/text", name: "postal_code", label: "Postal Code", value: stripe_data["postal_code"]) %>
                 </div>
+
                 <div class="col-span-full">
                   <%== part(
                     "components/form/textarea",
@@ -113,6 +142,7 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4">
                   <%== part(
                     "components/form/text",
@@ -123,18 +153,22 @@ end
                   <% if billing_info.country&.in_eu_vat? %>
                     <div class="mt-2 text-sm text-gray-500">
                       <% if billing_info.country.alpha2 == "NL" %>
-                        21% VAT is collected from customers located in the Netherlands.
+                        21% VAT is collected from customers located in the
+                        Netherlands.
                       <% elsif stripe_data["tax_id"].to_s.strip.empty? %>
-                        EU registered business can enter their VAT ID to remove VAT from future invoices.
+                        EU registered business can enter their VAT ID to remove
+                        VAT from future invoices.
                       <% else %>
                         VAT subject to reverse charge.
                       <% end %>
                     </div>
                   <% end %>
                 </div>
+
                 <div class="sm:col-span-4">
                   <%== part("components/form/text", name: "company_name", label: "Company Name", value: stripe_data["company_name"]) %>
                 </div>
+
                 <div class="col-span-full">
                   <%== part(
                     "components/form/textarea",
@@ -158,6 +192,7 @@ end
         </div>
       <% end %>
     </div>
+
     <!-- Payment Methods Card -->
     <%== part(
       "components/table_card",
@@ -194,30 +229,72 @@ end
     <div>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          <h3
+            class="
+              text-2xl font-bold leading-7 text-gray-900 sm:truncate
+              sm:text-2xl sm:tracking-tight
+            "
+          >
             Invoices
           </h3>
         </div>
       </div>
-      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div
+        class="
+          overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+          bg-white divide-y divide-gray-200
+        "
+      >
         <table class="min-w-full divide-y divide-gray-300">
           <thead class="bg-gray-50">
             <tr>
-              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Invoice</th>
-              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Amount</th>
-              <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold text-gray-900">Status</th>
+              <th
+                scope="col"
+                class="
+                  py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                  text-gray-900 sm:pl-6
+                "
+              >
+                Invoice
+              </th>
+              <th
+                scope="col"
+                class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+              >
+                Amount
+              </th>
+              <th
+                scope="col"
+                class="
+                  py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold
+                  text-gray-900
+                "
+              >
+                Status
+              </th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @invoices.each do |inv| %>
               <tr id="invoice-<%= inv.path_id %>">
-                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-                  <a href="<%= billing_path + inv.path %>" target="_blank" class="text-orange-600 hover:text-orange-700">
+                <td
+                  class="
+                    whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                    text-gray-900 sm:pl-6
+                  "
+                  scope="row"
+                >
+                  <a
+                    href="<%= billing_path + inv.path %>"
+                    target="_blank"
+                    class="text-orange-600 hover:text-orange-700"
+                  >
                     <%= inv.name %>
                   </a>
                   <span class="text-xs text-gray-400 italic">
                     <% if inv.invoice_number %>
-                      #<%= inv.invoice_number %>
+                      #
+                      <%= inv.invoice_number %>
                     <% else %>
                       (not finalized)
                     <% end %>
@@ -237,8 +314,10 @@ end
             <% if @invoices.count == 1 %>
               <tr>
                 <td colspan="3">
-                  <div class="text-center text-lg p-4">No invoices finalized yet. Invoice for the current month will be created on the first day of next
-                    month.</div>
+                  <div class="text-center text-lg p-4">
+                    No invoices finalized yet. Invoice for the current month
+                    will be created on the first day of next month.
+                  </div>
                 </td>
               </tr>
             <% end %>
@@ -257,33 +336,50 @@ end
       button_title: "Add new billing information"
     ) %>
   <% end %>
-  <br/>
+  <br />
   <%== part("components/discount_code") %>
 <% end %>
-<br/>
+
+<br />
+
 <!-- Usage alerts -->
+
 <div>
   <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Usage Alerts
       </h3>
     </div>
   </div>
   <div class="grid gap-6">
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <!-- Add usage alert -->
       <div class="px-4 py-5 sm:p-6">
         <% form(action: "#{@project.path}/usage-alert", role: :form, method: :post) do %>
           <div class="space-y-4">
             <div>
-              <h2 class="text-lg font-medium leading-6 text-gray-900">Add new usage alert</h2>
+              <h2 class="text-lg font-medium leading-6 text-gray-900">
+                Add new usage alert
+              </h2>
               <p class="mt-1 text-sm text-gray-500">
-                Usage alerts will be sent to your email address. If you want to send alerts to specific email
-                addresses, you need to log in with that email address.
-                <br/>
-                <br/>
-                Please note that alerts are only for informational purposes and no action is taken automatically.
+                Usage alerts will be sent to your email address. If you want to
+                send alerts to specific email addresses, you need to log in with
+                that email address.
+                <br />
+                <br />
+                Please note that alerts are only for informational purposes and
+                no action is taken automatically.
               </p>
             </div>
             <div class="grid grid-cols-12 gap-6">
@@ -299,6 +395,7 @@ end
                   extra_class: "pr-3"
                 ) %>
               </div>
+
               <div class="col-span-5 sm:col-span-3">
                 <%== part(
                   "components/form/text",
@@ -312,22 +409,47 @@ end
                   extra_class: "pr-3"
                 ) %>
               </div>
+
               <div class="col-span-2 sm:col-span-3 flex justify-begin items-end">
                 <%== part("components/form/submit_button", text: "Add") %>
               </div>
             </div>
           </div>
         <% end %>
-
       </div>
+
       <!-- List alerts -->
       <% if @usage_alerts.count > 0 %>
         <table class="min-w-full divide-y divide-gray-300">
           <thead class="bg-gray-50">
             <tr>
-              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">Name</th>
-              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">Limit</th>
-              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">E-mail</th>
+              <th
+                scope="col"
+                class="
+                  py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                  text-gray-900 sm:pl-4
+                "
+              >
+                Name
+              </th>
+              <th
+                scope="col"
+                class="
+                  py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                  text-gray-900 sm:pl-4
+                "
+              >
+                Limit
+              </th>
+              <th
+                scope="col"
+                class="
+                  py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                  text-gray-900 sm:pl-4
+                "
+              >
+                E-mail
+              </th>
               <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-4">
                 <span class="sr-only">Remove</span>
               </th>
@@ -335,10 +457,19 @@ end
           </thead>
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @usage_alerts.each do |alert| %>
-              <tr id="alert-<%= alert.ubid %>" class="whitespace-nowrap text-sm font-medium">
-                <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row"><%= alert.name %></td>
-                <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row"><%= alert.limit %></td>
-                <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row"><%= alert.user.email %></td>
+              <tr
+                id="alert-<%= alert.ubid %>"
+                class="whitespace-nowrap text-sm font-medium"
+              >
+                <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row">
+                  <%= alert.name %>
+                </td>
+                <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row">
+                  <%= alert.limit %>
+                </td>
+                <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row">
+                  <%= alert.user.email %>
+                </td>
                 <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
                   <%== part(
                     "components/delete_button",

--- a/views/project/create.erb
+++ b/views/project/create.erb
@@ -5,7 +5,12 @@
 <div class="grid gap-6">
   <% form(action: "/project", method: :post) do %>
     <!-- Create Card -->
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
           <div class="sm:col-span-3">
@@ -20,11 +25,15 @@
             ) %>
           </div>
         </div>
-
       </div>
       <div class="px-4 py-5 sm:p-6">
         <div class="flex items-center justify-end gap-x-6">
-          <a href="/project" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>
+          <a
+            href="/project"
+            class="text-sm font-semibold leading-6 text-gray-900"
+          >
+            Cancel
+          </a>
           <%== part("components/form/submit_button", text: "Create") %>
         </div>
       </div>

--- a/views/project/dashboard.erb
+++ b/views/project/dashboard.erb
@@ -113,15 +113,22 @@ cards = [
 
 <div id="tiles" class="grid gap-6">
   <div
-    class="mb-5 grid grid-cols-2 divide-x divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow lg:grid-cols-3 xl:grid-cols-6 xl:divide-y-0"
+    class="
+      mb-5 grid grid-cols-2 divide-x divide-y divide-gray-200
+      overflow-hidden rounded-lg bg-white shadow lg:grid-cols-3
+      xl:grid-cols-6 xl:divide-y-0
+    "
   >
     <% tiles.each do |title, count, link, perm| %>
       <% if perm %>
         <a href="<%= link %>">
           <div class="px-4 py-5 sm:p-6">
-            <dt class="truncate text-sm font-medium text-gray-900"><%= title %></dt>
+            <dt class="truncate text-sm font-medium text-gray-900">
+              <%= title %>
+            </dt>
             <dd class="mt-1 text-3xl font-semibold tracking-tight text-orange-600">
-              <%= count %></dd>
+              <%= count %>
+            </dd>
           </div>
         </a>
       <% else %>
@@ -130,18 +137,37 @@ cards = [
     <% end %>
   </div>
 
-  <h2 class="text-xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Getting Started with your Project</h2>
+  <h2
+    class="
+      text-xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+      sm:tracking-tight
+    "
+  >
+    Getting Started with your Project
+  </h2>
 
-  <div id="cards" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 lg:gap-8">
+  <div
+    id="cards"
+    class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 lg:gap-8"
+  >
     <% cards.each do |icon, title, description, link| %>
       <div
-        class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-orange-600"
+        class="
+          rounded-lg shadow group relative bg-white p-6 focus-within:ring-2
+          focus-within:ring-inset focus-within:ring-orange-600
+        "
       >
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-orange-50 text-orange-700 ring-4 ring-white">
+          <span
+            class="
+              inline-flex rounded-lg p-3 bg-orange-50 text-orange-700 ring-4
+              ring-white
+            "
+          >
             <%== part("components/icon", name: icon) %>
           </span>
         </div>
+
         <div class="mt-8">
           <h3 class="text-base font-semibold leading-6 text-gray-900">
             <a href="<%= link %>" class="focus:outline-none">
@@ -152,7 +178,12 @@ cards = [
           </h3>
           <p class="mt-2 text-sm text-gray-500"><%= description %></p>
         </div>
-        <span class="pointer-events-none absolute right-6 top-6 text-gray-300 group-hover:text-gray-400">
+        <span
+          class="
+            pointer-events-none absolute right-6 top-6 text-gray-300
+            group-hover:text-gray-400
+          "
+        >
           <%== part("components/icon", name: "hero-arrow-up-right") %>
         </span>
       </div>

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -10,8 +10,7 @@
   ]
 ) %>
 
-<%
-  footer_content = [
+<% footer_content = [
     ["Subtotal", @invoice_data.subtotal],
     (@invoice_data.discount != "$0.00") ? ["Discount", "-#{@invoice_data.discount}"] : nil,
     (@invoice_data.credit != "$0.00") ? ["Credit", "-#{@invoice_data.credit}"] : nil,
@@ -25,13 +24,16 @@
         <dd class="text-gray-500" id="invoice-#{name.downcase.tr(" ", "-")}">#{value}</dd>
       </dl>
     CONTENT
-  end.join
-%>
+  end.join %>
 
 <div class="grid gap-6">
   <div class="md:flex md:items-center md:justify-between text-2xl">
-    <div class="min-w-0 flex-1">This invoice will be finalized on the first day of next month</div>
-    <div class="text-right"><%= @invoice_data.begin_time %> to <%= @invoice_data.end_time %></div>
+    <div class="min-w-0 flex-1">
+      This invoice will be finalized on the first day of next month
+    </div>
+    <div class="text-right">
+      <%= @invoice_data.begin_time %> to <%= @invoice_data.end_time %>
+    </div>
   </div>
 
   <!-- Invoice Card -->
@@ -51,6 +53,5 @@
       end,
       empty_state: "No resources",
       footer: "<div class=\"px-4 py-5 sm:p-6 flex justify-end\"><div class=\"grid gap-2 text-right\">#{footer_content}</div></div>"
-    )
-  %>
+    ) %>
 </div>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -43,13 +43,27 @@
       ]
     ) %>
   <% end %>
+
   <!-- Quota Card -->
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <div class="px-4 py-5 sm:p-6">
       <h3 class="text-base font-semibold leading-6 text-gray-900">Quotas</h3>
       <div class="mt-2 text-sm text-gray-500">
-        <p>If you want to increase your quota, please get in touch at
-          <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">support@ubicloud.com</a>.</p>
+        <p>
+          If you want to increase your quota, please get in touch at
+          <a
+            href="mailto:support@ubicloud.com"
+            class="font-semibold leading-6 text-orange-500 hover:text-orange-700"
+          >
+            support@ubicloud.com
+          </a>
+          .
+        </p>
       </div>
     </div>
 
@@ -65,17 +79,27 @@
         </div>
       <% end %>
     </div>
-
   </div>
+
   <!-- Delete Card -->
   <% if has_permission?("Project:delete", @project.ubid) %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete project</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">
+              Delete project
+            </h3>
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this project. Deleted data cannot be recovered. Use it carefully.</p>
+              <p>
+                This action will permanently delete this project. Deleted data
+                cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">

--- a/views/project/tag-list.erb
+++ b/views/project/tag-list.erb
@@ -20,24 +20,31 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
 
 <div class="grid gap-6">
   <div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <% if modification_allowed %>
         <div class="px-4 py-5 sm:p-6 space-y-2">
-          <h3 class="text-lg font-medium leading-6 text-gray-900"><%= "Create #{@display_tag_type} Tag" %></h3>
+          <h3 class="text-lg font-medium leading-6 text-gray-900">
+            <%= "Create #{@display_tag_type} Tag" %>
+          </h3>
+
           <p class="text-sm text-gray-500">
             <% case @tag_type
            when "subject" %>
-              Subject tags in Ubicloud are similar to roles or user groups. Instead of creating separate access control
-              entries for each user, you can create a single access control entry for the subject tag, and add the
-              appropriate users to the tag.
             <% when "action" %>
-              Action tags in Ubicloud are groups of actions. Instead of creating separate access control entries for
-              each action, you can create a single access control entry for the action tag, and add the appropriate
-              actions to the tag.
+              Action tags in Ubicloud are groups of actions. Instead of creating
+              separate access control entries for each action, you can create a
+              single access control entry for the action tag, and add the
+              appropriate actions to the tag.
             <% else %>
-              Objects tags in Ubicloud are groups of related objects. Instead of creating separate access control
-              entries for each object, you can create a single access control entry for the object tag, and add the
-              appropriate objects to the tag.
+              Objects tags in Ubicloud are groups of related objects. Instead of
+              creating separate access control entries for each object, you can
+              create a single access control entry for the object tag, and add
+              the appropriate objects to the tag.
             <% end %>
             <%= @display_tag_type %>
             tags can contain other
@@ -56,24 +63,50 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
       <% end %>
       <% if @tags.empty? %>
         <div class="text-center py-4 px-8 lg:px-32">
-          <h3 class="text-xl leading-10 font-medium mb-2"><%= "No managable #{@tag_type} tags to display" %></h3>
+          <h3 class="text-xl leading-10 font-medium mb-2">
+            <%= "No managable #{@tag_type} tags to display" %>
+          </h3>
         </div>
       <% else %>
         <table id="tag-list" class="min-w-full divide-y divide-gray-300">
           <thead class="bg-gray-50">
             <tr>
-              <th scope="col" class="pl-4 pr-3 sm:pl-6 py-3.5 text-left text-sm font-semibold text-gray-900">Name</th>
-              <th scope="col" class="pl-3 pr-4 sm:pr-6 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+              <th
+                scope="col"
+                class="
+                  pl-4 pr-3 sm:pl-6 py-3.5 text-left text-sm font-semibold
+                  text-gray-900
+                "
+              >
+                Name
+              </th>
+              <th
+                scope="col"
+                class="
+                  pl-3 pr-4 sm:pr-6 py-3.5 text-left text-sm font-semibold
+                  text-gray-900
+                "
+              ></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @tags.each do |tag| %>
               <% editable = !(@tag_type == "subject" && tag.name == "Admin") && modification_allowed %>
               <tr id="<%= tag.ubid %>">
-                <td class="pl-4 pr-3 sm:pl-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <td
+                  class="
+                    pl-4 pr-3 sm:pl-6 py-4 whitespace-nowrap text-sm
+                    text-gray-500
+                  "
+                >
                   <%= tag.name %>
                 </td>
-                <td class="pl-3 pr-4 sm:pr-6 py-4 flex items-center space-x-2 justify-end">
+                <td
+                  class="
+                    pl-3 pr-4 sm:pr-6 py-4 flex items-center space-x-2
+                    justify-end
+                  "
+                >
                   <%== part(
                     "components/button",
                     text: "Manage",

--- a/views/project/tag.erb
+++ b/views/project/tag.erb
@@ -38,6 +38,7 @@ current_members =
     @current_members.map { [ace_label(_2), _2.ubid] }
   end
 current_members.sort! %>
+
 <%== render("project/user-tabbar") %>
 
 <div class="space-y-1">
@@ -56,9 +57,16 @@ current_members.sort! %>
 
 <div class="grid gap-6">
   <% if editable %>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6 space-y-2">
-        <h3 class="text-lg font-medium leading-6 text-gray-900"><%= "Update #{@display_tag_type} Tag" %></h3>
+        <h3 class="text-lg font-medium leading-6 text-gray-900">
+          <%= "Update #{@display_tag_type} Tag" %>
+        </h3>
         <% form(action: path(@tag), role: :form, method: :post) do %>
           <div class="grid grid-cols-12 gap-3">
             <div class="col-span-12 md:col-span-5">
@@ -79,34 +87,64 @@ current_members.sort! %>
       </div>
     </div>
   <% end %>
+
   <div>
     <% if current_members.empty? %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
-        No current members of
-        <%= @tag_type %>
-        tag.
+        No current members of <%= @tag_type %> tag.
       </div>
     <% else %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Current Members</h3>
+          <h3
+            class="
+              text-2xl font-bold leading-7 text-gray-900 sm:truncate
+              sm:text-2xl sm:tracking-tight
+            "
+          >
+            Current Members
+          </h3>
         </div>
       </div>
       <% form(action: disassociate_path, role: :form, method: :post) do %>
-        <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-          <table id="tag-membership-remove" class="min-w-full divide-y divide-gray-300">
+        <div
+          class="
+            overflow-hidden rounded-lg shadow ring-1 ring-black
+            ring-opacity-5 bg-white divide-y divide-gray-200
+          "
+        >
+          <table
+            id="tag-membership-remove"
+            class="min-w-full divide-y divide-gray-300"
+          >
             <thead class="bg-gray-50">
               <tr>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Name</th>
+                <th
+                  scope="col"
+                  class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                >
+                  Name
+                </th>
                 <% if removal_allowed %>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Remove?</th>
+                  <th
+                    scope="col"
+                    class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                  >
+                    Remove?
+                  </th>
                 <% end %>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
               <% current_members.each do |label, ubid| %>
                 <tr id="<%= ubid %>" class="cursor-pointer">
-                  <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                  <td
+                    class="
+                      whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                      text-gray-900 sm:pl-6
+                    "
+                    scope="row"
+                  >
                     <%== label %>
                   </td>
                   <% if removal_allowed %>
@@ -131,31 +169,66 @@ current_members.sort! %>
       <% end %>
     <% end %>
   </div>
+
   <div>
     <% if addition_allowed && !add_groups.all? { _2.empty? } %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Add Members</h3>
+          <h3
+            class="
+              text-2xl font-bold leading-7 text-gray-900 sm:truncate
+              sm:text-2xl sm:tracking-tight
+            "
+          >
+            Add Members
+          </h3>
         </div>
       </div>
       <% form(action: associate_path, method: :post) do %>
-        <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-          <table id="tag-membership-add" class="min-w-full divide-y divide-gray-300">
+        <div
+          class="
+            overflow-hidden rounded-lg shadow ring-1 ring-black
+            ring-opacity-5 bg-white divide-y divide-gray-200
+          "
+        >
+          <table
+            id="tag-membership-add"
+            class="min-w-full divide-y divide-gray-300"
+          >
             <thead class="bg-gray-50">
               <tr>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Name</th>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Add?</th>
+                <th
+                  scope="col"
+                  class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                >
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                >
+                  Add?
+                </th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
               <% add_groups.each do |name, available_to_add| %>
                 <% name = name["label"] if name.is_a?(Hash) %>
                 <tr>
-                  <th colspan="2" class="text-left px-3 py-3.5 bg-gray-50"><%= name %></th>
+                  <th colspan="2" class="text-left px-3 py-3.5 bg-gray-50">
+                    <%= name %>
+                  </th>
                 </tr>
+
                 <% available_to_add.each do |label, ubid| %>
                   <tr id="<%= ubid %>" class="cursor-pointer">
-                    <td class="whitespace-nowrap py-4 pl-5 pr-3 text-sm font-medium text-gray-900 sm:pl-7" scope="row">
+                    <td
+                      class="
+                        whitespace-nowrap py-4 pl-5 pr-3 text-sm font-medium
+                        text-gray-900 sm:pl-7
+                      "
+                      scope="row"
+                    >
                       <%== label %>
                     </td>
                     <td class="py-4 pl-3 pr-4 text-right sm:pr-6">

--- a/views/project/token.erb
+++ b/views/project/token.erb
@@ -12,9 +12,10 @@
 <div class="grid gap-6">
   <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
     <div class="min-w-0 flex-1">
-      Personal access tokens are both account-specific and project-specific. You can use a separate access control
-      entries for each token, but be aware that regardless of the access permissions of the token, requests made using
-      the token cannot exceed the access permissions of your account.
+      Personal access tokens are both account-specific and project-specific. You
+      can use a separate access control entries for each token, but be aware
+      that regardless of the access permissions of the token, requests made
+      using the token cannot exceed the access permissions of your account.
     </div>
   </div>
 

--- a/views/project/user-tabbar.erb
+++ b/views/project/user-tabbar.erb
@@ -7,4 +7,5 @@
   )
 ]
 tabs.compact! %>
+
 <%== part("components/tabbar", tabs:) if tabs.length >= 2 %>

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -5,6 +5,7 @@
 @allowed_add_tag_names_map = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").select_hash(:name, Sequel.as(true, :v))
 @allowed_remove_tag_names_map = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:remove").select_hash(:name, Sequel.as(true, :v))
 @invitations = @project.invitations_dataset.order_by(:email).all %>
+
 <%== render("project/user-tabbar") %>
 
 <%== part(
@@ -18,27 +19,40 @@
   <div>
     <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        <h3
+          class="
+            text-2xl font-bold leading-7 text-gray-900 sm:truncate
+            sm:text-2xl sm:tracking-tight
+          "
+        >
           Invite a new user
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div
+      class="
+        overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+        bg-white divide-y divide-gray-200
+      "
+    >
       <div class="px-4 py-5 sm:p-6">
         <% form(action: user_path, role: :form, method: :post) do %>
           <div class="space-y-4">
             <div>
               <p class="mt-1 text-sm text-gray-500">
-                You can invite a new user to your project, adding them to the given subject tag (role).
+                You can invite a new user to your project, adding them to the
+                given subject tag (role).
               </p>
             </div>
             <div class="grid grid-cols-12 gap-3">
               <div class="col-span-12 sm:col-span-5">
                 <%== part("components/form/text", name: "email", type: "email", attributes: { required: true, placeholder: "Email" }) %>
               </div>
+
               <div class="col-span-12 sm:col-span-3">
                 <%== part("components/form/policy_select", name: "policy", selected: "Member", id: "invited-user-policy") %>
               </div>
+
               <div class="col-span-3 sm:col-span-2">
                 <%== part("components/form/submit_button", text: "Invite") %>
               </div>
@@ -48,38 +62,79 @@
       </div>
     </div>
   </div>
+
   <!-- User List -->
   <div>
     <% form(action: "#{user_path}/policy/managed", role: :form, method: :post, id: "managed-policy") do %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          <h3
+            class="
+              text-2xl font-bold leading-7 text-gray-900 sm:truncate
+              sm:text-2xl sm:tracking-tight
+            "
+          >
             Users
           </h3>
         </div>
       </div>
-      <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div
+        class="
+          overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+          bg-white divide-y divide-gray-200
+        "
+      >
         <table class="min-w-full divide-y divide-gray-300">
           <thead class="bg-gray-50">
             <tr>
-              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Email</th>
-              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Subject Tag</th>
-              <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold text-gray-900"></th>
+              <th
+                scope="col"
+                class="
+                  py-3.5 pl-4 pr-3 text-left text-sm font-semibold
+                  text-gray-900 sm:pl-6
+                "
+              >
+                Email
+              </th>
+              <th
+                scope="col"
+                class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+              >
+                Subject Tag
+              </th>
+              <th
+                scope="col"
+                class="
+                  py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold
+                  text-gray-900
+                "
+              ></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @users.each do |user| %>
               <tr id="user-<%= user.ubid %>">
-                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <td
+                  class="
+                    whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                    text-gray-900 sm:pl-6
+                  "
+                  scope="row"
+                >
                   <%= user.email %>
                 </td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                   <% if (tags = @subject_tag_map[user.id]) && tags.length >= 2 %>
-                    <span title="You can manage this user's policies from the Access Control tab.">
+                    <span
+                      title="You can manage this user's policies from the Access Control tab."
+                    >
                       <%= tags.join(", ") %>
                     </span>
                   <% elsif (tag = tags&.first) && !@allowed_remove_tag_names_map[tag] %>
-                    <span id="user-<%= user.ubid %>-noremove" title="You cannot change the policy for this user">
+                    <span
+                      id="user-<%= user.ubid %>-noremove"
+                      title="You cannot change the policy for this user"
+                    >
                       <%= tag %>
                     </span>
                   <% else %>
@@ -103,13 +158,22 @@
             <% end %>
             <% @invitations.each do |invitation| %>
               <tr id="invitation-<%= invitation.email.gsub(/\W+/, "") %>">
-                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <td
+                  class="
+                    whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium
+                    text-gray-900 sm:pl-6
+                  "
+                  scope="row"
+                >
                   <%= invitation[:email] %>
                   <span
-                    class="inline-flex items-baseline rounded-full ml-1 px-2 text-xs font-semibold leading-5 bg-yellow-100 text-yellow-800"
+                    class="
+                      inline-flex items-baseline rounded-full ml-1 px-2
+                      text-xs font-semibold leading-5 bg-yellow-100
+                      text-yellow-800
+                    "
                   >
-                    Invitation expires on
-                    <%= invitation.expires_at.strftime("%B %d, %Y") %>
+                    Invitation expires on <%= invitation.expires_at.strftime("%B %d, %Y") %>
                   </span>
                 </td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -5,7 +5,6 @@
 @option_tree, @option_parents = generate_vm_options
 @page_title = "Create #{"GPU " if @show_gpu}Virtual Machine" %>
 
-
 <%== render("components/billing_warning") %>
 
 <%== part(
@@ -18,8 +17,7 @@
   ]
 ) %>
 
-<%
-  ps_description = "<p class='mt-1 text-sm leading-6 text-gray-600'>We recommend using the default subnet for most use-cases. If you'd like to learn more about private subnets, please visit <a href='https://www.ubicloud.com/docs/networking/private-subnet' class='text-orange-600 hover:text-orange-700'>Private Subnets</a> page.</p>"
+<% ps_description = "<p class='mt-1 text-sm leading-6 text-gray-600'>We recommend using the default subnet for most use-cases. If you'd like to learn more about private subnets, please visit <a href='https://www.ubicloud.com/docs/networking/private-subnet' class='text-orange-600 hover:text-orange-700'>Private Subnets</a> page.</p>"
 
   form_elements = [
     {name: "name", type: "text", label: "Name", placeholder: "Enter name", required: "required", opening_tag: "<div class='sm:col-span-3'>"},
@@ -55,7 +53,6 @@
     form_elements << {name: "show_gpu", type: "hidden", value: @show_gpu}
   end
 
-  action = "#{@project.path}/vm"
-%>
+  action = "#{@project.path}/vm" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Virtual Machines" %>
+
 <div class="auto-refresh hidden" data-interval="10"></div>
 
 <%== part(

--- a/views/vm/networking.erb
+++ b/views/vm/networking.erb
@@ -1,5 +1,4 @@
-<% 
-viewable_fws =
+<% viewable_fws =
   dataset_authorize(Firewall.where(id: @vm.firewalls.map(&:id)), "Firewall:view")
     .select_hash(:id, Sequel.as(true, :v))
     .transform_keys! { UBID.from_uuidish(it).to_s } %>

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -9,24 +9,45 @@
 <div class="p-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+      <h3
+        class="
+          text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl
+          sm:tracking-tight
+        "
+      >
         Danger Zone
       </h3>
     </div>
   </div>
-  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+  <div
+    class="
+      overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5
+      bg-white divide-y divide-gray-200
+    "
+  >
     <!-- Restart Card -->
     <% if edit_perm %>
       <div class="px-4 py-5 sm:p-6">
         <% form(action: "#{path(@vm)}/restart", role: :form, method: :post) do %>
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Restart virtual machine</h3>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">
+                Restart virtual machine
+              </h3>
               <div class="mt-2 text-sm text-gray-500">
-                <p>This action will restart the virtual machine, causing it to be temporarily offline.</p>
+                <p>
+                  This action will restart the virtual machine, causing it to be
+                  temporarily offline.
+                </p>
               </div>
             </div>
-            <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+            <div
+              id="vm-restart-<%= @vm.ubid %>"
+              class="
+                mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0
+                sm:items-center
+              "
+            >
               <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                 <%== part("components/form/submit_button", text: "Restart", extra_class: "restart-btn") %>
               </div>
@@ -35,18 +56,26 @@
         <% end %>
       </div>
     <% end %>
+
     <!-- Delete Card -->
     <% if has_permission?("Vm:delete", @vm.ubid) %>
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete virtual machine</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900">
+              Delete virtual machine
+            </h3>
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this virtual machine. Deleted data cannot be recovered. Use it
-                carefully.</p>
+              <p>
+                This action will permanently delete this virtual machine.
+                Deleted data cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
-          <div id="vm-delete-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+          <div
+            id="vm-delete-<%= @vm.ubid %>"
+            class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+          >
             <%== part("components/delete_button", confirmation: @vm.name, url: path(@vm), redirect: "#{@project.path}/vm") %>
           </div>
         </div>


### PR DESCRIPTION
Herb is a relatively new html+erb library. One of the most useful parts of it for us is a formatter and linter. Currently, the herb formatter and linter have a number of bugs that prevent our switching to it, but I expect the bugs to be fixed. After the bugs are fixed, I think it's worth considering a switch from erb_formatter to herb's formatter and linter.

This gives an example of a switch, though it required manually fixing some things the formatter broke,  and the linter currently results in 4 false positives. I've filed upstream bug reports for all issues.