### PR TITLE
Make PageNexus.assemble upsert existing Pages instead of ignoring them

### DIFF
--- a/spec/prog/page_nexus_spec.rb
+++ b/spec/prog/page_nexus_spec.rb
@@ -28,4 +28,57 @@ RSpec.describe Prog::PageNexus do
       expect { pn.wait }.to nap(6 * 60 * 60)
     end
   end
+
+  describe ".assemble" do
+    let(:summary) { "New Page Summary" }
+    let(:tag_parts) { ["TestTag", "resource123"] }
+    let(:related_resources) { ["ubid1", "ubid2"] }
+    let(:severity) { "warning" }
+    let(:extra_data) { {"foo" => "bar"} }
+
+    it "creates a new page when one does not exist" do
+      expect {
+        described_class.assemble(summary, tag_parts, related_resources, severity:, extra_data:)
+      }.to change(Page, :count).by(1).and change(Strand, :count).by(1)
+
+      page = Page.from_tag_parts(tag_parts)
+      expect(page.summary).to eq(summary)
+      expect(page.tag).to eq("TestTag-resource123")
+      expect(page.severity).to eq(severity)
+      expect(page.details["related_resources"]).to eq(related_resources)
+      expect(page.details["foo"]).to eq("bar")
+      expect(page.resolved_at).to be_nil
+
+      strand = Strand.last
+      expect(strand.prog).to eq("PageNexus")
+      expect(strand.label).to eq("start")
+    end
+
+    it "updates existing page when one exists with same tag" do
+      existing_page = described_class.assemble(
+        "Old Summary",
+        tag_parts,
+        ["old_ubid"],
+        severity: "error",
+        extra_data: {"old_data" => "old_value"}
+      ).subject
+
+      expect(existing_page.summary).not_to eq(summary)
+      expect(existing_page.severity).not_to eq(severity)
+      expect(existing_page.details["related_resources"]).not_to eq(related_resources)
+      expect(existing_page.details["old_data"]).to eq("old_value")
+      expect(existing_page.details["foo"]).to be_nil
+
+      expect {
+        described_class.assemble(summary, tag_parts, related_resources, severity:, extra_data:)
+      }.to not_change(Page, :count).and not_change(Strand, :count)
+
+      existing_page.reload
+      expect(existing_page.summary).to eq(summary)
+      expect(existing_page.severity).to eq(severity)
+      expect(existing_page.details["related_resources"]).to eq(related_resources)
+      expect(existing_page.details["foo"]).to eq("bar")
+      expect(existing_page.details["old_data"]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Previously, when PageNexus.assemble was called with tag_parts that matched an existing active Page, it would simply return early and ignore the new data. This meant that updates to page summaries, details, or severity would be lost.

Now, when an existing active Page is found by tag, it gets updated with the new summary, details, and severity. This ensures Pages always reflect the most current state.