### PR TITLE
Handle invalid email addresses when using Util.send_email 

### DIFF
--- a/lib/util.rb
+++ b/lib/util.rb
@@ -86,6 +86,8 @@ module Util
 
   def self.send_email(...)
     EmailRenderer.sendmail("/", ...)
+  rescue Net::SMTPSyntaxError
+    raise CloverError.new(400, "InvalidRequest", "Invalid email address used")
   end
 
   def self.aws_tag_specifications(resource_type, name, additional_tags = {})

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe Clover, "auth" do
     expect(page).to have_content("Name must only contain letters, numbers, spaces, and hyphens and have max length 63.")
   end
 
+  it "can not create new account with invalid email" do
+    visit "/create-account"
+    fill_in "Email Address", with: "\u1234@something.com"
+    fill_in "Full Name", with: "test"
+    fill_in "Password", with: TEST_USER_PASSWORD
+    fill_in "Password Confirmation", with: TEST_USER_PASSWORD
+    expect(EmailRenderer).to receive(:sendmail) { raise Net::SMTPSyntaxError, "501 5.1.3 Bad recipient address syntax" }
+    click_button "Create Account"
+
+    expect(page.title).to eq("Ubicloud - Create Account")
+    expect(Mail::TestMailer.deliveries.length).to eq 0
+    expect(page).to have_flash_error("Invalid email address used")
+  end
+
   it "can send email verification email again after 300 seconds" do
     visit "/create-account"
     fill_in "Full Name", with: "John Doe"

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -117,6 +117,7 @@ module ThawedMock
   allow_mocking(Clog, :emit)
   allow_mocking(CloudflareClient, :new)
   allow_mocking(Clover, :call, :authorized_project)
+  allow_mocking(EmailRenderer, :sendmail)
   allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :hardware_reset_server, :set_server_name)
   allow_mocking(InvoiceGenerator, :new)
   allow_mocking(Minio::Client, :new)

--- a/views/error.erb
+++ b/views/error.erb
@@ -1,4 +1,5 @@
 <% @page_title = @error[:type] %>
+<% @direct_body_yield = true %>
 
 <main class="grid min-h-full place-items-center px-6 py-24 sm:py-32 lg:px-8">
   <div class="text-center">

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -69,7 +69,7 @@
         </div>
       </div>
       <%== render("layouts/notifications") %>
-    <% elsif @error %>
+    <% elsif @direct_body_yield %>
       <%== yield %>
     <% else %>
       <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">


### PR DESCRIPTION
This requires a layout change. I found that rendering a template other than `error` with the `@error` instance variable set results in missing flash messages and a messed up display.