### PR TITLE
Add dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 14
     versioning-strategy: lockfile-only
     allow:
       - dependency-type: "all"
@@ -16,6 +18,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 14
     allow:
       - dependency-type: "all"
     groups:
@@ -26,6 +30,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 14
     allow:
       - dependency-type: "all"
     groups:
@@ -36,6 +42,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 14
     allow:
       - dependency-type: "all"
     groups:


### PR DESCRIPTION
I always thought: "that would be a nice feature to have" to mitigate supply chain attacks before they can get noticed,
https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns made me aware that this feature was at hand.