### PR TITLE
Avoid M+N+1 query issue in update_aws_firewall_rules

### DIFF
--- a/prog/vnet/update_firewall_rules.rb
+++ b/prog/vnet/update_firewall_rules.rb
@@ -172,7 +172,7 @@ TEMPLATE
   end
 
   label def update_aws_firewall_rules
-    rules = vm.firewalls.flat_map(&:firewall_rules)
+    rules = vm.firewalls(eager: :firewall_rules).flat_map(&:firewall_rules)
     permissions = rules.select(&:port_range).map! do |rule|
       perm = {
         ip_protocol: "tcp",


### PR DESCRIPTION
Without this, there are N+1 query issues for both the private_subnet_firewalls and vm_firewalls associations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes N+1 query issue in `update_aws_firewall_rules` by using eager loading for `firewall_rules`.
> 
>   - **Performance Optimization**:
>     - Fixes N+1 query issue in `update_aws_firewall_rules` by using eager loading for `firewall_rules` in `update_firewall_rules.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ce68be0f7ea6bb5b85e66ad6b826691b77329ee9. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->