### PR TITLE
Log unmatched labels for further investigation

### DIFF
--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -70,12 +70,16 @@ class Clover
       label = custom_label.alias_for
     end
 
-    return error("Unmatched label") unless label
+    repository_name = data["repository"]["full_name"]
+    unless label
+      Clog.emit("Unmatched label") { {unmatched_label: {repository_name:, labels: job_labels}} } if data["action"] == "queued"
+      return error("Unmatched label")
+    end
 
     if data["action"] == "queued"
       st = Prog::Vm::GithubRunner.assemble(
         installation,
-        repository_name: data["repository"]["full_name"],
+        repository_name:,
         label:,
         actual_label:,
         default_branch: data["repository"]["default_branch"]
@@ -91,7 +95,7 @@ class Clover
 
     runner = GithubRunner.first(
       installation_id: installation.id,
-      repository_name: data["repository"]["full_name"],
+      repository_name:,
       runner_id:
     )
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe Clover, "github" do
     end
 
     it "fails if label not matched" do
+      send_webhook("workflow_job", workflow_job_payload(action: "completed", workflow_job: workflow_job_object(label: "other")))
+
+      expect(page.status_code).to eq(200)
+      expect(page.body).to eq({error: {message: "Unmatched label"}}.to_json)
+    end
+
+    it "fails if label not matched and logs if queued" do
+      expect(Clog).to receive(:emit).with("Unmatched label").and_call_original
       send_webhook("workflow_job", workflow_job_payload(action: "queued", workflow_job: workflow_job_object(label: "other")))
 
       expect(page.status_code).to eq(200)


### PR DESCRIPTION
With the introduction of custom labels, it's important to understand which labels are failing to match. This change adds logging for unmatched labels to make it easier to identify and debug issues related to label matching.