### PR TITLE
Do not create firewalls for subnets in general

### DIFF
--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -14,6 +14,16 @@ class Firewall < Sequel::Model
 
   dataset_module Pagination
 
+  def self.create_with_open_rules(port_range, **kwargs)
+    firewall = create(**kwargs)
+    DB.ignore_duplicate_queries do
+      ["0.0.0.0/0", "::/0"].each do |cidr|
+        FirewallRule.create(firewall_id: firewall.id, cidr: cidr, port_range: Sequel.pg_range(port_range))
+      end
+    end
+    firewall
+  end
+
   def display_location
     location.display_name
   end

--- a/model/project.rb
+++ b/model/project.rb
@@ -179,12 +179,7 @@ class Project < Sequel::Model
     firewall_name = "#{name}-default"
     firewall = firewalls_dataset.first(location_id:, name: firewall_name)
     unless firewall
-      firewall = Firewall.create(name: firewall_name, location_id:, project_id: id)
-      DB.ignore_duplicate_queries do
-        ["0.0.0.0/0", "::/0"].each do |cidr|
-          FirewallRule.create(firewall_id: firewall.id, cidr: cidr, port_range: Sequel.pg_range(0..65535))
-        end
-      end
+      firewall = Firewall.create_with_open_rules(0..65535, name: firewall_name, location_id:, project_id: id)
     end
 
     Prog::Vnet::SubnetNexus.assemble(id, name:, location_id:, firewall_id: firewall.id).subject

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -22,12 +22,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       else
         # Create customer private subnet with customer firewall
         firewall_name = "#{ubid}-firewall"
