### PR TITLE
Redact trusted_ca_certs column from PostgresResource output

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -18,7 +18,7 @@ class PostgresResource < Sequel::Model
   plugin :association_dependencies, metric_destinations: :destroy
   dataset_module Pagination
 
-  plugin ResourceMethods, redacted_columns: [:root_cert_1, :root_cert_2, :server_cert],
+  plugin ResourceMethods, redacted_columns: [:root_cert_1, :root_cert_2, :server_cert, :trusted_ca_certs],
     encrypted_columns: [:superuser_password, :root_cert_key_1, :root_cert_key_2, :server_cert_key]
   plugin SemaphoreMethods, :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy, :promote, :refresh_certificates, :use_different_az
   include ObjectTag::Cleanup


### PR DESCRIPTION
This column is not meaningful to the operators and it crowds the output.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Redacts `trusted_ca_certs` column in `PostgresResource` output for clarity.
> 
>   - **Behavior**:
>     - Redacts `trusted_ca_certs` column in `PostgresResource` output by adding it to `redacted_columns` in `postgres_resource.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6541cd8a54856b29c4bceb88b1841663a69a10ba. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->