### PR TITLE
Decrease mocking in nexus specs


### DIFF
--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -1092,7 +1092,7 @@ RSpec.describe Prog::Vm::Nexus do
   describe "#destroy_slice" do
     it "#destroy_slice when no slice" do
       expect { nx.destroy_slice }.to exit({"msg" => "vm deleted"})
-      expect(Vm[vm.id]).to be_nil
+      expect(vm.exists?).to be(false)
     end
 
     it "#destroy_slice with a slice" do
@@ -1103,7 +1103,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.destroy_slice }.to exit({"msg" => "vm deleted"})
       expect(vm_host_slice.reload.enabled).to be(false)
       expect(Semaphore[strand_id: vm_host_slice.id, name: "destroy"]).not_to be_nil
-      expect(Vm[vm.id]).to be_nil
+      expect(vm.exists?).to be(false)
     end
 
     it "skips destroy slice when slice already disabled" do
@@ -1114,7 +1114,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.destroy_slice }.to exit({"msg" => "vm deleted"})
       expect(vm_host_slice.reload.enabled).to be(false)
       expect(Semaphore[strand_id: vm_host_slice.id, name: "destroy"]).to be_nil
-      expect(Vm[vm.id]).to be_nil
+      expect(vm.exists?).to be(false)
     end
   end
 
@@ -1126,7 +1126,7 @@ RSpec.describe Prog::Vm::Nexus do
       expect { nx.destroy_slice }.to exit({"msg" => "vm deleted"})
         .and change { nic.reload.destroy_set? }.from(false).to(true)
         .and change(nic, :vm_id).from(vm.id).to(nil)
-      expect(Vm[vm.id]).to be_nil
+      expect(vm.exists?).to be(false)
     end
   end
 


### PR DESCRIPTION
### Here’s my PR to help me use my 5-hour flight productively while offline. I removed excessive mocking in the nexus specs. This adds more verification, especially for destroy tests, while also removing 78 lines of code.


- **Rename prj to project in Nexus spec**
  It's better to use consistent `let(:)` variable names across specs to
  make moving code around easier. Since most of our specs use project
  instead of prj, I’m updating it here for consistency.
  

- **Create vm related resources instead of mocking in nexus specs**
  Currently, the tests do not persist these models to the database and
  mock some parts of them.
  
  Since we try to avoid mocking database operations, it’s better to create
  real resources.
  
  Because we don’t need them in all tests, I’ve moved their creation to
  the relevant tests in future commits. I also removed mocking in those
  commits.
  

- **Remove project mocks in nexus specs**
  

- **Remove vm host mocks in nexus specs**
  I was surprised by some tests, especially the destroy ones.
  
  After destroying a VM host/slice, the tests didn’t actually check if the
  resources were freed which I think is the most important thing to verify
  in destroy tests. Instead, they were just mocking some data and checking
  that associated objects were called.
  
  I’ve removed the VM host mocks and added real verification that
  resources get freed in destroy tests. While I was at it, I also
  reordered some destroy tests to make them cover specific cases.
  
  Finally, the `#destroy_slice` and `#destroy` tests were mixed together,
  so I separated them for clarity.
  

- **Remove billing record and storage volume mocks in nexus specs**
  Also we don't need to create these resources for each tests.
  

- **Use real strand for nexus tests**
  It helps us to remove semaphore and stack mocks.
  

- **Remove nic mocks in nexus specs**
  