### PR TITLE
Update default runner version change warning message

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -328,7 +328,7 @@ class Prog::Vm::GithubRunner < Prog::Base
     end
 
     if !github_runner.label.include?("ubuntu")
-      message = "The default operating system for this runner will change to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. For more information: https://www.ubicloud.com/docs/github-actions-integration/runner-types#ubuntu-24-04-migration"
+      message = "The default operating system for this runner has been changed to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. If you have any questions, feel free to reach out at support@ubicloud.com"
       command += <<~COMMAND
         echo "::notice::#{message}" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
       COMMAND

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -563,7 +563,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
-        echo "::notice::The default operating system for this runner will change to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. For more information: https://www.ubicloud.com/docs/github-actions-integration/runner-types#ubuntu-24-04-migration" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
+        echo "::notice::The default operating system for this runner has been changed to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. If you have any questions, feel free to reach out at support@ubicloud.com" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")
@@ -581,7 +581,7 @@ RSpec.describe Prog::Vm::GithubRunner do
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment > /dev/null
-        echo "::notice::The default operating system for this runner will change to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. For more information: https://www.ubicloud.com/docs/github-actions-integration/runner-types#ubuntu-24-04-migration" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
+        echo "::notice::The default operating system for this runner has been changed to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. If you have any questions, feel free to reach out at support@ubicloud.com" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")


### PR DESCRIPTION
Default runner version has been changed to Ubuntu 24.04. In case
that cause issues on user workflows, updating message to explicitly
show that change and also direct users to support mail.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update message in `github_runner.rb` and `github_runner_spec.rb` to reflect the change in default runner OS to Ubuntu 24.04.
> 
>   - **Behavior**:
>     - Update message in `setup_environment` in `github_runner.rb` to reflect the change in default runner OS to Ubuntu 24.04.
>     - Update corresponding test message in `github_runner_spec.rb` to match the new OS version.
>   - **Misc**:
>     - Update support contact information in the message to `support@ubicloud.com`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a7ee0c1405e8e804a2927253578617cf03e8463c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->