### PR TITLE
Do not attempt to update removed CoreDNS config files

### DIFF
--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -574,6 +574,18 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       allow(kubernetes_cluster).to receive(:sshable).and_return(sshable)
     end
 
+    it "returns early if Corefile is not found" do
+      get_cm = <<~YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: coredns
+      namespace: kube-system
+      YAML
+      expect(client).to receive(:kubectl).with("-n kube-system get cm coredns -oyaml").and_return(get_cm)
+      expect { nx.sync_internal_dns_config }.to hop("wait")
+    end
+
     it "adds the ubicloud block and replaces the configmap" do
       nodes = kubernetes_cluster.functional_nodes
       expect(nodes.first.vm).to receive_messages(


### PR DESCRIPTION
During the sync_internal_dns_config label, we check whether the Corefile entry exists. If it does not, we stop and leave it unchanged, since this indicates the customer has custom tunings or removed the config entirely.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `sync_internal_dns_config` now returns early if CoreDNS `Corefile` is missing, indicating custom configurations or deletions.
> 
>   - **Behavior**:
>     - In `kubernetes_cluster_nexus.rb`, `sync_internal_dns_config` now checks if `Corefile` exists in the CoreDNS config map. If not, it returns early, indicating possible custom configurations or deletions.
>   - **Tests**:
>     - In `kubernetes_cluster_nexus_spec.rb`, adds test to verify early return when `Corefile` is missing in `sync_internal_dns_config`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5184b3bdbac96fe7ee0c412c14103aa5a2d724bf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->