### PR TITLE
Change ubid type of BillingInfo from `et` to `b1`

### DIFF
--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -9,7 +9,7 @@ class BillingInfo < Sequel::Model
   one_to_many :payment_methods, order: Sequel.desc(:created_at)
   one_to_one :project
 
-  plugin ResourceMethods, etc_type: true
+  plugin ResourceMethods
 
   def stripe_data
     if (Stripe.api_key = Config.stripe_secret_key)

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe UBID do
-  let(:all_types) { described_class.constants.select { it.start_with?("TYPE_") }.map { described_class.const_get(it) } }
+  let(:type_constants) { described_class.constants.select { it.start_with?("TYPE_") } }
+  let(:all_types) { type_constants.map { described_class.const_get(it) } }
 
   it ".generate_vanity_action_type supports creating vanity ubids for action types" do
     expect(described_class.generate_vanity_action_type("Project:view").to_s).to eq "ttzzzzzzzz021gzzz0pj0v1ew0"
@@ -220,6 +221,14 @@ RSpec.describe UBID do
       ubid = described_class.generate(type).to_s
       expect(ubid).to start_with type
     }
+  end
+
+  it "types have correct ubid_type defined" do
+    (type_constants - [:TYPE_ETC, :TYPE_OBJECT_METATAG]).each do |t|
+      klass_name = t.to_s.sub(/^TYPE_/, "").split("_").map(&:capitalize).join
+      klass = Object.const_get(klass_name)
+      expect(klass.ubid_type).to eq(described_class.const_get(t))
+    end
   end
 
   it "has unique type identifiers" do


### PR DESCRIPTION
While working on something else, I realized that the ubid type of BillingInfo was set to ETC_TYPE in #3360. So all BillingInfo's after the change have their ubids start with `et` not `b1` and causing decoding to break.

This change also adds a test that check all types (with exceptions) have the correct ubid_type defined.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `ubid` type of `BillingInfo` from `et` to `b1` and add test for correct `ubid_type` in `ubid_spec.rb`.
> 
>   - **Behavior**:
>     - Change `ubid` type of `BillingInfo` from `et` to `b1` by removing `etc_type: true` from `plugin ResourceMethods` in `billing_info.rb`.
>   - **Testing**:
>     - Add test in `ubid_spec.rb` to verify all types (except `TYPE_ETC` and `TYPE_OBJECT_METATAG`) have correct `ubid_type` defined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c4444ea1b461881b6d8eef0184f22ca68ecb3da0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->