### PR TITLE
Update SSH command on admin site to use root@ and not use -i

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe CloverAdmin do
     fill_in "UBID", with: vm_host.ubid
     click_button "Show Object"
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vm_host.ubid}"
-    expect(page).to have_content "SSH Command: ssh -i <PRIVATE_KEY_PATH> rhizome@1.2.3.4"
+    expect(page).to have_content "SSH Command: ssh root@1.2.3.4"
 
     visit "/"
     fill_in "UBID", with: vm_pool.ubid

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -1,7 +1,7 @@
 <% @page_title = "#{@klass.name} #{@obj.ubid}" %>
 
 <% if @klass.associations.include?(:sshable) && (sshable = @obj.sshable) %>
-  <p>SSH Command: <code>ssh -i &lt;PRIVATE_KEY_PATH&gt; <%= sshable.unix_user %>@<%= sshable.host %></code></p>
+  <p>SSH Command: <code>ssh root@<%= sshable.host %></code></p>
 <% end %>
 
 <div id="strand-info">


### PR DESCRIPTION
The SSH command for the admin site was taken from the SSH command we display to users on the console, but in general this is more helpful for admins.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update SSH command in admin site to use `root@` and remove `-i`, with corresponding test update in `admin_spec.rb`.
> 
>   - **Behavior**:
>     - Update SSH command in `object.erb` to use `ssh root@<host>` instead of `ssh -i <PRIVATE_KEY_PATH> <user>@<host>`.
>     - Update test in `admin_spec.rb` to expect the new SSH command format.
>   - **Tests**:
>     - Modify test in `admin_spec.rb` to check for `ssh root@1.2.3.4` instead of `ssh -i <PRIVATE_KEY_PATH> rhizome@1.2.3.4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 766ecbed6baaa8da376693b0df41c1d0e9c9af4a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->