### PR TITLE
Move Vm::GithubRunner to Github::GithubRunnerNexus

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -58,7 +58,7 @@ class GithubRunner < Sequel::Model
   end
 
   def provision_spare_runner
-    Prog::Vm::GithubRunner.assemble(installation, repository_name: repository_name, label: label).subject
+    Prog::Github::GithubRunnerNexus.assemble(installation, repository_name: repository_name, label: label).subject
   end
 
   def init_health_monitor_session

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -74,7 +74,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
       Clog.emit("extra runner needed") { {needed_extra_runner: {repository_name: github_repository.name, label: label, actual_label: actual_label, count: required_runner_count}} }
 
       required_runner_count.times do
-        Prog::Vm::GithubRunner.assemble(
+        Prog::Github::GithubRunnerNexus.assemble(
           github_repository.installation,
           repository_name: github_repository.name,
           label:,

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -3,7 +3,7 @@
 require "forwardable"
 require "net/ssh"
 
-class Prog::Vm::GithubRunner < Prog::Base
+class Prog::Github::GithubRunnerNexus < Prog::Base
   subject_is :github_runner
 
   extend Forwardable
@@ -26,7 +26,7 @@ class Prog::Vm::GithubRunner < Prog::Base
         actual_label: actual_label || label
       )
 
-      Strand.create_with_id(github_runner, prog: "Vm::GithubRunner", label: "start")
+      Strand.create_with_id(github_runner, prog: "Github::GithubRunnerNexus", label: "start")
     end
   end
 

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -72,7 +72,7 @@ class Clover
       r.on web?, "runner" do
         r.get true do
           @runners = @installation.runners_dataset.eager(:vm).eager_graph(:strand)
-            .exclude(Sequel[:strand][:prog] => "Vm::GithubRunner", Sequel[:strand][:label] => ["destroy", "wait_vm_destroy"])
+            .exclude(Sequel[:strand][:prog] => ["Vm::GithubRunner", "Github::GithubRunnerNexus"], Sequel[:strand][:label] => ["destroy", "wait_vm_destroy"])
             .reverse(Sequel[:github_runner][:created_at])
             .all
 

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -76,7 +76,7 @@ class Clover
     end
 
     if data["action"] == "queued"
-      st = Prog::Vm::GithubRunner.assemble(
+      st = Prog::Github::GithubRunnerNexus.assemble(
         installation,
         repository_name:,
         label:,

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe GithubRunner do
   end
 
   it "provisions a spare runner" do
-    expect(Prog::Vm::GithubRunner).to receive(:assemble)
+    expect(Prog::Github::GithubRunnerNexus).to receive(:assemble)
       .with(github_runner.installation, repository_name: github_runner.repository_name, label: github_runner.label)
       .and_return(instance_double(Strand, subject: instance_double(described_class)))
     github_runner.provision_spare_runner

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Page do
       expect(described_class.order(:tag).group_by_vm_host).to eq({nil => [p1, p2, p3], vmh.ubid => [p4, p5, p6]})
 
       gi = GithubInstallation.create(installation_id: 1, name: "t", type: "t")
-      gr = Prog::Vm::GithubRunner.assemble(gi, repository_name: "a", label: "ubicloud").subject
+      gr = Prog::Github::GithubRunnerNexus.assemble(gi, repository_name: "a", label: "ubicloud").subject
       p7 = described_class.create(tag: "g", details: {"related_resources" => [gr.ubid]})
       expect(described_class.order(:tag).group_by_vm_host).to eq({nil => [p1, p2, p3, p7], vmh.ubid => [p4, p5, p6]})
 

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -168,12 +168,12 @@ RSpec.describe Project do
     gr = gi.add_runner(label: "ubicloud", repository_name: "a/a")
     gr.update(vm_id: vm1.id)
     expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 0
-    grst = Strand.new(id: gr.id, label: "start", prog: "Prog::Vm::GithubRunner")
+    grst = Strand.new(id: gr.id, label: "start", prog: "Prog::Github::GithubRunnerNexus")
     expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 0
     grst.update(label: "wait_vm")
     expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 2
     gr2 = gi.add_runner(label: "ubicloud-standard-60", repository_name: "a/a")
-    grst2 = Strand.new(id: gr2.id, label: "wait_concurrency_limit", prog: "Prog::Vm::GithubRunner")
+    grst2 = Strand.new(id: gr2.id, label: "wait_concurrency_limit", prog: "Prog::Github::GithubRunnerNexus")
     expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 2
     grst2.update(label: "wait_vm")
     expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 62

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect(github_repository.runners_dataset).to receive(:where).with(actual_label: "ubicloud-standard-8", workflow_job: nil).and_return([instance_double(GithubRunner)])
       expect(github_repository.runners_dataset).to receive(:where).with(actual_label: "custom-label-1", workflow_job: nil).and_return([instance_double(GithubRunner)])
       expect(github_repository.runners_dataset).to receive(:where).with(actual_label: "custom-label-2", workflow_job: nil).and_return([])
-      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud", actual_label: "ubicloud").twice
-      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-4", actual_label: "ubicloud-standard-4")
-      expect(Prog::Vm::GithubRunner).not_to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-8", actual_label: "ubicloud-standard-8")
-      expect(Prog::Vm::GithubRunner).not_to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-4", actual_label: "custom-label-1")
-      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-8", actual_label: "custom-label-2")
+      expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud", actual_label: "ubicloud").twice
+      expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-4", actual_label: "ubicloud-standard-4")
+      expect(Prog::Github::GithubRunnerNexus).not_to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-8", actual_label: "ubicloud-standard-8")
+      expect(Prog::Github::GithubRunnerNexus).not_to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-4", actual_label: "custom-label-1")
+      expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).with(github_repository.installation, repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-8", actual_label: "custom-label-2")
       nx.check_queued_jobs
       expect(nx.polling_interval).to eq(5 * 60)
     end

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../model/spec_helper"
 require "netaddr"
 require "octokit"
 
-RSpec.describe Prog::Vm::GithubRunner do
+RSpec.describe Prog::Github::GithubRunnerNexus do
   subject(:nx) {
     described_class.new(runner.strand).tap { it.instance_variable_set(:@github_runner, runner) }
   }
@@ -16,7 +16,7 @@ RSpec.describe Prog::Vm::GithubRunner do
     vm_id = create_vm(location_id: Location::GITHUB_RUNNERS_ID, project_id: runner_project.id, boot_image: "github-ubuntu-2204").id
     Sshable.create_with_id(vm_id)
     runner = GithubRunner.create(installation_id:, vm_id:, repository_name: "test-repo", label: "ubicloud-standard-4", actual_label: "ubicloud-standard-4", created_at: now, allocated_at: now + 10, ready_at: now + 20, workflow_job: {"id" => 123})
-    Strand.create_with_id(runner, prog: "Vm::GithubRunner", label: "start")
+    Strand.create_with_id(runner, prog: "Github::GithubRunnerNexus", label: "start")
     runner
   end
   let(:vm) { runner.vm }

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -416,13 +416,13 @@ usermod -L ubuntu
 
       it "recreates runner when alternative_families is not set" do
         expect(nx).to receive(:frame).and_return({}).at_least(:once)
-        expect(Prog::Vm::GithubRunner).to receive(:assemble).and_call_original
+        expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).and_call_original
         expect { nx.create_instance }.to nap(0)
       end
 
       it "recreates runner when alternative_families is empty" do
         expect(nx).to receive(:frame).and_return({"alternative_families" => []}).at_least(:once)
-        expect(Prog::Vm::GithubRunner).to receive(:assemble).and_call_original
+        expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).and_call_original
         expect { nx.create_instance }.to nap(0)
       end
 
@@ -442,7 +442,7 @@ usermod -L ubuntu
       it "recreates runner when current_family is the last family" do
         vm.update(family: "m6a")
         expect(nx).to receive(:frame).and_return({"alternative_families" => ["m7i", "m6a"]}).at_least(:once)
-        expect(Prog::Vm::GithubRunner).to receive(:assemble).and_call_original
+        expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).and_call_original
         expect { nx.create_instance }.to nap(0)
       end
     end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -506,7 +506,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "do not upgrade to the premium runner if not allowed" do
       vm.location_id = Location::GITHUB_RUNNERS_ID
       installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: project.id, allocator_preferences: {"family_filter" => ["standard", "premium"]})
