### PR TITLE
Recursively reap children in Prog::Base#reap

### DIFF
--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Prog::Base do
     expect(failer.this.get(:exitval)).to be_nil
   end
 
+  it "reap works if child strand has child strand that needs to be reaped" do
+    parent = Strand.create(prog: "Test", label: "reap_exit_no_children")
+    child = Strand.create(parent_id: parent.id, prog: "Test", label: "popper", exitval: {"msg" => "child exit"})
+    grandchild = Strand.create(parent_id: child.id, prog: "Test", label: "failer", exitval: {"msg" => "grandchild exit"})
+    parent.run
+    expect(parent.exists?).to be false
+    expect(child.exists?).to be false
+    expect(grandchild.exists?).to be false
+  end
+
   it "parent reap naps for 0.1 seconds less than child if single child naps" do
     parent = Strand.create(prog: "Test", label: "bud_short_napper")
     hop = parent.unsynchronized_run


### PR DESCRIPTION
If you have a child strand that exited, and that strand has an unreaped child strand that exited, then before this change, reap will fail with a foreign key violation, because it tries to destroy the child strand while the grandchild strand still exists.

While this case is unlikely, it is possible to hit for at least kubernetes:

* KubernetesNodepoolNexus#destroy reaps
  * Has ProvisionKubernetesNode child with exitval
    * Which has BootstrapRhizome child with exitval

ProvisionKubernetesNode in this case didn't reap the BootstrapRhizome child because before the reaping, the related cluster was destroyed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `reap` method in `prog/base.rb` to recursively handle child strands, preventing foreign key violations, with tests added in `base_spec.rb`.
> 
>   - **Behavior**:
>     - Modify `reap` method in `prog/base.rb` to recursively reap child strands, preventing foreign key violations when a child strand has unreaped child strands.
>     - Handles cases where a child strand has exited but has its own child strands that need reaping.
>   - **Tests**:
>     - Add test in `base_spec.rb` to verify recursive reaping of child strands, ensuring all strands are properly destroyed without foreign key violations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 98fd7a784e7d38c739ebbd2b05eb220932a29583. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->