### PR TITLE
Hide Upgrade page for Read Replicas

### DIFF
--- a/views/postgres/show.erb
+++ b/views/postgres/show.erb
@@ -13,12 +13,12 @@ unless @pg.read_replica?
     ["Resize", "resize", "hero-arrow-top-right-on-square"],
     ["High Availability", "high-availability", "hero-square-2-stack-modified"],
     ["Read Replica", "read-replica", "read-replica"],
-    ["Backup/Restore", "backup-restore", "hero-circle-stack"]
+    ["Backup/Restore", "backup-restore", "hero-circle-stack"],
+    ["Upgrade", "upgrade", "hero-cloud-arrow-up"]
   )
 end
 
 tabs.push(
-  ["Upgrade", "upgrade", "hero-cloud-arrow-up"],
   ["Configuration", "config", "hero-document-text"],
   ["Settings", "settings", "hero-cog-8-tooth"]
 ) %>


### PR DESCRIPTION
Read replicas cannot be upgraded by themselves, so the "Upgrade" tab should be hidden when viewing a read replica. Endpoints already check for this condition and doesn't allow upgrading, but the UI should also reflect this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Hide "Upgrade" tab in `views/postgres/show.erb` for read replicas to match backend restrictions.
> 
>   - **UI Change**:
>     - Hide "Upgrade" tab in `views/postgres/show.erb` when viewing a read replica by checking `@pg.read_replica?` condition.
>   - **Behavior**:
>     - Ensures UI reflects backend restrictions on upgrading read replicas.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 21c5f1b7eec0dae234c384d6647d3f066274b57d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->