### PR TITLE
Do not include server cert when providing CA data to Minio::Client

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -91,7 +91,7 @@ class MinioServer < Sequel::Model
       endpoint: server_url,
       access_key: cluster.admin_user,
       secret_key: cluster.admin_password,
-      ssl_ca_data: cluster.root_certs + cert,
+      ssl_ca_data: cluster.root_certs,
       socket: socket
     )
   end


### PR DESCRIPTION
This causes problems in some environments. Only the CA certificates should be provided as CA data.

This fixes a `certificate signature failure` I experienced when setting up a MinioCluster in the staging environment.