### PR TITLE
Revoke project invitations when an account is suspended

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -41,8 +41,8 @@ class Account < Sequel::Model(:accounts)
     update(suspended_at: Time.now)
     DB[:account_active_session_keys].where(account_id: id).delete(force: true)
     api_keys_dataset.update(is_valid: false)
-
     PaymentMethod.where(billing_info_id: projects_dataset.select(:billing_info_id)).update(fraud: true)
+    ProjectInvitation.where(inviter_id: id).destroy
   end
 end
 

--- a/spec/model/account_spec.rb
+++ b/spec/model/account_spec.rb
@@ -13,4 +13,20 @@ RSpec.describe Account do
     expect(tag.member_ids).to be_empty
     expect(ace).not_to be_exists
   end
+
+  it "suspend" do
+    now = Time.now
+    expect(Time).to receive(:now).and_return(now).at_least(:once)
+    project = account.create_project_with_default_policy("project-1")
+    ApiKey.create_personal_access_token(account, project: project)
+    DB[:account_active_session_keys].insert(account_id: account.id, session_id: "session-id")
+    project.update(billing_info_id: BillingInfo.create(stripe_id: "cus123").id)
+    payment_method = project.billing_info.add_payment_method(stripe_id: "pm123")
+    project.add_invitation(inviter_id: account.id, email: "test2@example.com", expires_at: now + 60 * 60)
+    expect { account.suspend }
+      .to change(account, :suspended_at).from(nil).to(now)
+      .and change { DB[:account_active_session_keys].where(account_id: account.id).count }.from(1).to(0)
+      .and change { payment_method.reload.fraud }.from(false).to(true)
+      .and change { project.invitations_dataset.count }.from(1).to(0)
+  end
 end

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -39,12 +39,6 @@ RSpec.describe Clover, "billing" do
     expect(page.body).to eq "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
   end
 
-  it "tag payment method fraud after account suspension" do
-    expect(payment_method.reload.fraud).to be(false)
-    user.suspend
-    expect(payment_method.reload.fraud).to be(true)
-  end
-
   context "when Stripe enabled" do
     before do
       allow(Config).to receive(:stripe_secret_key).and_return("secret_key")


### PR DESCRIPTION
If a user sent project invitations before their account was suspended, the invitees can still create new accounts and use those old invitations to access the project. Revoking all pending invitations when an account is suspended prevents suspended users from regaining access through previously issued invites.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revoke all pending project invitations when an account is suspended to prevent access through old invites.
> 
>   - **Behavior**:
>     - `suspend` method in `account.rb` now revokes all pending `ProjectInvitation` for the suspended account.
>   - **Tests**:
>     - Updated `suspend` test in `account_spec.rb` to check that project invitations are revoked.
>     - Removed redundant test in `billing_spec.rb` for payment method fraud tagging after account suspension.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 6b3e1af4f256c92b7839fca3d5603b4262cae3a5. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->