### PR TITLE
Page on PG promotion failure

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -599,6 +599,7 @@ SQL
 
   label def prepare_for_unplanned_take_over
     decr_unplanned_take_over
+    register_deadline("wait", 10 * 60)
 
     representative_server = postgres_server.resource.representative_server
 
@@ -614,6 +615,7 @@ SQL
 
   label def prepare_for_planned_take_over
     decr_planned_take_over
+    register_deadline("wait", 10 * 60)
 
     postgres_server.resource.representative_server.incr_fence
     hop_wait_fencing_of_old_primary

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1099,6 +1099,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "stops postgres in representative server and destroys it" do
       standby_nx.incr_unplanned_take_over
+      expect(@standby_nx).to receive(:register_deadline).with("wait", 10 * 60)
       expect(representative_sshable).to receive(:_cmd).with("sudo pg_ctlcluster 16 main stop -m immediate")
       expect { standby_nx.prepare_for_unplanned_take_over }.to hop("taking_over")
       expect(Semaphore.where(strand_id: standby_nx.postgres_server.id, name: "unplanned_take_over").count).to eq(0)
@@ -1107,6 +1108,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "handles SSH connection errors gracefully and continues with destroy" do
       standby_nx.incr_unplanned_take_over
+      expect(@standby_nx).to receive(:register_deadline).with("wait", 10 * 60)
       expect(representative_sshable).to receive(:_cmd).with("sudo pg_ctlcluster 16 main stop -m immediate").and_raise(Sshable::SshError.new("", "", "", "", ""))
       expect { standby_nx.prepare_for_unplanned_take_over }.to hop("taking_over")
       expect(Semaphore.where(strand_id: standby_nx.postgres_server.id, name: "unplanned_take_over").count).to eq(0)
@@ -1121,6 +1123,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "starts fencing on representative server" do
       @standby_nx.incr_planned_take_over
+      expect(@standby_nx).to receive(:register_deadline).with("wait", 10 * 60)
       expect { @standby_nx.prepare_for_planned_take_over }.to hop("wait_fencing_of_old_primary")
       expect(Semaphore.where(strand_id: @standby_nx.postgres_server.id, name: "planned_take_over").count).to eq(0)
       expect(Semaphore.where(strand_id: postgres_server.id, name: "fence").count).to eq(1)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Handle PostgreSQL promotion failures by creating a page and retrying in `Prog::Postgres::PostgresServerNexus`.
> 
>   - **Behavior**:
>     - In `Prog::Postgres::PostgresServerNexus`, `taking_over` method now creates a page on promotion failure and retries the promotion.
>     - On successful promotion, resolves any existing failure page.
>   - **Tests**:
>     - Added tests in `postgres_server_nexus_spec.rb` to verify page creation on promotion failure and resolution on success.
>     - Tests cover scenarios for both initial promotion attempts and retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a5eb95449738bf3759ac1fa2b3fcd807f58fdb1c. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->