### PR TITLE
Fix strand test with undeterministic mock count

### DIFF
--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -90,9 +90,11 @@ RSpec.describe Strand do
   end
 
   it "logs end of strand if it took long" do
+    now = Time.now
     st.label = "napper"
     st.save_changes
-    expect(Time).to receive(:now).and_return(Time.now - 10, Time.now, Time.now)
+    expect(Time).to receive(:now).and_return(now - 10)
+    expect(Time).to receive(:now).and_return(now).at_least(:once)
     expect(Clog).to receive(:emit).with("finished strand").and_call_original
     st.unsynchronized_run
   end


### PR DESCRIPTION
This test mysteriously fails on my local machine even on the main branch, but it seems to pass on CI. It might be a macOS specific issue.

    Failures:

      1) Strand logs end of strand if it took long
        Failure/Error: expect(Time).to receive(:now).and_return(Time.now - 10, Time.now, Time.now)

          (Time (class)).now(*(any args))
              expected: 3 times with any arguments
              received: 4 times with any arguments
        # ./spec/model/strand_spec.rb:95:in 'block (2 levels) in <top (required)>'
        # ./spec/spec_helper.rb:60:in 'block (3 levels) in <top (required)>'
        # ./spec/spec_helper.rb:59:in 'block (2 levels) in <top (required)>'

    Finished in 46.92 seconds (files took 6.28 seconds to load)
    4108 examples, 1 failure

    Failed examples:

    rspec ./spec/model/strand_spec.rb:92 # Strand logs end of strand if it took long

Since we are generally loose on the mock count and don't specify an exact number, we can loosen this test by using `.at_least(:once)` as well.

Interestingly, we're mocking `Time.now`, but the mock returns the actual `Time.now` again.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix undeterministic mock count issue in `strand_spec.rb` by adjusting `Time.now` expectations.
> 
>   - **Test Fix**:
>     - In `strand_spec.rb`, fix test failure by changing `expect(Time).to receive(:now)` to use `.at_least(:once)` for the second call.
>     - This change addresses an undeterministic mock count issue, likely specific to macOS, where the test expected 3 calls but received 4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 487f3dc44e40ef3352e0e580130eb5e603e68375. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->