### PR TITLE
Cleanup prep_done/create_billing_record_done stack setting

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -254,8 +254,6 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     Clog.emit("vm provisioned") { [vm, {provision: {vm_ubid: vm.ubid, instance_id: vm.aws_instance.instance_id, duration: (Time.now - vm.allocated_at).round(3)}}] }
 
     project = vm.project
-    strand.stack[-1]["create_billing_record_done"] = true
-    strand.modified!(:stack)
     hop_wait unless project.billable
 
     BillingRecord.create(

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -660,7 +660,6 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(vm).to receive(:update).with(display_state: "running", provisioned_at: now).and_return(true)
       expect(Clog).to receive(:emit).with("vm provisioned").and_yield
       allow(vm).to receive(:allocated_at).and_return(now - 100)
-      nx.strand.stack[-1]["create_billing_record_done"] = true
       expect { nx.wait_sshable }.to hop("wait")
     end
 
@@ -672,7 +671,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(vm).to receive(:update).with(display_state: "running", provisioned_at: now).and_return(true)
       expect(Clog).to receive(:emit).with("vm provisioned").and_yield
       allow(vm).to receive(:allocated_at).and_return(now - 100)
-      expect { nx.wait_sshable }.to hop("create_billing_record")
+      expect { nx.wait_sshable }.to hop("wait")
     end
   end
 
@@ -706,8 +705,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       vm.ip4_enabled = true
       adr = Address.create(cidr: "192.168.1.0/24", routed_to_host_id: vm_host.id)
       AssignedVmAddress.create(ip: "192.168.1.1", address_id: adr.id, dst_vm_id: vm.id)
-      nx.strand.stack[-1]["prep_done"] = true
-      expect { nx.create_billing_record }.to hop("wait")
+      expect { nx.create_billing_record }.to hop("prep")
         .and change(BillingRecord, :count).from(0).to(2)
       expect(vm.active_billing_records.map { it.billing_rate["resource_type"] }.sort).to eq(["IPAddress", "VmVCpu"])
     end


### PR DESCRIPTION
After all VMs who were in prep, clean_prep, or wait_sshable before the switch to create billing records before prep have reached wait, we don't need to check flags, we can assume normal control flow at that point.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove unnecessary `create_billing_record_done` and `prep_done` flag checks in AWS and Metal VM `nexus.rb` files, simplifying control flow.
> 
>   - **Behavior**:
>     - Remove `create_billing_record_done` and `prep_done` flag checks in `before_run` and `create_billing_record` in `nexus.rb` for AWS and Metal VMs.
>     - Assume normal control flow without these flags as all VMs have transitioned past relevant states.
>   - **Tests**:
>     - Update `nexus_spec.rb` to align with the removal of flag checks, ensuring tests reflect new logic.
>     - Modify tests for `wait_sshable` and `create_billing_record` to reflect changes in control flow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5406d34171c061d5f98ab815fe62870885e79d2c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->