### PR TITLE
Avoid NoMethodError in AWS NicNexus

### DIFF
--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -123,7 +123,8 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
 
   label def attach_eip_network_interface
     eip_response = client.describe_addresses({filters: [{name: "allocation-id", values: [nic.nic_aws_resource.eip_allocation_id]}]})
-    unless eip_response.addresses.first.network_interface_id
+    nap(1) unless (address = eip_response.addresses.first)
+    unless address.network_interface_id
       client.associate_address({allocation_id: nic.nic_aws_resource.eip_allocation_id, network_interface_id: nic.nic_aws_resource.network_interface_id})
     end
     hop_wait

--- a/spec/prog/vnet/aws/nic_nexus_spec.rb
+++ b/spec/prog/vnet/aws/nic_nexus_spec.rb
@@ -179,6 +179,14 @@ RSpec.describe Prog::Vnet::Aws::NicNexus do
       expect { nx.attach_eip_network_interface }.to hop("wait")
     end
 
+    it "associates the elastic ip with the network interface if it has no addresses" do
+      expect(nic.nic_aws_resource).to receive(:eip_allocation_id).and_return("eip-0123456789abcdefg").at_least(:once)
+      client.stub_responses(:describe_addresses, addresses: [])
+      client.stub_responses(:associate_address)
+      expect(client).not_to receive(:associate_address)
+      expect { nx.attach_eip_network_interface }.to nap(1)
+    end
+
     it "skips association if elastic ip is already associated" do
       client.stub_responses(:describe_addresses, addresses: [{allocation_id: "eip-0123456789abcdefg", network_interface_id: "eni-existing"}])
       expect(client).not_to receive(:associate_address)


### PR DESCRIPTION
This should avoid an exception seen in production:

```
NoMethodError | undefined method 'network_interface_id' for nil
/app/prog/vnet/aws/nic_nexus.rb:132:in 'Prog::Vnet::Aws::NicNexus#attach_eip_network_interface'
```

I'm not sure if this is the correct behavior if there are no addresses, though. If we should wait for an address, this should be changed to nap until there is an address.