### PR TITLE
Use dashes instead of underscores for fields in the CLI output

### DIFF
--- a/cli-commands/fw/post/show.rb
+++ b/cli-commands/fw/post/show.rb
@@ -29,7 +29,7 @@ UbiCli.on("fw").run_on("show") do
 
     body = []
 
-    keys.each do |key|
+    each_with_dashed(keys) do |key, display_key|
       case key
       when :firewall_rules
         body << "rules:\n"
@@ -43,21 +43,21 @@ UbiCli.on("fw").run_on("show") do
       when :private_subnets
         data[key].each_with_index do |ps, i|
           body << "private subnet " << (i + 1).to_s << ":\n"
-          private_subnet_keys.each do |ps_key|
+          each_with_dashed(private_subnet_keys) do |ps_key, display_ps_key|
             if ps_key == :nics
               ps[ps_key].each_with_index do |nic, i|
                 body << "  nic " << (i + 1).to_s << ":\n"
-                nic_keys.each do |nic_key|
-                  body << "    " << nic_key.to_s << ": " << nic[nic_key].to_s << "\n"
+                each_with_dashed(nic_keys) do |nic_key, display_nic_key|
+                  body << "    " << display_nic_key << ": " << nic[nic_key].to_s << "\n"
                 end
               end
             else
-              body << "  " << ps_key.to_s << ": " << ps[ps_key].to_s << "\n"
+              body << "  " << display_ps_key << ": " << ps[ps_key].to_s << "\n"
             end
           end
         end
       else
-        body << key.to_s << ": " << data[key].to_s << "\n"
+        body << display_key << ": " << data[key].to_s << "\n"
       end
     end
 

--- a/cli-commands/kc/post/show.rb
+++ b/cli-commands/kc/post/show.rb
@@ -25,33 +25,33 @@ UbiCli.on("kc").run_on("show") do
 
     body = []
 
-    keys.each do |key|
+    each_with_dashed(keys) do |key, display_key|
       case key
       when :nodepools
         data[key].each_with_index do |nodepool, i|
           body << "nodepool " << (i + 1).to_s << ":\n"
-          nodepool_keys.each do |np_key|
+          each_with_dashed(nodepool_keys) do |np_key, display_np_key|
             if np_key == :vms
               nodepool[np_key].each_with_index do |vm, i|
                 body << "  vm " << (i + 1).to_s << ":\n"
-                vm_keys.each do |vm_key|
-                  body << "    " << vm_key.to_s << ": " << vm[vm_key].to_s << "\n"
+                each_with_dashed(vm_keys) do |vm_key, display_vm_key|
+                  body << "    " << display_vm_key << ": " << vm[vm_key].to_s << "\n"
                 end
               end
             else
-              body << "  " << np_key.to_s << ": " << nodepool[np_key].to_s << "\n"
+              body << "  " << display_np_key << ": " << nodepool[np_key].to_s << "\n"
             end
           end
         end
       when :cp_vms
         data[key].each_with_index do |vm, i|
-          body << "cp vm " << (i + 1).to_s << ":\n"
-          vm_keys.each do |vm_key|
-            body << "  " << vm_key.to_s << ": " << vm[vm_key].to_s << "\n"
+          body << "cp-vms " << (i + 1).to_s << ":\n"
+          each_with_dashed(vm_keys) do |vm_key, display_vm_key|
+            body << "  " << display_vm_key << ": " << vm[vm_key].to_s << "\n"
           end
         end
       else
-        body << key.to_s << ": " << data[key].to_s << "\n"
+        body << display_key << ": " << data[key].to_s << "\n"
       end
     end
 

--- a/cli-commands/lb/post/show.rb
+++ b/cli-commands/lb/post/show.rb
@@ -16,7 +16,7 @@ UbiCli.on("lb").run_on("show") do
 
     body = []
 
-    keys.each do |key|
+    each_with_dashed(keys) do |key, display_key|
       case key
       when :vms
         body << "vms:\n"
@@ -24,9 +24,9 @@ UbiCli.on("lb").run_on("show") do
           body << "  " << vm.id << "\n"
         end
       when :subnet
-        body << key.to_s << ": " << data.subnet.name << "\n"
+        body << display_key << ": " << data.subnet.name << "\n"
       else
-        body << key.to_s << ": " << data[key].to_s << "\n"
+        body << display_key << ": " << data[key].to_s << "\n"
       end
     end
 

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -17,7 +17,7 @@ UbiCli.on("pg").run_on("show") do
 
     body = []
 
-    underscore_keys(keys).each do |key|
+    each_with_dashed(underscore_keys(keys)) do |key, display_key|
       case key
       when :parent
         body << "parent: "
@@ -31,24 +31,24 @@ UbiCli.on("pg").run_on("show") do
           body << "  " << k << ": " << v << "\n"
         end
       when :firewall_rules
