### PR TITLE
Update to Ruby 3.4.6

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 3.4.5
+ruby 3.4.6
 postgres 15.8
 nodejs 24.6.0
 golang 1.24.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM docker.io/library/ruby:3.4.5-alpine3.21 AS bundler
+FROM docker.io/library/ruby:3.4.6-alpine3.21 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -20,7 +20,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM docker.io/library/ruby:3.4.5-alpine3.21
+FROM docker.io/library/ruby:3.4.6-alpine3.21
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Update ruby version in Dockerfile and .tool_versions when updating this
-ruby "3.4.5"
+ruby "3.4.6"
 
 gem "acme-client"
 gem "argon2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,7 +528,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.4.5p51
+   ruby 3.4.6p54
 
 BUNDLED WITH
    2.7.1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Ruby version from 3.4.5 to 3.4.6 in `.tool-versions`, `Dockerfile`, and `Gemfile`.
> 
>   - **Ruby Version Update**:
>     - Update Ruby version from `3.4.5` to `3.4.6` in `.tool-versions`, `Dockerfile`, and `Gemfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ac462b61a0e45ab51b5d8f30c15bb2ae8493c52c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->