### PR TITLE
Add account renaming functionality

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -111,6 +111,7 @@ class Clover < Roda
   ].each { path(it, class_name: true, &under_project_path) }
 
   path("Project", class_name: true, &:path)
+  path("Account", class_name: true) { |_| "/account" }
   path("GithubInstallation", class_name: true) { "#{it.project.path}/github/#{it.ubid}" }
   path("Invoice", class_name: true) { "#{it.project.path}/billing#{it.path}" }
 

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -24,7 +24,11 @@ class Clover < Roda
     def rename(object, perm:, serializer:, template_prefix:)
       post "rename" do
         scope.instance_exec do
-          authorize(perm, object)
+          if perm
+            authorize(perm, object)
+          else
+            no_authorization_needed
+          end
           handle_validation_failure("#{template_prefix}/show") { @page = "settings" }
           name = typecast_body_params.nonempty_str!("name")
 

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -37,6 +37,8 @@ class Clover < Roda
           else
             if object.is_a?(KubernetesCluster)
               Validation.validate_kubernetes_name(name)
+            elsif object.is_a?(Account)
+              Validation.validate_account_name(name)
             else
               Validation.validate_name(name)
             end

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -134,6 +134,9 @@ class Clover < Roda
     return unless LOGGED_ACTIONS.include?(action) || Config.test?
     # :nocov:
 
+    # log only if we have a project context
+    return unless @project
+
     project_id = @project.id
     subject_id = current_account.id
     ubid_type = object.class.ubid_type

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -21,7 +21,7 @@ class Clover < Roda
       end
     end
 
-    def rename(object, perm:, serializer:, template_prefix:)
+    def rename(object, perm:, serializer:, template:)
       post "rename" do
         scope.instance_exec do
           if perm
@@ -29,7 +29,7 @@ class Clover < Roda
           else
             no_authorization_needed
           end
-          handle_validation_failure("#{template_prefix}/show") { @page = "settings" }
+          handle_validation_failure(template) { @page = "settings" }
           name = typecast_body_params.nonempty_str!("name")
 
           if name == object.name

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -21,7 +21,7 @@ class Clover < Roda
       end
     end
 
-    def rename(object, perm:, serializer:, template:)
+    def rename(object, perm:, serializer:, template:, page: "settings")
       post "rename" do
         scope.instance_exec do
           if perm
@@ -29,7 +29,7 @@ class Clover < Roda
           else
             no_authorization_needed
           end
-          handle_validation_failure(template) { @page = "settings" }
+          handle_validation_failure(template) { @page = page }
           name = typecast_body_params.nonempty_str!("name")
 
           if name == object.name
@@ -52,7 +52,7 @@ class Clover < Roda
             serializer.serialize(object)
           else
             flash["notice"] = "Name updated"
-            request.redirect object, "/settings"
+            request.redirect object, "/#{page}"
           end
         end
       end

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -60,7 +60,7 @@ module Validation
 
   # - Max length 63
   # - Unicode letters, numbers, hyphen, space
-  ALLOWED_ACCOUNT_NAME = %r{\A\p{L}[\p{L}0-9\- ]{1,62}\z}
+  ALLOWED_ACCOUNT_NAME = %r{\A\p{L}[\p{L}0-9\- ]{1,61}[\p{L}0-9]\z}
 
   # Allow Kubernetes Names
   # - Same with regular name pattern, but shorter (40 chars)

--- a/routes/account.rb
+++ b/routes/account.rb
@@ -8,6 +8,13 @@ class Clover
         r.redirect "/account/multifactor-manage"
       end
 
+      r.get "rename" do
+        no_authorization_needed
+        view "account/rename"
+      end
+
+      r.rename current_account, perm: nil, serializer: Serializers::Account, template: "account/rename", page: "rename"
+
       r.on "login-method" do
         r.get true do
           no_authorization_needed

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -48,7 +48,7 @@ class Clover
         end
       end
 
-      r.rename firewall, perm: "Firewall:edit", serializer: Serializers::Firewall, template_prefix: "networking/firewall"
+      r.rename firewall, perm: "Firewall:edit", serializer: Serializers::Firewall, template: "networking/firewall/show"
 
       r.show_object(firewall, actions: %w[overview networking settings], perm: "Firewall:view", template: "networking/firewall/show")
 

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -43,7 +43,7 @@ class Clover
         end
       end
 
-      r.rename kc, perm: "KubernetesCluster:edit", serializer: Serializers::KubernetesCluster, template_prefix: "kubernetes-cluster"
+      r.rename kc, perm: "KubernetesCluster:edit", serializer: Serializers::KubernetesCluster, template: "kubernetes-cluster/show"
 
       r.show_object(kc, actions: %w[overview nodes settings], perm: "KubernetesCluster:view", template: "kubernetes-cluster/show")
 

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -121,7 +121,7 @@ class Clover
         end
       end
 
-      r.rename lb, perm: "LoadBalancer:edit", serializer: Serializers::LoadBalancer, template_prefix: "networking/load_balancer" do
+      r.rename lb, perm: "LoadBalancer:edit", serializer: Serializers::LoadBalancer, template: "networking/load_balancer/show" do
         lb.incr_rewrite_dns_records
         lb.incr_refresh_cert
       end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -100,7 +100,7 @@ class Clover
         end
       end
 
