### PR TITLE
Use random file names for write-read healthchecks of VmHost

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -318,7 +318,7 @@ class VmHost < Sequel::Model
     end
 
     all_mount_points.uniq.all? do |mount_point|
-      file_name = Shellwords.escape(File.join(mount_point, "test-file"))
+      file_name = Shellwords.escape(File.join(mount_point, "test-file-#{SecureRandom.hex(4)}"))
 
       write_result = ssh_session.exec!("sudo bash -c \"head -c 1M </dev/zero > #{file_name}\"")
       write_status = write_result.exitstatus == 0


### PR DESCRIPTION
There were times where we would run VmHost healthchecks in parallel, and the code prior to this commit had a race condition for reading or deleting the file, causing the healthcheck to randomly fail.

With this commit, every time we run the healthcheck, we are ensuring a unique file name to avoid the race condition.