### PR TITLE
Restrict SNAT to NEW connections to preserve client IP

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -83,7 +83,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   label def bootstrap_rhizome
     nap 5 unless vm.strand.label == "wait"
 
-    vm.sshable.cmd("sudo iptables-nft -t nat -A POSTROUTING -s :private_ipv4 -o ens3 -j MASQUERADE", private_ipv4: vm.nics.first.private_ipv4)
+    vm.sshable.cmd("sudo iptables-nft -t nat -A POSTROUTING -s :private_ipv4 ! -d :subnet_ipv4_range -o ens3 -m state --state NEW -j MASQUERADE", private_ipv4: vm.nics.first.private_ipv4, subnet_ipv4_range: kubernetes_cluster.private_subnet.net4)
     vm.sshable.cmd("sudo nft --file -", stdin: <<TEMPLATE)
 table ip6 pod_access;
 delete table ip6 pod_access;


### PR DESCRIPTION
The previous unconditional MASQUERADE rule caused SNAT on return traffic for incoming requests, masking the real client source IP. This caused issues for our customers trying to inspect the real ip of the packets.

Restricting the rule to '-m state --state NEW' ensures that only outbound connections initiated by the Pod are masqueraded.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Restrict SNAT to new connections in `provision_kubernetes_node.rb` to preserve client IP, with corresponding test updates in `provision_kubernetes_node_spec.rb`.
> 
>   - **Behavior**:
>     - Modify iptables rule in `provision_kubernetes_node.rb` to restrict SNAT to `-m state --state NEW`, preserving client IP for incoming requests.
>   - **Tests**:
>     - Update `provision_kubernetes_node_spec.rb` to reflect changes in iptables rule, ensuring correct command execution and behavior.
>     - Adjust expected IP addresses in test cases to match new configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 83d2989eaf269c21b9627c6c61967df54f6e0427. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->