### PR TITLE
Prevent Monitoring Exceptions Before a GH runner is ready

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -62,7 +62,7 @@ class GithubRunner < Sequel::Model
 
   def init_health_monitor_session
     {
-      ssh_session: vm.sshable.start_fresh_session
+      ssh_session: (vm && vm.strand.label == "wait") ? vm.sshable.start_fresh_session : nil
     }
   end
 


### PR DESCRIPTION
There's a race for pulse_checking a GH runner by the monitor and creating of the VM by the respirator. We can reduce the amount of exceptions by gracefully reporting "down" when the VM is not ready.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `init_health_monitor_session` to handle unready VMs and update tests accordingly.
> 
>   - **Behavior**:
>     - Modify `init_health_monitor_session` in `github_runner.rb` to return `nil` for `ssh_session` if VM is not ready (i.e., `vm.strand.label` is not "wait").
>     - Update `check_pulse` in `github_runner.rb` to handle `nil` `ssh_session` by returning "down".
>   - **Tests**:
>     - Add test in `github_runner_spec.rb` to verify `init_health_monitor_session` returns `nil` when VM is not ready.
>     - Update `check_pulse` test in `github_runner_spec.rb` to check behavior with `nil` `ssh_session`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 40322d95181dc4f24c6eb3ea598870a51dd65bb4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->