### PR TITLE
Fix: tests for vpc creation with iam auth

### DIFF
--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
   let(:ps) {
     prj = Project.create(name: "test-prj")
     loc = Location.create(name: "us-west-2", provider: "aws", project_id: prj.id, display_name: "aws-us-west-2", ui_name: "AWS US East 1", visible: true)
-    LocationCredential.create_with_id(loc.id, access_key: "test-access-key", secret_key: "test-secret-key")
+    LocationCredential.create_with_id(loc.id, access_key: "stubbed-akid", secret_key: "stubbed-secret")
     ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps", location_id: loc.id).subject
     PrivateSubnetAwsResource.create_with_id(ps.id)
     ps
@@ -24,7 +24,9 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
 
   before do
     allow(nx).to receive(:private_subnet).and_return(ps)
-    allow(Aws::EC2::Client).to receive(:new).with(access_key_id: "test-access-key", secret_access_key: "test-secret-key", region: "us-west-2").and_return(client)
+    aws_credentials = Aws::Credentials.new("stubbed-akid", "stubbed-secret")
+    allow(Aws::Credentials).to receive(:new).with("stubbed-akid", "stubbed-secret").and_return(aws_credentials)
+    allow(Aws::EC2::Client).to receive(:new).with(credentials: aws_credentials, region: "us-west-2").and_return(client)
   end
 
   it "hops to destroy if when_destroy_set?" do


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace hardcoded AWS credentials with stubbed credentials in `vpc_nexus_spec.rb` for improved test isolation and security.
> 
>   - **Test Setup**:
>     - Replace hardcoded AWS credentials with stubbed credentials in `vpc_nexus_spec.rb`.
>     - Modify `LocationCredential.create_with_id` to use `stubbed-akid` and `stubbed-secret`.
>     - Update `Aws::EC2::Client` initialization to use `Aws::Credentials` with stubbed values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6ef000ea4ea7aa97fa7a94e2fa846b4258546077. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->