### PR TITLE
Make Project#has_valid_payment_methods? return true if discount is 100%

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -53,6 +53,7 @@ class Project < Sequel::Model
 
   def has_valid_payment_method?
     return true unless Config.stripe_secret_key
+    return true if discount == 100
     !!billing_info&.payment_methods&.any? || (!!billing_info && credit > 0)
   end
 

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe Project do
       expect(project.has_valid_payment_method?).to be true
     end
 
+    it "returns true when discount is 100" do
+      expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
+      project.discount = 100
+      expect(project.has_valid_payment_method?).to be true
+    end
+
     it "returns false when no billing info" do
       expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
       expect(project.has_valid_payment_method?).to be false


### PR DESCRIPTION
With a 100% discount, there will never be a bill, so a valid payment method is not needed. I can only see this causing problems if the 100% discount is temporary and not permanent.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `has_valid_payment_method?` now returns true if discount is 100% in `project.rb`, with corresponding test added in `project_spec.rb`.
> 
>   - **Behavior**:
>     - `has_valid_payment_method?` in `project.rb` now returns true if `discount` is 100.
>   - **Tests**:
>     - Added test in `project_spec.rb` to verify `has_valid_payment_method?` returns true when `discount` is 100.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for acd5abc0de5259d0821957a03fd4914b270e37cd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->