### PR TITLE
feat(dns): support custom boot image (#41)

### DIFF
--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -3,7 +3,7 @@
 class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   subject_is :vm, :sshable
 
-  def self.assemble(dns_server_id, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID)
+  def self.assemble(dns_server_id, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-jammy")
     unless (dns_server = DnsServer[dns_server_id])
       fail "No existing Dns Server"
     end
@@ -32,7 +32,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
         storage_volumes: [
           {encrypted: true, size_gib: storage_size_gib}
         ],
-        boot_image: "ubuntu-jammy",
+        boot_image: boot_image,
         enable_ip4: true
       )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `boot_image` parameter to `assemble` method in `setup_dns_server_vm.rb` for custom DNS server VM boot images.
> 
>   - **Behavior**:
>     - Adds `boot_image` parameter to `assemble` method in `setup_dns_server_vm.rb` to allow custom boot images for DNS server VMs.
>     - Default boot image remains `ubuntu-jammy` if not specified.
>   - **Code Changes**:
>     - Replaces hardcoded `boot_image: "ubuntu-jammy"` with `boot_image: boot_image` in `assemble` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for b8ddb643d7cf3612c2ed1f4dcd1654859948b81b. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->