### PR TITLE
Upgrade default runner label's Ubuntu version from 22.04 to 24.04

### DIFF
--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -1,10 +1,10 @@
-- { name: ubicloud,                             alias_for: ubicloud-standard-2-ubuntu-2204 }
-- { name: ubicloud-standard-2,                  alias_for: ubicloud-standard-2-ubuntu-2204 }
-- { name: ubicloud-standard-4,                  alias_for: ubicloud-standard-4-ubuntu-2204 }
-- { name: ubicloud-standard-8,                  alias_for: ubicloud-standard-8-ubuntu-2204 }
-- { name: ubicloud-standard-16,                 alias_for: ubicloud-standard-16-ubuntu-2204 }
-- { name: ubicloud-standard-30,                 alias_for: ubicloud-standard-30-ubuntu-2204 }
-- { name: ubicloud-standard-60,                 alias_for: ubicloud-standard-60-ubuntu-2204 }
+- { name: ubicloud,                             alias_for: ubicloud-standard-2-ubuntu-2404 }
+- { name: ubicloud-standard-2,                  alias_for: ubicloud-standard-2-ubuntu-2404 }
+- { name: ubicloud-standard-4,                  alias_for: ubicloud-standard-4-ubuntu-2404 }
+- { name: ubicloud-standard-8,                  alias_for: ubicloud-standard-8-ubuntu-2404 }
+- { name: ubicloud-standard-16,                 alias_for: ubicloud-standard-16-ubuntu-2404 }
+- { name: ubicloud-standard-30,                 alias_for: ubicloud-standard-30-ubuntu-2404 }
+- { name: ubicloud-standard-60,                 alias_for: ubicloud-standard-60-ubuntu-2404 }
 - { name: ubicloud-standard-2-ubuntu-2404,      family: standard,     vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-4-ubuntu-2404,      family: standard,     vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-8-ubuntu-2404,      family: standard,     vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
@@ -17,11 +17,11 @@
 - { name: ubicloud-standard-16-ubuntu-2204,     family: standard,     vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-standard-30-ubuntu-2204,     family: standard,     vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-standard-60-ubuntu-2204,     family: standard,     vcpus: 60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-premium-2,                   alias_for: ubicloud-premium-2-ubuntu-2204 }
-- { name: ubicloud-premium-4,                   alias_for: ubicloud-premium-4-ubuntu-2204 }
-- { name: ubicloud-premium-8,                   alias_for: ubicloud-premium-8-ubuntu-2204 }
-- { name: ubicloud-premium-16,                  alias_for: ubicloud-premium-16-ubuntu-2204 }
-- { name: ubicloud-premium-30,                  alias_for: ubicloud-premium-30-ubuntu-2204 }
+- { name: ubicloud-premium-2,                   alias_for: ubicloud-premium-2-ubuntu-2404 }
+- { name: ubicloud-premium-4,                   alias_for: ubicloud-premium-4-ubuntu-2404 }
+- { name: ubicloud-premium-8,                   alias_for: ubicloud-premium-8-ubuntu-2404 }
+- { name: ubicloud-premium-16,                  alias_for: ubicloud-premium-16-ubuntu-2404 }
+- { name: ubicloud-premium-30,                  alias_for: ubicloud-premium-30-ubuntu-2404 }
 - { name: ubicloud-premium-2-ubuntu-2404,       family: premium,      vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
 - { name: ubicloud-premium-4-ubuntu-2404,       family: premium,      vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
 - { name: ubicloud-premium-8-ubuntu-2404,       family: premium,      vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
@@ -32,13 +32,13 @@
 - { name: ubicloud-premium-8-ubuntu-2204,       family: premium,      vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-premium-16-ubuntu-2204,      family: premium,      vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2204 }
 - { name: ubicloud-premium-30-ubuntu-2204,      family: premium,      vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2204 }
-- { name: ubicloud-arm,                         alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
-- { name: ubicloud-standard-2-arm,              alias_for: ubicloud-standard-2-arm-ubuntu-2204 }
-- { name: ubicloud-standard-4-arm,              alias_for: ubicloud-standard-4-arm-ubuntu-2204 }
-- { name: ubicloud-standard-8-arm,              alias_for: ubicloud-standard-8-arm-ubuntu-2204 }
-- { name: ubicloud-standard-16-arm,             alias_for: ubicloud-standard-16-arm-ubuntu-2204 }
-- { name: ubicloud-standard-30-arm,             alias_for: ubicloud-standard-30-arm-ubuntu-2204 }
-- { name: ubicloud-standard-60-arm,             alias_for: ubicloud-standard-60-arm-ubuntu-2204 }
+- { name: ubicloud-arm,                         alias_for: ubicloud-standard-2-arm-ubuntu-2404 }
+- { name: ubicloud-standard-2-arm,              alias_for: ubicloud-standard-2-arm-ubuntu-2404 }
+- { name: ubicloud-standard-4-arm,              alias_for: ubicloud-standard-4-arm-ubuntu-2404 }
+- { name: ubicloud-standard-8-arm,              alias_for: ubicloud-standard-8-arm-ubuntu-2404 }
+- { name: ubicloud-standard-16-arm,             alias_for: ubicloud-standard-16-arm-ubuntu-2404 }
+- { name: ubicloud-standard-30-arm,             alias_for: ubicloud-standard-30-arm-ubuntu-2404 }
+- { name: ubicloud-standard-60-arm,             alias_for: ubicloud-standard-60-arm-ubuntu-2404 }
 - { name: ubicloud-standard-2-arm-ubuntu-2404,  family: standard,     vcpus: 2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-4-arm-ubuntu-2404,  family: standard,     vcpus: 4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-8-arm-ubuntu-2404,  family: standard,     vcpus: 8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2404 }

--- a/spec/lib/github_spec.rb
+++ b/spec/lib/github_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Github do
 
   it "can map alias to actual label" do
     labels = described_class.runner_labels
-    expect(labels["ubicloud"]).to eq(labels["ubicloud-standard-2-ubuntu-2204"])
-    expect(labels["ubicloud-standard-8"]).to eq(labels["ubicloud-standard-8-ubuntu-2204"])
-    expect(labels["ubicloud-standard-4-arm"]).to eq(labels["ubicloud-standard-4-arm-ubuntu-2204"])
+    expect(labels["ubicloud"]).to eq(labels["ubicloud-standard-2-ubuntu-2404"])
+    expect(labels["ubicloud-standard-8"]).to eq(labels["ubicloud-standard-8-ubuntu-2404"])
+    expect(labels["ubicloud-standard-4-arm"]).to eq(labels["ubicloud-standard-4-arm-ubuntu-2404"])
   end
 
   it "can map all aliases to actual tag" do

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses the existing vm if pool can pick one" do
-      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
       vm = create_vm(pool_id: pool.id, display_state: "running")
       picked_vm = nx.pick_vm
       expect(vm.id).to eq(picked_vm.id)
     end
 
     it "uses the premium vm pool if the installation prefers premium runners" do
-      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
       vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
       expect(installation).to receive(:premium_runner_enabled?).and_return(true)
       picked_vm = nx.pick_vm
@@ -92,7 +92,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "uses the premium vm pool if a free premium upgrade is enabled" do
-      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
       vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
       expect(installation).to receive(:premium_runner_enabled?).and_return(false)
       expect(installation).to receive(:free_runner_upgrade?).and_return(true)
@@ -102,7 +102,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     end
 
     it "skips pool if feature flag is enabled even when the pool has a vm" do
-      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2204", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
       vm = create_vm(pool_id: pool.id, display_state: "running")
       project.set_ff_skip_runner_pool(true)
       expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).and_call_original
@@ -119,7 +119,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       picked_vm = nx.pick_vm
       expect(picked_vm.family).to eq("m7a")
       expect(picked_vm.location.aws?).to be(true)
-      expect(picked_vm.boot_image).to eq(Config.github_ubuntu_2204_aws_ami_version)
+      expect(picked_vm.boot_image).to eq(Config.github_ubuntu_2404_aws_ami_version)
       expect(picked_vm.strand.stack.first["alternative_families"]).to eq(["m7i", "m6a"])
     end
 
@@ -130,7 +130,7 @@ RSpec.describe Prog::Vm::GithubRunner do
       picked_vm = nx.pick_vm
       expect(picked_vm.family).to eq("m7a")
       expect(picked_vm.location.aws?).to be(true)
-      expect(picked_vm.boot_image).to eq(Config.github_ubuntu_2204_aws_ami_version)
+      expect(picked_vm.boot_image).to eq(Config.github_ubuntu_2404_aws_ami_version)
     end
   end
 

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -227,8 +227,8 @@ RSpec.describe Clover, "github" do
       displayed_runner_rows = page.all("table.min-w-full tbody tr").map { |row| row.all("td").map(&:text) }
       expect(displayed_runner_rows).to eq [
         ["my-repo", "#{runner_with_job.ubid}\n4 vCPU\npremium\nx64\nubuntu-24", "test-workflow\ntest-job", "Running for 40s\nStarted in 20s", ""],
-        ["my-repo", "#{runner_waiting_job.ubid}\n2 vCPU\nstandard\nx64\nubuntu-22", "Waiting for GitHub to assign a job\nReady for 6m 40s", "", ""],
-        ["my-repo", "#{runner_not_created.ubid}\n2 vCPU\nstandard\narm64\nubuntu-22", "Provisioning an ephemeral virtual machine\nWaiting for 38s", "", ""],
+        ["my-repo", "#{runner_waiting_job.ubid}\n2 vCPU\nstandard\nx64\nubuntu-24", "Waiting for GitHub to assign a job\nReady for 6m 40s", "", ""],
+        ["my-repo", "#{runner_not_created.ubid}\n2 vCPU\nstandard\narm64\nubuntu-24", "Provisioning an ephemeral virtual machine\nWaiting for 38s", "", ""],
         ["my-repo", "#{runner_concurrency_limit.ubid}\n6 vCPU\nstandard-gpu\nx64\nubuntu-22", "Reached your concurrency limit\nWaiting for 3h 40m 48s", "", ""]
       ]
     end


### PR DESCRIPTION
Following GitHub's own move, upgrading Ubuntu version for runners using default labels to 24.04 from 22.04
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update runner labels and tests to use Ubuntu 24.04 instead of 22.04.
> 
>   - **Configuration**:
>     - Update Ubuntu version from 22.04 to 24.04 in `config/github_runner_labels.yml` for runner labels `ubicloud`, `ubicloud-standard`, `ubicloud-premium`, and `ubicloud-arm`.
>   - **Tests**:
>     - Update expected runner labels in `github_spec.rb` and `github_runner_spec.rb` to reflect Ubuntu 24.04.
>     - Modify test cases in `github_runner_spec.rb` to use `github-ubuntu-2404` boot image.
>     - Adjust runner display expectations in `github_spec.rb` and `project/github_spec.rb` to show Ubuntu 24.04.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 20bd24d15e575ed89049e6cd48771e9f2d31dbed. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->