### PR TITLE
Test alien VM runners in the E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
     if: vars.RUN_E2E == 'true'
     runs-on: ubicloud-standard-4
     environment: E2E-CI
-    timeout-minutes: 60
+    timeout-minutes: 65
     concurrency: e2e_environment
 
     steps:
@@ -83,6 +83,8 @@ jobs:
         DISPATCHER_MAX_THREADS: 16
         E2E_HETZNER_SERVER_ID: ${{ secrets.E2E_HETZNER_SERVER_ID }}
         E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GH_INSTALLATION_ID }}
+        E2E_AWS_ACCESS_KEY: ${{ secrets.E2E_AWS_ACCESS_KEY }}
+        E2E_AWS_SECRET_KEY: ${{ secrets.E2E_AWS_SECRET_KEY }}
         HETZNER_SSH_PUBLIC_KEY: ${{ secrets.HETZNER_SSH_PUBLIC_KEY }}
         HETZNER_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_PRIVATE_KEY }}
         HETZNER_USER: ${{ secrets.HETZNER_USER }}
@@ -102,6 +104,7 @@ jobs:
         GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
         GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
         GITHUB_RUNNER_SERVICE_PROJECT_ID: "89841457-35a2-8ed2-a88a-424ea5ddd83b"
+        GITHUB_RUNNER_AWS_LOCATION_ID: "88adf710-4d8b-8c20-a480-618cbbef802d"
         GITHUB_CACHE_BLOB_STORAGE_ENDPOINT: ${{ secrets.GH_CACHE_BLOB_STORAGE_ENDPOINT }}
         GITHUB_CACHE_BLOB_STORAGE_REGION: ${{ secrets.GH_CACHE_BLOB_STORAGE_REGION }}
         GITHUB_CACHE_BLOB_STORAGE_ACCESS_KEY: ${{ secrets.GH_CACHE_BLOB_STORAGE_ACCESS_KEY }}
@@ -123,7 +126,7 @@ jobs:
         VHOST_BLOCK_BACKEND_VERSION: v0.2.1
       run: |
         set -o pipefail
-        timeout 55m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
+        timeout 62m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
 
     - name: Print logs
       if: always()

--- a/config.rb
+++ b/config.rb
@@ -197,6 +197,8 @@ module Config
   override :e2e_hetzner_server_id, string
   optional :e2e_github_installation_id, string
   override :is_e2e, false, bool
+  optional :e2e_aws_access_key, string, clear: true
+  optional :e2e_aws_secret_key, string, clear: true
 
   # Load Balancer
   optional :load_balancer_service_project_id, string

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -68,6 +68,7 @@ module ThawedMock
   allow_mocking(KubernetesCluster, :[], :kubeconfig, :generate_ubid)
   allow_mocking(KubernetesNodepool, :generate_uuid)
   allow_mocking(LoadBalancer, :[], :generate_uuid)
+  allow_mocking(Location, :[])
   allow_mocking(MinioCluster, :[], :first)
   allow_mocking(Nic, :[], :create_with_id, :generate_ubid)
   allow_mocking(OidcProvider, :generate_uuid)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for testing AWS-based alien VM runners in E2E workflow with updated configurations and tests.
> 
>   - **E2E Workflow**:
>     - Increase `timeout-minutes` from 60 to 65 in `.github/workflows/e2e.yml`.
>     - Add `E2E_AWS_ACCESS_KEY` and `E2E_AWS_SECRET_KEY` to environment variables.
>     - Update `timeout` command in `run` step to 62 minutes.
>   - **Configuration**:
>     - Add `e2e_aws_access_key` and `e2e_aws_secret_key` as optional in `config.rb`.
>   - **Github Runner Logic**:
>     - Add `enable_alien_runners` method in `github_runner.rb` to set up AWS location and credentials.
>     - Modify `check_test_runs` to hop to `enable_alien_runners` if `github_runner_aws_location_id` is not set.
>     - Update `clean_resources` to destroy AWS location.
>   - **Testing**:
>     - Add tests for `enable_alien_runners` in `github_runner_spec.rb`.
>     - Update tests in `github_runner_spec.rb` to check for AWS location setup and cleanup.
>     - Allow mocking of `Location` in `thawed_mock.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e5ee55a32959bbb2fb90efc0f8305d2f6136d877. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->