### PR TITLE
Use spot instances for alien runners

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -110,6 +110,7 @@ module Config
   optional :github_runner_service_project_id, string
   override :enable_github_workflow_poller, true, bool
   optional :github_runner_aws_location_id, string
+  override :github_runner_aws_spot_instance_enabled, false, bool
 
   # GitHub Cache
   optional :github_cache_blob_storage_endpoint, string

--- a/config.rb
+++ b/config.rb
@@ -111,6 +111,7 @@ module Config
   override :enable_github_workflow_poller, true, bool
   optional :github_runner_aws_location_id, string
   override :github_runner_aws_spot_instance_enabled, false, bool
+  optional :github_runner_aws_spot_instance_max_price_per_vcpu, float
 
   # GitHub Cache
   optional :github_cache_blob_storage_endpoint, string

--- a/spec/prog/aws/instance_spec.rb
+++ b/spec/prog/aws/instance_spec.rb
@@ -247,7 +247,8 @@ usermod -L ubuntu
         iam_instance_profile: {
           name: "#{vm.name}-instance-profile"
         },
-        client_token: vm.id
+        client_token: vm.id,
+        instance_market_options: nil
       }).and_call_original
       expect(AwsInstance).to receive(:create_with_id).with(vm.id, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
@@ -278,6 +279,23 @@ usermod -L ubuntu
       new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
       expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
       expect(client).to receive(:run_instances).with(hash_including(user_data: Base64.encode64(new_data))).and_call_original
+      expect(AwsInstance).to receive(:create_with_id).with(vm.id, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
+      expect { nx.create_instance }.to hop("wait_instance_created")
+    end
+
+    it "uses spot instances for runners when enabled" do
+      expect(Config).to receive(:github_runner_aws_spot_instance_enabled).and_return(true)
+      client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
+      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
+      expect(vm).to receive(:private_ipv4).and_return("1.2.3.4")
+      vm.update(unix_user: "runneradmin")
+      expect(vm).to receive(:sshable).and_return(instance_double(Sshable, keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
+      new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
+      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
+      expect(client).to receive(:run_instances).with(hash_including(
+        user_data: Base64.encode64(new_data),
+        instance_market_options: {market_type: "spot", spot_options: {instance_interruption_behavior: "terminate", spot_instance_type: "one-time"}}
+      )).and_call_original
       expect(AwsInstance).to receive(:create_with_id).with(vm.id, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
     end


### PR DESCRIPTION
- **Use spot instances for alien runners**
  On-demand AWS instances are about 3x more expensive than our own virtual
  machines. To make this feature viable, we plan to use spot instances for
  alien runners. The average spot cost for m7a is still close to our
  runner prices, but since we’ll only use them for spillover spiky
  workloads, that should be fine.
  
  If we start spilling too many runners, that’s a clear signal that we
  need to add more hosts to our fleet.
  

- **Allow setting max_price for spot instances**
  When max_price is not set, AWS charges up to the on-demand price. Since
  on-demand prices are ~3x higher than our runner costs, this isn't ideal.
  
  We'll run experiments with different max_price settings to see how they
  affect interruption rates and provisioning times.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce AWS spot instances for alien runners with configuration for enabling and setting max price per vCPU.
> 
>   - **Behavior**:
>     - Use AWS spot instances for alien runners to reduce costs, implemented in `prog/aws/instance.rb`.
>     - Add configuration options `github_runner_aws_spot_instance_enabled` and `github_runner_aws_spot_instance_max_price_per_vcpu` in `config.rb`.
>     - Spot instances are used for spillover workloads, with max price setting affecting interruption rates and provisioning times.
>   - **Implementation**:
>     - In `create_instance` method of `Prog::Aws::Instance`, add logic to handle spot instances when `github_runner_aws_spot_instance_enabled` is true.
>     - Set `instance_market_options` with `spot_options` including `max_price` if `github_runner_aws_spot_instance_max_price_per_vcpu` is greater than 0.
>   - **Testing**:
>     - Add tests in `spec/prog/aws/instance_spec.rb` to verify spot instance usage and max price setting.
>     - Ensure tests cover scenarios where spot instances are enabled and max price is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8da8f4c30f40d226ea3b4dbe7fe55f641a8908b8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->