### PR TITLE
Adjust sshd MaxStartups and LoginGraceTime.

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -43,6 +43,12 @@ LogLevel VERBOSE
 # Terminate sessions with clients that cannot return packets rapidly.
 ClientAliveInterval 2
 ClientAliveCountMax 4
+
+# Increase the maximum number of concurrent unauthenticated connections.
+MaxStartups 50:1:150
+
+# Reduce the time allowed for login.
+LoginGraceTime 20s
 SSHD_CONFIG
 
   LOGIND_CONFIG = <<LOGIND

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -78,6 +78,12 @@ echo \#\ Supported\ HostKey\ algorithms\ by\ order\ of\ preference.'
 '\#\ Terminate\ sessions\ with\ clients\ that\ cannot\ return\ packets\ rapidly.'
 'ClientAliveInterval\ 2'
 'ClientAliveCountMax\ 4'
+''
+'\#\ Increase\ the\ maximum\ number\ of\ concurrent\ unauthenticated\ connections.'
+'MaxStartups\ 50:1:150'
+''
+'\#\ Reduce\ the\ time\ allowed\ for\ login.'
+'LoginGraceTime\ 20s'
 ' | sudo tee /etc/ssh/sshd_config.d/10-clover.conf > /dev/null
 echo test\ key | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 sync


### PR DESCRIPTION
Recent short-lived host unavailability events were traced to MaxStartups throttling. This change updates our configs to reduce the likelihood of connection drops while limiting how long pre-auth sessions can consume resources:

- MaxStartups is updated from 10:30:100 to 50:1:150 to allow more simultaneous pre-auth connections with minimal drop probability.
- LoginGraceTime is reduced from 120s to 20s to ensure stalled authentication attempts release resources quickly.

This change applies only to newly provisioned hosts. Existing hosts will require a manual update to adopt the new sshd configuration.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update SSH `MaxStartups` and `LoginGraceTime` in `bootstrap_rhizome.rb` to improve connection handling and resource management for new hosts.
> 
>   - **Behavior**:
>     - Update `MaxStartups` from `10:30:100` to `50:1:150` in `bootstrap_rhizome.rb` to allow more simultaneous pre-auth connections.
>     - Reduce `LoginGraceTime` from `120s` to `20s` in `bootstrap_rhizome.rb` to release resources from stalled authentication attempts quickly.
>     - Changes apply only to newly provisioned hosts; existing hosts require manual updates.
>   - **Testing**:
>     - `bootstrap_rhizome_spec.rb` updated to test new `MaxStartups` and `LoginGraceTime` configurations.
>     - Verifies SSH configuration updates are correctly applied during setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b03b24ae334c12e7a413921904b50cca1fd6c18c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->