### PR TITLE
rubocop: Style/HashTransformKeys

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,9 @@ Rake:
 Sequel:
   Enabled: true
 
+Style/HashTransformKeys:
+  Enabled: true
+
 # Seems to be buggy and flags non-redundant line continuations as redundant
 Style/RedundantLineContinuation:
   Enabled: false

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -39,8 +39,8 @@ class Clover
     pgbouncer_errors = pgbouncer_validator.validation_errors(pgbouncer_user_config)
 
     if pg_errors.any? || pgbouncer_errors.any?
-      pg_errors = pg_errors.map { |key, value| ["pg_config.#{key}", value] }.to_h
-      pgbouncer_errors = pgbouncer_errors.map { |key, value| ["pgbouncer_config.#{key}", value] }.to_h
+      pg_errors = pg_errors.transform_keys { |key| "pg_config.#{key}" }
+      pgbouncer_errors = pgbouncer_errors.transform_keys { |key| "pgbouncer_config.#{key}" }
       raise Validation::ValidationFailed.new(pg_errors.merge(pgbouncer_errors))
     end
 

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -111,7 +111,7 @@ module Option
     [PostgresResource::Flavor::STANDARD, "ubicloud", "PostgreSQL Database", "Get started by creating a new PostgreSQL database which is managed by Ubicloud team. It's a good choice for general purpose databases."],
     [PostgresResource::Flavor::PARADEDB, "paradedb", "ParadeDB PostgreSQL Database", "ParadeDB is an Elasticsearch alternative built on Postgres. ParadeDB instances are managed by the ParadeDB team and are optimal for search and analytics workloads."],
     [PostgresResource::Flavor::LANTERN, "lantern", "Lantern PostgreSQL Database", "Lantern is a PostgreSQL-based vector database designed specifically for building AI applications. Lantern instances are managed by the Lantern team and are optimal for AI workloads."]
-  ].map { |args| [args[0], PostgresFlavorOption.new(*args)] }.to_h.freeze
+  ].to_h { |args| [args[0], PostgresFlavorOption.new(*args)] }.freeze
 
   PostgresFamilyOption = Data.define(:name, :description)
   POSTGRES_FAMILY_OPTIONS = [
@@ -122,7 +122,7 @@ module Option
     ["c6gd", "Compute Optimized, Graviton2"],
     ["m6id", "General Purpose, Intel Xeon"],
     ["m6gd", "General Purpose, Graviton2"]
-  ].map { |args| [args[0], PostgresFamilyOption.new(*args)] }.to_h.freeze
+  ].to_h { |args| [args[0], PostgresFamilyOption.new(*args)] }.freeze
 
   PostgresSizeOption = Data.define(:name, :family, :vcpu_count, :memory_gib)
   POSTGRES_SIZE_OPTIONS = [
@@ -164,7 +164,7 @@ module Option
     ["i8g", 16, 128],
     ["i8g", 32, 256],
     ["i8g", 64, 512]
-  ].map do |args|
+  ].to_h do |args|
     name = if AWS_FAMILY_OPTIONS.include?(args[0])
       aws_instance_type_name(args[0], args[1])
     else
@@ -172,7 +172,7 @@ module Option
     end
 
     [name, PostgresSizeOption.new(name, *args)]
-  end.to_h.freeze
+  end.freeze
 
   POSTGRES_STORAGE_SIZE_OPTIONS = ["16", "32", "64", "128", "256", "512", "1024", "2048", "4096"].freeze
 
@@ -187,7 +187,7 @@ module Option
     [PostgresResource::HaType::NONE, 0, "No Standbys"],
     [PostgresResource::HaType::ASYNC, 1, "1 Standby"],
     [PostgresResource::HaType::SYNC, 2, "2 Standbys"]
-  ].map { |args| [args[0], PostgresHaOption.new(*args)] }.to_h.freeze
+  ].to_h { |args| [args[0], PostgresHaOption.new(*args)] }.freeze
 
   AWS_LOCATIONS = ["us-west-2", "us-east-1", "us-east-2", "ap-southeast-2", "eu-west-1", "eu-central-1"].freeze
 

--- a/lib/option_tree_generator.rb
+++ b/lib/option_tree_generator.rb
@@ -18,10 +18,10 @@ class OptionTreeGenerator
       next if option[:check] && !option[:check].call(*path, value)
 
       child_options = @options.select { |opt| opt[:parent] == option[:name] }
-      subtree[value] = child_options.map do |child_option|
+      subtree[value] = child_options.to_h do |child_option|
         @parents[child_option[:name]] = @parents[option[:name]] + [option[:name]]
         [child_option[:name], build_subtree(child_option, path + [value])]
