### PR TITLE
Remove apiserver.advertise-address from kubeadm config to prevent outdated IP in upgrades

### DIFF
--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -49,10 +49,6 @@ cluster_config = {
       {
         "name" => "bind-address",
         "value" => "::"
-      },
-      {
-        "name" => "advertise-address",
-        "value" => node_ipv4
       }
     ]
   },


### PR DESCRIPTION
Upgrades (including control plane VM replacements) caused disruptions in pod-to-service communication. Symptoms included CoreDNS failing to reach the API server ("no route to host"), leading to DNS resolution failures (e.g., connection refused to kube-dns at 10.96.0.10), reject rules in iptables, and broader service access issues. Pod-to-pod and pod-to-host traffic were unaffected, indicating a service endpoint problem.

Root cause: The kubeadm-config ConfigMap set apiServer.extraArgs.advertise- address to a static IP (e.g., the initial control plane IP). During upgrades, this IP became outdated as new VMs received new IPs, but the config wasn't updated. This led to:

- kube-apiserver advertising the old IP

- The default/kubernetes service’s Endpoints/EndpointSlice being recreated with the wrong backend IP

- kube-proxy DNAT rules routing traffic (e.g., to 10.96.0.1:443) to the unreachable old IP

- Circular dependency: CoreDNS couldn’t sync with the API, preventing readiness and worsening DNS issues.

Solution: Remove the advertise-address arg entirely from kubeadm-config. This lets kube-apiserver auto-detect and advertise the node’s primary interface IP (default behavior per Kubernetes docs). On upgrade:

- New control plane VMs advertise their current IP

- Endpoints/EndpointSlice update automatically during manifest regeneration or upgrade apply

This fix applies universally:

Single-node: Prevents total disruption from IP changes

Multi-node (HA): Each control plane node advertises its own IP; Endpoints include all nodes for failover
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `advertise-address` from `init-cluster` to prevent outdated IP issues during upgrades, allowing `kube-apiserver` to auto-detect the node's primary IP.
> 
>   - **Behavior**:
>     - Removes `advertise-address` from `apiServer.extraArgs` in `init-cluster` to prevent outdated IP issues during upgrades.
>     - Allows `kube-apiserver` to auto-detect and advertise the node's primary interface IP.
>   - **Impact**:
>     - Fixes disruptions in pod-to-service communication, such as CoreDNS failures and incorrect iptables rules.
>     - Ensures correct endpoint updates for both single-node and multi-node (HA) setups.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4db794b0f80a2a5f32204c3846c4d3d87a05348a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->