### PR TITLE
Fix double nested exception logs

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -24,7 +24,7 @@ Util.safe_write_to_file(postgres_monitor_db_ca_bundle_filename, Config.postgres_
 begin
   POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool_monitor, pool_timeout: Config.database_timeout, driver_options:) if Config.postgres_monitor_database_url
 rescue Sequel::DatabaseConnectionError => ex
-  Clog.emit("Failed to connect to Postgres Monitor database") { {database_connection_failed: {exception: Util.exception_to_hash(ex)}} }
+  Clog.emit("Failed to connect to Postgres Monitor database") { {database_connection_failed: Util.exception_to_hash(ex)} }
 end
 
 # Load Sequel Database/Global extensions here

--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -22,7 +22,7 @@ class Clover < Roda
     begin
       jobs = runner.installation.client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
     rescue Octokit::ClientError, Octokit::ServerError, Faraday::ConnectionFailed, Faraday::TimeoutError => ex
-      log_context[:expection] = Util.exception_to_hash(ex)
+      log_context.merge!(Util.exception_to_hash(ex))
       Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }
       return
     end

--- a/lib/metrics_target_resource.rb
+++ b/lib/metrics_target_resource.rb
@@ -34,7 +34,7 @@ class MetricsTargetResource
     rescue => ex
       @last_export_success = false
       close_resource_session