-        body << "firewall rules:\n"
+        body << "firewall-rules:\n"
         data[key].each_with_index do |rule, i|
           body << "  " << (i + 1).to_s << ": " << rule[:id] << "  " << rule[:cidr].to_s << "  " << rule[:port].to_s << "  " << rule[:description].to_s << "\n"
         end
       when :metric_destinations
-        body << "metric destinations:\n"
+        body << "metric-destinations:\n"
         data[key].each_with_index do |md, i|
           body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
         end
       when :read_replicas
-        body << "read replicas:\n"
+        body << "read-replicas:\n"
         sdk_object.read_replicas.each do |rr|
           body << "  " << rr[:location] << "/" << rr[:name] << "\n"
         end
       when :ca_certificates
-        body << "CA certificates:\n" << data[key].to_s << "\n"
+        body << "ca-certificates:\n" << data[key].to_s << "\n"
       else
-        body << key.to_s << ": " << data[key].to_s << "\n"
+        body << display_key << ": " << data[key].to_s << "\n"
       end
     end
 

--- a/cli-commands/ps/post/show.rb
+++ b/cli-commands/ps/post/show.rb
@@ -29,12 +29,12 @@ UbiCli.on("ps").run_on("show") do
 
     body = []
 
-    keys.each do |key|
+    each_with_dashed(keys) do |key, display_key|
       case key
       when :firewalls
         data[key].each_with_index do |firewall, i|
           body << "firewall " << (i + 1).to_s << ":\n"
-          firewall_keys.each do |fw_key|
+          each_with_dashed(firewall_keys) do |fw_key, display_fw_key|
             if fw_key == :firewall_rules
               body << "  rules:\n"
               firewall[fw_key].each_with_index do |rule, i|
@@ -45,19 +45,19 @@ UbiCli.on("ps").run_on("show") do
                 body << "\n"
               end
             else
-              body << "  " << fw_key.to_s << ": " << firewall[fw_key].to_s << "\n"
+              body << "  " << display_fw_key << ": " << firewall[fw_key].to_s << "\n"
             end
           end
         end
       when :nics
         data[key].each_with_index do |nic, i|
           body << "nic " << (i + 1).to_s << ":\n"
-          nic_keys.each do |nic_key|
-            body << "  " << nic_key.to_s << ": " << nic[nic_key].to_s << "\n"
+          each_with_dashed(nic_keys) do |nic_key, display_nic_key|
+            body << "  " << display_nic_key << ": " << nic[nic_key].to_s << "\n"
           end
         end
       else
-        body << key.to_s << ": " << data[key].to_s << "\n"
+        body << display_key << ": " << data[key].to_s << "\n"
       end
     end
 

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -27,12 +27,12 @@ UbiCli.on("vm").run_on("show") do
 
     firewall_keys = underscore_keys(firewall_keys)
     firewall_rule_keys = underscore_keys(firewall_rule_keys)
-    underscore_keys(keys).each do |key|
+    each_with_dashed(underscore_keys(keys)) do |key, display_key|
       case key
       when :firewalls
         data[key].each_with_index do |firewall, i|
           body << "firewall " << (i + 1).to_s << ":\n"
-          firewall_keys.each do |fw_key|
+          each_with_dashed(firewall_keys) do |fw_key, display_fw_key|
             if fw_key == :firewall_rules
               body << "  rules:\n"
               firewall[fw_key].each_with_index do |rule, i|
@@ -43,14 +43,14 @@ UbiCli.on("vm").run_on("show") do
                 body << "\n"
               end
             else
-              body << "  " << fw_key.to_s << ": " << firewall[fw_key].to_s << "\n"
+              body << "  " << display_fw_key << ": " << firewall[fw_key].to_s << "\n"
             end
           end
         end
       when :subnet
-        body << key.to_s << ": " << data[key].name << "\n"
+        body << display_key << ": " << data[key].name << "\n"
       else
-        body << key.to_s << ": " << data[key].to_s << "\n"
+        body << display_key << ": " << data[key].to_s << "\n"
       end
     end
 

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -346,7 +346,7 @@ class UbiCli
     results = []
 
     sizes = Hash.new(0)
-    keys.each do |key|
+    keys.each_with_index do |key, idx|
       sizes[key] = headers ? key.size : 0
     end
     rows = rows.map do |row|
@@ -364,13 +364,13 @@ class UbiCli
 
     if headers
       sep = false
-      keys.each do |key|
+      each_with_dashed(keys) do |key, display_key|
         if sep
           results << col_sep
         else
           sep = true
         end
-        results << (sizes[key] % key)
+        results << (sizes[key] % display_key)
       end
       results << "\n"
     end
@@ -400,6 +400,12 @@ class UbiCli
       keys.transform_keys { it.to_s.tr("-", "_").to_sym }
     else # when Array
       keys.map { it.tr("-", "_").to_sym }
