### PR TITLE
Fix PostgresTimeline parent association

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -5,7 +5,7 @@ require "aws-sdk-s3"
 
 class PostgresTimeline < Sequel::Model
   one_to_one :strand, key: :id
-  one_to_one :parent, key: :parent_id, class: self
+  many_to_one :parent, class: self
   one_to_one :leader, class: :PostgresServer, key: :timeline_id, conditions: {timeline_access: "push"}
   many_to_one :location
 


### PR DESCRIPTION
Needed by #4416.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change `parent` association in `PostgresTimeline` from `one_to_one` to `many_to_one`.
> 
>   - **Associations**:
>     - Change `parent` association in `PostgresTimeline` from `one_to_one` to `many_to_one` to allow multiple timelines to share the same parent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for 322f9323c419df7b21dd2eccc6f76f1b99b37ef4. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->