### PR TITLE
No customer firewall for PG creation through api

### DIFF
--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -27,7 +27,19 @@ UbiCli.on("pg").run_on("create") do
     pg_tags_to_hash(params, cmd)
     params_to_hash(params, :pg_config, "config", cmd)
     params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
-    id = sdk.postgres.create(location: @location, name: @name, **params).id
-    response("PostgreSQL database created with id: #{id}")
+    pg = sdk.postgres.create(location: @location, name: @name, **params)
+
+    ps_name = params[:private_subnet_name] || "#{pg.id}-subnet"
+    response(<<END)
+PostgreSQL database created with id: #{pg.id}
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw #{@location}/YOUR-FIREWALL-NAME create
+  ubi fw #{@location}/YOUR-FIREWALL-NAME attach-subnet #{ps_name}
+  ubi fw #{@location}/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW
+END
   end
 end

--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -12,7 +12,7 @@ UbiCli.on("pg").run_on("create") do
     on("-c", "--pg-config=config", "postgres config (e.g key1=value1,key2=value2)")
     on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
     on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
-    on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")
+    on("-R", "--restrict-by-default", "ignored (deprecated)")
     on("-P", "--private-subnet-name=name", "override name of created private subnet")
   end
   help_option_values("Flavor:", Option::POSTGRES_FLAVOR_OPTIONS.keys)
@@ -23,6 +23,7 @@ UbiCli.on("pg").run_on("create") do
 
   run do |opts, cmd|
     params = underscore_keys(opts[:pg_create])
+    params.delete(:restrict_by_default)
     pg_tags_to_hash(params, cmd)
     params_to_hash(params, :pg_config, "config", cmd)
     params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)

--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -13,6 +13,7 @@ UbiCli.on("pg").run_on("create") do
     on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
     on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
     on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")
+    on("-P", "--private-subnet-name=name", "override name of created private subnet")
   end
   help_option_values("Flavor:", Option::POSTGRES_FLAVOR_OPTIONS.keys)
   help_option_values("Replication Type:", Option::POSTGRES_HA_OPTIONS.keys)

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -14,6 +14,7 @@ class Clover
     pgbouncer_user_config = typecast_params.Hash("pgbouncer_config", {})
     tags = typecast_params.array(:Hash, "tags", [])
     with_firewall_rules = !typecast_params.bool("restrict_by_default")
+    private_subnet_name = typecast_params.nonempty_str("private_subnet_name") if api?
 
     postgres_params = {
       "flavor" => flavor,
@@ -56,6 +57,7 @@ class Clover
         ha_type:,
         with_firewall_rules:,
         flavor:,
+        private_subnet_name:,
         user_config:,
         pgbouncer_user_config:
       ).subject

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -13,7 +13,7 @@ class Clover
     user_config = typecast_params.Hash("pg_config", {})
     pgbouncer_user_config = typecast_params.Hash("pgbouncer_config", {})
     tags = typecast_params.array(:Hash, "tags", [])
-    with_firewall_rules = !typecast_params.bool("restrict_by_default")
+    with_firewall_rules = !api?
     private_subnet_name = typecast_params.nonempty_str("private_subnet_name") if api?
 
     postgres_params = {

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -994,6 +994,9 @@ paths:
                 restrict_by_default:
                   description: 'Whether to restrict access by default (if so, firewall rules must be added to access)'
                   type: boolean
+                private_subnet_name:
+                  description: 'Name for the private subnet (if not provided, a name will be auto-generated)'
+                  type: string
                 pg_config:
                   type: object
                   example:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -992,7 +992,7 @@ paths:
                   description: PostgreSQL version
                   type: string
                 restrict_by_default:
-                  description: 'Whether to restrict access by default (if so, firewall rules must be added to access)'
+                  description: ignored (deprecated)
                   type: boolean
                 private_subnet_name:
                   description: 'Name for the private subnet (if not provided, a name will be auto-generated)'

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -13,7 +13,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
   def self.assemble(project_id:, location_id:, name:, target_vm_size:, target_storage_size_gib:,
     target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
-    ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true, user_config: {}, pgbouncer_user_config: {})
+    ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true, user_config: {}, pgbouncer_user_config: {}, private_subnet_name: nil)
 
     unless Project[project_id]
       fail "No existing project"
