### PR TITLE
Add extra fields about postgres connection info

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -2961,6 +2961,18 @@ components:
                     description: Connection string to the Postgres database
                     type: string
                     nullable: true
+                  username:
+                    description: Username for the Postgres database
+                    type: string
+                    nullable: true
+                  password:
+                    description: Password for the Postgres database
+                    type: string
+                    nullable: true
+                  hostname:
+                    description: Hostname for the Postgres database
+                    type: string
+                    nullable: true
                   earliest_restore_time:
                     description: Earliest restore time (if primary)
                     type: string
@@ -2986,6 +2998,9 @@ components:
                       $ref: '#/components/schemas/PostgresTag'
                 required:
                   - connection_string
+                  - username
+                  - password
+                  - hostname
                   - earliest_restore_time
                   - firewall_rules
                   - latest_restore_time

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -25,6 +25,9 @@ class Serializers::Postgres < Serializers::Base
     if options[:detailed]
       base.merge!(
         connection_string: pg.connection_string,
+        username: "postgres",
+        password: pg.superuser_password,
+        hostname: pg.hostname,
         primary: pg.representative_server&.primary?,
         firewall_rules: Serializers::PostgresFirewallRule.serialize(pg.firewall_rules.sort_by { |fwr| fwr.cidr.version && fwr.cidr.to_s }),
         metric_destinations: pg.metric_destinations.map { {id: it.ubid, username: it.username, url: it.url} },


### PR DESCRIPTION
We normally only return the connection string, but then clients might need to parse it if they need individual fields, which is not very straightforward as each field might contain special characters requiring extra attention during parsing. So we are adding username, password and hostname fields to make it easier for clients to consume this information.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `username`, `password`, and `hostname` fields to Postgres database response for detailed connection info.
> 
>   - **Behavior**:
>     - Added `username`, `password`, and `hostname` fields to Postgres database response in `openapi.yml` and `serializers/postgres.rb`.
>     - These fields are included when `detailed` option is true.
>   - **OpenAPI**:
>     - Updated `openapi.yml` to include `username`, `password`, and `hostname` in Postgres database schema.
>     - Marked these fields as required in detailed responses.
>   - **Serializers**:
>     - Updated `serialize_internal()` in `serializers/postgres.rb` to add `username`, `password`, and `hostname` when `detailed` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a19bba13eda4249396c1b97efe8fc31a53e16077. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->