### PR TITLE
Make UBID.decode return nil instead of raising

### DIFF
--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -361,10 +361,8 @@ RSpec.describe UBID do
     expect(string_kv(described_class.decode(nic.ubid))).to eq(string_kv(nic))
   end
 
-  it "fails to decode unknown type" do
-    expect {
-      described_class.decode("han2sefsk4f61k91z77vn0y978")
-    }.to raise_error UBIDParseError, "Couldn't decode ubid: han2sefsk4f61k91z77vn0y978"
+  it "returns nil when decoding unknown type" do
+    expect(described_class.decode("han2sefsk4f61k91z77vn0y978")).to be_nil
   end
 
   it "can be inspected" do

--- a/ubid.rb
+++ b/ubid.rb
@@ -211,11 +211,9 @@ class UBID
 
   def self.decode(ubid)
     ubid_str = ubid.to_s
-    uuid = UBID.parse(ubid_str).to_uuid
-    klass = class_for_ubid(ubid)
-    fail UBIDParseError.new("Couldn't decode ubid: #{ubid_str}") if klass.nil?
-
-    klass[uuid]
+    if (uuid = UBID.to_uuid(ubid_str)) && (klass = class_for_ubid(ubid))
+      klass[uuid]
+    end
   end
 
   def self.from_uuidish(uuidish)


### PR DESCRIPTION
UBID.decode previously had two separate failure modes:

* raise UBID::ParseError (for invalid ubid or ubid without associated class)

* return nil if ubid is valid and has a class, but there is no object with the related ubid in that class.

In general, it's better to only have a single failure mode, where the method either returns nil on failure or raises an exception on failure.

This changes UBID.decode to always return nil on failure, instead of raising UBID::ParseError. This makes UBID.decode more like UBID.to_uuid.