### PR TITLE
Log instance id for alien vms

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -51,6 +51,7 @@ class GithubRunner < Sequel::Model
         values[:vm_host_ubid] = vm.vm_host.ubid
         values[:data_center] = vm.vm_host.data_center
       end
+      values[:instance_id] = vm.aws_instance.instance_id if vm.aws_instance
       values[:vm_pool_ubid] = VmPool[vm.pool_id].ubid if vm.pool_id
     end
     Clog.emit(message) { {message => values} }

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -377,7 +377,7 @@ class Prog::Vm::Nexus < Prog::Base
   label def create_billing_record
     vm.update(display_state: "running", provisioned_at: Time.now)
 
-    Clog.emit("vm provisioned") { [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host&.ubid, duration: (Time.now - vm.allocated_at).round(3)}}] }
+    Clog.emit("vm provisioned") { [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host&.ubid, instance_id: vm.aws_instance&.instance_id, duration: (Time.now - vm.allocated_at).round(3)}}] }
 
     project = vm.project
     hop_wait unless project.billable

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -61,11 +61,13 @@ RSpec.describe GithubRunner do
   it "can log duration when vm does not have vm_host" do
     github_runner.vm.update(vm_host_id: nil)
     vm = github_runner.vm
+    AwsInstance.create_with_id(vm.id, instance_id: "i-0123456789abcdefg")
     expect(clog_emit_hash).to eq({
       repository_name: "test-repo",
       ubid: github_runner.ubid,
       label: github_runner.label,
       duration: 10,
+      instance_id: "i-0123456789abcdefg",
       conclusion: nil,
       vm_ubid: vm.ubid,
       arch: vm.arch,

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -841,6 +841,7 @@ RSpec.describe Prog::Vm::Nexus do
     it "creates a billing record when host is nil, too" do
       expect(vm).to receive(:vm_host).and_return(nil)
       vm.location.provider = "aws"
+      AwsInstance.create_with_id(vm.id, instance_id: "i-0123456789abcdefg")
       expect(BillingRecord).to receive(:create).once
       expect(vm).to receive(:project).and_return(prj).at_least(:once)
 


### PR DESCRIPTION
Alien vms don’t have a VM host; they use an aws_instance resource instead.

I've found myself needing the instance id multiple times in the past, so this adds instance_id to our lifecycle logs for easier debugging.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Log `instance_id` for alien VMs using `aws_instance` in lifecycle logs for easier debugging.
> 
>   - **Behavior**:
>     - Log `instance_id` for VMs using `aws_instance` in `log_duration()` in `github_runner.rb` and `create_billing_record()` in `nexus.rb`.
>   - **Tests**:
>     - Update `github_runner_spec.rb` to test logging of `instance_id` when `vm_host` is nil.
>     - Update `nexus_spec.rb` to test billing record creation with `instance_id` when `vm_host` is nil.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 887f796c530b79b31cf2d88a73723589b8b07e33. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->