### PR TITLE
Stop hiding 'Create GPU Virtual Machine' buttons

### DIFF
--- a/routes/project/vm.rb
+++ b/routes/project/vm.rb
@@ -25,7 +25,11 @@ class Clover
 
       r.get "create" do
         authorize("Vm:create", @project)
-        view "vm/create"
+        if typecast_params.bool("show_gpu") && !@project.get_ff_gpu_vm
+          view "vm/create_gpu_request_access"
+        else
+          view "vm/create"
+        end
       end
     end
   end

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -340,6 +340,15 @@ RSpec.describe Clover, "vm" do
         expect(page).to have_content "1x NVIDIA A100 80GB PCIe"
       end
 
+      it "handles case where gpu vms are not enabled for the project" do
+        project
+        visit "#{project.path}/vm"
+        click_link "Create GPU Virtual Machine"
+
+        expect(page.title).to eq("Ubicloud - Create GPU Virtual Machine")
+        expect(page).to have_content "GPU virtual machines are not enabled for this project. Email support@ubicloud.com to enable GPU VMs."
+      end
+
       it "handles case where no gpus are available on create gpu virtual machine page by redirecting" do
         project
         project.set_ff_gpu_vm(true)

--- a/views/vm/create_gpu_request_access.erb
+++ b/views/vm/create_gpu_request_access.erb
@@ -1,0 +1,64 @@
+
+<% @page_title = "Create GPU Virtual Machine" %>
+
+<%== part(
+  "components/page_header",
+  breadcrumbs: [
+    %w[Projects /project],
+    [@project.name, @project.path],
+    ["Virtual Machines", "#{@project.path}/vm"],
+    %w[Create #]
+  ]
+) %>
+
+<div class="grid gap-6">
+  <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white">
+    <div class="px-4 py-5 sm:p-6">
+      <div class="max-w-3xl">
+
+        <% gpu_options = [
+                    [
+            "nvidia-rtx-pro-6000",
+            ["NVIDIA RTX PRO 6000", "Blackwell, 96 GB VRAM", "$1150/mo", "$1.58/hour"],
+            "opacity-50 h-full flex",
+            { disabled: "disabled" }
+          ],
+          [
+            "nvidia-b200",
+            ["NVIDIA B200", "Blackwell, up to 8x GPUs / 1.5TB VRAM per instance", "Contact for pricing", ""],
+            "opacity-50 h-full flex",
+            { disabled: "disabled" }
+          ]
+        ] %>
+
+        <div class="[&_.radio-small-cards>div]:items-stretch">
+          <%== part(
+            "components/form/radio_small_cards",
+            name: "gpu",
+            label: "Select a GPU",
+            options: gpu_options,
+            attributes: {}
+          ) %>
+        </div>
+
+        <div class="mt-6 text-sm text-gray-600">
+          GPU virtual machines are not enabled for this project.
+          Email
+          <a href="mailto:support@ubicloud.com"
+            class="font-medium text-orange-600 hover:text-orange-700">
+            support@ubicloud.com
+          </a>
+          to enable GPU VMs.
+        </div>
+      </div>
+    </div>
+    <div class="px-4 py-5 sm:p-6">
+      <div class="flex items-center justify-end gap-x-6">
+        <a href="<%= @project.path %>/vm"
+           class="text-sm font-semibold leading-6 text-gray-900">
+          Cancel
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -5,14 +5,10 @@
   "components/page_header",
   breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Virtual Machines", "#"]],
   right_items: (!@vms.empty? && has_project_permission("Vm:create")) ?
-    (if @project.get_ff_gpu_vm
-      [
+    ([
         part("components/button", text: "Create Virtual Machine", link: "vm/create?show_gpu=f", extra_class: "mr-2"),
         part("components/button", text: "Create GPU Virtual Machine", link: "vm/create?show_gpu=t"),
-      ]
-     else
-      [part("components/button", text: "Create Virtual Machine", link: "vm/create")]
-     end) : []
+      ]) : []
 ) %>
 
 <div class="grid gap-6">
@@ -38,15 +34,10 @@
       description: "You don't have permission to create virtual machines."
     }.merge(has_project_permission("Vm:create") ? {
       description: "Get started by creating a new virtual machine.",
-      buttons: (
-        if @project.get_ff_gpu_vm
-          {
-            "Create Virtual Machine" => "#{@project.path}/vm/create?show_gpu=f",
-            "Create GPU Virtual Machine" => "#{@project.path}/vm/create?show_gpu=t",
-          }
-        else
-          {"Create Virtual Machine" => "#{@project.path}/vm/create"}
-        end)
+      buttons: {
+          "Create Virtual Machine" => "#{@project.path}/vm/create?show_gpu=f",
+          "Create GPU Virtual Machine" => "#{@project.path}/vm/create?show_gpu=t",
+        }
     } : {})
   ) %>
 </div>


### PR DESCRIPTION
For projects without the `gpu_vm` feature flag, stop hiding the
"Create GPU Virtual Machine" buttons.

Instead, route these users to a static view that explains GPU VMs are
not enabled and directs them to contact `support@ubicloud.com` to
request access.



<img width="796" height="398" alt="image" src="https://github.com/user-attachments/assets/d6bc1c6d-8dc6-4b3e-82fe-ddb52052bf51" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> The PR changes the 'Create GPU Virtual Machine' button to route users to a static view explaining GPU VMs are unavailable for projects without the feature flag, instead of hiding the button.
> 
>   - **Behavior**:
>     - For projects without `gpu_vm` feature flag, 'Create GPU Virtual Machine' button now routes to `create_gpu_request_access` view instead of being hidden (`routes/project/vm.rb`).
>     - `create_gpu_request_access.erb` view informs users GPU VMs are not enabled and provides contact information for support.
>   - **Tests**:
>     - Added test in `vm_spec.rb` to verify routing to `create_gpu_request_access` when GPU VMs are not enabled.
>   - **Views**:
>     - Updated `index.erb` to always show 'Create GPU Virtual Machine' button, regardless of feature flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f73e1e7c7565dec6d02d2ea4089ed13710c58fa8. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->