### PR TITLE
Allow rhizome to handle VM init scripts in setup-vm

### DIFF
--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -68,6 +68,7 @@ begin
   slice_name = params.fetch("slice_name", "system.slice")
   cpu_percent_limit = params.fetch("cpu_percent_limit", 0)
   cpu_burst_percent_limit = params.fetch("cpu_burst_percent_limit", 0)
+  init_script = params.fetch("init_script", "")
   ipv6_disabled = params.fetch("ipv6_disabled", false)
 rescue KeyError => e
   puts "Needed #{e.key} in parameters json"
@@ -86,7 +87,8 @@ when "prep"
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets, swap_size_bytes,
     pci_devices, boot_image, dns_ipv4,
-    slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled)
+    slice_name, cpu_percent_limit, cpu_burst_percent_limit,
+    init_script, ipv6_disabled)
 when "recreate-unpersisted"
   secrets = JSON.parse($stdin.read)
   unless (storage_secrets = secrets["storage"])

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -57,9 +57,10 @@ class VmSetup
 
   def prep(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology,
     mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices,
-    boot_image, dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled)
+    boot_image, dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit,
+    init_script, ipv6_disabled)
 
-    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled: ipv6_disabled)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled: ipv6_disabled, init_script: init_script)
     network_thread = Thread.new do
       setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, dns_ipv4, multiqueue: max_vcpus > 1)
     end
@@ -482,7 +483,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "ip netns exec #{q_vm} nft -f #{vp.q_nftables_conf}"
   end
 
-  def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled:)
+  def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled:, init_script: nil)
     vp.write_meta_data(<<EOS)
 instance-id: #{yq(@vm_name)}
 local-hostname: #{yq(@vm_name)}
@@ -563,7 +564,7 @@ ethernets:
 #{ethernets}
 EOS
 
-    write_user_data(unix_user, public_keys, swap_size_bytes, boot_image)
+    write_user_data(unix_user, public_keys, swap_size_bytes, boot_image, init_script: init_script)
 
     FileUtils.rm_rf(vp.cloudinit_img)
     r "mkdosfs -n CIDATA -C #{vp.q_cloudinit_img} 128"
@@ -584,7 +585,7 @@ EOS
     SWAP_CONFIG
   end
 
-  def write_user_data(unix_user, public_keys, swap_size_bytes, boot_image)
+  def write_user_data(unix_user, public_keys, swap_size_bytes, boot_image, init_script: nil)
     install_cmd = if boot_image.include?("almalinux")
       "  - [dnf, install, '-y', nftables]\n"
     elsif boot_image.include?("debian")
@@ -601,6 +602,8 @@ YAML
   - [nft, add, rule, ip6, filter, output, ip6, daddr, 'fd00:0b1c:100d:5AFE::/64', meta, skuid, "!=", 0, tcp, flags, syn, reject, with, tcp, reset]
 NFT_ADD_COMMS
 
+    init_script_cmd = "  - #{yq(init_script)}\n" if init_script
+
     vp.write_user_data(<<EOS)
 #cloud-config
 users:
@@ -615,6 +618,7 @@ ssh_pwauth: False
 runcmd:
   - [systemctl, daemon-reload]
 #{install_cmd}
+#{init_script_cmd}
 
 bootcmd:
 #{nft_safe_sudo_allow}


### PR DESCRIPTION
This recognizes an init_script param, and adds the execution of it as a runcmd.

Separated out of #4079 to allow for easier phased deployment.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `init_script` parameter to VM setup for executing custom scripts during initialization, modifying `setup-vm` and `vm_setup.rb`.
> 
>   - **Behavior**:
>     - Adds `init_script` parameter to `setup-vm` and `vm_setup.rb` for executing custom scripts during VM initialization.
>     - Updates `prep` function in `vm_setup.rb` to pass `init_script` to `cloudinit`.
>     - Modifies `cloudinit` and `write_user_data` functions to include `init_script` in the `runcmd` section.
>   - **Misc**:
>     - Extracted from #4079 for phased deployment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1816821fd715a57fcc22cace366e7f040af7aa52. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->