### PR TITLE
Support Ubiblk v0.2.1.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,7 +119,7 @@ jobs:
         SMTP_TLS: false
         STRIPE_PUBLIC_KEY: ${{ secrets.STRIPE_PUBLIC_KEY }}
         STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-        VHOST_BLOCK_BACKEND_VERSION: v0.2.0
+        VHOST_BLOCK_BACKEND_VERSION: v0.2.1
       run: |
         set -o pipefail
         timeout 55m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"

--- a/config.rb
+++ b/config.rb
@@ -122,7 +122,7 @@ module Config
   override :spdk_version, "v23.09-ubi-0.3"
 
   # Vhost Block Backend
-  override :vhost_block_backend_version, "v0.2.0"
+  override :vhost_block_backend_version, "v0.2.1"
 
   # Boot Images
   override :default_boot_image_name, "ubuntu-jammy", string

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -4,8 +4,8 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   subject_is :sshable, :vm_host
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
-    ["v0.2.0", "x64"],
-    ["v0.2.0", "arm64"]
+    ["v0.2.1", "x64"],
+    ["v0.2.1", "arm64"]
   ].freeze.each(&:freeze)
 
   def self.assemble(vm_host_id, version, allocation_weight: 0)

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -9,10 +9,10 @@ class VhostBlockBackend
   end
 
   def sha256
-    if @version == "v0.2.0" && Arch.x64?
-      "68638b779a227424cbe81674de4b26122ea27a337f1c6d81db895a1ffa3a917a"
-    elsif @version == "v0.2.0" && Arch.arm64?
-      "6b15ca96cd3134524a639d3c913b43b794423a8dddc897c1604a5085625d44e3"
+    if @version == "v0.2.1" && Arch.x64?
+      "86b29835ead14b20e87a058108a13d9e71243a2e261df144f6e59e2de1e60378"
+    elsif @version == "v0.2.1" && Arch.arm64?
+      "ebf24fac90411fcc78c9383aabfea3bae9d3df936b667b7c4c0097b0cb4c6357"
     else
       fail "Unsupported version: #{@version}, #{Arch.sym}"
     end


### PR DESCRIPTION
Ubiblk v0.2.1 fixes two bugs:

- A stripe could be fetch multiple times, and repeat fetches could
  overwrite changes after the earlier fetches.
- If copy_on_read was false and a read spanned multiple stripes with
  some already fetched and others not, we incorrectly served data from
  the base image. This caused wrong data to be returned.