### PR TITLE
Create info pages when last_boot_id differs from the actual boot_id

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -349,6 +349,14 @@ class VmHost < Sequel::Model
     error_count.empty?
   end
 
+  def check_last_boot_id(ssh_session)
+    boot_id = ssh_session.exec!("cat /proc/sys/kernel/random/boot_id")
+    fail "Failed to exec on session: #{boot_id}" unless boot_id.exitstatus.zero?
+    if boot_id.strip != last_boot_id
+      Prog::PageNexus.assemble("Recorded last_boot_id of #{ubid} in database differs from the actual boot_id", ["LastBootIDDiscrepancy", ubid], ubid, severity: "info")
+    end
+  end
+
   def init_health_monitor_session
     {
       ssh_session: sshable.start_fresh_session

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -431,7 +431,9 @@ TIMER
   end
 
   def available?
-    vm_host.perform_health_checks(sshable.connect, test_file_suffix: "respirate")
+    session = sshable.connect
+    vm_host.check_last_boot_id(session)
+    vm_host.perform_health_checks(session, test_file_suffix: "respirate")
   rescue
     false
   end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -658,12 +658,14 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#available?" do
     it "returns the available status when disks are healthy" do
       expect(sshable).to receive(:connect).and_return(nil)
+      expect(vm_host).to receive(:check_last_boot_id)
       expect(vm_host).to receive(:perform_health_checks).and_return(true)
       expect(nx.available?).to be true
     end
 
     it "returns the available status when disks are not healthy" do
       expect(sshable).to receive(:connect).and_return(nil)
+      expect(vm_host).to receive(:check_last_boot_id)
       allow(vm_host).to receive(:perform_health_checks).and_return(false)
       expect(nx.available?).to be false
     end


### PR DESCRIPTION
This page with its severity set to info will inform us if a VmHost crashes and restarts without us doing an incr_reboot on it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `check_last_boot_id` method to detect boot ID discrepancies in VM hosts and integrate it into availability checks.
> 
>   - **Behavior**:
>     - Adds `check_last_boot_id` method in `vm_host.rb` to compare `last_boot_id` with the current boot ID from `/proc/sys/kernel/random/boot_id`.
>     - If IDs differ, an info page is assembled using `Prog::PageNexus`.
>     - Integrates `check_last_boot_id` into `available?` method in `host_nexus.rb`.
>   - **Tests**:
>     - Adds tests for `check_last_boot_id` in `vm_host_spec.rb` to verify behavior when boot IDs match, differ, or command execution fails.
>     - Updates `available?` tests in `host_nexus_spec.rb` to include `check_last_boot_id` execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5b41494a67f90ee504af2925655b9cd9885315d6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->