### PR TITLE
Cache CSI gems as well

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -27,6 +27,14 @@ runs:
         ruby-version: .tool-versions
         bundler-cache: true
 
+    - name: Set up Ruby for CSI gems
+      uses: ruby/setup-ruby@v1
+      env:
+        BUNDLE_GEMFILE: kubernetes/csi/Gemfile
+      with:
+        ruby-version: .tool-versions
+        bundler-cache: true
+
     - name: Create .env.rb file
       shell: bash
       run: "bundle exec rake overwrite_envrb && echo '$stdout.sync = true' >> .env.rb"
@@ -37,7 +45,3 @@ runs:
         createuser -U postgres clover
         createuser -U postgres clover_password
         bundle exec rake setup_database\[test,true\]
-
-    - name: Install CSI gems
-      shell: bash
-      run: "cd kubernetes/csi && bundle install"


### PR DESCRIPTION
I noticed some slowness in the “Set up Clover” step.

Since the CSI gems are installed manually, they aren’t cached by default.

`ruby/setup-ruby` doesn’t support multiple Gemfiles, but their recommended approach is to invoke the action multiple times within the same job.

https://github.com/ruby/setup-ruby/issues/170#issuecomment-841666827
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Caches CSI gems in `setup-clover/action.yml` using `ruby/setup-ruby`, removing manual installation.
> 
>   - **Behavior**:
>     - Caches CSI gems using `ruby/setup-ruby` in `setup-clover/action.yml`.
>     - Removes manual CSI gem installation step.
>   - **Setup**:
>     - Adds `Set up Ruby for CSI gems` step with `BUNDLE_GEMFILE` set to `kubernetes/csi/Gemfile`.
>     - Ensures `bundler-cache: true` for CSI gems setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0f888761eb182800ee84fea9189bd58e04dd0b72. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->