@@ -56,7 +56,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       # Customer firewall, will be attached to created customer subnet
       firewall = Firewall.create(name: "#{postgres_resource.ubid}-firewall", location_id: location.id, description: "Firewall for PostgreSQL database #{postgres_resource.name}", project_id:)
-      private_subnet = Prog::Vnet::SubnetNexus.assemble(project_id, name: "#{postgres_resource.ubid}-subnet", location_id: location.id, firewall_id: firewall.id).subject
+      subnet_name = private_subnet_name || "#{postgres_resource.ubid}-subnet"
+      private_subnet = Prog::Vnet::SubnetNexus.assemble(project_id, name: subnet_name, location_id: location.id, firewall_id: firewall.id).subject
       private_subnet_id = private_subnet.id
       postgres_resource.update(private_subnet_id:)
 

--- a/spec/routes/api/cli/golden-files/fw list -N.txt
+++ b/spec/routes/api/cli/golden-files/fw list -N.txt
@@ -1,4 +1,4 @@
 eu-central-h1  default-eu-central-h1-default        fw4gj2v4h1fe3q28q0hnf7g8n1
+eu-central-h1  pgvm1qb9gwct1mqmay7m54yma5-firewall  fw62hyxjdfpp0qetrd4ejabqg7
 eu-central-h1  kcnzrctjjg4j4g6eqvdsvzthwp-firewall  fwgm7nd1rtet6h54t25c2dmgee
 eu-central-h1  test-ps-default                      fwx623er9tyy2q9n1e2c55kvkc
-eu-central-h1  pgvm1qb9gwct1mqmay7m54yma5-firewall  fwytb5erseje6gfxaqrjy6a3hd

--- a/spec/routes/api/cli/golden-files/fw list -l eu-central-h1 -N -f name,id.txt
+++ b/spec/routes/api/cli/golden-files/fw list -l eu-central-h1 -N -f name,id.txt
@@ -1,4 +1,4 @@
 default-eu-central-h1-default        fw4gj2v4h1fe3q28q0hnf7g8n1
+pgvm1qb9gwct1mqmay7m54yma5-firewall  fw62hyxjdfpp0qetrd4ejabqg7
 kcnzrctjjg4j4g6eqvdsvzthwp-firewall  fwgm7nd1rtet6h54t25c2dmgee
 test-ps-default                      fwx623er9tyy2q9n1e2c55kvkc
-pgvm1qb9gwct1mqmay7m54yma5-firewall  fwytb5erseje6gfxaqrjy6a3hd

--- a/spec/routes/api/cli/golden-files/fw list -l eu-central-h1 -f name,id.txt
+++ b/spec/routes/api/cli/golden-files/fw list -l eu-central-h1 -f name,id.txt
@@ -1,5 +1,5 @@
 name                                 id                        
 default-eu-central-h1-default        fw4gj2v4h1fe3q28q0hnf7g8n1
+pgvm1qb9gwct1mqmay7m54yma5-firewall  fw62hyxjdfpp0qetrd4ejabqg7
 kcnzrctjjg4j4g6eqvdsvzthwp-firewall  fwgm7nd1rtet6h54t25c2dmgee
 test-ps-default                      fwx623er9tyy2q9n1e2c55kvkc
-pgvm1qb9gwct1mqmay7m54yma5-firewall  fwytb5erseje6gfxaqrjy6a3hd

--- a/spec/routes/api/cli/golden-files/fw list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/fw list -l eu-central-h1.txt
@@ -1,5 +1,5 @@
 location       name                                 id                        
 eu-central-h1  default-eu-central-h1-default        fw4gj2v4h1fe3q28q0hnf7g8n1
