### PR TITLE
Add kubernetes vcpus quotas

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -2,3 +2,4 @@
 - { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerVCpu,         new_value: 300,  verified_value: 300 }
 - { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, new_value: 30,   verified_value: 30  }
 - { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresVCpu,             new_value: 128,  verified_value: 256 }
+- { id: 3acfffdb-37d6-42ff-8d1f-78a1915c7912, resource_type: KubernetesVCpu,           new_value: 32,  verified_value: 256 }

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -8,6 +8,11 @@ class Clover
     version, target_node_size = typecast_params.nonempty_str!(["version", "worker_size"])
     node_count = typecast_params.pos_int("worker_nodes", 1)
     cp_node_count = typecast_params.pos_int("cp_nodes", 1)
+    node_size = Validation.validate_vm_size(target_node_size, "x64")
+
+    requested_kubernetes_vcpu_count = cp_node_count * 2 # since default control plane size is standard-2
+    requested_kubernetes_vcpu_count += node_count * node_size.vcpus
+    Validation.validate_vcpu_quota(@project, "KubernetesVCpu", requested_kubernetes_vcpu_count, name: :worker_size)
 
     DB.transaction do
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -224,12 +224,12 @@ module Validation
     fail ValidationFailed.new({url: "Invalid URL"})
   end
 
-  def self.validate_vcpu_quota(project, resource_type, requested_vcpu_count)
+  def self.validate_vcpu_quota(project, resource_type, requested_vcpu_count, name: :size)
     if !project.quota_available?(resource_type, requested_vcpu_count)
       current_used_vcpu_count = project.current_resource_usage(resource_type)
       effective_quota_value = project.effective_quota_value(resource_type)
 
-      fail ValidationFailed.new({size: "Insufficient quota for requested size. Requested vCPU count: #{requested_vcpu_count}, currently used vCPU count: #{current_used_vcpu_count}, maximum allowed vCPU count: #{effective_quota_value}, remaining vCPU count: #{effective_quota_value - current_used_vcpu_count}"})
+      fail ValidationFailed.new({name => "Insufficient quota for requested size. Requested vCPU count: #{requested_vcpu_count}, currently used vCPU count: #{current_used_vcpu_count}, maximum allowed vCPU count: #{effective_quota_value}, remaining vCPU count: #{effective_quota_value - current_used_vcpu_count}"})
     end
   end
 


### PR DESCRIPTION
- **Allow passing field name to vCPU validation**
  Currently, vCPU validation assumes the field name is "size". However, in
  some cases, the field name can differ. For example, a Kubernetes cluster
  uses "worker_size".
  

- **Add a default quota for KubernetesVCpu**
  

- **Calculate effective vCPUs quota for Kubernetes clusters of projects**
  To determine the total effective vCPU usage for each Kubernetes cluster,
  sum the vCPUs of all control plane nodes and all worker nodes via node
  pools.
  
  Initially, I implemented something similar to the PostgreSQL vCPU usage
  calculation to keep the entire logic within the database.
  
      (kubernetes_clusters_dataset.association_join(nodes: :vm).sum(:vcpus) || 0) + (kubernetes_clusters_dataset.association_join(nodepools: {nodes: :vm}).sum(:vcpus) || 0)
  
  The issue with summing vCPUs of all control plane and worker nodes is
  that it assumes all nodes are already created. Kubernetes clusters
  differ from PostgreSQL resources: node pools are created at the next
  labels of the nexus, not immediately in the assemble.
  
  If a customer creates many clusters at once, the vCPU usage will show as
  0 until the strand runs and actually provisions the nodes. To handle
  this, I decided to base part of the calculation on the planned target
  node sizes (target_node_sizes) instead of relying solely on existing
  nodes.
  

- **Validate vCPUs quota for kubernetes cluster creation**
  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Kubernetes vCPU quotas, modify validation for field names, and calculate effective vCPU usage for clusters.
> 
>   - **Behavior**:
>     - Adds Kubernetes vCPU quota validation in `kubernetes_cluster.rb` using `validate_vcpu_quota()`.
>     - Calculates effective vCPU usage for Kubernetes clusters in `project.rb` by summing control plane and worker nodes.
>     - Adds default quota for `KubernetesVCpu` in `default_quotas.yml`.
>   - **Validation**:
>     - Modifies `validate_vcpu_quota()` in `validation.rb` to accept a field name parameter.
>   - **Tests**:
>     - Updates `project_spec.rb` to test Kubernetes vCPU usage and quota validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 20bf86c8c34d8704ccebca005e4ff72798f56e0c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->