### PR TITLE
Support Cloud Hypervisor ≥36 --device syntax

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -699,7 +699,12 @@ DNSMASQ_SERVICE
     vhost_user_block_requires = vhost_user_block_services.map { |s| "Requires=#{s}" }.join("\n")
 
     net_params = nics.map { "--net mac=#{_1.mac},tap=#{_1.tap},ip=,mask=,num_queues=#{max_vcpus * 2 + 1}" }
-    pci_device_params = pci_devices.map { " --device path=/sys/bus/pci/devices/0000:#{_1[0]}/" }.join
+    pci_device_params =
+      if Gem::Version.new(@ch_version.version) >= Gem::Version.new("36")
+        pci_devices.empty? ? "" : " --device #{pci_devices.map { |dev| "path=/sys/bus/pci/devices/0000:#{dev[0]}/" }.join(" ")}"
+      else
+        pci_devices.map { |dev| " --device path=/sys/bus/pci/devices/0000:#{dev[0]}/" }.join
+      end
     limit_memlock = pci_devices.empty? ? "" : "LimitMEMLOCK=#{mem_gib * 1073741824}"
     cpu_quota = (cpu_percent_limit == 0) ? "" : "CPUQuota=#{cpu_percent_limit}%"
 


### PR DESCRIPTION
Cloud Hypervisor v36 and later require passing multiple PCI device paths using a single --device argument instead of multiple --device flags. See the v36.0 release notes for details:
https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v36.0

This update adjusts PCI device parameter generation in vm_setup to handle the new syntax while preserving compatibility with older CH versions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `pci_device_params` in `vm_setup.rb` to support Cloud Hypervisor v36 `--device` syntax while maintaining backward compatibility.
> 
>   - **Behavior**:
>     - Update `pci_device_params` in `install_systemd_unit` in `vm_setup.rb` to use a single `--device` argument for multiple PCI devices for Cloud Hypervisor v36 and later.
>     - Retain old syntax for versions before v36.
>   - **Compatibility**:
>     - Ensures compatibility with both new and old Cloud Hypervisor versions by checking `@ch_version.version`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 99ab52fd95164c227a6b56dad323541bed64ce34. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->