+    end
+  end
+
+  def each_with_dashed(keys)
+    keys.each do
+      yield it, it.to_s.tr("_", "-")
     end
   end
 

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets -p net4,net6,nics.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets -p net4,net6,nics.txt
@@ -4,6 +4,6 @@ private subnet 1:
   nic 1:
     id: nc69z0cda8jt0g5b120hamn4vf
     name: test-vm-nic
-    private_ipv4: 10.67.141.133
-    private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-    vm_name: test-vm
+    private-ipv4: 10.67.141.133
+    private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+    vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets -p nics -n id,name,vm-name.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets -p nics -n id,name,vm-name.txt
@@ -2,4 +2,4 @@ private subnet 1:
   nic 1:
     id: nc69z0cda8jt0g5b120hamn4vf
     name: test-vm-nic
-    vm_name: test-vm
+    vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets -p nics -n private-ipv4,private-ipv6.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets -p nics -n private-ipv4,private-ipv6.txt
@@ -1,4 +1,4 @@
 private subnet 1:
   nic 1:
-    private_ipv4: 10.67.141.133
-    private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+    private-ipv4: 10.67.141.133
+    private-ipv6: fda0:d79a:93e7:d4fd:1c2::2

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets,firewall-rules.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets,firewall-rules.txt
@@ -8,9 +8,9 @@ private subnet 1:
   nic 1:
     id: nc69z0cda8jt0g5b120hamn4vf
     name: test-vm-nic
-    private_ipv4: 10.67.141.133
-    private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-    vm_name: test-vm
+    private-ipv4: 10.67.141.133
+    private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+    vm-name: test-vm
 rules:
   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
   2: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show.txt
@@ -15,6 +15,6 @@ private subnet 1:
   nic 1:
     id: nc69z0cda8jt0g5b120hamn4vf
     name: test-vm-nic
-    private_ipv4: 10.67.141.133
-    private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-    vm_name: test-vm
+    private-ipv4: 10.67.141.133
+    private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+    vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/fw fw4gj2v4h1fe3q28q0hnf7g8n1 show.txt
+++ b/spec/routes/api/cli/golden-files/fw fw4gj2v4h1fe3q28q0hnf7g8n1 show.txt
@@ -15,6 +15,6 @@ private subnet 1:
   nic 1:
     id: nc69z0cda8jt0g5b120hamn4vf
     name: test-vm-nic
-    private_ipv4: 10.67.141.133
-    private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-    vm_name: test-vm
+    private-ipv4: 10.67.141.133
+    private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+    vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/fw show eu-central-h1_default-eu-central-h1-default.txt
+++ b/spec/routes/api/cli/golden-files/fw show eu-central-h1_default-eu-central-h1-default.txt
@@ -15,6 +15,6 @@ private subnet 1:
   nic 1:
     id: nc69z0cda8jt0g5b120hamn4vf
     name: test-vm-nic
-    private_ipv4: 10.67.141.133
-    private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-    vm_name: test-vm
+    private-ipv4: 10.67.141.133
+    private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+    vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f id,name,location,display-state,cp-node-count.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f id,name,location,display-state,cp-node-count.txt
@@ -1,5 +1,5 @@
 id: kcnzrctjjg4j4g6eqvdsvzthwp
 name: test-kc
 location: eu-central-h1
-display_state: creating
-cp_node_count: 1
+display-state: creating
+cp-node-count: 1

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
@@ -1,29 +1,29 @@
-node_size: standard-2
+node-size: standard-2
 version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node_count: 1
-  node_size: standard-2
+  node-count: 1
+  node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
     name: kc-np-vm
     state: creating
     location: eu-central-h1
     size: standard-2
-    unix_user: ubi
-    storage_size_gib: 0
+    unix-user: ubi
+    storage-size-gib: 0
     ip6: bbab:de77:9a94:fa69::2
-    ip4_enabled: true
+    ip4-enabled: true
     ip4: 130.0.0.3
-cp vm 1:
+cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm
   state: creating
   location: eu-central-h1
   size: standard-2
-  unix_user: ubi
-  storage_size_gib: 0
+  unix-user: ubi
+  storage-size-gib: 0
   ip6: ccab:de77:9a94:fa69::2
-  ip4_enabled: true
+  ip4-enabled: true
   ip4: 129.0.0.2

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
@@ -1,22 +1,22 @@
 id: kcnzrctjjg4j4g6eqvdsvzthwp
 name: test-kc
 location: eu-central-h1
-display_state: creating
-cp_node_count: 1
-node_size: standard-2
+display-state: creating
+cp-node-count: 1
+node-size: standard-2
 version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node_count: 1
-cp vm 1:
+  node-count: 1
+cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm
   state: creating
   location: eu-central-h1
   size: standard-2
-  unix_user: ubi
-  storage_size_gib: 0
+  unix-user: ubi
+  storage-size-gib: 0
   ip6: ccab:de77:9a94:fa69::2
-  ip4_enabled: true
+  ip4-enabled: true
   ip4: 129.0.0.2

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
@@ -1,31 +1,31 @@
 id: kcnzrctjjg4j4g6eqvdsvzthwp
 name: test-kc
 location: eu-central-h1
