### PR TITLE
RSpec: allow_message_expectations_on_nil = false

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,6 +98,8 @@ RSpec.configure do |config|
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
+    # Prevents expect(nil).to receive(...) which is only a warning by default
+    mocks.allow_message_expectations_on_nil = false
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will


### PR DESCRIPTION
Tests don't currently ever call `expect(nil)`, & never should
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `mocks.allow_message_expectations_on_nil = false` in `spec_helper.rb` to prevent `expect(nil).to receive(...)` calls.
> 
>   - **RSpec Configuration**:
>     - In `spec_helper.rb`, set `mocks.allow_message_expectations_on_nil = false` to prevent `expect(nil).to receive(...)` calls, which are only warnings by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7261f03f2211f2f515f3e55ff5f537fd9824b45a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->