### PR TITLE
Remove deletion from postgres_firewall_rule when destroying postgres resource

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -23,11 +23,6 @@ class PostgresResource < Sequel::Model
   plugin SemaphoreMethods, :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy, :promote, :refresh_certificates, :use_different_az
   include ObjectTag::Cleanup
 
-  def before_destroy
-    DB[:postgres_firewall_rule].where(postgres_resource_id: id).delete
-    super
-  end
-
   def display_location
     location.display_name
   end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -170,13 +170,6 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.pg_firewall_rules).to eq []
   end
 
-  it "#destroy works if there are left over postgres_firewall_rules referencing resource" do
-    postgres_resource.update(project_id: Project.create(name: "t").id, target_vm_size: "standard-2", target_storage_size_gib: 64, location_id: Location::HETZNER_FSN1_ID)
-    DB[:postgres_firewall_rule].insert(id: postgres_resource.id, postgres_resource_id: postgres_resource.id, cidr: "::/0")
-    postgres_resource.destroy
-    expect(DB[:postgres_firewall_rule].count).to eq 0
-  end
-
   describe "display_state" do
     it "returns 'deleting' when strand label is 'destroy'" do
       expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "destroy")).at_least(:once)


### PR DESCRIPTION
The postgres_firewall_rule table is no longer used, and will be dropped after this commit.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `before_destroy` callback in `PostgresResource` for `postgres_firewall_rule` cleanup, as the table is deprecated.
> 
>   - **Behavior**:
>     - Removes `before_destroy` callback in `PostgresResource` that deleted entries from `postgres_firewall_rule`.
>   - **Tests**:
>     - Removes test for `#destroy` handling leftover `postgres_firewall_rule` entries in `postgres_resource_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f8fb7ef37f1aa495807769bbe553fd090e3656f3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->