### PR TITLE
[destroying #3] Start using destroying semaphore in before_run

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -77,7 +77,10 @@ end
 
   def before_run
     if defined?(hop_destroy)
-      hop_destroy if destroy_set? && !destroying_set?
+      unless destroying_set?
+        fail "BUG: destroying semaphore not set on destroy label" if @strand.label == "destroy"
+        hop_destroy if destroy_set?
+      end
     end
   end
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -456,5 +456,12 @@ RSpec.describe Prog::Base do
       expect { st.unsynchronized_run }
         .not_to change(st, :label)
     end
+
+    it "fails if destroying semaphore not set on destroy label" do
+      st.update(label: "destroy")
+      expect {
+        st.unsynchronized_run
+      }.to raise_error(RuntimeError, "BUG: destroying semaphore not set on destroy label")
+    end
   end
 end


### PR DESCRIPTION
- **Add <SEM>_set? helper to base prog**
  Models have `incr_<SEM>` and `<SEM>_set?` to interact with semaphores.
  Progs also have `incr_<SEM>`, `decr_<SEM>`, and `when_<SEM>_set?` to
  interact with semaphores. The `when_<SEM>_set?` method accepts a block
  and executes it when the semaphore is set, so we can't negate the
  condition. Additionally, it doesn't offer much advantage over
  `<SEM>_set?`. Having two different interfaces makes things more complex,
  so we might consider removing `when_<SEM>_set?`. As a first step, I
  added a `<SEM>_set?` helper to the base prog. I used it to check for the
  absence of the destroying semaphore instead of checking via its subject.
  Since we have the `incr` method on both the prog and model, we can also
  have the `set?` method on both.
  

- **Start using destroying semaphore in before_run**
  We began incrementing the destroying semaphore in 9cb106e41.
  
  Instead of checking individual labels, we now rely on the `destroying`
  semaphore alongside the existing destroy semaphore, keeping it
  incremented until the resource is fully destroyed.
  
  This ensures we don’t forget to include new labels in the before_run
  checks, helps consolidate the before_run logic, and reduces code
  duplication.
  

- **Add safety check for destroying semaphore**
  We automatically increment the destroying semaphore when hopping to the
  destroy label.
  
  If a strand’s label is updated to "destroy" without incrementing the
  destroying semaphore, we now fail fast with a bug error. This prevents
  inconsistent state transitions.
  
  We also prevent double hopping to "destroy" and enforce incrementing the
  destroying semaphore whenever a strand enters the destroy flow.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances semaphore handling in `prog/base.rb` by adding `destroying_set?` helper and modifying `before_run` to ensure `destroying` semaphore is set, with tests in `base_spec.rb`.
> 
>   - **Behavior**:
>     - Adds `destroying_set?` helper in `prog/base.rb` to check `destroying` semaphore.
>     - Modifies `before_run` in `prog/base.rb` to use `destroying_set?` and ensure `destroying` semaphore is set before hopping to `destroy`.
>     - Fails fast with error if `destroying` semaphore is not set when label is `destroy`.
>   - **Tests**:
>     - Adds tests in `base_spec.rb` to verify behavior when `destroying` semaphore is set or not set.
>     - Ensures tests cover cases where `destroy` and `destroying` semaphores are incremented.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 1989211d4c2398952662b620843647e512177b94. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->