### PR TITLE
Fix N+1 query issue on load balancer list page

### DIFF
--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -2,7 +2,7 @@
 
 class Clover
   def load_balancer_list
-    dataset = dataset_authorize(@project.load_balancers_dataset, "LoadBalancer:view").eager(:private_subnet)
+    dataset = dataset_authorize(@project.load_balancers_dataset, "LoadBalancer:view").eager(private_subnet: :location)
     dataset = dataset.join(:private_subnet, id: Sequel[:load_balancer][:private_subnet_id]).where(location_id: @location.id).select_all(:load_balancer) if @location
     if api?
       paginated_result(dataset.eager(:ports), Serializers::LoadBalancer)


### PR DESCRIPTION
Multiple AI services came up with this same solution, using the following prompt:

When looking at the list of load balancers in the development environment web site, the following warning appeared in the webserver output:

```
duplicate queries detected:

times:2
sql:SELECT * FROM "location" WHERE "id" = 'caa7a807-36c5-8420-a75c-f906839dad71'
backtrace (filtered):
model/private_subnet.rb:49:in 'PrivateSubnet#display_location'
model/load_balancer.rb:28:in 'LoadBalancer#display_location'
model/load_balancer.rb:48:in 'LoadBalancer#path'
clover.rb:106:in 'block in <class:Clover>'
views/networking/load_balancer/index.erb:11:in 'block in Clover::RodaCompiledTemplates#__tilt_3056'
views/networking/load_balancer/index.erb:8:in 'Array#map'
views/networking/load_balancer/index.erb:8:in 'Clover::RodaCompiledTemplates#__tilt_3056'
helpers/load_balancer.rb:11:in 'Clover#load_balancer_list'
routes/project/load_balancer.rb:6:in 'block (2 levels) in <class:Clover>'
routes/project/load_balancer.rb:5:in 'block in <class:Clover>'
routes/project.rb:98:in 'block (2 levels) in <class:Clover>'
routes/project.rb:45:in 'block in <class:Clover>'
clover.rb:1030:in 'block in <class:Clover>'
```

Fix this warning.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes N+1 query issue in `load_balancer_list` method of `Clover` class by changing eager loading strategy to preload `location` with `private_subnet`.
> 
>   - **Behavior**:
>     - Fixes N+1 query issue in `load_balancer_list` method of `Clover` class in `helpers/load_balancer.rb` by changing eager loading strategy.
>     - Uses `eager(private_subnet: :location)` to preload `location` associated with `private_subnet`.
>   - **Performance**:
>     - Reduces duplicate queries when displaying load balancer list, improving performance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8ac25f19d9ce70bfd2b95320e89d2b4ae946d5c6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->