### PR TITLE
Add BillingInfo.fix_ids to change et ubids to bi ubids

### DIFF
--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -61,6 +61,45 @@ class BillingInfo < Sequel::Model
       fail "Unexpected response from VAT service: #{status}"
     end
   end
+
+  # :nocov:
+  def self.fix_ids
+    DB.run "ALTER TABLE project ALTER CONSTRAINT project_billing_info_id_fkey DEFERRABLE INITIALLY IMMEDIATE"
+    DB.run "ALTER TABLE payment_method ALTER CONSTRAINT payment_method_billing_info_id_fkey DEFERRABLE INITIALLY IMMEDIATE"
+
+    # Find all BillingInfo records with ubids starting with "et" and change to "bi"
+    DB.transaction do
+      DB.run "SET CONSTRAINTS ALL DEFERRED"
+
+      # Iterate through all BillingInfo records and check if their ubid starts with "et"
+      all.each do |billing_info|
+        old_ubid = billing_info.ubid
+        next unless old_ubid.start_with?("et")
+
+        print "Fixing id for BillingInfo #{old_ubid}..."
+
+        old_id = billing_info.id
+        new_id = BillingInfo.generate_uuid
+
+        # Update the billing_info.id
+        DB[:billing_info].where(id: old_id).update(id: new_id)
+
+        # Update references in project table
+        DB[:project].where(billing_info_id: old_id).update(billing_info_id: new_id)
+
+        # Update references in payment_method table
+        DB[:payment_method].where(billing_info_id: old_id).update(billing_info_id: new_id)
+
+        puts "done, new_ubid: #{UBID.from_uuidish(new_id)}"
+      end
+    end
+
+    nil
+  ensure
+    DB.run "ALTER TABLE project ALTER CONSTRAINT project_billing_info_id_fkey NOT DEFERRABLE"
+    DB.run "ALTER TABLE payment_method ALTER CONSTRAINT payment_method_billing_info_id_fkey NOT DEFERRABLE"
+  end
+  # :nocov:
 end
 
 # Table: billing_info


### PR DESCRIPTION
If we used ON UPDATE CASCADE when defining the foreign key constraints, this would be trivial. Without that, it requires deferred foreign constraints.  I wanted to do this without a migration, since using deferred foreign key constraints should be a temporary change to work around this specific issue.

This changes the deferrability setting, then changes all affected BillingInfo ids inside a transaction, then uses ensure to change the deferrability setting back.  I would have liked to do the deferrability change inside the transaction, but alas, it results in:

```
cannot ALTER TABLE "project" because it has pending trigger events
```

Partially written by Claude Code using the following prompt:

```
A mistake was made in an earlier commit that resulted in new
BillingInfo model instances using "et" ubids instead of "b1" ubids. The
code issue has been fixed to use "b1" ubids for new BillingInfo model
instances, but the database still contains model instances using "et"
ubids. Write a migration that will alter the foreign key constraints
for `project.billing_info_id` and `payment_method.billing_info_id`
to be deferrable. Then write a `BillingInfo.fix_ids` method
that will find all BillingInfo model instances that have ubids
that start with "et", generate a new BillingInfo uuid, and use
it to update `billing_info.id`, `project.billing_info_id`, and
`payment_method.billing_info_id`. Have `BillingInfo.fix_ids` use a
transaction and issue `SET CONSTRAINTS ALL DEFERRED` statement to
avoid foreign key constraint violations.
```

Claude had the migration drop the existing constraints and add new ones instead of using ALTER CONSTRAINT.  I eventually decided to avoid a migration entirely as this is only a temporary change.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `BillingInfo.fix_ids` to update `ubid` prefixes from "et" to "bi" with deferrable constraints.
> 
>   - **Behavior**:
>     - Adds `BillingInfo.fix_ids` to update `ubid` prefixes from "et" to "bi".
>     - Alters foreign key constraints in `project` and `payment_method` to be deferrable during the update.
>     - Uses a transaction to update `billing_info.id`, `project.billing_info_id`, and `payment_method.billing_info_id`.
>     - Reverts foreign key constraints to non-deferrable after updates.
>   - **Constraints**:
>     - Temporarily sets `project_billing_info_id_fkey` and `payment_method_billing_info_id_fkey` as deferrable.
>     - Ensures constraints are reset to non-deferrable post-update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9e401b7e48c6e98aa87bc2f08b5a4b98e03d191e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->