### PR TITLE
E2E: add a test to communicate with ubiblk's rpc server.

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -84,11 +84,23 @@ class Prog::Test::VmGroup < Prog::Test::Base
     test_slices = frame.fetch("test_slices")
 
     if !test_slices || (retval&.dig("msg") == "Verified VM Host Slices!")
-      hop_verify_firewall_rules
+      hop_verify_storage_rpc
     end
 
     slices = frame["vms"].map { Vm[it].vm_host_slice&.id }.reject(&:nil?)
     push Prog::Test::VmHostSlices, {"slices" => slices}
+  end
+
+  label def verify_storage_rpc
+    frame["vms"].each do |id|
+      vm = Vm[id]
+      command = {command: "version"}.to_json
+      response = JSON.parse(vm_host.sshable.cmd("sudo nc -U /var/storage/:inhost_name/0/rpc.sock -q 0", inhost_name: vm.inhost_name, stdin: command))
+      expected_version = Config.vhost_block_backend_version.delete_prefix("v")
+      fail_test "Failed to get vhost-block-backend version for VM #{vm.id} using RPC" unless response["version"] == expected_version
+    end
+
+    hop_verify_firewall_rules
   end
 
   label def verify_firewall_rules


### PR DESCRIPTION
Ensures that ubiblk's rpc server has been correctly setup by sending a version command to its socket & verifying the response.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `verify_storage_rpc` to test ubiblk's RPC server setup by verifying version response, with corresponding tests in `vm_group_spec.rb`.
> 
>   - **Behavior**:
>     - Adds `verify_storage_rpc` method in `vm_group.rb` to send a version command to ubiblk's RPC server and verify the response.
>     - If the response version does not match the expected version, the test fails with an error message.
>     - Integrates `verify_storage_rpc` into the VM verification workflow, hopping to `verify_firewall_rules` upon success.
>   - **Tests**:
>     - Adds tests in `vm_group_spec.rb` for `verify_storage_rpc` to check correct version verification and error handling.
>     - Ensures the method hops to `verify_firewall_rules` on success and `failed` on error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 448171bfe47cd41a629dce4cbcee0a1446d4b8df. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->