### PR TITLE
Collect final telemetry for alien runners as well

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -425,9 +425,10 @@ class Prog::Vm::GithubRunner < Prog::Base
     # If the runner is not assigned any job or job is not successful, we log
     # journalctl output to debug if there was any problem with the runner script.
     if (job = github_runner.workflow_job).nil? || job.fetch("conclusion") != "success"
-      serial_log_path = "/vm/#{vm.inhost_name}/serial.log"
-      vm.vm_host.sshable.cmd("sudo ln #{serial_log_path} /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
-
+      if vm.vm_host
+        serial_log_path = "/vm/#{vm.inhost_name}/serial.log"
+        vm.vm_host.sshable.cmd("sudo ln #{serial_log_path} /var/log/ubicloud/serials/#{github_runner.ubid}_serial.log")
+      end
       # We grep only the lines related to 'run-withenv' and 'systemd'. Other
       # logs include outputs from subprocesses like php, sudo, etc., which
       # could contain sensitive data. 'run-withenv' is the main process,
@@ -491,7 +492,7 @@ class Prog::Vm::GithubRunner < Prog::Base
         subnet.incr_destroy
       end
 
-      collect_final_telemetry if vm.vm_host
+      collect_final_telemetry if vm.allocated_at
 
       vm.incr_destroy
     end

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -766,6 +766,23 @@ RSpec.describe Prog::Vm::GithubRunner do
       vm.update(vm_host_id: create_vm_host(data_center: "FSN1-DC8").id)
     end
 
+    it "collects vm logs but not serial.log if vm host is nil" do
+      runner.update(workflow_job: nil)
+      vm.update(vm_host_id: nil)
+      expect(vm.sshable).to receive(:cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND, log: false)
+        TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
+      COMMAND
+      expect(vm.sshable).to receive(:cmd).with("sudo cat /var/log/cacheproxy.log", log: false).and_return("Received request - method: GET urlPath: foo\nReceived request - method: GET urlPath: foo\nGetCacheEntry  request failed with status code: 204\n")
+
+      expect(Clog).to receive(:emit).with("Cache proxy log line counts") do |&blk|
+        expect(blk.call).to eq(cache_proxy_log_line_counts: {"Received request - method: GET urlPath: foo" => 2, "GetCacheEntry  request failed with status code: 204" => 1})
+      end
+
+      nx.collect_final_telemetry
+    end
+
     it "Logs journalctl, docker limits, and cache proxy log if workflow_job is not successful" do
       runner.update(workflow_job: {"conclusion" => "failure"})
       expect(vm.vm_host.sshable).to receive(:cmd).with("sudo ln /vm/#{vm.inhost_name}/serial.log /var/log/ubicloud/serials/#{runner.ubid}_serial.log")
@@ -881,7 +898,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "destroys resources and hops if runner deregistered" do
-      vm.update(vm_host_id: create_vm_host.id)
+      vm.update(allocated_at: Time.now)
       expect(nx).to receive(:decr_destroy)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
       expect(client).not_to receive(:delete)
@@ -897,7 +914,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "skip deregistration and destroy vm immediately" do
-      vm.update(vm_host_id: create_vm_host.id)
+      vm.update(allocated_at: Time.now)
       expect(nx).to receive(:decr_destroy)
       expect(runner).to receive(:skip_deregistration_set?).and_return(true)
       expect(nx).to receive(:collect_final_telemetry)


### PR DESCRIPTION
Previously, we only collected final telemetry when vm_host was not nil, since a runner could be deleted before being allocated on a host. However, alien runners don’t have a vm_host because they’re provisioned on AWS.

To address this, we now check vm.allocated_at instead of vm.vm_host. If vm_host is nil, we still skip collecting serial logs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update telemetry collection in `github_runner.rb` to use `vm.allocated_at` for alien runners, skipping serial logs if `vm_host` is nil.
> 
>   - **Behavior**:
>     - `collect_final_telemetry` in `github_runner.rb` now checks `vm.allocated_at` instead of `vm.vm_host` to determine if telemetry should be collected.
>     - Serial logs are skipped if `vm_host` is nil.
>   - **Tests**:
>     - Added test in `github_runner_spec.rb` to verify telemetry collection when `vm_host` is nil and `vm.allocated_at` is set.
>     - Ensures serial logs are not collected if `vm_host` is nil.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2bf3092c5356b9ccf2554e514cc6e777b863d503. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->