### PR TITLE
Have Prog::Base#reap run children in order of how they are scheduled

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -208,6 +208,7 @@ end
   def reap(hop = nil, reaper: nil, nap: nil, fallthrough: false)
     children = strand
       .children_dataset
+      .order(:schedule)
       .select_append(Sequel.lit("lease < now() AND exitval IS NOT NULL").as(:reapable))
       .all
 


### PR DESCRIPTION
Fixes nondeterministic test failure, and in general is a more sensible behavior.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `Prog::Base#reap`, children strands are now processed in order of their schedule, fixing a nondeterministic test failure.
> 
>   - **Behavior**:
>     - In `reap` method of `Prog::Base`, children strands are now ordered by `:schedule` before processing, ensuring deterministic execution order.
>     - Fixes nondeterministic test failure by processing children in scheduled order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 462a46ebe3aed556b3019fdd44f59d0310e5e61a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->