### PR TITLE
Remove rackup from Gemfile

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -489,11 +489,11 @@ Done in 767ms.
 After that, start up the web server.
 
 ```sh
-$ bundle exec rackup
+$ bundle exec puma
 ```
 
 And then visiting [http://localhost:9292](http://localhost:9292), you can
-create an account. Check the rackup log for the verification link to navigate
+create an account. Check the puma log for the verification link to navigate
 to, in production, we would send that output as email. Having verified, log
 in. You'll see the "Getting Started" page.
 

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,6 @@ group :development do
   gem "cuprite"
   gem "foreman"
   gem "pry-byebug"
-  gem "rackup"
 end
 
 group :rubocop do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,8 +295,6 @@ GEM
     rack-test (2.2.0)
       rack (>= 1.3)
     rack-unreloader (2.1.0)
-    rackup (2.2.1)
-      rack (>= 3)
     rainbow (3.1.1)
     rake (13.3.1)
     refrigerator (1.8.0)
@@ -491,7 +489,6 @@ DEPENDENCIES
   pry-byebug
   puma (>= 6.2.2)
   rack-unreloader (>= 1.8)
-  rackup
   rake
   refrigerator (>= 1)
   reline


### PR DESCRIPTION
rackup serves no purpose anymore, it's just an unnecessary abstraction layer. Just use puma directly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `rackup` gem and update `DEVELOPERS.md` to use `puma` directly for starting the web server.
> 
>   - **Gemfile**:
>     - Remove `rackup` gem from the development group.
>   - **Documentation**:
>     - Update `DEVELOPERS.md` to replace `bundle exec rackup` with `bundle exec puma` for starting the web server.
>     - Update reference from "rackup log" to "puma log" in `DEVELOPERS.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ubicloud%2Fubicloud&utm_source=github&utm_medium=referral)<sup> for accd98b168da27f6488856af7a0951b60553b18f. You can [customize](https://app.ellipsis.dev/ubicloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->