### PR TITLE
Revert "Remove postgres customer firewall rules that duplicate internal firewall rules"

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -23,25 +23,6 @@ class PostgresResource < Sequel::Model
   plugin SemaphoreMethods, :initial_provisioning, :update_firewall_rules, :refresh_dns_record, :update_billing_records, :destroy, :promote, :refresh_certificates, :use_different_az
   include ObjectTag::Cleanup
 
-  # :nocov:
-  def self.remove_internal_firewall_rules
-    all do |pg|
-      next unless (firewall = pg.customer_firewall)
-
-      print "Removing internal firewall rules from customer firewall for #{pg.ubid}..."
-
-      ds = firewall.firewall_rules_dataset
-      ps = pg.private_subnet
-      ds.where(port_range: Sequel.pg_range(22..22), cidr: %w[0.0.0.0/0 ::/0]).destroy
-      ds.where(port_range: [Sequel.pg_range(5432..5432), Sequel.pg_range(6432..6432)], cidr: [ps.net4.to_s, ps.net6.to_s]).destroy
-
-      puts "done"
-    end
-
-    nil
-  end
-  # :nocov:
-
   def display_location
     location.display_name
   end


### PR DESCRIPTION
This reverts commit 27e6c080068a3b1ea45eade503cad63e7d66f8f5.

The method was run and it is no longer needed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts removal of `remove_internal_firewall_rules` method in `postgres_resource.rb` to restore functionality for removing internal firewall rules from customer firewalls.
> 
>   - **Revert Changes**:
>     - Reverts removal of `remove_internal_firewall_rules` method in `postgres_resource.rb`.
>     - Method removes internal firewall rules from customer firewalls, which was previously deemed unnecessary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for eeb0a74cc41689d94c4a930cd2bfe7152c689f00. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->