### PR TITLE
fix: add billing check to pg similar to vm

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -185,27 +185,29 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   label def update_billing_records
     decr_update_billing_records
 
-    postgres_resource.active_billing_records.each(&:finalize)
+    if postgres_resource.project.billable
+      postgres_resource.active_billing_records.each(&:finalize)
 
-    flavor = postgres_resource.flavor
-    vm_family = representative_server.vm.family
-    vcpu_count = representative_server.vm.vcpus
-    storage_size_gib = representative_server.storage_size_gib
+      flavor = postgres_resource.flavor
+      vm_family = representative_server.vm.family
+      vcpu_count = representative_server.vm.vcpus
+      storage_size_gib = representative_server.storage_size_gib
 
-    billing_record_parts = []
-    postgres_resource.target_server_count.times do |index|
-      billing_record_parts.push({resource_type: index.zero? ? "PostgresVCpu" : "PostgresStandbyVCpu", resource_family: "#{flavor}-#{vm_family}", amount: vcpu_count})
-      billing_record_parts.push({resource_type: index.zero? ? "PostgresStorage" : "PostgresStandbyStorage", resource_family: flavor, amount: storage_size_gib})
-    end
+      billing_record_parts = []
+      postgres_resource.target_server_count.times do |index|
+        billing_record_parts.push({resource_type: index.zero? ? "PostgresVCpu" : "PostgresStandbyVCpu", resource_family: "#{flavor}-#{vm_family}", amount: vcpu_count})
+        billing_record_parts.push({resource_type: index.zero? ? "PostgresStorage" : "PostgresStandbyStorage", resource_family: flavor, amount: storage_size_gib})
+      end
 
-    billing_record_parts.each do |brp|
-      BillingRecord.create(
-        project_id: postgres_resource.project_id,
-        resource_id: postgres_resource.id,
-        resource_name: postgres_resource.name,
-        billing_rate_id: BillingRate.from_resource_properties(brp[:resource_type], brp[:resource_family], Location[postgres_resource.location_id].name)["id"],
-        amount: brp[:amount]
-      )
+      billing_record_parts.each do |brp|
+        BillingRecord.create(
+          project_id: postgres_resource.project_id,
+          resource_id: postgres_resource.id,
+          resource_name: postgres_resource.name,
+          billing_rate_id: BillingRate.from_resource_properties(brp[:resource_type], brp[:resource_family], Location[postgres_resource.location_id].name)["id"],
+          amount: brp[:amount]
+        )
+      end
     end
 
     decr_initial_provisioning


### PR DESCRIPTION
https://github.com/ubicloud/ubicloud/blob/3bdf60d49f62defc266c18695ad5d5ed2b584fa8/prog/vm/nexus.rb#L387

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add billing check to `update_billing_records` in `postgres_resource_nexus.rb` to skip billing for non-billable projects, with corresponding tests.
> 
>   - **Behavior**:
>     - In `update_billing_records` in `postgres_resource_nexus.rb`, added a check to skip billing record updates if `postgres_resource.project.billable` is false.
>     - If the project is not billable, the function hops to "wait" instead of creating billing records.
>   - **Tests**:
>     - Added test in `postgres_resource_nexus_spec.rb` to verify that `update_billing_records` skips billing record creation for non-billable projects.
>     - Ensures that billing records are created when the project is billable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 271f848d92aa10a130baf3a6eb0312f5993cd4fa. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->