### PR TITLE
Handle empty prep.json file gracefully during VM deletion

### DIFF
--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -16,7 +16,7 @@ end
 
 params = begin
   JSON.parse(File.read(VmPath.new(vm_name).prep_json))
-rescue Errno::ENOENT
+rescue Errno::ENOENT, JSON::ParserError
   if action.start_with?("delete")
     # Params were not historically needed for the delete actions,
     # so handle case where prep file has already been deleted.

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -192,8 +192,8 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def purge_storage
-    # prep.json doesn't exist, nothing more to do
-    return if !File.exist?(vp.prep_json)
+    # prep.json doesn't exist or empty, nothing more to do
+    return if !File.exist?(vp.prep_json) || File.empty?(vp.prep_json)
 
     storage_roots = []
 


### PR DESCRIPTION
It turns out we handle missing prep.json file during delete operations, but we don't handle empty prep.json file. So we try to delete the VM, but it stucks trying to read and parse empty prep.json file. This commit adds handling of empty prep.json file.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Handle empty `prep.json` file during VM deletion to prevent process from getting stuck.
> 
>   - **Behavior**:
>     - Handle empty `prep.json` file during VM deletion in `setup-vm` and `vm_setup.rb`.
>     - Prevents process from getting stuck by checking for empty file and proceeding with deletion.
>   - **Error Handling**:
>     - In `setup-vm`, catch `JSON::ParserError` alongside `Errno::ENOENT` when reading `prep.json`.
>     - In `vm_setup.rb`, add `File.empty?` check in `purge_storage()` to handle empty `prep.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 096df438ee2e894796c5a738838787fc06d5e638. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->