### PR TITLE
Fix nondeterministic reap spec failure

### DIFF
--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe Prog::Base do
   it "does not allow failure of one child strand inside donate to affect other strands" do
     parent = Strand.create(prog: "Test", label: "reap_exit_no_children")
     popper = Strand.create(parent_id: parent.id, prog: "Test", label: "popper")
-    failer = Strand.create(parent_id: parent.id, prog: "Test", label: "failer")
+    failer = Strand.create(parent_id: parent.id, prog: "Test", label: "failer", schedule: Time.now + 5)
     Strand.create(parent_id: parent.id, prog: "Test", label: "napper", lease: Time.now + 10)
-
-    expect(parent).to receive(:children_dataset).twice.and_wrap_original do
-      # Force popper before failer
-      it.call.order(Sequel.case({"popper" => 1}, 2, :label))
-    end
 
     expect { parent.run(10) }.to raise_error(RuntimeError)
     expect(popper.this.get(:exitval)).to eq("msg" => "popped")


### PR DESCRIPTION
Forcing an order no longer works, as there is an explicit order by schedule. Make the failer schedule after the popper schedule to ensure deterministic behavior.

Failure looks like:

```
  1) Prog::Base does not allow failure of one child strand inside donate to affect other strands
     Failure/Error: expect(popper.this.get(:exitval)).to eq("msg" => "popped")

       expected: {"msg" => "popped"}
            got: nil

       (compared using ==)
     # ./spec/prog/base_spec.rb:18:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:60:in 'block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/transactions.rb:257:in 'Sequel::Database#_transaction'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/transactions.rb:239:in 'block in Sequel::Database#transaction'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/connection_pool/timed_queue.rb:90:in 'Sequel::TimedQueueConnectionPool#hold'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/connecting.rb:283:in 'Sequel::Database#synchronize'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/transactions.rb:197:in 'Sequel::Database#transaction'
     # ./spec/spec_helper.rb:59:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure deterministic behavior in `base_spec.rb` by scheduling `failer` strand after `popper` and removing forced order logic.
> 
>   - **Behavior**:
>     - In `base_spec.rb`, modify the test to ensure deterministic behavior by scheduling `failer` strand 5 seconds after `popper`.
>     - Remove forced order using `Sequel.case` in the same test.
>   - **Misc**:
>     - Remove redundant `expect` block that forced order in `base_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ab1778317de9b0b9b5e31b3d81eca001dad0af72. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->