### PR TITLE
Workaround for nil project access in E2E tests

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -48,7 +48,7 @@ class PostgresResource < Sequel::Model
   end
 
   def hostname_suffix
-    project.get_ff_postgres_hostname_override || Config.postgres_service_hostname
+    project&.get_ff_postgres_hostname_override || Config.postgres_service_hostname
   end
 
   def dns_zone

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -140,4 +140,11 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.ongoing_failover?).to be true
     end
   end
+
+  describe "#hostname_suffix" do
+    it "returns default hostname suffix if project is nil" do
+      expect(postgres_resource).to receive(:project).and_return(nil)
+      expect(postgres_resource.hostname_suffix).to eq(Config.postgres_service_hostname)
+    end
+  end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `hostname_suffix` in `PostgresResource` to handle `nil` `project` safely, with accompanying test.
> 
>   - **Behavior**:
>     - Modify `hostname_suffix` in `postgres_resource.rb` to handle `nil` `project` by using safe navigation (`&.`).
>     - Returns `Config.postgres_service_hostname` if `project` is `nil`.
>   - **Tests**:
>     - Add test case in `postgres_resource_spec.rb` to verify `hostname_suffix` returns default when `project` is `nil`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for bc7aa6a012dec1b72c963f16155a2734074ac360. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->