### PR TITLE
Demock download_boot_image_spec.rb more

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -310,6 +310,16 @@ RSpec.configure do |config|
       addr = Address.create(cidr: cidr.to_s, routed_to_host_id: host.id)
       AssignedVmAddress.create(ip: ipv4, address_id: addr.id, dst_vm_id: vm.id)
     end
+
+    def refresh_frame(prog, new_frame: nil, new_values: nil)
+      st = prog.strand
+      fail "cannot pass both new_frame and new_values" if new_frame && new_values
+      st.stack.first.merge!(new_values) if new_values
+      st.stack[0] = new_frame if new_frame
+      st.modified!(:stack)
+      st.save_changes
+      prog.instance_variable_set(:@frame, nil)
+    end
   end)
 end
 


### PR DESCRIPTION
We need to mock the `frame` in multiple tests because it doesn't change when we update the stack. With the help of the `refresh_frame` helper, we can force the `frame` to be reloaded.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `download_boot_image_spec.rb` to use `refresh_frame` helper, reducing direct mocking and improving test reliability.
> 
>   - **Test Improvements**:
>     - Refactor `download_boot_image_spec.rb` to use `refresh_frame` helper for updating `frame` in tests, reducing the need for direct mocking.
>     - Remove instance variable setup for `@sshable` and `@vm_host` in `download_boot_image_spec.rb`.
>     - Replace direct `frame` mocking with `refresh_frame` in various test cases.
>   - **Helper Function**:
>     - Add `refresh_frame` function in `spec_helper.rb` to update `frame` or `stack` values in `Strand` objects, improving test flexibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 2250becf7e205c4d0182d5fe0f92f149e5397956. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->