### PR TITLE
Remove `security: - BearerAuth: []` from a couple openapi.yml endpoints

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -25,8 +25,6 @@ paths:
           $ref: '#/components/responses/Projects'
         default:
           $ref: '#/components/responses/Error'
-      security:
-        - BearerAuth: []
       tags:
         - Project
     post:
@@ -50,8 +48,6 @@ paths:
           $ref: '#/components/responses/Project'
         default:
           $ref: '#/components/responses/Error'
-      security:
-        - BearerAuth: []
       tags:
         - Project
   '/project/{project_id}':


### PR DESCRIPTION
I'm not sure why these are in only these two endpoints. This is already a top-level openapi.yml setting that sets a default, so you would only want to specify it for specific endpoints to override the default. However, we aren't doing that, since the endpoint values match the top-level setting.

CC @geemus 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant `security: - BearerAuth: []` from two endpoints in `openapi.yml`.
> 
>   - **Security**:
>     - Removed `security: - BearerAuth: []` from `GET /project` and `POST /project` endpoints in `openapi.yml` as they matched the top-level default setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1eb1b92ac85ac545a89f7d3ec78567ad613c89c0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->