### PR TITLE
Show warning for default runner OS change

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -327,6 +327,13 @@ class Prog::Vm::GithubRunner < Prog::Base
       COMMAND
     end
 
+    if !github_runner.label.include?("ubuntu")
+      message = "The default operating system for this runner will change to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. For more information: https://www.ubicloud.com/docs/github-actions-integration/runner-types#ubuntu-24-04-migration"
+      command += <<~COMMAND
+        echo "::notice::#{message}" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
+      COMMAND
+    end
+
     begin
       # Remove comments and empty lines before sending them to the machine
       vm.sshable.cmd(command.gsub(/^(\s*# .*)?\n/, ""))

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -563,6 +563,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
+        echo "::notice::The default operating system for this runner will change to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. For more information: https://www.ubicloud.com/docs/github-actions-integration/runner-types#ubuntu-24-04-migration" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")
@@ -580,6 +581,23 @@ RSpec.describe Prog::Vm::GithubRunner do
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment > /dev/null
+        echo "::notice::The default operating system for this runner will change to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. For more information: https://www.ubicloud.com/docs/github-actions-integration/runner-types#ubuntu-24-04-migration" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
+      COMMAND
+
+      expect { nx.setup_environment }.to hop("register_runner")
+    end
+
+    it "hops to register_runner without OS upgrade warning" do
+      expect(vm).to receive(:runtime_token).and_return("my_token")
+      installation.update(use_docker_mirror: false, cache_enabled: false)
+      runner.update(label: "ubicloud-standard-4-ubuntu-2204")
+      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
+        set -ueo pipefail
+        echo "image version: $ImageVersion"
+        sudo usermod -a -G sudo,adm runneradmin
+        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4-ubuntu-2204\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
+        echo "UBICLOUD_RUNTIME_TOKEN=my_token
+        UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")


### PR DESCRIPTION
Display a warning in the GitHub UI for customers using runners with the default operating system, which will change from Ubuntu 22.04 to Ubuntu 24.04 on November 23, 2025.

This helps customers be aware of the upcoming OS change and allows them to explicitly select Ubuntu 22.04 if needed.

<img width="5116" height="1898" alt="CleanShot 2025-11-18 at 19 37 15@2x" src="https://github.com/user-attachments/assets/fe1cae83-b0aa-4314-9cb4-21fd95394ba8" />
