### PR TITLE
Bump Ubicsi version to 0.2.0

### DIFF
--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:0.1.0
+          image: ubicloud/ubicsi:0.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ID

--- a/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:0.1.0
+          image: ubicloud/ubicsi:0.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ID


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `ubicsi` image version to `0.2.0` in Kubernetes manifests.
> 
>   - **Image Version Update**:
>     - Bump `ubicsi` image version from `0.1.0` to `0.2.0` in `nodeplugin-daemonset.yaml` and `provisioner-deployment.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 63a4a3011532b9ff8a5134132bddd33f9df76e42. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->