+eu-central-h1  pgvm1qb9gwct1mqmay7m54yma5-firewall  fw62hyxjdfpp0qetrd4ejabqg7
 eu-central-h1  kcnzrctjjg4j4g6eqvdsvzthwp-firewall  fwgm7nd1rtet6h54t25c2dmgee
 eu-central-h1  test-ps-default                      fwx623er9tyy2q9n1e2c55kvkc
-eu-central-h1  pgvm1qb9gwct1mqmay7m54yma5-firewall  fwytb5erseje6gfxaqrjy6a3hd

--- a/spec/routes/api/cli/golden-files/fw list.txt
+++ b/spec/routes/api/cli/golden-files/fw list.txt
@@ -1,5 +1,5 @@
 location       name                                 id                        
 eu-central-h1  default-eu-central-h1-default        fw4gj2v4h1fe3q28q0hnf7g8n1
+eu-central-h1  pgvm1qb9gwct1mqmay7m54yma5-firewall  fw62hyxjdfpp0qetrd4ejabqg7
 eu-central-h1  kcnzrctjjg4j4g6eqvdsvzthwp-firewall  fwgm7nd1rtet6h54t25c2dmgee
 eu-central-h1  test-ps-default                      fwx623er9tyy2q9n1e2c55kvkc
-eu-central-h1  pgvm1qb9gwct1mqmay7m54yma5-firewall  fwytb5erseje6gfxaqrjy6a3hd

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -597,7 +597,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -598,6 +598,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule 1.2.3.0_24.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg add-firewall-rule 1.2.3.0_24.txt
@@ -1,4 +1,4 @@
 Firewall rule added to PostgreSQL database.
-  rule id: fr5mf40qkedy0hm80v7pp95qwp
+  rule id: frdncgte2zh25pvc0m1wy3hgvc
   cidr: 1.2.3.0/24
   description: ""

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f firewall-rules,metric-destinations,ca-certificates.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show -f firewall-rules,metric-destinations,ca-certificates.txt
@@ -1,8 +1,5 @@
 firewall-rules:
   1: frpqgkgjd09y4pnjaq2pkeacam  0.0.0.0/0  5432  pg-fw-desc
-  2: frwhnrpxm8wa4jwnpj8hjd6ehc  0.0.0.0/0  6432  
-  3: frw2040y4rsy2qxt70bp95j8yg  ::/0  5432  
-  4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
 metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
 ca-certificates:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show.txt
@@ -20,9 +20,6 @@ tags:
   foo: bar
 firewall-rules:
   1: frpqgkgjd09y4pnjaq2pkeacam  0.0.0.0/0  5432  pg-fw-desc
-  2: frwhnrpxm8wa4jwnpj8hjd6ehc  0.0.0.0/0  6432  
-  3: frw2040y4rsy2qxt70bp95j8yg  ::/0  5432  
-  4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
 metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
 read-replicas:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
@@ -14,7 +14,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
@@ -14,7 +14,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f paradedb.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f paradedb.txt
@@ -1,1 +1,9 @@
 PostgreSQL database created with id: pgjzngmxvrd63kq5t8s0pvq2wk
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME create
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME attach-subnet pgjzngmxvrd63kq5t8s0pvq2wk-subnet
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
@@ -14,7 +14,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h sync.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h sync.txt
@@ -1,1 +1,9 @@
 PostgreSQL database created with id: pgjzngmxvrd63kq5t8s0pvq2wk
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME create
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME attach-subnet pgjzngmxvrd63kq5t8s0pvq2wk-subnet
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
@@ -14,7 +14,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v 17.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v 17.txt
@@ -1,1 +1,9 @@
 PostgreSQL database created with id: pgjzngmxvrd63kq5t8s0pvq2wk
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME create
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME attach-subnet pgjzngmxvrd63kq5t8s0pvq2wk-subnet
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
@@ -14,7 +14,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64.txt
@@ -1,1 +1,9 @@
 PostgreSQL database created with id: pgjzngmxvrd63kq5t8s0pvq2wk
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME create
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME attach-subnet pgjzngmxvrd63kq5t8s0pvq2wk-subnet
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
@@ -14,7 +14,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-4 -S 128.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-4 -S 128.txt
@@ -1,1 +1,9 @@
 PostgreSQL database created with id: pgjzngmxvrd63kq5t8s0pvq2wk
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME create
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME attach-subnet pgjzngmxvrd63kq5t8s0pvq2wk-subnet
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
@@ -14,7 +14,7 @@ Options:
     -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
