### PR TITLE
[destroying #2]  Move before_run to the base prog

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -207,7 +207,7 @@ SQL
     DB.transaction do
       SemSnap.use(id) do |snap|
         prg = load(snap)
-        prg.public_send(:before_run) if prg.respond_to?(:before_run)
+        prg.public_send(:before_run)
         prg.public_send(label)
       end
     rescue Prog::Base::Nap => e

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -83,14 +83,6 @@ class Prog::Ai::InferenceEndpointNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        hop_destroy
-      end
-    end
-  end
-
   label def start
     reconcile_replicas
     register_deadline("wait", 10 * 60)

--- a/prog/ai/inference_router_nexus.rb
+++ b/prog/ai/inference_router_nexus.rb
@@ -49,14 +49,6 @@ class Prog::Ai::InferenceRouterNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        hop_destroy
-      end
-    end
-  end
-
   label def start
     reconcile_replicas
     register_deadline("wait", 10 * 60)

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -71,6 +71,14 @@ end
     end
   end
 
+  def before_run
+    if defined?(hop_destroy) && defined?(when_destroy_set?)
+      when_destroy_set? do
+        hop_destroy if @strand.label != "destroy"
+      end
+    end
+  end
+
   def nap(seconds = 30)
     fail Nap.new(seconds)
   end

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -126,15 +126,6 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        register_deadline(nil, 5 * 60)
-        hop_destroy
-      end
-    end
-  end
-
   label def wait
     cleanup_cache if github_repository.access_key
     nap 15 * 60 if Time.now - github_repository.last_job_at > 6 * 60 * 60
@@ -157,6 +148,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
   label def destroy
     decr_destroy
 
+    register_deadline(nil, 5 * 60)
     unless github_repository.runners.empty?
       Clog.emit("Cannot destroy repository with active runners") { {not_destroyed_repository: {repository_name: github_repository.name}} }
       nap 5 * 60

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -32,14 +32,6 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        hop_destroy
-      end
-    end
-  end
-
   def cluster
     kubernetes_node.kubernetes_cluster
   end

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -17,14 +17,6 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        hop_destroy
-      end
-    end
-  end
-
   label def start
     register_deadline("wait", 120 * 60)
     when_start_bootstrapping_set? do

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -30,14 +30,6 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        hop_destroy
-      end
-    end
-  end
-
   label def start
     if postgres_timeline.blob_storage
       setup_blob_storage

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -3,7 +3,7 @@
 # A no-operation prog for testing.
 class Prog::Test < Prog::Base
   subject_is :sshable
-  semaphore :test_semaphore
+  semaphore :test_semaphore, :destroy
 
   label def start
   end
@@ -169,6 +169,10 @@ class Prog::Test < Prog::Base
 
   def find_current_prog
     Base.current_prog
+  end
+
+  label def destroy
+    pop "destroyed"
   end
 
   class Test2 < self

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -42,14 +42,6 @@ class Prog::Vm::HostNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        hop_destroy
-      end
-    end
-  end
-
   label def start
     hop_setup_ssh_keys
   end

--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -28,12 +28,6 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
     @host ||= vm_host_slice.vm_host
   end
 
-  def before_run
-    when_destroy_set? do
-      hop_destroy if strand.label != "destroy"
-    end
-  end
-
   label def prep
     name = vm_host_slice.name
     case host.sshable.cmd("common/bin/daemonizer --check prep_:name", name:)

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -20,12 +20,6 @@ class Prog::Vnet::CertNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      hop_destroy unless %w[destroy].include?(strand.label)
-    end
-  end
-
   label def start
     register_deadline("wait", 10 * 60)
 

--- a/prog/vnet/metal/nic_nexus.rb
+++ b/prog/vnet/metal/nic_nexus.rb
@@ -3,12 +3,6 @@
 class Prog::Vnet::Metal::NicNexus < Prog::Base
   subject_is :nic
 
-  def before_run
-    when_destroy_set? do
-      hop_destroy if strand.label != "destroy"
-    end
-  end
-
   label def start
     when_vm_allocated_set? do
       hop_wait_setup

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -3,15 +3,6 @@
 class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   subject_is :private_subnet
 
-  def before_run
-    when_destroy_set? do
-      if strand.label != "destroy"
-        register_deadline(nil, 10 * 60)
-        hop_destroy
-      end
-    end
-  end
-
   label def start
     hop_wait
   end
@@ -106,7 +97,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
 
       nap 5
     end
-
+    register_deadline(nil, 10 * 60)
     decr_destroy
     private_subnet.remove_all_firewalls
 

--- a/spec/prog/ai/inference_endpoint_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_nexus_spec.rb
@@ -131,20 +131,6 @@ RSpec.describe Prog::Ai::InferenceEndpointNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx).to receive(:incr_destroying)
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "reconciles replicas and hops to wait_replicas" do
       expect(nx).to receive(:reconcile_replicas)

--- a/spec/prog/ai/inference_router_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_nexus_spec.rb
@@ -76,19 +76,6 @@ RSpec.describe Prog::Ai::InferenceRouterNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "reconciles replicas and hops to wait_replicas" do
       expect(nx).to receive(:reconcile_replicas)

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -433,4 +433,28 @@ RSpec.describe Prog::Base do
       expect(page.details["data_center"]).to eq(vm.vm_host.data_center)
     end
   end
