### PR TITLE
Fix lease violation issues at AWS resources

### DIFF
--- a/prog/aws/nic.rb
+++ b/prog/aws/nic.rb
@@ -4,6 +4,12 @@ require "aws-sdk-ec2"
 class Prog::Aws::Nic < Prog::Base
   subject_is :nic
 
+  def before_run
+    when_destroy_set? do
+      pop "exiting early due to destroy semaphore"
+    end
+  end
+
   label def create_subnet
     register_deadline("attach_eip_network_interface", 3 * 60)
     vpc_response = client.describe_vpcs({filters: [{name: "vpc-id", values: [private_subnet.private_subnet_aws_resource.vpc_id]}]}).vpcs[0]

--- a/prog/aws/vpc.rb
+++ b/prog/aws/vpc.rb
@@ -4,6 +4,12 @@ require "aws-sdk-ec2"
 class Prog::Aws::Vpc < Prog::Base
   subject_is :private_subnet
 
+  def before_run
+    when_destroy_set? do
+      pop "exiting early due to destroy semaphore"
+    end
+  end
+
   label def create_vpc
     vpc_response = client.describe_vpcs({filters: [{name: "tag:Name", values: [private_subnet.name]}]})
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -525,7 +525,7 @@ class Prog::Vm::Nexus < Prog::Base
 
     vm.update(display_state: "deleting")
     if vm.location.aws?
-      strand.children.select { it.prog == "Aws::Instance" }.each { it.destroy }
+      Semaphore.incr(strand.children_dataset.where(prog: "Aws::Instance").select(:id), "destroy")
       bud Prog::Aws::Instance, {"subject_id" => vm.id}, :destroy
       hop_wait_aws_vm_destroyed
     end

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -128,7 +128,7 @@ class Prog::Vnet::NicNexus < Prog::Base
     decr_destroy
 
     if nic.private_subnet.location.aws?
-      strand.children.select { it.prog == "Aws::Nic" }.each { it.destroy }
+      Semaphore.incr(strand.children_dataset.where(prog: "Aws::Nic").select(:id), "destroy")
       bud Prog::Aws::Nic, {"subject_id" => nic.id}, :destroy
       hop_wait_aws_nic_destroyed
     end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -191,10 +191,10 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     end
 
     decr_destroy
-    strand.children.each { it.destroy }
     if private_subnet.location.aws?
       private_subnet.nics.map(&:incr_destroy)
       private_subnet.firewalls.map(&:destroy)
+      strand.children.each { it.destroy }
       bud Prog::Aws::Vpc, {"subject_id" => private_subnet.id}, :destroy
       hop_wait_aws_vpc_destroyed
     end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -194,7 +194,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     if private_subnet.location.aws?
       private_subnet.nics.map(&:incr_destroy)
       private_subnet.firewalls.map(&:destroy)
-      strand.children.each { it.destroy }
+      Semaphore.incr(strand.children_dataset.where(prog: "Aws::Vpc").select(:id), "destroy")
       bud Prog::Aws::Vpc, {"subject_id" => private_subnet.id}, :destroy
       hop_wait_aws_vpc_destroyed
     end

--- a/spec/prog/aws/nic_spec.rb
+++ b/spec/prog/aws/nic_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Prog::Aws::Nic do
     allow(Aws::EC2::Client).to receive(:new).with(access_key_id: "test-access-key", secret_access_key: "test-secret-key", region: "us-west-2").and_return(client)
   end
 
