### PR TITLE
Support creating private subnet when creating virtual machine

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -29,3 +29,13 @@
     animation: sweep 1.6s linear infinite;
   }
 }
+
+#creation-form {
+  #new-private-subnet-name {
+    display: none;
+  }
+
+  &:has(select#private_subnet_id option[value^=new-]:checked) #new-private-subnet-name {
+    display: block;
+  }
+}

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -16,7 +16,7 @@ class Prog::Vm::Nexus < Prog::Base
     private_subnet_id: nil, nic_id: nil, storage_volumes: nil, boot_disk_index: 0,
     enable_ip4: false, pool_id: nil, arch: "x64", swap_size_bytes: nil,
     distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [], gpu_count: 0, gpu_device: nil,
-    hugepages: true, ch_version: nil, firmware_version: nil)
+    hugepages: true, ch_version: nil, firmware_version: nil, new_private_subnet_name: nil)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -89,6 +89,8 @@ class Prog::Vm::Nexus < Prog::Base
           raise "Given subnet doesn't exist with the id #{private_subnet_id}" unless subnet
           raise "Given subnet is not available in the given project" unless project.private_subnets.any? { |ps| ps.id == subnet.id }
           subnet
+        elsif new_private_subnet_name
+          Prog::Vnet::SubnetNexus.assemble(project_id, name: new_private_subnet_name, location_id:).subject
         else
           project.default_private_subnet(location)
         end

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -25,6 +25,7 @@
     {name: "name", type: "text", label: "Name", placeholder: "Enter name", required: "required", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
     {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Default", description_html: ps_description, content_generator: ContentGenerator::Vm.method(:private_subnet), opening_tag: "<div class='sm:col-span-3'>"},
+    {name: "new_private_subnet_name", type: "text", label: "Private Subnet Name", placeholder: "Private Subnet Name", opening_tag: "<div class='sm:col-span-3' id='new-private-subnet-name'>", value: typecast_body_params.str("new_private_subnet_name")},
     {name: "enable_ip4", type: "checkbox", label: "Public IPv4 Support", description: "Needed for inbound and outbound public IPv4 connections. Websites that do not support IPv6 will be inaccessible without an IPv4 address.", content_generator: ContentGenerator::Vm.method(:enable_ipv4)},
     {name: "family", type: "radio_small_cards", label: "Server family", required: "required", content_generator: ContentGenerator::Vm.method(:family)}
   ]


### PR DESCRIPTION
This adds a "New Private Subnet" option to the Private Subnet select box. When chosen, the "Private Subnet Name" input displays. When filled out correctly, it creates the virtual machine in the newly created private subnet.

This uses a CSS approach instead of a Javascript approach for handling the display of the "Private Subnet Name" input when the "New Private Subnet" option is selected. This type of CSS is now widely supported by browsers: https://caniuse.com/css-has

<img width="240" height="130" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_vm_create_show_gpu=f" src="https://github.com/user-attachments/assets/caeb93fb-7d88-4ceb-869f-07d4e0b41e46" />
<img width="240" height="130" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_vm_create_show_gpu=f (1)" src="https://github.com/user-attachments/assets/fa47fc78-87af-4f05-9550-ab573519533e" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for creating a new private subnet when creating a virtual machine, with CSS-based UI changes and backend logic updates.
> 
>   - **Behavior**:
>     - Adds "New Private Subnet" option to the "Private Subnet" select box in `create.erb`.
>     - Displays "Private Subnet Name" input when "New Private Subnet" is selected, using CSS in `tailwind.css`.
>     - Validates new subnet name against `Validation::ALLOWED_NAME_PATTERN` in `vm.rb`.
>     - Creates VM in new subnet if valid name is provided.
>   - **Backend Logic**:
>     - Updates `vm_post()` in `vm.rb` to handle new subnet creation.
>     - Modifies `assemble()` in `nexus.rb` to support `new_private_subnet_name` parameter.
>   - **Testing**:
>     - Adds test for creating VM in a new private subnet in `vm_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c193582fe9bc6e7c7b3a051417c143ea894e06bf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->