### PR TITLE
Pretty print JSONB columns in the admin object view

### DIFF
--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -46,6 +46,8 @@
       <td>
         <% if v.is_a?(String) && v.bytesize == 26 && (column_class = UBID.class_for_ubid(v)) && column_class.method_defined?(:ubid) && (obj = UBID.decode(v)) %>
           <a href="/model/<%= column_class %>/<%= v %>"><%= obj.admin_label %></a>
+        <% elsif v&.is_a?(Sequel::Postgres::JSONBHash) %>
+          <pre><%== linkify_ubids(JSON.pretty_generate(v)) %></pre>
         <% else %>
           <%== linkify_ubids(v.to_s) %>
         <% end %>


### PR DESCRIPTION
JSONB columns like feature_flags were displayed as inline text, making them difficult to read. This adds special handling for JSONB values that formats them with proper indentation using JSON.pretty_generate and wraps them in a `<pre>` tag. UBIDs within the JSON are also linkified for easy navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


| Before | After |
|--------|-------|
| <img width="2624" height="172" alt="CleanShot 2025-12-30 at 16 38 38@2x" src="https://github.com/user-attachments/assets/45ea69e2-1432-46f3-a262-90d2f4339a15" /> | <img width="1070" height="572" alt="CleanShot 2025-12-30 at 16 34 43@2x" src="https://github.com/user-attachments/assets/6130f854-3cc7-4140-a7e7-cf61adc5c9c7" /> |

