### PR TITLE
Begin logging the sshable ubid that is contended

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -174,7 +174,7 @@ LOCK
         end
 
         Clog.emit("session lock failure") do
-          {contended_session_lock: {exit_code:, session_fail_msg:}}
+          {contended_session_lock: {exit_code:, session_fail_msg:, sshable_ubid: ubid.to_s}}
         end
       end
     end

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -78,9 +78,14 @@ LOCK
       end
 
       it "reports lock conflicts when an obscure exit code is raised" do
+        sa.id = "624ec0d1-95d9-8f31-bbaa-bcccb76fe98b"
         expect(sa).to receive(:cmd).with(lock_script, log: false).and_raise(Sshable::SshError.new(lock_script, "", "", 124, nil))
         expect(Clog).to receive(:emit).with("session lock failure").and_wrap_original do |m, a, &b|
-          expect(b.call.dig(:contended_session_lock, :session_fail_msg)).to eq("session lock conflict for testlockname")
+          expect(b.call).to eq(contended_session_lock: {
+            exit_code: 124,
+            session_fail_msg: "session lock conflict for testlockname",
+            sshable_ubid: "shc97c1mcnv67qenbsk5qdzmrp"
+          })
         end
         sa.connect
       end


### PR DESCRIPTION
After monitoring the output of
7968f98ede70e40363fd75783b7276ccf62be58b, there's a lot of contention.

Although Clog's `emit` includes automatic enrichment of the thread title and thus the ubid of the Prog having the contention, the emitted Clog didn't have any information about the sshable host having the contention.

And so, rectify that here.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `sshable_ubid` to Clog output for session lock failures in `Sshable` class and update tests accordingly.
> 
>   - **Behavior**:
>     - Adds `sshable_ubid` to Clog output in `connect` method of `Sshable` class in `sshable.rb` when session lock failure occurs.
>   - **Tests**:
>     - Updates test in `sshable_spec.rb` to verify `sshable_ubid` is included in Clog output for session lock failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ee5eda638dad933a9dcf7fc1e34e1f5aa6db4749. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->