### PR TITLE
Add strand table to admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -266,6 +266,18 @@ class CloverAdmin < Roda
       end
     end
 
+    model Strand do
+      order Sequel.desc(:try)
+      columns do |type_symbol, request|
+        if type_symbol == :search_form
+          [:prog, :label, :try]
+        else
+          [:name, :prog, :label, :schedule, :try]
+        end
+      end
+      column_options try: {type: "number", value: nil}
+    end
+
     model Vm do
       order Sequel.desc(:created_at)
       eager [:location, :vm_host]

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -24,6 +24,8 @@ class Strand < Sequel::Model
     @subject = UBID.decode(ubid)
   end
 
+  alias_method :name, :ubid
+
   RespirateMetrics = Struct.new(:scheduled, :scan_picked_up, :worker_started, :lease_checked, :lease_acquired, :queue_size, :available_workers, :old_strand, :lease_expired) do
     def scan_delay
       scan_picked_up - scheduled

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -133,8 +133,7 @@ RSpec.describe CloverAdmin do
     click_link "hetzner-fsn1"
     expect(page.title).to eq "Ubicloud Admin - Location #{Location::HETZNER_FSN1_UBID}"
 
-    sshable = Sshable.create_with_id(VmHost.generate_uuid, host: "1.1.0.0")
-    vmh = VmHost.create_with_id(sshable.id, location_id: Location::HETZNER_FSN1_ID, family: "standard")
+    vmh = Prog::Vm::HostNexus.assemble("1.1.0.0", location_id: Location::HETZNER_FSN1_ID, family: "standard").subject
     click_link "Ubicloud Admin"
     click_link "VmHost"
     click_link "Search"
@@ -144,7 +143,7 @@ RSpec.describe CloverAdmin do
     click_button "Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [vmh.ubid, "1.1.0.0", "unprepared", "", "hetzner-fsn1", "", "standard", "", "0"]
 
-    vm = Vm.create(unix_user: "ubi", public_key: "k y", name: "vm1", location_id: Location::HETZNER_FSN1_ID, boot_image: "github-ubuntu-2204", family: "standard", arch: "x64", cores: 2, vcpus: 2, memory_gib: 8, project_id: project.id)
+    vm = Prog::Vm::Nexus.assemble("k y", project.id, unix_user: "ubi", name: "vm1", location_id: Location::HETZNER_FSN1_ID, boot_image: "github-ubuntu-2204", size: "standard-2", arch: "x64").subject
     click_link "Ubicloud Admin"
     click_link "Vm"
     click_link "Search"
@@ -194,6 +193,13 @@ RSpec.describe CloverAdmin do
     select "False", from: "Suspended"
     click_button "Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq ["", "user@example.com", "2", "github", account.created_at.to_s, ""]
+
+    click_link "Ubicloud Admin"
+    click_link "Strand"
+    click_link "Search"
+    fill_in "Prog", with: "Vm::Nexus"
+    click_button "Search"
+    expect(page.all("#autoforme_content td").map(&:text)).to eq [vm.ubid, "Vm::Nexus", "start", vm.strand.schedule.to_s, "0"]
   end
 
   it "handles basic pagination when browsing by class" do


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Strand` model to admin panel with search and display capabilities, update `Strand` model with `name` alias, and modify tests to include `Strand` functionality.
> 
>   - **Admin Panel**:
>     - Add `Strand` model to `clover_admin.rb` with columns `:name`, `:prog`, `:label`, `:schedule`, `:try`.
>     - Order `Strand` by `Sequel.desc(:try)`.
>     - Add search form columns `:prog`, `:label`, `:try`.
>   - **Model Changes**:
>     - Add `alias_method :name, :ubid` in `model/strand.rb`.
>   - **Tests**:
>     - Update `admin_spec.rb` to include tests for `Strand` model in admin panel.
>     - Add test for searching `Strand` by `prog` and verifying displayed columns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0e9dd41264a71cd825e3906aeb4093e71f939c8e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->