### PR TITLE
Fix busy wait for parent strand when child strand naps in respirate

### DIFF
--- a/prog/test.rb
+++ b/prog/test.rb
@@ -80,6 +80,10 @@ class Prog::Test < Prog::Base
     fail "failure"
   end
 
+  label def short_napper
+    nap(12)
+  end
+
   label def napper
     nap(123)
   end
@@ -94,6 +98,21 @@ class Prog::Test < Prog::Base
 
   label def invalid_hop_target
     dynamic_hop :black_hole
+  end
+
+  label def bud_short_napper
+    bud self.class, frame, :short_napper
+    hop_reaper
+  end
+
+  label def bud_short_nappers
+    2.times { bud self.class, frame, :short_napper }
+    hop_reaper
+  end
+
+  label def bud_napper
+    bud self.class, frame, :napper
+    hop_reaper
   end
 
   label def budder


### PR DESCRIPTION
The parent would nap 0 in this case. The nap 0 makes sense for exit or hop, since that is a state change, so immediately retrying makes sense. However, it does not make sense for nap, since the state did not change.

For a single child, have the parent nap using slightly less time than the child nap, so the parent runs the child.

For multiple children, nap until slightly before the earliest child without an active lease is scheduled.

In all cases where the child naps, do not nap less than 0.1 seconds or more than 120 seconds.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes busy-wait in `Prog::Base` by adjusting parent nap time based on child nap time, with tests verifying behavior.
> 
>   - **Behavior**:
>     - Fixes busy-wait issue in `reap` method of `Prog::Base` when child strands nap.
>     - Parent naps slightly less than child nap time for single child, or until slightly before the earliest scheduled child for multiple children.
>     - Ensures nap time is between 0.1 and 120 seconds.
>   - **Tests**:
>     - Adds tests in `base_spec.rb` to verify parent nap behavior for single and multiple child strands.
>     - Tests cover scenarios for nap times exceeding 120 seconds and multiple children with different schedules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0a1fb19ab96d0ff54bd2b410b30f222c6a0df500. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->