### PR TITLE
QEMU systemd service definition updates

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -866,17 +866,17 @@ DNSMASQ_SERVICE
       ]
     }
 
-    pci_parts = if pci_devices.any?
-      pci_devices.map.with_index(1) do |dev, i|
-        "-device pcie-root-port,id=rp#{i},slot=#{i},chassis=#{i},hotplug=off -device vfio-pci,host=0000:#{dev[0]},bus=rp#{i},x-no-mmap=true"
-      end
-    else
-      []
-    end
+    pci_parts = pci_devices.map.with_index(1) do |(bdf), i|
+      [
+        "-device pcie-root-port,id=rp#{i},slot=#{i},chassis=#{i},bus=pcie.0,hotplug=off",
+        "-device vfio-pci,host=0000:#{bdf},bus=rp#{i},addr=0x0,x-no-mmap=true,rombar=0"
+      ]
+    end.flatten
 
     serial_parts = [
       "-serial file:#{vp.serial_log}",
       "-display none",
+      "-vga none",
       "-no-reboot"
     ]
 


### PR DESCRIPTION
Add `-vga none` to disable creation of the default VGA device.
Specify additional `pcie-root-port` and `vfio-pci` parameters
(`bus`, `addr`, `rombar`) to ensure a more deterministic PCI
device layout.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `-vga none` and specify PCI parameters in `build_qemu_service()` for improved QEMU configuration.
> 
>   - **Behavior**:
>     - Add `-vga none` to `serial_parts` in `build_qemu_service()` to disable default VGA device creation.
>     - Specify `bus`, `addr`, and `rombar` parameters for `pcie-root-port` and `vfio-pci` in `pci_parts` in `build_qemu_service()` for deterministic PCI layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 336f6139887d3e797d09d7a70b89c249060cca97. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->