### PR TITLE
Update the default ubiblk version to v0.2.0.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -134,7 +134,7 @@ module Config
   override :spdk_version, "v23.09-ubi-0.3"
 
   # Vhost Block Backend
-  override :vhost_block_backend_version, "v0.1-7"
+  override :vhost_block_backend_version, "v0.2.0"
 
   # Boot Images
   override :default_boot_image_name, "ubuntu-jammy", string

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -4,8 +4,6 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   subject_is :sshable, :vm_host
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
-    ["v0.1-7", "x64"],
-    ["v0.1-7", "arm64"],
     ["v0.2.0", "x64"],
     ["v0.2.0", "arm64"]
   ].freeze.each(&:freeze)

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -9,11 +9,7 @@ class VhostBlockBackend
   end
 
   def sha256
-    if @version == "v0.1-7" && Arch.x64?
-      "114119bc78609db3795bcd426a386eb97a623ba78e9177de6b375b9616927ca6"
-    elsif @version == "v0.1-7" && Arch.arm64?
-      "aa92b91130de6e086332c4ad8dcb76e233624055532d5494db0a987883adee0f"
-    elsif @version == "v0.2.0" && Arch.x64?
+    if @version == "v0.2.0" && Arch.x64?
       "68638b779a227424cbe81674de4b26122ea27a337f1c6d81db895a1ffa3a917a"
     elsif @version == "v0.2.0" && Arch.arm64?
       "6b15ca96cd3134524a639d3c913b43b794423a8dddc897c1604a5085625d44e3"


### PR DESCRIPTION
Now that we have tested ubiblk v0.2.0 in prod for a week, we can change the default version from v0.1-7 to v0.2.0.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update default vhost block backend version to v0.2.0 and remove support for v0.1-7.
> 
>   - **Version Update**:
>     - Update default `vhost_block_backend_version` to `v0.2.0` in `config.rb`.
>     - Remove support for `v0.1-7` in `SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS` in `setup_vhost_block_backend.rb`.
>     - Remove `v0.1-7` SHA256 checks in `sha256` method in `vhost_block_backend.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2d01a9d4b8f77a36fd8285ebe5d0c66d232c74d5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->