### PR TITLE
Make the session interlocking spec not write to stdout

### DIFF
--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -46,7 +46,7 @@ LOCK
 
     if File.directory?("/dev/shm")
       it "interlocks" do
-        portable_pkill = lambda { system("fuser -k /dev/shm/session-lock-testlockname 2>/dev/null") }
+        portable_pkill = lambda { system("fuser -k /dev/shm/session-lock-testlockname >/dev/null 2>&1") }
         portable_pkill.call
         q_lock_script = NetSsh.command(":lock_script", lock_script:)
         expect([`bash -c #{q_lock_script}`, $?.exitstatus]).to eq(["", 0])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Redirects stdout to null in `portable_pkill` lambda in `sshable_spec.rb` to prevent writing to stdout during test execution.
> 
>   - **Behavior**:
>     - Redirects stdout to null in `portable_pkill` lambda in `sshable_spec.rb` to prevent writing to stdout during test execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for a6367bede3266eea2e6dee18e42a71e3f2a58d44. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->