### PR TITLE
E2E: add a test to verify persistence across boots.

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -10,6 +10,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
       stack: [{
         "storage_encrypted" => storage_encrypted,
         "test_reboot" => test_reboot,
+        "first_boot" => true,
         "test_slices" => test_slices,
         "vms" => [],
         "boot_images" => boot_images,
@@ -61,7 +62,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def verify_vms
-    frame["vms"].each { bud(Prog::Test::Vm, {subject_id: it}) }
+    frame["vms"].each { bud(Prog::Test::Vm, {subject_id: it, first_boot: frame["first_boot"]}) }
     hop_wait_verify_vms
   end
 
@@ -101,7 +102,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def verify_connected_subnets
     if retval&.dig("msg") == "Verified Connected Subnets!"
-      if frame["test_reboot"]
+      if frame["test_reboot"] && frame["first_boot"]
         hop_test_reboot
       else
         hop_destroy_resources
@@ -120,7 +121,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   label def wait_reboot
     if vm_host.strand.label == "wait" && vm_host.strand.semaphores.empty?
       # Run VM tests again, but avoid rebooting again
-      update_stack({"test_reboot" => false})
+      update_stack({"first_boot" => false})
       hop_verify_vms
     end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#verify_vms" do
     it "runs tests for the first vm" do
-      expect(vg_test).to receive(:frame).and_return({"vms" => ["111", "222"]})
-      expect(vg_test).to receive(:bud).with(Prog::Test::Vm, {subject_id: "111"})
-      expect(vg_test).to receive(:bud).with(Prog::Test::Vm, {subject_id: "222"})
+      expect(vg_test).to receive(:frame).and_return({"vms" => ["111", "222"], "first_boot" => true}).at_least(:once)
+      expect(vg_test).to receive(:bud).with(Prog::Test::Vm, {subject_id: "111", first_boot: true})
+      expect(vg_test).to receive(:bud).with(Prog::Test::Vm, {subject_id: "222", first_boot: true})
       expect { vg_test.verify_vms }.to hop("wait_verify_vms")
     end
   end


### PR DESCRIPTION
On each VM, create 5 files with 1MB of random data in ~/persistence_test. Each file is named after the SHA256 of its contents.

After a reboot, verify that the files still exist and their SHA256 sums match.

The host reboot should shut down VMs cleanly, so we do not call sync explicitly and rely on the guest OS to flush data on shutdown.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a test to verify data persistence across VM reboots by creating and verifying files with random data in `vm.rb` and updating `vm_group.rb` to handle reboot logic.
> 
>   - **Behavior**:
>     - Adds `storage_persistence` method in `vm.rb` to create and verify files across reboots.
>     - On first boot, creates 5 files with random data and stores their SHA256 in `~/persistence_test`.
>     - On subsequent boots, verifies file existence and content integrity.
>   - **VM Group**:
>     - Updates `vm_group.rb` to pass `first_boot` flag to `Prog::Test::Vm`.
>     - Modifies `verify_connected_subnets` to handle reboot logic based on `first_boot`.
>   - **Tests**:
>     - Adds tests in `vm_spec.rb` for `storage_persistence` method to check file creation and verification.
>     - Updates `vm_group_spec.rb` to test `first_boot` logic in VM group assembly and verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d798822eda5203384a527129854af6726bba37ef. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->