### PR TITLE
Download boot images from R2 in production by default

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -227,7 +227,7 @@ class VmHost < Sequel::Model
   end
 
   # Introduced for downloading a new boot image via REPL.
-  def download_boot_image(image_name, version:, custom_url: nil, download_r2: false)
+  def download_boot_image(image_name, version:, custom_url: nil, download_r2: true)
     Strand.create(prog: "DownloadBootImage", label: "start", stack: [{subject_id: id, image_name:, custom_url:, version:, download_r2:}])
   end
 

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -26,7 +26,7 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   def download_from_r2?
-    frame["download_r2"] || Config.is_e2e
+    frame["download_r2"] || Config.production?
   end
 
   def url

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe VmHost do
     vh.id = "46683a25-acb1-4371-afe9-d39f303e44b4"
     expect(Strand).to receive(:create) do |args|
       expect(args[:prog]).to eq("DownloadBootImage")
-      expect(args[:stack]).to eq([subject_id: vh.id, image_name: "my-image", custom_url: "https://example.com/my-image.raw", version: "20230303", download_r2: false])
+      expect(args[:stack]).to eq([subject_id: vh.id, image_name: "my-image", custom_url: "https://example.com/my-image.raw", version: "20230303", download_r2: true])
     end
     vh.download_boot_image("my-image", custom_url: "https://example.com/my-image.raw", version: "20230303")
   end


### PR DESCRIPTION
We started downloading boot images from R2 in E2E tests several months ago. We’ve also been downloading them from R2 manually in production.

It has been reliable and performed well so far. We can enable R2 by default in production and disable it only when necessary.