### PR TITLE
Fix: reassign ipv6 fix for cert_enabled lbs

### DIFF
--- a/prog/vm/update_ipv6.rb
+++ b/prog/vm/update_ipv6.rb
@@ -11,7 +11,7 @@ class Prog::Vm::UpdateIpv6 < Prog::Base
 
   label def start
     vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}.service")
-    vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}-metadata-endpoint.service") if vm.load_balancer
+    vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}-metadata-endpoint.service") if vm.load_balancer&.cert_enabled
     vm_host.sshable.cmd("sudo systemctl stop #{vm.inhost_name}-dnsmasq.service")
     vm_host.sshable.cmd("sudo ip netns del #{vm.inhost_name}")
     hop_rewrite_persisted
@@ -32,7 +32,7 @@ class Prog::Vm::UpdateIpv6 < Prog::Base
     addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
 
     vm_host.sshable.cmd("sudo ip -n #{vm.inhost_name.shellescape} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
-    vm_host.sshable.cmd("sudo systemctl start #{vm.inhost_name}-metadata-endpoint.service") if vm.load_balancer
+    vm_host.sshable.cmd("sudo systemctl start #{vm.inhost_name}-metadata-endpoint.service") if vm.load_balancer&.cert_enabled
     vm.incr_update_firewall_rules
     vm.private_subnets.first.incr_refresh_keys
     pop "VM #{vm.name} updated"

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -105,8 +105,8 @@ class VmSetup
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
     install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
-    update_via_routes(nics)
     start_systemd_unit
+    update_via_routes(nics)
     enable_bursting(slice_name, cpu_burst_percent_limit) unless cpu_burst_percent_limit == 0
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `metadata-endpoint.service` handling based on cert-enabled status and reorders operations in `reassign_ip6()`.
> 
>   - **Behavior**:
>     - In `update_ipv6.rb`, `metadata-endpoint.service` is stopped/started only if `vm.load_balancer&.cert_enabled` is true.
>     - In `vm_setup.rb`, `update_via_routes(nics)` is moved after `start_systemd_unit` in `reassign_ip6()`.
>   - **Tests**:
>     - Updated `update_ipv6_spec.rb` to test `metadata-endpoint.service` behavior based on `cert_enabled` status.
>     - Added tests for cases where `load_balancer` is nil or not cert-enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c54c17f704591ba8456fc22a5e1694e4aedea7c3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->