### PR TITLE
Fix Nic provisioning for old AWS subnets

### DIFF
--- a/prog/vnet/nic_nexus.rb
+++ b/prog/vnet/nic_nexus.rb
@@ -16,7 +16,7 @@ class Prog::Vnet::NicNexus < Prog::Base
 
     DB.transaction do
       prog, ipv4_addr, mac, state = if subnet.location.aws?
-        ["Vnet::Aws::NicNexus", (ipv4_addr || subnet.random_private_ipv4.nth_subnet(32, 4)).to_s, nil, "active"]
+        ["Vnet::Aws::NicNexus", (ipv4_addr || subnet.random_private_ipv4.nth_subnet(32, 4) || subnet.random_private_ipv4).to_s, nil, "active"]
       else
         ["Vnet::Metal::NicNexus", (ipv4_addr || subnet.random_private_ipv4).to_s, gen_mac, "initializing"]
       end


### PR DESCRIPTION
We broke this with the commit ec3f786. Only old clusters are impacted
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes NIC provisioning for old AWS subnets by adding a fallback IPv4 address assignment in `assemble` method of `nic_nexus.rb`.
> 
>   - **Behavior**:
>     - Fixes NIC provisioning for old AWS subnets in `assemble` method of `nic_nexus.rb`.
>     - Adds fallback to `subnet.random_private_ipv4` if `nth_subnet(32, 4)` returns nil, ensuring IPv4 address assignment.
>   - **Misc**:
>     - Only impacts old clusters as per commit ec3f786.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5d1e4bc6a8877a6b8179243839eb4bd7cf8b718a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->