### PR TITLE
Replace grayed out BYOC button if BYOC is enabled

### DIFF
--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can create new PostgreSQL database in a custom AWS region" do
-        project
+        project.set_ff_private_locations(true)
         private_location = create_private_location(project: project)
         Location.where(id: [Location::HETZNER_FSN1_ID, Location::LEASEWEB_WDC02_ID]).destroy
 

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -26,8 +26,17 @@
 ) %>
 
 <%
-  byoc_description_html = "<p class='mt-1 text-sm leading-6 text-gray-600'>To run Ubicloud Postgres in your own AWS account using <a href='https://www.ubicloud.com/postgresql-on-aws-high-iops' class='text-orange-600 hover:text-orange-700'>BYOC (AWS)</a>, email us at <a href='mailto:support@ubicloud.com' class='text-orange-600 hover:text-orange-700'>support@ubicloud.com</a></p>"
-  additional_element_html = "<label class=\"form_flavor form_flavor_standard cursor-not-allowed\"><input type='radio' name='byoc' value='byoc' class='peer sr-only' disabled><span class=\"radio-small-card justify-center p-3 text-sm font-semibold pointer-events-none bg-gray-100 text-gray-500\">Your Own AWS Account</span></label>"
+  byoc_description_html, additional_element_html = if @project.get_ff_private_locations
+    [
+      "<p class='mt-1 text-sm leading-6 text-gray-600'><a href='https://www.ubicloud.com/postgresql-on-aws-high-iops' class='text-orange-600 hover:text-orange-700'>Learn more</a> about running Ubicloud Postgres on AWS, including in your own account with Bring-Your-Own-Cloud.</p>",
+      "<label class=\"form_flavor form_flavor_standard cursor-pointer\"><a href=\"#{@project.path}/private-location/create\" class=\"radio-small-card justify-center p-3 text-sm font-semibold\">+ Create a new region (BYOC)</a></label>"
+    ]
+  else
+    [
+      "<p class='mt-1 text-sm leading-6 text-gray-600'>To run Ubicloud Postgres in your own AWS account using <a href='https://www.ubicloud.com/postgresql-on-aws-high-iops' class='text-orange-600 hover:text-orange-700'>BYOC (AWS)</a>, email us at <a href='mailto:support@ubicloud.com' class='text-orange-600 hover:text-orange-700'>support@ubicloud.com</a></p>",
+      "<label class=\"form_flavor form_flavor_standard cursor-not-allowed\"><input type='radio' name='byoc' value='byoc' class='peer sr-only' disabled><span class=\"radio-small-card justify-center p-3 text-sm font-semibold pointer-events-none bg-gray-100 text-gray-500\">Your Own AWS Account</span></label>"
+    ]
+  end
 
   form_elements = [
     {name: "flavor", type: "hidden", value: @flavor},


### PR DESCRIPTION
Seeing grayed out button even when BYOC is enabled is confusing. This makes BYOC flow more intuitive. 

<img width="1458" height="609" alt="image" src="https://github.com/user-attachments/assets/9c81ccf6-73c2-416e-9606-814de7a736d2" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace grayed out BYOC button with a clickable link in `create.erb` if BYOC is enabled, and update test in `postgres_spec.rb`.
> 
>   - **Behavior**:
>     - Updates `create.erb` to replace grayed out BYOC button with a clickable link if `@project.get_ff_private_locations` is true.
>     - If false, retains the grayed out button with disabled input.
>   - **Tests**:
>     - Updates `postgres_spec.rb` to set `project.set_ff_private_locations(true)` before creating a private location in the test for creating a PostgreSQL database in a custom AWS region.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 5a5aa312e4440414d418fc020ca9d49f92ec5238. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->