### PR TITLE
Support custom QEMU binary

### DIFF
--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe VmSetup do
         expect(content).to include("Slice=system.slice")
         expect(content).to include("NetworkNamespacePath=/var/run/netns/test")
 
-        expect(content).to include("ExecStart=/usr/bin/qemu-system-#{Arch.render(x64: "x86_64", arm64: "aarch64")}")
+        expect(content).to include("ExecStart=qemu-system-#{Arch.render(x64: "x86_64", arm64: "aarch64")}")
         %w[
           -bios /opt/fw/QEMU.fd
           -object memory-backend-memfd,id=mem0,size=2G,hugetlb=on,hugetlbsize=1G,prealloc=on,share=on
@@ -287,9 +287,9 @@ RSpec.describe VmSetup do
           -enable-kvm
           -machine accel=kvm,type=q35
           -drive if=none,file=/vm/test/cloudinit.img,format=raw,readonly=on,id=cidrive
-          -device virtio-blk-pci,drive=cidrive
+          -device virtio-blk-pci,drive=cidrive,romfile=
           -netdev tap,id=net0,ifname=tap0,script=no,downscript=no,queues=5,vhost=on
-          -device virtio-net-pci,mac=02:aa:bb:cc:dd:01,netdev=net0,mq=on
+          -device virtio-net-pci,mac=02:aa:bb:cc:dd:01,netdev=net0,mq=on,romfile=
           -serial file:/vm/test/serial.log
           -display none
           -no-reboot


### PR DESCRIPTION
- Invoke QEMU via just `qemu-system-${arch}` instead of hardcoding
  `/usr/bin/qemu-system-${arch}`. This allows locally built QEMU
  binaries installed in /usr/local/bin to take precedence.

- Remove `x-no-mmap=true` and `rombar=0` from passed-through GPUs.
  With a custom QEMU build these work correctly without disabling mmap,
  while the distro QEMU requires `x-no-mmap=true` to avoid severe stalls.

- Add `romfile=` to virtio-blk-pci, virtio-net-pci, and vhost-user-blk-pci
  devices. Explicitly suppressing option ROMs avoids unnecessary firmware
  loading.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Support custom QEMU binaries and improve device option handling in `vm_setup.rb`.
> 
>   - **Behavior**:
>     - Change QEMU invocation to `qemu-system-${arch}` in `vm_setup.rb` and `vm_setup_spec.rb`, allowing custom QEMU binaries in `/usr/local/bin` to be used.
>     - Remove `x-no-mmap=true` and `rombar=0` from GPU passthrough options in `vm_setup.rb`.
>     - Add `romfile=` option to `virtio-blk-pci`, `virtio-net-pci`, and `vhost-user-blk-pci` devices in `vm_setup.rb` to suppress option ROMs.
>   - **Tests**:
>     - Update `vm_setup_spec.rb` to reflect changes in QEMU invocation and device options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5c1c7ec84afc5d6b3c23dd88cd568576da2388a2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->