-    -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -R, --restrict-by-default        ignored (deprecated)
     -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
@@ -15,6 +15,7 @@ Options:
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)
+    -P, --private-subnet-name=name   override name of created private subnet
 
 Allowed Option Values:
     Flavor: standard paradedb lantern

--- a/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
+++ b/spec/routes/api/cli/golden-files/pg pgvm1qb9gwct1mqmay7m54yma5 show.txt
@@ -20,9 +20,6 @@ tags:
   foo: bar
 firewall-rules:
   1: frpqgkgjd09y4pnjaq2pkeacam  0.0.0.0/0  5432  pg-fw-desc
-  2: frwhnrpxm8wa4jwnpj8hjd6ehc  0.0.0.0/0  6432  
-  3: frw2040y4rsy2qxt70bp95j8yg  ::/0  5432  
-  4: frtrp88sbzke2mn45n1vj6mmrh  ::/0  6432  
 metric-destinations:
   1: md8ntmx8e1764nwc7p970vf3xw  foo  https://baz.example.com
 read-replicas:

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Clover, "cli" do
     expect(PrivateSubnet).to receive(:generate_ubid).and_return(UBID.parse("psfzm9e26xky5m9ggetw4dpqe2"))
     expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("nc69z0cda8jt0g5b120hamn4vf"), UBID.parse("nchfcq5bmsae7mc7bm6nx82d2n"))
     expect(Firewall).to receive(:generate_uuid).and_return("24242d92-217b-85fc-b891-7046af3c1150", "f6965763-2e93-8dfc-83fa-abe25e328716")
-    expect(FirewallRule).to receive(:generate_uuid).and_return("51e5bc7d-245b-8df8-bf91-7c5d150cb160", "3b367895-7f18-89f8-a295-ff247e9d5192", "305d838d-a3cd-85f8-aa08-9a66e71a5877", "5aa5b086-37bd-81f8-8d03-dd4b0e09a436", "20c360fa-bc06-8df8-b067-33f4a1ebdbbd", "2b628450-25bd-8df8-8b42-fb5cc5d01ad1", "da42e2ef-b5f1-8df8-966d-1387afb1b2f4", "bc9b093a-0e00-89f8-991a-5e0cd15a7942", "b5e13849-a04f-89f8-b564-ab8ad37298aa", "e46b8b76-88e2-89f8-972b-692232699d16", "e0804078-98cf-85f8-bf74-702ec92c91e8", "d62c8465-7f9b-85f8-a548-5a8772352988", "ff48a299-529c-8df8-993a-ddb0450be4a4", "ce327a30-12cb-8df8-86c3-d2db53a4b837")
+    expect(FirewallRule).to receive(:generate_uuid).and_return("51e5bc7d-245b-8df8-bf91-7c5d150cb160", "3b367895-7f18-89f8-a295-ff247e9d5192", "305d838d-a3cd-85f8-aa08-9a66e71a5877", "5aa5b086-37bd-81f8-8d03-dd4b0e09a436", "20c360fa-bc06-8df8-b067-33f4a1ebdbbd", "2b628450-25bd-8df8-8b42-fb5cc5d01ad1", "da42e2ef-b5f1-8df8-966d-1387afb1b2f4", "bc9b093a-0e00-89f8-991a-5e0cd15a7942", "b5e13849-a04f-89f8-b564-ab8ad37298aa", "ff48a299-529c-8df8-993a-ddb0450be4a4", "ce327a30-12cb-8df8-86c3-d2db53a4b837")
     expect(PostgresResource).to receive(:generate_uuid).and_return("dd0375a6-1c66-82d0-a5e8-af1e8527a8a2")
     expect(PostgresMetricDestination).to receive(:generate_uuid).and_return("45754ea1-c139-8a8d-af18-7b24e0dbc7de")
     SshPublicKey.create_with_id("32092997-2a00-8f33-8129-4c0f18e5153c", project_id: @project.id, name: "spk", public_key: "a a")
