### PR TITLE
Fix coverage check and missing test coverage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -253,7 +253,7 @@ desc "Run specs in parallel with coverage"
 task "coverage_pspec" do
   output_file = "coverage/output.txt"
   coverage_setup.call
-  command = "bundle exec turbo_tests -n #{nproc.call} 2>&1 | tee #{output_file}"
+  command = "bash -o pipefail -c 'bundle exec turbo_tests -n #{nproc.call} 2>&1 | tee #{output_file}'"
   sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "COVERAGE" => "1", "RODA_RENDER_COMPILED_METHOD_SUPPORT" => "no"}, command)
   command_output = File.binread(output_file)
   unless command_output.include?("Line Coverage: 100.0%") && command_output.include?("Branch Coverage: 100.0%")

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -195,11 +195,8 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       described_class.new(Strand.create(prog: "Vnet::SubnetNexus", label: "wait_old_state_drop", id: ps.id))
     }
 
-    before do
-      expect(nx).to receive(:get_locked_nics).and_return([nic])
-    end
-
     it "donates if policy update is ongoing" do
+      expect(nx).to receive(:get_locked_nics).and_return([nic])
       nic
       expect { nx.wait_old_state_drop }.to nap(5)
     end


### PR DESCRIPTION

    I noticed coverage checks were failing locally when they were working
    in GitHub CI.  This can happen when the number of covered branches
    rounds to 100%, but is slightly lower than that: the shell pipeline
    (that is, `tee`) succeeds, the string match succeeds, but to get the
    correct behavior shell pipeline should have failed, as simplecov's
    enforcement did return non-zero.
    
    Claude figured it out, its text follows:
    
    Two bugs that were masking each other:
    
    1. Rakefile: coverage_pspec used `| tee` which masks exit status
       The pipeline returns tee's exit status (0), not turbo_tests'.
       SimpleCov could fail with exit 2 but shell reported success.
       Fix: Use `bash -o pipefail -c '...'` to preserve exit status.
    
    2. Test: get_locked_nics was always mocked, line 136 never executed
       Moved mock from before block to only the test that needs it.
       The "hops to wait if all is done" test now actually exercises
       get_locked_nics via the real code path.
    
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix coverage check in Rakefile and correct test coverage in `subnet_nexus_spec.rb`.
> 
>   - **Rakefile**:
>     - Fix `coverage_pspec` task to preserve exit status by using `bash -o pipefail -c`.
>   - **Tests**:
>     - In `subnet_nexus_spec.rb`, move `get_locked_nics` mock from `before` block to specific test to ensure line 136 is executed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for fae5b3696e883830f639dcf40c7b6e2a971b63dc. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->