### PR TITLE
Fix sync_worker_mesh undeterministic spec

### DIFF
--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -538,8 +538,8 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     let(:second_ssh_key) { SshKey.generate }
 
     before do
-      KubernetesNode.create(vm_id: first_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
-      KubernetesNode.create(vm_id: second_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
+      KubernetesNode.create(vm_id: first_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id, created_at: Time.now - 1)
+      KubernetesNode.create(vm_id: second_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id, created_at: Time.now)
       expect(SshKey).to receive(:generate).and_return(first_ssh_key, second_ssh_key)
     end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `created_at` timestamp to `KubernetesNode.create` in `kubernetes_cluster_nexus_spec.rb` for deterministic test order.
> 
>   - **Spec Fix**:
>     - Add `created_at` timestamp to `KubernetesNode.create` in `kubernetes_cluster_nexus_spec.rb` to ensure deterministic order of nodes in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d41b01aba45ef2f1c7e0475a9a1bff4a00d6feaf. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->