### PR TITLE
Use the pg_auto_parameterize_duplicate_query_detection Sequel extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", ">= 5.96"
+gem "sequel", github: "jeremyevans/sequel", ref: "8c023e5ed726f48391093c0c91fd1e58f599d8e3"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       rodauth (~> 2.36)
 
 GIT
+  remote: https://github.com/jeremyevans/sequel.git
+  revision: 8c023e5ed726f48391093c0c91fd1e58f599d8e3
+  ref: 8c023e5ed726f48391093c0c91fd1e58f599d8e3
+  specs:
+    sequel (5.97.0)
+      bigdecimal
+
+GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -345,8 +353,6 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    sequel (5.96.0)
-      bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
     sequel_pg (1.17.2)
@@ -482,7 +488,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel (>= 5.96)
+  sequel!
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -12,7 +12,10 @@ UbiCli.on("lb").run_on("update") do
     src_port = need_integer_arg(src_port, "src-port", cmd)
     dst_port = need_integer_arg(dst_port, "dst-port", cmd)
     cert_enabled = need_boolean_arg(cert_enabled, "cert-enabled", cmd)
-    id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, cert_enabled:, vms: vms.map { convert_name_to_id(sdk.vm, it) }).id
+    DB.ignore_duplicate_queries do
+      vms = vms.map { convert_name_to_id(sdk.vm, it) }
+    end
+    id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, cert_enabled:, vms:).id
     response("Updated load balancer with id #{id}")
   end
 end

--- a/clover.rb
+++ b/clover.rb
@@ -829,6 +829,7 @@ class Clover < Roda
     recovery_codes_route "account/multifactor/recovery-codes"
     recovery_codes_view { view "account/multifactor/recovery_codes", "My Account" }
     recovery_codes_link_text "View"
+    add_recovery_code { DB.ignore_duplicate_queries { super() } }
     add_recovery_codes_view { view "account/multifactor/recovery_codes", "My Account" }
     auto_add_recovery_codes? true
     auto_remove_recovery_codes? true

--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,17 @@ require_relative "loader"
 
 clover_freeze
 
