### PR TITLE
Fix LoadBalancer VM removal when VM/LB are already destroyed

### DIFF
--- a/prog/vnet/load_balancer_remove_vm.rb
+++ b/prog/vnet/load_balancer_remove_vm.rb
@@ -4,7 +4,11 @@ class Prog::Vnet::LoadBalancerRemoveVm < Prog::Base
   subject_is :vm
 
   def load_balancer
-    @load_balancer ||= vm.load_balancer
+    @load_balancer ||= vm&.load_balancer
+  end
+
+  label def before_run
+    pop "vm is removed from load balancer" unless load_balancer
   end
 
   label def destroy_vm_ports_and_update_node

--- a/spec/prog/vnet/load_balancer_remove_vm_spec.rb
+++ b/spec/prog/vnet/load_balancer_remove_vm_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe Prog::Vnet::LoadBalancerRemoveVm do
     allow(Vm).to receive(:[]).and_return(vm)
   end
 
+  describe "#before_run" do
+    it "pops if the vm is not found" do
+      expect(Vm).to receive(:[]).and_return(nil)
+      expect { nx.before_run }.to exit({"msg" => "vm is removed from load balancer"})
+    end
+
+    it "pops if the vm exists but the load balancer reference is nil" do
+      expect(Vm).to receive(:[]).and_return(vm)
+      expect(vm).to receive(:load_balancer).and_return(nil)
+      expect { nx.before_run }.to exit({"msg" => "vm is removed from load balancer"})
+    end
+
+    it "does nothing if the vm exists and the load balancer reference is not nil" do
+      expect(Vm).to receive(:[]).and_return(vm)
+      expect(vm).to receive(:load_balancer).and_return(lb)
+      expect { nx.before_run }.not_to exit
+    end
+  end
+
   describe "#destroy_vm_ports_and_update_node" do
     it "removes the vm from load balancer and hops to wait_for_node_update" do
       expect(lb).to receive(:vm_ports_by_vm).with(vm).and_return(instance_double(LoadBalancerPort, destroy: nil)).at_least(:once)


### PR DESCRIPTION
When we destroy a kubernetes cluster, we are deleting VMs and the load balancer in parallel, which causes the load_balancer_vm_removal prog to be created twice, therefore, one finishes early and the other gets stuck. We solve this by simply adding a before_run state.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `before_run` check in `LoadBalancerRemoveVm` to prevent duplicate processes during parallel VM and load balancer destruction.
> 
>   - **Behavior**:
>     - Adds `before_run` method in `load_balancer_remove_vm.rb` to check if VM or load balancer is already removed, exiting early if true.
>     - Prevents duplicate `load_balancer_vm_removal` processes when destroying VMs and load balancers in parallel.
>   - **Tests**:
>     - Adds tests for `before_run` in `load_balancer_remove_vm_spec.rb` to verify early exit when VM or load balancer is missing.
>     - Ensures no exit occurs if both VM and load balancer exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3036a3d13f89acfcf387d722223d3a97685a5797. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->