### PR TITLE
postgres: walg-daemon-client

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -324,7 +324,7 @@ class PostgresServer < Sequel::Model
   def refresh_walg_credentials
     return if timeline.blob_storage.nil?
 
-    walg_config = timeline.generate_walg_config
+    walg_config = timeline.generate_walg_config(version)
     vm.sshable.cmd("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: walg_config)
     vm.sshable.cmd("sudo tee /usr/lib/ssl/certs/blob_storage_ca.crt > /dev/null", stdin: timeline.blob_storage.root_certs) unless timeline.aws?
   end

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -18,7 +18,7 @@ class PostgresTimeline < Sequel::Model
     ubid
   end
 
-  def generate_walg_config
+  def generate_walg_config(version)
     walg_credentials = if access_key
       <<-WALG_CONF
 AWS_ACCESS_KEY_ID=#{access_key}
@@ -32,6 +32,7 @@ AWS_ENDPOINT=#{blob_storage_endpoint}
 AWS_REGION=#{aws? ? location.name : "us-east-1"}
 AWS_S3_FORCE_PATH_STYLE=true
 PGHOST=/var/run/postgresql
+PGDATA=/dat/#{version}/data
     WALG_CONF
   end
 

--- a/rhizome/postgres/bin/install-wal-g
+++ b/rhizome/postgres/bin/install-wal-g
@@ -27,4 +27,24 @@ Dir.chdir("var/wal-g") do
   r "make deps"
   r "make pg_build"
   r "GOBIN=/usr/bin make pg_install"
+
+  # Compile and install walg-daemon-client
+  r "make build_client"
+  r "cp bin/walg-daemon-client /usr/bin/walg-daemon-client"
 end
+
+File.write("/etc/systemd/system/wal-g.service", <<WALG_SERVICE)
+[Unit]
+Description="WAL-G daemon"
+After=network.target
+
+[Service]
+Type=simple
+User=postgres
+ExecStart=/usr/bin/wal-g daemon --config /etc/postgresql/wal-g.env /tmp/wal-g
+
+[Install]
+WantedBy=multi-user.target
+WALG_SERVICE
+
+r "systemctl enable wal-g.service --now"

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -21,11 +21,12 @@ AWS_SECRET_ACCESS_KEY=dummy-secret-key
 AWS_REGION=us-east-1
 AWS_S3_FORCE_PATH_STYLE=true
 PGHOST=/var/run/postgresql
+PGDATA=/dat/18/data
     WALG_CONF
 
-    expect(postgres_timeline.generate_walg_config).to eq(walg_config)
+    expect(postgres_timeline.generate_walg_config(18)).to eq(walg_config)
     expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, name: "us-east-2", aws?: true)).at_least(:once)
-    expect(postgres_timeline.generate_walg_config).to eq(walg_config.sub("us-east-1", "us-east-2"))
+    expect(postgres_timeline.generate_walg_config(18)).to eq(walg_config.sub("us-east-1", "us-east-2"))
   end
 
   it "returns walg config without keys when vm has iam_role" do
@@ -39,11 +40,12 @@ AWS_ENDPOINT=https://blob-endpoint
 AWS_REGION=us-east-1
 AWS_S3_FORCE_PATH_STYLE=true
 PGHOST=/var/run/postgresql
+PGDATA=/dat/17/data
     WALG_CONF
 
-    expect(postgres_timeline.generate_walg_config).to eq(walg_config)
+    expect(postgres_timeline.generate_walg_config(17)).to eq(walg_config)
     expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, name: "us-east-2", aws?: true)).at_least(:once)
-    expect(postgres_timeline.generate_walg_config).to eq(walg_config.sub("us-east-1", "us-east-2"))
+    expect(postgres_timeline.generate_walg_config(17)).to eq(walg_config.sub("us-east-1", "us-east-2"))
   end
 
   describe "#need_backup?" do


### PR DESCRIPTION
only install client & run daemon for now,
changing archive_command deferred until fleet can assume daemon

another option would be to use https://github.com/wal-g/walg_archive
configuring archive_library instead, but this library doesn't seem to've been updated since PG15
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `walg-daemon-client` installation and systemd service setup, and update WAL-G configuration to include version-specific data paths.
> 
>   - **Behavior**:
>     - Install and run `walg-daemon-client` in `install-wal-g` script.
>     - Create and enable `wal-g.service` for systemd to manage the daemon.
>   - **Configuration**:
>     - Modify `generate_walg_config` in `postgres_timeline.rb` to include `PGDATA` path with version.
>     - Update `refresh_walg_credentials` in `postgres_server.rb` to use versioned `walg_config`.
>   - **Tests**:
>     - Update tests in `postgres_timeline_spec.rb` to check versioned `walg_config` generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 74cf60ce4a149c2f4321928adb0f4299718d9a12. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->