### PR TITLE
Consolidate vm host access in Nexus.wait_vm_removal_from_load_balancer

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -603,7 +603,7 @@ class Prog::Vm::Nexus < Prog::Base
 
   label def wait_vm_removal_from_load_balancer
     reap(nap: 10) do
-      vm.vm_host&.sshable&.cmd("sudo host/bin/setup-vm delete_net #{q_vm}")
+      host&.sshable&.cmd("sudo host/bin/setup-vm delete_net #{q_vm}")
       hop_destroy_slice
     end
   end

--- a/spec/prog/vm/nexus_spec.rb
+++ b/spec/prog/vm/nexus_spec.rb
@@ -1160,17 +1160,14 @@ RSpec.describe Prog::Vm::Nexus do
 
     it "hops to destroy_slice if vm is removed" do
       expect(nx).to receive(:reap).and_yield
-      expect(vm.vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-vm delete_net #{vm.inhost_name}")
+      expect(sshable).to receive(:cmd).with("sudo host/bin/setup-vm delete_net #{vm.inhost_name}")
       expect { nx.wait_vm_removal_from_load_balancer }.to hop("destroy_slice")
     end
 
     it "handles the case when the vm_host is not set" do
-      expect(nx).to receive(:reap).and_yield.twice
+      expect(nx).to receive(:reap).and_yield
 
-      expect(vm.vm_host).to receive(:sshable).and_return(nil)
-      expect { nx.wait_vm_removal_from_load_balancer }.to hop("destroy_slice")
-
-      expect(vm).to receive(:vm_host).and_return(nil)
+      expect(nx).to receive(:host).and_return(nil).at_least(:once)
       expect { nx.wait_vm_removal_from_load_balancer }.to hop("destroy_slice")
     end
   end


### PR DESCRIPTION
We already access the VM's host via the @host variable in the Nexus prog. This method is the only place where we fetch the host using vm.vm_host. Unless there's a specific reason to do it differently here, we should switch to using @host for consistency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Consolidate VM host access in `Nexus.wait_vm_removal_from_load_balancer` by using `@host` instead of `vm.vm_host`.
> 
>   - **Behavior**:
>     - In `nexus.rb`, `wait_vm_removal_from_load_balancer` now uses `host&.sshable` instead of `vm.vm_host&.sshable` for consistency.
>   - **Tests**:
>     - Updated `nexus_spec.rb` to use `sshable` directly in tests for `wait_vm_removal_from_load_balancer`.
>     - Ensures tests handle cases where `host` is `nil`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 588d64c29b9122cd927b1b6fac63abb899f3d513. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->