### PR TITLE
Use VM strand stack for generating new params_json

### DIFF
--- a/prog/vm/update_ipv6.rb
+++ b/prog/vm/update_ipv6.rb
@@ -39,6 +39,6 @@ class Prog::Vm::UpdateIpv6 < Prog::Base
   def write_params_json
     vm_host.sshable.cmd("sudo rm /vm/#{vm.inhost_name}/prep.json")
 
-    vm_host.sshable.cmd("sudo -u #{vm.inhost_name} tee /vm/#{vm.inhost_name}/prep.json", stdin: vm.params_json)
+    vm_host.sshable.cmd("sudo -u #{vm.inhost_name} tee /vm/#{vm.inhost_name}/prep.json", stdin: vm.params_json(**vm.strand.stack.first.slice("swap_size_bytes", "hugepages", "hypervisor", "ch_version", "firmware_version").transform_keys!(&:to_sym)))
   end
 end

--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
   it "writes params json" do
     expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
     expect(vm).to receive(:params_json).and_return("params_json")
+    expect(vm).to receive(:strand).and_return(instance_double(Strand, stack: [{"gpu_count" => 0, "hugepages" => true, "ch_version" => nil, "gpu_device" => nil, "hypervisor" => nil, "force_host_id" => nil, "swap_size_bytes" => nil, "exclude_host_ids" => [], "firmware_version" => nil, "alternative_families" => [], "last_label_changed_at" => "2025-11-24 11:30:57 +0000", "distinct_storage_devices" => true}]))
     expect(vm_host.sshable).to receive(:cmd).with("sudo rm /vm/test/prep.json")
     expect(vm_host.sshable).to receive(:cmd).with("sudo -u test tee /vm/test/prep.json", stdin: "params_json")
     pr.write_params_json


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `write_params_json` in `update_ipv6.rb` to use specific keys from VM's strand stack for `params_json`, and update test in `update_ipv6_spec.rb`.
> 
>   - **Behavior**:
>     - Modify `write_params_json` in `update_ipv6.rb` to use specific keys from `vm.strand.stack.first` for generating `params_json`.
>     - Keys used: `swap_size_bytes`, `hugepages`, `hypervisor`, `ch_version`, `firmware_version`.
>   - **Tests**:
>     - Update test in `update_ipv6_spec.rb` to mock `vm.strand.stack` and verify `write_params_json` behavior with new input format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fd37d4164f77038d2d9baa31425e66da1d8aeecd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->