### PR TITLE
Reassign IPv6 fixes for lb enabled or burstable VMs

### DIFF
--- a/prog/vm/update_ipv6.rb
+++ b/prog/vm/update_ipv6.rb
@@ -11,6 +11,7 @@ class Prog::Vm::UpdateIpv6 < Prog::Base
 
   label def start
     vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}.service")
+    vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}-metadata-endpoint.service") if vm.load_balancer
     vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}-dnsmasq.service")
     vm_host.sshable.cmd("sudo ip netns del #{vm.inhost_name}")
     hop_rewrite_persisted
@@ -31,8 +32,9 @@ class Prog::Vm::UpdateIpv6 < Prog::Base
     addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
 
     vm_host.sshable.cmd("sudo ip -n #{vm.inhost_name.shellescape} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
-    vm_host.sshable.cmd("sudo systemctl start #{vm.inhost_name}.service")
+    vm_host.sshable.cmd("sudo systemctl start #{vm.inhost_name}-metadata-endpoint.service") if vm.load_balancer
     vm.incr_update_firewall_rules
+    vm.private_subnets.first.incr_refresh_keys
     pop "VM #{vm.name} updated"
   end
 

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -106,7 +106,7 @@ class VmSetup
     storage(storage_params, storage_secrets, false)
     install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
     update_via_routes(nics)
-
+    start_systemd_unit
     enable_bursting(slice_name, cpu_burst_percent_limit) unless cpu_burst_percent_limit == 0
   end
 


### PR DESCRIPTION
Start the service before enabling burst for reassign-ipv6. Otherwise, we don't see the service in the slice which means the process fails to write to cpu.max.burst.

We also need to stop and start the metadata-endpoint for VMs with loadbalancers before and after the reassignment.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix IPv6 reassignment for VMs with load balancers or burstable configurations by adjusting service management.
> 
>   - **Behavior**:
>     - In `update_ipv6.rb`, stop `metadata-endpoint` service if VM has a load balancer before reassignment.
>     - Start `metadata-endpoint` service after reassignment if VM has a load balancer.
>     - In `vm_setup.rb`, call `start_systemd_unit` before enabling burst in `reassign_ip6()`.
>   - **Tests**:
>     - Update `update_ipv6_spec.rb` to test stopping and starting of `metadata-endpoint` service based on load balancer presence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a1a8883c902d89dcb2c264904ae3dba3ce9d4c01. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->