### PR TITLE
Monitor: only increment checkup when not already set

### DIFF
--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -41,7 +41,7 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_que
             yield r
           rescue => ex
             Clog.emit("Monitoring job has failed.") { {monitoring_job_failure: {resource: r.resource, exception: Util.exception_to_hash(ex)}} }
-            r.resource.incr_checkup if r.resource.respond_to?(:incr_checkup)
+            r.resource.incr_checkup if r.resource.respond_to?(:incr_checkup) && !r.resource.checkup_set?
           ensure
             # We unset the started at time so we will not check for stuck pulses
             # while this is in the run queue.

--- a/spec/lib/monitor_resource_type_spec.rb
+++ b/spec/lib/monitor_resource_type_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe MonitorResourceType do
       expect(@mr.resource).to receive(:respond_to?).with(:incr_checkup).and_return(false)
       @mrt.submit_queue.push(@mr)
     end
+
+    it "does not call incr_checkup if checkup is already set" do
+      @started_at = nil
+      @mrt = described_class.create(Object, :foo, 2, [[]]) do
+        @started_at = it.monitor_job_started_at
+        raise StandardError
+      end
+
+      resource = VmHost.new { it.id = "f9249e31-0a70-8f71-b08c-72d857c878d2" }
+      @mr = MonitorableResource.new(resource)
+
+      expect(resource).to receive(:checkup_set?).and_return(true)
+      expect(resource).not_to receive(:incr_checkup)
+
+      @mrt.submit_queue.push(@mr)
+    end
   end
 
   describe "#check_stuck_pulses" do


### PR DESCRIPTION
Failed monitoring jobs incremented the checkup semaphore whenever the
resource responded to `incr_checkup`. In production we had a case where
a resource accumulated almost 150k checkup semaphores. In order to avoid
runaway accumulation of these semaphores, we now only increment the
checkup semaphore when the resource supports it and has not already set
a checkup .

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `incr_checkup` call in `lib/monitor_resource_type.rb` to prevent incrementing when `checkup` is already set, with corresponding test added.
> 
>   - **Behavior**:
>     - In `lib/monitor_resource_type.rb`, modify `incr_checkup` call to check `!r.resource.checkup_set?` before incrementing.
>     - Prevents excessive semaphore increments when `checkup` is already set.
>   - **Tests**:
>     - Add test in `monitor_resource_type_spec.rb` to verify `incr_checkup` is not called if `checkup_set?` returns true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 32408b54fa17700cebfc0ef9d8af7f535ca9dca7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->