### PR TITLE
Move github models to github folder

### DIFF
--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../model"
+require_relative "../../model"
 
 class GithubInstallation < Sequel::Model
   many_to_one :project

--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../model"
-require_relative "../lib/net_ssh"
+require_relative "../../model"
+require_relative "../../lib/net_ssh"
 
 class GithubRunner < Sequel::Model
   one_to_one :strand, key: :id

--- a/spec/model/github/github_installation_spec.rb
+++ b/spec/model/github/github_installation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe GithubInstallation do
   subject(:installation) {

--- a/spec/model/github/github_runner_spec.rb
+++ b/spec/model/github/github_runner_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe GithubRunner do
   subject(:github_runner) {


### PR DESCRIPTION
- **Move github models to github folder**
  We initially placed all models in the models folder. Then we started
  grouping them by functionality. This change moves all remaining
  GitHub-related models to the github folder.
 