### PR TITLE
Bump Forme version to 2.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     fiddle (1.1.8)
     foreman (0.90.0)
       thor (~> 1.4)
-    forme (2.6.0)
+    forme (2.7.0)
       bigdecimal
     hashdiff (1.2.0)
     hashery (2.1.2)

--- a/views/project/token.erb
+++ b/views/project/token.erb
@@ -4,7 +4,7 @@
   "components/page_header",
   title: "Personal Access Tokens",
   breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Personal Access Tokens", "#"]],
-  right_items: [form(nil, {action: "#{@project.path}/token", method: :post, id: "create-pat"}, emit: false) do |f|
+  right_items: [form({action: "#{@project.path}/token", method: :post, id: "create-pat"}, emit: false) do |f|
     f << part("components/form/submit_button", text: "Create Token")
   end]
 ) %>


### PR DESCRIPTION
Among other things, this fixes a bug that required an explicit nil argument to one form call to work around.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove explicit `nil` argument from `form` call in `views/project/token.erb` due to Forme version 2.7.0 update.
> 
>   - **Behavior**:
>     - Removes explicit `nil` argument from `form` call in `views/project/token.erb`.
>     - Relies on Forme version 2.7.0 to handle form initialization without `nil`.
>   - **Misc**:
>     - Bumps Forme version to 2.7.0 to fix related bug.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ab4defb2a99a5e3104f6821e8805fee792b9107b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->