### PR TITLE
Use Roda 3.96.0 now that is has been released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "rack-unreloader", ">= 1.8"
 gem "rake"
 gem "refrigerator", ">= 1"
 gem "reline" # Remove it when pry adds it as a dependency
-gem "roda", github: "jeremyevans/roda", ref: "30da88b47fadca1487bcbf6103d110a45795b602"
+gem "roda", ">= 3.96"
 gem "rodauth", ">= 2.40"
 gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"
 gem "rodish", ">= 2.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,6 @@ GIT
       rodauth (~> 2.36)
 
 GIT
-  remote: https://github.com/jeremyevans/roda.git
-  revision: 30da88b47fadca1487bcbf6103d110a45795b602
-  ref: 30da88b47fadca1487bcbf6103d110a45795b602
-  specs:
-    roda (3.95.0)
-      rack
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -318,6 +310,8 @@ GEM
     reline (0.6.2)
       io-console (~> 0.5)
     rexml (3.4.2)
+    roda (3.96.0)
+      rack
     rodauth (2.40.0)
       roda (>= 2.6.0)
       sequel (>= 4)
@@ -507,7 +501,7 @@ DEPENDENCIES
   rake
   refrigerator (>= 1)
   reline
-  roda!
+  roda (>= 3.96)
   rodauth (>= 2.40)
   rodauth-omniauth!
   rodish (>= 2.0.1)


### PR DESCRIPTION
We were previously using the Roda master branch for the redirect_path plugin, but that is now in a released version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `roda` gem in `Gemfile` to version `3.96` from a specific commit on the master branch.
> 
>   - **Gemfile Update**:
>     - Update `roda` gem from a specific commit on the master branch to version `3.96`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6347b1ca8bca93d1708f46dfab67ec9a223582ed. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->