### PR TITLE
Fix invoice PDF spec

### DIFF
--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -648,8 +648,8 @@ RSpec.describe Clover, "billing" do
         text = PDF::Reader.new(StringIO.new(page.body)).pages.map(&:text).join(" ")
         expect(text).to include("We kindly request you to remit the amount to")
         expect(text).to include("Beneficiary Ubicloud B.V.")
-        expect(text).to include("Invoice date: #{invoice.created_at.strftime("%B %d, %Y")}")
-        expect(text).to include("Due date: #{(invoice.created_at + 30 * 24 * 60 * 60).strftime("%B %d, %Y")}")
+        expect(text).to include(/Invoice date:\s+#{invoice.created_at.strftime("%B %d, %Y")}/)
+        expect(text).to include(/Due date:\s+#{(invoice.created_at + 30 * 24 * 60 * 60).strftime("%B %d, %Y")}/)
       end
 
       it "show finalized invoice as PDF with old issuer info" do


### PR DESCRIPTION
December and January have different character lengths, so the layout adds extra spacing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes spacing issue in invoice PDF by using regex for date fields in `billing_spec.rb` to handle variable month name lengths.
> 
>   - **Behavior**:
>     - Fixes spacing issue in invoice PDF by using regex for `Invoice date` and `Due date` fields in `billing_spec.rb`.
>     - Handles variable month name lengths (e.g., December vs. January).
>   - **Tests**:
>     - Updates expectations in `billing_spec.rb` to use regex for date fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 3f1c7b8eb63946922dfb39437da99ef1f9795e19. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->