### PR TITLE
Proxy ARP on all interfaces for IPv4

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -73,6 +73,7 @@ File.write("/etc/sysctl.d/72-clover-forward-packets.conf", <<CONF)
 net.ipv6.conf.all.forwarding=1
 net.ipv6.conf.all.proxy_ndp=1
 net.ipv4.conf.all.forwarding=1
+net.ipv4.conf.all.proxy_arp=1
 net.ipv4.ip_forward=1
 CONF
 r "sysctl --system"


### PR DESCRIPTION
We used the enable proxy_arp per interface during VM provisioning. However, that has a drawback. The proxy_arp entries do not stick when an interface is swapped. For example, after a recent incident, our provider had to replace the server chassis which resulted in the interface names to be refreshed. This meant, our proxy_arp settings to be refreshed as well. With this setting to be applied with "all", we don't need to refresh the proxy_arp setting anymore.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable proxy ARP on all interfaces for IPv4 in `prep_host.rb` to ensure settings persist across interface changes.
> 
>   - **Behavior**:
>     - Enable `net.ipv4.conf.all.proxy_arp=1` in `prep_host.rb` to apply proxy ARP on all interfaces for IPv4.
>     - Ensures proxy ARP settings persist across interface changes, addressing issues with server chassis replacements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1e4a6dd927fbf01f0b265a276f5e1a0812826cfc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->