-      runner = Prog::Vm::GithubRunner.assemble(installation, repository_name: "ubicloud/test", label: "ubicloud-standard-2").subject.update(vm_id: vm.id)
+      runner = Prog::Github::GithubRunnerNexus.assemble(installation, repository_name: "ubicloud/test", label: "ubicloud-standard-2").subject.update(vm_id: vm.id)
       runner.incr_not_upgrade_premium
       expect(Scheduling::Allocator).to receive(:allocate).with(
         vm, storage_volumes,

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -200,8 +200,8 @@ RSpec.describe Clover, "github" do
     it "can list active runners" do
       now = Time.now
       expect(Time).to receive(:now).and_return(now).at_least(:once)
-      runner_deleted = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").update(label: "wait_vm_destroy")
-      runner_with_job = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud-standard-4-ubuntu-2404", repository_name: "my-repo").subject.update(
+      runner_deleted = Prog::Github::GithubRunnerNexus.assemble(installation, label: "ubicloud", repository_name: "my-repo").update(label: "wait_vm_destroy")
+      runner_with_job = Prog::Github::GithubRunnerNexus.assemble(installation, label: "ubicloud-standard-4-ubuntu-2404", repository_name: "my-repo").subject.update(
         created_at: now + 20,
         ready_at: now - 50,
         runner_id: 2,
@@ -215,9 +215,9 @@ RSpec.describe Clover, "github" do
           "started_at" => (now - 40).iso8601
         }
       )
