### PR TITLE
Observe archival backlog and page if it exceeds threshold

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -250,6 +250,10 @@ class PostgresServer < Sequel::Model
       end
     end
 
+    if pulse[:reading_rpt] % 12 == 1
+      observe_archival_backlog(session:)
+    end
+
     pulse
   end
 
@@ -333,6 +337,35 @@ class PostgresServer < Sequel::Model
     if Config.aws_postgres_iam_access && timeline.aws? && vm.aws_instance.iam_role
       timeline.location.location_credential.iam_client.attach_role_policy(role_name: vm.aws_instance.iam_role, policy_arn: timeline.aws_s3_policy_arn)
     end
+  end
+
+  def observe_archival_backlog(session:)
+    result = session[:ssh_session].exec!(
+      "sudo find /dat/:version/data/pg_wal/archive_status -name '*.ready' | wc -l",
+      version:
+    )
+    archival_backlog = result.strip.to_i
+
+    if archival_backlog > archival_backlog_threshold
+      Prog::PageNexus.assemble("#{ubid} archival backlog high",
+        ["PGArchivalBacklogHigh", id], ubid,
+        severity: "warning", extra_data: {archival_backlog: archival_backlog})
+    else
+      Page.from_tag_parts("PGArchivalBacklogHigh", id)&.incr_resolve
+    end
+  rescue => ex
+    Clog.emit("Failed to observe archival backlog") do
+      {postgres_server_id: id, exception: Util.exception_to_hash(ex)}
+    end
+  end
+
+  def archival_backlog_threshold
+    # To make the threshold adaptive to storage size, we set it as percent of
+    # the storage size as WAL file count based on the allocated storage size,
+    # capped to 1000 to avoid high thresholds on large storage sizes.
+    archival_backlog_threshold_percent = 5
+    archival_backlog_threshold_count = 1000
+    [(storage_size_gib * 1024 / (16 * 100)) * archival_backlog_threshold_percent, archival_backlog_threshold_count].min
   end
 
   FAILOVER_LABELS = ["prepare_for_unplanned_take_over", "prepare_for_planned_take_over", "wait_fencing_of_old_primary", "taking_over"].freeze

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MonitorableResource do
       expect(session[:ssh_session]).to receive(:close)
       expect(Thread).to receive(:new).and_call_original
       expect(session[:ssh_session]).to receive(:loop).and_raise(StandardError)
-      expect(Clog).to receive(:emit).twice.and_call_original
+      expect(Clog).to receive(:emit).at_least(:once).and_call_original
       r_w_event_loop.check_pulse
     end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -441,6 +441,7 @@ RSpec.describe PostgresServer do
     expect(PostgresLsnMonitor).to receive(:new).and_return(lsn_monitor)
     expect(lsn_monitor).to receive(:insert_conflict).and_return(lsn_monitor)
     expect(lsn_monitor).to receive(:save_changes).and_raise(Sequel::Error)
+    expect(postgres_server).to receive(:observe_archival_backlog)
     expect(Clog).to receive(:emit).with("Failed to update PostgresLsnMonitor").and_call_original
     expect(postgres_server).to receive(:primary?).and_return(true)
     postgres_server.check_pulse(session: {db_connection: DB}, previous_pulse: {})
@@ -517,6 +518,64 @@ RSpec.describe PostgresServer do
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: "walg_config")
       expect(postgres_server.vm.sshable).not_to receive(:_cmd).with("sudo tee /usr/lib/ssl/certs/blob_storage_ca.crt > /dev/null", stdin: "root_certs")
       expect { postgres_server.refresh_walg_credentials }.not_to raise_error
+    end
+  end
+
+  describe "#observe_archival_backlog" do
+    let(:session) {
+      {ssh_session: Net::SSH::Connection::Session.allocate}
+    }
+
+    before do
+      allow(postgres_server).to receive(:archival_backlog_threshold).and_return(10)
+    end
+
+    it "checks archival backlog and does nothing if it is within limits" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "sudo find /dat/16/data/pg_wal/archive_status -name '*.ready' | wc -l"
+      ).and_return("5\n")
+      expect(Prog::PageNexus).not_to receive(:assemble)
+      expect(Page).to receive(:from_tag_parts).with("PGArchivalBacklogHigh", postgres_server.id).and_return(nil)
+
+      postgres_server.observe_archival_backlog(session:)
+    end
+
+    it "checks archival backlog and creates a page if it is outside of limits" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "sudo find /dat/16/data/pg_wal/archive_status -name '*.ready' | wc -l"
+      ).and_return("15\n")
+      expect(Prog::PageNexus).to receive(:assemble).with(
+        "#{postgres_server.ubid} archival backlog high",
+        ["PGArchivalBacklogHigh", postgres_server.id],
+        postgres_server.ubid,
+        severity: "warning",
+        extra_data: {archival_backlog: 15}
+      )
+
+      postgres_server.observe_archival_backlog(session:)
+    end
+
+    it "checks archival backlog and resolves a page if it is back within limits" do
+      existing_page = instance_double(Page)
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "sudo find /dat/16/data/pg_wal/archive_status -name '*.ready' | wc -l"
+      ).and_return("3\n")
+      expect(Page).to receive(:from_tag_parts).with("PGArchivalBacklogHigh", postgres_server.id).and_return(existing_page)
+      expect(existing_page).to receive(:incr_resolve)
+
+      postgres_server.observe_archival_backlog(session:)
+    end
+  end
+
+  describe "#archival_backlog_threshold" do
+    it "returns 1000 if the storage size is large" do
+      allow(postgres_server).to receive(:storage_size_gib).and_return(1024)
+      expect(postgres_server.archival_backlog_threshold).to eq(1000)
+    end
+
+    it "returns smaller threshold for smaller storage sizes" do
+      allow(postgres_server).to receive(:storage_size_gib).and_return(100)
+      expect(postgres_server.archival_backlog_threshold).to eq(320)
     end
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add archival backlog monitoring and paging to PostgreSQL server with adaptive threshold.
> 
>   - **Behavior**:
>     - Adds `observe_archival_backlog` method in `postgres_server.rb` to monitor archival backlog and page if it exceeds a threshold.
>     - Updates `check_pulse` in `postgres_server.rb` to call `observe_archival_backlog` every 12th pulse.
>     - Threshold is adaptive to storage size, capped at 1000.
>   - **Tests**:
>     - Adds tests for `observe_archival_backlog` and `archival_backlog_threshold` in `postgres_server_spec.rb`.
>     - Updates existing tests in `monitorable_resource_spec.rb` to expect `observe_archival_backlog` call.
>   - **Misc**:
>     - Adjusts logging expectations in `monitorable_resource_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f38f97c7b6059e9562f284d2e2e158da82c935f0. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->