### PR TITLE
Handle empty network interface

### DIFF
--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -100,7 +100,10 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
   end
 
   label def assign_ipv6_address
-    client.assign_ipv_6_addresses({network_interface_id: nic.nic_aws_resource.network_interface_id, ipv_6_address_count: 1}) if get_network_interface.ipv_6_addresses.empty?
+    nap 1 unless (network_interface = get_network_interface)
+    if network_interface.ipv_6_addresses.empty?
+      client.assign_ipv_6_addresses({network_interface_id: nic.nic_aws_resource.network_interface_id, ipv_6_address_count: 1})
+    end
     hop_wait_network_interface_created
   end
 

--- a/spec/prog/vnet/aws/nic_nexus_spec.rb
+++ b/spec/prog/vnet/aws/nic_nexus_spec.rb
@@ -146,6 +146,12 @@ RSpec.describe Prog::Vnet::Aws::NicNexus do
       expect(client).not_to receive(:assign_ipv_6_addresses)
       expect { nx.assign_ipv6_address }.to hop("wait_network_interface_created")
     end
+
+    it "naps while waiting for the network interface" do
+      client.stub_responses(:describe_network_interfaces, network_interfaces: [])
+      expect(nic.nic_aws_resource).to receive(:network_interface_id).and_return("eni-0123456789abcdefg").at_least(:once)
+      expect { nx.assign_ipv6_address }.to nap(1)
+    end
   end
 
   describe "#wait_network_interface_created" do


### PR DESCRIPTION
We’ve seen cases where the network interface returns nil temporarily and succeeds in subsequent runs.

Instead of raising an exception, it's better to handle this condition gracefully and nap.

    {
      "backtrace": [
        "/app/prog/vnet/aws/nic_nexus.rb:103:in 'Prog::Vnet::Aws::NicNexus#assign_ipv6_address'",
        ...
      ],
      "class": "NoMethodError",
      "message": "undefined method 'ipv_6_addresses' for nil"
    }
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add nap to handle nil network interface in `assign_ipv6_address` in `nic_nexus.rb` and update tests in `nic_nexus_spec.rb`.
> 
>   - **Behavior**:
>     - In `assign_ipv6_address` in `nic_nexus.rb`, add a `nap 1` to handle nil network interface before checking `ipv_6_addresses`.
>   - **Tests**:
>     - Add test in `nic_nexus_spec.rb` to verify `nap` is called when network interface is nil in `assign_ipv6_address`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 98c4bdaaed5b906c4f0785180597202c5fe0b12e. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->