### PR TITLE
Handle errors raised by String#shellsplit in web shell

### DIFF
--- a/routes/project/cli.rb
+++ b/routes/project/cli.rb
@@ -33,7 +33,13 @@ class Clover
           end
 
           @last_cli = @last_cli.sub(/\A\s*ubi\s+/, "")
-          argv = @last_cli.shellsplit
+          begin
+            argv = @last_cli.shellsplit
+          rescue ArgumentError => ex
+            @repeat_cli = @no_last_cli = true
+            flash.now["error"] = "Unable to parse CLI command: #{ex.message}"
+            next view "cli"
+          end
 
           env["clover.project_id"] = @project.id
           env["clover.project_ubid"] = @project.ubid
@@ -63,14 +69,7 @@ class Clover
             end
           end
 
-          if (@ubi_confirm = headers["ubi-confirm"])
-            if @cli
-              @clis ||= []
-              @clis.prepend(@cli)
-            end
-            @cli = @last_cli
-          end
-
+          @repeat_cli = @ubi_confirm = headers["ubi-confirm"]
           view "cli"
         end
       end

--- a/views/cli.erb
+++ b/views/cli.erb
@@ -1,5 +1,13 @@
-<% @page_title = "Web Shell" %>
-<% multi = typecast_query_params.bool("multi") %>
+<% @page_title = "Web Shell"
+multi = typecast_query_params.bool("multi")
+if @repeat_cli
+  if @cli
+    @clis ||= []
+    @clis.prepend(@cli)
+  end
+  @cli = @last_cli
+  @last_cli = nil if @no_last_cli
+end %>
 
 <%== part(
   "components/page_header",


### PR DESCRIPTION
Typical error would be an unmatched quote. Report the error in the flash error message, and allow editing of the command to fix it. Ensure that it works as expected if there are additional queued commands.