### PR TITLE
Treat missing family utilization as 100

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -211,8 +211,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       .select_append { round(sum(:used_cores) * 100.0 / sum(:total_cores), 2).cast(:float).as(:utilization) }
       .to_hash(:family, :utilization)
 
-    std_util = family_utilization["standard"]
-    prem_util = family_utilization["premium"]
+    std_util = family_utilization.fetch("standard", 100)
+    prem_util = family_utilization.fetch("premium", 100)
 
     is_high_util = if x64? && label_data["family"] == "standard" && installation.premium_runner_enabled?
       prem_util > 75 && std_util > 80


### PR DESCRIPTION
Our production environment includes both standard and premium families, while other environments (e.g., staging) only have standard.

This causes high utilization detection to fail for premium family instances in staging, since the utilization data is missing and results in nil values.

Previously, we didn't encounter this issue because it only appeared when concurrency limits were also reached.

I considered setting the default to either 0 or 100. Since we have no capacity in this case, both interpretations make sense. However, setting it to 100 is safer. It assumes full utilization and prevents using the family in detection.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> In `github_runner_nexus.rb`, treat missing utilization data for 'standard' and 'premium' families as 100 to ensure high utilization detection works in all environments.
> 
>   - **Behavior**:
>     - In `github_runner_nexus.rb`, `quota_available?` now treats missing utilization data for 'standard' and 'premium' families as 100.
>     - Ensures high utilization detection works in environments without premium family data.
>   - **Rationale**:
>     - Defaulting to 100 is safer, assuming full utilization to prevent using the family in detection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 490dd2cbcdc42428d502c417c414db61fd40d3ce. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->