### PR TITLE
Add note to payment method success page about pre-authorization

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -131,7 +131,7 @@ class Clover
           })
         end
 
-        flash["notice"] = "Billing info updated"
+        flash["notice"] = "Payment method added successfully. $#{preauth_amount / 100} is authorized on your card for verification purposes. It's canceled already and depending on your bank, it may take up to two weeks to refund the money."
         r.redirect billing_path
       end
 

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Clover, "billing" do
       click_button "Add new billing information"
 
       expect(page.title).to eq("Ubicloud - Project Billing")
-      expect(page).to have_flash_notice("Billing info updated")
+      expect(page).to have_flash_notice("Payment method added successfully. $#{PaymentMethod[stripe_id: "pm_1234567890"].preauth_amount / 100} is authorized on your card for verification purposes. It's canceled already and depending on your bank, it may take up to two weeks to refund the money.")
 
       billing_info = project.reload.billing_info
       expect(page.status_code).to eq(200)
@@ -221,6 +221,7 @@ RSpec.describe Clover, "billing" do
       expect(billing_info.payment_methods.count).to eq(2)
       expect(page).to have_content "Visa"
       expect(page).to have_content "Mastercard"
+      expect(page).to have_flash_notice "Payment method added successfully. $#{PaymentMethod[stripe_id: "pm_222222222"].preauth_amount / 100} is authorized on your card for verification purposes. It's canceled already and depending on your bank, it may take up to two weeks to refund the money."
     end
 
     it "can copy billing address from new payment method when missing" do


### PR DESCRIPTION
We're receiving questions about pre-authorization charges on credit cards. It would be helpful to add a note to the payment method success page explaining this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add a note to the payment method success page about pre-authorization charges and refund timeline in `routes/project/billing.rb`, with tests updated in `billing_spec.rb`.
> 
>   - **Behavior**:
>     - Update `flash["notice"]` in `routes/project/billing.rb` to include a note about pre-authorization charges and refund timeline.
>   - **Tests**:
>     - Update `billing_spec.rb` to check for the new flash notice message after adding a payment method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a856e1326c9ddc86d38c45dfb8b75699b7413c15. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->