### PR TITLE
Fix read replica promotion with IAM S3 auth

### DIFF
--- a/model/postgres/metal/postgres_server.rb
+++ b/model/postgres/metal/postgres_server.rb
@@ -19,5 +19,8 @@ class PostgresServer < Sequel::Model
     def metal_attach_s3_policy_if_needed
       # nothing
     end
+
+    def metal_increment_s3_new_timeline
+    end
   end
 end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -17,7 +17,7 @@ class PostgresServer < Sequel::Model
   plugin ProviderDispatcher, __FILE__
   plugin SemaphoreMethods, :initial_provisioning, :refresh_certificates, :update_superuser_password, :checkup,
     :restart, :configure, :fence, :unfence, :planned_take_over, :unplanned_take_over, :configure_metrics,
-    :destroy, :recycle, :promote, :refresh_walg_credentials
+    :destroy, :recycle, :promote, :refresh_walg_credentials, :configure_s3_new_timeline
   include HealthMonitorMethods
   include MetricsTargetMethods
 
@@ -311,8 +311,8 @@ class PostgresServer < Sequel::Model
       timeline_id: Prog::Postgres::PostgresTimelineNexus.assemble(location_id: resource.location_id, parent_id:).id,
       timeline_access: "push"
     )
-
-    refresh_walg_credentials
+    increment_s3_new_timeline
+    incr_refresh_walg_credentials
   end
 
   def refresh_walg_credentials

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -445,7 +445,6 @@ SQL
 
     if !is_in_recovery
       postgres_server.switch_to_new_timeline
-
       hop_configure
     end
 
@@ -503,6 +502,11 @@ SQL
     when_refresh_walg_credentials_set? do
       decr_refresh_walg_credentials
       postgres_server.refresh_walg_credentials
+    end
+
+    when_configure_s3_new_timeline_set? do
+      decr_configure_s3_new_timeline
+      postgres_server.attach_s3_policy_if_needed
     end
 
     if postgres_server.read_replica? && postgres_server.resource.parent

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -779,6 +779,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
+    it "decrements and calls attach_s3_policy_if_needed if configure_s3_new_timeline is set" do
+      expect(nx).to receive(:when_configure_s3_new_timeline_set?).and_yield
+      expect(nx).to receive(:decr_configure_s3_new_timeline)
+      expect(postgres_server).to receive(:attach_s3_policy_if_needed)
+      expect { nx.wait }.to nap(6 * 60 * 60)
+    end
+
     it "pushes restart if restart is set" do
       expect(nx).to receive(:when_restart_set?).and_yield
       expect(nx).to receive(:push).with(described_class, {}, "restart").and_call_original


### PR DESCRIPTION
After promotion read replica policies updated to match new timeline

Policies to the parent's bucket should be pruned
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes read replica promotion with IAM S3 auth by updating policies for new timelines and detaching parent bucket policies.
> 
>   - **Behavior**:
>     - Updates `aws_attach_s3_policy_if_needed` in `postgres_server.rb` to detach parent bucket policies after promotion.
>     - Adds `configure_s3_new_timeline` semaphore method in `postgres_server.rb` to handle AWS-specific timeline configuration.
>     - Modifies `switch_to_new_timeline` in `postgres_server.rb` to increment `configure_s3_new_timeline` for AWS timelines.
>   - **Tests**:
>     - Adds test for `configure_s3_new_timeline` in `postgres_server_spec.rb` to ensure AWS timeline configuration is triggered.
>     - Updates `postgres_server_nexus_spec.rb` to test decrement and policy attachment behavior when `configure_s3_new_timeline` is set.
>   - **Misc**:
>     - Changes `parent` association in `postgres_timeline.rb` from `one_to_one` to `many_to_one`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for d836c197ebe1bebc51b8fd1958d5b3a089de96ad. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->