-      r.rename pg, perm: "Postgres:edit", serializer: Serializers::Postgres, template_prefix: "postgres" do
+      r.rename pg, perm: "Postgres:edit", serializer: Serializers::Postgres, template: "postgres/show" do
         pg.incr_refresh_dns_record
         pg.incr_refresh_certificates
       end

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -66,7 +66,7 @@ class Clover
         end
       end
 
-      r.rename ps, perm: "PrivateSubnet:edit", serializer: Serializers::PrivateSubnet, template_prefix: "networking/private_subnet"
+      r.rename ps, perm: "PrivateSubnet:edit", serializer: Serializers::PrivateSubnet, template: "networking/private_subnet/show"
 
       r.show_object(ps, actions: %w[overview vms networking settings], perm: "PrivateSubnet:view", template: "networking/private_subnet/show")
     end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -43,7 +43,7 @@ class Clover
         204
       end
 
-      r.rename vm, perm: "Vm:edit", serializer: Serializers::Vm, template_prefix: "vm"
+      r.rename vm, perm: "Vm:edit", serializer: Serializers::Vm, template: "vm/show"
 
       r.show_object(vm, actions: %w[overview networking settings], perm: "Vm:view", template: "vm/show")
 

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -322,6 +322,7 @@ RSpec.describe Validation do
         nil,
         "",
         " John Doe",
+        "John Doe ",
         "1john Doe",
         ".john Doe",
         "https://example.com",

--- a/spec/routes/web/account_spec.rb
+++ b/spec/routes/web/account_spec.rb
@@ -207,5 +207,19 @@ RSpec.describe Clover, "account" do
       click_button "Remove All Multifactor Authentication Methods"
       expect(page).to have_flash_notice "All multifactor authentication methods have been disabled"
     end
+
+    it "allows renaming account" do
+      visit "/account/rename"
+
+      fill_in "name", with: "Invalid Name !@#"
+      click_button "Rename"
+      expect(page).to have_flash_error "Validation failed for following fields: name"
+
+      fill_in "name", with: "New Name"
+      click_button "Rename"
+
+      expect(page).to have_flash_notice "Name updated"
+      expect(Account.first.name).to eq "New Name"
+    end
   end
 end

--- a/views/account/rename.erb
+++ b/views/account/rename.erb
@@ -1,0 +1,21 @@
+<% @page_title = "Change Name" %>
+
+<%== part("components/page_header", title: "My Account") %>
+
+<main>
+  <div class="max-w-screen-xl pb-6 lg:pb-16">
+    <div class="overflow-hidden rounded-lg bg-white shadow">
+      <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
+        <%== render("account/submenu") %>
+        <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
+          <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
+            <h2 class="text-lg font-medium leading-6 text-gray-900">Change Name</h2>
+            <% form(action: "#{path(current_account)}/rename", method: :post) do %>
+              <%== part("components/rename_object_input", object: current_account) %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/views/account/submenu.erb
+++ b/views/account/submenu.erb
@@ -6,6 +6,7 @@
         ["Login Methods", "/account/login-method", "hero-finger-print", disallow_login_methods],
         ["#{rodauth.has_password? ? "Change" : "Create"} Password", "/account/change-password", "hero-key", disallow_login_methods],
         ["Change Email", "/account/change-login", "hero-envelope", disallow_login_methods],
+        ["Change Name", "/account/rename", "hero-document-text", disallow_login_methods],
         ["Close Account", "/account/close-account", "hero-x-circle"]
       ].each do |label, url, icon, disallowed| %>
       <% next if disallowed %>

--- a/views/components/rename_object_input.erb
+++ b/views/components/rename_object_input.erb
@@ -1,9 +1,10 @@
-<%# locals: (object:, type:, text: nil) %>
+<%# locals: (object:, type: nil, text: nil) %>
 
 <div class="sm:flex sm:items-center sm:justify-between">
   <div>
-    <h3 class="text-base font-semibold leading-6 text-gray-900">Rename
-      <%= type %></h3>
+    <% if type %>
+      <h3 class="text-base font-semibold leading-6 text-gray-900">Rename <%= type %></h3>
+    <% end %>
     <% if text %>
       <div class="mt-2 text-sm text-gray-500">
         <p><%= text %></p>


### PR DESCRIPTION
# !! It doesn't have tests yet !!

- **Combine account password change and login pages**
  Previously, we had separate pages for changing passwords and logging in,
  which was unnecessary. This change combines them into a single unified
  page for a simpler user experience.
  
  I plan to add account renaming functionality to this page in a future
  commit.
  

- **Add path helper to account model**
  

- **Do not check authorization for renaming if it's passed as nil explicitly**
  We don't need to check authorization for all cases such as renaming
  accounts.
  

- **Skip storing audit logs when no project context is available**
  Some actions, such as renaming accounts, call the audit_log helper
  without a project context. In these cases, there's no relevant project
  information to log, so we now skip storing audit logs when the project
  context is missing.
  

- **Add account renaming functionality**
  Thanks to @jeremyevans's renaming helpers, it was straightforward to
  implement.
  
<img width="5120" height="2060" alt="account_rename" src="https://github.com/user-attachments/assets/e30c70bc-475a-4301-915c-68f0ef6d07d5" />

