### PR TITLE
Remove MinioServer project association

### DIFF
--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -5,7 +5,6 @@ require_relative "../../model"
 
 class MinioServer < Sequel::Model
   one_to_one :strand, key: :id
-  many_to_one :project
   many_to_one :vm
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, conditions: {Sequel.function(:upper, :span) => nil}
   many_to_one :pool, key: :minio_pool_id, class: :MinioPool


### PR DESCRIPTION
There is no project_id column in the minio_server table, so this makes no sense.

Fixes viewing MinioServer in the admin site.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `many_to_one :project` association from `MinioServer` to fix admin site viewing issue.
> 
>   - **Associations**:
>     - Remove `many_to_one :project` association from `MinioServer` in `minio_server.rb`.
>   - **Fixes**:
>     - Fixes issue with viewing `MinioServer` in the admin site due to the removed association.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6f0a0e089b5875b2deee86594a718e6762fd3bf4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->