### PR TITLE
Filter subnet ranges by CIDR size before selection

### DIFF
--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -65,11 +65,17 @@ class PrivateSubnet < Sequel::Model
 
   plugin SemaphoreMethods, :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules, :migrate
 
-  def self.random_subnet
+  def self.random_subnet(cidr_size)
     subnet_dict = PRIVATE_SUBNET_RANGES.each_with_object({}) do |subnet, hash|
       prefix_length = Integer(subnet.split("/").last, 10)
+      next unless prefix_length < cidr_size
       hash[subnet] = (2**16 + 2**12 + 2**8 - 2**prefix_length)
     end
+
+    if subnet_dict.empty?
+      raise "No subnet found for cidr size #{cidr_size}"
+    end
+
     subnet_dict.max_by { |_, weight| rand**(1.0 / weight) }.first
   end
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -70,7 +70,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
   def self.random_private_ipv4(location, project, cidr_size = 26)
     raise ArgumentError, "CIDR size must be between 0 and 32" unless cidr_size.between?(0, 32)
 
-    private_range = PrivateSubnet.random_subnet
+    private_range = PrivateSubnet.random_subnet(cidr_size)
     addr = NetAddr::IPv4Net.parse(private_range)
 
     selected_addr = if addr.netmask.prefix_len < cidr_size

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -119,6 +119,17 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       project = Project.create(name: "test-project")
       expect { described_class.random_private_ipv4(Location[name: "hetzner-fsn1"], project, 33) }.to raise_error(ArgumentError)
     end
+
+    it "raises an error when no subnet is found" do
+      project = Project.create(name: "test-project")
+      expect { described_class.random_private_ipv4(Location[name: "hetzner-fsn1"], project, 8) }.to raise_error(RuntimeError, "No subnet found for cidr size 8")
+    end
+
+    it "filters out subnets that are smaller than the requested cidr size" do
+      project = Project.create(name: "test-project")
+      expect(SecureRandom).to receive(:random_number).with(2**(10 - 8) - 1).and_return(1)
+      expect(described_class.random_private_ipv4(Location[name: "hetzner-fsn1"], project, 10).to_s).to eq("10.128.0.0/10")
+    end
   end
 
   describe ".random_private_ipv6" do


### PR DESCRIPTION
PrivateSubnet.random_subnet now accepts a cidr_size parameter and filters
out subnet ranges with prefix lengths >= cidr_size before selecting. This
prevents selecting ranges that are too small and adds proper error handling
when no suitable subnet is available.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `cidr_size` filtering to `random_subnet` in `private_subnet.rb` and update `random_private_ipv4` in `subnet_nexus.rb` to use it, with tests for new behavior.
> 
>   - **Behavior**:
>     - `PrivateSubnet.random_subnet` now accepts `cidr_size` parameter to filter subnets with prefix lengths >= `cidr_size`.
>     - Raises error if no suitable subnet is found for given `cidr_size`.
>   - **Functionality**:
>     - `random_private_ipv4` in `subnet_nexus.rb` updated to pass `cidr_size` to `random_subnet`.
>     - Ensures CIDR size is between 0 and 32, raising `ArgumentError` otherwise.
>   - **Tests**:
>     - Added test for error when no subnet is found in `subnet_nexus_spec.rb`.
>     - Added test to ensure subnets smaller than requested `cidr_size` are filtered out.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 9203eadaaf5436b1dd107bb453566aeb1ef6c5ec. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->