+  it "exits if destroy is set" do
+    expect(nx.before_run).to be_nil
+    expect(nx).to receive(:when_destroy_set?).and_yield
+    expect { nx.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
+  end
+
   describe "#create_subnet" do
     it "creates a subnet and hops to wait_subnet_created" do
       expect(nic.private_subnet).to receive(:old_aws_subnet?).and_return(false)

--- a/spec/prog/aws/vpc_spec.rb
+++ b/spec/prog/aws/vpc_spec.rb
@@ -24,7 +24,13 @@ RSpec.describe Prog::Aws::Vpc do
 
   before do
     allow(nx).to receive(:private_subnet).and_return(ps)
-    expect(Aws::EC2::Client).to receive(:new).with(access_key_id: "test-access-key", secret_access_key: "test-secret-key", region: "us-west-2").and_return(client)
+    allow(Aws::EC2::Client).to receive(:new).with(access_key_id: "test-access-key", secret_access_key: "test-secret-key", region: "us-west-2").and_return(client)
+  end
+
+  it "exits if destroy is set" do
+    expect(nx.before_run).to be_nil
+    expect(nx).to receive(:when_destroy_set?).and_yield
+    expect { nx.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
   end
 
   describe "#create_vpc" do


### PR DESCRIPTION
- **Fix Vm::Nexus#destroy to not violate strand leases**
  Previously, Vm::Nexus#destroy ran:
  
  ```ruby
  strand.children.select { it.prog == "Aws::Instance" }.each { it.destroy }
  ```
  
  This is not safe as there could be an existing lease for Aws::Instance children.
  
  @jeremy fixed a similar issue at 773562ebc.
  
  Fix this by VM increments the destroy semaphore instead of destroying directly.
  Aws::Instance will pop out if the destroy semaphore is incremented.
  
  I didn’t add semaphore :destroy to Aws::Instance, since one of its
  subjects is :vm, which already has a destroy semaphore.
  

- **Fix Vnet::NicNexus#destroy to not violate strand leases**
  Previously, Vnet::NicNexus#destroy ran:
  
  ```ruby
  strand.children.select { it.prog == "Aws::Nic" }.each { it.destroy }
  ```
  
  This is not safe as there could be an existing lease for Aws::Nic
  children.
  
  @jeremy fixed a similar issue at 773562ebc.
  
  Fix this by NicNexus increments the destroy semaphore instead of destroying
  directly. Aws::Nic will pop out if the destroy semaphore is
  incremented.
  
  I didn’t add semaphore :destroy to Aws::Nic, since one of its
  subjects is :nic, which already has a destroy semaphore.
  

- **Destroy children strands only for AWS resources in Vnet::SubnetNexus#destroy**
  We started destroying children strands of Vnet::SubnetNexus in ecf059371
  to handle `bud Prog::Vnet::UpdateFirewallRules`.
  
  However, the budding of Prog::Vnet::UpdateFirewallRules was moved from
  SubnetNexus to Vm::Nexus in f3836aeab. To stay consistent with other AWS
  resources, children strands should now only be destroyed for AWS, so
  this logic moved into the if block.
  

- **Fix Vnet::SubnetNexus#destroy to not violate strand leases**
  Previously, Vnet::SubnetNexus#destroy ran:
  
  ```ruby
  strand.children.select { it.prog == "Aws::Vpc" }.each { it.destroy }
  ```
  
  This is not safe as there could be an existing lease for Aws::Vpc
  children.
  
  @jeremy fixed a similar issue at 773562ebc.
  
  Fix this by private subnet increments the destroy semaphore instead of
  destroying directly. Aws::Vpc will pop out if the destroy semaphore is
  incremented.
  
  I didn’t add semaphore :destroy to Aws::Vpc, since one of its subjects
  is :private_subnet, which already has a destroy semaphore.
  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes lease violation issues in AWS resources by using semaphores for destruction management in `Vm::Nexus`, `Vnet::NicNexus`, and `Vnet::SubnetNexus`.
> 
>   - **Behavior**:
>     - `Vm::Nexus#destroy`, `Vnet::NicNexus#destroy`, and `Vnet::SubnetNexus#destroy` now use semaphores to manage destruction, preventing lease violations for `Aws::Instance`, `Aws::Nic`, and `Aws::Vpc`.
>     - `Vnet::SubnetNexus#destroy` only destroys children strands for AWS resources.
>   - **Code Changes**:
>     - Added `before_run` hooks in `prog/aws/instance.rb`, `prog/aws/nic.rb`, and `prog/aws/vpc.rb` to exit early if destroy semaphore is set.
>     - Updated `destroy` methods in `prog/vm/nexus.rb`, `prog/vnet/nic_nexus.rb`, and `prog/vnet/subnet_nexus.rb` to increment destroy semaphore instead of direct destruction.
>   - **Tests**:
>     - Added tests for early exit on destroy semaphore in `instance_spec.rb`, `nic_spec.rb`, and `vpc_spec.rb`.
>     - Updated tests in `nexus_spec.rb`, `nic_nexus_spec.rb`, and `subnet_nexus_spec.rb` to verify semaphore behavior and destruction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4ed8de4ba12d386e8e42c39fa3489c4f09b3285c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->