### PR TITLE
Approve kubelet serving CSR after VM provisioning

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -223,6 +223,11 @@ TEMPLATE
 }
 CONFIG
     vm.sshable.cmd("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: cni_config)
+    hop_approve_new_csr
+  end
+
+  label def approve_new_csr
+    kubernetes_cluster.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get csr | awk '/Pending/ && /kubelet-serving/ && /'\"#{node.name}\"'/ {print $1}' | xargs -r sudo kubectl --kubeconfig /etc/kubernetes/admin.conf certificate approve")
     pop({node_id: node.id})
   end
 end


### PR DESCRIPTION
After adding serverTLSBootstrap to kubelet configs, kubelet creates a new CSR after bootstrap to secure its communication. This was required for the metrics server.

After deploying the metrics server, new nodes created during a resize requested new CSRs, but none were approved, causing commands like exec and logs to fail.

The initial bootstrap worked because all CSRs were approved at the end of cluster provisioning during metrics server installation.

This commit ensures the kubelet-serving CSR is approved after a new node is provisioned.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `approve_new_csr` method to approve kubelet-serving CSRs for new nodes, ensuring command functionality post-provisioning.
> 
>   - **Behavior**:
>     - Adds `approve_new_csr` method in `provision_kubernetes_node.rb` to approve kubelet-serving CSRs for new nodes.
>     - Ensures CSRs are approved after node provisioning to prevent command failures like `exec` and `logs`.
>   - **Tests**:
>     - Adds test for `approve_new_csr` in `provision_kubernetes_node_spec.rb` to verify CSR approval functionality.
>     - Updates `install_cni` test to check for hop to `approve_new_csr`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d6f30fa5e4b3690c38cfcdeb170210548a965f47. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->