-      runner_waiting_job = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").subject.update(ready_at: now - 400, created_at: now)
-      runner_not_created = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud-arm", repository_name: "my-repo").subject.update(created_at: now - 38)
-      runner_concurrency_limit = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud-gpu", repository_name: "my-repo").update(label: "wait_concurrency_limit").subject.update(created_at: now - 3.68 * 60 * 60)
+      runner_waiting_job = Prog::Github::GithubRunnerNexus.assemble(installation, label: "ubicloud", repository_name: "my-repo").subject.update(ready_at: now - 400, created_at: now)
+      runner_not_created = Prog::Github::GithubRunnerNexus.assemble(installation, label: "ubicloud-arm", repository_name: "my-repo").subject.update(created_at: now - 38)
+      runner_concurrency_limit = Prog::Github::GithubRunnerNexus.assemble(installation, label: "ubicloud-gpu", repository_name: "my-repo").update(label: "wait_concurrency_limit").subject.update(created_at: now - 3.68 * 60 * 60)
 
       visit "#{project.path}/github/#{installation.ubid}/runner"
 
@@ -234,7 +234,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "can terminate runner" do
-      runner = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").subject
+      runner = Prog::Github::GithubRunnerNexus.assemble(installation, label: "ubicloud", repository_name: "my-repo").subject
 
       visit "#{project.path}/github/#{installation.ubid}/runner"
 
