### PR TITLE
Prevent long cache keys from overflowing table

### DIFF
--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -33,7 +33,7 @@
             <% entries.each do |entry| %>
               <tr id="entry-<%= entry.ubid %>" class="hidden cache-group-<%= repository_id %>">
                 <td class="py-3 pl-4 pr-3 text-sm sm:pl-6 w-full" scope="row">
-                  <div class="font-medium text-gray-900"><%= entry.key %></div>
+                  <div class="font-medium text-gray-900 break-all"><%= entry.key %></div>
                   <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry.created_at.strftime("%Y-%m-%d %H:%M UTC") %>"><%= humanize_time(entry.created_at) %></span></div>
                 </td>
                 <td class="px-3 py-3 text-sm text-gray-500">


### PR DESCRIPTION
Cache entry keys can be arbitrarily long strings without spaces or natural break points. When displayed in the table, these keys would not wrap, causing the column to expand indefinitely and breaking the table layout.

Adding the break-all class forces word-breaking at any character, ensuring long keys wrap properly within their column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| Before | After |
|--------|-------|
| <img width="3020" height="1440" alt="CleanShot 2025-12-30 at 10 41 35@2x" src="https://github.com/user-attachments/assets/4af0ecdb-e67d-42fd-a42f-0bc4e9cd8f33" /> | <img width="3024" height="1572" alt="CleanShot 2025-12-30 at 10 41 21@2x" src="https://github.com/user-attachments/assets/9e0865cd-654b-4430-8b69-1ccce7397c11" /> |