### PR TITLE
postgres create: pg_config & pgbouncer fields

### DIFF
--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -9,6 +9,8 @@ UbiCli.on("pg").run_on("create") do
     on("-s", "--size=size", Option::POSTGRES_SIZE_OPTIONS.keys, "server size")
     on("-S", "--storage-size=size", Option::POSTGRES_STORAGE_SIZE_OPTIONS, "storage size GB")
     on("-v", "--version=version", Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD], "PostgreSQL version")
+    on("-c", "--pg-config=config", "postgres config (e.g key1=value1,key2=value2)")
+    on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
     on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
     on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")
   end
@@ -21,6 +23,8 @@ UbiCli.on("pg").run_on("create") do
   run do |opts, cmd|
     params = underscore_keys(opts[:pg_create])
     pg_tags_to_hash(params, cmd)
+    params_to_hash(params, :pg_config, "config", cmd)
+    params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
     id = sdk.postgres.create(location: @location, name: @name, **params).id
     response("PostgreSQL database created with id: #{id}")
   end

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -10,6 +10,8 @@ class Clover
     storage_size = typecast_params.pos_int("storage_size")
     ha_type = typecast_params.nonempty_str("ha_type", PostgresResource::HaType::NONE)
     version = typecast_params.nonempty_str("version", PostgresResource::DEFAULT_VERSION)
+    user_config = typecast_params.Hash("pg_config", {})
+    pgbouncer_user_config = typecast_params.Hash("pgbouncer_config", {})
     tags = typecast_params.array(:Hash, "tags", [])
     with_firewall_rules = !typecast_params.bool("restrict_by_default")
 
@@ -30,6 +32,18 @@ class Clover
     requested_postgres_vcpu_count = (requested_standby_count + 1) * parsed_size.vcpu_count
     Validation.validate_vcpu_quota(@project, "PostgresVCpu", requested_postgres_vcpu_count)
 
+    pg_validator = Validation::PostgresConfigValidator.new(version)
+    pg_errors = pg_validator.validation_errors(user_config)
+
+    pgbouncer_validator = Validation::PostgresConfigValidator.new("pgbouncer")
+    pgbouncer_errors = pgbouncer_validator.validation_errors(pgbouncer_user_config)
+
+    if pg_errors.any? || pgbouncer_errors.any?
+      pg_errors = pg_errors.map { |key, value| ["pg_config.#{key}", value] }.to_h
+      pgbouncer_errors = pgbouncer_errors.map { |key, value| ["pgbouncer_config.#{key}", value] }.to_h
+      raise Validation::ValidationFailed.new(pg_errors.merge(pgbouncer_errors))
+    end
+
     pg = nil
     DB.transaction do
       pg = Prog::Postgres::PostgresResourceNexus.assemble(
@@ -41,7 +55,9 @@ class Clover
         target_version: version,
         ha_type:,
         with_firewall_rules:,
-        flavor:
+        flavor:,
+        user_config:,
+        pgbouncer_user_config:
       ).subject
       pg.update(tags:)
       audit_log(pg, "create")

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -251,16 +251,20 @@ class UbiCli
     response(body)
   end
 
-  def pg_tags_to_hash(params, cmd)
-    if params[:tags]
-      params[:tags] = params[:tags].split(",").to_h do
+  def params_to_hash(params, key, singular, cmd)
+    if params[key]
+      params[key] = params[key].split(",").to_h do
         if it.include?("=")
           it.split("=", 2)
         else
-          raise Rodish::CommandFailure.new("invalid tag, does not include `=`: #{it.inspect}", cmd)
+          raise Rodish::CommandFailure.new("invalid #{singular}, does not include `=`: #{it.inspect}", cmd)
         end
       end
     end
+  end
+
+  def pg_tags_to_hash(params, cmd)
+    params_to_hash(params, :tags, "tag", cmd)
   end
 
   def config_entries_to_hash(args, cmd)

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -971,6 +971,18 @@ paths:
                 restrict_by_default:
                   description: 'Whether to restrict access by default (if so, firewall rules must be added to access)'
                   type: boolean
