### PR TITLE
Do not try to abort multipart uploads if the bucket is already deleted

### DIFF
--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -38,7 +38,7 @@ class GithubRepository < Sequel::Model
       blob_storage_client.list_multipart_uploads(bucket: bucket_name).uploads.each do
         blob_storage_client.abort_multipart_upload(bucket: bucket_name, key: it.key, upload_id: it.upload_id)
       end
-    rescue Aws::S3::Errors::Unauthorized
+    rescue Aws::S3::Errors::Unauthorized, Aws::S3::Errors::NoSuchBucket
       Clog.emit("Repository credentials failed to abort multipart uploads") { {failed_abort_multipart_uploads: {bucket_name: bucket_name}} }
     end
 


### PR DESCRIPTION
Currently, this operation is not idempotent. If it fails after deleting the bucket, the next run will also fail because the bucket no longer exists.

We already catch Aws::S3::Errors::NoSuchBucket in the delete_bucket call. We should do the same for aborting multipart uploads.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add error handling for `NoSuchBucket` in `destroy_blob_storage` to ensure idempotency when aborting multipart uploads.
> 
>   - **Error Handling**:
>     - In `destroy_blob_storage` method of `GithubRepository`, added `Aws::S3::Errors::NoSuchBucket` to rescue block for aborting multipart uploads.
>     - Ensures idempotency by handling cases where the bucket is already deleted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 54839110de1fa7c4cbe2ac78d620b611927a6b3c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->