### PR TITLE
Rewrite dns records and refresh cert when renaming load balancer

### DIFF
--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -113,7 +113,10 @@ class Clover
         end
       end
 
-      r.rename lb, perm: "LoadBalancer:edit", serializer: Serializers::LoadBalancer, template_prefix: "networking/load_balancer"
+      r.rename lb, perm: "LoadBalancer:edit", serializer: Serializers::LoadBalancer, template_prefix: "networking/load_balancer" do
+        lb.incr_rewrite_dns_records
+        lb.incr_refresh_cert
+      end
 
       r.show_object(lb, actions: %w[overview vms settings], perm: "LoadBalancer:view", template: "networking/load_balancer/show")
     end

--- a/spec/routes/api/cli/lb/rename_spec.rb
+++ b/spec/routes/api/cli/lb/rename_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe Clover, "cli lb rename" do
   it "renames load balancer" do
     cli(%w[ps eu-central-h1/test-ps create])
     cli(%W[lb eu-central-h1/test-lb create #{PrivateSubnet.first.ubid} 12345 54321])
+    lb = LoadBalancer.first
+    expect(lb.semaphores_dataset.all).to eq []
     expect(cli(%w[lb eu-central-h1/test-lb rename new-name])).to eq "Load balancer renamed to new-name\n"
     expect(LoadBalancer.first.name).to eq "new-name"
+    expect(lb.semaphores_dataset.select_order_map(:name)).to eq %w[refresh_cert rewrite_dns_records]
   end
 end

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -360,9 +360,12 @@ RSpec.describe Clover, "load balancer" do
       end
 
       it "does not show rename option without permissions" do
-        AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:view"])
+        AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["LoadBalancer:view"])
+        AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["LoadBalancer:delete"])
         visit "#{project_wo_permissions.path}#{lb_wo_permission.path}/settings"
+        expect(page.title).to eq "Ubicloud - dummy-lb-2"
         expect(page).to have_no_content("Rename")
+        find ".delete-btn"
       end
     end
 
@@ -385,11 +388,15 @@ RSpec.describe Clover, "load balancer" do
       it "can not delete load balancer when does not have permissions" do
         # Give permission to view, so we can see the detail page
         AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["LoadBalancer:view"])
-
         visit "#{project_wo_permissions.path}#{lb_wo_permission.path}/settings"
         expect(page.title).to eq "Ubicloud - dummy-lb-2"
+        expect(page).to have_no_content("Rename")
 
         expect { find ".delete-btn" }.to raise_error Capybara::ElementNotFound
+
+        AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["LoadBalancer:edit"])
+        page.refresh
+        expect(page).to have_content("Rename")
       end
 
       it "can not delete load balancer when it doesn't exist" do

--- a/views/networking/load_balancer/settings.erb
+++ b/views/networking/load_balancer/settings.erb
@@ -1,10 +1,7 @@
-<% if has_permission?("LoadBalancer:edit", @lb.id) %>
-  <div class="p-6">
-    <%== part("components/rename_object", object: @lb, type: "load balancer") %>
-  </div>
-<% end %>
+<% edit_perm = has_permission?("LoadBalancer:edit", @lb.id)
+delete_perm = has_permission?("LoadBalancer:delete", @lb.ubid) %>
 
-<% if has_permission?("LoadBalancer:delete", @lb.ubid) %>
+<% if edit_perm || delete_perm %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
@@ -14,20 +11,29 @@
       </div>
     </div>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-      <div class="px-4 py-5 sm:p-6">
-        <div class="sm:flex sm:items-center sm:justify-between">
-          <div>
-            <h3 class="text-base font-semibold leading-6 text-gray-900">Delete load balancer</h3>
-            <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this load balancer. Deleted load balancer cannot be recovered. Use
-                it carefully.</p>
+      <% if edit_perm %>
+        <div class="px-4 py-5 sm:p-6">
+          <% form(action: "#{path(@lb)}/rename", method: :post) do %>
+            <%== part("components/rename_object_input", object: @lb, type: "load balancer", text: "Renaming a load balancer changes the DNS name used, so configuration changes may be required if the load balancer is renamed. You will also need to renew the SSL certificate in the virtual machines attached to this load balancer.") %>
+          <% end %>
+        </div>
+      <% end %>
+      <% if delete_perm %>
+        <div class="px-4 py-5 sm:p-6">
+          <div class="sm:flex sm:items-center sm:justify-between">
+            <div>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">Delete load balancer</h3>
+              <div class="mt-2 text-sm text-gray-500">
+                <p>This action will permanently delete this load balancer. Deleted load balancer cannot be recovered.
+                  Use it carefully.</p>
+              </div>
+            </div>
+            <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <%== part("components/delete_button", url: path(@lb), confirmation: @lb.name, redirect: "#{@project.path}/load-balancer") %>
             </div>
           </div>
-          <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-            <%== part("components/delete_button", url: path(@lb), confirmation: @lb.name, redirect: "#{@project.path}/load-balancer") %>
-          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Since this is a potentially dangerous operation, move the rename form in the Web UI to the Danger Zone.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance load balancer renaming by updating DNS records and refreshing certificates, and move rename option to "Danger Zone" in UI.
> 
>   - **Behavior**:
>     - `r.rename` in `load_balancer.rb` now calls `lb.incr_rewrite_dns_records` and `lb.incr_refresh_cert` to update DNS records and refresh certificates when renaming a load balancer.
>     - Rename form moved to "Danger Zone" in `settings.erb` to highlight potential risks.
>   - **Tests**:
>     - Updated `rename_spec.rb` to check for `refresh_cert` and `rewrite_dns_records` semaphores after renaming.
>     - Updated `load_balancer_spec.rb` to ensure rename option visibility depends on permissions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a566ba4b1d040921339ecbb980604ca48f57cf35. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->