### PR TITLE
PostgresTimeline related fixes

### DIFF
--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -154,14 +154,15 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
 
   describe "#wait" do
     it "naps if blob storage is not configured" do
-      expect(postgres_timeline).to receive(:leader).and_return("something")
+      expect(PostgresServer).to receive(:[]).and_return("something")
       expect(postgres_timeline).to receive(:backups).and_return([])
       expect(postgres_timeline).to receive(:blob_storage).and_return(nil)
       expect { nx.wait }.to nap(20 * 60)
     end
 
     it "self-destructs if there's no leader, no backups and the timeline is old enough" do
-      expect(postgres_timeline).to receive(:leader).and_return(nil)
+      expect(PostgresServer).to receive(:[]).and_return(nil)
+      expect(postgres_timeline).to receive(:backups).and_return([])
       expect(postgres_timeline).to receive(:created_at).and_return(Time.now - 11 * 24 * 60 * 60)
       expect(Clog).to receive(:emit).with(/Self-destructing timeline/)
       expect { nx.wait }.to hop("destroy")


### PR DESCRIPTION
**Don't skip backup call when leader is nil**
Even when the leader is nil, there could be backups until the retention period
is over. Therefore, we should not skip the backup call in such cases.

**Check for all dependents not just leader of timeline**
Leader can be nil, but in case of read replicas, there can still be servers
dependent on this timeline. So we should check for existence of any dependent,
not just the leader.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve timeline handling by checking for any dependents and ensuring backups are not skipped when the leader is nil in `postgres_timeline_nexus.rb`.
> 
>   - **Behavior**:
>     - In `postgres_timeline_nexus.rb`, change `wait` method to check for any dependents using `PostgresServer[timeline_id: postgres_timeline.id]` instead of just the leader.
>     - Ensure backups are checked even if the leader is nil, preventing premature timeline destruction.
>   - **Tests**:
>     - Update `wait` method tests in `postgres_timeline_nexus_spec.rb` to reflect changes in dependent checking logic.
>     - Remove test case that avoided API calls for backups when there is no leader.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 8ecbf2fec7f69393478e0200a1ea93113497486a. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->