### PR TITLE
Fix passed frame for load balancer buds

### DIFF
--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -145,7 +145,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
     decr_destroy
     strand.children.map { it.destroy }
     load_balancer.vms.each do |vm|
-      bud Prog::Vnet::LoadBalancerRemoveVm, {subject_id: vm.id, load_balancer_id: load_balancer.id}, :destroy_vm_ports_and_update_node
+      bud Prog::Vnet::LoadBalancerRemoveVm, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :destroy_vm_ports_and_update_node
     end
     hop_wait_all_vms_removed
   end

--- a/prog/vnet/load_balancer_remove_vm.rb
+++ b/prog/vnet/load_balancer_remove_vm.rb
@@ -13,7 +13,7 @@ class Prog::Vnet::LoadBalancerRemoveVm < Prog::Base
 
   label def destroy_vm_ports_and_update_node
     load_balancer.vm_ports_by_vm(vm).destroy
-    bud Prog::Vnet::UpdateLoadBalancerNode, {subject_id: vm.id, load_balancer_id: load_balancer.id}, :update_load_balancer
+    bud Prog::Vnet::UpdateLoadBalancerNode, {"subject_id" => vm.id, "load_balancer_id" => load_balancer.id}, :update_load_balancer
     hop_wait_for_node_update
   end
 
@@ -27,7 +27,7 @@ class Prog::Vnet::LoadBalancerRemoveVm < Prog::Base
   end
 
   label def initiate_cert_server_removal
-    bud Prog::Vnet::CertServer, {subject_id: load_balancer.id, vm_id: vm.id}, :remove_cert_server if load_balancer.cert_enabled
+    bud Prog::Vnet::CertServer, {"subject_id" => load_balancer.id, "vm_id" => vm.id}, :remove_cert_server if load_balancer.cert_enabled
     hop_wait_for_cert_server_removal
   end
 

--- a/spec/prog/vnet/load_balancer_remove_vm_spec.rb
+++ b/spec/prog/vnet/load_balancer_remove_vm_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Prog::Vnet::LoadBalancerRemoveVm do
     it "removes the vm from load balancer and hops to wait_for_node_update" do
       expect(lb).to receive(:vm_ports_by_vm).with(vm).and_return(instance_double(LoadBalancerPort, destroy: nil)).at_least(:once)
       expect(lb.vm_ports_by_vm(vm)).to receive(:destroy)
-      expect(nx).to receive(:bud).with(Prog::Vnet::UpdateLoadBalancerNode, {subject_id: vm.id, load_balancer_id: lb.id}, :update_load_balancer)
+      expect(nx).to receive(:bud).with(Prog::Vnet::UpdateLoadBalancerNode, {"subject_id" => vm.id, "load_balancer_id" => lb.id}, :update_load_balancer)
       expect { nx.destroy_vm_ports_and_update_node }.to hop("wait_for_node_update")
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe Prog::Vnet::LoadBalancerRemoveVm do
   describe "#initiate_cert_server_removal" do
     it "removes the certificate server and hops to wait_for_cert_server_removal" do
       expect(lb).to receive(:cert_enabled).and_return(true)
-      expect(nx).to receive(:bud).with(Prog::Vnet::CertServer, {subject_id: lb.id, vm_id: vm.id}, :remove_cert_server)
+      expect(nx).to receive(:bud).with(Prog::Vnet::CertServer, {"subject_id" => lb.id, "vm_id" => vm.id}, :remove_cert_server)
       expect { nx.initiate_cert_server_removal }.to hop("wait_for_cert_server_removal")
     end
 


### PR DESCRIPTION
In our codebase, we try to keep our JSON keys as string, since when they fetched from DB, they are always string. When we pass it as a symbol, it causes failure especially in equality check.

I found a place where we are passing symbol instead of string thanks to new version of json package. It prints following warning:

    This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true`
    .../mise/installs/ruby/3.4.7/lib/ruby/3.4.0/delegate.rb:349: warning: detected duplicate key "subject_id" in {"subject_id" => "9749a267-586c-842b-962c-666f22da28fa", subject_id: "adede52c-c92e-8774-9b28-e33ff0c42d62", load_balancer_id: "9749a267-586c-842b-962c-666f22da28fa"}.

As you see `"subject_id"` and `:subject_id` are different keys. They can't merged in `hash.merge` method.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix JSON key handling by changing from symbols to strings in `load_balancer_nexus.rb` and `load_balancer_remove_vm.rb`, and update tests accordingly.
> 
>   - **Behavior**:
>     - Fix JSON key handling by changing from symbols to strings in `load_balancer_nexus.rb` and `load_balancer_remove_vm.rb`.
>     - Specifically, update `bud` method calls to use string keys for `subject_id` and `load_balancer_id`.
>   - **Tests**:
>     - Update `load_balancer_remove_vm_spec.rb` to expect string keys in `bud` method calls.
>     - Ensure tests reflect changes in JSON key handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ee5296e000bea81400a736c6dd95c64929819b7f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->