### PR TITLE
Add IPv6 reassignment functionality

### DIFF
--- a/prog/vm/update_ipv6.rb
+++ b/prog/vm/update_ipv6.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/util"
+
+class Prog::Vm::UpdateIpv6 < Prog::Base
+  subject_is :vm
+
+  def vm_host
+    @vm_host ||= VmHost[vm.vm_host_id]
+  end
+
+  label def start
+    vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}.service")
+    vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}-dnsmasq.service")
+    vm_host.sshable.cmd("sudo ip netns del #{vm.inhost_name}")
+    hop_rewrite_persisted
+  end
+
+  label def rewrite_persisted
+    vm.update(
+      ephemeral_net6: vm_host.ip6_random_vm_network.to_s
+    )
+
+    write_params_json
+    vm_host.sshable.cmd("sudo host/bin/setup-vm reassign-ip6 #{vm.inhost_name}", stdin: JSON.generate({storage: vm.storage_secrets}))
+    hop_start_vm
+  end
+
+  label def start_vm
+    nic = vm.nics.first
+    addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
+
+    vm_host.sshable.cmd("sudo ip -n #{vm.inhost_name.shellescape} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
+    vm_host.sshable.cmd("sudo systemctl start #{vm.inhost_name}.service")
+    vm.incr_update_firewall_rules
+    pop "VM #{vm.name} updated"
+  end
+
+  def write_params_json
+    vm_host.sshable.cmd("sudo rm /vm/#{vm.inhost_name}/prep.json")
+
+    vm_host.sshable.cmd("sudo -u #{vm.inhost_name} tee /vm/#{vm.inhost_name}/prep.json", stdin: vm.params_json)
+  end
+end

--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Vm::UpdateIpv6 do
+  subject(:pr) {
+    described_class.new(Strand.new)
+  }
+
+  let(:vm) {
+    instance_double(Vm,
+      inhost_name: "test",
+      storage_secrets: "storage_secrets",
+      nics: [instance_double(Nic,
+        private_subnet: instance_double(
+          PrivateSubnet,
+          net4: NetAddr::IPv4Net.parse("1.0.0.0/8")
+        ),
+        ubid_to_tap_name: "ubid_to_tap_name")],
+      name: "test",
+      vm_host_id: 1)
+  }
+
+  let(:vm_host) {
+    instance_double(VmHost, sshable: instance_double(Sshable, host: "1.1.1.1"), ip6_random_vm_network: NetAddr::IPv6Net.parse("2001:0::"))
+  }
+
+  before do
+    allow(pr).to receive(:vm).and_return(vm)
+  end
+
+  it "returns vm_host" do
+    expect(VmHost).to receive(:[]).with(1).and_return(vm_host)
+    expect(pr.vm_host).to eq(vm_host)
+  end
+
+  it "stops services and cleans up namespace" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm_host.sshable).to receive(:cmd).with("sudo systemctl stop test.service")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo systemctl stop test-dnsmasq.service")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo ip netns del test")
+    expect(pr).to receive(:hop_rewrite_persisted)
+    pr.start
+  end
+
+  it "rewrites persisted" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm).to receive(:update).with(ephemeral_net6: "2001::/64")
+    expect(pr).to receive(:write_params_json)
+    expect(vm_host.sshable).to receive(:cmd).with("sudo host/bin/setup-vm reassign-ip6 test", stdin: JSON.generate({storage: "storage_secrets"}))
+    expect(pr).to receive(:hop_start_vm)
+    pr.rewrite_persisted
+  end
+
+  it "starts vm" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm_host.sshable).to receive(:cmd).with("sudo ip -n test addr replace 1.0.0.1/8 dev ubid_to_tap_name")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo systemctl start test.service")
+    expect(vm).to receive(:incr_update_firewall_rules)
+    expect(pr).to receive(:pop).with("VM test updated")
+    pr.start_vm
+  end
+
+  it "writes params json" do
+    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
+    expect(vm).to receive(:params_json).and_return("params_json")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo rm /vm/test/prep.json")
+    expect(vm_host.sshable).to receive(:cmd).with("sudo -u test tee /vm/test/prep.json", stdin: "params_json")
+    pr.write_params_json
+  end
+end


### PR DESCRIPTION
This is required because Leaseweb decided to renew the IPv6 Prefixes assigned to our hosts. Therefore, we need a way to update the IPv6 prefix of the VMs running on the impacted hosts. 

We have previously performed this operation because of Hetzner @ https://github.com/ubicloud/ubicloud/pull/1633
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Prog::Vm::UpdateIpv6` class to handle IPv6 reassignment for VMs with corresponding tests.
> 
>   - **Functionality**:
>     - Adds `Prog::Vm::UpdateIpv6` class in `update_ipv6.rb` to handle IPv6 reassignment for VMs.
>     - Implements `start`, `rewrite_persisted`, `start_vm`, and `write_params_json` methods to manage VM service stopping, IPv6 updating, and service restarting.
>   - **Testing**:
>     - Adds `update_ipv6_spec.rb` to test `Prog::Vm::UpdateIpv6` methods.
>     - Tests include service stopping, IPv6 update, and service restart verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 05fe89450dae6b4172c948235b558f1a305489a3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->