### PR TITLE
Add tags to pg /read-replica endpoint

### DIFF
--- a/cli-commands/pg/post/create-read-replica.rb
+++ b/cli-commands/pg/post/create-read-replica.rb
@@ -3,12 +3,16 @@
 UbiCli.on("pg").run_on("create-read-replica") do
   desc "Create a read replica for a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) create-read-replica name"
+  options("ubi pg (location/pg-name | pg-id) create-read-replica name [options]", key: :pg_create_read_replica) do
+    on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
+  end
 
   args 1
 
-  run do |name|
-    id = sdk_object.create_read_replica(name).id
+  run do |name, opts, cmd|
+    params = underscore_keys(opts[:pg_create_read_replica])
+    pg_tags_to_hash(params, cmd)
+    id = sdk_object.create_read_replica(name, **params).id
     response("Read replica for PostgreSQL database created with id: #{id}")
   end
 end

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1359,7 +1359,13 @@ paths:
               type: object
               properties:
                 name:
+                  description: Name for the read replica
                   type: string
+                tags:
+                  description: Tags for the read replica
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/PostgresTag'
               additionalProperties: false
               required:
                 - name

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
   def self.assemble(project_id:, location_id:, name:, target_vm_size:, target_storage_size_gib:,
     target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
-    ha_type: PostgresResource::HaType::NONE, parent_id: nil, restore_target: nil, with_firewall_rules: true, user_config: {}, pgbouncer_user_config: {})
+    ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true, user_config: {}, pgbouncer_user_config: {})
 
     unless Project[project_id]
       fail "No existing project"
@@ -51,7 +51,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       postgres_resource = PostgresResource.create(
         project_id:, location_id: location.id, name:,
         target_vm_size:, target_storage_size_gib:,
-        superuser_password:, ha_type:, target_version:, flavor:, parent_id:, restore_target:, hostname_version: "v2", user_config:, pgbouncer_user_config:
+        superuser_password:, ha_type:, target_version:, flavor:, parent_id:, tags:, restore_target:, hostname_version: "v2", user_config:, pgbouncer_user_config:
       )
 
       # Customer firewall, will be attached to created customer subnet

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -239,6 +239,7 @@ class Clover
         handle_validation_failure("postgres/show") { @page = "read-replica" }
 
         name = typecast_params.nonempty_str!("name")
+        tags = typecast_params.array(:Hash, "tags", [])
 
         Validation.validate_name(name)
 
@@ -260,6 +261,7 @@ class Clover
             target_version: pg.version,
             flavor: pg.flavor,
             parent_id: pg.id,
+            tags:,
             restore_target: nil
           ).subject
           audit_log(pg, "create_replica", replica)

--- a/sdk/ruby/lib/ubicloud/model/postgres.rb
+++ b/sdk/ruby/lib/ubicloud/model/postgres.rb
@@ -108,8 +108,8 @@ module Ubicloud
     end
 
     # Create a read replica of this database, with the given name.
-    def create_read_replica(name)
-      Postgres.new(adapter, adapter.post(_path("/read-replica"), name:))
+    def create_read_replica(name, tags: [])
+      Postgres.new(adapter, adapter.post(_path("/read-replica"), name:, tags:))
     end
 
     # Promote this database from a read replica to a primary.

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -577,7 +577,10 @@ Usage:
 Create a read replica for a PostgreSQL database
 
 Usage:
-    ubi pg (location/pg-name | pg-id) create-read-replica name
+    ubi pg (location/pg-name | pg-id) create-read-replica name [options]
+
+Options:
+    -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
 
 
 Create a PostgreSQL database

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -58,7 +58,7 @@ ubi pg (location/pg-name | pg-id) add-firewall-rule [options] cidr
 ubi pg (location/pg-name | pg-id) add-metric-destination username password url
 ubi pg (location/pg-name | pg-id) add-pgbouncer-config-entries key=value [...]
 ubi pg (location/pg-name | pg-id) ca-certificates
-ubi pg (location/pg-name | pg-id) create-read-replica name
+ubi pg (location/pg-name | pg-id) create-read-replica name [options]
 ubi pg location/pg-name create [options]
 ubi pg (location/pg-name | pg-id) delete-firewall-rule rule-id
 ubi pg (location/pg-name | pg-id) delete-metric-destination md-id


### PR DESCRIPTION
Aligns with /create which already accepts tags

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for creating Postgres read replicas with tags via API, updating OpenAPI spec, route handling, and tests.
> 
>   - **Behavior**:
>     - Add `tags` property to read replica creation in `openapi.yml`.
>     - Update `createPostgresDatabaseReadReplica` in `postgres.rb` to accept and process `tags`.
>     - Ensure `tags` are applied to replicas in `postgres.rb`.
>   - **Tests**:
>     - Add test for read replica creation with `tags` in `postgres_spec.rb`.
>     - Validate `tags` are correctly set on created replicas in `postgres_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9f33011649052722488c33ffadda271ca28b45ff. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->