### PR TITLE
fix(postgres-timeline): use delimiter when listing backups

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -103,10 +103,10 @@ class Minio::Client
     response.status == 200
   end
 
-  def list_objects(bucket_name, folder_path, max_keys: 1000)
+  def list_objects(bucket_name, folder_path, max_keys: 1000, delimiter: "")
     objects = []
     query = URI.encode_www_form({
-      "delimiter" => "",
+      "delimiter" => delimiter,
       "encoding-type" => "url",
       "list-type" => 2,
       "prefix" => folder_path,
@@ -125,7 +125,7 @@ class Minio::Client
     while is_truncated
       query = URI.encode_www_form({
         "continuation-token" => continuation_token,
-        "delimiter" => "",
+        "delimiter" => delimiter,
         "encoding-type" => "url",
         "list-type" => 2,
         "prefix" => folder_path,


### PR DESCRIPTION
Without a delimiter, AWS's list_objects_v2 will go through all files which can be 10s of thousands.
Using / delimiter, this stops and lists only files just under given prefix, where `backup_stop_sentinel.json` resides
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `delimiter` parameter to `list_objects` to optimize object listing in `PostgresTimeline` and `Minio::Client`.
> 
>   - **Behavior**:
>     - Adds `delimiter` parameter to `list_objects` in `lib/minio/client.rb` and `model/postgres/postgres_timeline.rb` to limit object listing to a specific directory level.
>     - Updates `backups` method in `PostgresTimeline` to use `delimiter: "/"`, listing only files directly under `basebackups_005/`.
>   - **Functions**:
>     - Modifies `list_objects` and `aws_list_objects` in `PostgresTimeline` to accept and use `delimiter`.
>     - Updates `list_objects` in `Minio::Client` to include `delimiter` in query parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ab3a2323cac7cdc4b188b004bba669caaefe1232. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->