### PR TITLE
Add a prog to sync vm removal from load balancer

### DIFF
--- a/prog/vnet/load_balancer_remove_vm.rb
+++ b/prog/vnet/load_balancer_remove_vm.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Prog::Vnet::LoadBalancerRemoveVm < Prog::Base
+  subject_is :vm
+
+  def load_balancer
+    @load_balancer ||= vm.load_balancer
+  end
+
+  label def destroy_vm_ports_and_update_node
+    load_balancer.vm_ports_by_vm(vm).destroy
+    bud Prog::Vnet::UpdateLoadBalancerNode, {subject_id: vm.id, load_balancer_id: load_balancer.id}, :update_load_balancer
+    hop_wait_for_node_update
+  end
+
+  label def wait_for_node_update
+    reap(:initiate_cert_server_removal, nap: 5)
+  end
+
+  label def mark_vm_ports_as_evacuating
+    load_balancer.vm_ports_by_vm_and_state(vm, ["up", "down"]).update(state: "evacuating")
+    hop_initiate_cert_server_removal
+  end
+
+  label def initiate_cert_server_removal
+    bud Prog::Vnet::CertServer, {subject_id: load_balancer.id, vm_id: vm.id}, :remove_cert_server if load_balancer.cert_enabled_lb?
+    hop_wait_for_cert_server_removal
+  end
+
+  label def wait_for_cert_server_removal
+    reap(:finalize_vm_removal, nap: 5)
+  end
+
+  label def finalize_vm_removal
+    load_balancer.incr_update_load_balancer
+    load_balancer.incr_rewrite_dns_records
+    load_balancer.vm_ports_by_vm(vm).destroy
+    load_balancer.load_balancer_vms_dataset.where(vm_id: vm.id).destroy
+    pop "vm is removed from load balancer"
+  end
+end

--- a/spec/prog/vnet/load_balancer_remove_vm_spec.rb
+++ b/spec/prog/vnet/load_balancer_remove_vm_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::LoadBalancerRemoveVm do
+  subject(:nx) {
+    described_class.new(st)
+  }
+
+  let(:st) {
+    Strand.create(prog: "Vnet::LoadBalancerRemoveVm", stack: [{"subject_id" => lb.id, "vm_id" => vm.id}], label: "remove_vm")
+  }
+
+  let(:lb) {
+    prj = Project.create(name: "test-prj")
+    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps").subject
+    lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "test-lb", src_port: 80, dst_port: 8080).subject
+    lb
+  }
+
+  let(:vm) {
+    instance_double(Vm, inhost_name: "test-vm", id: "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e", load_balancer: lb)
+  }
+
+  before do
+    allow(Vm).to receive(:[]).and_return(vm)
+  end
+
+  describe "#destroy_vm_ports_and_update_node" do
+    it "removes the vm from load balancer and hops to wait_for_node_update" do
+      expect(lb).to receive(:vm_ports_by_vm).with(vm).and_return(instance_double(LoadBalancerPort, destroy: nil)).at_least(:once)
+      expect(lb.vm_ports_by_vm(vm)).to receive(:destroy)
+      expect(nx).to receive(:bud).with(Prog::Vnet::UpdateLoadBalancerNode, {subject_id: vm.id, load_balancer_id: lb.id}, :update_load_balancer)
+      expect { nx.destroy_vm_ports_and_update_node }.to hop("wait_for_node_update")
+    end
+  end
+
+  describe "#wait_for_node_update" do
+    it "reaps the wait_for_node_update and hops to initiate_cert_server_removal" do
+      expect { nx.wait_for_node_update }.to hop("initiate_cert_server_removal")
+    end
+  end
+
+  describe "#mark_vm_ports_as_evacuating" do
+    it "evacuates the vm and hops to remove_cert_server" do
+      vm_port = instance_double(LoadBalancerVmPort)
+      expect(lb).to receive(:vm_ports_by_vm_and_state).with(vm, ["up", "down"]).and_return(vm_port).at_least(:once)
+      expect(vm_port).to receive(:update).with(state: "evacuating")
+      expect { nx.mark_vm_ports_as_evacuating }.to hop("initiate_cert_server_removal")
+    end
+  end
+
+  describe "#initiate_cert_server_removal" do
+    it "removes the certificate server and hops to wait_for_cert_server_removal" do
+      expect(lb).to receive(:cert_enabled_lb?).and_return(true)
+      expect(nx).to receive(:bud).with(Prog::Vnet::CertServer, {subject_id: lb.id, vm_id: vm.id}, :remove_cert_server)
+      expect { nx.initiate_cert_server_removal }.to hop("wait_for_cert_server_removal")
+    end
+
+    it "hops to wait_for_cert_server_removal if cert_enabled_lb? is false" do
+      expect(lb).to receive(:cert_enabled_lb?).and_return(false)
+      expect(nx).not_to receive(:bud)
+      expect { nx.initiate_cert_server_removal }.to hop("wait_for_cert_server_removal")
+    end
+  end
+
+  describe "#wait_for_cert_server_removal" do
+    it "reaps the wait_for_cert_server_removal and hops to finalize_vm_removal" do
+      expect { nx.wait_for_cert_server_removal }.to hop("finalize_vm_removal")
+    end
+  end
+
+  describe "#finalize_vm_removal" do
+    it "removes the vm from load balancer and exits" do
+      expect(lb).to receive(:vm_ports_by_vm).with(vm).and_return(instance_double(LoadBalancerPort, destroy: nil)).at_least(:once)
+      expect(lb.vm_ports_by_vm(vm)).to receive(:destroy)
+      expect(lb).to receive(:incr_update_load_balancer)
+      expect(lb).to receive(:incr_rewrite_dns_records)
+      dataset = instance_double(Sequel::Dataset)
+      expect(lb).to receive(:load_balancer_vms_dataset).and_return(dataset)
+      expect(dataset).to receive(:where).with(vm_id: vm.id).and_return(instance_double(LoadBalancerVm, destroy: nil))
+      expect { nx.finalize_vm_removal }.to exit({"msg" => "vm is removed from load balancer"})
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a new program to handle VM removal from load balancers, replacing the previous wait for expiry with direct removal, and updates tests accordingly.
> 
>   - **Behavior**:
>     - Replaces `wait_lb_expiry` with `remove_vm_from_load_balancer` in `nexus.rb` to directly handle VM removal from load balancers.
>     - Introduces `Prog::Vnet::LoadBalancerRemoveVm` to manage VM removal process, including port evacuation and certificate server removal.
>   - **Functions**:
>     - Adds `remove_vm_from_load_balancer` and `wait_vm_removal_from_load_balancer` in `nexus.rb`.
>     - Implements `destroy_vm_ports_and_update_node`, `mark_vm_ports_as_evacuating`, `initiate_cert_server_removal`, `wait_for_cert_server_removal`, and `finalize_vm_removal` in `load_balancer_remove_vm.rb`.
>   - **Tests**:
>     - Updates `nexus_spec.rb` to test new VM removal process.
>     - Adds `load_balancer_remove_vm_spec.rb` to test `Prog::Vnet::LoadBalancerRemoveVm` functionality.
>     - Modifies `load_balancer_nexus_spec.rb` to ensure compatibility with new VM removal process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 779023ba288b91c38e97ebc1525230c1910a617e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->