### PR TITLE
Use released version for rodauth-omniauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "refrigerator", ">= 1"
 gem "reline" # Remove it when pry adds it as a dependency
 gem "roda", ">= 3.96"
 gem "rodauth", ">= 2.41"
-gem "rodauth-omniauth", github: "janko/rodauth-omniauth", ref: "477810179ba0cab8d459be1a0d87dca5b57ec94b"
+gem "rodauth-omniauth", ">= 0.6.2"
 gem "rodish", ">= 2.0.1"
 gem "rotp"
 gem "rqrcode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,6 @@ GIT
       pg (~> 1.3)
 
 GIT
-  remote: https://github.com/janko/rodauth-omniauth.git
-  revision: 477810179ba0cab8d459be1a0d87dca5b57ec94b
-  ref: 477810179ba0cab8d459be1a0d87dca5b57ec94b
-  specs:
-    rodauth-omniauth (0.6.0)
-      omniauth (~> 2.0)
-      rodauth (~> 2.36)
-
-GIT
   remote: https://github.com/ubicloud/erb-formatter.git
   revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
   ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
@@ -307,6 +298,9 @@ GEM
     rodauth (2.41.0)
       roda (>= 2.6.0)
       sequel (>= 4)
+    rodauth-omniauth (0.6.2)
+      omniauth (~> 2.0)
+      rodauth (~> 2.36)
     rodish (2.0.1)
       optparse
     rotp (6.3.0)
@@ -494,7 +488,7 @@ DEPENDENCIES
   reline
   roda (>= 3.96)
   rodauth (>= 2.41)
-  rodauth-omniauth!
+  rodauth-omniauth (>= 0.6.2)
   rodish (>= 2.0.1)
   rotp
   rqrcode


### PR DESCRIPTION
We previously switched to a commit based version to pick up https://github.com/janko/rodauth-omniauth/commit/e15b67da29ab189a480588a30d86c30360b0d718.

Since this change is now included in the released version 0.6.1, we can switch back to using the released version instead of pinning to a commit.