### PR TITLE
Use Rodauth base_url configuration method

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -348,6 +348,7 @@ class Clover < Roda
 
     title_instance_variable :@page_title
     check_csrf? false
+    base_url Config.base_url
 
     # :nocov:
     unless Config.development?

--- a/spec/routes/web/account_spec.rb
+++ b/spec/routes/web/account_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Clover, "account" do
       end
 
       it "allows setting up#{", authenticating," if clear_last_password_entry} and removing Webauthn authentication when password entry is #{"not " unless clear_last_password_entry}required" do
-        webauthn_client = WebAuthn::FakeClient.new("http://www.example.com")
+        webauthn_client = WebAuthn::FakeClient.new("http://localhost:9292")
         2.times do |i|
           visit "/clear-last-password-entry" if clear_last_password_entry
           visit "/account/multifactor-manage"
@@ -195,7 +195,7 @@ RSpec.describe Clover, "account" do
 
       visit "/account/multifactor-manage"
       click_link "Add"
-      webauthn_client = WebAuthn::FakeClient.new("http://www.example.com")
+      webauthn_client = WebAuthn::FakeClient.new("http://localhost:9292")
       challenge = JSON.parse(page.find_by_id("webauthn-setup-form")["data-credential-options"])["challenge"]
       fill_in "Key Name", with: "My Key"
       fill_in "webauthn-setup", with: webauthn_client.create(challenge: challenge).to_json, visible: false


### PR DESCRIPTION
Otherwise, if the application is reachable by arbitrary host names, it's simple to trick Rodauth into sending a password reset email with a link to an arbitrary (attacker-provided) host name. If the user clicks the link, it leaks the password reset link to the attacker.

In terms of effect, if the user is actually requesting a password reset, they won't be impersonating a host name, so this isn't an issue. If the attacker is requesting a password reset, this isn't much different from a typical phishing attack, albeit one that looks more legitimate than the average since it's actually sent from the server. The email explicitly states "If you did not initiate this request, no action is needed.", so it's unlikely the user would click on the password reset request if they did not initiate it. If the user would do this, the attacker could just send them a normal phishing email which will likely result in them getting the user's password instead of just the password reset key.

If the attacker is able to MITM the HTTPS traffic from the user in order to pull off this attack transparently (where the user requests a password reset and the MITM changes the host name, so that the user receives a password reset email with the modified host name), this attack isn't necessary, since the MITM attack could just read the actual password submitted during the password reset. This provides more information for the attacker, since instead of just the password reset key, they have the user's password, which is potentially reused on other sites.

One possible attack pattern is if the attacker cannot MITM, but knows when you will be submitting a password reset request. If they can time it right, they can request a password reset directly before the user. Due to Rodauth's supression of duplicate password reset, the user will only get one email, with the attacker-provided header. However, the flash message the user receives when submitting will indicate the reset password email was not sent as it had been sent recently, which could potentially alert them to this issue. Note that an attacker not being able to MITM but knowing when a password reset request will be submitted and being able to pull of the timing attack is a fairly unlikely attack scenario.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `base_url` in Rodauth to prevent phishing attacks and update test URLs for consistency.
> 
>   - **Security**:
>     - Set `base_url` in `clover.rb` to `Config.base_url` to prevent phishing attacks by ensuring password reset links use a fixed host.
>   - **Tests**:
>     - Update `webauthn_client` URL in `account_spec.rb` from `http://www.example.com` to `http://localhost:9292` for local testing consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ec1ba10afb42758ff7c38a63746835f08b5882cc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->