### PR TITLE
Fix E2E test to expect correct response for workflow_dispatch

### DIFF
--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -153,7 +153,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   end
 
   def trigger_test_run(repo_name, workflow_name, branch_name)
-    client.workflow_dispatch(repo_name, workflow_name, branch_name, {inputs: {triggered_by: ENV["GITHUB_RUN_ID"]}})
+    client.post("repos/#{repo_name}/actions/workflows/#{workflow_name}/dispatches", {ref: branch_name, inputs: {triggered_by: ENV["GITHUB_RUN_ID"]}})
   end
 
   def latest_run(repo_name, workflow_name, branch_name)

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Prog::Test::GithubRunner do
     it "triggers test runs" do
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
-      expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main", {inputs: {triggered_by: "12345"}}).and_return(true)
+      expect(client).to receive(:post).with("repos/ubicloud/github-e2e-test-workflows/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return({workflow_run_id: 123456789})
       expect(gr_test).to receive(:sleep).with(30)
       expect { gr_test.trigger_test_runs }.to hop("check_test_runs")
     end
@@ -76,7 +76,7 @@ RSpec.describe Prog::Test::GithubRunner do
     it "can not triggers test runs" do
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
-      expect(client).to receive(:workflow_dispatch).with("ubicloud/github-e2e-test-workflows", "test_2204.yml", "main", {inputs: {triggered_by: "12345"}}).and_return(false)
+      expect(client).to receive(:post).with("repos/ubicloud/github-e2e-test-workflows/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return(false)
       expect { gr_test.trigger_test_runs }.to hop("clean_resources")
     end
   end


### PR DESCRIPTION
It looks like GitHub introduced a breaking change in the API response for workflow_dispatch.

The API now returns `200 OK` with a response body, while both the documentation[^1] and the SDK[^2] still expect the old `204 No Content` response.

https://github.com/orgs/community/discussions/182272

[^1]: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event--status-codes
[^2]: https://github.com/octokit/octokit.rb/blob/ea3413c3174571e87c83d358fc893cc7613091fa/lib/octokit/client/actions_workflows.rb#L41-L43
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update E2E test to handle new GitHub API response for `workflow_dispatch` by modifying `trigger_test_run` and related tests.
> 
>   - **Behavior**:
>     - Update `trigger_test_run` in `github_runner.rb` to use `client.post` for triggering workflow dispatches, aligning with new GitHub API response.
>     - Modify test expectations in `github_runner_spec.rb` to expect `client.post` with response body instead of `workflow_dispatch`.
>   - **Tests**:
>     - Update `trigger_test_runs` and `check_test_runs` tests in `github_runner_spec.rb` to reflect new API response expectations.
>     - Ensure tests handle `200 OK` response with body instead of `204 No Content`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 533fd7cc440a56b9f2dd18ccf575c0a47a0eaef1. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->