### PR TITLE
Make Vm::Nexus Handle the Destroy when Host is not assigned

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -590,7 +590,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   label def wait_vm_removal_from_load_balancer
     reap(nap: 10) do
-      vm.vm_host.sshable.cmd("sudo host/bin/setup-vm delete_net #{q_vm}")
+      vm.vm_host&.sshable&.cmd("sudo host/bin/setup-vm delete_net #{q_vm}")
       hop_destroy_slice
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -1202,6 +1202,16 @@ RSpec.describe Prog::Vm::Nexus do
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-vm delete_net #{vm.inhost_name}")
       expect { nx.wait_vm_removal_from_load_balancer }.to hop("destroy_slice")
     end
+
+    it "handles the case when the vm_host is not set" do
+      expect(nx).to receive(:reap).and_yield.twice
+
+      expect(vm.vm_host).to receive(:sshable).and_return(nil)
+      expect { nx.wait_vm_removal_from_load_balancer }.to hop("destroy_slice")
+
+      expect(vm).to receive(:vm_host).and_return(nil)
+      expect { nx.wait_vm_removal_from_load_balancer }.to hop("destroy_slice")
+    end
   end
 
   describe "#start_after_host_reboot" do


### PR DESCRIPTION
In the wait_vm_removal_from_load_balancer, we make a call to the host for dropping the network, which fails when the VM is destroyed before it gets a host, such as in out-of-capacity situations. This happens in Kubernetes workflow where the VM is added to a LB before it's creation is completed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `wait_vm_removal_from_load_balancer` in `nexus.rb` to handle nil `vm_host` and add corresponding test in `nexus_spec.rb`.
> 
>   - **Behavior**:
>     - Update `wait_vm_removal_from_load_balancer` in `nexus.rb` to handle nil `vm_host` by using safe navigation (`&.`) when calling `sshable`.
>     - If `vm_host` is nil, skips network deletion command and proceeds to `destroy_slice`.
>   - **Tests**:
>     - Add test in `nexus_spec.rb` to verify `wait_vm_removal_from_load_balancer` handles nil `vm_host` and proceeds to `destroy_slice`.
>     - Ensure test covers both cases: `vm_host` returning nil and `sshable` returning nil.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3e32b06ac8e9fa2958882e82f65adbf17e463e66. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->