### PR TITLE
[destroying #4] Move before_run with multi label checks to the base prog

### DIFF
--- a/prog/minio/minio_cluster_nexus.rb
+++ b/prog/minio/minio_cluster_nexus.rb
@@ -52,14 +52,6 @@ class Prog::Minio::MinioClusterNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      unless ["destroy", "wait_pools_destroyed"].include?(strand.label)
-        hop_destroy
-      end
-    end
-  end
-
   label def wait_pools
     register_deadline("wait", 10 * 60)
     if minio_cluster.pools.all? { it.strand.label == "wait" }

--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -41,14 +41,6 @@ class Prog::Minio::MinioPoolNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      unless ["destroy", "wait_servers_destroyed"].include?(strand.label)
-        hop_destroy
-      end
-    end
-  end
-
   def cluster
     @cluster ||= minio_pool.cluster
   end

--- a/prog/victoria_metrics/victoria_metrics_resource_nexus.rb
+++ b/prog/victoria_metrics/victoria_metrics_resource_nexus.rb
@@ -48,14 +48,6 @@ class Prog::VictoriaMetrics::VictoriaMetricsResourceNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      unless ["destroy", "wait_servers_destroyed"].include?(strand.label)
-        hop_destroy
-      end
-    end
-  end
-
   label def wait_servers
     register_deadline("wait", 10 * 60)
 

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -22,14 +22,6 @@ class Prog::Vm::VmPool < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      unless ["destroy", "wait_vms_destroy"].include?(strand.label)
-        hop_destroy
-      end
-    end
-  end
-
   label def create_new_vm
     storage_params = {
       size_gib: vm_pool.storage_size_gib,

--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -5,12 +5,6 @@ require "aws-sdk-ec2"
 class Prog::Vnet::Aws::NicNexus < Prog::Base
   subject_is :nic
 
-  def before_run
-    when_destroy_set? do
-      hop_destroy unless ["destroy", "release_eip", "delete_subnet", "destroy_entities"].include?(strand.label)
-    end
-  end
-
   label def start
     register_deadline("wait", 3 * 60)
     NicAwsResource.create_with_id(nic.id)

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -4,14 +4,6 @@ require "aws-sdk-ec2"
 class Prog::Vnet::Aws::VpcNexus < Prog::Base
   subject_is :private_subnet
 
-  def before_run
-    when_destroy_set? do
-      when_destroying_set? { return }
-      register_deadline(nil, 10 * 60)
-      hop_destroy
-    end
-  end
-
   label def start
     PrivateSubnetAwsResource.create_with_id(private_subnet.id)
     hop_create_vpc
@@ -124,7 +116,7 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
 
       nap 5
     end
-
+    register_deadline(nil, 10 * 60)
     decr_destroy
     private_subnet.nics.each(&:incr_destroy)
     private_subnet.remove_all_firewalls

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -53,12 +53,6 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
       health_check_up_threshold:, health_check_down_threshold:, health_check_protocol:, ports: [[src_port, dst_port]], custom_hostname_prefix:, custom_hostname_dns_zone_id:, stack:, cert_enabled:)
   end
 
-  def before_run
-    when_destroy_set? do
-      hop_destroy unless %w[destroy wait_destroy_children wait_all_vms_removed].include?(strand.label)
-    end
-  end
-
   label def wait
     if load_balancer.need_certificates?
       load_balancer.incr_refresh_cert

--- a/spec/prog/minio/minio_cluster_nexus_spec.rb
+++ b/spec/prog/minio/minio_cluster_nexus_spec.rb
@@ -173,22 +173,4 @@ RSpec.describe Prog::Minio::MinioClusterNexus do
       expect(Semaphore.where(strand_id: private_subnet_id, name: "destroy").count).to eq(1)
     end
   end
-
-  describe "#before_run" do
-    it "hops to destroy if destroy is set" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if destroy is not set" do
-      expect(nx).to receive(:when_destroy_set?).and_return(false)
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if strand label is destroy" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
 end

--- a/spec/prog/minio/minio_pool_nexus_spec.rb
+++ b/spec/prog/minio/minio_pool_nexus_spec.rb
@@ -112,30 +112,4 @@ RSpec.describe Prog::Minio::MinioPoolNexus do
       expect { nx.wait_servers_destroyed }.to exit({"msg" => "pool destroyed"})
     end
   end
-
-  describe "#before_run" do
-    it "hops to destroy if strand is not destroy" do
-      st = described_class.assemble(minio_cluster.id, 0, 1, 1, 100, "standard-2")
-      st.update(label: "start")
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if strand is destroy" do
-      st = described_class.assemble(minio_cluster.id, 0, 1, 1, 100, "standard-2")
-      st.update(label: "destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if destroy is not set" do
-      expect(nx).to receive(:when_destroy_set?).and_return(false)
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if strand label is destroy" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
 end

--- a/spec/prog/victoria_metrics/victoria_metrics_resource_nexus_spec.rb
+++ b/spec/prog/victoria_metrics/victoria_metrics_resource_nexus_spec.rb
@@ -86,25 +86,6 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsResourceNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_servers_destroyed state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("wait_servers_destroyed")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#wait_servers" do
     it "naps if servers not ready" do
       expect(victoria_metrics_resource.servers).to all(receive(:strand).and_return(instance_double(Strand, label: "start")))

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -106,17 +106,4 @@ RSpec.describe Prog::Vm::VmPool do
       expect { nx.wait_vms_destroy }.to nap(10)
     end
   end
-
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
 end

--- a/spec/prog/vnet/aws/nic_nexus_spec.rb
+++ b/spec/prog/vnet/aws/nic_nexus_spec.rb
@@ -30,25 +30,6 @@ RSpec.describe Prog::Vnet::Aws::NicNexus do
     allow(Aws::EC2::Client).to receive(:new).with(credentials: anything, region: "us-west-2").and_return(client)
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state or one of the other destroying states" do
-      expect(nx).to receive(:when_destroy_set?).and_yield.at_least(:once)
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-      expect(nx.strand).to receive(:label).and_return("release_eip")
-      expect { nx.before_run }.not_to hop("destroy")
-      expect(nx.strand).to receive(:label).and_return("delete_subnet")
-      expect { nx.before_run }.not_to hop("destroy")
-      expect(nx.strand).to receive(:label).and_return("destroy_entities")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#start" do
     it "creates a nic aws resource" do
       NicAwsResource[nic.id].destroy

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -22,17 +22,6 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
     allow(Aws::EC2::Client).to receive(:new).with(credentials: aws_credentials, region: "us-west-2").and_return(client)
   end
 
-  it "hops to destroy if when_destroy_set?" do
-    nx.incr_destroy
-    expect { nx.before_run }.to hop("destroy")
-  end
-
-  it "does not hop to destroy if already destroying" do
-    nx.incr_destroy
-    nx.incr_destroying
-    expect { nx.before_run }.not_to hop("destroy")
-  end
-
   describe "#start" do
     it "creates PrivateSubnetAwsResource and hops to create_vpc" do
       expect(PrivateSubnetAwsResource).to receive(:create_with_id).with(ps.id)

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -49,31 +49,6 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_destroy_children state" do
-      expect(nx.strand).to receive(:label).and_return("wait_destroy_children").at_least(:once)
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_all_vms_removed state" do
-      expect(nx.strand).to receive(:label).and_return("wait_all_vms_removed").at_least(:once)
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-  end
-
   describe "#wait" do
     it "naps for 5 seconds if nothing to do" do
       expect(nx.load_balancer).to receive(:need_certificates?).and_return(false)


### PR DESCRIPTION
Since we now use the destroying semaphore to prevent multi hop to the destroy label at e6188ff73, we no longer need to perform manual label checks in each individual prog. The before_run in the base prog can handle this logic.