### PR TITLE
Fix CI setup failure caused by PostgreSQL default version change

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         # Remove the default PostgreSQL cluster on the runner
-        sudo -u postgres pg_dropcluster 14 main --stop
+        sudo -u postgres pg_dropcluster 16 main --stop
         # Install PostgreSQL
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -


### PR DESCRIPTION
To ensure consistent behavior, we remove the default PostgreSQL installation on the runner and install the required version explicitly.

The newer runner image has switched from Ubuntu 22.04 to Ubuntu 24.04, which changes the default PostgreSQL version from 14 to 16. This breaks our CI setup, which relies on a specific PostgreSQL version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CI setup by updating PostgreSQL version to 17 in `setup-clover/action.yml` for compatibility with Ubuntu 24.04 runner.
> 
>   - **CI Setup**:
>     - Updates PostgreSQL version from 14 to 16 in `.github/actions/setup-clover/action.yml` to match the new Ubuntu 24.04 runner image.
>     - Removes default PostgreSQL 16 cluster and installs PostgreSQL 17 explicitly.
>     - Configures PostgreSQL 17 for runner access by updating `pg_ident.conf` and `pg_hba.conf`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 20f157b74c90281871cabc78315172d639b091b2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->