### PR TITLE
Remove spurious double from postgres_resource_nexus_spec

### DIFF
--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
           Vm,
           family: "standard",
           vcpus: 2,
-          vm_host: instance_double(VmHost, id: "dd9ef3e7-6d55-8371-947f-a8478b42a17d"),
           private_subnets: [instance_double(PrivateSubnet, id: "627a23ee-c1fb-86d9-a261-21cc48415916")],
           display_state: "running"
         )


### PR DESCRIPTION
This double doesn't seem to do anything, but does introduce a coupling on VmHost, which is undesirable in a pure-cloud installation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary `vm_host` double from `postgres_resource_nexus_spec.rb` to reduce coupling with `VmHost`.
> 
>   - **Behavior**:
>     - Removes `vm_host` double from `postgres_resource_nexus_spec.rb`, reducing coupling with `VmHost`.
>   - **Misc**:
>     - Improves compatibility for pure-cloud installations by removing unnecessary dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b8341adab2e9113b2409ae82d40abbad342ebc5e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->