### PR TITLE
Partition management for archived_records

### DIFF
--- a/migrate/20250922_archived_record_maintenance.rb
+++ b/migrate/20250922_archived_record_maintenance.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    Array.new(2) { |i| Date.new(2025, 7, 1).next_month(i) }.each do |month|
+      drop_table("archived_record_#{month.strftime("%Y_%m")}")
+    end
+
+    Array.new(2) { |i| Date.new(2026, 9, 1).next_month(i) }.each do |month|
+      create_table("archived_record_#{month.strftime("%Y_%m")}", partition_of: :archived_record) do
+        from month
+        to month.next_month
+      end
+    end
+  end
+end


### PR DESCRIPTION
Drop partitions:
archived_record_2025_07
archived_record_2025_08

Create partitions:
archived_record_2026_09
archived_record_2026_10
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds migration to drop 2025 partitions and create 2026 partitions for `archived_record`.
> 
>   - **Migration**:
>     - Adds `20250922_archived_record_maintenance.rb` to manage partitions for `archived_record`.
>     - Drops partitions `archived_record_2025_07` and `archived_record_2025_08`.
>     - Creates partitions `archived_record_2026_09` and `archived_record_2026_10`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2e7545879a1a458bae1df786d1a07c921b114b00. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->