### PR TITLE
Restrict VictoriaMetrics to serve selected endpoints

### DIFF
--- a/rhizome/victoria_metrics/bin/configure
+++ b/rhizome/victoria_metrics/bin/configure
@@ -52,7 +52,16 @@ auth_config = <<-AUTH_CONFIG
 users:
   - username: "#{user}"
     password: "#{password}"
-    url_prefix: "http://127.0.0.1:8428"
+    url_map:
+      - src_paths:
+          - /health
+          - /api/v1/import/prometheus
+          - /api/v1/query
+          - /api/v1/query_range
+          - /api/v1/series
+          - /api/v1/labels
+          - /api/v1/label/.*/values
+        url_prefix: "http://127.0.0.1:8428"
 AUTH_CONFIG
 
 safe_write_to_file("/etc/victoria_metrics/auth-config.yml", auth_config)


### PR DESCRIPTION
This change updates the vmauth config to serve specific endpoints we need for the client and grafana, to minimize exposure.
With this change, all other endpoints return `remoteAddr: "xx.xx.xx.xx:54042"; requestURI: /debug/pprof/heap?debug=1; missing route for "/debug/pprof/heap?debug=1"`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Restricts VictoriaMetrics to serve only specific endpoints by updating `url_map` in `configure`, returning errors for all other endpoints.
> 
>   - **Behavior**:
>     - Restricts VictoriaMetrics to serve only specific endpoints by updating `url_map` in `configure`.
>     - Allowed endpoints: `/health`, `/api/v1/import/prometheus`, `/api/v1/query`, `/api/v1/query_range`, `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/.*/values`.
>     - All other endpoints return a missing route error with client IP and request URI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0564f44abf50523563333516d0ca2e81933b1097. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->