### PR TITLE
Sleep 1 second while waiting for aws nic

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -210,7 +210,7 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   label def start_aws
-    nap 2 unless vm.nics.all? { |nic| nic.strand.label == "wait" }
+    nap 1 unless vm.nics.all? { |nic| nic.strand.label == "wait" }
     bud Prog::Aws::Instance, {"subject_id" => vm.id}, :start
     hop_wait_aws_vm_started
   end

--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -41,7 +41,7 @@ class Prog::Vnet::NicNexus < Prog::Base
   end
 
   label def wait_aws_nic_created
-    reap(:wait, nap: 2)
+    reap(:wait, nap: 1)
   end
 
   label def wait_allocation

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Prog::Vm::Nexus do
   describe "#start_aws" do
     it "naps if vm nics are not in wait state" do
       expect(nx).to receive(:vm).and_return(instance_double(Vm, nics: [instance_double(Nic, strand: instance_double(Strand, label: "start"))]))
-      expect { nx.start_aws }.to nap(2)
+      expect { nx.start_aws }.to nap(1)
     end
 
     it "hops to wait_aws_vm_started if vm nics are in wait state" do

--- a/spec/prog/vnet/nic_nexus_spec.rb
+++ b/spec/prog/vnet/nic_nexus_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Prog::Vnet::NicNexus do
     it "naps if not leaf" do
       st.update(prog: "Vnet::NicNexus", label: "wait_aws_nic_created", stack: [{}])
       Strand.create(parent_id: st.id, prog: "Aws::Nic", label: "create_network_interface", stack: [{}], lease: Time.now + 10)
-      expect { nx.wait_aws_nic_created }.to nap(2)
+      expect { nx.wait_aws_nic_created }.to nap(1)
     end
   end
 


### PR DESCRIPTION
 We were sleeping 2 seconds for aws nic to not cause load on control plane, though it generally adds 2-3 seconds to the provisioning time of the runner and having that load only for aws runners is acceptable. So, reducing that nap time to 1 second.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reduce sleep time from 2 to 1 second in `start_aws` and `wait_aws_nic_created`, updating tests accordingly.
> 
>   - **Behavior**:
>     - Reduce sleep time from 2 seconds to 1 second in `start_aws` in `nexus.rb` and `wait_aws_nic_created` in `nic_nexus.rb`.
>   - **Tests**:
>     - Update tests in `nexus_spec.rb` and `nic_nexus_spec.rb` to expect 1 second nap instead of 2 seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for adaffa7be7479471ca5bf228f8b208ad19acceb0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->