-display_state: creating
-cp_node_count: 1
-node_size: standard-2
+display-state: creating
+cp-node-count: 1
+node-size: standard-2
 version: v1.34
 nodepool 1:
-  node_size: standard-2
+  node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
     name: kc-np-vm
     state: creating
     location: eu-central-h1
     size: standard-2
-    unix_user: ubi
-    storage_size_gib: 0
+    unix-user: ubi
+    storage-size-gib: 0
     ip6: bbab:de77:9a94:fa69::2
-    ip4_enabled: true
+    ip4-enabled: true
     ip4: 130.0.0.3
-cp vm 1:
+cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm
   state: creating
   location: eu-central-h1
   size: standard-2
-  unix_user: ubi
-  storage_size_gib: 0
+  unix-user: ubi
+  storage-size-gib: 0
   ip6: ccab:de77:9a94:fa69::2
-  ip4_enabled: true
+  ip4-enabled: true
   ip4: 129.0.0.2

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
@@ -1,28 +1,28 @@
 id: kcnzrctjjg4j4g6eqvdsvzthwp
 name: test-kc
 location: eu-central-h1
-display_state: creating
-cp_node_count: 1
-node_size: standard-2
+display-state: creating
+cp-node-count: 1
+node-size: standard-2
 version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node_count: 1
-  node_size: standard-2
+  node-count: 1
+  node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
     name: kc-np-vm
     state: creating
     location: eu-central-h1
     size: standard-2
-    unix_user: ubi
-    storage_size_gib: 0
-cp vm 1:
+    unix-user: ubi
+    storage-size-gib: 0
+cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm
   state: creating
   location: eu-central-h1
   size: standard-2
-  unix_user: ubi
-  storage_size_gib: 0
+  unix-user: ubi
+  storage-size-gib: 0

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
@@ -1,20 +1,20 @@
 id: kcnzrctjjg4j4g6eqvdsvzthwp
 name: test-kc
 location: eu-central-h1
-display_state: creating
-cp_node_count: 1
-node_size: standard-2
+display-state: creating
+cp-node-count: 1
+node-size: standard-2
 version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node_count: 1
-  node_size: standard-2
+  node-count: 1
+  node-size: standard-2
   vm 1:
     ip6: bbab:de77:9a94:fa69::2
-    ip4_enabled: true
+    ip4-enabled: true
     ip4: 130.0.0.3
-cp vm 1:
+cp-vms 1:
   ip6: ccab:de77:9a94:fa69::2
-  ip4_enabled: true
+  ip4-enabled: true
   ip4: 129.0.0.2

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
@@ -1,34 +1,34 @@
 id: kcnzrctjjg4j4g6eqvdsvzthwp
 name: test-kc
 location: eu-central-h1
-display_state: creating
-cp_node_count: 1
-node_size: standard-2
+display-state: creating
+cp-node-count: 1
+node-size: standard-2
 version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node_count: 1
-  node_size: standard-2
+  node-count: 1
+  node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
     name: kc-np-vm
     state: creating
     location: eu-central-h1
     size: standard-2
-    unix_user: ubi
-    storage_size_gib: 0
+    unix-user: ubi
+    storage-size-gib: 0
     ip6: bbab:de77:9a94:fa69::2
-    ip4_enabled: true
+    ip4-enabled: true
     ip4: 130.0.0.3
-cp vm 1:
+cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm
   state: creating
   location: eu-central-h1
   size: standard-2
-  unix_user: ubi
-  storage_size_gib: 0
+  unix-user: ubi
+  storage-size-gib: 0
   ip6: ccab:de77:9a94:fa69::2
-  ip4_enabled: true
+  ip4-enabled: true
   ip4: 129.0.0.2

--- a/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
+++ b/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
@@ -1,34 +1,34 @@
 id: kcnzrctjjg4j4g6eqvdsvzthwp
 name: test-kc
 location: eu-central-h1
-display_state: creating
-cp_node_count: 1
-node_size: standard-2
+display-state: creating
+cp-node-count: 1
+node-size: standard-2
 version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node_count: 1
-  node_size: standard-2
+  node-count: 1
+  node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
     name: kc-np-vm
     state: creating
     location: eu-central-h1
     size: standard-2
-    unix_user: ubi
-    storage_size_gib: 0
+    unix-user: ubi
+    storage-size-gib: 0
     ip6: bbab:de77:9a94:fa69::2
-    ip4_enabled: true
+    ip4-enabled: true
     ip4: 130.0.0.3
-cp vm 1:
+cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm
   state: creating
   location: eu-central-h1
   size: standard-2
-  unix_user: ubi
-  storage_size_gib: 0
+  unix-user: ubi
+  storage-size-gib: 0
   ip6: ccab:de77:9a94:fa69::2
-  ip4_enabled: true
+  ip4-enabled: true
   ip4: 129.0.0.2

