### PR TITLE
Switch back to kernel's default memory overcommit settings

### DIFF
--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -18,11 +18,11 @@ class PostgresSetup
   end
 
   def configure_memory_overcommit
-    r "sudo sysctl -w vm.overcommit_memory=2"
-    r "echo 'vm.overcommit_memory=2' | sudo tee -a /etc/sysctl.conf"
+    # r "sudo sysctl -w vm.overcommit_memory=2"
+    # r "echo 'vm.overcommit_memory=2' | sudo tee -a /etc/sysctl.conf"
 
-    r "sudo sysctl -w vm.overcommit_ratio=150"
-    r "echo 'vm.overcommit_ratio=150' | sudo tee -a /etc/sysctl.conf"
+    # r "sudo sysctl -w vm.overcommit_ratio=150"
+    # r "echo 'vm.overcommit_ratio=150' | sudo tee -a /etc/sysctl.conf"
   end
 
   def setup_data_directory


### PR DESCRIPTION
We realized that setting overcommit_ratio to fixed 150% is not optimal for some workloads. Until we have a better solution, we decided to switch back to kernel's default memory overcommit settings.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Comments out memory overcommit settings in `postgres_setup.rb`, reverting to kernel defaults.
> 
>   - **Behavior**:
>     - Comments out memory overcommit settings in `configure_memory_overcommit` method of `postgres_setup.rb`, reverting to kernel defaults.
>     - Specifically, `vm.overcommit_memory=2` and `vm.overcommit_ratio=150` are commented out.
>   - **Misc**:
>     - No other changes to functionality or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 70aaa4566fa222a67f2ce872d555af9897af08ce. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->