### PR TITLE
Clean up kubernetes nodepool destroy

### DIFF
--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -94,7 +94,6 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
       decr_destroy
 
       kubernetes_nodepool.nodes.each(&:incr_destroy)
-      kubernetes_nodepool.vms.each(&:incr_destroy)
       nap 5 unless kubernetes_nodepool.nodes.empty?
       kubernetes_nodepool.destroy
       pop "kubernetes nodepool is deleted"

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -232,17 +232,14 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kn.cluster.id, kubernetes_nodepool_id: kn.id)
       st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "destroy", stack: [{}])
       expect(kn.nodes).to all(receive(:incr_destroy))
-      expect(kn.vms).to all(receive(:incr_destroy))
 
       expect { nx.destroy }.to nap(5)
     end
 
     it "destroys the nodepool and its nodes" do
-      kn.nodes.map(&:destroy)
-      kn.reload
+      kn.nodes_dataset.destroy
 
       expect(kn.nodes).to all(receive(:incr_destroy))
-      expect(kn.vms).to all(receive(:incr_destroy))
       expect(kn).to receive(:destroy)
       expect { nx.destroy }.to exit({"msg" => "kubernetes nodepool is deleted"})
     end


### PR DESCRIPTION
I noticed several exceptions like the one below in the E2E logs:

```
    Exception: PG::ForeignKeyViolation - ERROR:  update or delete on table "vm" violates foreign key constraint "kubernetes_node_vm_id_fkey" on table "kubernetes_node"
DETAIL:  Key (id)=(e756628c-a84d-8b74-8696-8f20869a3c04) is still referenced from table "kubernetes_node".
```

These errors eventually disappear, but they make the logs noisy and harder to read.

The root cause is that we trigger the destruction of vms and nodes of the nodepool first, and then wait for the nodes to be deleted. However, the vms can’t be deleted until the corresponding kubernetes node row is removed due to the foreign key constraint.

We don’t need to destroy vms separately, since node already handles the destruction of its vm.