-run(Config.development? ? Unreloader : Clover.app)
+app = if Config.development?
+  backtrace_filter = %r{\A#{Regexp.escape(Dir.pwd)}/(?!spec/)}
+  lambda do |env|
+    DB.detect_duplicate_queries(backtrace_filter:, warn: true) do
+      Unreloader.call(env)
+    end
+  end
+else
+  Clover.app
+end
+
+run(app)
 
 Tilt.finalize! unless Config.development?

--- a/db.rb
+++ b/db.rb
@@ -26,6 +26,14 @@ end
 DB.extension :pg_array, :pg_json, :pg_auto_parameterize, :pg_auto_parameterize_in_array, :pg_timestamptz, :pg_range, :pg_enum
 Sequel.extension :pg_range_ops, :pg_json_ops
 
+if Config.development? || (Config.test? && ENV["CLOVER_FREEZE"] != "1")
+  DB.extension :pg_auto_parameterize_duplicate_query_detection
+else
+  def DB.ignore_duplicate_queries
+    yield
+  end
+end
+
 # Replace dangerous (for cidrs) Ruby IPAddr type that is otherwise
 # used by sequel_pg.  Has come up more than once in the bug tracker:
 #

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -35,8 +35,10 @@ class Firewall < Sequel::Model
 
   def replace_firewall_rules(new_firewall_rules)
     firewall_rules.each(&:destroy)
-    new_firewall_rules.each do
-      add_firewall_rule(it)
+    DB.ignore_duplicate_queries do
+      new_firewall_rules.each do
+        add_firewall_rule(it)
+      end
     end
 
     update_private_subnet_firewall_rules

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -91,12 +91,16 @@ class LoadBalancer < Sequel::Model
 
   def enable_cert_server
     update(cert_enabled: true)
-    vms.each { |vm| setup_cert_server(vm.id) }
+    DB.ignore_duplicate_queries do
+      vms.each { |vm| setup_cert_server(vm.id) }
+    end
   end
 
   def disable_cert_server
     update(cert_enabled: false)
-    vms.each { |vm| remove_cert_server(vm.id) }
+    DB.ignore_duplicate_queries do
+      vms.each { |vm| remove_cert_server(vm.id) }
+    end
     certs.each(&:incr_destroy)
   end
 

--- a/model/object_tag.rb
+++ b/model/object_tag.rb
@@ -8,9 +8,11 @@ class ObjectTag < Sequel::Model
 
   module Cleanup
     def before_destroy
-      AccessControlEntry.where(object_id: id).destroy
-      DB[:applied_object_tag].where(object_id: id).delete
-      super
+      DB.ignore_duplicate_queries do
+        AccessControlEntry.where(object_id: id).destroy
+        DB[:applied_object_tag].where(object_id: id).delete
+        super
+      end
     end
   end
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -43,7 +43,9 @@ class Prog::Vnet::SubnetNexus < Prog::Base
         end
 
         firewall = Firewall.create(name: fw_name, location_id: location.id, project_id:)
-        ["0.0.0.0/0", "::/0"].each { |cidr| FirewallRule.create(firewall_id: firewall.id, cidr: cidr, port_range: Sequel.pg_range(port_range)) }
+        DB.ignore_duplicate_queries do
+          ["0.0.0.0/0", "::/0"].each { |cidr| FirewallRule.create(firewall_id: firewall.id, cidr: cidr, port_range: Sequel.pg_range(port_range)) }
+        end
       end
       firewall.associate_with_private_subnet(ps, apply_firewalls: false)
 

--- a/routes/project/inference_playground.rb
+++ b/routes/project/inference_playground.rb
@@ -3,8 +3,10 @@
 class Clover
   hash_branch(:project_prefix, "inference-playground") do |r|
     r.get web? do
-      @inference_models = [inference_router_model_ds.eager(inference_router: {load_balancer: :private_subnet}), inference_endpoint_ds.eager(:location, load_balancer: :private_subnet)].flat_map do |ds|
-        ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation").all
+      DB.ignore_duplicate_queries do
+        @inference_models = [inference_router_model_ds.eager(inference_router: {load_balancer: :private_subnet}), inference_endpoint_ds.eager(:location, load_balancer: :private_subnet)].flat_map do |ds|
+          ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation").all
+        end
       end
 
       @inference_api_keys = inference_api_key_ds.all

--- a/spec/routes/web/spec_helper.rb
+++ b/spec/routes/web/spec_helper.rb
@@ -20,16 +20,8 @@ end
 
 Gem.suffix_pattern
 
-Capybara.app = Clover.app
+Capybara.app = RACK_TEST_APP
 Capybara.exact = true
-
-module RackTestPlus
-  include Rack::Test::Methods
-
-  def app
-    Capybara.app
-  end
-end
 
 # Work around Middleware should not call #each error.
 # Fix bugs with cookies, because the default behavior
@@ -42,7 +34,7 @@ class Capybara::RackTest::Browser
 end
 
 RSpec.configure do |config|
-  config.include RackTestPlus
+  config.include Rack::Test::Methods
   config.include Capybara::DSL
   config.after do
     Capybara.reset_sessions!

--- a/views/networking/private_subnet/networking.erb
+++ b/views/networking/private_subnet/networking.erb
@@ -20,8 +20,10 @@ perm_checks = {
 ps_path = path(@ps)
 
 viewable_fws, viewable_subnets, disconnectable_subnets =
-  perm_checks.map do |perm, ds|
-    dataset_authorize(ds, perm).select_hash(:id, Sequel.as(true, :v))
+  DB.ignore_duplicate_queries do
+    perm_checks.map do |perm, ds|
+      dataset_authorize(ds, perm).select_hash(:id, Sequel.as(true, :v))
+    end
   end %>
 
 <div class="p-6">


### PR DESCRIPTION
This makes route specs raise if there are duplicate queries that are not inside explicit `ignore_duplicate_queries` blocks.  This is the Sequel tooling that that found all of the N+1 issues in #4006.

This also enables duplicate query reporting in development mode, though it warns instead of raising. Testing things in development found a bunch of N+1 issues not found by the specs, because this tooling will only find issues if N is greater than 1.

Any place where `ignore_duplicate_queries` is used is a place where we definitely have duplicate queries. We may want to address some of these places in the future.

This modifies the route spec helpers slightly to ensure that we only build a single app to test against. Previously, `spec/routes/web/spec_helper.rb` used an unnecessary `RackTestPlus` module with an `app` method that override `app` method in `spec/routes/spec_helper.rb`, but returned the same value. This defines a `RackTestApp` for the wrapper app with the duplicate query testing, has `app` return that, and sets `Capybara.app` to it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Integrates Sequel extension for duplicate query detection, modifies route specs to handle duplicates, and refactors test setup for single app instance.
> 
>   - **Behavior**:
>     - Integrates `pg_auto_parameterize_duplicate_query_detection` Sequel extension in `db.rb` for duplicate query detection.
>     - Route specs now raise errors for duplicate queries unless wrapped in `ignore_duplicate_queries`.
>     - Development mode warns about duplicate queries instead of raising errors.
>   - **Refactoring**:
>     - Refactors `spec/routes/web/spec_helper.rb` and `spec/routes/spec_helper.rb` to use a single `RACK_TEST_APP` instance for testing.
>     - Removes redundant `RackTestPlus` module in `spec/routes/web/spec_helper.rb`.
>   - **Code Changes**:
>     - Wraps existing duplicate queries in `ignore_duplicate_queries` blocks in `cli-commands/lb/post/update.rb`, `model/firewall.rb`, `model/load_balancer.rb`, `model/object_tag.rb`, `model/project.rb`, `prog/vnet/subnet_nexus.rb`, `routes/project/inference_playground.rb`, `routes/project/token.rb`, `routes/project/user.rb`, and `views/networking/private_subnet/networking.erb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ff36c9613892563d620ecc5a6f4778809225ac6e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->