-      Clog.emit("Metrics export has failed.") { {metrics_export_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Metrics export has failed.") { {metrics_export_failure: {ubid: @resource.ubid}.merge(Util.exception_to_hash(ex))} }
       # TODO: Consider raising the exception here, and let the caller handle it.
     end
   end

--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -40,7 +40,7 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_que
             # handled differently.
             yield r
           rescue => ex
-            Clog.emit("Monitoring job has failed.") { {monitoring_job_failure: {resource: r.resource, exception: Util.exception_to_hash(ex)}} }
+            Clog.emit("Monitoring job has failed.") { {monitoring_job_failure: {resource: r.resource}.merge(Util.exception_to_hash(ex))} }
             r.resource.incr_checkup if r.resource.respond_to?(:incr_checkup) && !r.resource.checkup_set?
           ensure
             # We unset the started at time so we will not check for stuck pulses

--- a/lib/monitor_runner.rb
+++ b/lib/monitor_runner.rb
@@ -145,7 +145,7 @@ class MonitorRunner
     shutdown! unless @shutdown
     nil
   rescue => ex
-    Clog.emit("Pulse checking or resource scanning has failed.") { {pulse_checking_or_resource_scanning_failure: {exception: Util.exception_to_hash(ex)}} }
+    Clog.emit("Pulse checking or resource scanning has failed.") { {pulse_checking_or_resource_scanning_failure: Util.exception_to_hash(ex)} }
     ThreadPrinter.run
     Kernel.exit! 2
   end

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -33,7 +33,7 @@ class MonitorableResource
         @session[:ssh_session].loop(0.01) { run_event_loop }
       rescue => ex
         event_loop_failed = true
-        Clog.emit("SSH event loop has failed.") { {event_loop_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("SSH event loop has failed.") { {event_loop_failure: {ubid: @resource.ubid}.merge(Util.exception_to_hash(ex))} }
         @session[:ssh_session].shutdown!
         begin
           @session[:ssh_session].close
@@ -65,7 +65,7 @@ class MonitorableResource
         @session.merge!(@resource.init_health_monitor_session)
         retry
       end
-      Clog.emit("Pulse checking has failed.") { {pulse_check_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Pulse checking has failed.") { {pulse_check_failure: {ubid: @resource.ubid}.merge(Util.exception_to_hash(ex))} }
       # TODO: Consider raising the exception here, and let the caller handle it.
     end
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -246,7 +246,7 @@ class PostgresServer < Sequel::Model
               update: {last_known_lsn: last_known_lsn}
             ).save_changes
         rescue Sequel::Error => ex
-          Clog.emit("Failed to update PostgresLsnMonitor") { {lsn_update_error: {ubid: ubid, last_known_lsn: last_known_lsn, exception: Util.exception_to_hash(ex)}} }
+          Clog.emit("Failed to update PostgresLsnMonitor") { {lsn_update_error: {ubid:, last_known_lsn:}.merge(Util.exception_to_hash(ex))} }
         end
       end
 

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -262,7 +262,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
           )
         end
       rescue Sequel::Error => ex
-        Clog.emit("Failed to update billing record") { {billing_record_update_error: {project_ubid: project.ubid, model_name: inference_endpoint.model_name, replica_ubid: inference_endpoint_replica.ubid, tokens: tokens, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("Failed to update billing record") { {billing_record_update_error: {project_ubid: project.ubid, model_name: inference_endpoint.model_name, replica_ubid: inference_endpoint_replica.ubid, tokens:}.merge(Util.exception_to_hash(ex))} }
       end
     end
   end

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -351,7 +351,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
           )
         end
       rescue Sequel::Error => ex
-        Clog.emit("Failed to update billing record") { {billing_record_update_error: {project_ubid: project.ubid, replica_ubid: inference_router_replica.ubid, tokens: tokens, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("Failed to update billing record") { {billing_record_update_error: {project_ubid: project.ubid, replica_ubid: inference_router_replica.ubid, tokens:}.merge(Util.exception_to_hash(ex))} }
       end
     end
   end

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -186,7 +186,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     server_data = minio_server.server_data
     server_data["state"] == "online" && server_data["drives"].all? { it["state"] == "ok" }
   rescue => ex
-    Clog.emit("Minio server is down") { {minio_server_down: {ubid: minio_server.ubid, exception: Util.exception_to_hash(ex)}} }
+    Clog.emit("Minio server is down") { {minio_server_down: {ubid: minio_server.ubid}.merge(Util.exception_to_hash(ex))} }
     false
   end
 

--- a/prog/victoria_metrics/victoria_metrics_server_nexus.rb
+++ b/prog/victoria_metrics/victoria_metrics_server_nexus.rb
@@ -215,7 +215,7 @@ class Prog::VictoriaMetrics::VictoriaMetricsServerNexus < Prog::Base
 
     victoria_metrics_server.client.health
   rescue => ex
-    Clog.emit("victoria_metrics server is down") { {victoria_metrics_server_down: {ubid: victoria_metrics_server.ubid, exception: Util.exception_to_hash(ex)}} }
+    Clog.emit("victoria_metrics server is down") { {victoria_metrics_server_down: {ubid: victoria_metrics_server.ubid}.merge(Util.exception_to_hash(ex))} }
     false
   end
 

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -409,6 +409,6 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     Aws::IAM::Errors::InvalidRoleName,
     Aws::IAM::Errors::NoSuchEntity,
     Aws::IAM::Errors::EntityAlreadyExists => e
-    Clog.emit("ID not found or already exists for aws instance") { {ignored_aws_instance_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+    Clog.emit("ID not found or already exists for aws instance") { {ignored_aws_instance_failure: Util.exception_to_hash(e, backtrace: nil)} }
   end
 end

--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -160,7 +160,7 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
     rescue Aws::EC2::Errors::DependencyViolation => e
       raise e if private_subnet.nics.count == 1
 
-      Clog.emit("dependency violation for aws nic") { {ignored_aws_nic_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+      Clog.emit("dependency violation for aws nic") { {ignored_aws_nic_failure: Util.exception_to_hash(e, backtrace: nil)} }
     end
 
     hop_destroy_entities
@@ -205,6 +205,6 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
     Aws::EC2::Errors::InvalidAllocationIDNotFound,
     Aws::EC2::Errors::InvalidAddressIDNotFound,
     Aws::EC2::Errors::InvalidSubnetIDNotFound => e
-    Clog.emit("ID not found for aws nic") { {ignored_aws_nic_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+    Clog.emit("ID not found for aws nic") { {ignored_aws_nic_failure: Util.exception_to_hash(e, backtrace: nil)} }
   end
 end

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -171,7 +171,7 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     Aws::EC2::Errors::InvalidNetworkInterfaceIDNotFound,
     Aws::EC2::Errors::InvalidInternetGatewayIDNotFound,
     Aws::EC2::Errors::InvalidVpcIDNotFound => e
-    Clog.emit("ID not found for aws vpc") { {ignored_aws_vpc_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+    Clog.emit("ID not found for aws vpc") { {ignored_aws_vpc_failure: Util.exception_to_hash(e, backtrace: nil)} }
   end
 
   def location

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -117,12 +117,12 @@ class Prog::Vnet::CertNexus < Prog::Base
     begin
       acme_client.revoke(certificate: cert.cert, reason: REVOKE_REASON) if cert.cert
     rescue Acme::Client::Error::AlreadyRevoked => ex
-      Clog.emit("Certificate is already revoked") { {cert_revoke_failure: {ubid: cert.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Certificate is already revoked") { {cert_revoke_failure: {ubid: cert.ubid}.merge(Util.exception_to_hash(ex))} }
     rescue Acme::Client::Error::NotFound => ex
-      Clog.emit("Certificate is not found") { {cert_revoke_failure: {ubid: cert.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Certificate is not found") { {cert_revoke_failure: {ubid: cert.ubid}.merge(Util.exception_to_hash(ex))} }
     rescue Acme::Client::Error::Unauthorized => ex
       if ex.message.include?("The certificate has expired and cannot be revoked")
-        Clog.emit("Certificate is expired and cannot be revoked") { {cert_revoke_failure: {ubid: cert.ubid, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("Certificate is expired and cannot be revoked") { {cert_revoke_failure: {ubid: cert.ubid}.merge(Util.exception_to_hash(ex))} }
       else
         raise ex
       end

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -134,7 +134,7 @@ class Clover
               # :nocov:
               retry
             else
-              Clog.emit("Could not authorize multipart upload") { {could_not_authorize_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid, exception: Util.exception_to_hash(ex)}} }
+              Clog.emit("Could not authorize multipart upload") { {could_not_authorize_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid}.merge(Util.exception_to_hash(ex))} }
               fail CloverError.new(400, "InvalidRequest", "Could not authorize multipart upload")
             end
           end
@@ -180,10 +180,10 @@ class Clover
             multipart_upload: {parts: etags.map.with_index { {part_number: _2 + 1, etag: _1} }}
           })
         rescue Aws::S3::Errors::InvalidPart, Aws::S3::Errors::NoSuchUpload => ex
-          Clog.emit("could not complete multipart upload") { {failed_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid, exception: Util.exception_to_hash(ex)}} }
+          Clog.emit("could not complete multipart upload") { {failed_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid}.merge(Util.exception_to_hash(ex))} }
           fail CloverError.new(400, "InvalidRequest", "Wrong parameters")
         rescue Aws::S3::Errors::ServiceUnavailable => ex
-          Clog.emit("s3 service unavailable") { {failed_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid, exception: Util.exception_to_hash(ex)}} }
+          Clog.emit("s3 service unavailable") { {failed_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid}.merge(Util.exception_to_hash(ex))} }
           fail CloverError.new(503, "ServiceUnavailable", "Service unavailable")
         end
 


### PR DESCRIPTION
`Util.exception_to_hash` already returns a hash with an exception key, so wrapping it again with another exception key is unnecessary and results in double nesting.