### PR TITLE
Skip SSH session locking tests on unsupported systems

### DIFF
--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -44,13 +44,15 @@ exec -a session-lock-testlockname sleep infinity </dev/null >/dev/null 2>&1 &
 disown
 LOCK
 
-    it "interlocks" do
-      portable_pkill = lambda { system(%q(ps -eo pid,args | awk '$2=="session-lock-testlockname"{print $1}' | xargs -I {} sh -c 'test -n "{}" && kill {}')) }
-      portable_pkill.call
-      q_lock_script = lock_script.shellescape
-      expect([`bash -c #{q_lock_script}`, $?.exitstatus]).to eq(["", 0])
-      expect([`bash -c #{q_lock_script}`, $?.exitstatus]).to eq(["Another session active:  testlockname\n", 124])
-      expect(portable_pkill.call).to be true
+    if File.directory?("/dev/shm")
+      it "interlocks" do
+        portable_pkill = lambda { system(%q(ps -eo pid,args | awk '$2=="session-lock-testlockname"{print $1}' | xargs -I {} sh -c 'test -n "{}" && kill {}')) }
+        portable_pkill.call
+        q_lock_script = lock_script.shellescape
+        expect([`bash -c #{q_lock_script}`, $?.exitstatus]).to eq(["", 0])
+        expect([`bash -c #{q_lock_script}`, $?.exitstatus]).to eq(["Another session active:  testlockname\n", 124])
+        expect(portable_pkill.call).to be true
+      end
     end
 
     describe "exit code handling" do


### PR DESCRIPTION
`/dev/shm` is a linux-ism, and other platforms (especially: macOS) cannot test SSH session-locking functionality introduced in https://github.com/ubicloud/ubicloud/commit/c43d8ccd573ca5ac0d7369aaa82e549b3551e932.  Skip this test with this change.

Previously, these tests failed with errors like:
```
bash: /dev/shm/session-lock-testlockname: No such file or directory

  1) Sshable session locking interlocks
     Failure/Error: expect([`bash -c #{q_lock_script}`, $?.exitstatus]).to eq(["", 0])

       expected: ["", 0]
            got: ["", 92]

       (compared using ==)
```