### PR TITLE
Use whitespace: pre-wrap when displaying web cli input/output

### DIFF
--- a/views/cli.erb
+++ b/views/cli.erb
@@ -47,7 +47,7 @@
             <p class="text-xl font-semibold">Remaining commands:</p>
             <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
               <% @clis.each do %>
-                <pre><code class="next-clis"><%= it %></code></pre>
+                <pre class="whitespace-pre-wrap"><code class="next-clis"><%= it %></code></pre>
                 <input type="hidden" name="clis[]" value="<%= it %>">
               <% end %>
             </div>
@@ -58,14 +58,14 @@
           <div class="space-y-2">
             <p class="text-xl font-semibold">Ran command:</p>
             <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
-              <pre><code id="cli-executed"><%= @last_cli %></code></pre>
+              <pre class="whitespace-pre-wrap"><code id="cli-executed"><%= @last_cli %></code></pre>
             </div>
           </div>
 
           <div class="space-y-2">
             <p class="text-xl font-semibold"><%= @ubi_command_execute ? "Would execute" : "Output" %>:</p>
             <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
-              <pre><code id="cli-output"><%== @output %></code></pre>
+              <pre class="whitespace-pre-wrap"><code id="cli-output"><%== @output %></code></pre>
             </div>
           </div>
           <% if @ubi_confirm %>
@@ -77,7 +77,7 @@
           <% unless multi %>
             <div class="space-y-2">
               <h2 class="text-xl font-semibold">Examples</h2>
-              <dl class="w-full text-sm border p-3 bg-slate-100 text-rose-500 font-mono rounded">
+              <dl class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
                 <dt><code>help -ru</code></dt>
                 <dd class="inline-block ml-6 mb-4">Display the syntax for all supported commands</dd>
                 <dt><code>help -r</code></dt>


### PR DESCRIPTION
Otherwise, the display of the example commands `help -ru` and `help -ru` looks bad, as does any long command output.

While here, remove text-rose-500 from the example commands list. It is no longer used in the output, so it now looks inconsistent.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `whitespace-pre-wrap` for CLI input/output in `views/cli.erb` and remove unused `text-rose-500` class.
> 
>   - **Display**:
>     - Use `whitespace-pre-wrap` for `<pre>` elements in `views/cli.erb` to improve display of CLI input/output.
>     - Affects `next-clis`, `cli-executed`, and `cli-output` sections.
>   - **Styling**:
>     - Remove `text-rose-500` from the examples list in `views/cli.erb` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1e7ccc7976b05ae0c8c12ef463520a07da879f92. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->