### PR TITLE
Fix nondeterministic instance double reuse in dispatcher spec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,7 @@ RSpec.configure do |config|
     DB.transaction(rollback: :always, auto_savepoint: true) do
       example.run
     end
+    Thread.current[:clover_ssh_cache] = nil
     Mail::TestMailer.deliveries.clear if defined?(Mail)
 
     unless @skip_leaked_thread_check


### PR DESCRIPTION
Clear the clover_ssh_cache thread variable after every spec.

Should fix this CI failure:

```
  1) Scheduling::Dispatcher#run_strand print exceptions if they are raised
     Failure/Error: expect(di.run_strand(st, start_queue, finish_queue)).to eq ex
       #<InstanceDouble(Net::SSH::Connection::Session) (anonymous)> was originally created in one example but has leaked into another example and can no longer be used. rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
     # ./scheduling/dispatcher.rb:490:in 'block in Scheduling::Dispatcher#run_strand'
     # ./scheduling/dispatcher.rb:487:in 'Hash#each_value'
     # ./scheduling/dispatcher.rb:487:in 'Scheduling::Dispatcher#run_strand'
     # ./spec/scheduling/dispatcher_spec.rb:432:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:60:in 'block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/gems/sequel-5.96.0/lib/sequel/database/transactions.rb:257:in 'Sequel::Database#_transaction'
     # ./vendor/bundle/ruby/3.4.0/gems/sequel-5.96.0/lib/sequel/database/transactions.rb:239:in 'block in Sequel::Database#transaction'
     # ./vendor/bundle/ruby/3.4.0/gems/sequel-5.96.0/lib/sequel/connection_pool/timed_queue.rb:90:in 'Sequel::TimedQueueConnectionPool#hold'
     # ./vendor/bundle/ruby/3.4.0/gems/sequel-5.96.0/lib/sequel/database/connecting.rb:283:in 'Sequel::Database#synchronize'
     # ./vendor/bundle/ruby/3.4.0/gems/sequel-5.96.0/lib/sequel/database/transactions.rb:197:in 'Sequel::Database#transaction'
     # ./spec/spec_helper.rb:59:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix nondeterministic instance double reuse in RSpec by clearing `Thread.current[:clover_ssh_cache]` after each spec in `spec_helper.rb`.
> 
>   - **Behavior**:
>     - Clears `Thread.current[:clover_ssh_cache]` after each spec in `spec_helper.rb` to prevent instance double reuse across tests.
>     - Fixes nondeterministic CI failure related to `InstanceDouble` reuse in RSpec tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 714680440c24b843870e49eee1dc4fb9a08e01bc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->