### PR TITLE
Make *_NAME_OR_UBID matchers yield uuid instead of ubid

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -68,6 +68,16 @@ class Clover < Roda
   symbol_matcher(:ubid_uuid, /([a-tv-z0-9]{26})/) do |s|
     UBID.to_uuid(s)
   end
+  [Firewall, KubernetesCluster, LoadBalancer, PostgresResource, PrivateSubnet, Vm].each do |model|
+    sym = :"#{model.table_name}_ubid_uuid"
+    symbol_matcher(sym, /(#{model.ubid_type}[a-tv-z0-9]{24})/) do |ubid|
+      if (uuid = UBID.to_uuid(ubid))
+        # yield nil as first element to differentiate case where name matches
+        [nil, uuid]
+      end
+    end
+    const_set(:"#{model.table_name.upcase}_NAME_OR_UBID", [sym, /([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)/])
+  end
 
   plugin :response_content_type,
     mime_types: {

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 class Clover < Roda
-  def self.name_or_ubid_for(model)
-    # (\z)? to force a nil as first capture
-    [/(\z)?(#{model.ubid_type}[a-tv-z0-9]{24})/, /([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)/]
-  end
-  [Firewall, KubernetesCluster, LoadBalancer, PostgresResource, PrivateSubnet, Vm].each do |model|
-    const_set(:"#{model.table_name.upcase}_NAME_OR_UBID", name_or_ubid_for(model))
-  end
-
   # Designed only for compatibility with existing mocking in the specs
   def self.authorized_project(account, project_id)
     account.projects_dataset[Sequel[:project][:id] => project_id, :visible => true]

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -15,7 +15,7 @@ class Clover
 
         filter = {Sequel[:firewall][:name] => firewall_name}
       else
-        filter = {Sequel[:firewall][:id] => UBID.to_uuid(firewall_id)}
+        filter = {Sequel[:firewall][:id] => firewall_id}
       end
 
       filter[:location_id] = @location.id

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -6,7 +6,7 @@ class Clover
       kubernetes_cluster_list
     end
 
-    r.on KUBERNETES_CLUSTER_NAME_OR_UBID do |kc_name, kc_ubid|
+    r.on KUBERNETES_CLUSTER_NAME_OR_UBID do |kc_name, kc_id|
       filter = if kc_name
         r.post api? do
           check_visible_location
@@ -15,7 +15,7 @@ class Clover
 
         {Sequel[:kubernetes_cluster][:name] => kc_name}
       else
-        {Sequel[:kubernetes_cluster][:id] => UBID.to_uuid(kc_ubid)}
+        {Sequel[:kubernetes_cluster][:id] => kc_id}
       end
 
       filter[:location_id] = @location.id

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -15,7 +15,7 @@ class Clover
 
         filter = {Sequel[:load_balancer][:name] => lb_name}
       else
-        filter = {Sequel[:load_balancer][:id] => UBID.to_uuid(lb_id)}
+        filter = {Sequel[:load_balancer][:id] => lb_id}
       end
 
       filter[:private_subnet_id] = @project.private_subnets_dataset.where(location_id: @location.id).select(Sequel[:private_subnet][:id])

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -6,7 +6,7 @@ class Clover
       postgres_list
     end
 
-    r.on POSTGRES_RESOURCE_NAME_OR_UBID do |pg_name, pg_ubid|
+    r.on POSTGRES_RESOURCE_NAME_OR_UBID do |pg_name, pg_id|
       if pg_name
         r.post api? do
           check_visible_location
@@ -15,7 +15,7 @@ class Clover
 
         filter = {Sequel[:postgres_resource][:name] => pg_name}
       else
-        filter = {Sequel[:postgres_resource][:id] => UBID.to_uuid(pg_ubid)}
+        filter = {Sequel[:postgres_resource][:id] => pg_id}
       end
 
       filter[:location_id] = @location.id

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -15,7 +15,7 @@ class Clover
 
         filter = {Sequel[:private_subnet][:name] => ps_name}
       else
-        filter = {Sequel[:private_subnet][:id] => UBID.to_uuid(ps_id)}
+        filter = {Sequel[:private_subnet][:id] => ps_id}
       end
 
       filter[:location_id] = @location.id

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -6,7 +6,7 @@ class Clover
       vm_list_api_response(vm_list_dataset)
     end
 
-    r.on VM_NAME_OR_UBID do |vm_name, vm_ubid|
+    r.on VM_NAME_OR_UBID do |vm_name, vm_id|
       if vm_name
         r.post api? do
           check_visible_location
@@ -15,7 +15,7 @@ class Clover
 
         filter = {Sequel[:vm][:name] => vm_name}
       else
-        filter = {Sequel[:vm][:id] => UBID.to_uuid(vm_ubid)}
+        filter = {Sequel[:vm][:id] => vm_id}
       end
 
       filter[:location_id] = @location.id

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -642,6 +642,12 @@ RSpec.describe Clover, "postgres" do
         expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
       end
 
+      it "not found with valid looking but invalid ubid" do
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/pgg54eqqv6q26kgqrszmkypn7g"
+
+        expect(last_response).to have_api_error(404, "Sorry, we couldn’t find the resource you’re looking for.")
+      end
+
       it "show firewall" do
         get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/firewall-rule"
 


### PR DESCRIPTION
This DRYs up some route code.

Implement this using a symbol matcher that does the ubid to uuid conversion.

This also avoids an unnecessary query to look up a resource when the route segment looks like a ubid, but is not a valid ubid.