### PR TITLE
Add PostgresResource list by tag endpoint

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1757,6 +1757,7 @@ paths:
       summary: List visible Postgres Databases
       parameters:
         - $ref: '#/components/parameters/project_id'
+        - $ref: '#/components/parameters/tags'
         - $ref: '#/components/parameters/start_after'
         - $ref: '#/components/parameters/page_size'
         - $ref: '#/components/parameters/order_column'
@@ -2187,6 +2188,14 @@ components:
       required: false
       schema:
         type: string
+    tags:
+      description: 'Filter by tags in key:value format (comma-separated for multiple tags)'
+      in: query
+      name: tags
+      required: false
+      schema:
+        type: string
+        example: 'environment:production,team:backend'
     vm_reference:
       description: Virtual machine ID or name
       examples:

--- a/routes/project/postgres.rb
+++ b/routes/project/postgres.rb
@@ -3,7 +3,8 @@
 class Clover
   hash_branch(:project_prefix, "postgres") do |r|
     r.get true do
-      postgres_list
+      tags_param = typecast_params.nonempty_str("tags")
+      postgres_list(tags_param:)
     end
 
     r.web do

--- a/spec/routes/api/project/postgres_spec.rb
+++ b/spec/routes/api/project/postgres_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Clover, "vm" do
       allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
     end
 
-    it "success all vms" do
+    it "success all postgres resources" do
       Prog::Postgres::PostgresResourceNexus.assemble(
         project_id: project.id,
         location_id: Location::HETZNER_FSN1_ID,
@@ -43,6 +43,146 @@ RSpec.describe Clover, "vm" do
 
       expect(last_response.status).to eq(200)
       expect(JSON.parse(last_response.body)["items"].length).to eq(2)
+    end
+
+    it "filters by single tag with key and value" do
+      pg = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-production",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg.update(tags: [{key: "environment", value: "production"}])
+
+      get "/project/#{project.ubid}/postgres?tags=environment:production"
+
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body["items"].length).to eq(1)
+      expect(body["items"][0]["name"]).to eq("pg-production")
+    end
+
+    it "pass empty tags filter and return all postgres resources" do
+      pg = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-production",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg.update(tags: [{key: "environment", value: "production"}])
+
+      get "/project/#{project.ubid}/postgres?tags="
+
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body["items"].length).to eq(1)
+      expect(body["items"][0]["name"]).to eq("pg-production")
+    end
+
+    it "filters by multiple tags (AND logic)" do
+      pg1 = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-prod-backend",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg1.update(tags: [{key: "environment", value: "production"}, {key: "team", value: "backend"}])
+
+      pg2 = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-prod-frontend",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg2.update(tags: [{key: "environment", value: "production"}, {key: "team", value: "frontend"}])
+
+      pg3 = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-staging-backend",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg3.update(tags: [{key: "environment", value: "staging"}, {key: "team", value: "backend"}])
+
+      get "/project/#{project.ubid}/postgres?tags=environment:production,team:backend"
+
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body["items"].length).to eq(1)
+      expect(body["items"][0]["name"]).to eq("pg-prod-backend")
+    end
+
+    it "returns empty when no resources match tag filter" do
+      pg = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-test",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg.update(tags: [{key: "environment", value: "development"}])
+
+      get "/project/#{project.ubid}/postgres?tags=environment:production"
+
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)["items"].length).to eq(0)
+    end
+
+    it "returns empty when resource doesn't have all required tags" do
+      pg = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-test",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg.update(tags: [{key: "environment", value: "production"}, {key: "team", value: "frontend"}])
+
+      # Requires both tags, but resource only has one
+      get "/project/#{project.ubid}/postgres?tags=environment:production,team:backend"
+
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)["items"].length).to eq(0)
+    end
+
+    it "handles mixed key:value filters" do
+      pg1 = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-prod-backend",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg1.update(tags: [{key: "environment", value: "production"}, {key: "team", value: "backend"}])
+
+      pg2 = Prog::Postgres::PostgresResourceNexus.assemble(
+        project_id: project.id,
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "pg-staging-backend",
+        target_vm_size: "standard-2",
+        target_storage_size_gib: 128
+      ).subject
+      pg2.update(tags: [{key: "environment", value: "staging"}, {key: "team", value: "backend"}])
+
+      # Match environment production and team backend
+      get "/project/#{project.ubid}/postgres?tags=environment:production,team:backend"
+
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body["items"].length).to eq(1)
+      names = body["items"].map { |item| item["name"] }
+      expect(names).to eq(["pg-prod-backend"])
+    end
+
+    it "returns error when tags are in invalid format" do
+      get "/project/#{project.ubid}/postgres?tags=environment,team:backend"
+
+      expect(last_response).to have_api_error(400, "Validation failed for following fields: tags")
     end
   end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add endpoint to filter Postgres resources by tags, update OpenAPI spec, and add tests for validation and filtering logic.
> 
>   - **Behavior**:
>     - Adds `tags_param` to `postgres_list()` in `postgres.rb` to filter Postgres resources by tags.
>     - Validates tag format and filters resources using `Sequel.pg_jsonb_op(:tags).contains(tags_param)`.
>     - Updates OpenAPI spec in `openapi.yml` to include `tags` parameter for `/project/{project_id}/postgres` endpoint.
>   - **Routes**:
>     - Updates `routes/project/postgres.rb` to pass `tags_param` to `postgres_list()`.
>   - **Tests**:
>     - Adds tests in `postgres_spec.rb` for filtering by single and multiple tags, empty tags, and invalid tag formats.
>     - Tests ensure correct filtering logic and error handling for invalid formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for acfd7c142617a2b82c32f1cf94b534b82fa048e8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->