### PR TITLE
Fix destroy for aws vpc when it is destroyed before the resource is created

### DIFF
--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -129,6 +129,8 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     private_subnet.nics.each(&:incr_destroy)
     private_subnet.remove_all_firewalls
 
+    hop_finish unless private_subnet_aws_resource
+
     ignore_invalid_id do
       client.delete_security_group({group_id: private_subnet_aws_resource.security_group_id})
     end
@@ -150,9 +152,12 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     ignore_invalid_id do
       client.delete_vpc({vpc_id: private_subnet_aws_resource.vpc_id})
     end
+    hop_finish
+  end
 
+  label def finish
     nap 5 unless private_subnet.nics.empty?
-    private_subnet_aws_resource.destroy
+    private_subnet_aws_resource&.destroy
     private_subnet.destroy
     pop "vpc destroyed"
   end


### PR DESCRIPTION
- **Demock vpc_nexus_spec.rb**
  

- **Fix destroy for aws vpc when it is destroyed before the resource is created**
  If Aws::VpcNexus is destroyed before the `start` label runs,
  `private_subnet_aws_resource` is nil in the `destroy` label, causing the
  strand to get stuck.
  
  If private_subnet_aws_resource is nil, we should skip destroying AWS
  resources since they were never created and exit the strand.
  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix AWS VPC destruction process to skip if resources are nil, preventing strand from getting stuck.
> 
>   - **Behavior**:
>     - In `vpc_nexus.rb`, skip AWS resource destruction if `private_subnet_aws_resource` is nil, preventing process from getting stuck.
>     - Add `hop_finish` in `destroy` label to exit strand if AWS resources were never created.
>   - **Tests**:
>     - Update `vpc_nexus_spec.rb` to test new behavior when AWS resources are nil.
>     - Add tests for skipping destruction and hopping to finish when resources are not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for ecea9285f1407009c99c2aed4463b1691a5bd2a3. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->