### PR TITLE
Add stopped label to postgres server

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -47,6 +47,7 @@ class PostgresResource < Sequel::Model
     return "restoring_backup" if server_strand_label == "initialize_database_from_backup"
     return "replaying_wal" if ["wait_catch_up", "wait_synchronization"].include?(server_strand_label)
     return "finalizing_restore" if server_strand_label == "wait_recovery_completion"
+    return "stopped" if server_strand_label == "stopped"
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
 
     "creating"

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -16,7 +16,7 @@ class PostgresServer < Sequel::Model
   plugin ResourceMethods
   plugin SemaphoreMethods, :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup,
     :restart, :configure, :fence, :unfence, :planned_take_over, :unplanned_take_over, :configure_metrics,
-    :destroy, :recycle, :promote, :refresh_walg_credentials
+    :destroy, :recycle, :promote, :refresh_walg_credentials, :stop
   include HealthMonitorMethods
   include MetricsTargetMethods
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -467,6 +467,10 @@ SQL
       hop_update_superuser_password
     end
 
+    when_stop_set? do
+      hop_stopped
+    end
+
     when_checkup_set? do
       hop_unavailable if !available?
       decr_checkup
@@ -524,6 +528,16 @@ SQL
     end
 
     nap 6 * 60 * 60
+  end
+
+  label def stopped
+    when_stop_set? do
+      vm.sshable.cmd("sudo pg_ctlcluster #{postgres_server.version} main stop -m immediate")
+      vm.sshable.cmd("sudo systemctl stop pgbouncer@*.service")
+    end
+    decr_stop
+
+    nap 60 * 60
   end
 
   label def unavailable

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -207,6 +207,12 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.display_state).to eq("finalizing_restore")
     end
 
+    it "returns 'stopped' when representative server's strand label is 'stopped'" do
+      expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait")).at_least(:once)
+      expect(postgres_resource).to receive(:representative_server).and_return(instance_double(PostgresServer, strand: instance_double(Strand, label: "stopped"))).at_least(:once)
+      expect(postgres_resource.display_state).to eq("stopped")
+    end
+
     it "returns 'running' when strand label is 'wait' and has no children" do
       expect(postgres_resource).to receive(:strand).and_return(instance_double(Strand, label: "wait", children: [])).at_least(:once)
       expect(postgres_resource.display_state).to eq("running")


### PR DESCRIPTION
We need to stop a few postgres resources every month due to fraudulent activity before permanently deleting the data.

Currently, we destroy the resource, since we can restore from backup if needed. However, it consumes some engineering time.

We can manually stop the resource on the dataplane, which causes an unavailability page, and users can't see that it's stopped in the UI.

A proper stop may require releasing CPU and memory resources, but the initial version only stops the PG process without releasing those resources.

This will help with operational tasks.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'stopped' state to Postgres servers, allowing them to be stopped without releasing resources, with corresponding logic and tests.
> 
>   - **Behavior**:
>     - Adds 'stopped' label to `display_state` in `postgres_resource.rb` for when `server_strand_label` is 'stopped'.
>     - Introduces `stop` functionality in `PostgresServer` and `PostgresServerNexus` classes, allowing servers to be stopped without releasing resources.
>   - **Methods**:
>     - Adds `when_stop_set?` and `hop_stopped` logic in `before_run` and `wait` methods in `postgres_server_nexus.rb`.
>     - Implements `stopped` method in `postgres_server_nexus.rb` to stop Postgres and PgBouncer services.
>   - **Tests**:
>     - Adds test for 'stopped' state in `display_state` in `postgres_resource_spec.rb`.
>     - Adds tests for `when_stop_set?` and `stopped` method in `postgres_server_nexus_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fb8cab96e7d310e3fe7bbcb0f1d4b27e0331d505. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->