### PR TITLE
Update Util.exception_to_hash

### DIFF
--- a/helpers/runtime.rb
+++ b/helpers/runtime.rb
@@ -22,7 +22,7 @@ class Clover < Roda
     begin
       jobs = runner.installation.client.workflow_run_jobs(runner.repository_name, run_id)[:jobs]
     rescue Octokit::ClientError, Octokit::ServerError, Faraday::ConnectionFailed, Faraday::TimeoutError => ex
-      log_context[:expection] = Util.exception_to_hash(ex)
+      Util.exception_to_hash(ex, into: log_context)
       Clog.emit("Could not list the jobs of the workflow run ") { {runner_scope_failure: log_context} }
       return
     end

--- a/lib/metrics_target_resource.rb
+++ b/lib/metrics_target_resource.rb
@@ -34,7 +34,7 @@ class MetricsTargetResource
     rescue => ex
       @last_export_success = false
       close_resource_session
-      Clog.emit("Metrics export has failed.") { {metrics_export_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Metrics export has failed.") { {metrics_export_failure: Util.exception_to_hash(ex, into: {ubid: @resource.ubid})} }
       # TODO: Consider raising the exception here, and let the caller handle it.
     end
   end

--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -40,7 +40,7 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :submit_que
             # handled differently.
             yield r
           rescue => ex
-            Clog.emit("Monitoring job has failed.") { {monitoring_job_failure: {resource: r.resource, exception: Util.exception_to_hash(ex)}} }
+            Clog.emit("Monitoring job has failed.") { {monitoring_job_failure: Util.exception_to_hash(ex, into: {resource: r.resource})} }
             r.resource.incr_checkup if r.resource.respond_to?(:incr_checkup) && !r.resource.checkup_set?
           ensure
             # We unset the started at time so we will not check for stuck pulses

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -33,7 +33,7 @@ class MonitorableResource
         @session[:ssh_session].loop(0.01) { run_event_loop }
       rescue => ex
         event_loop_failed = true
-        Clog.emit("SSH event loop has failed.") { {event_loop_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("SSH event loop has failed.") { {event_loop_failure: Util.exception_to_hash(ex, into: {ubid: @resource.ubid})} }
         @session[:ssh_session].shutdown!
         begin
           @session[:ssh_session].close
@@ -65,7 +65,7 @@ class MonitorableResource
         @session.merge!(@resource.init_health_monitor_session)
         retry
       end
-      Clog.emit("Pulse checking has failed.") { {pulse_check_failure: {ubid: @resource.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Pulse checking has failed.") { {pulse_check_failure: Util.exception_to_hash(ex, into: {ubid: @resource.ubid})} }
       # TODO: Consider raising the exception here, and let the caller handle it.
     end
 

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -71,8 +71,18 @@ module Util
     [cert, key]
   end
 
-  def self.exception_to_hash(ex, backtrace: ex.backtrace)
-    {exception: {message: ex.message, class: ex.class.to_s, backtrace:, cause: ex.cause.inspect}}
+  def self.exception_to_hash(ex, backtrace: ex.backtrace, into: {})
+    into[:exception] = {message: ex.message, class: ex.class.to_s, backtrace:}
+    # Don't log causes if we aren't logging backtraces
+    if backtrace && (cause = ex.cause)
+      array = into[:causes] = []
+      while cause && (cause != ex)
+        ex = cause
+        cause = ex.cause
+        array << {message: ex.message, class: ex.class.to_s, backtrace: ex.backtrace}
+      end
+    end
+    into
   end
 
   def self.safe_write_to_file(filename, content)

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -246,7 +246,7 @@ class PostgresServer < Sequel::Model
               update: {last_known_lsn:}
             ).save_changes
         rescue Sequel::Error => ex
-          Clog.emit("Failed to update PostgresLsnMonitor") { {lsn_update_error: {ubid:, last_known_lsn:, exception: Util.exception_to_hash(ex)}} }
+          Clog.emit("Failed to update PostgresLsnMonitor") { {lsn_update_error: Util.exception_to_hash(ex, into: {ubid:, last_known_lsn:})} }
         end
       end
 
@@ -311,6 +311,7 @@ class PostgresServer < Sequel::Model
       timeline_id: Prog::Postgres::PostgresTimelineNexus.assemble(location_id: resource.location_id, parent_id:).id,
       timeline_access: "push"
     )
+
     increment_s3_new_timeline
     incr_refresh_walg_credentials
   end

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -262,7 +262,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
           )
         end
       rescue Sequel::Error => ex
-        Clog.emit("Failed to update billing record") { {billing_record_update_error: {project_ubid: project.ubid, model_name: inference_endpoint.model_name, replica_ubid: inference_endpoint_replica.ubid, tokens:, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("Failed to update billing record") { {billing_record_update_error: Util.exception_to_hash(ex, into: {project_ubid: project.ubid, model_name: inference_endpoint.model_name, replica_ubid: inference_endpoint_replica.ubid, tokens:})} }
       end
     end
   end

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -351,7 +351,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
           )
         end
       rescue Sequel::Error => ex
-        Clog.emit("Failed to update billing record") { {billing_record_update_error: {project_ubid: project.ubid, replica_ubid: inference_router_replica.ubid, tokens:, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("Failed to update billing record") { {billing_record_update_error: Util.exception_to_hash(ex, into: {project_ubid: project.ubid, replica_ubid: inference_router_replica.ubid, tokens:})} }
       end
     end
   end

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -186,7 +186,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     server_data = minio_server.server_data
     server_data["state"] == "online" && server_data["drives"].all? { it["state"] == "ok" }
   rescue => ex
-    Clog.emit("Minio server is down") { {minio_server_down: {ubid: minio_server.ubid, exception: Util.exception_to_hash(ex)}} }
+    Clog.emit("Minio server is down") { {minio_server_down: Util.exception_to_hash(ex, into: {ubid: minio_server.ubid})} }
     false
   end
 

--- a/prog/victoria_metrics/victoria_metrics_server_nexus.rb
+++ b/prog/victoria_metrics/victoria_metrics_server_nexus.rb
@@ -215,7 +215,7 @@ class Prog::VictoriaMetrics::VictoriaMetricsServerNexus < Prog::Base
 
     victoria_metrics_server.client.health
   rescue => ex
-    Clog.emit("victoria_metrics server is down") { {victoria_metrics_server_down: {ubid: victoria_metrics_server.ubid, exception: Util.exception_to_hash(ex)}} }
+    Clog.emit("victoria_metrics server is down") { {victoria_metrics_server_down: Util.exception_to_hash(ex, into: {ubid: victoria_metrics_server.ubid})} }
     false
   end
 

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -117,12 +117,12 @@ class Prog::Vnet::CertNexus < Prog::Base
     begin
       acme_client.revoke(certificate: cert.cert, reason: REVOKE_REASON) if cert.cert
     rescue Acme::Client::Error::AlreadyRevoked => ex
-      Clog.emit("Certificate is already revoked") { {cert_revoke_failure: {ubid: cert.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Certificate is already revoked") { {cert_revoke_failure: Util.exception_to_hash(ex, into: {ubid: cert.ubid})} }
     rescue Acme::Client::Error::NotFound => ex
-      Clog.emit("Certificate is not found") { {cert_revoke_failure: {ubid: cert.ubid, exception: Util.exception_to_hash(ex)}} }
+      Clog.emit("Certificate is not found") { {cert_revoke_failure: Util.exception_to_hash(ex, into: {ubid: cert.ubid})} }
     rescue Acme::Client::Error::Unauthorized => ex
       if ex.message.include?("The certificate has expired and cannot be revoked")
-        Clog.emit("Certificate is expired and cannot be revoked") { {cert_revoke_failure: {ubid: cert.ubid, exception: Util.exception_to_hash(ex)}} }
+        Clog.emit("Certificate is expired and cannot be revoked") { {cert_revoke_failure: Util.exception_to_hash(ex, into: {ubid: cert.ubid})} }
       else
         raise ex
       end

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -134,7 +134,7 @@ class Clover
               # :nocov:
               retry
             else
-              Clog.emit("Could not authorize multipart upload") { {could_not_authorize_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid, exception: Util.exception_to_hash(ex)}} }
+              Clog.emit("Could not authorize multipart upload") { {could_not_authorize_multipart_upload: Util.exception_to_hash(ex, into: {ubid: runner.ubid, repository_ubid: repository.ubid})} }
               fail CloverError.new(400, "InvalidRequest", "Could not authorize multipart upload")
             end
           end
@@ -180,10 +180,10 @@ class Clover
             multipart_upload: {parts: etags.map.with_index { {part_number: _2 + 1, etag: _1} }}
           })
         rescue Aws::S3::Errors::InvalidPart, Aws::S3::Errors::NoSuchUpload => ex
-          Clog.emit("could not complete multipart upload") { {failed_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid, exception: Util.exception_to_hash(ex)}} }
+          Clog.emit("could not complete multipart upload") { {failed_multipart_upload: Util.exception_to_hash(ex, into: {ubid: runner.ubid, repository_ubid: repository.ubid})} }
           fail CloverError.new(400, "InvalidRequest", "Wrong parameters")
         rescue Aws::S3::Errors::ServiceUnavailable => ex
-          Clog.emit("s3 service unavailable") { {failed_multipart_upload: {ubid: runner.ubid, repository_ubid: repository.ubid, exception: Util.exception_to_hash(ex)}} }
+          Clog.emit("s3 service unavailable") { {failed_multipart_upload: Util.exception_to_hash(ex, into: {ubid: runner.ubid, repository_ubid: repository.ubid})} }
           fail CloverError.new(503, "ServiceUnavailable", "Service unavailable")
         end
 

--- a/scheduling/dispatcher.rb
+++ b/scheduling/dispatcher.rb
@@ -472,13 +472,6 @@ class Scheduling::Dispatcher
     strand.run(STRAND_RUNTIME)
   rescue => ex
     Clog.emit("exception terminates strand run") { Util.exception_to_hash(ex) }
-
-    cause = ex
-    loop do
-      break unless (cause = cause.cause)
-
-      Clog.emit("nested exception") { Util.exception_to_hash(cause) }
-    end
     ex
   ensure
     Thread.current[:apoptosis_at] = nil

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -422,9 +422,8 @@ RSpec.describe Scheduling::Dispatcher do
 
       # Go to the trouble of emitting those exceptions to provoke
       # plausible crashes in serialization.
-      expect(Config).to receive(:test?).and_return(false).twice
-      expect($stdout).to receive(:write).with(a_string_matching(/outer test error/))
-      expect($stdout).to receive(:write).with(a_string_matching(/nested test error/))
+      expect(Config).to receive(:test?).and_return(false)
+      expect($stdout).to receive(:write).with(a_string_matching(/outer test error.*nested test error/))
 
       start_queue = Queue.new
       finish_queue = Queue.new


### PR DESCRIPTION
This makes two changes to Util.exception.to_hash:

* It adds an into keyword argument. This will add the :exception
  key to that hash instead of always using a new hash. For backwards
  compatibility, the default is a new empty hash.

* It uses an array to hold the exception information. If backtraces are
  being logged (the default), it includes all exception causes in the
  array.

This switches callers of the form:

```ruby
{...}.merge(Util.exception_to_hash(ex))
```

to:

```ruby
Util.exception_to_hash(ex, into: {...})
```

Which eliminates 2 hash allocations per call (as merge returns a new
hash).

This also removes the loop in the dispatcher to emit each exception
cause as a separate log entry, since now the single log entry includes
all causes.

This builds on top of #4446.