### PR TITLE
Show attached PostgreSQL database and Kubernetes cluster on private subnet VMs page

### DIFF
--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -273,6 +273,15 @@ RSpec.describe Clover, "Kubernetes" do
         expect(page.body).to include "auto-refresh hidden"
       end
 
+      it "shows up on customer private subnet vms page" do
+        visit "#{project.path}/location/#{kc.display_location}/private-subnet/#{kc.private_subnet.ubid}/vms"
+        expect(page.title).to eq "Ubicloud - mysubnet"
+        expect(page.all("#private-subnet-nics h3").map(&:text)).to eq ["Attached VMs", "Other Attached Resources"]
+        expect(page.all("#private-subnet-nics td").map(&:text)).to eq ["No VM attached", "Kubernetes Cluster", kc.name, kc.ubid]
+        click_link kc.name
+        expect(page.title).to eq "Ubicloud - #{kc.name}"
+      end
+
       it "works with ubid" do
         visit "#{project.path}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}"
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -283,6 +283,15 @@ RSpec.describe Clover, "postgres" do
         expect(page).to have_content pg.name
       end
 
+      it "shows up on customer private subnet vms page" do
+        visit "#{project.path}/location/#{pg.display_location}/private-subnet/#{pg.private_subnet.ubid}/vms"
+        expect(page.title).to eq "Ubicloud - #{pg.ubid}-subnet"
+        expect(page.all("#private-subnet-nics h3").map(&:text)).to eq ["Attached VMs", "Other Attached Resources"]
+        expect(page.all("#private-subnet-nics td").map(&:text)).to eq ["No VM attached", "PostgreSQL Database", pg.name, pg.ubid]
+        click_link pg.name
+        expect(page.title).to eq "Ubicloud - #{pg.name}"
+      end
+
       it "can show PostgreSQL database details even when no subpage is specified" do
         pg
         visit "#{project.path}#{pg.path}"

--- a/views/networking/private_subnet/vms.erb
+++ b/views/networking/private_subnet/vms.erb
@@ -2,7 +2,10 @@
 viewable_vm_ds = dataset_authorize(vm_ds, "Vm:view")
 displayable_vm_map, linkable_vm_map = [vm_ds, viewable_vm_ds].map! do
   it.select_hash(Sequel[:vm][:id], Sequel.as(true, :v))
-end %>
+end
+pg_resources = dataset_authorize(@project.postgres_resources_dataset.where(private_subnet_id: @ps.id), "Postgres:view").all
+kcs = dataset_authorize(@project.kubernetes_clusters_dataset.where(private_subnet_id: @ps.id), "KubernetesCluster:view").all
+other_resources = pg_resources + kcs %>
 
 <div id="private-subnet-nics" class="p-6">
   <%== part(
@@ -32,4 +35,25 @@ end %>
         ]
       end
   ) %>
+
+  <% unless other_resources.empty? %>
+    <div class="pt-4">
+      <%== part(
+        "components/table_card",
+        title: "Other Attached Resources",
+        headers: ["Type", "Name", "ID"],
+        rows:
+          other_resources.map! do |resource|
+            link = path(resource)
+            [
+              [
+                [resource.is_a?(PostgresResource) ? "PostgreSQL Database" : "Kubernetes Cluster"],
+                [resource.name, {link:}],
+                [resource.ubid, {link:}]
+              ],
+            ]
+          end
+      ) %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Currently, this is only the web page. We may want to consider including similar information in the API/CLI, but that requires consideration of how to include it and modifications to openapi.yml, so I'll leave that for later.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Display attached PostgreSQL databases and Kubernetes clusters on the private subnet VMs page with tests in `kubernetes_cluster_spec.rb` and `postgres_spec.rb`.
> 
>   - **Behavior**:
>     - Display attached PostgreSQL databases and Kubernetes clusters on the private subnet VMs page in `vms.erb`.
>     - Adds a new section "Other Attached Resources" with resource type, name, and ID.
>   - **Tests**:
>     - Adds tests in `kubernetes_cluster_spec.rb` to verify Kubernetes clusters appear on the private subnet VMs page.
>     - Adds tests in `postgres_spec.rb` to verify PostgreSQL databases appear on the private subnet VMs page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2bfef89afb00f22e40b52f224941a23a089d0b90. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->