### PR TITLE
Update regen-screenshots with PG Upgrade screenshots

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -143,7 +143,8 @@ class RegenScreenshots
       target_vm_size: "standard-2",
       target_storage_size_gib: 10,
       superuser_password: "1",
-      project_id: project.id
+      project_id: project.id,
+      target_version: "16"
     ) do |pg|
       pg.id = UBID.parse("pgmjy3v4ef1y7gdpzv6b3fchef").to_uuid
     end
@@ -174,7 +175,8 @@ class RegenScreenshots
     pg_server = PostgresServer.create(
       resource_id: pg_resource.id,
       vm_id: pg_vm.id,
-      timeline_id: pg_timeline.id
+      timeline_id: pg_timeline.id,
+      version: "16"
     ) do |server|
       server.id = UBID.parse("pvmjy3v4ef1y7gdpzv6b3fchef").to_uuid
     end
@@ -187,6 +189,8 @@ class RegenScreenshots
     PostgresResource.define_method(:representative_server) { pg_server }
     PostgresResource.define_method(:user_config) { {"max_connections" => 1000, "work_mem" => "64MB"} }
     PostgresResource.define_method(:pgbouncer_user_config) { {"default_pool_size" => 50} }
+    PostgresResource.define_method(:upgrade_stage) { "upgrade_standby" }
+    PostgresResource.define_method(:version) { "16" }
     Authorization.define_singleton_method(:authorize) { |*| }
     PostgresServer.define_method(:storage_size_gib) { 128 }
 
@@ -286,6 +290,15 @@ class RegenScreenshots
     resize(1200, width: 1600)
     click_link "Resize"
     screenshot "managed-postgresql/resizing-screenshot.png"
+
+    resize(900, width: 1200)
+    click_link "Upgrade"
+    screenshot "managed-postgresql/upgrade-screenshot.png"
+
+    pg_resource.update(target_version: "17")
+    resize(900, width: 1200)
+    click_link "Upgrade"
+    screenshot "managed-postgresql/upgrade-progress-screenshot.png"
 
     resize(850, width: 1600)
     click_link "Configuration"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `regen-screenshots` to include PostgreSQL upgrade screenshots and related functionality.
> 
>   - **Behavior**:
>     - Adds `target_version: "16"` to `PostgresResource.create` and `version: "16"` to `PostgresServer.create` in `regen-screenshots`.
>     - Adds `upgrade_stage` and `version` methods to `PostgresResource`.
>     - Updates `pg_resource` to `target_version: "17"` for upgrade progress.
>   - **Screenshots**:
>     - Adds `upgrade-screenshot.png` and `upgrade-progress-screenshot.png` for PostgreSQL upgrade process.
>   - **Misc**:
>     - Adds `click_link "Upgrade"` and `screenshot` calls for upgrade process in `regen-screenshots`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 30087ed8aa993d99a272d6349c6c27832e5344b6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->