### PR TITLE
Delay host unavailability pages by 90 sec

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -389,7 +389,7 @@ TIMER
       hop_wait
     end
 
-    register_deadline("wait", 45)
+    register_deadline("wait", 90)
     nap 30
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe Prog::Vm::HostNexus do
     end
 
     it "registers a short deadline if host is unavailable" do
-      expect(nx).to receive(:register_deadline).with("wait", 45)
+      expect(nx).to receive(:register_deadline).with("wait", 90)
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(30)
     end


### PR DESCRIPTION
We’ve been sporadically receiving host unavailability alerts that auto-
resolve within seconds. To reduce noise while we make more fundamental
improvements to our monitoring, we extend the delay for unavailability
pages from 45 to 90 seconds.
