### PR TITLE
Remove ResourceMethods plugin from models without IDs

### DIFF
--- a/model/load_balancer_cert.rb
+++ b/model/load_balancer_cert.rb
@@ -5,8 +5,6 @@ require_relative "../model"
 class LoadBalancerCert < Sequel::Model(:certs_load_balancers)
   many_to_one :cert
 
-  plugin ResourceMethods, etc_type: true
-
   def before_destroy
     cert.incr_destroy
     super

--- a/model/private_subnet_firewall.rb
+++ b/model/private_subnet_firewall.rb
@@ -3,7 +3,6 @@
 require_relative "../model"
 
 class PrivateSubnetFirewall < Sequel::Model(:firewalls_private_subnets)
-  plugin ResourceMethods, etc_type: true
 end
 
 # Table: firewalls_private_subnets

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
   end
 
+  it "allows browsing all classes" do
+    classes = Sequel::Model.subclasses.map { [it, it.subclasses] }.flatten.select { it < ResourceMethods::InstanceMethods }.sort_by(&:name)
+    classes.each do |cls|
+      visit "/model/#{cls.name}"
+      expect(page.status_code).to eq 200
+      expect(page.title).to eq "Ubicloud Admin - #{cls.name}"
+    end
+  end
+
   it "allows browsing by class when using Autoforme" do
     project = Project.create(name: "Default")
     vm = Prog::Vm::Nexus.assemble("dummy key", project.id, name: "my-vm").subject


### PR DESCRIPTION
While navigating through the admin panel, I noticed that the LoadBalancerCert model fails with the following internal server error:

    Sequel::DatabaseError:
        PG::UndefinedColumn: ERROR:  column "id" does not exist
        LINE 1: ...SELECT * FROM "firewalls_private_subnets" ORDER BY "id" LIMIT...

I then decided to write a test to ensure the index page works for all models. It revealed that PrivateSubnetFirewall has the same issue.

These two models do not have an id column; instead, they use composite primary keys. The ResourceMethods plugin assumes that all models have an id column and relies on it in several methods, especially those related to UBIDs. Therefore, these models should not use the ResourceMethods plugin.

If we think they still need some of the functionality provided by ResourceMethods, we can consider splitting the plugin into smaller, more focused ones.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `ResourceMethods` plugin from models without `id` columns and add test to ensure admin panel access for all models.
> 
>   - **Behavior**:
>     - Remove `ResourceMethods` plugin from `LoadBalancerCert` and `PrivateSubnetFirewall` models due to lack of `id` column.
>     - Add test in `admin_spec.rb` to ensure all models can be browsed without errors.
>   - **Testing**:
>     - New test in `admin_spec.rb` iterates over all classes inheriting from `ResourceMethods::InstanceMethods` to verify admin panel access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7e3fa50f1b9ccd6b91fd5320b1345d4dc486508d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->