### PR TITLE
Random sleep during subnet destroy

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -210,7 +210,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     else
       private_subnet.nics.map { |n| n.incr_destroy }
       private_subnet.load_balancers.map { |lb| lb.incr_destroy }
-      nap 1
+      nap rand(5..10)
     end
   end
 

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -444,7 +444,8 @@ RSpec.describe Prog::Vnet::SubnetNexus do
     it "increments the destroy semaphore of nics" do
       expect(ps).to receive(:nics).and_return([nic]).at_least(:once)
       expect(nic).to receive(:incr_destroy).and_return(true)
-      expect { nx.destroy }.to nap(1)
+      expect(nx).to receive(:rand).with(5..10).and_return(6)
+      expect { nx.destroy }.to nap(6)
     end
 
     it "deletes and pops if nics are destroyed" do


### PR DESCRIPTION
Before this commit, subnet nexus was napping for 1 second after triggering nic and load balancer destroys. However, nic destroy is not that quick, if the VM still exists, nic simply naps 5 more seconds, during that time, subnet is scheduled 5 more times unnecessarily. Therefore, I am changing the nap time in a stochastic way somewhere from 5 to 10 seconds.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change `nap` duration in `destroy` method of `subnet_nexus.rb` to random 5-10 seconds to improve efficiency.
> 
>   - **Behavior**:
>     - In `subnet_nexus.rb`, change `nap` duration in `destroy` method from fixed 1 second to random 5-10 seconds to reduce unnecessary scheduling when NICs are not immediately destroyed.
>   - **Tests**:
>     - Update `subnet_nexus_spec.rb` to test random sleep duration by mocking `rand` to return a specific value (6) and expecting `nap(6)` during `destroy` method execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f93ddc415e40ece14692fbe7ce284646f7e0f155. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->