### PR TITLE
Expose Scaling K8s Nodepools

### DIFF
--- a/cli-commands/kc/post/resize-nodepool.rb
+++ b/cli-commands/kc/post/resize-nodepool.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+UbiCli.on("kc").run_on("resize-nodepool") do
+  desc "Resize a Kubernetes cluster nodepool"
+
+  banner "ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count"
+
+  args 2
+
+  run do |nodepool_ref, node_count, _, cmd|
+    node_count = Integer(node_count, exception: false)
+
+    unless node_count&.>(0)
+      cmd.raise_failure("the node count must be a positive integer")
+    end
+
+    sdk_object.resize_nodepool(nodepool_ref, node_count)
+
+    response("Resized nodepool #{nodepool_ref} to #{node_count} nodes.")
+  end
+end

--- a/clover.rb
+++ b/clover.rb
@@ -110,6 +110,7 @@ class Clover < Roda
 
   path("Project", class_name: true, &:path)
   path("GithubInstallation", class_name: true) { "#{it.project.path}/github/#{it.ubid}" }
+  path("KubernetesNodepool", class_name: true) { "#{it.cluster.project.path}#{it.cluster.path}/nodepool/#{it.ubid}" }
 
   # :nocov:
   if Config.test? && defined?(SimpleCov)

--- a/clover.rb
+++ b/clover.rb
@@ -68,7 +68,7 @@ class Clover < Roda
   symbol_matcher(:ubid_uuid, /([a-tv-z0-9]{26})/) do |s|
     UBID.to_uuid(s)
   end
