### PR TITLE
Handle validation failures for PostgreSQL upgrades

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -564,6 +564,7 @@ class Clover
 
         r.post do
           authorize("Postgres:edit", pg.id)
+          handle_validation_failure("postgres/show") { @page = "upgrade" }
 
           Validation.validate_postgres_upgrade(pg)
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -911,6 +911,18 @@ RSpec.describe Clover, "postgres" do
         visit "#{project.path}#{pg.path}/upgrade"
         expect(page).to have_content "Your database is already on the latest version."
       end
+
+      it "shows correct error page if upgrade validation fails" do
+        pg.strand.update(label: "wait")
+        visit "#{project.path}#{pg.path}/upgrade"
+        expect(page.title).to eq "Ubicloud - pg-with-permission"
+
+        pg.update(target_version: "18")
+        click_button "Start Upgrade"
+        expect(page).to have_flash_error "Validation failed for following fields: needs_convergence"
+        expect(page).to have_text "Database cluster is waiting for convergence, please wait for it to complete"
+        expect(page).to have_current_path "#{project.path}#{pg.path}/upgrade", ignore_query: true
+      end
     end
   end
 end

--- a/views/postgres/upgrade.erb
+++ b/views/postgres/upgrade.erb
@@ -43,6 +43,10 @@ end %>
 <div class="p-6">
   <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Upgrade</h3>
 
+  <% flash["errors"]&.each_value do |msg| %>
+    <p class="text-red-900 mt-2"><%= msg %></p>
+  <% end %>
+
   <% if @pg.display_state == "creating" %>
     <p class="text-gray-500 mt-2">Upgrade operation is not available while the database is being created.</p>
   <% elsif @pg.target_version != @pg.version %>


### PR DESCRIPTION
Issue found in production Mezmo's missing handle validation failure log, so this is an actual issue, not just a theoretical problem.

Maybe the error message could be styled better, but if we don't add it, we only have the flash error, which is going to be cryptic for a user. FWIW, cryptic flash errors is probably true for most if not all ValidationFailed exception handling in the web routes.