### PR TITLE
Fix undeterministic Prog::RedeliverGithubFailures spec

### DIFF
--- a/spec/prog/redeliver_github_failures_spec.rb
+++ b/spec/prog/redeliver_github_failures_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Prog::RedeliverGithubFailures do
         .and change { prog.strand.stack.first["last_check_at"] }.from("2023-10-19 22:27:47 UTC").to("2023-10-19 23:27:47 UTC")
         .and change(Strand, :count).by(2)
       expect(prog.strand.children.count).to eq(2)
-      expect(prog.strand.children.last.stack.first["delivery_ids"]).to eq([26])
+      expect(prog.strand.children.map { it.stack.first["delivery_ids"] }).to include([26])
     end
   end
 


### PR DESCRIPTION
Since it has two child strands, their order may vary, which leads to nondeterministic behavior and test failures.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix nondeterministic test behavior in `redeliver_github_failures_spec.rb` by checking for inclusion of delivery IDs instead of order.
> 
>   - **Test Fix**:
>     - In `redeliver_github_failures_spec.rb`, change expectation from `prog.strand.children.last.stack.first["delivery_ids"]` to `prog.strand.children.map { it.stack.first["delivery_ids"] }.to include([26])` to handle nondeterministic child strand order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 96208c3f9805fc9199da152524e723eda9d60eab. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->