### PR TITLE
Fix typo in subnet migration logic

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -84,7 +84,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     # :nocov:
     when_migrate_set? do
       if private_subnet.location.aws?
-        strand.update(prog: "Vnet::Aws::SubnetNexus", label: "wait")
+        strand.update(prog: "Vnet::Aws::VpcNexus", label: "wait")
       else
         strand.update(prog: "Vnet::Metal::SubnetNexus", label: "wait")
       end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes typo in `subnet_nexus.rb` by changing `prog` from `Vnet::Aws::SubnetNexus` to `Vnet::Aws::VpcNexus` in `wait` method for AWS subnets.
> 
>   - **Fix**:
>     - Corrects typo in `subnet_nexus.rb` in `wait` method's `when_migrate_set?` block, changing `prog` from `Vnet::Aws::SubnetNexus` to `Vnet::Aws::VpcNexus` for AWS subnets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0ac81ceb1b2f7a99140039149b8d2512e1065ca3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->