### PR TITLE
Update PG image to optimize postgres_exporter

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -184,7 +184,7 @@ module Config
   override :github_gpu_ubuntu_2204_version, "20251208.1.0", string
   override :github_ubuntu_2204_aws_ami_version, "ami-06f02994ea7801a2d", string
   override :github_ubuntu_2404_aws_ami_version, "ami-0b44ef7a91252a724", string
-  override :postgres_ubuntu_2204_version, "20251216.1.0", string
+  override :postgres_ubuntu_2204_version, "20251218.1.0", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string
   override :postgres_paradedb_ubuntu_2204_version, "20250803.1.0", string

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20251208.1.0"] => "4586386b5244ab727cfccfb058d1d9ac7f97875bfc5de47baa5c06ef50a274fd",
     ["github-gpu-ubuntu-2204", "x64", "20251017.1.0"] => "a27a6a5f169093cc7ecb761833e256a22b0bf42ef914542cf013490db0ab8ba5",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
-    ["postgres-ubuntu-2204", "x64", "20251216.1.0"] => "d9232c6e3366e6e1b8abcfe03406faa9d4707a2c9002dd28805412679c48cf3a",
+    ["postgres-ubuntu-2204", "x64", "20251218.1.0"] => "90ceab88e8c4b9965fff41b56e12a5c0f28f54fa26ada2a1c51abd185268aebb",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20250803.1.0"] => "2ea5c3c54c3f4a4bcfbdb135c490c2ba7cc6c1a1848ef727e144fdefaf370be4",


### PR DESCRIPTION
In its default configuration, postgres_exporter outputs a number of timeseries whose cardinality scales with the count of logical databases on the instance. This produces two bad effects:

1. The metrics scrape size is unbounded, as it scales with however many databases the user creates. This leads to a backlog while exporting metrics and dropped metrics data on an instance with large (1k+) DBs.
2. More seriously, on low spec instances (standard-2), this can cause the exporter process to consume a significant amount of the available resources, which can potentially starve other processes disrupting other key operations like archiving.

In this change, we disable a lot of the collectors enabled by default. Additionally, to ensure we still have visibility into some key metrics, we introduce a set of custom queries that produce instance-aggregated metrics.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Postgres image version and SHA256 hash to optimize `postgres_exporter` in `config.rb` and `download_boot_image.rb`.
> 
>   - **Behavior**:
>     - Update `postgres_ubuntu_2204_version` to `20251218.1.0` in `config.rb`.
>     - Update SHA256 hash for `postgres-ubuntu-2204` in `download_boot_image.rb`.
>   - **Misc**:
>     - Update hash in `BOOT_IMAGE_SHA256` for `postgres-ubuntu-2204` in `download_boot_image.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for f3705683a08c8bab21d43f8b722209a0bd030622. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->