### PR TITLE
IPv6 reassign rhizome scripts update to use new cloudinit sign

### DIFF
--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -119,7 +119,7 @@ when "reassign-ip6"
     local_ip4, max_vcpus, cpu_topology, mem_gib,
     ndp_needed, storage_volumes, storage_secrets,
     swap_size_bytes, pci_devices, boot_image, dns_ipv4,
-    slice_name, cpu_percent_limit, cpu_burst_percent_limit)
+    slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled, init_script)
 when "restart"
   vm_setup.restart(slice_name, cpu_burst_percent_limit)
 else

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -98,9 +98,9 @@ class VmSetup
 
   def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology,
     mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices, boot_image,
-    dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit)
+    dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled, init_script)
 
-    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled: ipv6_disabled, init_script: init_script)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, dns_ipv4, multiqueue: max_vcpus > 1)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `reassign-ip6` to support `ipv6_disabled` and `init_script` parameters in `setup-vm` and `vm_setup.rb`.
> 
>   - **Behavior**:
>     - Update `reassign-ip6` action in `setup-vm` to include `ipv6_disabled` and `init_script` parameters.
>     - Modify `reassign_ip6()` in `vm_setup.rb` to pass `ipv6_disabled` and `init_script` to `cloudinit()`.
>   - **Functions**:
>     - Update `cloudinit()` in `vm_setup.rb` to accept `ipv6_disabled` and `init_script` parameters, allowing IPv6 to be disabled and an init script to be specified.
>   - **Misc**:
>     - Add `ipv6_disabled` and `init_script` parameters to `prep` and `reassign-ip6` actions in `setup-vm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 21440335765575c678f3c1f358fef328fe5267cd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->