### PR TITLE
Fix PostgresServerNexus#destroy to not violate strand leases

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -4,9 +4,16 @@ require_relative "../lib/util"
 
 class Prog::BootstrapRhizome < Prog::Base
   subject_is :sshable
+  semaphore :destroy
 
   def user
     @user ||= frame.fetch("user", "root")
+  end
+
+  def before_run
+    when_destroy_set? do
+      pop "exiting early due to destroy semaphore"
+    end
   end
 
   label def start

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -6,8 +6,15 @@ require "digest/sha2"
 
 class Prog::InstallRhizome < Prog::Base
   subject_is :sshable
+  semaphore :destroy
 
   SKIP_VALIDATION = ["Gemfile.lock"]
+
+  def before_run
+    when_destroy_set? do
+      pop "exiting early due to destroy semaphore"
+    end
+  end
 
   label def start
     tar = StringIO.new

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Prog::BootstrapRhizome do
     described_class.new(Strand.new(prog: "BootstrapRhizome"))
   }
 
+  it "exits if destroy is set" do
+    expect(br.before_run).to be_nil
+    expect(br).to receive(:when_destroy_set?).and_yield
+    expect { br.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
+  end
+
   describe "#start" do
     before { br.strand.label = "start" }
 

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Prog::InstallRhizome do
     allow(ir).to receive(:sshable).and_return(sshable)
   end
 
+  it "exits if destroy is set" do
+    expect(ir.before_run).to be_nil
+    expect(ir).to receive(:when_destroy_set?).and_yield
+    expect { ir.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
+  end
+
   describe "#start" do
     it "writes tar" do
       expect(sshable).to receive(:cmd) do |*args, **kwargs|

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -79,7 +79,7 @@ module ThawedMock
   allow_mocking(PostgresResource, :[], :generate_uuid)
   allow_mocking(PostgresServer, :create)
   allow_mocking(Project, :[], :order_by)
-  allow_mocking(Semaphore, :where, :create)
+  allow_mocking(Semaphore, :where, :create, :incr)
   allow_mocking(Sshable, :create_with_id, :repl?)
   allow_mocking(StorageKeyEncryptionKey, :create)
   allow_mocking(Strand, :create, :create_with_id)


### PR DESCRIPTION
Previously, PostgresServerNexus#destroy ran:

```ruby
strand.children.each { it.destroy }
```

This is not safe as there could be an existing lease for the strand children.  Child strands are either:

* BootstrapRhizome
* InstallRhizome (via push from Bootstrap Rhizome)
* Postgres::PostgresServerNexus (via restart from #unavailable)

Fix this by adding a destroy semaphore for all child strands, except the Postgres::PostgresServerNexus ones, as we don't want a child restart prog for the same server to also go into destroy.

Note that if a restart has been triggered via unavailable, and then the destroy semaphore has been incremented, the destroy cannot complete until after the restart commands return successfully.

It would probably be better to have restart in a separate prog, that could exit similarly to how Boostrap/InstallRhizome are setup, so that destruction could proceed even if the restart commands will not run successfully.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `PostgresServerNexus#destroy` to safely manage child strand destruction using a semaphore, with tests verifying the new behavior.
> 
>   - **Behavior**:
>     - `PostgresServerNexus#destroy` now uses a destroy semaphore to safely manage child strand destruction, excluding `PostgresServerNexus` children.
>     - Introduces `wait_children_destroy` and `destroy_vm_and_pg` labels in `postgres_server_nexus.rb` to handle destruction sequence.
>     - `BootstrapRhizome` and `InstallRhizome` exit early if destroy semaphore is set.
>   - **Tests**:
>     - Added tests in `bootstrap_rhizome_spec.rb`, `install_rhizome_spec.rb`, and `postgres_server_nexus_spec.rb` to verify semaphore behavior and destruction sequence.
>     - Mocking updates in `thawed_mock.rb` to support new semaphore logic.
>   - **Misc**:
>     - Minor refactoring in `postgres_server_nexus.rb` to accommodate new destruction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 773562ebcbb9f0882b3edc2243e27ea72d0d48b2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->