### PR TITLE
Ignore missing role on aws vm cleanup

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -336,9 +336,11 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     end
 
     if Config.aws_postgres_iam_access
-      iam_client.list_attached_role_policies(role_name:).attached_policies.each do |policy|
-        ignore_invalid_entity do
-          iam_client.detach_role_policy(role_name:, policy_arn: policy.policy_arn)
+      ignore_invalid_entity do
+        iam_client.list_attached_role_policies(role_name:).attached_policies.each do |policy|
+          ignore_invalid_entity do
+            iam_client.detach_role_policy(role_name:, policy_arn: policy.policy_arn)
+          end
         end
       end
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps AWS role policy listing and detachment in error handling block to ignore missing roles during VM cleanup in `Prog::Vm::Aws::Nexus`.
> 
>   - **Behavior**:
>     - In `before_run` method of `Prog::Vm::Aws::Nexus`, wraps `list_attached_role_policies` and `detach_role_policy` calls in `ignore_invalid_entity` block.
>     - Handles missing role scenarios during AWS VM cleanup, preventing errors from stopping the process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for e2f3ac0ab08a7312b28c071c11c3ecb4c939cc43. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->