### PR TITLE
Demock download_boot_image_spec.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -310,6 +310,16 @@ RSpec.configure do |config|
       addr = Address.create(cidr: cidr.to_s, routed_to_host_id: host.id)
       AssignedVmAddress.create(ip: ipv4, address_id: addr.id, dst_vm_id: vm.id)
     end
+
+    def refresh_frame(prog, new_frame: nil, new_values: nil)
+      st = prog.strand
+      fail "cannot pass both new_frame and new_values" if new_frame && new_values
+      st.stack.first.merge!(new_values) if new_values
+      st.stack[0] = new_frame if new_frame
+      st.modified!(:stack)
+      st.save_changes
+      prog.instance_variable_set(:@frame, nil)
+    end
   end)
 end
 


### PR DESCRIPTION
The decision to demock tests predates this change. AI made this refactoring affordable.

Replace instance_double mock with real persisted BootImage instance:
- Create actual BootImage record and verify activated_at changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace mocked `BootImage` instances with real instances in `download_boot_image_spec.rb` and add `refresh_frame` helper for dynamic test data updates.
> 
>   - **Behavior**:
>     - Replace `instance_double` mocks with real `BootImage` instances in `download_boot_image_spec.rb`.
>     - Use `refresh_frame` to update `Strand` stack data dynamically.
>   - **Helper Functions**:
>     - Add `refresh_frame` function in `spec_helper.rb` to modify `Strand` stack data.
>   - **Tests**:
>     - Ensure `BootImage` records are created and `activated_at` is updated in tests.
>     - Remove `allow` statements for mocks in favor of real data interactions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 0add050596c0e7c6b00b11bb78955fa0a3324aa4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->