### PR TITLE
Begin logging respirate session lock conflicts

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -40,6 +40,8 @@ Strand.dataset.insert_conflict.insert(id: "776c1c3a-d804-9f3a-6683-5d874ad04155"
 # We always insert this strand using the same UBID ("st10g0vmh0st0vt111zat10nzz")
 Strand.dataset.insert_conflict.insert(id: "08200dd2-20ce-833a-de82-10fd5a082bff", prog: "LogVmHostUtilizations", label: "wait")
 
+SSH_SESSION_LOCK_NAME = "respirate"
+
 clover_freeze
 
 if partition_number


### PR DESCRIPTION
By setting `SSH_SESSION_LOCK_NAME`, activate the conflict logging for respirate SSH sessions.  Keeping this commit separate makes it easy to revert in case there are side effects.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `SSH_SESSION_LOCK_NAME` in `bin/respirate` to enable logging of session lock conflicts.
> 
>   - **Behavior**:
>     - Sets `SSH_SESSION_LOCK_NAME` to "respirate" in `bin/respirate` to activate logging of session lock conflicts.
>     - Allows for easy reversion if side effects occur.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8ffbfad3c1fa9753ba851f63b90e009fdc70c0e9. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->