### PR TITLE
Add UBID tooltips to admin panel links

### DIFF
--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -45,7 +45,7 @@
       <td><%= k %></td>
       <td>
         <% if v.is_a?(String) && v.bytesize == 26 && (column_class = UBID.class_for_ubid(v)) && column_class.method_defined?(:ubid) && (obj = UBID.decode(v)) %>
-          <a href="/model/<%= column_class %>/<%= v %>"><%= obj.admin_label %></a>
+          <a href="/model/<%= column_class %>/<%= v %>" title="<%= v %>"><%= obj.admin_label %></a>
         <% elsif v&.is_a?(Sequel::Postgres::JSONBHash) %>
           <pre><%== linkify_ubids(JSON.pretty_generate(v)) %></pre>
         <% else %>
@@ -82,7 +82,7 @@
       <h3><%= assoc %></h3>
       <ul>
       <% assoc_objs.each do %>
-        <li><a href="/model/<%= associated_class %>/<%= it.ubid %>"><%= it.admin_label %></a></li>
+        <li><a href="/model/<%= associated_class %>/<%= it.ubid %>" title="<%= it.ubid %>"><%= it.admin_label %></a></li>
       <% end %>
       </ul>
     </div>


### PR DESCRIPTION
The admin_label provides a human-friendly representation of resources, but sometimes you need to see the actual UBID without clicking through. Adding title attributes to resource links shows the UBID on hover, making it easier to identify resource ubids.

<img width="762" height="392" alt="CleanShot 2025-12-31 at 10 28 24@2x" src="https://github.com/user-attachments/assets/b67abd26-296b-47a9-9cb7-8437d061fdf0" />
<img width="662" height="256" alt="CleanShot 2025-12-31 at 10 28 19@2x" src="https://github.com/user-attachments/assets/46092af5-a03d-406a-97ee-2ed370a28b86" />
<img width="922" height="480" alt="CleanShot 2025-12-31 at 10 27 49@2x" src="https://github.com/user-attachments/assets/312b74bb-fd1b-4c58-993a-cf38450d4457" />
