### PR TITLE
Fix postgres api spec nondeterminism

### DIFF
--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -639,8 +639,7 @@ RSpec.describe Clover, "postgres" do
         get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/firewall-rule"
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)["items"][0]["cidr"]).to eq("0.0.0.0/0")
-        expect(JSON.parse(last_response.body)["items"][1]["cidr"]).to eq("::/0")
+        expect(JSON.parse(last_response.body)["items"].map { it["cidr"] }.sort).to eq(%w[0.0.0.0/0 ::/0])
         expect(JSON.parse(last_response.body)["count"]).to eq(2)
       end
     end


### PR DESCRIPTION
This has always been there, since the dataset was unordered. It must have been exposed by the firewall rule description schema change.

This will be changed in the upcoming pg/k8s networking change, which changes the dataset to one that uses an order.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix nondeterministic behavior in `postgres_spec.rb` by sorting CIDR entries in firewall rule test for consistent results.
> 
>   - **Behavior**:
>     - Fix nondeterministic behavior in `postgres_spec.rb` by sorting CIDR entries in firewall rule test.
>     - Ensures consistent test results by comparing sorted CIDR entries.
>   - **Tests**:
>     - Update in `postgres_spec.rb` to sort CIDR entries before asserting equality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for df6870ee5432a09b3b131ac457b77c16e3b88216. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->