@@ -47,6 +47,9 @@ RSpec.describe Clover, "cli" do
 
     cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64 -t foo=bar -v 16])
     pg = PostgresResource.first(name: "test-pg")
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall create])
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall attach-subnet #{pg.ubid}-subnet])
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall add-rule -d pg-fw-desc -s 5432 0.0.0.0/0])
     pg.pg_firewall_rules.find { it.ubid == "frpqgkgjd09y4pnjaq2pkeacam" }.update(description: "pg-fw-desc")
     pg.update(user_config: {allow_in_place_tablespaces: "on", max_connections: "1000"}, pgbouncer_user_config: {server_round_robin: "1", disable_pqexec: "1"})
     pg.representative_server.vm.add_vm_storage_volume(boot: false, size_gib: 64, disk_index: 0)

--- a/spec/routes/api/cli/pg/add-firewall-rule_spec.rb
+++ b/spec/routes/api/cli/pg/add-firewall-rule_spec.rb
@@ -5,31 +5,29 @@ require_relative "../spec_helper"
 RSpec.describe Clover, "cli pg add-firewall-rule" do
   before do
     expect(Config).to receive(:postgres_service_project_id).and_return(@project.id).at_least(:once)
+    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64 -P ps])
+    @pg = PostgresResource.first
+    cli(%W[fw eu-central-h1/#{@pg.ubid}-firewall create])
+    cli(%W[fw eu-central-h1/#{@pg.ubid}-firewall attach-subnet ps])
   end
 
   it "adds a firewall rule to the database" do
-    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64])
-    pg = PostgresResource.first
-    expect(pg.pg_firewall_rules.map { it.cidr.to_s }.uniq).to eq %w[0.0.0.0/0 ::/0]
     expect(cli(%w[pg eu-central-h1/test-pg add-firewall-rule 1.2.3.0/24])).to eq <<~END
       Firewall rule added to PostgreSQL database.
-        rule id: #{pg.pg_firewall_rules.find { it.cidr.to_s == "1.2.3.0/24" && it.port_range.begin == 5432 }.ubid}
+        rule id: #{@pg.pg_firewall_rules.find { it.cidr.to_s == "1.2.3.0/24" && it.port_range.begin == 5432 }.ubid}
         cidr: 1.2.3.0/24
         description: ""
     END
-    expect(pg.pg_firewall_rules.map { it.cidr.to_s }.uniq).to eq %w[0.0.0.0/0 1.2.3.0/24 ::/0]
+    expect(@pg.pg_firewall_rules.map { [it.cidr.to_s, it.description] }.uniq).to eq [["1.2.3.0/24", nil]]
   end
 
-  it "ignores description when adding rule" do
-    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64])
-    pg = PostgresResource.first
-    expect(pg.pg_firewall_rules.map { it.cidr.to_s }.uniq).to eq %w[0.0.0.0/0 ::/0]
+  it "considers description when adding rule" do
     expect(cli(%w[pg eu-central-h1/test-pg add-firewall-rule -d] << "Example description" << "1.2.3.0/24")).to eq <<~END
       Firewall rule added to PostgreSQL database.
-        rule id: #{pg.pg_firewall_rules.find { it.cidr.to_s == "1.2.3.0/24" && it.port_range.begin == 5432 }.ubid}
+        rule id: #{@pg.pg_firewall_rules.find { it.cidr.to_s == "1.2.3.0/24" && it.port_range.begin == 5432 }.ubid}
         cidr: 1.2.3.0/24
         description: "Example description"
     END
