### PR TITLE
Avoid Prog::Test2 superclass mismatch error when reloading in development environment

### DIFF
--- a/prog/test.rb
+++ b/prog/test.rb
@@ -170,7 +170,7 @@ class Prog::Test < Prog::Base
   def find_current_prog
     Base.current_prog
   end
-end
 
-class Prog::Test2 < Prog::Test
+  class Test2 < self
+  end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe Prog::Base do
     end
 
     it "can create pages for progs that are not on the top of the stack" do
-      st = Strand.create(prog: "Test2", label: "pusher1")
+      st = Strand.create(prog: "Test::Test2", label: "pusher1")
       st.stack.first["deadline_target"] = "t1"
       st.stack.first["deadline_at"] = Time.now + 1
       st.unsynchronized_run
@@ -374,7 +374,7 @@ RSpec.describe Prog::Base do
       }.to change { Page.active.count }.from(0).to(2)
 
       expect(Page.all.map(&:summary)).to include(
-        "#{st.ubid} has an expired deadline! Test2.pusher2 did not reach t1 on time",
+        "#{st.ubid} has an expired deadline! Test::Test2.pusher2 did not reach t1 on time",
         "#{st.ubid} has an expired deadline! Test.pusher2 did not reach t2 on time"
       )
     end


### PR DESCRIPTION
Nest Test2 under Prog::Test so that when Prog::Test is reloaded, there is no superclass mismatch. This is only used in one test. I'm not sure why the spec uses a subclass, since it appears to be testing stacks and not subclass-specific behavior, but this seems to be a simple way to fix the issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Nest `Test2` under `Prog::Test` to avoid superclass mismatch errors during reloading, updating `base_spec.rb` accordingly.
> 
>   - **Behavior**:
>     - Nest `Test2` under `Prog::Test` in `test.rb` to prevent superclass mismatch errors during reloading.
>     - Update `base_spec.rb` to use `Test::Test2` instead of `Test2` in the relevant test case.
>   - **Misc**:
>     - The change is only relevant to one test case and does not affect subclass-specific behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 39266de9fba36b51865820702a716ca953c28ffd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->