--- a/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
@@ -1,2 +1,2 @@
-location       name     id                          display_state  version  cp_node_count
+location       name     id                          display-state  version  cp-node-count
 eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            

--- a/spec/routes/api/cli/golden-files/kc list -l eu-north-h1.txt
+++ b/spec/routes/api/cli/golden-files/kc list -l eu-north-h1.txt
@@ -1,1 +1,1 @@
-location  name  id  display_state  version  cp_node_count
+location  name  id  display-state  version  cp-node-count

--- a/spec/routes/api/cli/golden-files/kc list.txt
+++ b/spec/routes/api/cli/golden-files/kc list.txt
@@ -1,2 +1,2 @@
-location       name     id                          display_state  version  cp_node_count
+location       name     id                          display-state  version  cp-node-count
 eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            

--- a/spec/routes/api/cli/golden-files/lb 1bvp8yk1karj4ngwhtgrfh6esd show.txt
+++ b/spec/routes/api/cli/golden-files/lb 1bvp8yk1karj4ngwhtgrfh6esd show.txt
@@ -5,11 +5,11 @@ location: eu-central-h1
 hostname: test-lb.dpqe2.
 algorithm: round_robin
 stack: dual
-health_check_endpoint: /up
-health_check_protocol: http
-src_port: 12345
-dst_port: 54321
+health-check-endpoint: /up
+health-check-protocol: http
+src-port: 12345
+dst-port: 54321
 subnet: default-eu-central-h1
 vms:
   vmdzyppz6j166jh5e9t2dwrfas
-cert_enabled: false
+cert-enabled: false

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb show -f src-port,dst-port,subnet,vms.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb show -f src-port,dst-port,subnet,vms.txt
@@ -1,5 +1,5 @@
-src_port: 12345
-dst_port: 54321
+src-port: 12345
+dst-port: 54321
 subnet: default-eu-central-h1
 vms:
   vmdzyppz6j166jh5e9t2dwrfas

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb show -f stack,health-check-endpoint,health-check-protocol.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb show -f stack,health-check-endpoint,health-check-protocol.txt
@@ -1,3 +1,3 @@
 stack: dual
-health_check_endpoint: /up
-health_check_protocol: http
+health-check-endpoint: /up
+health-check-protocol: http

--- a/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb show.txt
+++ b/spec/routes/api/cli/golden-files/lb eu-central-h1_test-lb show.txt
@@ -5,11 +5,11 @@ location: eu-central-h1
 hostname: test-lb.dpqe2.
 algorithm: round_robin
 stack: dual
-health_check_endpoint: /up
-health_check_protocol: http
-src_port: 12345
-dst_port: 54321
+health-check-endpoint: /up
+health-check-protocol: http
+src-port: 12345
+dst-port: 54321
 subnet: default-eu-central-h1
 vms:
   vmdzyppz6j166jh5e9t2dwrfas
-cert_enabled: false
+cert-enabled: false

--- a/spec/routes/api/cli/golden-files/lb list -f src-port,dst-port,hostname.txt
+++ b/spec/routes/api/cli/golden-files/lb list -f src-port,dst-port,hostname.txt
@@ -1,2 +1,2 @@
-src_port  dst_port  hostname      
+src-port  dst-port  hostname      
 12345     54321     test-lb.dpqe2.

--- a/spec/routes/api/cli/golden-files/lb list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/lb list -l eu-central-h1.txt
@@ -1,2 +1,2 @@
-location       name     id                          src_port  dst_port  hostname      
+location       name     id                          src-port  dst-port  hostname      
 eu-central-h1  test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345     54321     test-lb.dpqe2.

--- a/spec/routes/api/cli/golden-files/lb list -l eu-north-h1.txt
+++ b/spec/routes/api/cli/golden-files/lb list -l eu-north-h1.txt
@@ -1,1 +1,1 @@
-location  name  id  src_port  dst_port  hostname
+location  name  id  src-port  dst-port  hostname

--- a/spec/routes/api/cli/golden-files/lb list.txt
+++ b/spec/routes/api/cli/golden-files/lb list.txt
@@ -1,2 +1,2 @@
-location       name     id                          src_port  dst_port  hostname      
+location       name     id                          src-port  dst-port  hostname      
 eu-central-h1  test-lb  1bvp8yk1karj4ngwhtgrfh6esd  12345     54321     test-lb.dpqe2.

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg list-backups.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg list-backups.txt
@@ -1,2 +1,2 @@
-key                                        last_modified       
+key                                        last-modified       
 basebackups_005/backup_stop_sentinel.json  2025-11-21T10:22:32Z

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f firewall-rules,metric-destinations,ca-certificates.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f firewall-rules,metric-destinations,ca-certificates.txt
@@ -1,9 +1,9 @@
-firewall rules:
+firewall-rules:
   1: frpqgkgjd09y4pnjaq2pkeacam  0.0.0.0/0  5432  pg-fw-desc
   2: frwhnrpxm8wa4jwnpj8hjd6ehc  0.0.0.0/0  6432  
   3: frw2040y4rsy2qxt70bp95j8yg  ::/0  5432  
   4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