+
+  describe "#before_run" do
+    let(:st) { Strand.create(prog: "Test", label: "napper") }
+
+    it "hops to destroy if destroy semaphore incremented" do
+      Semaphore.incr(st.id, :destroy)
+
+      expect { st.unsynchronized_run }
+        .to change(st, :label).from("napper").to("destroy")
+    end
+
+    it "does not hop to destroy if destroy semaphore not incremented" do
+      expect(Semaphore.where(strand_id: st.id).empty?).to be(true)
+      expect { st.unsynchronized_run }
+        .not_to change(st, :label)
+    end
+
+    it "does not hop to destroy if strand is destroy" do
+      st.update(label: "destroy")
+      Semaphore.incr(st.id, :destroy)
+      expect { st.unsynchronized_run }
+        .to change(st, :exitval).from(nil).to({"msg" => "destroyed"})
+    end
+  end
 end

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -186,20 +186,6 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx).to receive(:register_deadline)
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#wait" do
     it "checks queued jobs and cache usage then naps" do
       expect(github_repository).to receive(:access_key).and_return("key")

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -91,19 +91,6 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "hops to wait" do
       expect { nx.start }.to hop("wait")

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -73,19 +73,6 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "naps if the kubernetes cluster is not ready" do
       expect { nx.start }.to nap(10)

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -46,19 +46,6 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     let(:admin_blob_storage_client) { instance_double(Minio::Client) }
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -86,19 +86,6 @@ RSpec.describe Prog::Vm::HostNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "hops to setup_ssh_keys" do
       expect { nx.start }.to hop("setup_ssh_keys")

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -72,19 +72,6 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#prep" do
     it "starts prep on NotStarted" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check prep_standard").and_return("NotStarted")

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -35,19 +35,6 @@ RSpec.describe Prog::Vnet::CertNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx).to receive(:strand).and_return(Strand.new(label: "destroy"))
-      expect { nx.before_run }.not_to hop
-    end
-  end
-
   describe "#start" do
     let(:order) {
       dns_challenge = instance_double(Acme::Client::Resources::Challenges::DNS01, record_name: "test-record-name", record_type: "test-record-type", record_content: "test-record-content")

--- a/spec/prog/vnet/metal/nic_nexus_spec.rb
+++ b/spec/prog/vnet/metal/nic_nexus_spec.rb
@@ -11,19 +11,6 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
       net4: "10.0.0.0/26", state: "waiting", project_id: Project.create(name: "test").id).tap { it.id = "57afa8a7-2357-4012-9632-07fbe13a3133" }
   }
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "naps if nothing to do" do
       expect { nx.start }.to nap(5)

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -54,25 +54,6 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy if when_destroy_set?" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "hops to destroy if when_destroy_set? from wait_fw_rules" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("wait_fw_rules").at_least(:once)
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if strand is destroy" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "hops to wait if location is not aws" do
       expect { nx.start }.to hop("wait")


### PR DESCRIPTION
When the destroy semaphore is increased, we want to hop to the destroy label from any label. If the prog defines a before_run method, we call it just before running each label. Some of these methods have custom logic, but most of them are similar. To achieve 100% line coverage, we test similar functionality repeatedly. I’ve moved this to the base program. So, if the prog doesn’t override before_run and has a destroy label and semaphore, we call this basic flow in all progs.

The custom logics in progs also follow similar patterns. We can gradually move them to the base prog as well.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Centralize `before_run` logic in `Prog::Base`, removing redundant methods across multiple program classes and updating tests accordingly.
> 
>   - **Behavior**:
>     - Move `before_run` logic to `Prog::Base` class, centralizing destroy semaphore handling.
>     - Remove redundant `before_run` methods from `inference_endpoint_nexus.rb`, `inference_router_nexus.rb`, `github_repository_nexus.rb`, `kubernetes_node_nexus.rb`, `kubernetes_nodepool_nexus.rb`, `postgres_timeline_nexus.rb`, `host_nexus.rb`, `vm_host_slice_nexus.rb`, `cert_nexus.rb`, `nic_nexus.rb`, `subnet_nexus.rb`, and `test.rb`.
>   - **Tests**:
>     - Update tests in `inference_endpoint_nexus_spec.rb`, `inference_router_nexus_spec.rb`, `base_spec.rb`, `github_repository_nexus_spec.rb`, `kubernetes_node_nexus_spec.rb`, `kubernetes_nodepool_nexus_spec.rb`, `postgres_timeline_nexus_spec.rb`, `host_nexus_spec.rb`, `vm_host_slice_nexus_spec.rb`, `cert_nexus_spec.rb`, `nic_nexus_spec.rb`, and `subnet_nexus_spec.rb` to reflect the centralized `before_run` logic.
>   - **Misc**:
>     - Ensure all programs with a destroy label and semaphore utilize the base `before_run` logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ccb810b420062268fb1cb17e57b9e0197d7299d8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->