### PR TITLE
Don't generate keys for timeline when using IAM access

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -22,8 +22,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     DB.transaction do
       postgres_timeline = PostgresTimeline.create(
         parent_id: parent_id,
-        access_key: SecureRandom.hex(16),
-        secret_key: SecureRandom.hex(32),
+        access_key: (location.aws? && Config.aws_postgres_iam_access) ? nil : SecureRandom.hex(16),
+        secret_key: (location.aws? && Config.aws_postgres_iam_access) ? nil : SecureRandom.hex(32),
         location_id: location.id
       )
       Strand.create_with_id(postgres_timeline, prog: "Postgres::PostgresTimelineNexus", label: "start")

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       postgres_timeline = PostgresTimeline[st.id]
       expect(postgres_timeline).not_to be_nil
     end
+
+    it "does not generate access_key/secret_key when AWS & Config.aws_postgres_iam_access" do
+      allow(Config).to receive(:aws_postgres_iam_access).and_return(true)
+
+      tl = described_class.assemble(location_id: Location::HETZNER_FSN1_ID).subject
+      expect(tl.access_key).not_to be_nil
+      expect(tl.secret_key).not_to be_nil
+
+      location = Location.create(name: "l1", display_name: "l1", ui_name: "l1", visible: true, provider: "aws")
+      tl = described_class.assemble(location_id: location.id).subject
+      expect(tl.access_key).to be_nil
+      expect(tl.secret_key).to be_nil
+    end
   end
 
   describe "#start" do


### PR DESCRIPTION
These random keys were interfering with wal-g config generation, which expects nil values to skip encoding credentials
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `assemble` in `PostgresTimelineNexus` to skip key generation when `aws_postgres_iam_access` is true.
> 
>   - **Behavior**:
>     - In `assemble` method of `PostgresTimelineNexus`, set `access_key` and `secret_key` to `nil` if `Config.aws_postgres_iam_access` is true, otherwise generate random keys.
>   - **Reason**:
>     - Prevents interference with `wal-g` config generation, which expects nil values to skip encoding credentials.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 7115406c32c6e037c1d465dbbd589bfc811818e6. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->