### PR TITLE
Upgrade read replicas alongside parent

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -219,6 +219,10 @@ class PostgresResource < Sequel::Model
     target_version.to_i < Option::POSTGRES_VERSION_OPTIONS[flavor].map(&:to_i).max
   end
 
+  def ready_for_read_replica?
+    !needs_convergence? && !PostgresTimeline.earliest_restore_time(timeline).nil?
+  end
+
   module HaType
     NONE = "none"
     ASYNC = "async"

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -243,7 +243,7 @@ class Clover
         Validation.validate_name(name)
 
         Validation.validate_vcpu_quota(@project, "PostgresVCpu", Option::POSTGRES_SIZE_OPTIONS[pg.target_vm_size].vcpu_count)
-        if PostgresTimeline.earliest_restore_time(pg.timeline).nil?
+        unless pg.ready_for_read_replica?
           error_msg = "Parent server is not ready for read replicas. There are no backups, yet."
           fail CloverError.new(400, "InvalidRequest", error_msg)
         end
@@ -567,6 +567,7 @@ class Clover
 
           DB.transaction do
             pg.update(target_version: pg.version.to_i + 1)
+            pg.read_replicas_dataset.update(target_version: pg.target_version)
             audit_log(pg, "upgrade")
           end
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -309,4 +309,23 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.can_upgrade?).to be false
     end
   end
+
+  describe "#ready_for_read_replica?" do
+    it "returns true if the postgres resource is ready for read replica" do
+      allow(postgres_resource).to receive(:needs_convergence?).and_return(false)
+      allow(PostgresTimeline).to receive(:earliest_restore_time).with(postgres_resource.timeline).and_return(Time.now - 3600)
+      expect(postgres_resource.ready_for_read_replica?).to be true
+    end
+
+    it "returns false if the postgres resource needs convergence" do
+      allow(postgres_resource).to receive(:needs_convergence?).and_return(true)
+      expect(postgres_resource.ready_for_read_replica?).to be false
+    end
+
+    it "returns false if there is no earliest restore time" do
+      allow(postgres_resource).to receive(:needs_convergence?).and_return(false)
+      allow(PostgresTimeline).to receive(:earliest_restore_time).with(postgres_resource.timeline).and_return(nil)
+      expect(postgres_resource.ready_for_read_replica?).to be false
+    end
+  end
 end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe PostgresServer do
     it "returns nil if there is no fresh standby" do
       expect(postgres_server).to receive(:representative_at).and_return(Time.now)
       standby_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
-      expect(standby_server).to receive(:resource).and_return(resource)
+      expect(standby_server).to receive(:resource).at_least(:once).and_return(resource)
       expect(standby_server).to receive(:representative_at).and_return(nil).at_least(:once)
       expect(standby_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
       expect(standby_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4", sshable: Sshable.new))
@@ -257,7 +257,7 @@ RSpec.describe PostgresServer do
 
     it "returns nil if there is no fresh read_replica" do
       replica_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
-      expect(replica_server).to receive(:resource).and_return(resource)
+      expect(replica_server).to receive(:resource).at_least(:once).and_return(resource)
       expect(replica_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
       expect(replica_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4"))
       expect(resource).to receive(:servers).and_return([postgres_server, replica_server]).at_least(:once)

--- a/spec/routes/api/cli/pg/create-read-replica_spec.rb
+++ b/spec/routes/api/cli/pg/create-read-replica_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Clover, "cli pg create-read-replica" do
     expect(@project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
     expect(described_class).to receive(:authorized_project).with(@account, @project.id).and_return(@project)
     expect(@project).to receive(:quota_available?).and_return(true)
-    expect(pg.timeline).to receive(:earliest_restore_time).and_return(true)
+    expect(pg).to receive(:ready_for_read_replica?).and_return(true)
     body = cli(%w[pg eu-central-h1/test-pg create-read-replica test-pg-rr])
     pg = PostgresResource.first(name: "test-pg-rr")
     expect(pg.display_location).to eq "eu-central-h1"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -493,6 +493,7 @@ RSpec.describe Clover, "postgres" do
 
       it "can create a read replica of a PostgreSQL database" do
         pg.timeline.update(cached_earliest_backup_at: Time.now.utc)
+        VmStorageVolume.create(vm_id: pg.representative_server.vm.id, size_gib: pg.target_storage_size_gib, boot: false, disk_index: 0)
         visit "#{project.path}#{pg.path}/read-replica"
 
         fill_in "#{pg.name}-read-replica", with: "my-read-replica"
@@ -521,6 +522,7 @@ RSpec.describe Clover, "postgres" do
 
       it "can promote a read replica" do
         pg.timeline.update(cached_earliest_backup_at: Time.now.utc)
+        VmStorageVolume.create(vm_id: pg.representative_server.vm.id, size_gib: pg.target_storage_size_gib, boot: false, disk_index: 0)
         visit "#{project.path}#{pg.path}/read-replica"
 
         fill_in "#{pg.name}-read-replica", with: "my-read-replica"
@@ -538,6 +540,7 @@ RSpec.describe Clover, "postgres" do
 
       it "fails to promote if not a read replica" do
         pg.timeline.update(cached_earliest_backup_at: Time.now.utc)
+        VmStorageVolume.create(vm_id: pg.representative_server.vm.id, size_gib: pg.target_storage_size_gib, boot: false, disk_index: 0)
         visit "#{project.path}#{pg.path}/read-replica"
         expect(page).to have_content "Read Replicas"
 

--- a/views/postgres/upgrade.erb
+++ b/views/postgres/upgrade.erb
@@ -102,7 +102,8 @@ end %>
       If a maintenance window is configured, the upgrade will take place during
       the first available maintenance window after the new server is ready.
       Otherwise, the upgrade will take place as soon as the new server becomes
-      ready.") %>
+      ready. After the upgrade is successful, any read replicas for this database will
+      be upgraded.") %>
 
       <div class="flex justify-end mt-6">
         <%== part("components/form/submit_button", text: "Start Upgrade", extra_class: "") if @edit_perm %>


### PR DESCRIPTION
Read replicas now get upgraded with the parent, following a different upgrade path for simplicity. Instead of an in-place upgrade via `pg_upgrade`, we create a new server using the latest timeline and version, and failover to it after it is ready.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Read replicas are now upgraded by creating a new server and failing over, simplifying the process and ensuring consistency with parent upgrades.
> 
>   - **Behavior**:
>     - Read replicas are upgraded by creating a new server and failing over, instead of in-place upgrade.
>     - `ready_for_read_replica?` method in `postgres_resource.rb` checks if a parent is ready for read replica creation.
>     - `start` method in `converge_postgres_resource.rb` waits if parent is not ready for read replica.
>   - **Provisioning**:
>     - `assemble` method in `postgres_server_nexus.rb` uses `target_version` for read replicas.
>     - `provision_servers` in `converge_postgres_resource.rb` uses parent's timeline for read replicas.
>   - **Tests**:
>     - Added tests for `ready_for_read_replica?` in `postgres_resource_spec.rb`.
>     - Updated tests in `converge_postgres_resource_spec.rb` to cover new read replica behavior.
>     - Updated API and CLI tests to handle read replica creation and promotion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3a163b4549905876761677de7e50cd03fbf35029. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->