### PR TITLE
Run GitHub Actions tests on Alpine Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         cat > Dockerfile.alpine-test <<'EOF'
         FROM ruby:3.4.7-alpine3.21
         RUN apk add --no-cache \
+          bash \
           build-base \
           ruby-dev \
           linux-headers \


### PR DESCRIPTION
We had at least one platform portability issue when using our docker images, which are built against alpine, and thus busybox and musl libc.  That was the shebang in
4f6396d82c02f6176639c96f26196910dbc6ecd1. While not caught by the tests we have right now: it could be, and the first step to automating catching those regressions is to expand the build matrix.