### PR TITLE
Ensure begin time is in UTC in Invoice model

### DIFF
--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -25,7 +25,7 @@ class Invoice < Sequel::Model
   end
 
   def filename
-    "Ubicloud-#{begin_time.strftime("%Y-%m")}-#{invoice_number}.pdf"
+    "Ubicloud-#{begin_time.utc.strftime("%Y-%m")}-#{invoice_number}.pdf"
   end
 
   %i[subtotal cost].each do |meth|
@@ -52,7 +52,7 @@ class Invoice < Sequel::Model
         "non_eu"
       end
     end
-    "#{begin_time.strftime("%Y/%m")}/#{group}/#{filename}"
+    "#{begin_time.utc.strftime("%Y/%m")}/#{group}/#{filename}"
   end
 
   def after_destroy
@@ -64,7 +64,7 @@ class Invoice < Sequel::Model
   end
 
   def name
-    begin_time.strftime("%B %Y")
+    begin_time.utc.strftime("%B %Y")
   end
 
   def charge


### PR DESCRIPTION
Otherwise, the invoice specs fail if the database returns times using a timezone with a negative UTC offset.

By default, time with timezone will convert to the client's timezone. While that is UTC for production, it may not be UTC in other cases.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `begin_time` is in UTC in `Invoice` model methods to prevent timezone issues.
> 
>   - **Behavior**:
>     - Ensure `begin_time` is in UTC in `filename()`, `blob_key()`, and `name()` methods in `invoice.rb`.
>     - Prevents issues with timezones having negative UTC offsets during invoice generation.
>   - **Misc**:
>     - No changes to logic or additional functionality, just timezone handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 95b5c4059077832e4ff9d623e2c5912eb75a2483. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->