### PR TITLE
Avoid nondeterministic spec errors related to non-unique ephemeral_net6

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -300,6 +300,17 @@ class Vm < Sequel::Model
     }.to_h
   end
 
+  def save_with_ephemeral_net6_error_retrying(vm_host, max_retries: 2)
+    save_changes
+  rescue Sequel::ValidationFailed
+    if errors.keys == [:ephemeral_net6] && max_retries > 0
+      max_retries -= 1
+      self.ephemeral_net6 = vm_host.ip6_random_vm_network.to_s
+      retry
+    end
+    raise
+  end
+
   include Validation::PublicKeyValidation
 
   private

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -263,7 +263,8 @@ module Scheduling::Allocator
         allocated_at: Time.now
       }
       update_args[:family] = vm_host.family if vm.family != "burstable"
-      vm.update(**update_args)
+      vm.set(**update_args)
+      vm.save_with_ephemeral_net6_error_retrying(vm_host)
       AssignedVmAddress.create(dst_vm_id: vm.id, ip: ip4.to_s, address_id: address.id) if ip4
       vm.sshable&.update(host: vm.ip4_string || vm.ip6_string)
     end


### PR DESCRIPTION
Add Vm#save_with_ephemeral_net6_error_retrying, which will retry with a new random ip6 network if saving with the current one fails. By default, it will attempt to save only three times, then give up.

This should fix multiple different nondeterministic exceptions I've seen both locally and in CI.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `save_with_ephemeral_net6_error_retrying` to handle non-unique `ephemeral_net6` errors by retrying with a new IP, improving VM allocation reliability.
> 
>   - **Behavior**:
>     - Adds `save_with_ephemeral_net6_error_retrying` to `Vm` in `vm.rb`, which retries saving with a new `ephemeral_net6` if a `Sequel::ValidationFailed` error occurs due to non-unique `ephemeral_net6`. Defaults to 3 retries.
>     - Updates `update_vm` in `allocator.rb` to use `save_with_ephemeral_net6_error_retrying`.
>   - **Tests**:
>     - Adds tests for `save_with_ephemeral_net6_error_retrying` in `vm_spec.rb` to cover successful save, retry on `ephemeral_net6` error, and raise on other errors or after max retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e02b1bdce62f6590b5f473b0e42c6ac9c6fc9b24. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->