### PR TITLE
Don't show clover-production in staging pry

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -36,7 +36,9 @@ def udec(*)
 end
 
 opts = Pry::CLI.parse_options
-Pry.config.prompt_name = if Config.production?
+Pry.config.prompt_name = if Config.staging
+  "clover-staging"
+elsif Config.production?
   "\e[41m⚠️ %s\e[0m" % "clover-#{Config.rack_env}"
 else
   "clover-#{Config.rack_env}"

--- a/config.rb
+++ b/config.rb
@@ -56,6 +56,7 @@ module Config
   optional :hetzner_ssh_private_key, string, clear: true
   optional :hetzner_ssh_private_key_passphrase, string, clear: true
   optional :operator_ssh_public_keys, string
+  override :staging, false, bool
 
   # :nocov:
   override :mail_driver, (production? ? :smtp : :logger), symbol


### PR DESCRIPTION
This gives a false sense of urgency for staging. We should reserve this display only for the production environment.  The staging environment uses RACK_ENV=production to be as close as possible to the production. Support a STAGING=true environment variable that the staging environment can also use, and suppress the clover-production display in pry if set. We could potentially use Config.staging in additional cases in the future.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify Pry prompt to show `clover-staging` in staging environments by adding a `staging` config option.
> 
>   - **Behavior**:
>     - Modify `Pry.config.prompt_name` in `bin/pry` to show `clover-staging` if `Config.staging` is true, otherwise follow existing logic.
>     - Introduce `staging` configuration in `config.rb` to differentiate between staging and production environments.
>   - **Config**:
>     - Add `override :staging, false, bool` in `config.rb` to support the new staging environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fb6ed39669386259c1e9b16302e9ae6ef755c0ff. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->