### PR TITLE
Minor k8s improvements

### DIFF
--- a/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
@@ -329,10 +329,4 @@ RSpec.describe Csi::V1::ControllerService do
       end
     end
   end
-
-  describe "class inheritance" do
-    it "inherits from Controller::Service" do
-      expect(described_class.superclass).to eq(Csi::V1::Controller::Service)
-    end
-  end
 end

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -113,6 +113,12 @@ class KubernetesCluster < Sequel::Model
     aggregate_readings(previous_pulse: previous_pulse, reading: reading)
   end
 
+  def install_rhizome
+    cp_vms.each do |vm|
+      Strand.create(prog: "InstallRhizome", label: "start", stack: [{subject_id: vm.sshable.id, target_folder: "kubernetes"}])
+    end
+  end
+
   def all_nodes
     nodes + nodepools.flat_map(&:nodes)
   end

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -176,6 +176,18 @@ RSpec.describe KubernetesCluster do
     end
   end
 
+  describe "#install_rhizome" do
+    it "creates a strand for each control plane vm to update the contents of rhizome folder" do
+      sshable = instance_double(Sshable, id: "someid")
+      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id)
+      expect(kc.cp_vms.first).to receive(:sshable).and_return(sshable).twice
+      kc.cp_vms.each do |vm|
+        expect(Strand).to receive(:create).with(prog: "InstallRhizome", label: "start", stack: [{subject_id: vm.sshable.id, target_folder: "kubernetes"}])
+      end
+      kc.install_rhizome
+    end
+  end
+
   describe "#all_nodes" do
     it "returns all nodes in the cluster" do
       expect(kc).to receive(:nodes).and_return([1, 2])


### PR DESCRIPTION
Remove unnecessary test from CSI

---
Add install_rhizome function to update rhizome in control plane nodes
In order to install the latest version of CSI, we need to update
the contents of rhizome folder since those were filled during
the cluster bootstrap and may contain old content.

---
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary test and add `install_rhizome` function to update rhizome folder in control plane nodes.
> 
>   - **Behavior**:
>     - Remove unnecessary class inheritance test from `controller_service_spec.rb`.
>     - Add `install_rhizome` method in `KubernetesCluster` to update rhizome folder on control plane nodes.
>   - **Tests**:
>     - Add test for `install_rhizome` in `kubernetes_cluster_spec.rb` to verify strand creation for each control plane VM.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 069260d124cef5c75e4d17d0dfe82619b8606c2f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->