### PR TITLE
Use next minute for backup target times

### DIFF
--- a/views/postgres/backup_restore.erb
+++ b/views/postgres/backup_restore.erb
@@ -53,11 +53,12 @@ max_date = @pg.timeline.latest_restore_time %>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           <% backups.each do %>
+            <% target_time = Time.at((it.last_modified.to_i / 60.0).ceil * 60) %>
             <tr>
-              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= it.last_modified %></td>
+              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= target_time %></td>
               <td class="py-4 text-sm font-medium text-gray-900">Full Backup</td>
               <td class="py-4 text-sm font-medium text-gray-900">
-                <div class="cursor-pointer fork-icon" data-target-datetime="<%= it.last_modified %>">
+                <div class="cursor-pointer fork-icon" data-target-datetime="<%= target_time %>">
                   <%== part("components/icon", name: "fork", classes: "text-black-600 h-6 w-6") %>
                 </div>
               </td>


### PR DESCRIPTION
Our datetime picker omits seconds, so when we try to use the exact backup time, we round it down to the earlier minute. The problem is that time is the worst possible time to pick as restore target because it requires applying entire day worth of WAL changes. By rounding up to the next full minute, we encourage people to pick restore targets that are faster to complete.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adjusts backup target time to the next full minute in `backup_restore.erb` for improved restore efficiency.
> 
>   - **Behavior**:
>     - Adjusts backup target time to the next full minute in `backup_restore.erb` to improve restore efficiency.
>     - Uses `Time.at((it.last_modified.to_i / 60.0).ceil * 60)` to round up the time.
>   - **UI**:
>     - Updates display and data-target-datetime for backup entries to use the new target time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ce088677d3c929578e7181cc803a1bbc4cb3b2d6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->