### PR TITLE
Update PG default boot image version

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -172,7 +172,7 @@ module Config
   override :github_gpu_ubuntu_2204_version, "20251017.1.0", string
   override :github_ubuntu_2204_aws_ami_version, "ami-04b5534ef1aed6bde", string
   override :github_ubuntu_2404_aws_ami_version, "ami-0908b850ff3e635a2", string
-  override :postgres_ubuntu_2204_version, "20251007.1.0", string
+  override :postgres_ubuntu_2204_version, "20251103.1.0", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string
   override :postgres_paradedb_ubuntu_2204_version, "20250803.1.0", string


### PR DESCRIPTION
Update version to match the latest one in `download_boot_image.rb`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `postgres_ubuntu_2204_version` in `config.rb` to the latest boot image version.
> 
>   - **Configuration Update**:
>     - Update `postgres_ubuntu_2204_version` from `20251007.1.0` to `20251103.1.0` in `config.rb` to match the latest boot image version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 48193b174e38ec15fde8414a51d94207046f3b1c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->