### PR TITLE
Switch <tt> to <code> in web shell

### DIFF
--- a/views/cli.erb
+++ b/views/cli.erb
@@ -45,9 +45,9 @@
         <% if @clis && !@clis.empty? %>
           <div class="space-y-2">
             <p class="text-xl font-semibold">Remaining commands:</p>
-            <div class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
+            <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
               <% @clis.each do %>
-                <pre><tt class="next-clis"><%= it %></tt></pre>
+                <pre><code class="next-clis"><%= it %></code></pre>
                 <input type="hidden" name="clis[]" value="<%= it %>">
               <% end %>
             </div>
@@ -57,15 +57,15 @@
         <% if @last_cli %>
           <div class="space-y-2">
             <p class="text-xl font-semibold">Ran command:</p>
-            <div class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
-              <pre><tt id="cli-executed"><%= @last_cli %></tt></pre>
+            <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
+              <pre><code id="cli-executed"><%= @last_cli %></code></pre>
             </div>
           </div>
 
           <div class="space-y-2">
             <p class="text-xl font-semibold"><%= @ubi_command_execute ? "Would execute" : "Output" %>:</p>
-            <div class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
-              <pre><tt id="cli-output"><%== @output %></tt></pre>
+            <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
+              <pre><code id="cli-output"><%== @output %></code></pre>
             </div>
           </div>
           <% if @ubi_confirm %>


### PR DESCRIPTION
`<tt>` is deprecated in HTML5.

While here, remove text-rose-500. Using text-rose-500 with bg-slate-100 results in a color contrast ratio under 3:1, which is considered inaccessible.  Additionally, it makes it very difficult to see what text is linked versus what text isn't linked, since the color contrast between text-rose-500 and text-orange-600 is only 1.03:1. Removing text-rose-500 results in a color constrast ratio between linked and non-linked text over 5:1, and a color contrast ratio between non-linked text and the background of almost 17:1.