### PR TITLE
Fix likely underlying cause of monitor/respirate spec nondeterminism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", github: "jeremyevans/sequel", ref: "8c023e5ed726f48391093c0c91fd1e58f599d8e3"
+gem "sequel", github: "jeremyevans/sequel", ref: "071d6562c47c5781cf27f6b1574c247595cdb32f"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/jeremyevans/sequel.git
-  revision: 8c023e5ed726f48391093c0c91fd1e58f599d8e3
-  ref: 8c023e5ed726f48391093c0c91fd1e58f599d8e3
+  revision: 071d6562c47c5781cf27f6b1574c247595cdb32f
+  ref: 071d6562c47c5781cf27f6b1574c247595cdb32f
   specs:
     sequel (5.97.0)
       bigdecimal


### PR DESCRIPTION
I saw this nondeterministic spec failure:

```
Failures:

  1) Repartitioner#notify uses NOTIFY to notify listeners on given channel
     Failure/Error: expect(th.value).to eq "1"

       expected: "1"
            got: "2"

       (compared using ==)
     # ./spec/lib/repartitioner_spec.rb:38:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:60:in 'block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/transactions.rb:257:in 'Sequel::Database#_transaction'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/transactions.rb:239:in 'block in Sequel::Database#transaction'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/connection_pool/timed_queue.rb:90:in 'Sequel::TimedQueueConnectionPool#hold'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/connecting.rb:283:in 'Sequel::Database#synchronize'
     # ./vendor/bundle/ruby/3.4.0/bundler/gems/sequel-8c023e5ed726/lib/sequel/database/transactions.rb:197:in 'Sequel::Database#transaction'
     # ./spec/spec_helper.rb:59:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
```

I determined that it was impossible for anything inside the spec to cause this. The only way it could happen is if notifications were bleeding between specs.  I reviewed the Sequel Database#listen code and found that there was a race condition that allows notifications to bleed between Database#listen calls. I fixed the issue in Sequel. This updates the Sequel checkout to the commit that fixes the bug.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes nondeterministic spec failure by updating `sequel` gem to resolve race condition in `Database#listen`.
> 
>   - **Behavior**:
>     - Updates `sequel` gem in `Gemfile` to commit `071d6562c47c5781cf27f6b1574c247595cdb32f` to fix a race condition in `Database#listen`.
>     - Fixes nondeterministic spec failure in `Repartitioner#notify` by preventing notification bleed between specs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 233bf4fd6fedd3c63418cb7cc36d099646e80384. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->