### PR TITLE
Make authorized_object and related methods require location_id

### DIFF
--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Clover
-  def authorized_firewall(perm: "Firewall:view", location_id: nil)
+  def authorized_firewall(location_id:, perm: "Firewall:view")
     authorized_object(association: :firewalls, key: "firewall_id", perm:, location_id:)
   end
 

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -257,11 +257,9 @@ class Clover < Roda
     @current_account = Account[rodauth.session_value]
   end
 
-  def authorized_object(key:, perm:, association: nil, id: nil, ds: @project.send(:"#{association}_dataset"), location_id: nil)
+  def authorized_object(key:, perm:, location_id:, association: nil, id: nil, ds: @project.send(:"#{association}_dataset"))
     if id ||= typecast_params.ubid_uuid(key)
-      ds = dataset_authorize(ds, perm)
-      ds = ds.where(location_id:) if location_id
-      ds.first(id:)
+      dataset_authorize(ds, perm).first(location_id:, id:)
     end
   end
 

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -19,7 +19,7 @@ class Clover
     src_port, dst_port = typecast_params.pos_int!(%w[src_port dst_port])
     health_check_endpoint = typecast_params.nonempty_str("health_check_endpoint") || Prog::Vnet::LoadBalancerNexus::DEFAULT_HEALTH_CHECK_ENDPOINT
 
-    unless (ps = authorized_private_subnet)
+    unless (ps = authorized_private_subnet(location_id: Sequel::NOTNULL))
       fail Validation::ValidationFailed.new("private_subnet_id" => "Private subnet not found")
     end
 

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Clover
-  def authorized_postgres_resource(perm: "Postgres:view", location_id: nil, key: "postgres_resource_id", id: nil)
+  def authorized_postgres_resource(location_id:, perm: "Postgres:view", key: "postgres_resource_id", id: nil)
     authorized_object(association: :postgres_resources, key:, perm:, location_id:, id:)
   end
 

--- a/helpers/private_subnet.rb
+++ b/helpers/private_subnet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Clover
-  def authorized_private_subnet(perm: "PrivateSubnet:view", location_id: nil, key: "private_subnet_id", id: nil)
+  def authorized_private_subnet(location_id:, perm: "PrivateSubnet:view", key: "private_subnet_id", id: nil)
     authorized_object(association: :private_subnets, key:, perm:, location_id:, id:)
   end
 

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Clover
-  def authorized_vm(perm: "Vm:view", location_id: nil)
+  def authorized_vm(location_id:, perm: "Vm:view")
     authorized_object(association: :vms, key: "vm_id", perm:, location_id:)
   end
 


### PR DESCRIPTION
Always use the location_id as a filter. This prevents the accidental omission of location_id, which would allow objects to be related to objects in other locations.

There is one current case where no location is provided, and that is when creating a load balancer, where the load balancer doesn't have a location by itself, its location is derived from the related private subnet. Handle this by providing Sequel::NOTNULL as a filter, as a way to be explicit that any location is allowed. As location_id is a NOT NULL column, the PostgreSQL optimizer will remove the location_id IS NOT NULL predicate check.

This moves the location_id keyword argument to be before the optional keyword arguments in the methods, now that it is required.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforces `location_id` as a required argument in authorization methods to prevent cross-location object relations, with special handling for load balancers.
> 
>   - **Behavior**:
>     - Enforces `location_id` as a required argument in `authorized_object` and related methods to prevent cross-location object relations.
>     - Handles load balancer creation by allowing any location with `Sequel::NOTNULL`.
>   - **Methods**:
>     - Updates `authorized_object` in `general.rb` to require `location_id`.
>     - Changes `authorized_firewall`, `authorized_postgres_resource`, `authorized_private_subnet`, and `authorized_vm` to require `location_id`.
>   - **Misc**:
>     - Moves `location_id` before optional arguments in affected methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e202ddc72ca8596fd75daf5f3c72ad2a70941bf9. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->