### PR TITLE
Switch to released version of Rodauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "rake"
 gem "refrigerator", ">= 1"
 gem "reline" # Remove it when pry adds it as a dependency
 gem "roda", ">= 3.96"
-gem "rodauth", github: "jeremyevans/rodauth", ref: "f01bab524499eef21a21d83a9883a60a41dc0aeb"
+gem "rodauth", ">= 2.41"
 gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"
 gem "rodish", ">= 2.0.1"
 gem "rotp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,6 @@ GIT
       rodauth (~> 2.36)
 
 GIT
-  remote: https://github.com/jeremyevans/rodauth.git
-  revision: f01bab524499eef21a21d83a9883a60a41dc0aeb
-  ref: f01bab524499eef21a21d83a9883a60a41dc0aeb
-  specs:
-    rodauth (2.40.0)
-      roda (>= 2.6.0)
-      sequel (>= 4)
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -329,6 +320,9 @@ GEM
     rexml (3.4.2)
     roda (3.96.0)
       rack
+    rodauth (2.41.0)
+      roda (>= 2.6.0)
+      sequel (>= 4)
     rodish (2.0.1)
       optparse
     rotp (6.3.0)
@@ -518,7 +512,7 @@ DEPENDENCIES
   refrigerator (>= 1)
   reline
   roda (>= 3.96)
-  rodauth!
+  rodauth (>= 2.41)
   rodauth-omniauth!
   rodish (>= 2.0.1)
   rotp


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch `rodauth` gem to released version `>= 2.41` in `Gemfile`.
> 
>   - **Dependencies**:
>     - Switch `rodauth` gem from GitHub reference to released version `>= 2.41` in `Gemfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 47c4e90b948c5446e74d90c3b1a1a9716ab9a245. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->