### PR TITLE
Demock update_ipv6_spec.rb

### DIFF
--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -3,118 +3,153 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Vm::UpdateIpv6 do
-  subject(:pr) {
-    described_class.new(Strand.new)
-  }
+  subject(:pr) { described_class.new(strand) }
 
-  let(:vm) {
-    instance_double(Vm,
-      inhost_name: "test",
-      storage_secrets: "storage_secrets",
-      nics: [instance_double(Nic,
-        private_subnet: instance_double(
-          PrivateSubnet,
-          net4: NetAddr::IPv4Net.parse("1.0.0.0/8")
-        ),
-        ubid_to_tap_name: "ubid_to_tap_name")],
-      name: "test",
-      vm_host_id: 1)
+  let(:project) { Project.create(name: "test-project") }
+  let(:sshable) { pr.vm_host.sshable }
+  let(:location_id) { Location::HETZNER_FSN1_ID }
+
+  let(:private_subnet) {
+    ps = PrivateSubnet.create(
+      name: "test-subnet", project_id: project.id, location_id:,
+      net4: "1.0.0.0/8", net6: "fd10:9b0b:6b4b:8fbb::/64"
+    )
+    Strand.create_with_id(ps, prog: "Vnet::SubnetNexus", label: "wait")
+    ps
   }
 
   let(:vm_host) {
-    instance_double(VmHost, sshable: create_mock_sshable(host: "1.1.1.1"), ip6_random_vm_network: NetAddr::IPv6Net.parse("2001:0::"))
+    create_vm_host(
+      location_id:,
+      total_cpus: 48, total_cores: 48, total_dies: 1, total_sockets: 1,
+      net6: NetAddr::IPv6Net.parse("2001:db8::/48")
+    )
   }
 
-  before do
-    allow(pr).to receive(:vm).and_return(vm)
+  let(:vm_strand) {
+    Prog::Vm::Nexus.assemble_with_sshable(
+      project.id, name: "test", private_subnet_id: private_subnet.id,
+      location_id:, force_host_id: vm_host.id
+    )
+  }
+
+  let(:vm) {
+    v = vm_strand.subject
+    v.update(vm_host_id: vm_host.id)
+    v
+  }
+
+  let(:strand) {
+    Strand.create(
+      prog: "Vm::UpdateIpv6", label: "start",
+      parent_id: vm_strand.id,
+      stack: [
+        {"subject_id" => vm.id, "gpu_count" => 0, "hugepages" => true, "ch_version" => nil,
+         "gpu_device" => nil, "hypervisor" => nil, "force_host_id" => nil, "swap_size_bytes" => nil,
+         "exclude_host_ids" => [], "firmware_version" => nil, "alternative_families" => [],
+         "last_label_changed_at" => Time.now.to_s, "distinct_storage_devices" => true}
+      ]
+    )
+  }
+
+  def create_load_balancer(cert_enabled:)
+    lb = LoadBalancer.create(
+      name: "test-lb", private_subnet_id: private_subnet.id, project_id: project.id,
+      health_check_endpoint: "/health", cert_enabled: cert_enabled
+    )
+    LoadBalancerVm.create(load_balancer_id: lb.id, vm_id: vm.id)
+    lb
   end
 
   it "returns vm_host" do
-    expect(VmHost).to receive(:[]).with(1).and_return(vm_host)
-    expect(pr.vm_host).to eq(vm_host)
+    expect(pr.vm_host.id).to eq(vm_host.id)
   end
 
   it "stops services and cleans up namespace" do
-    expect(vm).to receive(:load_balancer).and_return(instance_double(LoadBalancer, cert_enabled: true))
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl stop test.service")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl stop test-metadata-endpoint.service")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl stop test-dnsmasq.service")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo ip netns del test")
-    expect(pr).to receive(:hop_rewrite_persisted)
-    pr.start
+    create_load_balancer(cert_enabled: true)
+    inhost_name = vm.inhost_name
+    expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{inhost_name}.service")
+    expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{inhost_name}-metadata-endpoint.service")
+    expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{inhost_name}-dnsmasq.service")
+    expect(sshable).to receive(:_cmd).with("sudo ip netns del #{inhost_name}")
+    expect { pr.start }.to hop("rewrite_persisted")
   end
 
   it "does not stop metadata endpoint service if not load balancer" do