-    expect(pg.pg_firewall_rules.map { it.cidr.to_s }.uniq).to eq %w[0.0.0.0/0 1.2.3.0/24 ::/0]
+    expect(@pg.pg_firewall_rules.map { [it.cidr.to_s, it.description] }.uniq).to eq [%w[1.2.3.0/24 Example\ description]]
   end
 end

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.ha_type).to eq "none"
     expect(pg.version).to eq "17"
     expect(pg.flavor).to eq "standard"
-    expect(pg.pg_firewall_rules_dataset.count).to eq 4
+    expect(pg.customer_firewall).to be_nil
     expect(pg.tags).to eq([])
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end
@@ -40,7 +40,7 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.user_config).to eq({"max_connections" => "100", "wal_level" => "logical"})
     expect(pg.pgbouncer_user_config).to eq({"max_client_conn" => "100"})
     expect(pg.flavor).to eq "paradedb"
-    expect(pg.pg_firewall_rules_dataset.count).to eq 0
+    expect(pg.customer_firewall).to be_nil
     expect(pg.tags).to eq([{"key" => "foo", "value" => "bar"}, {"key" => "baz", "value" => "quux"}])
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end
@@ -52,6 +52,7 @@ RSpec.describe Clover, "cli pg create" do
     pg = PostgresResource.first
     expect(pg).to be_a PostgresResource
     expect(pg.name).to eq "test-pg"
+    expect(pg.customer_firewall).to be_nil
     expect(pg.private_subnet.name).to eq "my-custom-subnet"
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -22,7 +22,17 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.flavor).to eq "standard"
     expect(pg.customer_firewall).to be_nil
     expect(pg.tags).to eq([])
-    expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
+    expect(body).to eq <<END
+PostgreSQL database created with id: #{pg.ubid}
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME create
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME attach-subnet #{pg.ubid}-subnet
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW
+END
   end
 
   it "creates PostgreSQL database with all options" do
@@ -42,7 +52,7 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.flavor).to eq "paradedb"
     expect(pg.customer_firewall).to be_nil
     expect(pg.tags).to eq([{"key" => "foo", "value" => "bar"}, {"key" => "baz", "value" => "quux"}])
-    expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
+    expect(body).to include "PostgreSQL database created with id: #{pg.ubid}\n"
   end
 
   it "creates PostgreSQL database with custom private subnet name" do
@@ -54,6 +64,16 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.name).to eq "test-pg"
     expect(pg.customer_firewall).to be_nil
     expect(pg.private_subnet.name).to eq "my-custom-subnet"
-    expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
+    expect(body).to eq <<END
+PostgreSQL database created with id: #{pg.ubid}
+
+No access is allowed to this database by default. To allow access, create a
+firewall, attach it to the database's private subnet, and add firewall rules
+to the firewall:
+
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME create
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME attach-subnet my-custom-subnet
+  ubi fw eu-central-h1/YOUR-FIREWALL-NAME add-rule -s 5432 CIDR-TO-ALLOW
+END
   end
 end

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -44,4 +44,15 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.tags).to eq([{"key" => "foo", "value" => "bar"}, {"key" => "baz", "value" => "quux"}])
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end
+
+  it "creates PostgreSQL database with custom private subnet name" do
+    expect(PostgresResource.count).to eq 0
+    body = cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64 -P my-custom-subnet])
+    expect(PostgresResource.count).to eq 1
+    pg = PostgresResource.first
+    expect(pg).to be_a PostgresResource
+    expect(pg.name).to eq "test-pg"
+    expect(pg.private_subnet.name).to eq "my-custom-subnet"
+    expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
+  end
 end

--- a/spec/routes/api/cli/pg/delete-firewall-rule_spec.rb
+++ b/spec/routes/api/cli/pg/delete-firewall-rule_spec.rb
@@ -8,11 +8,14 @@ RSpec.describe Clover, "cli pg delete-firewall-rule" do
   end
 
   it "deletes the specified firewall rule for the database" do
