### PR TITLE
Support extending a strand's schedule

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -179,6 +179,9 @@ class CloverAdmin < Roda
     "Strand" => {
       "schedule" => object_action("Schedule Strand to Run Immediately", "Scheduled strand to run immediately") do |obj|
         obj.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
+      end,
+      "extend" => object_action("Extend Schedule", "Extended schedule", {minutes: :pos_int!}) do |obj, minutes|
+        obj.this.update(schedule: Sequel.date_add(:schedule, minutes:))
       end
     },
     "Vm" => {

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -460,6 +460,21 @@ RSpec.describe CloverAdmin do
     expect(st.reload.schedule).to be_within(5).of(Time.now)
   end
 
+  it "supports adding 5 minutes to strand schedule" do
+    schedule = Time.now + 10
+    st = Strand.create(prog: "Test", label: "hop_entry", schedule:)
+    fill_in "UBID or UUID", with: st.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Strand #{st.ubid}"
+
+    click_link "Extend Schedule"
+    fill_in "minutes", with: "5"
+    click_button "Extend Schedule"
+    expect(page).to have_flash_notice("Extended schedule")
+    expect(page.title).to eq "Ubicloud Admin - Strand #{st.ubid}"
+    expect(st.reload.schedule).to be_within(5).of(schedule + 300)
+  end
+
   it "supports restarting Vms" do
     vm = Prog::Vm::Nexus.assemble("dummy-public key", Project.create(name: "Default").id, name: "dummy-vm-1").subject
     fill_in "UBID or UUID", with: vm.ubid


### PR DESCRIPTION
Partially written by Claude Code with the following prompt:

```
Add an Strand action to OBJECT_ACTIONS in clover_admin.rb that
will add 5 minutes to the strand's schedule. Add an appropriate
test to spec/routes/web/admin/admin_spec.rb.
```

I later decided to make the amount of time to extend the schedule to be set by the admin, similar to the process for adding credits to projects. I also changed the labels and messages, and switched from raw SQL to using Sequel.date_add.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `extend` action to `Strand` in `clover_admin.rb` for schedule extension by specified minutes, with corresponding test in `admin_spec.rb`.
> 
>   - **Behavior**:
>     - Adds `extend` action to `OBJECT_ACTIONS` in `clover_admin.rb` for `Strand`, allowing schedule extension by specified minutes using `Sequel.date_add`.
>   - **Tests**:
>     - Adds test in `admin_spec.rb` to verify extending a strand's schedule by 5 minutes, checking for correct schedule update and flash notice.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for c81d118d921657fda10bdfba070ac7711e969a55. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->