### PR TITLE
feat(metrics): add override for victoriametrics

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -124,6 +124,7 @@ module Config
   optional :victoria_metrics_service_project_id, string
   override :victoria_metrics_host_name, "metrics.ubicloud.com", string
   override :victoria_metrics_version, "v1.113.0"
+  optional :victoria_metrics_endpoint_override, string
 
   # Spdk
   override :spdk_version, "v23.09-ubi-0.3"

--- a/model/victoria_metrics_resource.rb
+++ b/model/victoria_metrics_resource.rb
@@ -14,6 +14,9 @@ class VictoriaMetricsResource < Sequel::Model
   plugin SemaphoreMethods, :destroy, :reconfigure
 
   def self.client_for_project(prj_id)
+    if Config.victoria_metrics_endpoint_override
+      return VictoriaMetrics::Client.new(endpoint: Config.victoria_metrics_endpoint_override)
+    end
     vmr = nil
     [prj_id, Config.victoria_metrics_service_project_id].each do |project_id|
       next unless project_id

--- a/spec/model/victoria_metrics/victoria_metrics_resource_spec.rb
+++ b/spec/model/victoria_metrics/victoria_metrics_resource_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe VictoriaMetricsResource do
     )
   }
 
+  it "can have endpoint overridden by Config.victoria_metrics_endpoint_override" do
+    allow(Config).to receive(:victoria_metrics_endpoint_override).and_return("http://victoria.endpoint")
+    client = instance_double(VictoriaMetrics::Client)
+    expect(VictoriaMetrics::Client).to receive(:new).with(endpoint: Config.victoria_metrics_endpoint_override).and_return(client)
+    expect(described_class.client_for_project(victoria_metrics_project.id)).to be(client)
+  end
+
   it "returns hostname properly" do
     allow(Config).to receive(:victoria_metrics_host_name).and_return("victoria.ubicloud.com")
     expect(vmr.hostname).to eq("victoria-metrics-name.victoria.ubicloud.com")


### PR DESCRIPTION
useful for setting up metrics proxy in lieu of prometheus/otel metrics
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional `victoria_metrics_endpoint_override` to `config.rb` and updates `client_for_project` in `VictoriaMetricsResource` to use it if set.
> 
>   - **Behavior**:
>     - Adds `victoria_metrics_endpoint_override` as an optional configuration in `config.rb`.
>     - In `VictoriaMetricsResource`, `client_for_project` method uses `victoria_metrics_endpoint_override` if set, otherwise defaults to existing logic.
>   - **Misc**:
>     - No changes to existing functionality if `victoria_metrics_endpoint_override` is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 4da9b6de2389bd9a4637652f5bac00409d3c86fe. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->