-metric destinations:
+metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
-CA certificates:
+ca-certificates:
 

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f ha-type,flavor,connection-string,primary,earliest-restore-time.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f ha-type,flavor,connection-string,primary,earliest-restore-time.txt
@@ -1,5 +1,5 @@
-ha_type: none
+ha-type: none
 flavor: standard
-connection_string: postgres://postgres:bar456FOO123@test-pg.pgvm1qb9gwct1mqmay7m54yma5.pg.example.com:5432/postgres?channel_binding=require
+connection-string: postgres://postgres:bar456FOO123@test-pg.pgvm1qb9gwct1mqmay7m54yma5.pg.example.com:5432/postgres?channel_binding=require
 primary: true
-earliest_restore_time: 2025-11-21T10:27:32Z
+earliest-restore-time: 2025-11-21T10:27:32Z

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f maintenance-window-start-at,read-replica,parent,read-replicas.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f maintenance-window-start-at,read-replica,parent,read-replicas.txt
@@ -1,4 +1,4 @@
-maintenance_window_start_at: 
-read_replica: false
+maintenance-window-start-at: 
+read-replica: false
 parent: 
-read replicas:
+read-replicas:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f name,state,location,vm-size,storage-size-gib,version,tags.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f name,state,location,vm-size,storage-size-gib,version,tags.txt
@@ -1,8 +1,8 @@
 name: test-pg
 state: creating
 location: eu-central-h1
-vm_size: standard-2
-storage_size_gib: 64
+vm-size: standard-2
+storage-size-gib: 64
 version: 16
 tags:
   foo: bar

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
@@ -2,29 +2,29 @@ id: pgvm1qb9gwct1mqmay7m54yma5
 name: test-pg
 state: creating
 location: eu-central-h1
-vm_size: standard-2
-target_vm_size: standard-2
-storage_size_gib: 64
-target_storage_size_gib: 64
+vm-size: standard-2
+target-vm-size: standard-2
+storage-size-gib: 64
+target-storage-size-gib: 64
 version: 16
-target_version: 16
-ha_type: none
+target-version: 16
+ha-type: none
 flavor: standard
-connection_string: postgres://postgres:bar456FOO123@test-pg.pgvm1qb9gwct1mqmay7m54yma5.pg.example.com:5432/postgres?channel_binding=require
+connection-string: postgres://postgres:bar456FOO123@test-pg.pgvm1qb9gwct1mqmay7m54yma5.pg.example.com:5432/postgres?channel_binding=require
 primary: true
-earliest_restore_time: 2025-11-21T10:27:32Z
-maintenance_window_start_at: 
-read_replica: false
+earliest-restore-time: 2025-11-21T10:27:32Z
+maintenance-window-start-at: 
+read-replica: false
 parent: 
 tags:
   foo: bar
-firewall rules:
+firewall-rules:
   1: frpqgkgjd09y4pnjaq2pkeacam  0.0.0.0/0  5432  pg-fw-desc
   2: frwhnrpxm8wa4jwnpj8hjd6ehc  0.0.0.0/0  6432  
   3: frw2040y4rsy2qxt70bp95j8yg  ::/0  5432  
   4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
-metric destinations:
+metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
-read replicas:
-CA certificates:
+read-replicas:
+ca-certificates:
 

--- a/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
+++ b/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
@@ -2,29 +2,29 @@ id: pgvm1qb9gwct1mqmay7m54yma5
 name: test-pg
 state: creating
 location: eu-central-h1
-vm_size: standard-2
-target_vm_size: standard-2
-storage_size_gib: 64
-target_storage_size_gib: 64
+vm-size: standard-2
+target-vm-size: standard-2
+storage-size-gib: 64
+target-storage-size-gib: 64
 version: 16
-target_version: 16
-ha_type: none
+target-version: 16
+ha-type: none
 flavor: standard
-connection_string: postgres://postgres:bar456FOO123@test-pg.pgvm1qb9gwct1mqmay7m54yma5.pg.example.com:5432/postgres?channel_binding=require
+connection-string: postgres://postgres:bar456FOO123@test-pg.pgvm1qb9gwct1mqmay7m54yma5.pg.example.com:5432/postgres?channel_binding=require
 primary: true
-earliest_restore_time: 2025-11-21T10:27:32Z
-maintenance_window_start_at: 
-read_replica: false
+earliest-restore-time: 2025-11-21T10:27:32Z
+maintenance-window-start-at: 
+read-replica: false
 parent: 
 tags:
   foo: bar
-firewall rules:
+firewall-rules:
   1: frpqgkgjd09y4pnjaq2pkeacam  0.0.0.0/0  5432  pg-fw-desc
   2: frwhnrpxm8wa4jwnpj8hjd6ehc  0.0.0.0/0  6432  
   3: frw2040y4rsy2qxt70bp95j8yg  ::/0  5432  
   4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
