### PR TITLE
Disallow API/CLI access when suspending accounts

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -328,7 +328,12 @@ class Clover < Roda
     # is when the provided personal access token is invalid.  Generate the JSON
     # error body up front and serve it, so it doesn't need to be generated per-request.
     json_response_body do |_|
-      invalid_auth_error_body
+      if request.env["PATH_INFO"] == "/cli"
+        response.content_type = :text
+        "! Invalid personal access token provided\n"
+      else
+        invalid_auth_error_body
+      end
     end
 
     require_bcrypt? false

--- a/model/account.rb
+++ b/model/account.rb
@@ -40,6 +40,7 @@ class Account < Sequel::Model(:accounts)
   def suspend
     update(suspended_at: Time.now)
     DB[:account_active_session_keys].where(account_id: id).delete(force: true)
+    api_keys_dataset.update(is_valid: false)
 
     PaymentMethod.where(billing_info_id: projects_dataset.select(:billing_info_id)).update(fraud: true)
   end

--- a/spec/routes/api/cli/help_spec.rb
+++ b/spec/routes/api/cli/help_spec.rb
@@ -3,6 +3,11 @@
 require_relative "spec_helper"
 
 RSpec.describe Clover, "cli help" do
+  it "fails if the account is suspended" do
+    @account.suspend
+    expect(cli(%w[help help], status: 401)).to eq "! Invalid personal access token provided\n"
+  end
+
   it "shows help for specific command if given" do
     expect(cli(%w[help help])).to eq <<~OUTPUT
       Get command help


### PR DESCRIPTION
Mark API keys for accounts as invalid in Account#suspend.

Use a plain text response in the CLI in this case.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disallow API/CLI access for suspended accounts by invalidating API keys and updating CLI error response.
> 
>   - **Behavior**:
>     - In `account.rb`, `Account#suspend` now marks API keys as invalid by setting `is_valid: false`.
>     - In `clover.rb`, CLI requests for suspended accounts return a plain text error message.
>   - **Tests**:
>     - Adds a test in `help_spec.rb` to check CLI response when account is suspended.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fd4d4abdae82b7185a16013ba0042bed261592c2. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->