### PR TITLE
Add github runner and project tables to admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -282,6 +282,28 @@ class CloverAdmin < Roda
       end
     end
 
+    model GithubRunner do
+      order Sequel.desc(:created_at)
+      eager_graph [:strand]
+      columns do |type_symbol, request|
+        cs = [:repository_name, :label, :strand_label, :created_at]
+        cs.prepend(:name) unless type_symbol == :search_form
+        cs
+      end
+
+      column_options strand_label: {type: "text"},
+        created_at: {type: "text"}
+
+      column_search_filter do |ds, column, value|
+        case column
+        when :strand_label
+          column_grep.call(ds, Sequel[:strand][:label], value)
+        when :created_at
+          column_grep.call(ds, column, value)
+        end
+      end
+    end
+
     model Project do
       order Sequel.desc(:created_at)
       columns [:name, :reputation, :billing_info_id, :credit, :created_at]

--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -80,6 +80,12 @@ class GithubRunner < Sequel::Model
   def custom_label
     GithubCustomLabel.first(name: actual_label, installation_id: installation_id)
   end
+
+  alias_method :name, :ubid
+
+  def strand_label
+    strand&.label
+  end
 end
 
 # Table: github_runner

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -170,6 +170,8 @@ RSpec.describe CloverAdmin do
     GithubInstallation.create(name: "ins1", installation_id: 1, type: "Organization", allocator_preferences: {family_filter: nil})
     ins2 = GithubInstallation.create(name: "ins2", installation_id: 2, type: "Organization", allocator_preferences: {"family_filter" => ["standard", "premium"]})
     ins3 = GithubInstallation.create(name: "ins3", installation_id: 3, type: "User", allocator_preferences: {"family_filter" => ["standard"]})
+    runner = Prog::Github::GithubRunnerNexus.assemble(ins2, repository_name: "ubicloud/test", label: "ubicloud").subject
+    GithubRunner.create(installation_id: ins2.id, repository_name: "ubicloud/test", label: "ubicloud")
     click_link "Ubicloud Admin"
     click_link "GithubInstallation"
     click_link "Search"
@@ -185,6 +187,16 @@ RSpec.describe CloverAdmin do
     select "User", from: "Type"
     click_button "Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq ["ins3", "3", "User", "true", "false", ins3.created_at.to_s, "{\"family_filter\" => [\"standard\"]}"]
+
+    click_link "Ubicloud Admin"
+    click_link "GithubRunner"
+    click_link "Search"
+
+    fill_in "Repository name", with: "ubicloud"
+    fill_in "Strand label", with: "start"
+    fill_in "Created at", with: ins2.created_at.strftime("%Y-%m")
+    click_button "Search"
+    expect(page.all("#autoforme_content td").map(&:text)).to eq [runner.ubid, "ubicloud/test", "ubicloud", "start", runner.created_at.to_s]
 
     account = create_account
     AccountIdentity.create(account_id: account.id, provider: "github", uid: "789")


### PR DESCRIPTION
- **Add project table to admin panel**
  

- **Add github runner table to admin panel**
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `GithubRunner` and `Project` tables to admin panel with search and display functionalities, updating models and tests accordingly.
> 
>   - **Admin Panel**:
>     - Add `GithubRunner` table with columns `repository_name`, `label`, `strand_label`, `created_at` in `clover_admin.rb`.
>     - Add `Project` table with columns `name`, `reputation`, `billing_info_id`, `credit`, `created_at` in `clover_admin.rb`.
>   - **Model Enhancements**:
>     - Add `name` alias and `strand_label` method to `GithubRunner` in `github_runner.rb`.
>   - **Testing**:
>     - Update `admin_spec.rb` to test `GithubRunner` and `Project` table functionalities, including search and display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 66d9a328d5a3b2604d3747059803d54e43772974. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->