### PR TITLE
Mark when prep/create_billing_record are done in Prog::Vm::Nexus

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -330,6 +330,8 @@ class Prog::Vm::Nexus < Prog::Base
     case host.sshable.cmd("common/bin/daemonizer --check prep_#{q_vm}")
     when "Succeeded"
       vm.nics.each(&:incr_setup_nic)
+      strand.stack[-1]["prep_done"] = true
+      strand.modified!(:stack)
       hop_clean_prep
     when "NotStarted", "Failed"
       secrets_json = JSON.generate({
@@ -380,6 +382,8 @@ class Prog::Vm::Nexus < Prog::Base
     Clog.emit("vm provisioned") { [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host&.ubid, duration: (Time.now - vm.allocated_at).round(3)}}] }
 
     project = vm.project
+    strand.stack[-1]["create_billing_record_done"] = true
+    strand.modified!(:stack)
     hop_wait unless project.billable
 
     BillingRecord.create(


### PR DESCRIPTION
This will allow safe reordering of the create_billing_record/prep order, to ensure that a VM does not go through either twice or skip either.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Marks completion of `prep` and `create_billing_record` tasks in `Prog::Vm::Nexus` to prevent duplicate execution.
> 
>   - **Behavior**:
>     - Marks `prep` completion by setting `"prep_done"` in `strand.stack` in `before_run`.
>     - Marks `create_billing_record` completion by setting `"create_billing_record_done"` in `strand.stack` in `write_params_json`.
>     - Calls `strand.modified!(:stack)` after marking each task as done to ensure changes are saved.
>   - **Misc**:
>     - These changes help prevent tasks from being executed twice or skipped, ensuring consistency in VM provisioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4d9fa3fbd040e447d724d201ba0c634e8d364d61. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->