### PR TITLE
Prevent deletion of GitHub installations for suspended accounts

### DIFF
--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -40,9 +40,8 @@ class Clover
     installation = GithubInstallation[installation_id: data["installation"]["id"]]
     case data["action"]
     when "deleted"
-      unless installation
-        return error("Unregistered installation")
-      end
+      return error("Unregistered installation") unless installation
+      return error("Inactive project") unless installation.project.active?
 
       Prog::Github::DestroyGithubInstallation.assemble(installation)
       return success("GithubInstallation[#{installation.ubid}] deleted")

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe Clover, "github" do
       expect(page.body).to eq({error: {message: "Unregistered installation"}}.to_json)
     end
 
+    it "fails if the project is inactive" do
+      account = create_account.update(suspended_at: Time.now)
+      account.add_project(installation.project)
+      send_webhook("installation", {action: "deleted", installation: {id: installation.installation_id}})
+
+      expect(page.status_code).to eq(200)
+      expect(page.body).to eq({error: {message: "Inactive project"}}.to_json)
+    end
+
     it "destroys installation when receive deleted action" do
       expect(Prog::Github::DestroyGithubInstallation).to receive(:assemble).with(installation)
       send_webhook("installation", {action: "deleted", installation: {id: installation.installation_id}})


### PR DESCRIPTION
When we suspend an account, the user can’t log in to the Ubicloud console, which prevents them from removing the GitHub installation. This helps block fraudulent users from repeatedly reusing the same GitHub organization.

However, if they remove the installation from the GitHub UI, we receive a webhook event and currently delete the installation on our side. This allows them to reuse the same GitHub organization with a new account.

To prevent this, if the installation’s project is inactive, we no longer delete the installation when handling the webhook event.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevent deletion of GitHub installations for inactive projects when handling deletion events in `github.rb`.
> 
>   - **Behavior**:
>     - In `handle_installation` in `github.rb`, prevent deletion of GitHub installation if the project is inactive when receiving a "deleted" action.
>   - **Tests**:
>     - Add test in `github_spec.rb` to verify error response when project is inactive during installation deletion event.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for dfcc08d29986511d7d70dfe37df1468a8879adae. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->