@@ -250,7 +250,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "raises not found when runner not exists" do
-      runner = Prog::Vm::GithubRunner.assemble(installation, label: "ubicloud", repository_name: "my-repo").subject
+      runner = Prog::Github::GithubRunnerNexus.assemble(installation, label: "ubicloud", repository_name: "my-repo").subject
       visit "#{project.path}/github/#{installation.ubid}/runner"
       runner.destroy
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Clover, "github" do
     it "uses custom label if label is an existing custom label" do
       GithubCustomLabel.create(installation_id: installation.id, name: "custom-label-1", alias_for: "ubicloud-standard-4")
       st = instance_double(Strand, id: runner.id)
-      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(installation, repository_name: "my-repo", label: "ubicloud-standard-4", actual_label: "custom-label-1", default_branch: "main").and_return(st)
+      expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).with(installation, repository_name: "my-repo", label: "ubicloud-standard-4", actual_label: "custom-label-1", default_branch: "main").and_return(st)
       send_webhook("workflow_job", workflow_job_payload(action: "queued", workflow_job: workflow_job_object(label: "custom-label-1")))
 
       expect(page.status_code).to eq(200)
@@ -108,7 +108,7 @@ RSpec.describe Clover, "github" do
 
     it "creates runner when receive queued action" do
       st = instance_double(Strand, id: runner.id)
-      expect(Prog::Vm::GithubRunner).to receive(:assemble).with(installation, repository_name: "my-repo", label: "ubicloud", actual_label: "ubicloud", default_branch: "main").and_return(st)
+      expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).with(installation, repository_name: "my-repo", label: "ubicloud", actual_label: "ubicloud", default_branch: "main").and_return(st)
 
       send_webhook("workflow_job", workflow_job_payload(action: "queued"))
 
@@ -141,7 +141,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "destroys runner when receive completed action" do
-      Strand.create_with_id(runner, prog: "Vm::GithubRunner", label: "start")
+      Strand.create_with_id(runner, prog: "Github::GithubRunnerNexus", label: "start")
 
       send_webhook("workflow_job", workflow_job_payload(action: "completed", workflow_job: workflow_job_object(runner_id: runner.runner_id)))
 

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -104,6 +104,7 @@ module ThawedMock
   allow_mocking(Prog::Ai::InferenceRouterReplicaNexus, :assemble)
   allow_mocking(Prog::DnsZone::SetupDnsServerVm, :vms_in_sync?)
   allow_mocking(Prog::Github::DestroyGithubInstallation, :assemble)
+  allow_mocking(Prog::Github::GithubRunnerNexus, :assemble)
   allow_mocking(Prog::Minio::MinioClusterNexus, :assemble)
   allow_mocking(Prog::PageNexus, :assemble)
   allow_mocking(Prog::Postgres::PostgresResourceNexus, :assemble)


### PR DESCRIPTION
- **Copy Vm::GithubRunner to Github::GithubRunnerNexus**

  Just copy files

- **Change Vm::GithubRunner to Github::GithubRunnerNexus**

  We initially placed the GithubRunner prog in the Vm module. Newer GitHub-related progs are in the Github module expect GithubRunner. The first phase is to duplicate the prog in the new module. Once no active runners are using the old prog, I will remove it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move `Prog::Vm::GithubRunner` to `Prog::Github::GithubRunnerNexus` and update references across the codebase.
> 
>   - **Behavior**:
>     - Move `Prog::Vm::GithubRunner` to `Prog::Github::GithubRunnerNexus`.
>     - Update references in `model/github_runner.rb`, `routes/project/github.rb`, and `routes/webhook/github.rb` to use `GithubRunnerNexus`.
>   - **Tests**:
>     - Update tests in `spec/model/github_runner_spec.rb`, `spec/model/page_spec.rb`, and `spec/model/project_spec.rb` to use `GithubRunnerNexus`.
>     - Add new tests in `spec/prog/github/github_runner_nexus_spec.rb` for `GithubRunnerNexus`.
>   - **Misc**:
>     - Update `spec/thawed_mock.rb` to allow mocking of `Prog::Github::GithubRunnerNexus`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b35eaebcc993f842e407f71cacc425de6ab973e6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->