### PR TITLE
Add suspend action for Account on admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -141,6 +141,9 @@ class CloverAdmin < Roda
   end
 
   OBJECT_ACTIONS = {
+    "Account" => {
+      "suspend" => object_action("Suspend", "Account suspended", &:suspend)
+    },
     "GithubRunner" => {
       "provision" => object_action("Provision Spare Runner", "Spare runner provisioned", &:provision_spare_runner)
     },

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -286,8 +286,8 @@ RSpec.describe CloverAdmin do
   end
 
   it "raises for 404 by default for missing action" do
-    account = create_account(with_project: false)
-    path = "/model/Account/#{account.ubid}/invalid"
+    location = Location.create(name: "l1", display_name: "l1", ui_name: "l1", visible: true, provider: "aws")
+    path = "/model/Location/#{location.ubid}/invalid"
     expect { visit path }.to raise_error(RuntimeError, "admin route not handled: #{path}")
   end
 
@@ -403,5 +403,19 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - GithubRunner #{ghr.ubid}"
     expect(GithubRunner.count).to eq 2
     expect(GithubRunner.select_map([:repository_name, :label, :installation_id])).to eq([["test-repo", "ubicloud", ins.id]] * 2)
+  end
+
+  it "supports suspending Accounts" do
+    account = create_account(with_project: false)
+    fill_in "UBID", with: account.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
+
+    expect(account.suspended_at).to be_nil
+    click_link "Suspend"
+    click_button "Suspend"
+    expect(page).to have_flash_notice("Account suspended")
+    expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
+    expect(account.reload.suspended_at).not_to be_nil
   end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add "suspend" action for accounts in admin panel and update tests to verify functionality.
> 
>   - **Behavior**:
>     - Adds "suspend" action for `Account` in `OBJECT_ACTIONS` in `clover_admin.rb`.
>     - Updates admin panel to allow suspending accounts, showing a flash notice "Account suspended".
>   - **Tests**:
>     - Adds test case in `admin_spec.rb` to verify account suspension functionality, checking `suspended_at` field is set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 55358e33345407c862fb2b09706ed4a6b149af52. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->