### PR TITLE
Skip Monitoring non-ready Runners

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -45,7 +45,7 @@ else
     PostgresServer,
     Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists),
     MinioServer,
-    GithubRunner,
+    GithubRunner.exclude(ready_at: nil),
     VmHostSlice,
     LoadBalancerVmPort,
     KubernetesCluster,


### PR DESCRIPTION
There's a race for pulse_checking a GH runner by the monitor and creating of the VM by the respirator. The GithubRunner#check_pulse assumes the existence of a VM and throws exception when it's not.

We can wait for registering the runner until it's ready.