-    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64])
+    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64 -P ps])
     pg = PostgresResource.first
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall create])
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall attach-subnet ps])
     expect(cli(%w[pg eu-central-h1/test-pg delete-firewall-rule a/b], status: 400)).to start_with "! Invalid firewall rule id format\n"
+    cli(%w[pg eu-central-h1/test-pg add-firewall-rule 1.2.3.0/24])
     all = pg.pg_firewall_rules
-    expect(all.length).to eq 4
+    expect(all.length).to eq 2
     fwr = all.shift
     expect(cli(%W[pg eu-central-h1/test-pg delete-firewall-rule #{fwr.ubid}])).to eq "Firewall rule, if it exists, has been scheduled for deletion\n"
     expect(pg.pg_firewall_rules_dataset.select_map(:id)).to eq all.map(&:id)

--- a/spec/routes/api/cli/pg/modify-firewall-rule_spec.rb
+++ b/spec/routes/api/cli/pg/modify-firewall-rule_spec.rb
@@ -8,9 +8,12 @@ RSpec.describe Clover, "cli pg modify-firewall-rule" do
   end
 
   it "modifies the cidr for the specified firewall rule for the database" do
-    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64])
+    cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64 -P ps])
     pg = PostgresResource.first
-    fwr = pg.pg_firewall_rules.find { it.cidr.to_s == "0.0.0.0/0" && it.port_range.begin == 5432 }
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall create])
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall attach-subnet ps])
+    cli(%W[fw eu-central-h1/#{pg.ubid}-firewall add-rule -s 5432 0.0.0.0/0])
+    fwr = pg.customer_firewall.firewall_rules.first
     expect(cli(%w[pg eu-central-h1/test-pg modify-firewall-rule -c 1.2.3.0/24 a/b], status: 400)).to start_with "! Invalid firewall rule id format\n"
     expect(fwr.reload.cidr.to_s).to eq "0.0.0.0/0"
     expect(cli(%W[pg eu-central-h1/test-pg modify-firewall-rule -c 1.2.3.0/24 #{fwr.ubid}])).to eq "PostgreSQL database firewall rule modified.\n  rule id: #{fwr.ubid}\n  cidr: 1.2.3.0/24\n  description: \"\"\n"


### PR DESCRIPTION
This changes the API/CLI so that creating a PostgreSQL database no longer creates a customer firewall. Previously, a customer firewall was also created, even if the `-R`/`restrict_by_default` option was used to not have any firewall rules created.

This breaks backwards compatibility. In order for PostgreSQL database creation via API/CLI to allow connections, customers must use the API/CLI to also attach a firewall with appropriate rules to the database's private subnet.

This is a trade-off. It makes it easier to use custom firewall rules. Previously, you would have to parse output from previous CLI commands or API responses to get the firewall name to use. However, this requries additional commands for the basic PostgreSQL database setup to work, since by default, no database access will be allowed until a firewall is manually created, attached to the private subnet, and has appropriate rules added to it. It also makes creation via web have different behavior than creation via api.

The previous `-R`/`restrict_by_default` options are now soft-deprecated. No warnings are displayed, but the documentation and CLI help now show the options as deprecated.

This does not add an API or CLI option to get the previous behavior of creating a customer firewall with the private subnet with open 5432/6432 firewall rules.

This makes the Postgres-level firewall rule commands pretty much pointless for new PostgreSQL databases created via the API/CLI, since those commands require a customer firewall to work. So unless the user manually creates a firewall with the ubid-prefixed name, they won't work.

The Prog::Postgres::PostgresResourceNexus.assemble with_firewall_rules argument now controls whether a firewall is added, instead of whether rules are added to the created firewall. The
Prog::Vnet::SubnetNexus.assemble method now accepts a no_firewall argument, which if set, will not create a Firewall.