-      end.to_h
+      end
     end
 
     subtree

--- a/prog/learn_pci.rb
+++ b/prog/learn_pci.rb
@@ -8,7 +8,7 @@ class Prog::LearnPci < Prog::Base
     def self.parse_all(lspci_str)
       out = []
       lspci_str.strip.split(/^\n+/).each do |dev_str|
-        dev_h = dev_str.split("\n").map { |e| e.split(":\t") }.to_h
+        dev_h = dev_str.split("\n").to_h { |e| e.split(":\t") }
         fail "BUG: lspci parse failed" unless REQUIRED_KEYS.all? { |s| dev_h.key? s }
         next unless dev_h.key? "IOMMUGroup"
 

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -525,8 +525,8 @@ class Clover
           pgbouncer_errors = pgbouncer_validator.validation_errors(pgbouncer_config)
 
           if pg_errors.any? || pgbouncer_errors.any?
-            pg_errors = pg_errors.map { |key, value| ["pg_config.#{key}", value] }.to_h
-            pgbouncer_errors = pgbouncer_errors.map { |key, value| ["pgbouncer_config.#{key}", value] }.to_h
+            pg_errors = pg_errors.transform_keys { |key| "pg_config.#{key}" }
+            pgbouncer_errors = pgbouncer_errors.transform_keys { |key| "pgbouncer_config.#{key}" }
             raise Validation::ValidationFailed.new(pg_errors.merge(pgbouncer_errors))
           end
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -4,7 +4,7 @@ require_relative "spec_helper"
 
 RSpec.describe CloverAdmin do
   def object_data
-    page.all(".object-table tbody tr").map { it.all("td").map(&:text) }.to_h.transform_keys(&:to_sym).except(:created_at)
+    page.all(".object-table tbody tr").to_h { it.all("td").map(&:text) }.transform_keys(&:to_sym).except(:created_at)
   end
 
   def page_data

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe UBID do
 
   # useful for comparing objects having network values
   def string_kv(obj)
-    obj.to_hash.map { |k, v| [k.to_s, v.to_s] }.to_h
+    obj.to_hash.to_h { |k, v| [k.to_s, v.to_s] }
   end
 
   it "can decode ids" do

--- a/ubid.rb
+++ b/ubid.rb
@@ -132,7 +132,7 @@ class UBID
   end
 
   # InferenceApiKey does not have a type, and using et (TYPE_ETC) seems like a bad idea
-  ACTION_TYPE_PREFIX_MAP = <<~TYPES.split("\n").map! { it.split(": ") }.to_h.freeze
+  ACTION_TYPE_PREFIX_MAP = <<~TYPES.split("\n").to_h { it.split(": ") }.freeze
     Project: pj
     Vm: vm
     PrivateSubnet: ps
@@ -180,7 +180,7 @@ class UBID
   # Map of prefixes to class name symbols, to avoid autoloading
   # classes until they are referenced by class_for_ubid
   TYPE2CLASSNAME = constants.select { it.start_with?("TYPE_") }.reject { it.to_s == "TYPE_ETC" }
-    .map { [const_get(it), camelize(it.to_s).to_sym] }.to_h.freeze
+    .to_h { [const_get(it), camelize(it.to_s).to_sym] }.freeze
   private_constant :TYPE2CLASSNAME
 
   def self.class_for_ubid(str)

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -85,9 +85,7 @@ end
                         .all
                         .reject { Config.sanctioned_countries.include?(it.alpha2) }
                         .sort_by(&:common_name)
-                        .map { |c| [c.alpha2, c.common_name] }
-                        .to_h
-                        .to_a,
+                        .map { |c| [c.alpha2, c.common_name] },
                     attributes: {
                       required: true
                     }


### PR DESCRIPTION
also remove redundant `.to_h.to_a`

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable `Style/HashTransformKeys` cop and refactor hash transformations using `transform_keys` and `to_h` with blocks across multiple files.
> 
>   - **Rubocop Configuration**:
>     - Enable `Style/HashTransformKeys` in `.rubocop.yml`.
>   - **Code Refactoring**:
>     - Use `transform_keys` in `postgres_post()` in `helpers/postgres.rb` and `routes/project/location/postgres.rb` for error key transformation.
>     - Replace `map.to_h` with `to_h` block in `build_subtree()` in `lib/option_tree_generator.rb` and `parse_all()` in `prog/learn_pci.rb`.
>     - Use `to_h` block in `string_kv()` in `spec/ubid_spec.rb`.
>     - Remove redundant `to_h.to_a` in `views/project/billing.erb` for country options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 01828e894fe8ebd40f6ad115b345955e3ce17293. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->