### PR TITLE
Add pkg-config to Postgres linux dependency instructions

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -188,7 +188,7 @@ Debian/Ubuntu based:
 apt-get install autoconf patch build-essential rustc libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libgmp-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev libdb-dev uuid-dev
 
 # Postgres
-apt-get install build-essential libssl-dev libreadline-dev zlib1g-dev libcurl4-openssl-dev uuid-dev icu-devtools libicu-dev
+apt-get install build-essential libssl-dev libreadline-dev zlib1g-dev libcurl4-openssl-dev uuid-dev icu-devtools libicu-dev pkg-config pkg-config bison flex
 ```
 
 ### `mise install`


### PR DESCRIPTION
I was setting up a machine from scratch, and although pkg-config is often found on a development system that has seen enough usage, it is not seen in the default install of Ubuntu.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `pkg-config` to Postgres dependencies for Debian/Ubuntu in `DEVELOPERS.md`.
> 
>   - **Dependencies**:
>     - Add `pkg-config` to Postgres dependencies for Debian/Ubuntu in `DEVELOPERS.md` to ensure proper setup on new systems.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d2df5d2358c7d95992be6391261301e62a3174b2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->