### PR TITLE
Send invoice success email when paid manually

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -234,6 +234,7 @@ class Clover
             raise_web_error("Invoice payment was not successful")
           end
           invoice.update(status: "paid")
+          invoice.send_success_email
           flash["notice"] = "Invoice #{invoice.invoice_number} paid successfully"
 
           r.redirect billing_path


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds email notification for successful manual invoice payments in `routes/project/billing.rb`.
> 
>   - **Behavior**:
>     - Adds `invoice.send_success_email` call in `routes/project/billing.rb` to send a success email when an invoice is marked as paid manually.
>     - Triggered in the `r.get "success"` block after verifying payment success and updating invoice status.
>   - **Misc**:
>     - No changes to existing logic or error handling, only adds email notification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c57bc4a90818aea44e70746b877976db48236a00. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->