### PR TITLE
Fix MetricsTargetResource spec

### DIFF
--- a/spec/lib/metrics_target_resource_spec.rb
+++ b/spec/lib/metrics_target_resource_spec.rb
@@ -7,22 +7,36 @@ RSpec.describe MetricsTargetResource do
   let(:resource) { described_class.new(postgres_server) }
 
   describe "#initialize" do
+    before do
+      allow(Config).to receive(:victoria_metrics_service_project_id).and_return("4d8f9896-26a3-4784-8f52-2ed5d5e55c0e")
+    end
+
     it "initializes with a resource and nil tsdb client when VictoriaMetrics is not found" do
       expect(Config).to receive(:postgres_service_project_id).and_return("4d8f9896-26a3-4784-8f52-2ed5d5e55c0e")
       expect(resource.instance_variable_get(:@resource)).to eq(postgres_server)
+      expect(resource.instance_variable_get(:@tsdb_client)).to be_nil
     end
 
-    %i[postgres_service_project_id victoria_metrics_service_project_id].each do |config_key|
-      it "initializes with a resource and a tsdb client when VictoriaMetrics is found using #{config_key}" do
-        expect(Config).to receive(config_key).at_least(:once).and_return("4d8f9896-26a3-4784-8f52-2ed5d5e55c0e")
-        prj = Project.create_with_id(Config.send(config_key), name: "pg-project")
-        vmr = instance_double(VictoriaMetricsResource, project_id: prj.id)
-        expect(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
-        expect(vmr).to receive(:servers).and_return([instance_double(VictoriaMetricsServer, client: "tsdb_client")])
+    it "initializes with a resource and a tsdb client when VictoriaMetrics is found using postgres_service_project_id" do
+      expect(Config).to receive(:postgres_service_project_id).at_least(:once).and_return("c147571a-661e-4de1-8631-73d2425343c0")
+      prj = Project.create_with_id(Config.send(:postgres_service_project_id), name: "pg-project")
+      vmr = instance_double(VictoriaMetricsResource, project_id: prj.id)
+      expect(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
+      expect(vmr).to receive(:servers).and_return([instance_double(VictoriaMetricsServer, client: "tsdb_client")])
 
-        expect(resource.instance_variable_get(:@resource)).to eq(postgres_server)
-        expect(resource.instance_variable_get(:@tsdb_client)).to eq("tsdb_client")
-      end
+      expect(resource.instance_variable_get(:@resource)).to eq(postgres_server)
+      expect(resource.instance_variable_get(:@tsdb_client)).to eq("tsdb_client")
+    end
+
+    it "initializes with a resource and a tsdb client when VictoriaMetrics is found using victoria_metrics_service_project_id" do
+      expect(Config).to receive(:postgres_service_project_id).at_least(:once).and_return(nil)
+      prj = Project.create_with_id(Config.send(:victoria_metrics_service_project_id), name: "pg-project")
+      vmr = instance_double(VictoriaMetricsResource, project_id: prj.id)
+      expect(VictoriaMetricsResource).to receive(:first).with(project_id: prj.id).and_return(vmr)
+      expect(vmr).to receive(:servers).and_return([instance_double(VictoriaMetricsServer, client: "tsdb_client")])
+
+      expect(resource.instance_variable_get(:@resource)).to eq(postgres_server)
+      expect(resource.instance_variable_get(:@tsdb_client)).to eq("tsdb_client")
     end
 
     it "initializes with a resource and a tsdb client when VictoriaMetrics is not found in development" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Clover, "postgres" do
         pg
         pg.representative_server.vm.add_vm_storage_volume(boot: false, size_gib: 128, disk_index: 0)
 
-        expect(VictoriaMetricsResource).to receive(:first).and_return(nil)
+        expect(VictoriaMetricsResource).to receive(:first).at_least(:once).and_return(nil)
 
         visit "#{project.path}#{pg.path}/overview"
         expect(page).to have_content "128 GB"


### PR DESCRIPTION
When running locally with an .env.rb which has postgres and victoria metrics service project ids set, the test fails with a UUID mismatch. Updated the specs to ignore local env settings and  assert for correct priority between different service projects.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix test setup in `metrics_target_resource_spec.rb` to ignore local env settings and assert correct service project priority.
> 
>   - **Behavior**:
>     - Update `metrics_target_resource_spec.rb` to ignore local `.env.rb` settings for `postgres_service_project_id` and `victoria_metrics_service_project_id`.
>     - Ensure correct priority assertion between different service projects in `#initialize` tests.
>   - **Tests**:
>     - Split `#initialize` test cases in `metrics_target_resource_spec.rb` for clarity on `postgres_service_project_id` and `victoria_metrics_service_project_id`.
>     - Modify `postgres_spec.rb` to call `VictoriaMetricsResource.first` at least once when checking for nil return.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 043df2416568916c10309db43880360f7455259b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->