### PR TITLE
Add Extra Info for some Models in Admin

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -26,6 +26,7 @@ class CloverAdmin < Roda
     extract_fixed_locals: true
   }
 
+  plugin :part
   plugin :public
   plugin :flash
   plugin :h
@@ -190,6 +191,11 @@ class CloverAdmin < Roda
     }
   }.freeze
   OBJECT_ACTIONS.each_value(&:freeze)
+
+  OBJECTS_WITH_EXTRAS = Dir["views/admin/extras/*.erb"]
+    .map { File.basename(it, ".erb") }
+    .each_with_object({}) { |name, h| h[name] = true }
+    .freeze
 
   plugin :autoforme do
     # :nocov:

--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -14,6 +14,8 @@ class Invoice < Sequel::Model
 
   plugin ResourceMethods
 
+  alias_method :admin_label, :invoice_number
+
   def path_id
     id ? ubid : "current"
   end
@@ -295,6 +297,15 @@ class Invoice < Sequel::Model
       content_type: "application/pdf",
       if_none_match: "*"
     )
+  end
+
+  def generate_download_link
+    Aws::S3::Presigner.new(client: Invoice.blob_storage_client).presigned_url(:get_object,
+      bucket: Config.invoices_bucket_name,
+      key: blob_key,
+      expires_in: 60 * 60)
+  rescue
+    nil
   end
 
   def self.blob_storage_client

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -209,4 +209,21 @@ RSpec.describe Invoice do
       invoice.persist(pdf)
     end
   end
+
+  describe ".generate_download_link" do
+    it "generates a presigned URL for PDF" do
+      allow(Config).to receive(:invoices_bucket_name).and_return("invoices-bucket")
+      url_presigner = instance_double(Aws::S3::Presigner)
+      allow(Aws::S3::Presigner).to receive(:new).with(client:).and_return(url_presigner)
+
+      url = "https://ubicloud-invoices.something.eu.r2.cloudflare.com/presigned_url"
+      expect(url_presigner).to receive(:presigned_url).with(:get_object, {
+        bucket: Config.invoices_bucket_name,
+        expires_in: 3600,
+        key: invoice.blob_key
+      }).and_return(url)
+
+      expect(invoice.generate_download_link).to eq(url)
+    end
+  end
 end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -63,6 +63,7 @@ module ThawedMock
   allow_mocking(Github, :app_client, :failed_deliveries, :installation_client, :oauth_client, :redeliver_failed_deliveries)
   allow_mocking(GithubRunner, :[], :any?, :first, :join)
   allow_mocking(HostProvider, :create)
+  allow_mocking(Invoice, :blob_storage_client)
   allow_mocking(IpsecTunnel, :[], :create)
   allow_mocking(KubernetesCluster, :[], :kubeconfig, :generate_ubid)
   allow_mocking(KubernetesNodepool, :generate_uuid)

--- a/views/admin/extras/BillingInfo.erb
+++ b/views/admin/extras/BillingInfo.erb
@@ -1,0 +1,6 @@
+<%# locals: (obj: nil) %>
+<div>
+  Stripe Data:
+  <br>
+  <pre><code><%= JSON.pretty_generate(obj.stripe_data) %></code></pre>
+</div>

--- a/views/admin/extras/Invoice.erb
+++ b/views/admin/extras/Invoice.erb
@@ -1,0 +1,4 @@
+<%# locals: (obj: nil) %>
+<% if link = obj.generate_download_link %>
+  <p><a href="<%= link %>">Download PDF</a></p>
+<% end %>

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -55,6 +55,8 @@
 </tbody>
 </table>
 
+<%== part("extras/#{@klass.name}", obj: @obj) if OBJECTS_WITH_EXTRAS[@klass.name] %>
+
 <h2 id="associations-header">Associations</h2>
 <div class="associations">
   <% @klass.associations.sort.each do |assoc| %>


### PR DESCRIPTION
This change adds some logic for showing extra information about different models in admin panel. This can be useful for many things such as quick metrics, health results as well as stripe data and invoice download links as implemented in this example.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance admin panel to display extra details for `BillingInfo` and `Invoice`, including download links for invoices.
> 
>   - **Admin Panel Enhancements**:
>     - Adds `OBJECTS_WITH_EXTRAS` in `clover_admin.rb` to track models with extra info views.
>     - Updates `object.erb` to render extra details for models listed in `OBJECTS_WITH_EXTRAS`.
>   - **Invoice Model**:
>     - Adds `generate_download_link` method to `Invoice` for generating presigned S3 URLs.
>     - Aliases `admin_label` to `invoice_number`.
>   - **Views**:
>     - Adds `BillingInfo.erb` to display Stripe data.
>     - Adds `Invoice.erb` to display download link if available.
>   - **Tests**:
>     - Adds tests in `invoice_spec.rb` for `generate_download_link`.
>     - Adds tests in `admin_spec.rb` to verify rendering of extra details and download links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 88b89dbae7ddea3223311141eaa3990149a24810. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->