### PR TITLE
Session lock log prog info

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -174,7 +174,7 @@ LOCK
         end
 
         Clog.emit("session lock failure") do
-          {contended_session_lock: {exit_code:, session_fail_msg:, sshable_ubid: ubid.to_s}}
+          {contended_session_lock: {exit_code:, session_fail_msg:, sshable_ubid: ubid.to_s, prog: Prog::Base.current_prog}}
         end
       end
     end

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -9,6 +9,13 @@ class Prog::Base
     @subject_id = frame.dig("subject_id") || @strand.id
   end
 
+  # Searches the stack for the Prog that caused execution of the code,
+  # which can be useful in logging from nested method calls.
+  def self.current_prog
+    caller_locations.reverse_each { return it.label if it.label.start_with?("Prog::") }
+    nil
+  end
+
   def self.subject_is(*names)
     names.each do |name|
       class_eval %(

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -142,6 +142,15 @@ class Prog::Test < Prog::Base
   label def push_subject_id
     push Prog::Test, {"subject_id" => "70b633b7-1d24-4526-a47f-d2580597d53f"}
   end
+
+  label def callee_find_current_prog
+    find_current_prog
+    pop ""
+  end
+
+  def find_current_prog
+    Base.current_prog
+  end
 end
 
 class Prog::Test2 < Prog::Test

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -84,7 +84,8 @@ LOCK
           expect(b.call).to eq(contended_session_lock: {
             exit_code: 124,
             session_fail_msg: "session lock conflict for testlockname",
-            sshable_ubid: "shc97c1mcnv67qenbsk5qdzmrp"
+            sshable_ubid: "shc97c1mcnv67qenbsk5qdzmrp",
+            prog: nil
           })
         end
         sa.connect

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -139,6 +139,20 @@ RSpec.describe Prog::Base do
     }.to change { Semaphore.where(strand_id: st.id).any? }.from(true).to(false)
   end
 
+  describe Prog::Base, :current_prog do
+    it "returns nil if Progs are not in the call stack" do
+      expect(described_class.current_prog).to be_nil
+    end
+
+    it "can have its label located deeper in the call stack by Prog.current_prog" do
+      st = Strand.create(prog: "Test", label: "callee_find_current_prog")
+      expect(described_class).to receive(:current_prog).and_wrap_original do |om, *args, **kwargs, &blk|
+        om.call(*args, **kwargs, &blk).tap { expect(it).to eq("Prog::Test#callee_find_current_prog") }
+      end
+      st.run
+    end
+  end
+
   it "calls before_run if it is available" do
     st = Strand.create(prog: "Prog::Vm::Nexus", label: "wait")
     prg = instance_double(Prog::Vm::Nexus)

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -94,6 +94,7 @@ module ThawedMock
   allow_mocking(VictoriaMetricsResource, :[], :first)
 
   # Progs
+  allow_mocking(Prog::Base, :current_prog)
   allow_mocking(Prog::Ai::InferenceEndpointNexus, :assemble, :model_for_id)
   allow_mocking(Prog::Ai::InferenceEndpointReplicaNexus, :assemble)
   allow_mocking(Prog::Ai::InferenceRouterReplicaNexus, :assemble)


### PR DESCRIPTION
commit e4334bc6a848fab8d4e50f2a54f49dec9488aa63

    Log prog information in event of SSH session contention
    
    Although I decline to test the stack-munging code in
    `sshable_spec.rb`, the tests in prog's `base_spec.rb` included with
    that functionality might be good enough.

commit 30ad4fefe46bb135ff3845b26fa4cfaa2464527c

    Add Prog::Base.current_prog to find prog information in the stack
    
    It'd be helpful for my Sshable session conflict assessment to know
    what progs and labels are involved in contention, but as the relevant
    code is down-stack, it's not immediately obvious how to get access to
    the current prog and label information.
    
    Searching the stack is a way to do the job.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Log program information during SSH session contention and add `Prog::Base.current_prog` to retrieve current program from call stack.
> 
>   - **Behavior**:
>     - Log program information during SSH session contention in `connect` method of `sshable.rb`.
>     - Add `Prog::Base.current_prog` to retrieve current program from call stack.
>   - **Tests**:
>     - Update `sshable_spec.rb` to test logging of program information during session lock failures.
>     - Add tests in `base_spec.rb` to verify `Prog::Base.current_prog` functionality.
>   - **Misc**:
>     - Allow mocking of `Prog::Base.current_prog` in `thawed_mock.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 55249b60bec18cca8fbfd3cbd82a0bad237568f3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->