### PR TITLE
Update PG E2E test case boot images

### DIFF
--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -1,6 +1,6 @@
 - { name: vm,                        images: ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"] }
 - { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2404.yml, branch_name: main} }
 - { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"], details: {repo_name: ubicloud/github-e2e-test-workflows, workflow_name: test_2204.yml, branch_name: main} }
-- { name: postgres_standard,         images: ["postgres17-ubuntu-2204"] }
-- { name: postgres_ha,               images: ["postgres17-ubuntu-2204", "ubuntu-jammy"] }
+- { name: postgres_standard,         images: ["postgres-ubuntu-2204"] }
+- { name: postgres_ha,               images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: kubernetes,                images: ["kubernetes-v1_34"]}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update PostgreSQL E2E test case images in `config/e2e_test_cases.yml`.
> 
>   - **Configuration Update**:
>     - In `config/e2e_test_cases.yml`, updated `postgres_standard` and `postgres_ha` test cases to use `postgres-ubuntu-2204` instead of `postgres17-ubuntu-2204`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for bfd9fae7c2e434418d26cf630c15ed6f6744e61e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->