### PR TITLE
Add retry logic when instance is unsupported in the AZ

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -57,6 +57,7 @@ class Prog::Vm::Nexus < Prog::Base
     Validation.validate_os_user_name(unix_user)
 
     DB.transaction do
+      subnet = nil
       # Here the logic is the following;
       # - If the user provided nic_id, that nic has to exist and we fetch private_subnet
       # from the reference of nic. We just assume it and not even check the validity of the
@@ -71,6 +72,7 @@ class Prog::Vm::Nexus < Prog::Base
           .where(location_id: location.id, vm_id: nil)
           .with_pk(nic_id)
         raise "Given nic is not available in the given project or location or is assigned to an existing VM" unless nic
+        subnet = nic.private_subnet
       else
         if private_subnet_id
           subnet = (allow_private_subnet_in_other_project ? PrivateSubnet : project.private_subnets_dataset)
@@ -151,7 +153,8 @@ class Prog::Vm::Nexus < Prog::Base
           "hypervisor" => hypervisor,
           "ch_version" => ch_version,
           "firmware_version" => firmware_version,
-          "alternative_families" => alternative_families
+          "alternative_families" => alternative_families,
+          "private_subnet_id" => subnet.id
         }]
       ) { it.id = vm.id }
     end


### PR DESCRIPTION
When AWS returns an Unsupported error during instance creation, it typically means the requested instance type is not available in the current availability zone. Previously, this would cause provisioning to fail and get stuck.

This change adds retry logic that:
- Catches Unsupported errors during instance creation
- Excludes the failed availability zone from future attempts
- Recreates the NIC in a different AZ using the exclusion list
- Limits retries to 5 attempts to prevent infinite loops
- Logs retry attempts for observability

The implementation introduces two new state machine labels: wait_old_nic_deleted waits for the old NIC to be fully deleted before creating a new one, preventing resource conflicts. wait_nic_recreated waits for the new NIC to be ready before retrying instance creation.

The retry state (count, excluded AZs, and subnet ID) is preserved in the strand stack to survive across state transitions.

fixes https://linear.app/ubicloud/issue/UBI-252/implement-az-changeretry-in-case-of-capacity-issues