### PR TITLE
Handle hardware_reset/reboot semaphores in more host nexus prog labels

### DIFF
--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -367,6 +367,21 @@ RSpec.describe Prog::Vm::HostNexus do
   end
 
   describe "#unavailable" do
+    it "hops to prep_graceful_reboot when needed" do
+      expect(nx).to receive(:when_graceful_reboot_set?).and_yield
+      expect { nx.unavailable }.to hop("prep_graceful_reboot")
+    end
+
+    it "hops to prep_reboot when needed" do
+      expect(nx).to receive(:when_reboot_set?).and_yield
+      expect { nx.unavailable }.to hop("prep_reboot")
+    end
+
+    it "hops to prep_hardware_reset when needed" do
+      expect(nx).to receive(:when_hardware_reset_set?).and_yield
+      expect { nx.unavailable }.to hop("prep_hardware_reset")
+    end
+
     it "registers a short deadline if host is unavailable" do
       expect(nx).to receive(:register_deadline).with("wait", 45)
       expect(nx).to receive(:available?).and_return(false)
@@ -459,6 +474,11 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(vms).to all receive(:update).with(display_state: "rebooting")
       expect(nx).to receive(:decr_reboot)
       expect { nx.prep_reboot }.to hop("reboot")
+    end
+
+    it "hops to prep_hardware_reset when needed, before checking other semaphores" do
+      expect(nx).to receive(:when_hardware_reset_set?).and_yield
+      expect { nx.reboot }.to hop("prep_hardware_reset")
     end
 
     it "reboot naps if host sshable is not available" do


### PR DESCRIPTION
If the host is unavailable, previously setting a reboot or hardware reset semaphore did nothing. Do the same hardware_reset/reboot checks in unavailable that we do in wait.

If the reboot semaphore was set, and we are stuck in reboot waiting for the sshable to become available, allow the hardware_reset semaphore to work.

This addresses an issue I ran into in my on call yesterday, where the host was in unavailable, and using the admin site to request a hardware reset had no effect.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add semaphore handling for hardware reset and reboot in `unavailable` and `reboot` states in `host_nexus.rb`.
> 
>   - **Behavior**:
>     - Add `hardware_reset_and_reboot_checks` method in `host_nexus.rb` to handle hardware reset and reboot semaphores.
>     - Call `hardware_reset_and_reboot_checks` in `unavailable`, `reboot`, and `wait` labels to ensure semaphores are checked in these states.
>   - **Tests**:
>     - Add tests in `host_nexus_spec.rb` to verify that `unavailable` and `reboot` states handle semaphores correctly.
>     - Ensure existing tests for `wait` state cover the new method usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for efe8c2f1b8a6707af186ad7c83daacc62c8e550a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->