### PR TITLE
Reorder kubernetes cluster destroy

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -276,18 +276,17 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     reap do
       decr_destroy
 
+      kubernetes_cluster.nodes.each(&:incr_destroy)
+      kubernetes_cluster.nodepools.each(&:incr_destroy)
+      nap 5 unless kubernetes_cluster.nodepools.empty?
+      nap 5 unless kubernetes_cluster.nodes.empty?
+
       if (services_lb = kubernetes_cluster.services_lb)
         services_lb.dns_zone&.delete_record(record_name: "*.#{services_lb.hostname}.")
         services_lb.incr_destroy
       end
-
       kubernetes_cluster.api_server_lb&.incr_destroy
-      kubernetes_cluster.cp_vms.each(&:incr_destroy)
-      kubernetes_cluster.nodes.each(&:incr_destroy)
-      kubernetes_cluster.nodepools.each { it.incr_destroy }
       kubernetes_cluster.private_subnet.incr_destroy
-      nap 5 unless kubernetes_cluster.nodepools.empty?
-      nap 5 unless kubernetes_cluster.nodes.empty?
       kubernetes_cluster.destroy
       pop "kubernetes cluster is deleted"
     end


### PR DESCRIPTION
I noticed several exceptions like the one below in the E2E logs:

    Exception: PG::ForeignKeyViolation - ERROR:  update or delete on table "load_balancer" violates foreign key constraint "kubernetes_cluster_api_server_lb_id_fkey" on table "kubernetes_cluster" DETAIL:  Key (id)=(1cab492d-8ec4-8c2b-8d29-877bd664a5f1) is still referenced from table "kubernetes_cluster".

These errors eventually disappear, but they make the logs noisy and harder to read.

The root cause is that we trigger the destruction of load balancers and nodes of the cluster first, and then wait for the nodes to be deleted. However, the load balancers can’t be deleted until the corresponding Kubernetes cluster row is removed due to the foreign key constraint.

To fix this, it’s better to first validate that the node destruction is complete, and only then trigger the destruction of the load balancers.

Also, we don’t need to destroy cp_vms separately, since cluster.nodes already handles the destruction of control plane VMs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorders Kubernetes cluster destruction sequence to prevent foreign key violations by destroying nodes before load balancers.
> 
>   - **Behavior**:
>     - Reorders destruction sequence in `destroy` method of `kubernetes_cluster_nexus.rb` to destroy nodes before load balancers, preventing foreign key violations.
>     - Removes separate destruction of `cp_vms` as `cluster.nodes` handles it.
>   - **Tests**:
>     - Updates tests in `kubernetes_cluster_nexus_spec.rb` to reflect new destruction order.
>     - Ensures tests check for correct destruction sequence and completion without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 729a7d284b8f3457d58fcb1b2399a656a68e1d97. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->