-metric destinations:
+metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
-read replicas:
-CA certificates:
+read-replicas:
+ca-certificates:
 

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f firewalls,nics.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f firewalls,nics.txt
@@ -10,6 +10,6 @@ firewall 1:
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f nics -n private-ipv4,private-ipv6,vm-name.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f nics -n private-ipv4,private-ipv6,vm-name.txt
@@ -1,4 +1,4 @@
 nic 1:
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w description,location,path.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w description,location,path.txt
@@ -11,6 +11,6 @@ firewall 1:
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules -r id,cidr.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules -r id,cidr.txt
@@ -11,6 +11,6 @@ firewall 1:
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules -r port-range.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules -r port-range.txt
@@ -11,6 +11,6 @@ firewall 1:
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules.txt
@@ -11,6 +11,6 @@ firewall 1:
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show.txt
@@ -16,6 +16,6 @@ firewall 1:
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/ps psfzm9e26xky5m9ggetw4dpqe2 show.txt
+++ b/spec/routes/api/cli/golden-files/ps psfzm9e26xky5m9ggetw4dpqe2 show.txt
@@ -16,6 +16,6 @@ firewall 1:
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic
-  private_ipv4: 10.67.141.133
-  private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
-  vm_name: test-vm
+  private-ipv4: 10.67.141.133
+  private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
+  vm-name: test-vm

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f id,name,state,location,size,unix-user,storage-size-gib.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f id,name,state,location,size,unix-user,storage-size-gib.txt
@@ -3,5 +3,5 @@ name: test-vm
 state: creating
 location: eu-central-h1
 size: standard-2
-unix_user: ubi
-storage_size_gib: 0
+unix-user: ubi
+storage-size-gib: 0

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f ip6,ip4-enabled,ip4,private-ipv4,private-ipv6,subnet.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f ip6,ip4-enabled,ip4,private-ipv4,private-ipv6,subnet.txt
@@ -1,6 +1,6 @@
 ip6: 
-ip4_enabled: true
+ip4-enabled: true
 ip4: 128.0.0.1
-private_ipv4: 10.67.141.133
-private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+private-ipv4: 10.67.141.133
+private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
 subnet: default-eu-central-h1

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
@@ -3,13 +3,13 @@ name: test-vm
 state: creating
 location: eu-central-h1
 size: standard-2
-unix_user: ubi
-storage_size_gib: 0
+unix-user: ubi
+storage-size-gib: 0
 ip6: 
-ip4_enabled: true
+ip4-enabled: true
 ip4: 128.0.0.1
-private_ipv4: 10.67.141.133
-private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+private-ipv4: 10.67.141.133
+private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
 subnet: default-eu-central-h1
 firewall 1:
   id: fw4gj2v4h1fe3q28q0hnf7g8n1

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -3,13 +3,13 @@ name: test-vm
 state: creating
 location: eu-central-h1
 size: standard-2
-unix_user: ubi
-storage_size_gib: 0
+unix-user: ubi
+storage-size-gib: 0
 ip6: 
-ip4_enabled: true
+ip4-enabled: true
 ip4: 128.0.0.1
-private_ipv4: 10.67.141.133
-private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+private-ipv4: 10.67.141.133
+private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
 subnet: default-eu-central-h1
 firewall 1:
   id: fw4gj2v4h1fe3q28q0hnf7g8n1

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -3,13 +3,13 @@ name: test-vm
 state: creating
 location: eu-central-h1
 size: standard-2
-unix_user: ubi
-storage_size_gib: 0
+unix-user: ubi
+storage-size-gib: 0
 ip6: 
-ip4_enabled: true
+ip4-enabled: true
 ip4: 128.0.0.1
-private_ipv4: 10.67.141.133
-private_ipv6: fda0:d79a:93e7:d4fd:1c2::2
+private-ipv4: 10.67.141.133
+private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
 subnet: default-eu-central-h1
 firewall 1:
   id: fw4gj2v4h1fe3q28q0hnf7g8n1

--- a/spec/routes/api/cli/pg/show_spec.rb
+++ b/spec/routes/api/cli/pg/show_spec.rb
@@ -29,30 +29,30 @@ RSpec.describe Clover, "cli pg show" do
       name: test-pg
       state: creating
       location: eu-central-h1
-      vm_size: standard-2
-      target_vm_size: standard-2
-      storage_size_gib: 64
-      target_storage_size_gib: 64
+      vm-size: standard-2
+      target-vm-size: standard-2
+      storage-size-gib: 64
+      target-storage-size-gib: 64
       version: 17
-      target_version: 17
-      ha_type: none
+      target-version: 17
+      ha-type: none
       flavor: standard
-      connection_string: postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?channel_binding=require
+      connection-string: postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?channel_binding=require
       primary: true
