### PR TITLE
Extract exceptions to E2E test summary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -176,6 +176,15 @@ jobs:
         echo '|---|---|---|---|' >> $GITHUB_STEP_SUMMARY
         grep "runner_started" foreman.log | cut -d'|' -f2 | jq -r '[.runner_started.ubid, .runner_started.label, .runner_started.vm_ubid, .runner_started.duration] | "| " + join(" | ") + " |"' >> $GITHUB_STEP_SUMMARY
 
+    - name: Extract exception
+      if: always()
+      continue-on-error: true
+      run: |
+        echo "## Exceptions" >> $GITHUB_STEP_SUMMARY
+        echo '| Time | Thread | Class | Message | First Backtrace Line |' >> $GITHUB_STEP_SUMMARY
+        echo '|---|---|---|---|---|' >> $GITHUB_STEP_SUMMARY
+        grep 'respirate.*"exception"' foreman.log | cut -d'|' -f2 | jq -r '[.time, .thread, .exception.class, .exception.message, (.exception.backtrace[0] // "" | gsub("\n"; " "))] | "| " + join(" | ") + " |"' >> $GITHUB_STEP_SUMMARY
+
     - name: Upload logs
       if: always()
       uses: actions/upload-artifact@v5


### PR DESCRIPTION
## **Extract exceptions to E2E test summary**

Exceptions in the E2E test summary to help identify potential issues
quickly.

AWS errors can be a bit noisy sometimes, but we can suppress them in
subsequent PRs.

## **Remove newlines from exception backtrace messages in E2E summary**

The first line of an exception backtrace can contain newline characters,
which break the markdown table in the E2E summary. We should strip
newlines from the backtrace message to keep the table formatting intact.


<img width="2428" height="1224" alt="CleanShot 2025-12-17 at 23 13 30@2x" src="https://github.com/user-attachments/assets/6507dd6f-02c4-4bb7-ae26-6a5c6ff75c12" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a step to extract and format exceptions from E2E test logs into a markdown table in the GitHub step summary, ensuring backtrace newlines are removed.
> 
>   - **Behavior**:
>     - Adds a step in `.github/workflows/e2e.yml` to extract exceptions from `foreman.log` and append them to `$GITHUB_STEP_SUMMARY`.
>     - Formats exceptions into a markdown table with columns: Time, Thread, Class, Message, First Backtrace Line.
>     - Strips newlines from the first line of exception backtrace to maintain table formatting.
>   - **Misc**:
>     - AWS errors are noted as potentially noisy but will be addressed in future PRs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 54d36a598d5d3ae11afcb9e007416ed36012cc2d. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->