### PR TITLE
Allow GitHub Actions cache support to work with Cloudflare Account API tokens

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -107,6 +107,7 @@ module Config
   optional :github_cache_blob_storage_secret_key, string, clear: true
   optional :github_cache_blob_storage_account_id, string
   optional :github_cache_blob_storage_api_key, string, clear: true
+  override :github_cache_blob_storage_use_account_token, false, bool
 
   # Minio
   override :minio_host_name, "minio.ubicloud.com", string

--- a/lib/cloudflare_client.rb
+++ b/lib/cloudflare_client.rb
@@ -9,12 +9,19 @@ class CloudflareClient
   end
 
   def create_token(name, policies)
-    response = @connection.post(path: "/client/v4/user/tokens", body: {name: name, policies: policies}.to_json, expects: 200)
+    response = @connection.post(path:, body: {name: name, policies: policies}.to_json, expects: 200)
     data = JSON.parse(response.body)
     [data["result"]["id"], data["result"]["value"]]
   end
 
   def delete_token(token_id)
-    @connection.delete(path: "/client/v4/user/tokens/#{token_id}", expects: [200, 404]).status
+    @connection.delete(path: "#{path}/#{token_id}", expects: [200, 404]).status
+  end
+
+  private
+
+  def path
+    frag = Config.github_cache_blob_storage_use_account_token ? "accounts/#{Config.github_cache_blob_storage_account_id}" : "user"
+    "/client/v4/#{frag}/tokens"
   end
 end

--- a/spec/lib/cloudflare_client_spec.rb
+++ b/spec/lib/cloudflare_client_spec.rb
@@ -13,4 +13,22 @@ RSpec.describe CloudflareClient do
     Excon.stub({path: "/client/v4/user/tokens/#{token_id}", method: :delete}, {status: 200})
     expect(client.delete_token(token_id)).to eq(200)
   end
+
+  describe "when setting Config.github_cache_blob_storage_use_account_token" do
+    before do
+      expect(Config).to receive(:github_cache_blob_storage_use_account_token).and_return(true)
+      expect(Config).to receive(:github_cache_blob_storage_account_id).and_return("XYZ")
+    end
+
+    it "create_token" do
+      Excon.stub({path: "/client/v4/accounts/XYZ/tokens", method: :post}, {status: 200, body: {result: {id: "123", value: "secret"}}.to_json})
+      expect(client.create_token("test-token", [{id: "test-policy"}])).to eq(["123", "secret"])
+    end
+
+    it "delete_token" do
+      token_id = "123"
+      Excon.stub({path: "/client/v4/accounts/XYZ/tokens/#{token_id}", method: :delete}, {status: 200})
+      expect(client.delete_token(token_id)).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
Previously, the code only worked with Cloudflare User API tokens.

Use Account API token endpoints if the GITHUB_CACHE_BLOB_STORAGE_USE_ACCOUNT_TOKEN environment variable is truthy.

I successfully tested this in the staging environment.