### PR TITLE
Use aws-assigned public IPs for runner instances

### DIFF
--- a/prog/aws/nic.rb
+++ b/prog/aws/nic.rb
@@ -49,6 +49,11 @@ class Prog::Aws::Nic < Prog::Base
           subnet_id: nic.nic_aws_resource.subnet_id
         })
       end
+
+      # Runner instances don't need to have EIP, so we pop here.
+      # Public IP will be assigned by AWS while creating the instance.
+      pop "subnet created" if is_runner?
+
       hop_create_network_interface
     end
     nap 1
@@ -143,6 +148,10 @@ class Prog::Aws::Nic < Prog::Base
 
   def get_network_interface
     client.describe_network_interfaces({filters: [{name: "network-interface-id", values: [nic.nic_aws_resource.network_interface_id]}, {name: "tag:Ubicloud", values: ["true"]}]}).network_interfaces[0]
+  end
+
+  def is_runner?
+    nic.vm&.unix_user == "runneradmin"
   end
 
   private

--- a/spec/prog/aws/instance_spec.rb
+++ b/spec/prog/aws/instance_spec.rb
@@ -252,8 +252,7 @@ usermod -L ubuntu
         iam_instance_profile: {
           name: "#{vm.name}-instance-profile"
         },
-        client_token: vm.id,
-        instance_market_options: nil
+        client_token: vm.id
       }).and_call_original
       expect(AwsInstance).to receive(:create_with_id).with(vm.id, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
@@ -264,7 +263,8 @@ usermod -L ubuntu
       client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
       vm.update(unix_user: "runneradmin")
       expect(vm).to receive(:sshable).and_return(instance_double(Sshable, keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
+      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, subnet_id: "subnet-12345678"))
+      expect(vm.nics.first).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, private_subnet_aws_resource: instance_double(PrivateSubnetAwsResource, security_group_id: "sg-12345678")))
       expect(client).to receive(:run_instances).with(hash_not_including(:iam_instance_profile)).and_call_original
       expect(AwsInstance).to receive(:create_with_id).with(vm.id, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
@@ -293,7 +293,8 @@ usermod -L ubuntu
       vm.update(unix_user: "runneradmin")
       expect(vm).to receive(:sshable).and_return(instance_double(Sshable, keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
       new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
+      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, subnet_id: "subnet-12345678"))
+      expect(vm.nics.first).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, private_subnet_aws_resource: instance_double(PrivateSubnetAwsResource, security_group_id: "sg-12345678")))
       expect(client).to receive(:run_instances).with(hash_including(user_data: Base64.encode64(new_data))).and_call_original
       expect(AwsInstance).to receive(:create_with_id).with(vm.id, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
@@ -307,7 +308,8 @@ usermod -L ubuntu
       vm.update(unix_user: "runneradmin")
       expect(vm).to receive(:sshable).and_return(instance_double(Sshable, keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
       new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
+      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, subnet_id: "subnet-12345678"))
+      expect(vm.nics.first).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, private_subnet_aws_resource: instance_double(PrivateSubnetAwsResource, security_group_id: "sg-12345678")))
       expect(client).to receive(:run_instances).with(hash_including(
         user_data: Base64.encode64(new_data),
         instance_market_options: {market_type: "spot", spot_options: {instance_interruption_behavior: "terminate", spot_instance_type: "one-time"}}
@@ -326,7 +328,8 @@ usermod -L ubuntu
       vm.update(unix_user: "runneradmin")
       expect(vm).to receive(:sshable).and_return(instance_double(Sshable, keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
       new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
+      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, subnet_id: "subnet-12345678"))
+      expect(vm.nics.first).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, private_subnet_aws_resource: instance_double(PrivateSubnetAwsResource, security_group_id: "sg-12345678")))
       expect(client).to receive(:run_instances).with(hash_including(
         user_data: Base64.encode64(new_data),
         instance_market_options: {market_type: "spot", spot_options: {instance_interruption_behavior: "terminate", spot_instance_type: "one-time", max_price: "0.12"}}
@@ -341,7 +344,8 @@ usermod -L ubuntu
       installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: vm.project_id)
       GithubRunner.create(label: "ubicloud-standard-2", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
       expect(vm).to receive(:sshable).and_return(instance_double(Sshable, keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
+      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, subnet_id: "subnet-12345678"))
+      expect(vm.nics.first).to receive(:private_subnet).and_return(instance_double(PrivateSubnet, private_subnet_aws_resource: instance_double(PrivateSubnetAwsResource, security_group_id: "sg-12345678")))
       expect(Clog).to receive(:emit).with("insufficient instance capacity").and_call_original
       expect(Prog::Vm::GithubRunner).to receive(:assemble).and_call_original
       expect { nx.create_instance }.to nap(30)


### PR DESCRIPTION
**Separate runner and standard aws instance creation logic**
Extract user data generation and network interface setup into dedicated
methods to improve code organization and maintainability.

**Use aws-assigned public IPs for runner instances**
Instead of creating separate EIPs, runner instances now rely on AWS
to assign public IPs during instance creation, simplifying the
networking setup and reducing resource overhead.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor AWS instance creation to use AWS-assigned public IPs for runner instances, simplifying networking and improving code organization.
> 
>   - **Behavior**:
>     - Runner instances now use AWS-assigned public IPs instead of creating EIPs, simplifying networking setup in `instance.rb` and `nic.rb`.
>     - Refactored `create_instance` in `instance.rb` to separate runner and standard instance logic.
>   - **Methods**:
>     - Extracted `runner_user_data`, `standard_user_data`, `runner_market_options`, `standard_network_interfaces`, and `runner_network_interfaces` in `instance.rb`.
>     - Added `is_runner?` check in `nic.rb` to skip EIP creation for runner instances.
>   - **Tests**:
>     - Updated `instance_spec.rb` and `nic_spec.rb` to test new behavior for runner instances using AWS-assigned public IPs and refactored logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 56bd53f29f6ef8a7828dbfb15d74782789904398. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->