-    expect(vm).to receive(:load_balancer).and_return(nil)
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl stop test.service")
-    expect(vm_host.sshable).not_to receive(:_cmd).with("sudo systemctl stop test-metadata-endpoint.service")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl stop test-dnsmasq.service")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo ip netns del test")
-    expect(pr).to receive(:hop_rewrite_persisted)
-    pr.start
+    inhost_name = vm.inhost_name
+    expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{inhost_name}.service")
+    expect(sshable).not_to receive(:_cmd).with(/metadata-endpoint/)
+    expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{inhost_name}-dnsmasq.service")
+    expect(sshable).to receive(:_cmd).with("sudo ip netns del #{inhost_name}")
+    expect { pr.start }.to hop("rewrite_persisted")
   end
 
   it "does not stop metadata endpoint service if load balancer is not cert enabled" do
-    expect(vm).to receive(:load_balancer).and_return(instance_double(LoadBalancer, cert_enabled: false))
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl stop test.service")
-    expect(vm_host.sshable).not_to receive(:_cmd).with("sudo systemctl stop test-metadata-endpoint.service")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl stop test-dnsmasq.service")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo ip netns del test")
-    expect(pr).to receive(:hop_rewrite_persisted)
-    pr.start
+    create_load_balancer(cert_enabled: false)
+    inhost_name = vm.inhost_name
+    expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{inhost_name}.service")
+    expect(sshable).not_to receive(:_cmd).with(/metadata-endpoint/)
+    expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{inhost_name}-dnsmasq.service")
+    expect(sshable).to receive(:_cmd).with("sudo ip netns del #{inhost_name}")
+    expect { pr.start }.to hop("rewrite_persisted")
   end
 
   it "rewrites persisted" do
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm).to receive(:update).with(ephemeral_net6: "2001::/64")
-    expect(pr).to receive(:write_params_json)
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo host/bin/setup-vm reassign-ip6 test", stdin: JSON.generate({storage: "storage_secrets"}))
-    expect(pr).to receive(:hop_start_vm)
-    pr.rewrite_persisted
+    inhost_name = vm.inhost_name
+    expect(sshable).to receive(:_cmd).with("sudo rm /vm/#{inhost_name}/prep.json")
+    expect(sshable).to receive(:_cmd) do |cmd, **kwargs|
+      expect(cmd).to eq("sudo -u #{inhost_name} tee /vm/#{inhost_name}/prep.json")
+      expect(kwargs[:stdin]).to include('"vm_name": "test"')
+    end
+    expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm reassign-ip6 #{inhost_name}", stdin: JSON.generate({storage: vm.storage_secrets}))
+    expect { pr.rewrite_persisted }.to hop("start_vm")
+    net6 = vm.reload.ephemeral_net6
+    expect(net6.to_s).to start_with("2001:db8:")
+    expect(net6.netmask.prefix_len).to eq(63)
   end
 
   it "starts vm" do
