### PR TITLE
Sanitize user input when constructing shell commands for health checks

### DIFF
--- a/model/load_balancer_vm_port.rb
+++ b/model/load_balancer_vm_port.rb
@@ -46,7 +46,7 @@ class LoadBalancerVmPort < Sequel::Model
     if load_balancer.health_check_protocol == "tcp"
       "sudo ip netns exec #{vm.inhost_name} nc -z -w #{load_balancer.health_check_timeout} #{address} #{load_balancer_port.dst_port} >/dev/null 2>&1 && echo 200 || echo 400"
     else
-      "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer_port.dst_port}:#{(address.version == 6) ? "[#{address}]" : address} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_url(use_endpoint: true)}"
+      "sudo ip netns exec #{vm.inhost_name} curl --insecure --resolve #{load_balancer.hostname}:#{load_balancer_port.dst_port}:#{(address.version == 6) ? "[#{address}]" : address} --max-time #{load_balancer.health_check_timeout} --silent --output /dev/null --write-out '%{http_code}' #{load_balancer.health_check_url(use_endpoint: true).shellescape}"
     end
   end
 


### PR DESCRIPTION
We need to ensure that any user-provided URLs or parameters are properly escaped to prevent shell injection vulnerabilities.

**Note:** This change is already deployed. I'm opening a PR to bring code base to same stage as the production.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Escapes user input in `health_check_cmd` in `load_balancer_vm_port.rb` to prevent shell injection vulnerabilities.
> 
>   - **Security**:
>     - Escapes user input in `health_check_cmd` in `load_balancer_vm_port.rb` using `shellescape` to prevent shell injection vulnerabilities.
>     - Specifically, the URL in the `curl` command is now escaped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7a419e0c54d56dda0808e4b430cd90a7df88e8c5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->