### PR TITLE
Remove invalid request method for firewall path from openapi.yml

### DIFF
--- a/bin/check-needed-openapi-paths
+++ b/bin/check-needed-openapi-paths
@@ -13,16 +13,20 @@ unnecessary_paths = []
 
 # Run all api specs with one path deleted. If there is not a failure,
 # the path isn't actually needed and should be removed.
-paths.keys.each do |path|
-  value = paths.delete(path)
-  File.write(file, YAML.dump(openapi))
-  print "#{path}..."
-  if system("rake api_spec >/dev/null 2>&1")
-    unnecessary_paths << path
-    puts "NOT NEEDED"
-  else
-    puts "needed"
-    paths[path] = value
+paths.each do |path, methods|
+  methods.keys.each do |meth|
+    next if meth == "parameters"
+    value = methods.delete(meth)
+    File.write(file, YAML.dump(openapi))
+    method_path = "#{meth.upcase} #{path}"
+    print "#{method_path}..."
+    if system("rake api_spec >/dev/null 2>&1")
+      unnecessary_paths << method_path
+      puts "NOT NEEDED"
+    else
+      puts "needed"
+      methods[meth] = value
+    end
   end
 end
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -86,32 +86,6 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Firewall
-    post:
-      operationId: createFirewall
-      summary: Create a new firewall
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                description:
-                  description: Description of the firewall
-                  type: string
-                name:
-                  description: Name of the firewall
-                  type: string
-              additionalProperties: false
-              required:
-                - name
-      responses:
-        '200':
-          $ref: '#/components/responses/Firewall'
-        default:
-          $ref: '#/components/responses/Error'
-      tags:
-        - Firewall
   '/project/{project_id}/inference-api-key':
     parameters:
       - $ref: '#/components/parameters/project_id'


### PR DESCRIPTION
While working on #4101, I came across a bogus openapi.yml entry, which I removed in 61d036ced03cad670efb834ee059a21b0d991e9c.

This led me to believe there may be other bogus entries. I modified bin/check-needed-openapi-paths to not just check whether a path was needed, but whether the request method + path combination was needed. It only found a single other bogus path
(`POST /project/{project_id}/firewall`), which this removes. The correct path to create a firewall is
`POST /project/{project_id}/location/{location}/firewall/{firewall_reference}`, which remains.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary `POST /project/{project_id}/firewall` from `openapi.yml` and update `check-needed-openapi-paths` to check method-path combinations.
> 
>   - **Behavior**:
>     - Removes `POST /project/{project_id}/firewall` from `openapi.yml` as it was not needed.
>     - The correct path for creating a firewall is `POST /project/{project_id}/location/{location}/firewall/{firewall_reference}`.
>   - **Scripts**:
>     - Updates `check-needed-openapi-paths` to check for unnecessary method-path combinations instead of just paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8d4b2347936aba11f0e5939a2ba87401cfefef48. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->