### PR TITLE
Remove default OS change warning for runners

### DIFF
--- a/prog/vm/github_runner.rb
+++ b/prog/vm/github_runner.rb
@@ -336,11 +336,6 @@ class Prog::Vm::GithubRunner < Prog::Base
       command += <<~COMMAND
         echo "::warning::#{message}" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
       COMMAND
-    elsif !github_runner.label.include?("ubuntu")
-      message = "The default operating system for this runner has been changed to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. If you have any questions, feel free to reach out at support@ubicloud.com"
-      command += <<~COMMAND
-        echo "::notice::#{message}" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
-      COMMAND
     end
 
     begin

--- a/spec/prog/vm/github_runner_spec.rb
+++ b/spec/prog/vm/github_runner_spec.rb
@@ -569,7 +569,6 @@ RSpec.describe Prog::Vm::GithubRunner do
         jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
-        echo "::notice::The default operating system for this runner has been changed to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. If you have any questions, feel free to reach out at support@ubicloud.com" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")
@@ -587,23 +586,6 @@ RSpec.describe Prog::Vm::GithubRunner do
         echo "UBICLOUD_RUNTIME_TOKEN=my_token
         UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
         echo "CUSTOM_ACTIONS_CACHE_URL=http://10.0.0.1:51123/random_token/" | sudo tee -a /etc/environment > /dev/null
-        echo "::notice::The default operating system for this runner has been changed to Ubuntu 24.04 on November 23, 2025. You can continue using Ubuntu 22.04 by explicitly specifying it. If you have any questions, feel free to reach out at support@ubicloud.com" | sudo -u runner tee /home/runner/actions-runner/.ubicloud_complete_message
-      COMMAND
-
-      expect { nx.setup_environment }.to hop("register_runner")
-    end
-
-    it "hops to register_runner without OS upgrade warning" do
-      expect(vm).to receive(:runtime_token).and_return("my_token")
-      installation.update(use_docker_mirror: false, cache_enabled: false)
-      runner.update(label: "ubicloud-standard-4-ubuntu-2204")
-      expect(vm.sshable).to receive(:cmd).with(<<~COMMAND)
-        set -ueo pipefail
-        echo "image version: $ImageVersion"
-        sudo usermod -a -G sudo,adm runneradmin
-        jq '. += [{"group":"Ubicloud Managed Runner","detail":"Name: #{runner.ubid}\\nLabel: ubicloud-standard-4-ubuntu-2204\\nVM Family: standard\\nArch: x64\\nImage: github-ubuntu-2204\\nVM Host: #{vm.vm_host.ubid}\\nVM Pool: \\nLocation: hetzner-fsn1\\nDatacenter: FSN1-DC8\\nProject: #{project.ubid}\\nConsole URL: http://localhost:9292/project/#{project.ubid}/github"}]' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
-        echo "UBICLOUD_RUNTIME_TOKEN=my_token
-        UBICLOUD_CACHE_URL=http://localhost:9292/runtime/github/" | sudo tee -a /etc/environment > /dev/null
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")


### PR DESCRIPTION
We changed the default OS version for our runners 5 days ago and displayed a warning to inform users whose workflows might have been affected. Since the daily success rate has returned to normal, the warning can now be safely removed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes the OS version change warning for GitHub runners in `github_runner.rb` and related tests in `github_runner_spec.rb`.
> 
>   - **Behavior**:
>     - Removes OS version change warning in `setup_info` in `github_runner.rb`.
>     - Removes related test cases in `github_runner_spec.rb`.
>   - **Misc**:
>     - The warning was for a default OS change to Ubuntu 24.04, which is no longer necessary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 69513687c8949474b3f40fe152f695ddcf1485e8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->