### PR TITLE
Ensure destroy flow runs when AWS runners fail to acquire instance

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -201,7 +201,8 @@ class Prog::Vm::Aws::Nexus < Prog::Base
         end
         runner.provision_spare_runner
         runner.incr_destroy
-        pop "exiting due to insufficient instance capacity"
+        vm.incr_destroy
+        nap 0
       end
       raise
     end

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -407,13 +407,13 @@ usermod -L ubuntu
       it "recreates runner when alternative_families is not set" do
         expect(nx).to receive(:frame).and_return({}).at_least(:once)
         expect(Prog::Vm::GithubRunner).to receive(:assemble).and_call_original
-        expect { nx.create_instance }.to exit({"msg" => "exiting due to insufficient instance capacity"})
+        expect { nx.create_instance }.to nap(0)
       end
 
       it "recreates runner when alternative_families is empty" do
         expect(nx).to receive(:frame).and_return({"alternative_families" => []}).at_least(:once)
         expect(Prog::Vm::GithubRunner).to receive(:assemble).and_call_original
-        expect { nx.create_instance }.to exit({"msg" => "exiting due to insufficient instance capacity"})
+        expect { nx.create_instance }.to nap(0)
       end
 
       it "creates runner with the first alternative when current_family is the initial family" do
@@ -433,7 +433,7 @@ usermod -L ubuntu
         vm.update(family: "m6a")
         expect(nx).to receive(:frame).and_return({"alternative_families" => ["m7i", "m6a"]}).at_least(:once)
         expect(Prog::Vm::GithubRunner).to receive(:assemble).and_call_original
-        expect { nx.create_instance }.to exit({"msg" => "exiting due to insufficient instance capacity"})
+        expect { nx.create_instance }.to nap(0)
       end
     end
 


### PR DESCRIPTION
Previously, when an AWS VM Nexus failed due to insufficient instance
capacity, it would `pop` itself directly. This left behind a VM
model without an associated strand, causing the owning GithubRunner
flow to hang and cause page. By `incr_destroy`ing the VM,
we aim proper handling of cleanup and preventing stuck runners.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure AWS VM Nexus lets GithubRunner handle cleanup on insufficient capacity, preventing stuck runners.
> 
>   - **Behavior**:
>     - In `nexus.rb`, when AWS VM Nexus encounters `InsufficientInstanceCapacity`, it no longer pops itself. Instead, it increments `vm.incr_destroy` and naps, allowing the owning `GithubRunner` to handle cleanup.
>     - This prevents the creation of VM models without associated strands, which previously caused the `GithubRunner` flow to hang.
>   - **Tests**:
>     - In `nexus_spec.rb`, updated tests to expect `nap(0)` instead of `exit` when `create_instance` encounters `InsufficientInstanceCapacity`.
>     - Tests cover scenarios with and without `alternative_families` set, ensuring proper handling of runner recreation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fc8ead27816f516af1e1e0698a75c9d7ee27d65f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->