### PR TITLE
Show info pages at the bottom of the admin page

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -414,13 +414,14 @@ class CloverAdmin < Roda
         flash.now["error"] = "Invalid ubid/uuid provided"
       end
 
-      @grouped_pages = Page.active.reverse(:created_at, :summary).group_by_vm_host
+      @grouped_pages = Page.active.reverse(:created_at, :summary).exclude(severity: "info").group_by_vm_host
       @classes = Sequel::Model
         .subclasses
         .map { [it, it.subclasses] }
         .flatten
         .select { it < ResourceMethods::InstanceMethods }
         .sort_by(&:name)
+      @info_pages = Page.where(severity: "info").reverse(:created_at).all
 
       view("index")
     end

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -49,4 +49,30 @@
     <li><a href="/change-password">Change Password</a></li>
     <li><a href="/multifactor-manage">Manage Multifactor Authentication</a></li>
   </ul>
+
+  <% if @info_pages.any? %>
+    <h2>Info Pages</h2>
+    <table class="info-page-table">
+      <thead>
+        <tr>
+          <th>Summary</th>
+          <th>Related Resources</th>
+          <th>Created At</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @info_pages.each do |info_page| %>
+          <tr>
+            <td><a href="/model/Page/<%= info_page.ubid %>"><%= info_page.summary %></a></td>
+            <% if info_page.details["related_resources"] %>
+              <td><%== linkify_ubids(info_page.details["related_resources"].join(" ")) %></td>
+            <% else %>
+              <td>No related resources</td>
+            <% end %>
+            <td><%= info_page.created_at.strftime("%F %T") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
 </div>


### PR DESCRIPTION
Info Pages will be rendered and shown on the admin index page if any exist. They will be sorted by creation time in reverse order.

A table will list all related_resources defined in the Page details, each with a link.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Display 'info' severity pages on the admin index page, sorted by creation time, with links to details and related resources.
> 
>   - **Behavior**:
>     - Display 'info' severity pages on the admin index page, sorted by creation time in reverse order in `clover_admin.rb`.
>     - Each info page includes a link to its details and related resources, if any, in `index.erb`.
>   - **Tests**:
>     - Add tests in `admin_spec.rb` to verify the rendering of info pages with and without related resources.
>     - Ensure the info pages section is not rendered when no info pages exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c04bd1953596c9dc490b6a5c4b228a2366c945b7. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->