### PR TITLE
[destroying #5] Use destroying label in before_run

### DIFF
--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -43,7 +43,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if !%w[destroy wait_children_destroyed].include?(strand.label)
+      if !destroying_set?
         hop_destroy
       elsif strand.stack.count > 1
         pop "operation is cancelled due to the destruction of the inference endpoint replica"

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -41,7 +41,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if !%w[destroy wait_children_destroyed].include?(strand.label)
+      if !destroying_set?
         hop_destroy
       elsif strand.stack.count > 1
         pop "operation is cancelled due to the destruction of the inference router replica"

--- a/prog/ai/inference_router_target_nexus.rb
+++ b/prog/ai/inference_router_target_nexus.rb
@@ -35,7 +35,7 @@ class Prog::Ai::InferenceRouterTargetNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if strand.label != "destroy"
+      if !destroying_set?
         hop_destroy
       elsif strand.stack.count > 1
         pop "operation is cancelled due to the destruction of the inference router target"

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -166,7 +166,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "wait_vm_destroy"].include?(strand.label)
+      unless destroying_set?
         register_deadline(nil, 15 * 60)
         update_billing_record
         hop_destroy

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -62,7 +62,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if strand.label != "destroy"
+      unless destroying_set?
         kubernetes_cluster.active_billing_records.each(&:finalize)
         hop_destroy
       end

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -42,7 +42,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      if strand.label != "destroy"
+      if !destroying_set?
         hop_destroy
       elsif strand.stack.count > 1
         pop "operation is cancelled due to the destruction of the minio server"

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -5,7 +5,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "cleanup_roles"].include? strand.label
+      unless destroying_set?
         vm.active_billing_records.each(&:finalize)
         register_deadline(nil, 5 * 60)
         hop_destroy

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -32,7 +32,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      unless ["destroy", "remove_vm_from_load_balancer", "wait_vm_removal_from_load_balancer", "destroy_slice"].include? strand.label
+      unless destroying_set?
         vm.active_billing_records.each(&:finalize)
         vm.assigned_vm_address&.active_billing_record&.finalize
         register_deadline(nil, 5 * 60)

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -84,26 +84,20 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
 
   describe "#before_run" do
     it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx).to receive(:incr_destroying)
+      nx.incr_destroy
       expect { nx.before_run }.to hop("destroy")
+        .and change { Semaphore[strand_id: st.id, name: "destroying"] }.from(nil).to(be_a(Semaphore))
     end
 
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_children_destroyed state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("wait_children_destroyed")
+    it "does not hop to destroy if already destroying" do
+      nx.incr_destroy
+      nx.incr_destroying
       expect { nx.before_run }.not_to hop("destroy")
     end
 
     it "pops additional operations from stack" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      nx.incr_destroy
+      nx.incr_destroying
       expect(nx.strand.stack).to receive(:count).and_return(2)
       expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the inference endpoint replica"})
     end

--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -85,26 +85,20 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
 
   describe "#before_run" do
     it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx).to receive(:incr_destroying)
+      nx.incr_destroy
       expect { nx.before_run }.to hop("destroy")
+        .and change { Semaphore[strand_id: st.id, name: "destroying"] }.from(nil).to(be_a(Semaphore))
     end
 
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_children_destroyed state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("wait_children_destroyed")
+    it "does not hop to destroy if already destroying" do
+      nx.incr_destroy
+      nx.incr_destroying
       expect { nx.before_run }.not_to hop("destroy")
     end
 
     it "pops additional operations from stack" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      nx.incr_destroy
+      nx.incr_destroying
       expect(nx.strand.stack).to receive(:count).and_return(2)
       expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the inference router replica"})
     end

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -279,21 +279,15 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
   describe "#before_run" do
     it "hops to destroy when needed" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
+      nx.incr_destroy
       expect(nx).to receive(:register_deadline)
       expect(nx).to receive(:update_billing_record)
       expect { nx.before_run }.to hop("destroy")
     end
 
-    it "does not hop to destroy if already in the destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_vm_destroy state" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("wait_vm_destroy")
+    it "does not hop to destroy if already destroying" do
+      nx.incr_destroy
+      nx.incr_destroying
       expect { nx.before_run }.not_to hop("destroy")
     end
   end

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -156,9 +156,9 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect { nx.before_run }.to hop("destroy")
     end
 
-    it "does not hop to destroy if already in the destroy state" do
+    it "does not hop to destroy if already destroying" do
       expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      expect(nx).to receive(:destroying_set?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
     end
   end

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -386,29 +386,23 @@ RSpec.describe Prog::Minio::MinioServerNexus do
 
   describe "#before_run" do
     it "hops to destroy if strand is not destroy" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
+      nx.incr_destroy
       expect { nx.before_run }.to hop("destroy")
     end
 
-    it "does not hop to destroy if strand is destroy" do
-      nx.strand.update(label: "destroy")
+    it "does not hop to destroy if already destroying" do
+      nx.incr_destroy
+      nx.incr_destroying
       expect { nx.before_run }.not_to hop("destroy")
     end
 
     it "does not hop to destroy if destroy is not set" do
-      expect(nx).to receive(:when_destroy_set?).and_return(false)
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if strand label is destroy" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
       expect { nx.before_run }.not_to hop("destroy")
     end
 
     it "pops additional operations from stack" do
-      expect(nx).to receive(:when_destroy_set?).and_yield
-      expect(nx.strand).to receive(:label).and_return("destroy")
+      nx.incr_destroy
+      nx.incr_destroying
       expect(nx.strand.stack).to receive(:count).and_return(2)
       expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the minio server"})
     end


### PR DESCRIPTION
We now rely on the destroying semaphore to prevent multiple hops to the destroy label.

Most duplicated before_run logic has already been moved to the base prog. For the remaining cases, we can use the destroying semaphore instead of checking labels directly.