### PR TITLE
Add more display states for PG replicas/PITR

### DIFF
--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -182,6 +182,30 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.display_state).to eq("unavailable")
     end
 
+    it "returns 'restoring_backup' when representative server's strand label is 'initialize_database_from_backup'" do
+      expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait")).at_least(:once)
+      expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "initialize_database_from_backup"))).at_least(:once)
+      expect(postgres_resource.display_state).to eq("restoring_backup")
+    end
+
+    it "returns 'replaying_wal' when representative server's strand label is 'wait_catch_up'" do
+      expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait")).at_least(:once)
+      expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait_catch_up"))).at_least(:once)
+      expect(postgres_resource.display_state).to eq("replaying_wal")
+    end
+
+    it "returns 'replaying_wal' when representative server's strand label is 'wait_synchronization'" do
+      expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait")).at_least(:once)
+      expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait_synchronization"))).at_least(:once)
+      expect(postgres_resource.display_state).to eq("replaying_wal")
+    end
+
+    it "returns 'finalizing_restore' when representative server's strand label is 'wait_recovery_completion'" do
+      expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait")).at_least(:once)
+      expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "wait_recovery_completion"))).at_least(:once)
+      expect(postgres_resource.display_state).to eq("finalizing_restore")
+    end
+
     it "returns 'running' when strand label is 'wait' and has no children" do
       expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait", children: [])).at_least(:once)
       expect(postgres_resource.display_state).to eq("running")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add new display states for PostgreSQL replicas and PITR in `PostgresResource` and update tests accordingly.
> 
>   - **Behavior**:
>     - Update `display_state` in `postgres_resource.rb` to handle new states: `restoring_backup`, `replaying_wal`, and `finalizing_restore` based on `representative_server` strand labels.
>   - **Tests**:
>     - Add tests in `postgres_resource_spec.rb` for new display states: `restoring_backup`, `replaying_wal`, and `finalizing_restore`.
>     - Ensure `display_state` returns correct state based on `representative_server` strand labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f89c2295b8388e7ee70fe521d34448327357f418. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->