### PR TITLE
Add new PG default boot image version to config

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -169,8 +169,10 @@ module Config
   override :github_gpu_ubuntu_2204_version, "20250821.1.0", string
   override :github_ubuntu_2204_aws_ami_version, "ami-04b5534ef1aed6bde", string
   override :github_ubuntu_2404_aws_ami_version, "ami-0908b850ff3e635a2", string
+  override :postgres_ubuntu_2204_version, "20251007.1.0", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string
+  override :postgres_paradedb_ubuntu_2204_version, "20250803.1.0", string
   override :postgres16_paradedb_ubuntu_2204_version, "20250901.1.0", string
   override :postgres17_paradedb_ubuntu_2204_version, "20250901.1.0", string
   override :postgres16_lantern_ubuntu_2204_version, "20250103.1.0", string


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add new PostgreSQL boot image version overrides for Ubuntu 22.04 in `config.rb`.
> 
>   - **Configuration Changes**:
>     - Add `postgres_ubuntu_2204_version` override with version `20251007.1.0` in `config.rb`.
>     - Add `postgres_paradedb_ubuntu_2204_version` override with version `20250803.1.0` in `config.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 112da91a863474760981a8c0a0f9f5e9ba023094. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->