### PR TITLE
Set nil when billing info attributes are empty

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -23,23 +23,22 @@ class Clover
           handle_validation_failure("project/billing")
           current_tax_id = billing_info.stripe_data["tax_id"]
           tp = typecast_params
-          new_tax_id = tp.str!("tax_id").gsub(/[^a-zA-Z0-9]/, "")
-
+          new_tax_id = tp.nonempty_str("tax_id")&.gsub(/[^a-zA-Z0-9]/, "")
           begin
             Stripe::Customer.update(billing_info.stripe_id, {
               name: tp.str!("name"),
               email: tp.str!("email").strip,
               address: {
                 country: tp.str!("country"),
-                state: tp.str!("state"),
-                city: tp.str!("city"),
-                postal_code: tp.str!("postal_code"),
+                state: tp.nonempty_str("state"),
+                city: tp.nonempty_str("city"),
+                postal_code: tp.nonempty_str("postal_code"),
                 line1: tp.str!("address"),
                 line2: nil
               },
               metadata: {
                 tax_id: new_tax_id,
-                company_name: tp.str!("company_name"),
+                company_name: tp.nonempty_str("company_name"),
                 note: tp.nonempty_str("note")
               }
             })

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -176,8 +176,24 @@ RSpec.describe Clover, "billing" do
       expect(page).to have_field("Billing Name", with: "New Inc.")
       expect(page).to have_field("Country", with: "US")
       expect(page).to have_field("Tax ID", with: "DE456789")
+    end
 
-      fill_in "Tax ID", with: nil
+    it "can remove tax id" do
+      expect(Stripe::Customer).to receive(:retrieve).with(billing_info.stripe_id).and_return(
+        {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "address" => {"country" => nil}, "metadata" => {"tax_id" => nil}}
+      ).at_least(:once)
+      expect(Stripe::Customer).to receive(:update).with(billing_info.stripe_id, anything).at_least(:once)
+
+      visit "#{project.path}/billing"
+
+      expect(page.title).to eq("Ubicloud - Project Billing")
+      fill_in "VAT ID", with: nil
+
+      click_button "Update"
+
+      fill_in "Tax ID", with: "TR123123"
 
       click_button "Update"
     end


### PR DESCRIPTION
tax_id, company_name, postal_code, state, and city are not required on the billing info update form. When they are not provided, we should set them to nil instead of an empty string.

Since an empty string is truthy in Ruby, it causes issues when we try to check whether billing info details are present.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set billing info fields to `nil` instead of empty strings when not provided, and add test for tax ID removal.
> 
>   - **Behavior**:
>     - Update `routes/project/billing.rb` to set `tax_id`, `company_name`, `postal_code`, `state`, and `city` to `nil` if not provided, using `tp.nonempty_str()`.
>     - Ensures these fields are not set to an empty string, which is truthy in Ruby.
>   - **Tests**:
>     - Add test case in `billing_spec.rb` to verify tax ID can be removed, ensuring it is set to `nil` when not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c32a9bfe5726d7a985f0c303352cdb26a6dfdd37. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->