### PR TITLE
Cache private subnet range weights calculation

### DIFF
--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -12,11 +12,15 @@ class PrivateSubnet < Sequel::Model
   many_to_one :location
   one_to_one :private_subnet_aws_resource, key: :id
 
+  PRIVATE_24_BLOCK_COUNT = 2**16 + 2**12 + 2**8
   PRIVATE_SUBNET_RANGES = [
     "10.0.0.0/8",
     "172.16.0.0/12",
     "192.168.0.0/16"
-  ].freeze
+  ].to_h {
+    prefix = Integer(it.split("/").last, 10)
+    [it, [prefix, PRIVATE_24_BLOCK_COUNT - 2**prefix].freeze]
+  }.freeze
 
   BANNED_IPV4_SUBNETS = [
     NetAddr::IPv4Net.parse("172.16.0.0/16"),
@@ -67,17 +71,13 @@ class PrivateSubnet < Sequel::Model
   plugin SemaphoreMethods, :destroy, :refresh_keys, :add_new_nic, :update_firewall_rules, :migrate
 
   def self.random_subnet(cidr_size)
-    subnet_dict = PRIVATE_SUBNET_RANGES.each_with_object({}) do |subnet, hash|
-      prefix_length = Integer(subnet.split("/").last, 10)
-      next unless prefix_length < cidr_size
-      hash[subnet] = (2**16 + 2**12 + 2**8 - 2**prefix_length)
-    end
+    subnets = PRIVATE_SUBNET_RANGES.select { |_, (prefix, _)|
+      prefix < cidr_size
+    }
 
-    if subnet_dict.empty?
-      raise "No subnet found for cidr size #{cidr_size}"
-    end
+    raise "No subnet found for cidr size #{cidr_size}" if subnets.empty?
 
-    subnet_dict.max_by { |_, weight| rand**(1.0 / weight) }.first
+    subnets.max_by { |_, (_, weight)| rand**(1.0 / weight) }.first
   end
 
   # Here we are blocking the bottom 4 and top 1 addresses of each subnet


### PR DESCRIPTION
We calculate same weights for each call again and again. Even before the recent change, it wasn't accept any parameters. Recent changes added a `cidr_size` parameter to it, but still we can cache the weights calculation in a constant.

~I split it multiple commits for easier review but I will squash them before merging.~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Cache subnet range weights in `PRIVATE_SUBNET_RANGES` to optimize `random_subnet()` in `private_subnet.rb`.
> 
>   - **Behavior**:
>     - Cache subnet range weights in `PRIVATE_SUBNET_RANGES` in `private_subnet.rb` to avoid recalculating in `random_subnet()`.
>     - `random_subnet(cidr_size)` now uses cached weights to select subnets.
>   - **Constants**:
>     - Add `PRIVATE_24_BLOCK_COUNT` to store the total block count for /24 subnets.
>     - Modify `PRIVATE_SUBNET_RANGES` to include prefix and weight as a hash.
>   - **Misc**:
>     - Remove redundant weight calculation logic from `random_subnet()` in `private_subnet.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 674bfcf7eec2b2c1938e412e8b6d911274f72168. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->