### PR TITLE
Drop exec -a from session lock script for uutils compatibility

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -193,7 +193,7 @@ class Sshable < Sequel::Model
       lock_contents = <<LOCK
 exec 999>/dev/shm/session-lock-:lock_name || exit 92
 flock -xn 999 || { echo "Another session active: " :lock_name; exit 124; }
-exec -a session-lock-:lock_name sleep infinity </dev/null >/dev/null 2>&1 &
+sleep infinity </dev/null >/dev/null 2>&1 &
 disown
 LOCK
 


### PR DESCRIPTION
Ubuntu 25.10 ships uutils (Rust coreutils) which blocks argv[0] renaming via exec -a, causing the session lock holder to fail silently.  The lock script's sleep infinity process would never start, so the interlock test always passed on second attempt. This worked on 25.04.

We lose the ability to identify session lock holders via pgrep by a distinctive process name, but use fuser to find processes by the lock file they hold instead. Misbehaving on new Ubuntus is worse than losing that legibility.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `exec -a` from session lock script for compatibility with Ubuntu 25.10's uutils, using `fuser` to identify lock holders by file.
> 
>   - **Behavior**:
>     - Remove `exec -a` from session lock script in `sshable.rb` to ensure compatibility with Ubuntu 25.10's uutils.
>     - Use `fuser` to identify session lock holders by lock file instead of process name.
>   - **Tests**:
>     - Update `sshable_spec.rb` to use `fuser` for process termination in session locking tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e54548aec1e6951474184e235148d9b0da19fccd. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->