### PR TITLE
Add boot image version to runner logs

### DIFF
--- a/model/github_runner.rb
+++ b/model/github_runner.rb
@@ -46,7 +46,7 @@ class GithubRunner < Sequel::Model
   def log_duration(message, duration)
     values = {ubid:, label:, repository_name:, duration: duration.round(3), conclusion: workflow_job&.dig("conclusion")}
     if vm
-      values.merge!(vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores, vcpus: vm.vcpus)
+      values.merge!(vm_ubid: vm.ubid, arch: vm.arch, cores: vm.cores, vcpus: vm.vcpus, boot_image: vm.vm_storage_volumes.first&.boot_image&.version || vm.boot_image)
       if vm.vm_host
         values[:vm_host_ubid] = vm.vm_host.ubid
         values[:data_center] = vm.vm_host.data_center

--- a/spec/model/github_runner_spec.rb
+++ b/spec/model/github_runner_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe GithubRunner do
 
   it "can log duration with a vm" do
     vm = github_runner.vm
+    boot_image = BootImage.create(vm_host_id: vm.vm_host_id, name: "github-ubuntu-2204", version: "20251211", size_gib: 75)
+    VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 75, disk_index: 0, boot_image_id: boot_image.id)
     expect(clog_emit_hash).to eq({
       repository_name: "test-repo",
       ubid: github_runner.ubid,
@@ -31,6 +33,7 @@ RSpec.describe GithubRunner do
       conclusion: nil,
       vm_ubid: vm.ubid,
       arch: vm.arch,
+      boot_image: boot_image.version,
       cores: vm.cores,
       vcpus: vm.vcpus,
       vm_host_ubid: vm.vm_host.ubid,
@@ -50,6 +53,7 @@ RSpec.describe GithubRunner do
       conclusion: nil,
       vm_ubid: vm.ubid,
       arch: vm.arch,
+      boot_image: vm.boot_image,
       cores: vm.cores,
       vcpus: vm.vcpus,
       vm_host_ubid: vm.vm_host.ubid,
@@ -71,6 +75,7 @@ RSpec.describe GithubRunner do
       conclusion: nil,
       vm_ubid: vm.ubid,
       arch: vm.arch,
+      boot_image: vm.boot_image,
       cores: vm.cores,
       vcpus: vm.vcpus
     })


### PR DESCRIPTION
We already include a conclusion field in runner_completed logs, which allows us to analyze success rates by location or VM host. Adding the boot image version to these logs will also let us track success rates per boot image.

This will make it easier to monitor the impact of new boot image rollouts and detect regressions early. Currently, we infer this indirectly via VM hosts while downloading new boot images, which requires manual effort. Logging the boot image version directly provides a cleaner and more reliable signal.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add boot image version to runner logs in `GithubRunner` to track success rates per boot image.
> 
>   - **Behavior**:
>     - Add `boot_image` version to runner logs in `log_duration` method of `GithubRunner` class.
>     - Handles cases where `vm_storage_volumes` is present or not.
>   - **Tests**:
>     - Update `github_runner_spec.rb` to test logging of `boot_image` version in `log_duration`.
>     - Add test cases for VMs with and without `vm_host`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 32299d3a1234e6074d172e5a50fd92c72998a437. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->