### PR TITLE
Update to Sequel 5.98.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"
-gem "sequel", github: "jeremyevans/sequel", ref: "071d6562c47c5781cf27f6b1574c247595cdb32f"
+gem "sequel", ">= 5.98"
 gem "sequel_pg", ">= 1.8", require: "sequel"
 gem "shellwords"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,6 @@ GIT
       rodauth (~> 2.36)
 
 GIT
-  remote: https://github.com/jeremyevans/sequel.git
-  revision: 071d6562c47c5781cf27f6b1574c247595cdb32f
-  ref: 071d6562c47c5781cf27f6b1574c247595cdb32f
-  specs:
-    sequel (5.97.0)
-      bigdecimal
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -353,6 +345,8 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    sequel (5.98.0)
+      bigdecimal
     sequel-annotate (1.7.0)
       sequel (>= 4)
     sequel_pg (1.17.2)
@@ -488,7 +482,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-sequel
-  sequel!
+  sequel (>= 5.98)
   sequel-annotate
   sequel_pg (>= 1.8)
   shellwords


### PR DESCRIPTION
The pg_auto_parameterize_duplicate_query_detection extension and Database#listen fixes we were relying on have now been released.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `sequel` gem to version `>= 5.98` in `Gemfile` to utilize new extensions and fixes.
> 
>   - **Gem Update**:
>     - Update `sequel` gem version in `Gemfile` to `>= 5.98`.
>   - **Reason**:
>     - The update includes the release of `pg_auto_parameterize_duplicate_query_detection` extension and `Database#listen` fixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f5dd25ae628001bea096fe10efd11fdb32493530. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->