### PR TITLE
Destroy runner when its prog is popped due to inactive project

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -173,7 +173,10 @@ class Prog::Vm::GithubRunner < Prog::Base
   end
 
   label def start
-    pop "Could not provision a runner for inactive project" unless github_runner.installation.project.active?
+    unless github_runner.installation.project.active?
+      github_runner.destroy
+      pop "Could not provision a runner for inactive project"
+    end
     hop_wait_concurrency_limit unless quota_available?
     hop_apply_custom_label_quota if github_runner.custom_label
     hop_allocate_vm

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -326,6 +326,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       expect(project).to receive(:active?).and_return(false)
 
       expect { nx.start }.to exit({"msg" => "Could not provision a runner for inactive project"})
+      expect(GithubRunner[runner.id]).to be_nil
     end
   end
 


### PR DESCRIPTION
If the project of installation is inactive (e.g., account suspended), we pop runner prog.

However, we should also destroy the runner itself; otherwise, it remains in the database indefinitely.

There are some leftover runners currently, which I will destroy.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Destroy runner in `start` method of `github_runner.rb` if project is inactive before popping the program.
> 
>   - **Behavior**:
>     - In `github_runner.rb`, `start` method now destroys the runner if the project is inactive before popping the program.
>   - **Tests**:
>     - In `github_runner_spec.rb`, added expectation to verify runner is destroyed when project is inactive in `#start` test.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3e3509bcfaa1f7050090d91b74d28074d778db95. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->