### PR TITLE
Allow column encryption key to be itself encrypted with KMS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,10 @@ gem "tilt", ">= 2.6.1"
 gem "warning"
 gem "webauthn"
 
+group :aws_kms do
+  gem "aws-sdk-kms"
+end
+
 group :aws_rds_iam do
   gem "pg-aws_rds_iam", github: "haines/pg-aws_rds_iam", ref: "fb91b9232837e350aa9c8440b7340346adae845e"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk-ec2 (~> 1.512)
   aws-sdk-iam
+  aws-sdk-kms
   aws-sdk-s3
   bcrypt_pbkdf
   brakeman

--- a/config.rb
+++ b/config.rb
@@ -44,6 +44,7 @@ module Config
   mandatory :rack_env, string
 
   optional :clover_runtime_token_secret, base64, clear: true
+  optional :kms_decrypt_clover_column_encryption_key_with_arn, string
   optional :heartbeat_url, string
   optional :clover_database_root_certs, string
   override :max_health_monitor_threads, 32, int


### PR DESCRIPTION
Avoids leaking key if environment is leaked

KMS decryption is an API call so not scalable to being used for actual SSH key encryption/decryption
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds AWS KMS decryption for column encryption key in `model.rb` using `aws-sdk-kms` if configured.
> 
>   - **Behavior**:
>     - Adds decryption of `clover_column_encryption_key` using AWS KMS in `model.rb` if `kms_encrypt_clover_column_encryption_key` is true.
>     - Uses `aws-sdk-kms` gem for KMS decryption.
>   - **Configuration**:
>     - Adds `kms_encrypt_clover_column_encryption_key` as a boolean override in `config.rb`.
>   - **Dependencies**:
>     - Adds `aws-sdk-kms` gem under `aws_kms` group in `Gemfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c24994641118250c0a85fc33c0d372826efc95a4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->