-  [Firewall, KubernetesCluster, LoadBalancer, PostgresResource, PrivateSubnet, Vm].each do |model|
+  [Firewall, KubernetesCluster, KubernetesNodepool, LoadBalancer, PostgresResource, PrivateSubnet, Vm].each do |model|
     sym = :"#{model.table_name}_ubid_uuid"
     symbol_matcher(sym, /(#{model.ubid_type}[a-tv-z0-9]{24})/) do |ubid|
       if (uuid = UBID.to_uuid(ubid))

--- a/clover.rb
+++ b/clover.rb
@@ -98,6 +98,7 @@ class Clover < Roda
     ApiKey
     Firewall
     KubernetesCluster
+    KubernetesNodepool
     LoadBalancer
     Location
     ObjectTag
@@ -110,7 +111,6 @@ class Clover < Roda
 
   path("Project", class_name: true, &:path)
   path("GithubInstallation", class_name: true) { "#{it.project.path}/github/#{it.ubid}" }
-  path("KubernetesNodepool", class_name: true) { "#{it.cluster.project.path}#{it.cluster.path}/nodepool/#{it.ubid}" }
 
   # :nocov:
   if Config.test? && defined?(SimpleCov)

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -12,7 +12,7 @@ class Clover
 
     requested_kubernetes_vcpu_count = cp_node_count * 2 # since default control plane size is standard-2
     requested_kubernetes_vcpu_count += node_count * node_size.vcpus
-    Validation.validate_vcpu_quota(@project, "KubernetesVCpu", requested_kubernetes_vcpu_count, name: :worker_size)
+    Validation.validate_vcpu_quota(@project, "KubernetesVCpu", requested_kubernetes_vcpu_count, name: :worker_nodes)
 
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -11,6 +11,10 @@ class KubernetesNodepool < Sequel::Model
 
   plugin ResourceMethods
   plugin SemaphoreMethods, :destroy, :start_bootstrapping, :upgrade, :scale_worker_count
+
+  def path
+    "#{cluster.path}/nodepool/#{ubid}"
+  end
 end
 
 # Table: kubernetes_nodepool

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -548,7 +548,7 @@ paths:
                 - node_count
       responses:
         '200':
-          $ref: '#/components/responses/KubernetesCluster'
+          $ref: '#/components/responses/KubernetesNodepool'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -2945,6 +2945,15 @@ components:
             required:
               - count
               - items
+    KubernetesNodepool:
+      description: A Kubernetes node pool
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            allOf:
+              - $ref: '#/components/schemas/KubernetesNodepool'
   securitySchemes:
     BearerAuth:
       bearerFormat: JWT

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -524,6 +524,35 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Kubernetes Cluster
+  '/project/{project_id}/location/{location}/kubernetes-cluster/{kubernetes_cluster_reference}/nodepool/{kubernetes_nodepool_reference}/resize':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/kubernetes_cluster_reference'
+      - $ref: '#/components/parameters/kubernetes_nodepool_reference'
+    post:
+      operationId: resizeKubernetesNodepool
+      summary: Change number of nodes of a kubernetes nodepool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                node_count:
+                  description: New number of nodes for the kubernetes nodepool
+                  type: integer
+              additionalProperties: false
+              required:
+                - node_count
+      responses:
+        '200':
+          $ref: '#/components/responses/KubernetesCluster'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Kubernetes Cluster
   '/project/{project_id}/location/{location}/kubernetes-cluster/{kubernetes_cluster_reference}/rename':
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -1778,6 +1807,18 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/Reference'
+    kubernetes_nodepool_reference:
+      description: Kubernetes nodepool ID or name
+      examples:
+        id:
+          value: kn66ktqjab025mkxhjmavpwjxs
+        name:
+          value: kubernetes-nodepool-name
+      in: path
+      name: kubernetes_nodepool_reference
+      required: true
+      schema:
+        $ref: '#/components/schemas/Reference'
     load_balancer_reference:
       description: Load balancer ID or name
       examples:
@@ -2503,7 +2544,7 @@ components:
           type: string
           example: my-nodepool-name
         node_count:
-          description: Count of worker nodes
+          description: Number of worker nodes
           type: integer
         node_size:
           description: Size of each worker node

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -70,6 +70,7 @@ class Clover
 
           r.post "resize" do
             authorize("KubernetesCluster:edit", kc.id)
+            handle_validation_failure("kubernetes-cluster/show") { @page = "settings" }
             node_count = typecast_params.pos_int!("node_count")
             Validation.validate_kubernetes_worker_node_count(node_count)
 
@@ -79,7 +80,12 @@ class Clover
               audit_log(kn, "update")
             end
 
-            Serializers::KubernetesCluster.serialize(kc, {detailed: true})
+            if api?
+              Serializers::KubernetesCluster.serialize(kc, {detailed: true})
+            else
+              flash["notice"] = "#{kc.name} node pool #{kn.name} will be resized"
+              r.redirect kc
+            end
           end
         end
       end

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -72,6 +72,13 @@ class Clover
         node_count = typecast_params.pos_int!("node_count")
         Validation.validate_kubernetes_worker_node_count(node_count)
 
+        if node_count > kn.node_count
+          node_size = Validation.validate_vm_size(kn.target_node_size, "x64")
+          extra_vcpu_count = (node_count - kn.node_count) * node_size.vcpus
+
+          Validation.validate_vcpu_quota(@project, "KubernetesVCpu", extra_vcpu_count, name: :node_count)
+        end
+
         DB.transaction do
           kn.update(node_count:)
           kn.incr_scale_worker_count

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -79,7 +79,7 @@ class Clover
         end
 
         if api?
-          Serializers::KubernetesCluster.serialize(kc, {detailed: true})
+          Serializers::KubernetesNodepool.serialize(kn, {detailed: true})
         else
           flash["notice"] = "#{kc.name} node pool #{kn.name} will be resized"
           r.redirect kc

--- a/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
+++ b/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
@@ -12,5 +12,9 @@ module Ubicloud
     def kubeconfig
       adapter.get(_path("/kubeconfig"))
     end
+
+    def resize_nodepool(nodepool_ref, node_count)
+      adapter.post(_path("/nodepool/#{nodepool_ref}/resize"), {node_count: node_count})
+    end
   end
 end

--- a/spec/routes/api/cli/golden-file-commands/error.txt
+++ b/spec/routes/api/cli/golden-file-commands/error.txt
@@ -92,3 +92,6 @@ vm vmdzyppz6j166jh5e9t2dwrfasa show
 kc eu-central-h1/test-kc create invalid
 kc eu-central-h1/test-kc create -c a
 kc eu-central-h1/test-kc create -c 1 -w bad
+kc eu-central-h1/test-kc resize-nodepool something
+kc eu-central-h1/test-kc resize-nodepool test-kc-np -1
+kc eu-central-h1/test-kc resize-nodepool test-kc-np 2.9

--- a/spec/routes/api/cli/golden-file-commands/missing.txt
+++ b/spec/routes/api/cli/golden-file-commands/missing.txt
@@ -1,1 +1,2 @@
+kc eu-central-h1/test-kc resize-nodepool something 5
 ps eu-central-h1/test-ps disconnect psfzm9e26xky5m9ggetw4dpqe2/foo

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -56,6 +56,7 @@ kc eu-central-h1/test-kc show -v id,name,state,location,size,unix-user,storage-s
 kc eu-central-h1/test-kc show -v ip6,ip4-enabled,ip4
 kc kcnzrctjjg4j4g6eqvdsvzthwp show
 kc list
+kc eu-central-h1/test-kc resize-nodepool test-kc-np 8
 kc list -f location
 kc list -l eu-central-h1
 kc list -l eu-central-h1 -f name,id

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -194,14 +194,15 @@ Usage:
     ubi kc (location/kc-name | kc-id) post-command [...]
 
 Commands:
-    list          List Kubernetes clusters
+    list               List Kubernetes clusters
 
 Post Commands:
-    create        Create a Kubernetes cluster
-    destroy       Destroy a Kubernetes cluster
-    kubeconfig    Print kubeconfig.yaml for a Kubernetes cluster
-    rename        Rename a Kubernetes cluster
-    show          Show details for a Kubernetes cluster
+    create             Create a Kubernetes cluster
+    destroy            Destroy a Kubernetes cluster
+    kubeconfig         Print kubeconfig.yaml for a Kubernetes cluster
+    rename             Rename a Kubernetes cluster
+    resize-nodepool    Resize a Kubernetes cluster nodepool
+    show               Show details for a Kubernetes cluster
 
 
 List Kubernetes clusters
@@ -253,6 +254,12 @@ Rename a Kubernetes cluster
 
 Usage:
     ubi kc (location/kc-name | kc-id) rename new-name
+
+
+Resize a Kubernetes cluster nodepool
+
+Usage:
+    ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count
 
 
 Show details for a Kubernetes cluster

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -25,6 +25,7 @@ ubi kc location/kc-name create [options]
 ubi kc (location/kc-name | kc-id) destroy [options]
 ubi kc (location/kc-name | kc-id) kubeconfig
 ubi kc (location/kc-name | kc-id) rename new-name
+ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count
 ubi kc (location/kc-name | kc-id) show [options]
 ubi lb command [...]
 ubi lb (location/lb-name | lb-id) post-command [...]

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool something 5.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool something 5.txt
@@ -1,0 +1,2 @@
+! Unexpected response status: 404
+Details: Sorry, we couldn’t find the resource you’re looking for.

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool something.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool something.txt
@@ -1,0 +1,6 @@
+! Invalid number of arguments for kc resize-nodepool subcommand (requires: 2, given: 1)
+
+Resize a Kubernetes cluster nodepool
+
+Usage:
+    ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool test-kc-np -1.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool test-kc-np -1.txt
@@ -1,0 +1,6 @@
+! The node count must be a positive integer
+
+Resize a Kubernetes cluster nodepool
+
+Usage:
+    ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool test-kc-np 2.9.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool test-kc-np 2.9.txt
@@ -1,0 +1,6 @@
+! The node count must be a positive integer
+
+Resize a Kubernetes cluster nodepool
+
+Usage:
+    ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool test-kc-np 8.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc resize-nodepool test-kc-np 8.txt
@@ -1,0 +1,1 @@
+Resized nodepool test-kc-np to 8 nodes.

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
 
             expect(last_response.status).to eq(200)
             body = JSON.parse(last_response.body)
-            expect(body["nodepools"][0]["node_count"]).to eq(new_count)
+            expect(body["node_count"]).to eq(new_count)
             expect(kn.reload.node_count).to eq(new_count)
             expect(kn.scale_worker_count_set?).to be true
           end

--- a/views/kubernetes-cluster/settings.erb
+++ b/views/kubernetes-cluster/settings.erb
@@ -1,6 +1,40 @@
 <% if has_permission?("KubernetesCluster:edit", @kc) %>
+  <% np = @kc.nodepools.first %>
   <div class="p-6">
     <%== part("components/rename_object", object: @kc, type: "Kubernetes Cluster") %>
+  </div>
+
+  <div class="p-6">
+    <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          Resize Worker Node Pool
+        </h3>
+      </div>
+    </div>
+
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div class="px-4 py-5 sm:p-6">
+        <% form(action: "#{path(np)}/resize", method: :post) do %>
+          <div class="gap-6 sm:flex sm:items-center sm:justify-between">
+            <div class="flex-grow">
+              <%== part(
+                "components/form/select",
+                name: "node_count",
+                selected: np.node_count,
+                attributes: { required: true },
+                options: (1..10).map {
+                  [it, ContentGenerator::KubernetesCluster.worker_nodes(@kc.location, np.target_node_size, {value: it, display_name: "#{it} Nodes"})]
+                }
+              ) %>
+            </div>
+            <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <%== part("components/button", text: "Resize") %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
 <% end %>
 


### PR DESCRIPTION
This PR adds a route and a UI for resizing nodepool(s). SDK & CLI to follow up.

<img width="1243" height="844" alt="image" src="https://github.com/user-attachments/assets/6b81c932-53ef-443b-b531-727cbe7d61e9" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR adds functionality to resize Kubernetes nodepools via API, CLI, and UI, with validation and tests.
> 
>   - **Behavior**:
>     - Adds `resize-nodepool` route in `routes/project/location/kubernetes_cluster.rb` to resize Kubernetes nodepools.
>     - Validates node count as a positive integer and checks vCPU quota when scaling up.
>     - Updates `openapi.yml` to include new endpoint for resizing nodepools.
>   - **CLI**:
>     - Adds `resize-nodepool` command in `cli-commands/kc/post/resize-nodepool.rb` for resizing nodepools via CLI.
>     - Updates CLI help files to include `resize-nodepool` command.
>   - **UI**:
>     - Updates `views/kubernetes-cluster/settings.erb` to add UI for resizing nodepools.
>   - **Models**:
>     - Adds `resize_nodepool` method to `KubernetesCluster` in `sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb`.
>   - **Tests**:
>     - Adds tests for resizing nodepools in `kubernetes_cluster_spec.rb` and `kubernetes_cluster_spec.rb` for both API and web interfaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 35a842aaa5059af9c51b8128431c3da0115b1834. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->