### PR TITLE
Log spot instance interruptions for alien runners

### DIFF
--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -671,6 +671,45 @@ RSpec.describe Prog::Vm::GithubRunner do
 
       expect { nx.wait }.to nap(60)
     end
+
+    it "raises ssh exception again for non-aws instance" do
+      expect(vm.sshable).to receive(:cmd).and_raise(Errno::ECONNRESET.new("connection failed"))
+
+      expect { nx.wait }.to raise_error(Errno::ECONNRESET)
+    end
+
+    it "raises ssh exception again if aws instance not terminated due to interruption" do
+      location_id = Location.create(name: "eu-central-1", provider: "aws", project_id: vm.project_id, display_name: "aws-eu-central-1", ui_name: "AWS Frankfurt", visible: true).id
+      LocationCredential.create_with_id(location_id, access_key: "key", secret_key: "secret")
+      vm.update(location_id:)
+      AwsInstance.create_with_id(vm.id, instance_id: "i-0123456789abcdefg")
+      client = Aws::EC2::Client.new(stub_responses: true)
+      expect(Aws::EC2::Client).to receive(:new).and_return(client).at_least(:once)
+      expect(vm.sshable).to receive(:cmd).and_raise(Errno::ECONNRESET.new("connection failed")).at_least(:once)
+
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Client.UserInitiatedShutdown"}}]}])
+      expect { nx.wait }.to raise_error(Errno::ECONNRESET)
+
+      client.stub_responses(:describe_instances, reservations: [{instances: []}])
+      expect { nx.wait }.to raise_error(Errno::ECONNRESET)
+
+      client.stub_responses(:describe_instances, reservations: [])
+      expect { nx.wait }.to raise_error(Errno::ECONNRESET)
+    end
+
+    it "logs when aws instance terminated due to interruption" do
+      location_id = Location.create(name: "eu-central-1", provider: "aws", project_id: vm.project_id, display_name: "aws-eu-central-1", ui_name: "AWS Frankfurt", visible: true).id
+      LocationCredential.create_with_id(location_id, access_key: "key", secret_key: "secret")
+      vm.update(location_id:)
+      AwsInstance.create_with_id(vm.id, instance_id: "i-0123456789abcdefg")
+      client = Aws::EC2::Client.new(stub_responses: true)
+      expect(Aws::EC2::Client).to receive(:new).and_return(client)
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Server.SpotInstanceTermination"}}]}])
+      expect(vm.sshable).to receive(:cmd).and_raise(Errno::ECONNRESET.new("connection failed"))
+      expect(Clog).to receive(:emit).with("Spot instance interrupted").and_call_original
+      expect { nx.wait }.to nap
+      expect(runner.destroy_set?).to be(true)
+    end
   end
 
   describe ".collect_final_telemetry" do


### PR DESCRIPTION
Spot instances are cost-effective but can be interrupted by AWS when capacity is reclaimed.

When this happens, SSH commands begin to fail. In such cases, we check the termination status via the AWS API.

For now, we simply log these interruptions. In the future, we may stop spilling over to alien runners when the number of interruptions becomes high.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Log AWS spot instance interruptions in `github_runner.rb` and update tests in `github_runner_spec.rb` to verify logging and runner destruction.
> 
>   - **Behavior**:
>     - In `github_runner.rb`, `wait` method now logs AWS spot instance interruptions using `Clog.emit` when SSH fails due to spot instance termination.
>     - If interruption is detected, the runner is marked for destruction with `github_runner.incr_destroy`.
>   - **Tests**:
>     - Added test in `github_runner_spec.rb` to verify logging of spot instance interruptions and runner destruction.
>     - Ensures SSH exceptions are re-raised for non-spot instance terminations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6205c9613ff807194d4ea818506c86d2bd59e235. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->