### PR TITLE
Enable frozen string literals in pry

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env -S ruby --enable-frozen-string-literal
 # frozen_string_literal: true
 
 REPL = true


### PR DESCRIPTION
env -S is not portable to all operating systems, but it should work in Linux and macOS.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable frozen string literals by default in `bin/pry` for Linux and macOS using `env -S`.
> 
>   - **Behavior**:
>     - Modifies shebang in `bin/pry` to `#!/usr/bin/env -S ruby --enable-frozen-string-literal` to enable frozen string literals by default.
>     - This change is applicable to Linux and macOS environments where `env -S` is supported.
>   - **Misc**:
>     - Retains `# frozen_string_literal: true` comment for compatibility and clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e1d80b081e86e7edee9e8fbfa49ddeebf8725b7f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->