### PR TITLE
Fix reloading of models using ProviderDispatcher

### DIFF
--- a/lib/provider_dispatcher.rb
+++ b/lib/provider_dispatcher.rb
@@ -8,7 +8,7 @@ module ProviderDispatcher
     methods = {}
     PROVIDERS.each do |const|
       subdir = const.to_s.downcase
-      require File.join(dir, const.to_s.downcase, file)
+      load File.join(dir, const.to_s.downcase, file)
       implementation = model.const_get(const)
       model.include implementation
 


### PR DESCRIPTION
Since ProviderDispatcher is the only place the related files are loaded, and it is only loaded once per model, switching from require to load fixes the issue.