### PR TITLE
Increase k8s subnet size to /16

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -26,7 +26,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
           name: "#{ubid}-subnet",
           location_id:,
           firewall_name: "#{ubid}-firewall",
-          ipv4_range: Prog::Vnet::SubnetNexus.random_private_ipv4(Location[location_id], project, 18).to_s
+          ipv4_range: Prog::Vnet::SubnetNexus.random_private_ipv4(Location[location_id], project, 16).to_s
         ).subject
       end
 

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       kc = st.subject
 
       expect(kc.version).to eq Option.kubernetes_versions.first
-      expect(kc.private_subnet.net4.to_s[-3..]).to eq "/18"
+      expect(kc.private_subnet.net4.to_s[-3..]).to eq "/16"
       expect(kc.private_subnet.name).to eq kc.ubid.to_s + "-subnet"
       expect(kc.private_subnet.firewalls.first.name).to eq kc.ubid.to_s + "-firewall"
       expect(kc.target_node_size).to eq "standard-2"


### PR DESCRIPTION
Currently we are provisioning subnets with /18 subnets and each vm gets an 18+8 (/26) ipv4 range, meaning each vm has 2^6 ips.

Each pod consumes two ips from the pool, meaning we can provision 31 pods at most in a node, which is below the kubelet default (110).

By increasing the subnet size to /16, each vm gets 254 ips for pods, allowing us to provision 127 pods, which is above kubelet defaults.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase Kubernetes subnet size from /18 to /16 to support more pods per node.
> 
>   - **Behavior**:
>     - Increase subnet size from `/18` to `/16` in `assemble()` in `kubernetes_cluster_nexus.rb`.
>     - Allows each VM to have 254 IPs, supporting up to 127 pods per node.
>   - **Tests**:
>     - Update test in `kubernetes_cluster_nexus_spec.rb` to expect `/16` subnet size.
>     - Ensure `assemble()` creates a subnet with `/16` size and validates the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6042282bcdec8d55732942e76b51e603c7cdcf7b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->