### PR TITLE
Delay host unavailability pages by 45 sec

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -373,7 +373,7 @@ TIMER
       hop_wait
     end
 
-    register_deadline("wait", 0)
+    register_deadline("wait", 45)
     nap 30
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -338,8 +338,8 @@ RSpec.describe Prog::Vm::HostNexus do
   end
 
   describe "#unavailable" do
-    it "registers an immediate deadline if host is unavailable" do
-      expect(nx).to receive(:register_deadline).with("wait", 0)
+    it "registers a short deadline if host is unavailable" do
+      expect(nx).to receive(:register_deadline).with("wait", 45)
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(30)
     end


### PR DESCRIPTION
We’ve been receiving a high number of alerts that auto-resolve within seconds. To reduce noise while we improve the robustness of our SSH-based pulse checks, we now wait 45 seconds before paging. This delay allows one additional health check by respirate and should significantly cut down on spurious host pages.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change delay for host unavailability pages to 45 seconds in `host_nexus.rb` to reduce spurious alerts.
> 
>   - **Behavior**:
>     - Change delay for host unavailability pages from 0 to 45 seconds in `unavailable` method of `host_nexus.rb`.
>     - Allows one additional health check before paging to reduce spurious alerts.
>   - **Tests**:
>     - Update test in `host_nexus_spec.rb` to expect a 45-second delay for unavailability in `#unavailable` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for bd55316ab28b1a65711efb8cdf2eb879c4f207c6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->