### PR TITLE
Increase overcommit_ratio temporarily

### DIFF
--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -21,8 +21,8 @@ class PostgresSetup
     r "sudo sysctl -w vm.overcommit_memory=2"
     r "echo 'vm.overcommit_memory=2' | sudo tee -a /etc/sysctl.conf"
 
-    r "sudo sysctl -w vm.overcommit_ratio=80"
-    r "echo 'vm.overcommit_ratio=80' | sudo tee -a /etc/sysctl.conf"
+    r "sudo sysctl -w vm.overcommit_ratio=150"
+    r "echo 'vm.overcommit_ratio=150' | sudo tee -a /etc/sysctl.conf"
   end
 
   def setup_data_directory


### PR DESCRIPTION
We are working on a solution to set overcommit_ratio or overcommit_kb based on the instance memory size. Until that is ready, this is a temporary fix because overcommit_ratio=80 is too restrictive.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Temporarily increase `vm.overcommit_ratio` from 80 to 150 in `configure_memory_overcommit` function in `postgres_setup.rb`.
> 
>   - **Behavior**:
>     - Temporarily increase `vm.overcommit_ratio` from 80 to 150 in `configure_memory_overcommit` function in `postgres_setup.rb`.
>     - This change is a temporary fix to address the restrictiveness of the previous setting while a more permanent solution is developed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e1ce8f5eca8f6afaa5a1a6a609d949ef387679a8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->