### PR TITLE
Remove unnecessary UpdateLoadBalancerNode spec

### DIFF
--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -51,10 +51,8 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
 
     balance_mode_ip4, balance_mode_ip6 = if load_balancer.algorithm == "round_robin"
       ["numgen inc", "numgen inc"]
-    elsif load_balancer.algorithm == "hash_based"
+    else # elsif load_balancer.algorithm == "hash_based"
       ["jhash ip saddr . tcp sport . ip daddr . tcp dport", "jhash ip6 saddr . tcp sport . ip6 daddr . tcp dport"]
-    else
-      fail ArgumentError, "Unsupported load balancer algorithm: #{load_balancer.algorithm}"
     end
 
     ipv4_prerouting = if load_balancer.ipv4_enabled?

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -521,11 +521,6 @@ LOAD_BALANCER
 
         expect { nx.update_load_balancer }.to exit({"msg" => "load balancer is updated"})
       end
-
-      it "raises exception if the algorithm is not supported" do
-        expect(lb).to receive(:algorithm).and_return("least_conn").at_least(:once)
-        expect { nx.update_load_balancer }.to raise_error("Unsupported load balancer algorithm: least_conn")
-      end
     end
   end
 


### PR DESCRIPTION
I assume this spec was only added for coverage, since it's impossible for the algorithm value to be least_conn. Remove unnecessary branch in the prog so this spec is not necessary for coverage.