### PR TITLE
Remove unused config variables

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -36,15 +36,12 @@ module Config
 
   # Mandatory -- exception is raised for these variables when missing.
   mandatory :clover_database_url, string, clear: true
+  mandatory :clover_column_encryption_key, base64, clear: true
+  mandatory :clover_session_secret, base64, clear: true
   mandatory :rack_env, string
 
   # Optional -- value is returned or `nil` if it wasn't present.
-  optional :app_name, string
-  optional :versioning_default, string
-  optional :versioning_app_name, string
-  optional :clover_session_secret, base64, clear: true
   optional :clover_runtime_token_secret, base64, clear: true
-  optional :clover_column_encryption_key, base64, clear: true
   optional :heartbeat_url, string
   optional :clover_database_root_certs, string
   override :max_health_monitor_threads, 32, int
@@ -74,21 +71,11 @@ module Config
   override :database_timeout, 10, int
   override :db_pool, 5, int
   override :db_pool_monitor, Config.db_pool, int
-  override :deployment, "production", string
-  override :force_ssl, true, bool
-  override :port, 3000, int
-  override :pretty_json, false, bool
   override :dispatcher_max_threads, 8, int
   override :dispatcher_min_threads, 1, int
   override :dispatcher_queue_size_ratio, 4, float
-  override :puma_max_threads, 16, int
-  override :puma_min_threads, 1, int
-  override :puma_workers, 3, int
-  override :raise_errors, false, bool
   override :recursive_tag_limit, 32, int
   override :root, File.expand_path(__dir__), string
-  override :timeout, 10, int
-  override :versioning, false, bool
   optional :hetzner_user, string, clear: true
   optional :hetzner_password, string, clear: true
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
@@ -120,7 +107,6 @@ module Config
   optional :github_cache_blob_storage_secret_key, string, clear: true
   optional :github_cache_blob_storage_account_id, string
   optional :github_cache_blob_storage_api_key, string, clear: true
-  optional :github_cache_proxy_repo_uri, string, clear: true
 
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string
@@ -230,7 +216,6 @@ module Config
   optional :kubernetes_service_hostname, string
 
   # Billing
-  optional :stripe_public_key, string, clear: true
   optional :stripe_secret_key, string, clear: true
   override :annual_non_dutch_eu_sales_exceed_threshold, false, bool
   optional :invalid_vat_notification_email, string


### PR DESCRIPTION
Some of these were used in the past. Some never used.

While here, make clover_column_encryption_key and clover_session_secret mandatory and not optional. You cannot load the models without clover_column_encryption_key, and you cannot load Clover without clover_session_secret.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused config variables and make `clover_column_encryption_key` and `clover_session_secret` mandatory in `config.rb`.
> 
>   - **Config Changes**:
>     - Remove unused config variables: `app_name`, `versioning_default`, `versioning_app_name`, `github_cache_proxy_repo_uri`, `stripe_public_key`, and others.
>     - Make `clover_column_encryption_key` and `clover_session_secret` mandatory in `config.rb`.
>   - **Behavior**:
>     - Application will raise an exception if `clover_column_encryption_key` or `clover_session_secret` is missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7fd43e93c3702c9d0b0b40dea81cbe2e72cb02f6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->