### PR TITLE
Add resolve action to Page on admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -147,6 +147,9 @@ class CloverAdmin < Roda
     "GithubRunner" => {
       "provision" => object_action("Provision Spare Runner", "Spare runner provisioned", &:provision_spare_runner)
     },
+    "Page" => {
+      "resolve" => object_action("Resolve", "Resolve scheduled for Page", &:incr_resolve)
+    },
     "PostgresResource" => {
       "restart" => object_action("Restart", "Restart scheduled for PostgresResource", &:incr_restart)
     },

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -485,4 +485,19 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
     expect(account.reload.suspended_at).not_to be_nil
   end
+
+  it "supports resolving Pages" do
+    p = Prog::PageNexus.assemble("XYZ has an expired deadline!", ["Deadline"], "XYZ").subject
+
+    fill_in "UBID", with: p.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Page #{p.ubid}"
+
+    expect(p.semaphores_dataset.select_map(:name)).to eq []
+    click_link "Resolve"
+    click_button "Resolve"
+    expect(page).to have_flash_notice("Resolve scheduled for Page")
+    expect(page.title).to eq "Ubicloud Admin - Page #{p.ubid}"
+    expect(p.semaphores_dataset.select_map(:name)).to eq ["resolve"]
+  end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `resolve` action for `Page` in admin panel, with corresponding test in `admin_spec.rb`.
> 
>   - **Behavior**:
>     - Adds `resolve` action for `Page` in `clover_admin.rb`, scheduling a resolve operation.
>     - Displays a flash notice "Resolve scheduled for Page" upon successful action.
>   - **Tests**:
>     - Adds test in `admin_spec.rb` to verify the `resolve` action for `Page`, checking the flash notice and semaphore update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e546429ed76a3aa7884a688876726fed70517bb8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->