### PR TITLE
Extract VM provisioning times to E2E test summary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -145,6 +145,15 @@ jobs:
         echo '|---|---|---|---|' >> $GITHUB_STEP_SUMMARY
         grep "vm provisioned" foreman.log | cut -d'|' -f2 | jq -r '[.thread, .vm.name, .vm.boot_image, .provision.duration] | "| " + join(" | ") + " |"' >> $GITHUB_STEP_SUMMARY
 
+    - name: Extract runner queue times
+      if: always()
+      continue-on-error: true
+      run: |
+        echo "## Runner Queue Times" >> $GITHUB_STEP_SUMMARY
+        echo '| Runner | Label | VM | Duration |' >> $GITHUB_STEP_SUMMARY
+        echo '|---|---|---|---|' >> $GITHUB_STEP_SUMMARY
+        grep "runner_started" foreman.log | cut -d'|' -f2 | jq -r '[.runner_started.ubid, .runner_started.label, .runner_started.vm_ubid, .runner_started.duration] | "| " + join(" | ") + " |"' >> $GITHUB_STEP_SUMMARY
+
     - name: Upload logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,6 +136,15 @@ jobs:
         echo "### Image downloaded in $download_time" >> $GITHUB_STEP_SUMMARY
         echo "DOWNLOAD_TIME=$download_time" >> $GITHUB_OUTPUT
 
+    - name: Extract vm provision times
+      if: always()
+      continue-on-error: true
+      run: |
+        echo "## VM Provisioning Times" >> $GITHUB_STEP_SUMMARY
+        echo '| UBID | Name | Boot Image | Duration |' >> $GITHUB_STEP_SUMMARY
+        echo '|---|---|---|---|' >> $GITHUB_STEP_SUMMARY
+        grep "vm provisioned" foreman.log | cut -d'|' -f2 | jq -r '[.thread, .vm.name, .vm.boot_image, .provision.duration] | "| " + join(" | ") + " |"' >> $GITHUB_STEP_SUMMARY
+
     - name: Upload logs
       if: always()
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- **Extract VM provisioning times to E2E test summary**
  VM provisioning times in the E2E test summary to help identify
  performance regressions and provide visibility into which VM types were
  provisioned during the tests.
  

- **Extract runner queue times to E2E test summary**
  