### PR TITLE
VM host monitoring optimizations

### DIFF
--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -51,7 +51,7 @@ class MonitorableResource
             # Seen when receiving on a broken connection.
             ex.is_a?(Errno::ECONNRESET) && ex.message.start_with?("Connection reset by peer - recvfrom(2)")
           ) &&
-          @session[:last_pulse]&.<(Time.now - 8)
+          (@session[:last_pulse].nil? || @session[:last_pulse] < (Time.now - 8))
         stale_retry = true
         @session.merge!(@resource.init_health_monitor_session)
         retry

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -41,6 +41,7 @@ class MonitorableResource
     @pulse_check_started_at = Time.now
     begin
       @pulse = @resource.check_pulse(session: @session, previous_pulse: @pulse)
+      @session[:last_pulse] = Time.now
       Clog.emit("Got new pulse.") { {got_pulse: {ubid: @resource.ubid, pulse: @pulse}} } if (rpt = @pulse[:reading_rpt]) && (rpt < 6 || rpt % 5 == 1) || @pulse[:reading] != "up"
     rescue => ex
       if !stale_retry &&

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -53,6 +53,10 @@ class MonitorableResource
           ) &&
           (@session[:last_pulse].nil? || @session[:last_pulse] < (Time.now - 8))
         stale_retry = true
+        begin
+          @session[:ssh_session].shutdown!
+        rescue
+        end
         @session.merge!(@resource.init_health_monitor_session)
         retry
       end

--- a/model/load_balancer_vm_port.rb
+++ b/model/load_balancer_vm_port.rb
@@ -39,7 +39,7 @@ class LoadBalancerVmPort < Sequel::Model
     end
 
     begin
-      ((session[:ssh_session].exec!(health_check_cmd(type)).strip == "200") ? "up" : "down").tap { session[:last_pulse] = Time.now }
+      (session[:ssh_session].exec!(health_check_cmd(type)).strip == "200") ? "up" : "down"
     rescue IOError, Errno::ECONNRESET
       raise
     rescue => e

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe MonitorableResource do
         expect(postgres_server).to receive(:check_pulse).and_raise(ex)
         second_session = instance_double(Net::SSH::Connection::Session)
         expect(postgres_server).to receive(:init_health_monitor_session).and_return(second_session)
+        expect(session[:ssh_session]).to receive(:shutdown!)
         expect(session).to receive(:merge!).with(second_session)
         expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 1})
         r_w_event_loop.check_pulse
@@ -144,6 +145,7 @@ RSpec.describe MonitorableResource do
         expect(postgres_server).to receive(:check_pulse).and_raise(ex)
         second_session = instance_double(Net::SSH::Connection::Session)
         expect(postgres_server).to receive(:init_health_monitor_session).and_return(second_session)
+        expect(session[:ssh_session]).to receive(:shutdown!)
         expect(session).to receive(:merge!).with(second_session)
         expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 1})
         r_w_event_loop.check_pulse
@@ -154,6 +156,7 @@ RSpec.describe MonitorableResource do
         expect(postgres_server).to receive(:check_pulse).and_raise(ex)
         second_session = instance_double(Net::SSH::Connection::Session)
         expect(postgres_server).to receive(:init_health_monitor_session).and_return(second_session)
+        expect(session[:ssh_session]).to receive(:shutdown!)
         expect(session).to receive(:merge!).with(second_session)
         expect(postgres_server).to receive(:check_pulse).and_return(ex)
         expect(Clog).to receive(:emit).and_call_original


### PR DESCRIPTION
- **Set last pulse of monitorable resources**
  This change ensures last_pulse is explicitly set after a resource is
  health-checked. Currently, only load balancers set last_pulse; all other
  resources leave it as nil. As a result, the retry logic in
  MonitorableResource#perform_checkup only applies to load balancers,
  because the condition:
  ```
  @session[:last_pulse]&.<(Time.now - 8)
  ```
  is always false when @session[:last_pulse] is nil.
  
  Because COMMON_SSH_ARGS sets the SSH timeout to 10 seconds, resources
  that don't swallow exceptions like IOError or Errno::ECONNRESET,
  primarily VM hosts, produce logs that typically look like this:
  
```
  Sep 24 13:59:29 ubicloud-console app[monitor] info Got new pulse.
  Sep 24 14:00:01 ubicloud-console app[monitor] info Pulse checking has failed.
  Sep 24 14:00:19 ubicloud-console app[monitor] info Pulse checking has failed.
  Sep 24 14:00:57 ubicloud-console app[monitor] info Pulse checking has failed.
  Sep 24 14:01:23 ubicloud-console app[monitor] info Pulse checking has failed.
  Sep 24 14:02:00 ubicloud-console app[monitor] info Pulse checking has failed.
  Sep 24 14:02:28 ubicloud-console app[monitor] info Pulse checking has failed.
  Sep 24 14:03:01 ubicloud-console app[monitor] info Pulse checking has failed.
  Sep 24 14:03:30 ubicloud-console app[monitor] info Pulse checking has failed.
  ...
  ```

  After restarting monitor, the first health check succeeds. However, the
  second health check - which runs 30 seconds later - fails because the SSH
  session has been idle for more than 10 seconds and is now broken.
  Subsequent health checks continue to fail because we neither retry on
  broken sessions nor reestablish them.
  

- **Retry when last pulse is not set**
  Previously, we skipped retries for monitorable resources when last_pulse
  was nil. However, a missing last_pulse simply means that the resource
  has not yet been successfully pulse-checked.
  
  Without this change, the following scenario can occur:
  1. The monitor starts up, and the first pulse check fails due to a
     transient network issue.
  2. The next check (30 seconds later) runs over a stale SSH connection
     that has already timed out.
  3. Since last_pulse was never set, we skip retries and never reestablish
     the SSH session - causing all subsequent checks to fail.
  
  This change ensures we do retry when last_pulse is unset, allowing us
  to recover from transient startup failures and reestablish broken
  connections.
  
  ⸻
  

- **Shutdown broken SSH connections during pulse checks**
  When a pulse check encounters a broken SSH connection, we now explicitly
  shut it down to make sure all resources are released.
  

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimizes VM host monitoring by refining SSH session handling, retry logic, and introducing lightweight pulse checks.
> 
>   - **Behavior**:
>     - Sets `last_pulse` for all resources in `check_pulse()` in `monitorable_resource.rb` to ensure retry logic applies to all, not just load balancers.
>     - Retries pulse checks when `last_pulse` is unset, allowing recovery from transient failures.
>     - Shuts down broken SSH connections during pulse checks to release resources.
>     - Introduces lightweight pulse checks in `vm_host.rb` for VM hosts, running separately from thorough checks.
>     - Avoids incrementing checkup semaphore on monitor thread failures due to unrelated database issues.
>   - **Tests**:
>     - Updates `monitorable_resource_spec.rb` to test retry logic when `last_pulse` is unset and SSH session handling.
>     - Updates `vm_host_spec.rb` to test lightweight pulse checks and SSH session management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9fd76a73b9dfe15d405be99156c3d9c51be61562. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->