-    expect(vm).to receive(:load_balancer).and_return(instance_double(LoadBalancer, cert_enabled: true))
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo ip -n test addr replace 1.0.0.1/8 dev ubid_to_tap_name")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo systemctl start test-metadata-endpoint.service")
-    expect(vm).to receive(:incr_update_firewall_rules)
-    expect(vm).to receive(:private_subnets).and_return([instance_double(PrivateSubnet, incr_refresh_keys: nil)])
-    expect(pr).to receive(:pop).with("VM test updated")
-    pr.start_vm
+    create_load_balancer(cert_enabled: true)
+    inhost_name = vm.inhost_name
+    nic = vm.nics.first
+    addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
+    expect(sshable).to receive(:_cmd).with("sudo ip -n #{inhost_name} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
+    expect(sshable).to receive(:_cmd).with("sudo systemctl start #{inhost_name}-metadata-endpoint.service")
+    expect { pr.start_vm }.to exit({"msg" => "VM test updated"})
+    expect(vm.reload.update_firewall_rules_set?).to be true
+    expect(private_subnet.reload.refresh_keys_set?).to be true
   end
 
   it "does not start metadata endpoint service if not load balancer" do
-    expect(vm).to receive(:load_balancer).and_return(nil)
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo ip -n test addr replace 1.0.0.1/8 dev ubid_to_tap_name")
-    expect(vm_host.sshable).not_to receive(:_cmd).with("sudo systemctl start test-metadata-endpoint.service")
-    expect(vm).to receive(:incr_update_firewall_rules)
-    expect(vm).to receive(:private_subnets).and_return([instance_double(PrivateSubnet, incr_refresh_keys: nil)])
-    expect(pr).to receive(:pop).with("VM test updated")
-    pr.start_vm
+    inhost_name = vm.inhost_name
+    nic = vm.nics.first
+    addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
+    expect(sshable).to receive(:_cmd).with("sudo ip -n #{inhost_name} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
+    expect(sshable).not_to receive(:_cmd).with(/metadata-endpoint/)
+    expect { pr.start_vm }.to exit({"msg" => "VM test updated"})
+    expect(vm.reload.update_firewall_rules_set?).to be true
+    expect(private_subnet.reload.refresh_keys_set?).to be true
   end
 
   it "does not start metadata endpoint service if load balancer is not cert enabled" do
-    expect(vm).to receive(:load_balancer).and_return(instance_double(LoadBalancer, cert_enabled: false))
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo ip -n test addr replace 1.0.0.1/8 dev ubid_to_tap_name")
-    expect(vm_host.sshable).not_to receive(:_cmd).with("sudo systemctl start test-metadata-endpoint.service")
-    expect(vm).to receive(:incr_update_firewall_rules)
-    expect(vm).to receive(:private_subnets).and_return([instance_double(PrivateSubnet, incr_refresh_keys: nil)])
-    expect(pr).to receive(:pop).with("VM test updated")
-    pr.start_vm
+    create_load_balancer(cert_enabled: false)
+    inhost_name = vm.inhost_name
+    nic = vm.nics.first
+    addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
+    expect(sshable).to receive(:_cmd).with("sudo ip -n #{inhost_name} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
+    expect(sshable).not_to receive(:_cmd).with(/metadata-endpoint/)
+    expect { pr.start_vm }.to exit({"msg" => "VM test updated"})
+    expect(vm.reload.update_firewall_rules_set?).to be true
+    expect(private_subnet.reload.refresh_keys_set?).to be true
   end
 
   it "writes params json" do
-    expect(pr).to receive(:vm_host).and_return(vm_host).at_least(:once)
-    expect(vm).to receive(:params_json).and_return("params_json")
-    expect(vm).to receive(:strand).and_return(instance_double(Strand, stack: [{"gpu_count" => 0, "hugepages" => true, "ch_version" => nil, "gpu_device" => nil, "hypervisor" => nil, "force_host_id" => nil, "swap_size_bytes" => nil, "exclude_host_ids" => [], "firmware_version" => nil, "alternative_families" => [], "last_label_changed_at" => "2025-11-24 11:30:57 +0000", "distinct_storage_devices" => true}]))
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo rm /vm/test/prep.json")
-    expect(vm_host.sshable).to receive(:_cmd).with("sudo -u test tee /vm/test/prep.json", stdin: "params_json")
+    inhost_name = vm.inhost_name
+    expect(sshable).to receive(:_cmd).with("sudo rm /vm/#{inhost_name}/prep.json")
+    expect(sshable).to receive(:_cmd) do |cmd, **kwargs|
+      expect(cmd).to eq("sudo -u #{inhost_name} tee /vm/#{inhost_name}/prep.json")
+      expect(kwargs[:stdin]).to include('"vm_name": "test"')
+    end
     pr.write_params_json
   end
 end


### PR DESCRIPTION
The decision to demock tests predates this change. AI made this refactoring affordable.

Replace instance_double mocks with real persisted model instances:
- Create actual VM, VmHost, and network objects
- Use factory helpers for complex object graphs
- Verify semaphore changes with SemSnap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace mocked instances with real model instances in `update_ipv6_spec.rb`, improving test reliability and handling load balancer scenarios accurately.
> 
>   - **Behavior**:
>     - Replace `instance_double` mocks with real model instances in `update_ipv6_spec.rb`.
>     - Create actual `VM`, `VmHost`, and network objects using factory helpers.
>     - Handle load balancer scenarios, checking if metadata endpoint service should be stopped or started based on `cert_enabled` status.
>   - **Testing**:
>     - Verify semaphore changes with SemSnap.
>     - Ensure `vm_host` is correctly returned and services are stopped/started as expected.
>     - Validate `rewrite_persisted` and `start_vm` behaviors, including IP address assignment and firewall rule updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 93f17936fed5344253ff2dc6fecdc8220f097d1f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->