### PR TITLE
Make ubid linker in web shell handle ubid-like output that isn't a valid ubid

### DIFF
--- a/routes/project/cli.rb
+++ b/routes/project/cli.rb
@@ -58,7 +58,11 @@ class Clover
             h("$ #{body.split("\0").prepend(@ubi_command_execute).shelljoin}")
           else
             ubids = {}
-            body.scan(UbiCli::OBJECT_INFO_REGEXP) { ubids[UBID.to_uuid(it[0])] ||= nil }
+            body.scan(UbiCli::OBJECT_INFO_REGEXP) do
+              if (uuid = UBID.to_uuid(it[0]))
+                ubids[uuid] ||= nil
+              end
+            end
             UBID.resolve_map(ubids)
             h(body).gsub(UbiCli::OBJECT_INFO_REGEXP) do
               if (obj = ubids[UBID.to_uuid(it)]) && obj.respond_to?(:path)

--- a/spec/routes/web/cli_spec.rb
+++ b/spec/routes/web/cli_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe Clover, "web shell" do
     expect(page.html).to include ">#{ps.ubid}</a>"
   end
 
+  it "handles ubid-like output that are not valid ubids" do
+    fill_in "cli", with: "ps eu-central-h1/vm78zgv9w9et4mg6pba1frsz8m create"
+    click_button "Run"
+    ps = PrivateSubnet.first
+    fill_in "cli", with: "ps list"
+    click_button "Run"
+    expect(page.html).to include " vm78zgv9w9et4mg6pba1frsz8m "
+    expect(page.html).to include ">#{ps.ubid}</a>"
+  end
+
   it "supports version" do
     fill_in "cli", with: "version"
     click_button "Run"


### PR DESCRIPTION
Check that UBID.to_uuid returns a valid uuid before adding it as an object to resolve.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `Clover` in `cli.rb` to validate UUIDs before processing UBIDs and add a test for handling invalid UBID-like strings.
> 
>   - **Behavior**:
>     - In `cli.rb`, modify `Clover` class to check if `UBID.to_uuid` returns a valid UUID before adding to `ubids`.
>     - Handles UBID-like strings that are not valid UBIDs by skipping them.
>   - **Tests**:
>     - Add test case in `cli_spec.rb` to verify handling of UBID-like output that isn't a valid UBID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 33c233c2d8d568a205984a943f2c518c734420bc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->