-        firewall = Firewall.create(name: firewall_name, location_id:, project_id:)
-        DB.ignore_duplicate_queries do
-          ["0.0.0.0/0", "::/0"].each do |cidr|
-            FirewallRule.create(firewall_id: firewall.id, cidr: cidr, port_range: Sequel.pg_range(0..65535))
-          end
-        end
+        firewall = Firewall.create_with_open_rules(0..65535, name: firewall_name, location_id:, project_id:)
 
         Prog::Vnet::SubnetNexus.assemble(
           project_id,

--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -70,12 +70,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     firewall_name = "github-runner-#{location.name}-firewall"
     firewall = project.firewalls_dataset.first(location_id:, name: firewall_name)
     unless firewall
-      firewall = Firewall.create(name: firewall_name, location_id:, project_id: Config.github_runner_service_project_id)
-      DB.ignore_duplicate_queries do
-        ["0.0.0.0/0", "::/0"].each do |cidr|
-          FirewallRule.create(firewall_id: firewall.id, cidr: cidr, port_range: Sequel.pg_range(22..22))
-        end
-      end
+      firewall = Firewall.create_with_open_rules(22..22, name: firewall_name, location_id:, project_id: Config.github_runner_service_project_id)
     end
 
     ps = Prog::Vnet::SubnetNexus.assemble(

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -42,12 +42,7 @@ class Prog::Vm::VmPool < Prog::Base
     firewall_name = "vm-pool-#{location.name}-firewall"
     firewall = project.firewalls_dataset.first(location_id: vm_pool.location_id, name: firewall_name)
     unless firewall
-      firewall = Firewall.create(name: firewall_name, location_id: vm_pool.location_id, project_id: Config.vm_pool_project_id)
-      DB.ignore_duplicate_queries do
-        ["0.0.0.0/0", "::/0"].each do |cidr|
-          FirewallRule.create(firewall_id: firewall.id, cidr: cidr, port_range: Sequel.pg_range(22..22))
-        end
-      end
+      firewall = Firewall.create_with_open_rules(22..22, name: firewall_name, location_id: vm_pool.location_id, project_id: Config.vm_pool_project_id)
     end
 
     ps = Prog::Vnet::SubnetNexus.assemble(

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -172,7 +172,10 @@ RSpec.describe PrivateSubnet do
   describe "incr_destroy_if_only_used_internally" do
     let(:prj) { Project.create(name: "test-prj") }
 
-    let(:ps) { Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps1", location_id: Location::HETZNER_FSN1_ID).subject }
+    let(:ps) {
+      fw = Firewall.create(name: "test-fw", location_id: Location::HETZNER_FSN1_ID, project_id: prj.id)
+      Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps1", location_id: Location::HETZNER_FSN1_ID, firewall_id: fw.id).subject
+    }
 
     it "destroys associated firewalls in any project if name matches and firewall is not related to other subnets" do
       ubid = described_class.generate_ubid

--- a/spec/prog/aws/vpc_spec.rb
+++ b/spec/prog/aws/vpc_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Prog::Aws::Vpc do
     prj = Project.create(name: "test-prj")
     loc = Location.create(name: "us-west-2", provider: "aws", project_id: prj.id, display_name: "aws-us-west-2", ui_name: "AWS US East 1", visible: true)
     LocationCredential.create_with_id(loc, access_key: "test-access-key", secret_key: "test-secret-key")
-    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps", location_id: loc.id).subject
+    fw = Firewall.create(name: "test-fw", location_id: loc.id, project_id: prj.id)
+    ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps", location_id: loc.id, firewall_id: fw.id).subject
     PrivateSubnetAwsResource.create_with_id(ps)
     ps
   }

--- a/spec/prog/test/connected_subnets_spec.rb
+++ b/spec/prog/test/connected_subnets_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe Prog::Test::ConnectedSubnets do
   }
 
   let(:ps_multiple) {
-    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-multiple", location_id: Location::HETZNER_FSN1_ID).subject
+    fw = Firewall.create(name: "ps-multiple-fw", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
+    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-multiple", location_id: Location::HETZNER_FSN1_ID, firewall_id: fw.id).subject
   }
 
   let(:ps_single) {
-    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-single", location_id: Location::HETZNER_FSN1_ID).subject
+    fw = Firewall.create(name: "ps-single-fw", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
+    Prog::Vnet::SubnetNexus.assemble(project.id, name: "ps-single", location_id: Location::HETZNER_FSN1_ID, firewall_id: fw.id).subject
   }
 
   let(:project) {

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -77,13 +77,6 @@ RSpec.describe Prog::Vnet::SubnetNexus do
         described_class.assemble(prj.id, firewall_id: fw.id)
       }.to raise_error RuntimeError, "Firewall with id #{fw.id} and location hetzner-fsn1 does not exist"
     end
-
-    it "fails if both allow_only_ssh and firewall_id are specified" do
-      fw = Firewall.create(name: "default-firewall", location_id: Location::HETZNER_FSN1_ID, project_id: prj.id)
-      expect {
-        described_class.assemble(prj.id, firewall_id: fw.id, allow_only_ssh: true)
-      }.to raise_error RuntimeError, "Cannot specify both allow_only_ssh and firewall_id"
-    end
   end
 
   describe ".gen_spi" do

--- a/spec/routes/api/cli/fw/attach-subnet_spec.rb
+++ b/spec/routes/api/cli/fw/attach-subnet_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe Clover, "cli fw attach-subnet" do
   before do
     cli(%w[ps eu-central-h1/test-ps create])
     @ps = PrivateSubnet.first
-    fw = Firewall.first
     cli(%w[fw eu-central-h1/test-fw create])
-    @fw = Firewall.exclude(id: fw.id).first
+    @fw = Firewall.first
   end
 
   it "attaches firewall to subnet by id" do

--- a/spec/routes/api/cli/fw/detach-subnet_spec.rb
+++ b/spec/routes/api/cli/fw/detach-subnet_spec.rb
@@ -4,9 +4,10 @@ require_relative "../spec_helper"
 
 RSpec.describe Clover, "cli fw attach-subnet" do
   before do
-    cli(%w[ps eu-central-h1/test-ps create])
-    @ps = PrivateSubnet.first
+    cli(%w[fw eu-central-h1/test-fw create])
     @fw = Firewall.first
+    cli(%W[ps eu-central-h1/test-ps create -f #{@fw.ubid}])
+    @ps = PrivateSubnet.first
   end
 
   it "detaches firewall from subnet by id" do

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule 1.2.3.0_24.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule 1.2.3.0_24.txt
@@ -1,4 +1,4 @@
 Firewall rule added to PostgreSQL database.
-  rule id: fr5mf40qkedy0hm80v7pp95qwp
+  rule id: frf94mc095xj2hjwvgkg5h56jx
   cidr: 1.2.3.0/24
   description: ""

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -51,8 +51,10 @@ RSpec.describe Clover, "cli" do
     PrivateSubnet.first(name: "#{pg.ubid}-subnet").update(net4: "10.147.205.0/26", net6: "fdab:de77:9a94:fa70::/64")
 
     expect(Firewall).to receive(:generate_uuid).and_return("e9843761-3af7-85fc-ba6a-1709852cf736")
+    cli(%w[fw eu-central-h1/test-ps-default create])
+    test_ps_fw = Firewall.first(name: "test-ps-default")
     expect(PrivateSubnet).to receive(:generate_ubid).and_return(UBID.parse("pshfgpzvs0t20gpezmz2kkk8e4"))
-    cli(%w[ps eu-central-h1/test-ps create])
+    cli(%W[ps eu-central-h1/test-ps create -f #{test_ps_fw.ubid}])
     PrivateSubnet["pshfgpzvs0t20gpezmz2kkk8e4"].update(net4: "10.147.204.0/26", net6: "fdab:de77:9a94:fa69::/64")
 
     expect(LoadBalancer).to receive(:generate_uuid).and_return("dd91e986-6ac4-882b-ac39-1d430f899d96")

--- a/spec/routes/api/cli/ps/create_spec.rb
+++ b/spec/routes/api/cli/ps/create_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Clover, "cli ps create" do
     expect(Firewall.count).to eq 0
     body = cli(%w[ps eu-central-h1/test-ps create])
     expect(PrivateSubnet.count).to eq 1
-    expect(Firewall.count).to eq 1
+    expect(Firewall.count).to eq 0
     ps = PrivateSubnet.first
     expect(ps).to be_a PrivateSubnet
     expect(ps.name).to eq "test-ps"
     expect(ps.display_location).to eq "eu-central-h1"
-    expect(ps.firewalls).to eq Firewall.all
+    expect(ps.firewalls).to be_empty
     expect(body).to eq "Private subnet created with id: #{ps.ubid}\n"
   end
 

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -152,9 +152,7 @@ RSpec.describe Clover, "private subnet" do
           ps.destroy
         end
 
-        expect(Firewall.where(name: "a123456789a123456789a123456789a123456789a123456789a1234-default")).not_to be_empty
-        expect(Firewall.count).to eq 2
-        expect(Firewall.get { sum(Sequel.char_length(:name)) }).to eq 126
+        expect(Firewall.count).to eq 0
       end
     end
 

--- a/spec/routes/web/private_subnet_spec.rb
+++ b/spec/routes/web/private_subnet_spec.rb
@@ -233,18 +233,24 @@ RSpec.describe Clover, "private subnet" do
         private_subnet
         ps2 = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-2", location_id: Location::HETZNER_FSN1_ID).subject
         private_subnet.connect_subnet(ps2)
+        fw = Firewall.create(project_id: project.id, name: "test-fw", location_id: Location::HETZNER_FSN1_ID)
+        fw.associate_with_private_subnet(private_subnet)
 
         visit "#{project.path}#{private_subnet.path}"
         within("#private-subnet-submenu") { click_link "Networking" }
 
         expect(page).to have_content ps2.name
         expect(page.all("a").map(&:text)).to include ps2.name
+        expect(page).to have_content fw.name
+        expect(page.all("a").map(&:text)).to include fw.name
 
         AccessControlEntry.dataset.destroy
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:view"], object_id: private_subnet.id)
         page.refresh
         expect(page).to have_content ps2.name
         expect(page.all("a").map(&:text)).not_to include ps2.name
+        expect(page).to have_content fw.name
+        expect(page.all("a").map(&:text)).not_to include fw.name
       end
 
       it "can disconnect connected subnet" do


### PR DESCRIPTION
The default subnet included with a project defaults to all-open to ease the learning curve.

However, all subnets in general follow the same algorithm: if a firewall is not passed, it gins up a new firewall record with all-open rules.  This is dangerous.  As-is the only way to suppress this implied firewall creation is to get the create request on private subnet exactly right, and pass a firewall object from the get-go. Failing (or not knowing) this, you have to read back the subnet to go and delete the all-open firewall rule.  I, personally, totally forgot about how to suppress the default rules until reminded.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevents automatic creation of all-open firewalls for subnets, requiring explicit firewall specification.
> 
>   - **Behavior**:
>     - Prevents automatic creation of all-open firewalls for subnets in `project.rb`, `kubernetes_cluster_nexus.rb`, `github_runner.rb`, and `vm_pool.rb`.
>     - Requires explicit firewall specification during subnet creation.
>   - **Functions**:
>     - Updates `assemble()` in `subnet_nexus.rb` to remove default firewall creation logic.
>     - Modifies `default_private_subnet()` in `project.rb` to handle firewall creation explicitly.
>   - **Tests**:
>     - Updates tests in `private_subnet_spec.rb`, `vpc_spec.rb`, `connected_subnets_spec.rb`, `subnet_nexus_spec.rb`, `attach-subnet_spec.rb`, `detach-subnet_spec.rb`, `golden_files_spec.rb`, `create_spec.rb`, and `private_subnet_spec.rb` to align with new firewall handling logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8f6b48f2c0f66fbe7e96516fdc57ddc6e56e7656. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->