### PR TITLE
Add BYOC (AWS) dummy location selector

### DIFF
--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -1,4 +1,4 @@
-<%# locals: (name:, label:, options:, attributes:) %>
+<%# locals: (name:, label:, options:, additional_element: nil, description_html: nil, attributes:) %>
 <% selected = typecast_body_params.str(name) || selected
 error = flash.dig("errors", name)
 is_content_array = options[0][1].is_a?(Array) %>
@@ -33,9 +33,11 @@ is_content_array = options[0][1].is_a?(Array) %>
           <% end %>
         </label>
       <% end %>
+      <%== additional_element %>
     </div>
   </fieldset>
   <% if error %>
     <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
   <% end %>
+  <%== description_html %>
 </div>

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -63,7 +63,7 @@ let option_dirty = <%==JSON.generate(form_elements.map { it[:name] }.each_with_o
 
     case type
     when "radio_small_cards"
-      locals = {name:, label:, options:, attributes:}
+      locals = {name:, label:, options:, attributes:, description_html: element[:description_html], additional_element: element[:additional_element]}
     when "select"
       locals = {name:, label:, options:, placeholder:, attributes:, description_html: element[:description_html]}
     when "checkbox"

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -26,10 +26,13 @@
 ) %>
 
 <%
+  byoc_description_html = "<p class='mt-1 text-sm leading-6 text-gray-600'>To run Ubicloud Postgres in your own AWS account using <a href='https://www.ubicloud.com/postgresql-on-aws-high-iops' class='text-orange-600 hover:text-orange-700'>BYOC (AWS)</a>, email us at <a href='mailto:support@ubicloud.com' class='text-orange-600 hover:text-orange-700'>support@ubicloud.com</a></p>"
+  additional_element = "<label class=\"form_flavor form_flavor_standard cursor-not-allowed\"><input type='radio' name='byoc' value='byoc' class='peer sr-only' disabled><span class=\"radio-small-card justify-center p-3 text-sm font-semibold pointer-events-none bg-gray-100 text-gray-500\">Your Own AWS Account</span></label>"
+
   form_elements = [
     {name: "flavor", type: "hidden", value: @flavor},
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-3'>"},
-    {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Postgres.method(:location)},
+    {name: "location", type: "radio_small_cards", label: "Location", required: "required", additional_element:, description_html: byoc_description_html, content_generator: ContentGenerator::Postgres.method(:location)},
     {name: "family", type: "radio_small_cards", label: "Server family", required: "required", content_generator: ContentGenerator::Postgres.method(:family)},
     {name: "size", type: "radio_small_cards", label: "Server size", required: "required", content_generator: ContentGenerator::Postgres.method(:size)},
     {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Postgres.method(:storage_size)},


### PR DESCRIPTION
Since we have recently introduced Ubi PG on AWS and we are capable of
running inside the customer account, we are adding a dummy location
selector to the console UI. This way, we will point the interested
parties and allow list manually. It will require AMI sharing and
location creation using PrivateLocation.

<img width="3212" height="2024" alt="CleanShot 2025-10-30 at 16 00 41@2x" src="https://github.com/user-attachments/assets/089808cf-12e6-4862-a20c-947b2a04d38d" />
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add dummy location selector for BYOC (AWS) in console UI with form updates for additional elements and descriptions.
> 
>   - **UI Changes**:
>     - Add dummy location selector for BYOC (AWS) in `create.erb` with `additional_element` and `byoc_description_html`.
>     - Update `radio_small_cards.erb` to support `additional_element` and `description_html`.
>   - **Form Logic**:
>     - Modify `resource_creation_form.erb` to pass `additional_element` and `description_html` to `radio_small_cards` type elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5a533e3ee14a428c2b059266ff9f377f6f0bcb5d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->