### PR TITLE
Fix LB VM removal pop issue with reap

### DIFF
--- a/prog/vnet/load_balancer_remove_vm.rb
+++ b/prog/vnet/load_balancer_remove_vm.rb
@@ -8,7 +8,7 @@ class Prog::Vnet::LoadBalancerRemoveVm < Prog::Base
   end
 
   label def before_run
-    pop "vm is removed from load balancer" unless load_balancer
+    reap { pop "vm is removed from load balancer" } unless load_balancer
   end
 
   label def destroy_vm_ports_and_update_node


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wrap `pop` operation in `reap` block in `before_run` method of `load_balancer_remove_vm.rb`.
> 
>   - **Behavior**:
>     - Wraps `pop "vm is removed from load balancer"` in a `reap` block in `before_run` method of `load_balancer_remove_vm.rb`.
>     - This change affects the execution when `load_balancer` is not present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c62cbd6682afcb17bea0628b33a0b1943599713b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->