### PR TITLE
Add client helper to GithubInstallation model

### DIFF
--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -20,8 +20,7 @@ class Clover < Roda
 
     Clog.emit("Get runner scope from GitHub API") { {get_runner_scope: log_context} }
     begin
-      client = Github.installation_client(runner.installation.installation_id)
-      jobs = client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
+      jobs = runner.installation.client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
     rescue Octokit::ClientError, Octokit::ServerError, Faraday::ConnectionFailed, Faraday::TimeoutError => ex
       log_context[:expection] = Util.exception_to_hash(ex)
       Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }

--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -31,6 +31,10 @@ class GithubInstallation < Sequel::Model
     !!allocator_preferences["family_filter"]&.include?("premium")
   end
 
+  def client(**)
+    Github.installation_client(installation_id, **)
+  end
+
   def cache_storage_gib
     [project.effective_quota_value("GithubRunnerCacheStorage"), premium_runner_enabled? ? 100 : 0].max
   end

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -18,10 +18,6 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     end
   end
 
-  def client
-    @client ||= Github.installation_client(github_repository.installation.installation_id, auto_paginate: true)
-  end
-
   # We dynamically adjust the polling interval based on the remaining rate
   # limit. It's 5 minutes by default, but it can be increased if the rate limit
   # is low.
@@ -34,16 +30,18 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
       @polling_interval = 24 * 60 * 60
       return
     end
+    client = github_repository.installation.client(auto_paginate: true)
     queued_runs = client.repository_workflow_runs(github_repository.name, {status: "queued"})[:workflow_runs]
     Clog.emit("polled queued runs") { {polled_queued_runs: {repository_name: github_repository.name, count: queued_runs.count}} }
 
     # We check the rate limit after the first API call to avoid unnecessary API
     # calls to fetch only the rate limit. Every response includes the rate limit
     # information in the headers.
-    remaining_quota = client.rate_limit.remaining / client.rate_limit.limit.to_f
+    rate_limit = client.rate_limit
+    remaining_quota = rate_limit.remaining / rate_limit.limit.to_f
     if remaining_quota < 0.1
-      Clog.emit("low remaining quota") { {low_remaining_quota: {repository_name: github_repository.name, limit: client.rate_limit.limit, remaining: client.rate_limit.remaining}} }
-      @polling_interval = (client.rate_limit.resets_at - Time.now).to_i
+      Clog.emit("low remaining quota") { {low_remaining_quota: {repository_name: github_repository.name, limit: rate_limit.limit, remaining: rate_limit.remaining}} }
+      @polling_interval = (rate_limit.resets_at - Time.now).to_i
       return
     end
 


### PR DESCRIPTION
Constructing a GitHub API client required passing installation_id to Github.installation_client, which was repetitive. The new GithubInstallation#client method encapsulates this, allowing callers to simply use installation.client.

It's useful for the oncall operations as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)