### PR TITLE
Always have Clover raise admin errors

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -220,7 +220,7 @@ class Clover < Roda
   end
 
   plugin :error_handler do |e|
-    if Config.test? && ENV["SHOW_ERRORS"]
+    if Config.test? && (ENV["SHOW_ERRORS"] || request.admin?)
       raise e
     end
 


### PR DESCRIPTION
Otherwise, Clover could return an error page or raise a different exception.

With a `Sequel::ValidationFailed` on the admin site:

Before:

```
     Failure/Error: Clover.app.call(env)

     Roda::RodaError:
       session called on request not using sessions
     # ./clover.rb:289:in 'block in <class:Clover>'
     # ./spec/routes/spec_helper.rb:64:in 'block (3 levels) in <top (required)>'
     # ./spec/routes/spec_helper.rb:63:in 'block (2 levels) in <top (required)>'
     # ./spec/routes/web/admin/admin_spec.rb:699:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:60:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:59:in 'block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Sequel::ValidationFailed:
     #   value is not present
     #   ./clover_admin.rb:215:in 'block in <class:CloverAdmin>'
```

After:

```
     Failure/Error: Clover.app.call(env)

     Sequel::ValidationFailed:
       value is not present
     # ./clover_admin.rb:215:in 'block in <class:CloverAdmin>'
     # ./clover_admin.rb:157:in 'CloverAdmin::ObjectAction#call'
     # ./clover_admin.rb:474:in 'block (5 levels) in <class:CloverAdmin>'
     # ./clover_admin.rb:472:in 'block (4 levels) in <class:CloverAdmin>'
     # ./clover_admin.rb:463:in 'block (3 levels) in <class:CloverAdmin>'
     # ./clover_admin.rb:455:in 'block (2 levels) in <class:CloverAdmin>'
     # ./clover_admin.rb:428:in 'block in <class:CloverAdmin>'
     # ./clover.rb:977:in 'block in <class:Clover>'
     # ./spec/routes/spec_helper.rb:64:in 'block (3 levels) in <top (required)>'
     # ./spec/routes/spec_helper.rb:63:in 'block (2 levels) in <top (required)>'
     # ./spec/routes/web/admin/admin_spec.rb:699:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:60:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:59:in 'block (2 levels) in <top (required)>'
```

Issue found while testing #4462.