### PR TITLE
Hide health check endpoint in load balancer create form when tcp is used

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -31,6 +31,10 @@
 }
 
 #creation-form {
+  &:has(select#health_check_protocol option[value=tcp]:checked) #health-check-endpoint-wrapper {
+    display: none;
+  }
+ 
   #new-private-subnet-name {
     display: none;
   }

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -21,7 +21,7 @@
     {name: "src_port", type: "number", label: "Load Balancer Port", required: "required", placeholder: "80", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-3 xl:col-end-2'>"},
     {name: "dst_port", type: "number", label: "Application Port", required: "required", placeholder: "80", opening_tag: "<div class='col-span-6 col-start-1 md:col-start-3 md:col-end-5 xl:col-start-2 xl:col-end-3'>"},
     {name: "monitoring", type: "section", label: "Monitoring", content: "The health check endpoint is used in combination with the Application Port. Make sure it returns 200.", separator: true},
-    {name: "health_check_endpoint", type: "text", label: "HTTP Health Check Endpoint", placeholder: "/up", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-3'>"},
+    {name: "health_check_endpoint", type: "text", label: "HTTP Health Check Endpoint", placeholder: "/up", opening_tag: "<div id='health-check-endpoint-wrapper' class='col-span-6 col-start-1 md:col-end-3'>"},
     {name: "health_check_protocol", type: "select", label: "Health Check Protocol", required: "required", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-start-3 md:col-end-5'>"}
   ]
 


### PR DESCRIPTION
TCP health check protocol doesn't need an endpoint. Use the same pure-CSS approach for hiding the endpoint that we use in other places.

<img width="256" height="230" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_load-balancer_create" src="https://github.com/user-attachments/assets/31861cf1-001b-4f52-aa07-ac70e6995a1d" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Hides health check endpoint field in load balancer form when TCP protocol is selected using CSS.
> 
>   - **Behavior**:
>     - Hides `health_check_endpoint` field in load balancer creation form when `health_check_protocol` is set to TCP.
>   - **CSS**:
>     - Adds CSS rule in `tailwind.css` to hide `#health-check-endpoint-wrapper` when TCP is selected.
>   - **HTML**:
>     - Wraps `health_check_endpoint` field in `create.erb` with `#health-check-endpoint-wrapper` div.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b8d0914e626d802c82f9d698fed7886e3ce3cc15. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->