### PR TITLE
Fix per_page for redeliver webhook requests

### DIFF
--- a/prog/redeliver_github_failures.rb
+++ b/prog/redeliver_github_failures.rb
@@ -30,7 +30,7 @@ class Prog::RedeliverGithubFailures < Prog::Base
   end
 
   def failed_deliveries(since, max_page = 100)
-    all_deliveries = client.get("/app/hook/deliveries")
+    all_deliveries = client.list_app_hook_deliveries
     page = 1
     while (next_url = client.last_response.rels[:next]&.href) && (since < all_deliveries.last[:delivered_at])
       break if page >= max_page

--- a/spec/prog/redeliver_github_failures_spec.rb
+++ b/spec/prog/redeliver_github_failures_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Prog::RedeliverGithubFailures do
   describe "failed deliveries" do
     it "fetches failed deliveries" do
       # page 1
-      expect(app_client).to receive(:get).with("/app/hook/deliveries").and_return([
+      expect(app_client).to receive(:list_app_hook_deliveries).and_return([
         {guid: "1", id: "11", status: "Fail", delivered_at: time + 5},
         {guid: "2", id: "21", status: "Fail", delivered_at: time + 4},
         {guid: "3", id: "31", status: "OK", delivered_at: time + 3}
@@ -78,7 +78,7 @@ RSpec.describe Prog::RedeliverGithubFailures do
     end
 
     it "fetches failed deliveries with max page" do
-      expect(app_client).to receive(:get).with("/app/hook/deliveries").and_return([
+      expect(app_client).to receive(:list_app_hook_deliveries).and_return([
         {guid: "2", id: "21", status: "OK", delivered_at: time + 3},
         {guid: "3", id: "31", status: "Fail", delivered_at: time + 3}
       ])


### PR DESCRIPTION
I moved the per_page configuration from per-request to client-level at aaa1fc601. However, this configuration only applies when calling Octokit wrapper methods or the paginate[^1] helper, not the raw get[^2] method.

The list_app_hook_deliveries[^3] method supports auto_paginate, but since it fetches all pages until the end, it could take too long. We want to limit the maximum page count here.

By switching to the wrapper method while keeping manual pagination, we get the client-level per_page value (100) applied correctly instead of default value (30).

[^1]: https://github.com/octokit/octokit.rb/blob/ea3413c3174571e87c83d358fc893cc7613091fa/lib/octokit/connection.rb#L78
[^2]: https://github.com/octokit/octokit.rb/blob/ea3413c3174571e87c83d358fc893cc7613091fa/lib/octokit/connection.rb#L18
[^3]: https://github.com/octokit/octokit.rb/blob/ea3413c3174571e87c83d358fc893cc7613091fa/lib/octokit/client/apps.rb#L180