### PR TITLE
Reload KubernetesCluster before checking for CCM related changes

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -81,6 +81,7 @@ class Kubernetes::Client
     k8s_svc_raw = kubectl("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson")
     svc_list = JSON.parse(k8s_svc_raw)["items"]
     @load_balancer.reload
+    @kubernetes_cluster.reload
 
     return true if svc_list.empty? && !@load_balancer.ports.empty?
 

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -246,6 +246,8 @@ RSpec.describe Kubernetes::Client do
         "items" => ["metadata" => {"name" => "svc", "namespace" => "default", "creationTimestamp" => "2024-01-03T00:00:00Z"}]
       }.to_json
       allow(kubernetes_client).to receive(:kubectl).with("get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(@response)
+      expect(kubernetes_client.instance_variable_get(:@kubernetes_cluster)).to receive(:reload).at_least(:once)
+      expect(kubernetes_client.instance_variable_get(:@load_balancer)).to receive(:reload).at_least(:once)
     end
 
     it "returns true early since there are no LoadBalancer services but there is a port" do


### PR DESCRIPTION
The KubernetesCluster was cached in the Kubernetes::Client object. It did not show the correct changes for nodepool VMs, so the VM diff for the load balancer was calculated incorrectly.

Reloading it before use ensures the calculation is correct.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reloads `KubernetesCluster` in `any_lb_services_modified?` to ensure correct VM diff calculation for load balancers.
> 
>   - **Behavior**:
>     - Reloads `@kubernetes_cluster` in `any_lb_services_modified?` in `client.rb` to ensure correct VM diff calculation for load balancers.
>   - **Tests**:
>     - Adds expectations in `client_spec.rb` to verify `@kubernetes_cluster` and `@load_balancer` are reloaded in `any_lb_services_modified?`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 851f3b10a63d9ffc434cf84a264e710c5b63ec5c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->