### PR TITLE
List postgres databases api call returns read replica ubids

### DIFF
--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -40,11 +40,6 @@ UbiCli.on("pg").run_on("show") do
         data[key].each_with_index do |md, i|
           body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
         end
-      when :read_replicas
-        body << "read-replicas:\n"
-        sdk_object.read_replicas.each do |rr|
-          body << "  " << rr[:location] << "/" << rr[:name] << "\n"
-        end
       when :ca_certificates
         body << "ca-certificates:\n" << data[key].to_s << "\n"
       else

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -73,7 +73,7 @@ class Clover
   end
 
   def postgres_list(tags_param: nil)
-    dataset = dataset_authorize(@project.postgres_resources_dataset.eager(:timeline, representative_server: [:strand, vm: :vm_storage_volumes]), "Postgres:view").eager(:semaphores, :location, strand: :children)
+    dataset = dataset_authorize(@project.postgres_resources_dataset.eager(:timeline, :read_replicas, representative_server: [:strand, vm: :vm_storage_volumes]), "Postgres:view").eager(:semaphores, :location, strand: :children)
 
     if tags_param
       tags_param = tags_param.split(",")

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -2728,6 +2728,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PostgresTag'
+        read_replicas:
+          description: Lists ids of read replicas for this database
+          type: array
+          items:
+            type: string
       additionalProperties: false
       required:
         - flavor
@@ -2743,6 +2748,7 @@ components:
         - maintenance_window_start_at
         - read_replica
         - tags
+        - read_replicas
     PostgresDatabaseMetrics:
       type: object
       properties:

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -19,7 +19,8 @@ class Serializers::Postgres < Serializers::Base
       maintenance_window_start_at: pg.maintenance_window_start_at,
       read_replica: !!pg.read_replica?,
       parent: pg.parent&.path,
-      tags: pg.tags || []
+      tags: pg.tags || [],
+      read_replicas: pg.read_replicas.map(&:ubid)
     }
 
     if options[:detailed]
@@ -30,8 +31,7 @@ class Serializers::Postgres < Serializers::Base
         hostname: pg.hostname,
         primary: pg.representative_server&.primary?,
         firewall_rules: Serializers::PostgresFirewallRule.serialize(pg.pg_firewall_rules),
-        metric_destinations: pg.metric_destinations.map { {id: it.ubid, username: it.username, url: it.url} },
-        read_replicas: Serializers::Postgres.serialize(pg.read_replicas, {include_path: true})
+        metric_destinations: pg.metric_destinations.map { {id: it.ubid, username: it.username, url: it.url} }
       )
 
       if pg.timeline && pg.representative_server&.primary?

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f maintenance-window-start-at,read-replica,parent,read-replicas.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f maintenance-window-start-at,read-replica,parent,read-replicas.txt
@@ -1,4 +1,4 @@
 maintenance-window-start-at: 
 read-replica: false
 parent: 
-read-replicas:
+read-replicas: []

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
@@ -25,6 +25,6 @@ firewall-rules:
   4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
 metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
-read-replicas:
+read-replicas: []
 ca-certificates:
 

--- a/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
+++ b/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
@@ -25,6 +25,6 @@ firewall-rules:
   4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
 metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
-read-replicas:
+read-replicas: []
 ca-certificates:
 

--- a/spec/routes/api/cli/pg/show_spec.rb
+++ b/spec/routes/api/cli/pg/show_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Clover, "cli pg show" do
         4: #{rules[3].ubid}  ::/0  6432  
       metric-destinations:
         1: #{@pg.metric_destinations[0].ubid}  md-user  https://md.example.com
-      read-replicas:
+      read-replicas: []
       ca-certificates:
       a
       b
@@ -85,8 +85,7 @@ RSpec.describe Clover, "cli pg show" do
         4: #{rules[3].ubid}  ::/0  6432  
       metric-destinations:
         1: #{@pg.metric_destinations[0].ubid}  md-user  https://md.example.com
-      read-replicas:
-        eu-central-h1/test-pg
+      read-replicas: ["#{@pg.ubid}"]
       ca-certificates:
       a
       b


### PR DESCRIPTION
Modify detailed serialization to also only be array of UBIDs

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> The PR updates the Postgres list API to include the number of read replicas for each database, with changes in dataset query, serialization, and OpenAPI spec, along with new tests.
> 
>   - **Behavior**:
>     - `postgres_list` in `helpers/postgres.rb` now includes `:read_replicas` in the dataset query to fetch the number of replicas.
>     - `serialize_internal` in `serializers/postgres.rb` adds `num_replicas` to the serialized output, counting `pg.read_replicas`.
>     - OpenAPI spec in `openapi.yml` updated to include `num_replicas` in `PostgresDatabase` schema.
>   - **Tests**:
>     - Added tests in `postgres_spec.rb` to verify `num_replicas` is 0 when no replicas exist and correct count when replicas are present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0d666911ab6db9a104bd09ee8895e6c43474c0d1. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->