### PR TITLE
Allow specifying private subnet name when creating PostgreSQL database in the API/CLI

### DIFF
--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -13,6 +13,7 @@ UbiCli.on("pg").run_on("create") do
     on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
     on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
     on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")
+    on("-P", "--private-subnet-name=name", "override name of created private subnet")
   end
   help_option_values("Flavor:", Option::POSTGRES_FLAVOR_OPTIONS.keys)
   help_option_values("Replication Type:", Option::POSTGRES_HA_OPTIONS.keys)

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -14,6 +14,7 @@ class Clover
     pgbouncer_user_config = typecast_params.Hash("pgbouncer_config", {})
     tags = typecast_params.array(:Hash, "tags", [])
     with_firewall_rules = !typecast_params.bool("restrict_by_default")
+    private_subnet_name = typecast_params.nonempty_str("private_subnet_name") if api?
 
     postgres_params = {
       "flavor" => flavor,
@@ -56,6 +57,7 @@ class Clover
         ha_type:,
         with_firewall_rules:,
         flavor:,
+        private_subnet_name:,
         user_config:,
         pgbouncer_user_config:
       ).subject

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -994,6 +994,9 @@ paths:
                 restrict_by_default:
                   description: 'Whether to restrict access by default (if so, firewall rules must be added to access)'
                   type: boolean
+                private_subnet_name:
+                  description: 'Name for the private subnet (if not provided, a name will be auto-generated)'
+                  type: string
                 pg_config:
                   type: object
                   example:

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
   def self.assemble(project_id:, location_id:, name:, target_vm_size:, target_storage_size_gib:,
     target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
-    ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true, user_config: {}, pgbouncer_user_config: {})
+    ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true, user_config: {}, pgbouncer_user_config: {}, private_subnet_name: nil)
 
     unless Project[project_id]
       fail "No existing project"
@@ -56,7 +56,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       # Customer firewall, will be attached to created customer subnet
       firewall = Firewall.create(name: "#{postgres_resource.ubid}-firewall", location_id: location.id, description: "Firewall for PostgreSQL database #{postgres_resource.name}", project_id:)
-      private_subnet = Prog::Vnet::SubnetNexus.assemble(project_id, name: "#{postgres_resource.ubid}-subnet", location_id: location.id, firewall_id: firewall.id).subject
+      subnet_name = private_subnet_name || "#{postgres_resource.ubid}-subnet"
+      private_subnet = Prog::Vnet::SubnetNexus.assemble(project_id, name: subnet_name, location_id: location.id, firewall_id: firewall.id).subject
       private_subnet_id = private_subnet.id
       postgres_resource.update(private_subnet_id:)
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -598,6 +598,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -44,4 +44,15 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.tags).to eq([{"key" => "foo", "value" => "bar"}, {"key" => "baz", "value" => "quux"}])
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end
+
+  it "creates PostgreSQL database with custom private subnet name" do
+    expect(PostgresResource.count).to eq 0
+    body = cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64 -P my-custom-subnet])
+    expect(PostgresResource.count).to eq 1
+    pg = PostgresResource.first
+    expect(pg).to be_a PostgresResource
+    expect(pg.name).to eq "test-pg"
+    expect(pg.private_subnet.name).to eq "my-custom-subnet"
+    expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
+  end
 end


### PR DESCRIPTION
This makes things simpler for the API/CLI user. Before, they could rename the created private subnet, but doing so requires knowing the ubid of the created postgres resource, which makes it more challenging to script. This allows for specifying the name up front, so that after creation, you can add firewalls directly to it without parsing the output from other requests/commands.

Mostly written by Claude Code using the following prompt:

```
Add support for accepting a private subnet name when creating a
postgres resource

* Update assemble in prog/postgres/postgres_resource_nexus.rb to
  accept private subnet name
* Update helpers/postgres.rb to pass private subnet name when calling
  subnet name, for api requests and not web resources.
* Update openapi/openapi.yml to accept private subnet name when
  creating a postgres database
* Update cli-commands/pg/post/create.rb to accept an option to specify
  the private subnet name
* Update spec/routes/api/cli/pg/create_spec.rb to pass the option to
  specify the private subnet name, and check that the created private
  subnet has that name.
```

I changed the CLI option from `-n` to `-P`, and did some minor refactoring.