### PR TITLE
Force GPU runners to use standard-gpu family

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -236,7 +236,7 @@ class Prog::Vm::Nexus < Prog::Base
           installation = runner&.installation
           prefs = installation&.allocator_preferences || {}
 
-          runner_family_filter = if runner&.not_upgrade_premium_set? || vm.family == "premium"
+          runner_family_filter = if runner&.not_upgrade_premium_set? || vm.family == "premium" || vm.family == "standard-gpu"
             [vm.family]
           elsif installation&.free_runner_upgrade?
             prefs["family_filter"] || [vm.family, "premium"]

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -619,6 +619,27 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.start }.to hop("create_unix_user")
     end
 
+    it "uses standard-gpu family even if premium enabled" do
+      vm.location_id = Location::GITHUB_RUNNERS_ID
+      vm.family = "standard-gpu"
+      installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: prj.id, allocator_preferences: {"family_filter" => ["standard", "premium"]})
+      GithubRunner.create(label: "ubicloud-gpu", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
+
+      expect(Scheduling::Allocator).to receive(:allocate).with(
+        vm, :storage_volumes,
+        allocation_state_filter: ["accepting"],
+        distinct_storage_devices: false,
+        host_filter: [],
+        host_exclusion_filter: [],
+        location_filter: [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID],
+        location_preference: [Location::GITHUB_RUNNERS_ID],
+        gpu_count: 0,
+        gpu_device: nil,
+        family_filter: ["standard-gpu"]
+      )
+      expect { nx.start }.to hop("create_unix_user")
+    end
+
     it "can force allocating a host" do
       allow(nx).to receive(:frame).and_return({
         "force_host_id" => :vm_host_id,


### PR DESCRIPTION
When the premium runners feature is enabled for an installation, the preferred families list currently is ["premium", "standard"]. However, GPU runners must explicitly use the standard-gpu family; otherwise, they cannot be allocated on GPU hosts.

This change ensures that GPU runners are correctly restricted to the standard-gpu family, preventing allocation failures observed in production.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure GPU runners use `standard-gpu` family to prevent allocation failures when premium runners are enabled.
> 
>   - **Behavior**:
>     - GPU runners now explicitly use the `standard-gpu` family in `nexus.rb` to prevent allocation failures when premium runners are enabled.
>   - **Tests**:
>     - Added test in `nexus_spec.rb` to verify that GPU runners use the `standard-gpu` family even if premium is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2f08b9ad7434a72e400e2516f952e5c947bc3443. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->