### PR TITLE
Observe archival backlog and page if it exceeds threshold (try 2)

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -278,6 +278,22 @@ class PostgresServer < Sequel::Model
     vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: query).chomp
   end
 
+  def export_metrics(session:, tsdb_client:)
+    session[:export_count] ||= 0
+    session[:export_count] += 1
+
+    # Check archival backlog every 12 exports (similar to pulse check frequency)
+    # We do this in metrics export rather than pulse check because the metrics
+    # export session does not use an event loop. Calling exec! on an SSH session
+    # with an active event loop is not thread-safe and leads to stuck sessions.
+    if session[:export_count] % 12 == 1
+      observe_archival_backlog(session)
+    end
+
+    # Call parent implementation to export actual metrics
+    super
+  end
+
   def metrics_config
     ignored_timeseries_patterns = [
       "pg_stat_user_tables_.*",
@@ -321,6 +337,35 @@ class PostgresServer < Sequel::Model
     walg_config = timeline.generate_walg_config(version)
     vm.sshable.cmd("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: walg_config)
     refresh_walg_blob_storage_credentials
+  end
+
+  def observe_archival_backlog(session)
+    result = session[:ssh_session].exec!(
+      "sudo find /dat/:version/data/pg_wal/archive_status -name '*.ready' | wc -l",
+      version:
+    )
+    archival_backlog = Integer(result.strip, 10)
+
+    if archival_backlog > archival_backlog_threshold
+      Prog::PageNexus.assemble("#{ubid} archival backlog high",
+        ["PGArchivalBacklogHigh", id], ubid,
+        severity: "warning", extra_data: {archival_backlog:})
+    else
+      Page.from_tag_parts("PGArchivalBacklogHigh", id)&.incr_resolve
+    end
+  rescue => ex
+    Clog.emit("Failed to observe archival backlog") do
+      {postgres_server_id: id, exception: Util.exception_to_hash(ex)}
+    end
+  end
+
+  def archival_backlog_threshold
+    # To make the threshold adaptive to storage size, we set it as percent of
+    # the storage size as WAL file count based on the allocated storage size,
+    # capped to 1000 to avoid high thresholds on large storage sizes.
+    archival_backlog_threshold_percent = 5
+    archival_backlog_threshold_count = 1000
+    [(storage_size_gib * 1024 / (16 * 100)) * archival_backlog_threshold_percent, archival_backlog_threshold_count].min
   end
 
   FAILOVER_LABELS = ["prepare_for_unplanned_take_over", "prepare_for_planned_take_over", "wait_fencing_of_old_primary", "taking_over"].freeze

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MonitorableResource do
       expect(session[:ssh_session]).to receive(:close)
       expect(Thread).to receive(:new).and_call_original
       expect(session[:ssh_session]).to receive(:loop).and_raise(StandardError)
-      expect(Clog).to receive(:emit).twice.and_call_original
+      expect(Clog).to receive(:emit).at_least(:once).and_call_original
       r_w_event_loop.check_pulse
     end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -533,6 +533,106 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "#export_metrics" do
+    let(:session) { {ssh_session: Net::SSH::Connection::Session.allocate} }
+    let(:tsdb_client) { instance_double(VictoriaMetrics::Client) }
+
+    it "calls observe_archival_backlog at every 12th export" do
+      session[:export_count] = 12
+      allow(postgres_server).to receive(:scrape_endpoints).and_return([])
+      expect(postgres_server).to receive(:observe_archival_backlog).with(session)
+
+      postgres_server.export_metrics(session:, tsdb_client:)
+    end
+
+    it "does not call observe_archival_backlog on every export" do
+      session[:export_count] = 2
+      allow(postgres_server).to receive(:scrape_endpoints).and_return([])
+      expect(postgres_server).not_to receive(:observe_archival_backlog).with(session)
+
+      postgres_server.export_metrics(session:, tsdb_client:)
+    end
+
+    it "increments export_count in session" do
+      allow(postgres_server).to receive(:observe_archival_backlog).with(session)
+      allow(postgres_server).to receive(:scrape_endpoints).and_return([])
+
+      expect(session[:export_count]).to be_nil
+      postgres_server.export_metrics(session:, tsdb_client:)
+      expect(session[:export_count]).to eq(1)
+
+      postgres_server.export_metrics(session:, tsdb_client:)
+      expect(session[:export_count]).to eq(2)
+    end
+  end
+
+  describe "#observe_archival_backlog" do
+    let(:session) {
+      {ssh_session: Net::SSH::Connection::Session.allocate}
+    }
+
+    before do
+      allow(postgres_server).to receive(:archival_backlog_threshold).and_return(10)
+    end
+
+    it "checks archival backlog and does nothing if it is within limits" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "sudo find /dat/16/data/pg_wal/archive_status -name '*.ready' | wc -l"
+      ).and_return("5\n")
+      expect(Prog::PageNexus).not_to receive(:assemble)
+      expect(Page).to receive(:from_tag_parts).with("PGArchivalBacklogHigh", postgres_server.id).and_return(nil)
+
+      postgres_server.observe_archival_backlog(session)
+    end
+
+    it "checks archival backlog and creates a page if it is outside of limits" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "sudo find /dat/16/data/pg_wal/archive_status -name '*.ready' | wc -l"
+      ).and_return("15\n")
+      expect(Prog::PageNexus).to receive(:assemble).with(
+        "#{postgres_server.ubid} archival backlog high",
+        ["PGArchivalBacklogHigh", postgres_server.id],
+        postgres_server.ubid,
+        severity: "warning",
+        extra_data: {archival_backlog: 15}
+      )
+
+      postgres_server.observe_archival_backlog(session)
+    end
+
+    it "checks archival backlog and resolves a page if it is back within limits" do
+      existing_page = instance_double(Page)
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "sudo find /dat/16/data/pg_wal/archive_status -name '*.ready' | wc -l"
+      ).and_return("3\n")
+      expect(Page).to receive(:from_tag_parts).with("PGArchivalBacklogHigh", postgres_server.id).and_return(existing_page)
+      expect(existing_page).to receive(:incr_resolve)
+
+      postgres_server.observe_archival_backlog(session)
+    end
+
+    it "logs errors when checking archival backlog fails" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "sudo find /dat/16/data/pg_wal/archive_status -name '*.ready' | wc -l"
+      ).and_raise(Net::SSH::Exception.new("SSH error"))
+      expect(Clog).to receive(:emit).with("Failed to observe archival backlog").and_call_original
+
+      postgres_server.observe_archival_backlog(session)
+    end
+  end
+
+  describe "#archival_backlog_threshold" do
+    it "returns 1000 if the storage size is large" do
+      allow(postgres_server).to receive(:storage_size_gib).and_return(1024)
+      expect(postgres_server.archival_backlog_threshold).to eq(1000)
+    end
+
+    it "returns smaller threshold for smaller storage sizes" do
+      allow(postgres_server).to receive(:storage_size_gib).and_return(100)
+      expect(postgres_server.archival_backlog_threshold).to eq(320)
+    end
+  end
+
   if Config.unfrozen_test?
     describe "#attach_s3_policy_if_needed" do
       it "calls attach_role_policy when needs s3 policy attachment" do


### PR DESCRIPTION
Add an SSH call to count the number of WAL files ready to be archived and raise a Page if it exceeds a threshold. In the previous attempt, this was added to pulse_check, which caused a problem. Since postgres server pulse checks require an event loop, running exec! on the same session is not safe, and can cause state corruption which lead to stuck SSH sessions. In this attempt, we move the backlog check to the metrics export path.