### PR TITLE
Demock destroy_github_installation_spec.rb

### DIFF
--- a/spec/prog/github/destroy_github_installation_spec.rb
+++ b/spec/prog/github/destroy_github_installation_spec.rb
@@ -10,7 +10,39 @@ RSpec.describe Prog::Github::DestroyGithubInstallation do
     }
   }
 
-  let(:github_installation) { GithubInstallation.new(name: "ubicloud", type: "Organization", installation_id: "123") }
+  let(:project) { Project.create(name: "test-github-project") }
+  let(:github_installation) {
+    GithubInstallation.create(
+      name: "ubicloud",
+      type: "Organization",
+      installation_id: 123,
+      project_id: project.id
+    )
+  }
+
+  # Helper to create GithubRepository with Strand
+  def create_test_repository(name: "test-repo")
+    id = GithubRepository.generate_uuid
+    repo = GithubRepository.create_with_id(id, installation_id: github_installation.id, name: name)
+    Strand.create_with_id(id, prog: "Github::GithubRepositoryNexus", label: "wait")
+    repo
+  end
+
+  # Helper to create GithubRunner with Strand and VM
+  def create_test_runner(repository:)
+    vm = create_vm
+    id = GithubRunner.generate_uuid
+    runner = GithubRunner.create_with_id(
+      id,
+      installation_id: github_installation.id,
+      repository_id: repository.id,
+      repository_name: repository.name,
+      label: "ubicloud",
+      vm_id: vm.id
+    )
+    Strand.create_with_id(id, prog: "Github::GithubRunnerNexus", label: "wait")
+    runner
+  end
 
   describe ".assemble" do
     it "creates a strand" do
@@ -25,8 +57,8 @@ RSpec.describe Prog::Github::DestroyGithubInstallation do
     end
 
     it "no ops if installation exists" do
-      expect(dgi).to receive(:github_installation).and_return(github_installation)
-      dgi.before_run
+      # Real github_installation exists, so before_run should not exit
+      expect { dgi.before_run }.not_to raise_error
     end
   end
 
@@ -55,35 +87,36 @@ RSpec.describe Prog::Github::DestroyGithubInstallation do
 
   describe "#destroy_resources" do
     it "hops after incrementing destroy for repositories and runners" do
-      repository = instance_double(GithubRepository)
-      runner = instance_double(GithubRunner)
-      expect(repository).to receive(:incr_destroy)
-      expect(runner).to receive(:incr_skip_deregistration)
-      expect(runner).to receive(:incr_destroy)
-      expect(github_installation).to receive(:repositories).and_return([repository])
-      expect(github_installation).to receive(:runners).and_return([runner])
+      repository = create_test_repository
+      runner = create_test_runner(repository: repository)
 
       expect { dgi.destroy_resources }.to hop("wait_resource_destroy")
+
+      # Verify semaphores were created
+      expect(Semaphore.where(strand_id: repository.id, name: "destroy").count).to eq(1)
+      expect(Semaphore.where(strand_id: runner.id, name: "destroy").count).to eq(1)
+      expect(Semaphore.where(strand_id: runner.id, name: "skip_deregistration").count).to eq(1)
     end
   end
 
   describe "#wait_resource_destroy" do
     it "naps if not all runners destroyed" do
-      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, empty?: false))
+      repository = create_test_repository
+      create_test_runner(repository: repository)
       expect { dgi.wait_resource_destroy }.to nap(10)
     end
 
     it "naps if not all repositories destroyed" do
-      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, empty?: true))
-      expect(github_installation).to receive(:repositories_dataset).and_return(instance_double(Sequel::Dataset, empty?: false))
+      create_test_repository
+      # No runners, but repository exists
       expect { dgi.wait_resource_destroy }.to nap(10)
     end
 
     it "deletes resource and pops" do
-      expect(github_installation).to receive(:runners_dataset).and_return(instance_double(Sequel::Dataset, empty?: true))
-      expect(github_installation).to receive(:repositories_dataset).and_return(instance_double(Sequel::Dataset, empty?: true))
-      expect(github_installation).to receive(:destroy)
+      # No repositories or runners - installation can be destroyed
+      installation_id = github_installation.id
       expect { dgi.wait_resource_destroy }.to exit({"msg" => "github installation destroyed"})
+      expect(GithubInstallation[installation_id]).to be_nil
     end
   end
 end


### PR DESCRIPTION
The decision to demock tests predates this change. AI made this refactoring affordable.

Replace instance_double mocks with real persisted model instances:
- instance_double(GithubInstallation) → real GithubInstallation.create
- instance_double(GithubRepository) → real GithubRepository.create
- incr_destroy stubs → real semaphore verification via SemSnap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace mocks with real model instances in `destroy_github_installation_spec.rb` to improve test reliability.
> 
>   - **Tests**:
>     - Replace `instance_double` mocks with real model instances in `destroy_github_installation_spec.rb`.
>     - Use `GithubInstallation.create` instead of `instance_double(GithubInstallation)`.
>     - Use `GithubRepository.create_with_id` and `GithubRunner.create_with_id` instead of `instance_double`.
>     - Add helper methods `create_test_repository` and `create_test_runner` for creating test data.
>   - **Behavior**:
>     - Verify semaphore creation for `destroy` and `skip_deregistration` in `destroy_resources`.
>     - Ensure `before_run` does not raise error if installation exists.
>     - Ensure `wait_resource_destroy` exits when all resources are destroyed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e37b962029e4de57f81dbf331e9bf06277af6984. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->