-      earliest_restore_time: 
-      maintenance_window_start_at: 
-      read_replica: false
+      earliest-restore-time: 
+      maintenance-window-start-at: 
+      read-replica: false
       parent: 
       tags:
-      firewall rules:
+      firewall-rules:
         1: #{rules[0].ubid}  0.0.0.0/0  5432  my fwr desc
         2: #{rules[1].ubid}  0.0.0.0/0  6432  
         3: #{rules[2].ubid}  ::/0  5432  
         4: #{rules[3].ubid}  ::/0  6432  
-      metric destinations:
+      metric-destinations:
         1: #{@pg.metric_destinations[0].ubid}  md-user  https://md.example.com
-      read replicas:
-      CA certificates:
+      read-replicas:
+      ca-certificates:
       a
       b
     END
@@ -63,31 +63,31 @@ RSpec.describe Clover, "cli pg show" do
       name: test-pg
       state: creating
       location: eu-central-h1
-      vm_size: standard-2
-      target_vm_size: standard-2
-      storage_size_gib: 64
-      target_storage_size_gib: 64
+      vm-size: standard-2
+      target-vm-size: standard-2
+      storage-size-gib: 64
+      target-storage-size-gib: 64
       version: 17
-      target_version: 17
-      ha_type: none
+      target-version: 17
+      ha-type: none
       flavor: standard
-      connection_string: postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?channel_binding=require
+      connection-string: postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?channel_binding=require
       primary: true
-      earliest_restore_time: 
-      maintenance_window_start_at: 
-      read_replica: true
+      earliest-restore-time: 
+      maintenance-window-start-at: 
+      read-replica: true
       parent: eu-central-h1/test-pg
       tags:
-      firewall rules:
+      firewall-rules:
         1: #{rules[0].ubid}  0.0.0.0/0  5432  my fwr desc
         2: #{rules[1].ubid}  0.0.0.0/0  6432  
         3: #{rules[2].ubid}  ::/0  5432  
         4: #{rules[3].ubid}  ::/0  6432  
-      metric destinations:
+      metric-destinations:
         1: #{@pg.metric_destinations[0].ubid}  md-user  https://md.example.com
-      read replicas:
+      read-replicas:
         eu-central-h1/test-pg
-      CA certificates:
+      ca-certificates:
       a
       b
     END

--- a/spec/routes/api/cli/vm/show_spec.rb
+++ b/spec/routes/api/cli/vm/show_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe Clover, "cli vm show" do
       state: running
       location: eu-central-h1
       size: standard-2
-      unix_user: ubi
-      storage_size_gib: 0
+      unix-user: ubi
+      storage-size-gib: 0
       ip6: 128:1234::2
-      ip4_enabled: false
+      ip4-enabled: false
       ip4: 128.0.0.1
-      private_ipv4: #{@vm.private_ipv4}
-      private_ipv6: #{@vm.private_ipv6}
+      private-ipv4: #{@vm.private_ipv4}
+      private-ipv6: #{@vm.private_ipv6}
       subnet: default-eu-central-h1
       firewall 1:
         id: #{@fw.ubid}


### PR DESCRIPTION
Almost all from Claude Code, using the following prompt:

```
In Ubicloud's CLI input and output, fields should use `-` and
not `_`. Internally, Ubicloud uses `_` to separate words. When
accepting CLI option input, Ubicloud converts `-` to `_`. However,
when outputing fields, Ubicloud does not convert from `_` back
to `-`. Fix this issue by modifying `lib/ubi_cli.rb` files under
`cli-commands` to convert output field names to use `-` instead of
`_`.
```

Only change made was removing an unused branch from the created dash_keys method.

In some cases, this changes from spaces to dashes and uppercase uppercase to lower case
(e.g. `CA certificates -> ca-certificates`).

Note that this may break programs that attempt to parse the current CLI output format.

Best reviewed with
`git diff --color-words --word-diff-regex='\\w+|[^[:space:]]'`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify CLI output to use dashes instead of underscores for field names across various commands, updating code and tests accordingly.
> 
>   - **Behavior**:
>     - Modify CLI output to use dashes instead of underscores for field names in `fw`, `kc`, `lb`, `pg`, `ps`, and `vm` commands.
>     - Introduce `each_with_dashed` method in `lib/ubi_cli.rb` to convert underscores to dashes in output field names.
>   - **Code Changes**:
>     - Update `fw/post/show.rb`, `kc/post/show.rb`, `lb/post/show.rb`, `pg/post/show.rb`, `ps/post/show.rb`, and `vm/post/show.rb` to use `each_with_dashed` for field name conversion.
>     - Remove unused branch from `dash_keys` method in `lib/ubi_cli.rb`.
>   - **Tests**:
>     - Update golden files in `spec/routes/api/cli/golden-files` to reflect new field name format with dashes.
>     - Modify `show_spec.rb` for `pg` and `vm` to match updated output format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a0f9c3b6f4e21d0599f19729a2134ef95ebb5a9b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->