### PR TITLE
Add last line to failure E2E slack notification

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -140,6 +140,14 @@ jobs:
         echo "### Image downloaded in $download_time" >> $GITHUB_STEP_SUMMARY
         echo "DOWNLOAD_TIME=$download_time" >> $GITHUB_OUTPUT
 
+    - name: Extract last line
+      if: always()
+      id: extract_last
+      run: |
+        last_line="$(grep "e2e.1" foreman.log | tail -2 | head -1 | cut -d'|' -f2,4,5)"
+        echo "### Last line: $last_line" >> $GITHUB_STEP_SUMMARY
+        echo "LAST_LINE=$last_line" >> $GITHUB_OUTPUT
+
     - name: Extract vm provision times
       if: always()
       continue-on-error: true
@@ -188,3 +196,6 @@ jobs:
                 - title: "Download Time"
                   short: true
                   value: "${{ steps.extract_download.outputs.DOWNLOAD_TIME }}"
+                - title: "Last Line"
+                  short: false
+                  value: "${{ steps.extract_last.outputs.LAST_LINE }}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds extraction of the last line from `foreman.log` to E2E failure Slack notifications in `.github/workflows/e2e.yml`.
> 
>   - **Behavior**:
>     - Adds a step `Extract last line` in `.github/workflows/e2e.yml` to extract the last relevant line from `foreman.log`.
>     - Updates Slack notification to include the extracted last line when E2E tests fail.
>   - **Misc**:
>     - Uses `grep`, `tail`, `head`, and `cut` to process `foreman.log` and extract the last line.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 611ad0654f9dfa9bd37bc61308c9dc52a108dfbe. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->