### PR TITLE
[destroying #7] Pop strand in before_run when prog lacks destroy label

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -76,12 +76,16 @@ end
   end
 
   def before_run
-    if defined?(hop_destroy)
+    if defined?(destroy_set?)
       unless destroying_set?
         fail "BUG: destroying semaphore not set on destroy label" if @strand.label == "destroy"
         if destroy_set?
           send(:before_destroy) if respond_to?(:before_destroy)
-          hop_destroy
+          if defined?(hop_destroy)
+            hop_destroy
+          else
+            pop "exiting early due to destroy semaphore"
+          end
         end
       end
     end

--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -10,12 +10,6 @@ class Prog::BootstrapRhizome < Prog::Base
     @user ||= frame.fetch("user", "root")
   end
 
-  def before_run
-    when_destroy_set? do
-      pop "exiting early due to destroy semaphore"
-    end
-  end
-
   label def start
     sshable.update(raw_private_key_1: SshKey.generate.keypair) if sshable.raw_private_key_1.nil?
     hop_setup

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -10,12 +10,6 @@ class Prog::InstallRhizome < Prog::Base
 
   SKIP_VALIDATION = ["Gemfile.lock"]
 
-  def before_run
-    when_destroy_set? do
-      pop "exiting early due to destroy semaphore"
-    end
-  end
-
   label def start
     tar = StringIO.new
     file_hash_map = {} # pun intended

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -5,12 +5,6 @@ require_relative "../../lib/util"
 class Prog::Postgres::ConvergePostgresResource < Prog::Base
   subject_is :postgres_resource
 
-  def before_run
-    when_destroy_set? do
-      pop "exiting early due to destroy semaphore"
-    end
-  end
-
   label def start
     nap 60 if postgres_resource.read_replica? && !postgres_resource.parent.ready_for_read_replica?
 

--- a/prog/test2.rb
+++ b/prog/test2.rb
@@ -11,8 +11,4 @@ class Prog::Test2 < Prog::Base
   label def pusher1
     push Prog::Test, {test_level: "2"}, :pusher2
   end
-
-  label def destroy
-    pop "destroyed"
-  end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -451,8 +451,7 @@ RSpec.describe Prog::Base do
       Semaphore.incr(st.id, :destroy)
       allow(Clog).to receive(:emit).and_call_original
       expect(Clog).to receive(:emit).with("before destroy called")
-      expect { st.unsynchronized_run }.to change(st, :label).from("pusher1").to("destroy")
-      expect { st.unsynchronized_run }.to change(st, :exitval).from(nil).to({"msg" => "destroyed"})
+      expect { st.unsynchronized_run }.to change(st, :exitval).from(nil).to({"msg" => "exiting early due to destroy semaphore"})
     end
 
     it "does not hop to destroy if destroy semaphore not incremented" do

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe Prog::BootstrapRhizome do
     Strand.create_with_id(sshable, prog: "BootstrapRhizome", label: "start")
   }
 
-  it "exits if destroy is set" do
-    expect(br.before_run).to be_nil
-    br.incr_destroy
-    expect { br.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
-  end
-
   describe "#start" do
     it "generates a keypair" do
       sshable.update(raw_private_key_1: nil)

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe Prog::InstallRhizome do
 
   let(:sshable) { Sshable.create }
 
-  it "exits if destroy is set" do
-    expect(ir.before_run).to be_nil
-    expect(ir).to receive(:when_destroy_set?).and_yield
-    expect { ir.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
-  end
-
   describe "#start" do
     it "writes tar" do
       expect(ir.sshable).to receive(:_cmd) do |*args, **kwargs|

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -66,11 +66,6 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
     server
   end
 
-  it "exits if destroy is set" do
-    nx.incr_destroy
-    expect { nx.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
-  end
-
   describe "#start" do
     it "naps if read replica parent is not ready" do
       parent = PostgresResource.create(


### PR DESCRIPTION
Previously, before_run assumed progs with a destroy semaphore also had a destroy label to hop to. Several progs (BootstrapRhizome, InstallRhizome, ConvergePostgresResource) needed custom before_run implementations to handle the case where they had the semaphore but no destroy label, manually popping the strand instead.

This change moves that logic into the base before_run. When destroy_set? is true but hop_destroy is not defined, pop the strand directly. This eliminates duplicate before_run implementations.