+                pg_config:
+                  type: object
+                  example:
+                    max_connections: '100'
+                  additionalProperties:
+                    type: string
+                pgbouncer_config:
+                  type: object
+                  example:
+                    max_client_conn: '100'
+                  additionalProperties:
+                    type: string
                 tags:
                   description: Tags for the Postgres Database
                   type: array

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
   def self.assemble(project_id:, location_id:, name:, target_vm_size:, target_storage_size_gib:,
     target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
-    ha_type: PostgresResource::HaType::NONE, parent_id: nil, restore_target: nil, with_firewall_rules: true)
+    ha_type: PostgresResource::HaType::NONE, parent_id: nil, restore_target: nil, with_firewall_rules: true, user_config: {}, pgbouncer_user_config: {})
 
     unless Project[project_id]
       fail "No existing project"
@@ -49,10 +49,9 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       end
 
       postgres_resource = PostgresResource.create(
-        project_id: project_id, location_id: location.id, name: name,
-        target_vm_size: target_vm_size, target_storage_size_gib: target_storage_size_gib,
-        superuser_password: superuser_password, ha_type: ha_type, target_version: target_version, flavor: flavor,
-        parent_id: parent_id, restore_target: restore_target, hostname_version: "v2"
+        project_id:, location_id: location.id, name:,
+        target_vm_size:, target_storage_size_gib:,
+        superuser_password:, ha_type:, target_version:, flavor:, parent_id:, restore_target:, hostname_version: "v2", user_config:, pgbouncer_user_config:
       )
 
       # Customer firewall, will be attached to created customer subnet

--- a/sdk/ruby/lib/ubicloud/model/postgres.rb
+++ b/sdk/ruby/lib/ubicloud/model/postgres.rb
@@ -102,7 +102,7 @@ module Ubicloud
       adapter.patch(_path("/config"), pg_config: values)[:pg_config]
     end
 
-    # Update configuration hash for the PostgreSQL database.
+    # Update pgbouncer configuration hash for the PostgreSQL database.
     def update_pgbouncer_config(**values)
       adapter.patch(_path("/config"), pgbouncer_config: values)[:pgbouncer_config]
     end

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -583,6 +583,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
@@ -11,6 +11,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
@@ -11,6 +11,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
@@ -11,6 +11,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
@@ -11,6 +11,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
@@ -11,6 +11,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
@@ -11,6 +11,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
@@ -11,6 +11,8 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
+    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
 

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Clover, "cli pg create" do
 
   it "creates PostgreSQL database with all options" do
     expect(PostgresResource.count).to eq 0
-    body = cli(%w[pg eu-central-h1/test-pg create -s standard-4 -S 128 -h async -v 17 -f paradedb -R -t foo=bar,baz=quux])
+    body = cli(%w[pg eu-central-h1/test-pg create -s standard-4 -S 128 -h async -v 17 -c max_connections=100,wal_level=logical -u max_client_conn=100 -f paradedb -R -t foo=bar,baz=quux])
     expect(PostgresResource.count).to eq 1
     pg = PostgresResource.first
     expect(pg).to be_a PostgresResource
@@ -37,6 +37,8 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.target_storage_size_gib).to eq 128
     expect(pg.ha_type).to eq "async"
     expect(pg.version).to eq "17"
+    expect(pg.user_config).to eq({"max_connections" => "100", "wal_level" => "logical"})
+    expect(pg.pgbouncer_user_config).to eq({"max_client_conn" => "100"})
     expect(pg.flavor).to eq "paradedb"
     expect(pg.pg_firewall_rules_dataset.count).to eq 0
     expect(pg.tags).to eq([{"key" => "foo", "value" => "bar"}, {"key" => "baz", "value" => "quux"}])


### PR DESCRIPTION
default configuration lacking what's necessary for failover slots,
adding pg_config to create request avoids needing to manage immediately updating config after create,
which helps with api usage where config tuning is a common use case

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `pg_config` field to Postgres creation, allowing custom configurations, with validation and updated OpenAPI spec.
> 
>   - **Behavior**:
>     - Adds `pg_config` field to Postgres creation in `postgres_post` in `helpers/postgres.rb` and `assemble` in `prog/postgres/postgres_resource_nexus.rb`.
>     - Validates `pg_config` using `PostgresConfigValidator`.
>     - Updates OpenAPI spec in `openapi.yml` to include `pg_config` in Postgres creation request.
>   - **Tests**:
>     - Adds tests in `postgres_spec.rb` for valid and invalid `pg_config` values during Postgres creation.
>     - Verifies `pg_config` is correctly set and retrievable via API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5cf5aacd792a15eccd232c4fbcea2e6daa50beff. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->