### PR TITLE
Update AWS runner images

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -172,8 +172,8 @@ module Config
   override :github_ubuntu_2404_version, "20251105.1.0", string
   override :github_ubuntu_2204_version, "20251105.1.0", string
   override :github_gpu_ubuntu_2204_version, "20251017.1.0", string
-  override :github_ubuntu_2204_aws_ami_version, "ami-04b5534ef1aed6bde", string
-  override :github_ubuntu_2404_aws_ami_version, "ami-0908b850ff3e635a2", string
+  override :github_ubuntu_2204_aws_ami_version, "ami-06f02994ea7801a2d", string
+  override :github_ubuntu_2404_aws_ami_version, "ami-0b44ef7a91252a724", string
   override :postgres_ubuntu_2204_version, "20251103.1.0", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string


### PR DESCRIPTION
Updating AWS runner images for 2204 and 2404. These AMIs are the first ones created directly on AWS with packer and include the latest runner application version
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update AWS AMI versions for Ubuntu 2204 and 2404 in `config.rb`.
> 
>   - **AWS AMI Updates**:
>     - Update `github_ubuntu_2204_aws_ami_version` to `ami-06f02994ea7801a2d` in `config.rb`.
>     - Update `github_ubuntu_2404_aws_ami_version` to `ami-0b44ef7a91252a724` in `config.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3b1a2129c3bcbc2aa1fab5815d42c441be6c5e1b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->